### PR TITLE
ENH: SNOMED-CT terminology assets and per-tool LabelToSCT bridges (ADR-0011)

### DIFF
--- a/Resources/Terminology/LabelToSCT/KumarOram.json
+++ b/Resources/Terminology/LabelToSCT/KumarOram.json
@@ -7,12 +7,12 @@
     "portal_root_seed": {
       "CodingSchemeDesignator": "SCT",
       "CodeValue": "32764006",
-      "CodeMeaning": "Portal vein structure"
+      "CodeMeaning": "Portal vein"
     },
     "hepatic_root_seed": {
       "CodingSchemeDesignator": "SCT",
       "CodeValue": "8993003",
-      "CodeMeaning": "Hepatic vein structure"
+      "CodeMeaning": "Hepatic vein"
     }
   },
   "mappings": []

--- a/Resources/Terminology/LabelToSCT/KumarOram.json
+++ b/Resources/Terminology/LabelToSCT/KumarOram.json
@@ -1,0 +1,19 @@
+{
+  "tool": "KumarOram",
+  "notes": "Kumar-Oram is a seed-based vessel-refinement algorithm. Its output labels (e.g. vessel_1, vessel_2) carry no intrinsic anatomical role — the role is determined by which seed the surgeon placed (portal root vs hepatic root). Mapping is therefore dynamic: each segmented vessel inherits the SCT triple of its originating seed. This file documents the seed-role contract; the static 'mappings' array stays empty and is populated at runtime from the seed-to-vessel correspondence.",
+  "schema": "https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0011-sct-terminology-dispatch.md",
+  "dynamic_mapping": true,
+  "seed_role_mapping": {
+    "portal_root_seed": {
+      "CodingSchemeDesignator": "SCT",
+      "CodeValue": "32764006",
+      "CodeMeaning": "Portal vein structure"
+    },
+    "hepatic_root_seed": {
+      "CodingSchemeDesignator": "SCT",
+      "CodeValue": "8993003",
+      "CodeMeaning": "Hepatic vein structure"
+    }
+  },
+  "mappings": []
+}

--- a/Resources/Terminology/LabelToSCT/MONAILabel.json
+++ b/Resources/Terminology/LabelToSCT/MONAILabel.json
@@ -1,0 +1,27 @@
+{
+  "tool": "MONAILabel",
+  "bundle": "segmentation_liver_and_tumor",
+  "notes": "Maps MONAILabel bundle output labels to SNOMED-CT triples per ADR-0011. This file targets the liver-and-tumor segmentation bundle commonly used in OUS workflows; alternate bundles (deepedit_anatomy, deepgrow_2d/3d, etc.) require their own LabelToSCT file or an additional 'bundle' entry.",
+  "schema": "https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0011-sct-terminology-dispatch.md",
+  "mappings": [
+    {
+      "label": "liver",
+      "integerLabel": 1,
+      "sct": {
+        "CodingSchemeDesignator": "SCT",
+        "CodeValue": "10200004",
+        "CodeMeaning": "Liver"
+      }
+    },
+    {
+      "label": "tumor",
+      "integerLabel": 2,
+      "sct": {
+        "CodingSchemeDesignator": "SCT",
+        "CodeValue": "86049000",
+        "CodeMeaning": "Neoplasm, Primary"
+      },
+      "notes": "Uses 'Neoplasm, Primary' (86049000) per DICOM SEG / MONAI ecosystem convention. Switch to 'Mass' (SCT 4147007) when malignancy is uncertain at segmentation time."
+    }
+  ]
+}

--- a/Resources/Terminology/LabelToSCT/TotalSegmentator.json
+++ b/Resources/Terminology/LabelToSCT/TotalSegmentator.json
@@ -1,0 +1,35 @@
+{
+  "tool": "TotalSegmentator",
+  "version": "v2",
+  "notes": "Maps TotalSegmentator (v2 label set) class names to SNOMED-CT triples for use by Slicer-Liver's terminology dispatch per ADR-0011. TotalSegmentator v1 combined some labels (e.g. portal_vein_and_splenic_vein) that v2 may separate; consult the bundled model docs for the active label set. Labels not in the Slicer-Liver core type set are mapped to null and surface in UI as Unknown until the type set expands.",
+  "schema": "https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0011-sct-terminology-dispatch.md",
+  "mappings": [
+    {
+      "label": "liver",
+      "sct": {
+        "CodingSchemeDesignator": "SCT",
+        "CodeValue": "10200004",
+        "CodeMeaning": "Liver"
+      }
+    },
+    {
+      "label": "portal_vein_and_splenic_vein",
+      "sct": {
+        "CodingSchemeDesignator": "SCT",
+        "CodeValue": "32764006",
+        "CodeMeaning": "Portal vein structure"
+      },
+      "notes": "TotalSegmentator v1 combines portal vein + splenic vein into a single label. Slicer-Liver maps to Portal vein; downstream consumers should expect over-inclusive masks until v2's separated labels are adopted by the bundled model."
+    },
+    {
+      "label": "inferior_vena_cava",
+      "sct": null,
+      "notes": "Out of Slicer-Liver core type set for v2.0.0. Surfaces as Unknown; revisit when ADR-0011 type set expands."
+    },
+    {
+      "label": "hepatic_vessels",
+      "sct": null,
+      "notes": "Out of core type set; combined hepatic veins + portal vein at the TS level. Pass to Kumar-Oram for refinement to per-vessel SCT codes when the surgeon opts in."
+    }
+  ]
+}

--- a/Resources/Terminology/LabelToSCT/TotalSegmentator.json
+++ b/Resources/Terminology/LabelToSCT/TotalSegmentator.json
@@ -17,7 +17,7 @@
       "sct": {
         "CodingSchemeDesignator": "SCT",
         "CodeValue": "32764006",
-        "CodeMeaning": "Portal vein structure"
+        "CodeMeaning": "Portal vein"
       },
       "notes": "TotalSegmentator v1 combines portal vein + splenic vein into a single label. Slicer-Liver maps to Portal vein; downstream consumers should expect over-inclusive masks until v2's separated labels are adopted by the bundled model."
     },

--- a/Resources/Terminology/SlicerLiver-Terminology.json
+++ b/Resources/Terminology/SlicerLiver-Terminology.json
@@ -1,0 +1,137 @@
+{
+  "SegmentationCategoryTypeContextName": "Segmentation category and type - Slicer-Liver",
+  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/segment-context-schema.json#",
+  "SegmentationCodes": {
+    "Category": [
+      {
+        "CodeMeaning": "Anatomical Structure",
+        "CodingSchemeDesignator": "SCT",
+        "SNOMEDCTConceptID": "123037004",
+        "CodeValue": "123037004",
+        "showAnatomy": true,
+        "Type": [
+          {
+            "recommendedDisplayRGBValue": [221, 130, 101],
+            "CodeMeaning": "Liver",
+            "CodingSchemeDesignator": "SCT",
+            "3dSlicerLabel": "liver",
+            "SNOMEDCTConceptID": "10200004",
+            "CodeValue": "10200004",
+            "contextGroupName": "AbdominalSegmentationTypes"
+          },
+          {
+            "recommendedDisplayRGBValue": [102, 153, 204],
+            "CodeMeaning": "Portal vein structure",
+            "CodingSchemeDesignator": "SCT",
+            "3dSlicerLabel": "portal_vein",
+            "SNOMEDCTConceptID": "32764006",
+            "CodeValue": "32764006"
+          },
+          {
+            "recommendedDisplayRGBValue": [204, 102, 102],
+            "CodeMeaning": "Hepatic vein structure",
+            "CodingSchemeDesignator": "SCT",
+            "3dSlicerLabel": "hepatic_vein",
+            "SNOMEDCTConceptID": "8993003",
+            "CodeValue": "8993003"
+          }
+        ]
+      },
+      {
+        "CodeMeaning": "Morphologically Altered Structure",
+        "CodingSchemeDesignator": "SCT",
+        "SNOMEDCTConceptID": "49755003",
+        "CodeValue": "49755003",
+        "showAnatomy": false,
+        "Type": [
+          {
+            "recommendedDisplayRGBValue": [200, 60, 60],
+            "CodeMeaning": "Neoplasm, Primary",
+            "CodingSchemeDesignator": "SCT",
+            "3dSlicerLabel": "tumor",
+            "SNOMEDCTConceptID": "86049000",
+            "CodeValue": "86049000"
+          }
+        ]
+      },
+      {
+        "CodeMeaning": "Liver segment",
+        "CodingSchemeDesignator": "99SLIVER",
+        "CodeValue": "LIVER-SEG-CATEGORY",
+        "showAnatomy": false,
+        "Type": [
+          {
+            "recommendedDisplayRGBValue": [218, 165, 32],
+            "CodeMeaning": "Liver segment I (caudate)",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "couinaud_I",
+            "CodeValue": "LIVER-SEG-I"
+          },
+          {
+            "recommendedDisplayRGBValue": [135, 206, 250],
+            "CodeMeaning": "Liver segment II",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "couinaud_II",
+            "CodeValue": "LIVER-SEG-II"
+          },
+          {
+            "recommendedDisplayRGBValue": [250, 128, 114],
+            "CodeMeaning": "Liver segment III",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "couinaud_III",
+            "CodeValue": "LIVER-SEG-III"
+          },
+          {
+            "recommendedDisplayRGBValue": [255, 182, 193],
+            "CodeMeaning": "Liver segment IV",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "couinaud_IV",
+            "CodeValue": "LIVER-SEG-IV"
+          },
+          {
+            "recommendedDisplayRGBValue": [144, 238, 144],
+            "CodeMeaning": "Liver segment V",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "couinaud_V",
+            "CodeValue": "LIVER-SEG-V"
+          },
+          {
+            "recommendedDisplayRGBValue": [255, 255, 102],
+            "CodeMeaning": "Liver segment VI",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "couinaud_VI",
+            "CodeValue": "LIVER-SEG-VI"
+          },
+          {
+            "recommendedDisplayRGBValue": [186, 85, 211],
+            "CodeMeaning": "Liver segment VII",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "couinaud_VII",
+            "CodeValue": "LIVER-SEG-VII"
+          },
+          {
+            "recommendedDisplayRGBValue": [255, 140, 0],
+            "CodeMeaning": "Liver segment VIII",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "couinaud_VIII",
+            "CodeValue": "LIVER-SEG-VIII"
+          },
+          {
+            "recommendedDisplayRGBValue": [139, 0, 0],
+            "CodeMeaning": "Right hemiliver (Couinaud V-VIII)",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "hemiliver_right",
+            "CodeValue": "LIVER-HEMI-RIGHT"
+          },
+          {
+            "recommendedDisplayRGBValue": [0, 0, 139],
+            "CodeMeaning": "Left hemiliver (Couinaud II-IV)",
+            "CodingSchemeDesignator": "99SLIVER",
+            "3dSlicerLabel": "hemiliver_left",
+            "CodeValue": "LIVER-HEMI-LEFT"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Resources/Terminology/SlicerLiver-Terminology.json
+++ b/Resources/Terminology/SlicerLiver-Terminology.json
@@ -21,7 +21,7 @@
           },
           {
             "recommendedDisplayRGBValue": [102, 153, 204],
-            "CodeMeaning": "Portal vein structure",
+            "CodeMeaning": "Portal vein",
             "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "portal_vein",
             "SNOMEDCTConceptID": "32764006",
@@ -29,7 +29,7 @@
           },
           {
             "recommendedDisplayRGBValue": [204, 102, 102],
-            "CodeMeaning": "Hepatic vein structure",
+            "CodeMeaning": "Hepatic vein",
             "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "hepatic_vein",
             "SNOMEDCTConceptID": "8993003",

--- a/Testing/Python/unit/test_terminology_assets.py
+++ b/Testing/Python/unit/test_terminology_assets.py
@@ -1,0 +1,100 @@
+"""Tests for the SCT terminology assets shipped per ADR-0011.
+
+Verifies four invariants:
+
+1. `Resources/Terminology/SlicerLiver-Terminology.json` and the three
+   `Resources/Terminology/LabelToSCT/*.json` files exist and are valid JSON.
+2. The main terminology JSON conforms to the dcmqi
+   `segment-context-schema.json` (the same schema Slicer's bundled
+   `DICOM-Master.json` declares).  Validation runs in any Python with
+   `jsonschema`; skipped when unavailable or when offline.
+3. The main terminology JSON loads via Slicer's Terminologies module logic
+   (`vtkSlicerTerminologiesModuleLogic`).  Requires Slicer's Python;
+   `importorskip` skips outside that environment.
+4. Each `LabelToSCT/*.json` bridge has the contract this project ships:
+   `tool`, `mappings`, and (per entry) `label` plus either `sct: null`
+   (out-of-scope) or a full `(CodingSchemeDesignator, CodeValue,
+   CodeMeaning)` triple.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import urllib.request
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+TERMINOLOGY_DIR = REPO_ROOT / "Resources" / "Terminology"
+MAIN_FILE = TERMINOLOGY_DIR / "SlicerLiver-Terminology.json"
+LABEL_BRIDGES = sorted((TERMINOLOGY_DIR / "LabelToSCT").glob("*.json"))
+
+# Current canonical location of the dcmqi schema (relocated from
+# doc/segment-context-schema.json to doc/schemas/segment-context-schema.json
+# upstream; Slicer's bundled JSONs still reference the old URL but the
+# schema content is identical).
+DCMQI_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/qiicr/dcmqi/master"
+    "/doc/schemas/segment-context-schema.json"
+)
+
+
+def test_main_terminology_file_exists():
+    assert MAIN_FILE.is_file(), f"missing {MAIN_FILE}"
+
+
+def test_label_bridges_present():
+    names = {p.stem for p in LABEL_BRIDGES}
+    assert names == {"TotalSegmentator", "MONAILabel", "KumarOram"}, names
+
+
+@pytest.mark.parametrize("path", [MAIN_FILE, *LABEL_BRIDGES], ids=lambda p: p.name)
+def test_files_are_valid_json(path):
+    json.loads(path.read_text())
+
+
+def test_main_terminology_validates_against_dcmqi_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    try:
+        with urllib.request.urlopen(DCMQI_SCHEMA_URL, timeout=15) as r:
+            schema = json.loads(r.read())
+    except Exception as exc:
+        pytest.skip(f"dcmqi schema fetch failed (offline?): {exc}")
+
+    data = json.loads(MAIN_FILE.read_text())
+    jsonschema.validate(data, schema)
+
+
+def test_main_terminology_loads_in_slicer():
+    slicer = pytest.importorskip("slicer", reason="requires Slicer Python")
+    terminologies_module = getattr(slicer.modules, "terminologies", None)
+    if terminologies_module is None:
+        pytest.skip("Slicer Terminologies module not available in this build")
+    logic = terminologies_module.logic()
+    context_name = logic.LoadTerminologyFromFile(str(MAIN_FILE))
+    assert context_name, (
+        f"LoadTerminologyFromFile returned empty context name for {MAIN_FILE.name}; "
+        "the JSON failed to load."
+    )
+    # Confirm categories actually populated under the loaded context name.
+    n_categories = logic.GetNumberOfCategoriesInTerminology(context_name)
+    assert n_categories > 0, (
+        f"Loaded context '{context_name}' has no categories — "
+        "structure parsed but content is empty."
+    )
+
+
+@pytest.mark.parametrize("bridge", LABEL_BRIDGES, ids=lambda p: p.name)
+def test_label_bridge_contract(bridge):
+    data = json.loads(bridge.read_text())
+    assert "tool" in data, f"{bridge.name}: missing top-level 'tool'"
+    assert "mappings" in data, f"{bridge.name}: missing top-level 'mappings'"
+    for entry in data["mappings"]:
+        assert "label" in entry, f"{bridge.name}: mapping entry missing 'label'"
+        sct = entry.get("sct")
+        if sct is not None:
+            for key in ("CodingSchemeDesignator", "CodeValue", "CodeMeaning"):
+                assert key in sct, (
+                    f"{bridge.name}: mapping '{entry['label']}' missing sct.{key}"
+                )


### PR DESCRIPTION
## Summary
- `Resources/Terminology/SlicerLiver-Terminology.json` — dcmqi segment-context schema, three categories: Anatomical Structure (Liver, Portal vein, Hepatic vein), Morphologically Altered Structure (Neoplasm Primary), Liver segment (private `99SLIVER` scheme, ten Couinaud codes).
- `Resources/Terminology/LabelToSCT/{TotalSegmentator,MONAILabel,KumarOram}.json` — per-tool label-to-SCT bridges per ADR-0011.

Closes #309.

## SCT code choices

| Concept | Code | Note |
|---|---|---|
| Liver | `SCT:10200004` | Matches Slicer DICOM-Master |
| Portal vein | `SCT:32764006` | Matches Slicer DICOM-Master |
| Hepatic vein | `SCT:8993003` | Matches Slicer DICOM-Master |
| Tumor | `SCT:86049000` "Neoplasm, Primary" | DICOM SEG / MONAI ecosystem default for hepatic tumor segmentation |

The portal/hepatic vein codes here intentionally diverge from a widely-cited alternate pair (`12830003` / `80334008`) — those are not the values Slicer ships in its bundled DICOM-Master terminology and would break interop with the Segment Editor selector and DICOM SEG export. Verified against `SegmentationCategoryTypeModifier-DICOM-Master.json` in upstream Slicer 5.8.1.

## Couinaud scheme

Ten codes in private scheme `99SLIVER`:
- `LIVER-SEG-I` through `LIVER-SEG-VIII` — standard eight Couinaud segments
- `LIVER-HEMI-RIGHT` (Couinaud V-VIII) and `LIVER-HEMI-LEFT` (Couinaud II-IV) — compound regions for anatomic-resection workflows

Per ADR-0011 §Versioning, the eight standard codes and the two hemiliver codes are immutable identifiers for v2.x. Adding finer subdivisions (e.g. IVa/IVb) is MINOR; renumbering or removing existing codes is MAJOR (N-class break under ADR-0007).

## Stubs / open items

- **TotalSegmentator** — `inferior_vena_cava` and `hepatic_vessels` are marked out-of-scope (Slicer-Liver core type set doesn't cover them in v2.0.0). They pass through as Unknown.
- **MONAILabel** — file targets the `segmentation_liver_and_tumor` bundle; alternate bundles need their own file or an additional `bundle` entry.
- **Kumar-Oram** — output labels carry no intrinsic role; mapping is dynamic from seed placement. File encodes the seed-role contract; the static `mappings` array stays empty by design.

## Test plan
- [ ] Load `SlicerLiver-Terminology.json` via Slicer's Terminologies module and confirm it parses
- [ ] Verify Segment Editor terminology selector surfaces the three categories
- [ ] Smoke-test a DICOM SEG export round-trip with one of the four SCT-coded types
- [ ] Spot-check `LabelToSCT` files load as JSON

## UX impact
N/A — non-UI change (data assets only).

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code. Schema research and SCT-code verification by a Claude Code subagent, which flagged a code mismatch against the original brief; corrected codes and final asset authoring by the orchestrating Opus 4.7 session. Opened for human review before merge.*