### PR TITLE
ENH: Add distance map filter for ui

### DIFF
--- a/Liver/Resources/UI/qSlicerDistanceMapsComputationWidget.ui
+++ b/Liver/Resources/UI/qSlicerDistanceMapsComputationWidget.ui
@@ -28,7 +28,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="TumorNodeLabel">
           <property name="text">
-           <string>Tumor Labelmap:</string>
+           <string>Tumor Label Map:</string>
           </property>
          </widget>
         </item>
@@ -53,7 +53,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="OutputVolumeLabel">
           <property name="text">
-           <string>Output Volume:</string>
+           <string>Output Distance Map: </string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
This prevents the use of any volume as distance maps. Only those volumes
processed by the distance maps algorithm will have the attribute to be
selected as distance maps. This closes alive-research/slicer-liver#70