### PR TITLE
ENH: Tests/modifications vtkMRMLLiverResectionNode

### DIFF
--- a/LiverResections/CMakeLists.txt
+++ b/LiverResections/CMakeLists.txt
@@ -8,7 +8,7 @@ string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 #-----------------------------------------------------------------------------
 add_subdirectory(MRML)
 add_subdirectory(Logic)
-add_subdirectory(Widgets)
+#add_subdirectory(Widgets)
 
 #-----------------------------------------------------------------------------
 set(MODULE_EXPORT_DIRECTIVE "Q_SLICER_QTMODULES_${MODULE_NAME_UPPER}_EXPORT")
@@ -51,6 +51,6 @@ slicerMacroBuildLoadableModule(
   )
 
 #-----------------------------------------------------------------------------
-# if(BUILD_TESTING)
-#   add_subdirectory(Testing)
-# endif()
+if(BUILD_TESTING)
+  add_subdirectory(Testing)
+endif()

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -273,11 +273,11 @@ vtkSlicerLiverResectionsLogic::AddResectionContour(vtkMRMLLiverResectionNode *re
     return nullptr;
     }
 
-  if (!resectionNode->GetSegmentationNode())
-    {
-     vtkErrorMacro("Error in AddResectionContour: no valid segmentation node.");
-     return nullptr;
-    }
+  // if (!resectionNode->GetSegmentationNode())
+  //   {
+  //    vtkErrorMacro("Error in AddResectionContour: no valid segmentation node.");
+  //    return nullptr;
+  //   }
 
   if (!resectionNode->GetTargetOrgan())
     {
@@ -285,11 +285,11 @@ vtkSlicerLiverResectionsLogic::AddResectionContour(vtkMRMLLiverResectionNode *re
       return nullptr;
     }
 
-  if (resectionNode->GetTargetTumors().empty())
-    {
-      vtkErrorMacro("Error in AddResectionContour: no valid target tumor.");
-      return nullptr;
-    }
+  // if (resectionNode->GetTargetTumors().empty())
+  //   {
+  //     vtkErrorMacro("Error in AddResectionContour: no valid target tumor.");
+  //     return nullptr;
+  //   }
 
   // Computing the position of the initial points
   const double *bounds = resectionNode->GetTargetOrgan()->GetPolyData()->GetBounds();

--- a/LiverResections/MRML/vtkMRMLLiverResectionNode.h
+++ b/LiverResections/MRML/vtkMRMLLiverResectionNode.h
@@ -94,23 +94,26 @@ public:
   //--------------------------------------------------------------------------------
   void CreateDefaultDisplayNodes() override;
 
-  /// Get target lesions identifiers
-  std::set<vtkMRMLModelNode*> GetTargetTumors() const {return this->TargetTumors;}
-  /// Add a new lesion identifier
-  void AddTargetTumor(vtkMRMLModelNode* tumorModel)
-  {this->TargetTumors.insert(tumorModel); this->Modified();}
-  /// Remove a lesion identifier
-  void RemoveTargetTumor(vtkMRMLModelNode* tumorModel)
-  {this->TargetTumors.erase(tumorModel); this->Modified();}
 
-  vtkMRMLSegmentationNode* GetSegmentationNode() const {return this->SegmentationNode;}
-  void SetSegmentationNode(vtkMRMLSegmentationNode *segmentationNode)
-  {this->SegmentationNode = segmentationNode; this->Modified();}
+  // TODO: Review the need for this further down the road
+  /// Get target lesions identifiers
+  // std::set<vtkMRMLModelNode*> GetTargetTumors() const {return this->TargetTumors;}
+  // /// Add a new lesion identifier
+  // void AddTargetTumor(vtkMRMLModelNode* tumorModel)
+  // {this->TargetTumors.insert(tumorModel); this->Modified();}
+  // /// Remove a lesion identifier
+  // void RemoveTargetTumor(vtkMRMLModelNode* tumorModel)
+  // {this->TargetTumors.erase(tumorModel); this->Modified();}
+
+  // TODO: Review the need for this further down the road
+  // vtkMRMLSegmentationNode* GetSegmentationNode() const {return this->SegmentationNode;}
+  // void SetSegmentationNode(vtkMRMLSegmentationNode *segmentationNode)
+  // {this->SegmentationNode = segmentationNode; this->Modified();}
 
   // Get resection margin
-  vtkGetMacro(ResectionMargin, float);
+  vtkGetMacro(ResectionMargin, double);
   // Set resection margin
-  vtkSetMacro(ResectionMargin, float);
+  vtkSetClampMacro(ResectionMargin, double, 0.0, VTK_DOUBLE_MAX);
 
   // Get resection status
   vtkGetMacro(Status, ResectionStatus);
@@ -130,18 +133,19 @@ public:
   void SetTargetOrgan(vtkMRMLModelNode *targetOrgan)
   {this->TargetOrgan = targetOrgan; this->Modified();}
 
-
 protected:
   vtkMRMLLiverResectionNode();
   ~vtkMRMLLiverResectionNode() override;
 
 private:
-  vtkWeakPointer<vtkMRMLSegmentationNode> SegmentationNode;
+
+  // TODO: Review the need of this further down the road
+  // std::set<vtkMRMLModelNode*> TargetTumors;
+  // vtkWeakPointer<vtkMRMLSegmentationNode> SegmentationNode;
   vtkWeakPointer<vtkMRMLModelNode> TargetOrgan;
-  std::set<vtkMRMLModelNode*> TargetTumors;
   ResectionStatus Status;
   InitializationMode Initialization;
-  float ResectionMargin; //Resection margin in mm
+  double ResectionMargin; //Resection margin in mm
 
 private:
  vtkMRMLLiverResectionNode(const vtkMRMLLiverResectionNode&);

--- a/LiverResections/Testing/CMakeLists.txt
+++ b/LiverResections/Testing/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Cxx)

--- a/LiverResections/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Testing/Cxx/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(KIT qSlicer${MODULE_NAME}Module)
+
+#-----------------------------------------------------------------------------
+set(TEMP ${Slicer_BINARY_DIR}/Testing/Temporary)
+set(INPUT ${CMAKE_CURRENT_SOURCE_DIR}/../Data/Input)
+
+#-----------------------------------------------------------------------------
+set(KIT_TEST_SRCS
+  vtkMRMLLiverResectionNodeTest1.cxx
+  )
+
+#-----------------------------------------------------------------------------
+slicerMacroConfigureModuleCxxTestDriver(
+  NAME ${KIT}
+  SOURCES ${KIT_TEST_SRCS}
+  TARGET_LIBRARIES
+    vtkSlicerAnnotationsModuleLogic
+  WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
+  )
+
+SIMPLE_TEST( vtkMRMLLiverResectionNodeTest1 )

--- a/LiverResections/Testing/Cxx/vtkMRMLLiverResectionNodeTest1.cxx
+++ b/LiverResections/Testing/Cxx/vtkMRMLLiverResectionNodeTest1.cxx
@@ -37,62 +37,35 @@
 
 ==============================================================================*/
 
-#include "vtkMRMLLiverResectionNode.h"
-#include "vtkMRMLLiverResectionDisplayNode.h"
-
 // MRML includes
-#include <vtkMRMLScene.h>
-#include <vtkMRMLSegmentationNode.h>
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLLiverResectionNode.h"
+#include "vtkMRMLModelNode.h"
+#include "vtkMRMLScene.h"
+
 
 // VTK includes
 #include <vtkNew.h>
-#include <vtkObjectFactory.h>
+#include <vtkType.h>
 
-//--------------------------------------------------------------------------------
-vtkMRMLNodeNewMacro(vtkMRMLLiverResectionNode);
-
-//--------------------------------------------------------------------------------
-vtkMRMLLiverResectionNode::vtkMRMLLiverResectionNode()
-  :Superclass(), TargetOrgan(nullptr), ResectionMargin(10.0),
-   Status(ResectionStatus::Initializing), Initialization(InitializationMode::Flat)
+//------------------------------------------------------------------------------
+int vtkMRMLLiverResectionNodeTest1(int, char *[])
 {
-}
+  vtkNew<vtkMRMLLiverResectionNode> node1;
+  vtkNew<vtkMRMLScene> scene;
 
-//----------------------------------------------------------------------------
-vtkMRMLLiverResectionNode::~vtkMRMLLiverResectionNode() = default;
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
 
-//----------------------------------------------------------------------------
-void vtkMRMLLiverResectionNode::PrintSelf(ostream& os, vtkIndent indent)
-{
-  Superclass::PrintSelf(os,indent);
-}
+  TEST_SET_GET_DOUBLE_RANGE(node1, ResectionMargin, 1.0, VTK_DOUBLE_MAX);
 
-//----------------------------------------------------------------------------
-void vtkMRMLLiverResectionNode::CreateDefaultDisplayNodes()
-{
-  auto displayNode = this->GetDisplayNode();
-  auto mrmlScene = this->GetScene();
+  TEST_SET_GET_VALUE(node1, Status, vtkMRMLLiverResectionNode::Initializing);
+  TEST_SET_GET_VALUE(node1, Status, vtkMRMLLiverResectionNode::Deformation);
+  TEST_SET_GET_VALUE(node1, Status, vtkMRMLLiverResectionNode::Completed);
 
-  if (displayNode != nullptr &&
-    vtkMRMLMarkupsDisplayNode::SafeDownCast(displayNode) != nullptr)
-    {
-    // display node already exists
-    return;
-    }
+  vtkNew<vtkMRMLModelNode> modelNode;
+  auto modelNodePtr = modelNode.GetPointer();
 
-  if (mrmlScene == nullptr)
-    {
-    vtkErrorMacro("vtkMRMLLiverResectionNode::CreateDefaultDisplayNodes failed: scene is invalid");
-    return;
-    }
+  TEST_SET_GET_VALUE(node1, TargetOrgan, modelNodePtr);
 
-  vtkMRMLLiverResectionDisplayNode* dispNode =
-    vtkMRMLLiverResectionDisplayNode::SafeDownCast(mrmlScene->AddNewNodeByClass("vtkMRMLLiverResectionDisplayNode"));
-  if (!dispNode)
-    {
-    vtkErrorMacro("vtkMRMLLiverResectionNode::CreateDefaultDisplayNodes failed: unable to create vtkMRMLLiverResectionDisplayNode");
-    return;
-    }
-
-  this->SetAndObserveDisplayNodeID(dispNode->GetID());
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- This adds unit testing for `vtkMRMLLiverResectionNode`. In addition,
and derived from the new UI design (ALive-research/Slicer-Liver#34), the
node has been simplified to hold only the resection margin and the
target organ (target tumors and segmentation node have been removed from
the node definition and its use in the logic). Finally, the resection
widget has been disabled (the code continues there)

This closes ALive-research/Slicer-Liver#42.