### PR TITLE
BUG: Fix multiple registration of markups nodes

### DIFF
--- a/LiverMarkups/Logic/vtkSlicerLiverMarkupsLogic.cxx
+++ b/LiverMarkups/Logic/vtkSlicerLiverMarkupsLogic.cxx
@@ -81,16 +81,8 @@ void vtkSlicerLiverMarkupsLogic::PrintSelf(ostream& os, vtkIndent indent)
 //-----------------------------------------------------------------------------
 void vtkSlicerLiverMarkupsLogic::RegisterNodes()
 {
-  assert(this->GetMRMLScene() != nullptr);
-
-  vtkMRMLScene *scene = this->GetMRMLScene();
-
-  // Nodes
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsSlicingContourNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsDistanceContourNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsBezierSurfaceNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsBezierSurfaceDisplayNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsSlicingContourDisplayNode>::New());
+  // Markups nodes are registerd by vtkSlicerMarkupsLogic::RegisterMarkupsNode
+  // called in the module class
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Markups nodes, as opposed to other nodes, are registered by the
RegisterMarkups function called in the module, therefore, there is no
need for their registration in vtkSlicerLiverMarkups::RegisterNodes
function. This fixes alive-research/slicer-liver#71