### PR TITLE
COMP: Fix compile errors

### DIFF
--- a/LiverMarkups/MRML/vtkMRMLMarkupsBezierSurfaceNode.h
+++ b/LiverMarkups/MRML/vtkMRMLMarkupsBezierSurfaceNode.h
@@ -76,10 +76,10 @@ public:
   const char* GetMarkupType() override {return "BezierSurface";}
 
   // Get markup type GUI display name
-  const char* GetTypeDisplayName() override {return "Bezier Surface";};
+  std::string GetTypeDisplayName() override {return "Bezier Surface";};
 
   /// Get markup short name
-  const char* GetDefaultNodeNamePrefix() override {return "BS";}
+  std::string GetDefaultNodeNamePrefix() override {return "BS";}
 
   /// Set the distance map
   void SetDistanceMapVolumeNode(vtkMRMLScalarVolumeNode* volumeNode)

--- a/LiverMarkups/MRML/vtkMRMLMarkupsDistanceContourNode.h
+++ b/LiverMarkups/MRML/vtkMRMLMarkupsDistanceContourNode.h
@@ -76,7 +76,7 @@ public:
   const char* GetMarkupType() override {return "DistanceContour";}
 
   /// Get markup short name
-  const char* GetDefaultNodeNamePrefix() override {return "SC";}
+  std::string GetDefaultNodeNamePrefix() override {return "SC";}
 
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsDistanceContourNode);

--- a/LiverMarkups/MRML/vtkMRMLMarkupsSlicingContourNode.h
+++ b/LiverMarkups/MRML/vtkMRMLMarkupsSlicingContourNode.h
@@ -76,7 +76,7 @@ public:
   const char* GetMarkupType() override {return "SlicingContour";}
 
   /// Get markup short name
-  const char* GetDefaultNodeNamePrefix() override {return "SC";}
+  std::string GetDefaultNodeNamePrefix() override {return "SC";}
 
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsSlicingContourNode);

--- a/LiverMarkups/VTKWidgets/vtkMultiTextureObjectHelper.cpp
+++ b/LiverMarkups/VTKWidgets/vtkMultiTextureObjectHelper.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "vtkMultiTextureObjectHelper.h"
-#include "vtk_glew.h"
 
 #include "vtkObjectFactory.h"
 


### PR DESCRIPTION
The following compilation errors correspond to the update of 3D Slicer API and underlying libraries (e.g., vtk).