### PR TITLE
BUG: Fixed LiverSegments module cannot edit and generate new segmentation after first-time calculation.

### DIFF
--- a/LiverSegments/Logic/vtkLiverSegmentsLogic.cxx
+++ b/LiverSegments/Logic/vtkLiverSegmentsLogic.cxx
@@ -233,11 +233,22 @@ void vtkLiverSegmentsLogic::calculateVascularTerritoryMap(vtkMRMLSegmentationNod
   //slicer.util.arrayFromVolumeModified(labelmapVolumeNode)
   labelmapVolumeNode->Modified();//Is this enough, or is more of the code in arrayFromVolumeModified needed?
   const char * segmentationId = vascularTerritorySegmentationNode->GetAttribute("LiverSegments.SegmentationId");
+  std::string segmentationIdCopy;
+  if (segmentationId)
+  {
+    segmentationIdCopy = segmentationId;
+  }
+
   vascularTerritorySegmentationNode->Reset(nullptr);
   vascularTerritorySegmentationNode->SetAttribute("LiverSegments.SegmentationId", segmentationId);
   vascularTerritorySegmentationNode->CreateDefaultDisplayNodes(); // only needed for display
   vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(labelmapVolumeNode, vascularTerritorySegmentationNode);
   vascularTerritorySegmentationNode->CreateClosedSurfaceRepresentation();
+
+  if (!segmentationIdCopy.empty())
+  {
+    vascularTerritorySegmentationNode->SetAttribute("LiverSegments.SegmentationId", segmentationIdCopy.c_str());
+  }
   mrmlScene->RemoveNode(labelmapVolumeNode);
 }
 


### PR DESCRIPTION
Issue statement: 
[LiverSegments.SegmentationID](https://github.com/ALive-research/Slicer-Liver/blob/ba54ac0d399d4174349dcd3223969750c3d8ac7d/LiverSegments/Logic/vtkLiverSegmentsLogic.cxx#L235C16-L235C30) is used to trace the SegmentationNode we are working with.  However, [this line ](https://github.com/ALive-research/Slicer-Liver/blob/ba54ac0d399d4174349dcd3223969750c3d8ac7d/LiverSegments/Logic/vtkLiverSegmentsLogic.cxx#L239) releases LiverSegments.SegmentationID attribute from memory, which makes the SegmentationNode cannot be recognized when trying to adjust the liver segments.

The fix:
Copy the value of LiverSegments.SegmentationID attribute and assign it back after [this line ](https://github.com/ALive-research/Slicer-Liver/blob/ba54ac0d399d4174349dcd3223969750c3d8ac7d/LiverSegments/Logic/vtkLiverSegmentsLogic.cxx#L239) 