### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ## Table of content
+
+[![gitcgr](https://gitcgr.com/badge/ALive-research/Slicer-Liver.svg)](https://gitcgr.com/ALive-research/Slicer-Liver)
 - [Introduction](#introduction)
     - [Installing the extension](#installing-the-extension)
     - [Sample Data](#sample-data)


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/ALive-research/Slicer-Liver.svg)](https://gitcgr.com/ALive-research/Slicer-Liver)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).