### PR TITLE
ENH: Add starter CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# CODEOWNERS
+#
+# Lines later in this file take precedence.  Each line is a glob pattern
+# followed by one or more code-owner usernames / teams.
+#
+# See: https://docs.github.com/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# The `preview` branch protection has `require_code_owner_reviews` enabled —
+# every matched path in this file requires explicit approval from at least
+# one listed owner before a PR can merge.
+
+# Catch-all: the project lead reviews any path not covered below.
+*                              @RafaelPalomar
+
+# Governance-grade artefacts (ADRs, architecture diagrams, CI policy)
+# always require the project lead's explicit approval.  Listed
+# specifically so the rule is unambiguous even if the catch-all is
+# narrowed in the future.
+/Docs/adr/                     @RafaelPalomar
+/Docs/architecture/            @RafaelPalomar
+/.github/                      @RafaelPalomar


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS`.  The `preview` branch protection already has `require_code_owner_reviews` enabled (mirror of the old `develop` rule); without this file, the flag is inert.

Starter scheme:
- Catch-all rule names the project lead (`@RafaelPalomar`).
- Governance paths (`Docs/adr/`, `Docs/architecture/`, `.github/`) are listed explicitly so the rule remains unambiguous if the catch-all is later narrowed.

## Why this scope and not finer-grained

Per-module owners (`LiverResections/ → X`, `LiverMarkups/ → Y`, etc.) require knowing each contributor's GitHub handle and a stable role assignment.  Easy to add later as the team grows; the catch-all keeps the protection rule operative immediately.

## Test plan

- [ ] Merge to `preview` (admin-merge OK; protection has `enforce_admins: false`)
- [ ] Open a smoke-test PR against `preview` and confirm `@RafaelPalomar` is auto-requested as reviewer

---

*Drafted with assistance from Claude (Opus 4.7) via Claude Code; reviewed by the author.*