### PR TITLE
ENH: pytest scaffold with render_interactive option per ADR-0008

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .idea/
+
+# Python / pytest artefacts (ADR-0008 scaffold).
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,5 +31,12 @@ add_subdirectory(LiverVolumetry)
 add_subdirectory(Liver)
 
 #-----------------------------------------------------------------------------
+# Shared (cross-module) pytest scaffold per ADR-0008.
+# Per-module Slicer self-tests continue to register from their own
+# <Module>/Testing/Python/CMakeLists.txt; this directory adds the
+# pytest-driven scaffold and (in follow-up PRs) the cross-module fixtures.
+add_subdirectory(Testing)
+
+#-----------------------------------------------------------------------------
 include(${Slicer_EXTENSION_GENERATE_CONFIG})
 include(${Slicer_EXTENSION_CPACK})

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Shared (cross-module) pytest scaffolding for Slicer-Liver.
+# See Docs/adr/0008-testing-strategy.md.
+#
+# Per-module Slicer self-tests continue to live under
+# <Module>/Testing/Python/ and register via ``slicer_add_python_unittest``;
+# this directory is the home for shared pytest scaffolding (conftest,
+# render_interactive option, cross-module fixtures) and for tests that
+# span more than one module.
+
+if(BUILD_TESTING)
+  add_subdirectory(Python)
+endif()

--- a/Testing/Python/CMakeLists.txt
+++ b/Testing/Python/CMakeLists.txt
@@ -1,0 +1,68 @@
+# CTest registration for the shared pytest scaffold.
+# See Docs/adr/0008-testing-strategy.md §6 (CI matrix).
+#
+# Two CTest entries register the *same* test tree twice, mirroring the
+# CI matrix described in ADR-0008 §6:
+#
+#   pytest_scaffold                  — bare ``pytest`` (offscreen, fast)
+#   pytest_scaffold_render_interactive
+#                                    — ``pytest --render-interactive=0.1``
+#                                      (briefly onscreen; exercises the
+#                                      ShowWindowOn() path)
+#
+# Both entries are gated on ``Python3_EXECUTABLE`` (provided by Slicer's
+# CMake macros) and on the presence of ``pytest`` in the active Python.
+# When pytest is not available the entries are skipped at configure time
+# rather than failing the build — this keeps the scaffold buildable in
+# environments where the pytest dependency hasn't been provisioned yet
+# (the slicer-build-ubuntu2404 CI image will need pytest added; tracked
+# as a follow-up to this PR — see ALive-Docker).
+
+if(NOT Python3_EXECUTABLE)
+  message(STATUS
+    "Slicer-Liver: Python3_EXECUTABLE not set; "
+    "skipping pytest scaffold registration.")
+  return()
+endif()
+
+# Probe for pytest in the configured Python.  ``execute_process`` with
+# ``RESULT_VARIABLE`` returns 0 when the import succeeds.
+execute_process(
+  COMMAND "${Python3_EXECUTABLE}" -c "import pytest"
+  RESULT_VARIABLE _pytest_probe_rc
+  OUTPUT_QUIET
+  ERROR_QUIET
+)
+
+if(NOT _pytest_probe_rc EQUAL 0)
+  message(STATUS
+    "Slicer-Liver: pytest not importable from ${Python3_EXECUTABLE}; "
+    "skipping pytest scaffold registration.  Install pytest in the "
+    "Slicer Python environment to enable these tests.")
+  return()
+endif()
+
+# ``-q`` keeps the CTest log short on success; ``-ra`` (from pytest.ini)
+# still surfaces non-pass summary lines.
+add_test(
+  NAME pytest_scaffold
+  COMMAND "${Python3_EXECUTABLE}" -m pytest
+    -q
+    "${CMAKE_SOURCE_DIR}/Testing/Python"
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+)
+set_tests_properties(pytest_scaffold PROPERTIES
+  LABELS "pytest;offscreen"
+)
+
+add_test(
+  NAME pytest_scaffold_render_interactive
+  COMMAND "${Python3_EXECUTABLE}" -m pytest
+    -q
+    --render-interactive=0.1
+    "${CMAKE_SOURCE_DIR}/Testing/Python"
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+)
+set_tests_properties(pytest_scaffold_render_interactive PROPERTIES
+  LABELS "pytest;onscreen-brief"
+)

--- a/Testing/Python/conftest.py
+++ b/Testing/Python/conftest.py
@@ -1,0 +1,201 @@
+"""
+Shared pytest scaffolding for Slicer-Liver (per ADR-0008).
+
+This conftest implements the canonical `render_interactive` pattern adopted
+from trame-slicer / SlicerLayerDisplayableManager.  The same test code serves
+two audiences:
+
+  * **CI / automated regression** — bare ``pytest`` runs offscreen; view
+    fixtures never call ``ShowWindowOn()``; the suite completes as fast as
+    possible.
+  * **Developer interactive exploration** — ``pytest --render-interactive=5``
+    yields visible Qt/VTK windows for 5 seconds per view-creating fixture,
+    letting a human watch the same assertions execute on real pixels.  No
+    parallel demo-script tree to maintain; the test *is* the demo.
+
+The default for ``--render-interactive`` is **0.0** (offscreen).  Rationale:
+
+  * Bare ``pytest`` must be safe for CI.  GitHub Actions runners drive Qt
+    via ``QT_QPA_PLATFORM=offscreen`` (see ``.github/workflows/ci.yml``);
+    a default-on flag would either hang on a missing DISPLAY or burn
+    wall-clock waiting for invisible windows to time out.
+  * ADR-0008 §6 specifies that CI explicitly runs the brief-onscreen
+    variant by *passing* ``--render-interactive=0.1`` as a separate
+    invocation — proving that the default for the bare invocation is OFF.
+  * Developers iterating locally pass ``--render-interactive=5`` (or longer
+    for bug-repro) by hand.  This matches trame-slicer's convention.
+
+Layered test taxonomy (per ADR-0008 §2):
+
+  * **unit/**     — pure-algorithm tests (no slicer import, no Qt)
+  * **module/**   — MRML scene + pipeline behaviour (slicer imported as a
+                    library; no Qt widgets)
+  * **workflow/** — widget + scene + Qt interaction (consume view fixtures;
+                    respect ``render_interactive``)
+
+This scaffold lands the option, the session-scoped ``render_interactive``
+fixture, and one example "Slicer-app boot" fixture demonstrating the dual-use
+pattern.  The full per-module fixture set (``a_resection_node``,
+``a_resectogram_view``, ``a_volumetry_node``, ``a_view_manager``,
+``a_segmentation_with_terminology``, ...) lands in follow-up PRs as each
+module's test surface migrates — see TODO markers below.
+
+See:
+  * Docs/adr/0008-testing-strategy.md  (the canonical strategy)
+  * Docs/adr/0003-testability-invariant.md  (the discipline)
+  * Docs/adr/0004-python-cpp-boundary.md   (Python-by-default for tests)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# CLI option
+# --------------------------------------------------------------------------- #
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the ``--render-interactive`` CLI option.
+
+    The option accepts a float number of seconds for which view-creating
+    fixtures should keep a visible window onscreen before tearing down.
+    A value of ``0`` (the default) keeps everything offscreen — the
+    CI-safe path.
+
+    Examples
+    --------
+    Bare CI run (offscreen, fast)::
+
+        pytest
+
+    Brief onscreen smoke (CI matrix's second pass, per ADR-0008 §6)::
+
+        pytest --render-interactive=0.1
+
+    Developer interactive run (windows visible for 5 s each)::
+
+        pytest --render-interactive=5
+
+    Bug-repro on a failing case (5 minutes of dwell time)::
+
+        pytest --render-interactive=300 -k test_failing_case
+    """
+    group = parser.getgroup(
+        "slicer-liver",
+        "Slicer-Liver testing options (see Docs/adr/0008-testing-strategy.md)",
+    )
+    group.addoption(
+        "--render-interactive",
+        action="store",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help=(
+            "Keep view-creating fixtures' windows visible for SECONDS "
+            "before teardown.  Default 0.0 (offscreen, CI-safe).  Pass a "
+            "positive value (e.g. 5) for developer interactive exploration."
+        ),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Core fixture: the render_interactive switch
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture(scope="session")
+def render_interactive(pytestconfig: pytest.Config) -> float:
+    """Session-scoped float: seconds to keep view windows visible.
+
+    A value of ``0.0`` means "offscreen, tear down immediately after
+    assertions" — the CI default.  A positive value means "show the window
+    that long before teardown" — the developer interactive default.
+
+    Every view-creating fixture in this project's test tree must consume
+    this fixture and respect its value, e.g.::
+
+        @pytest.fixture
+        def a_threed_view(a_view_manager, render_interactive):
+            view = a_view_manager.create_view(...)
+            if render_interactive:
+                view.render_window().ShowWindowOn()
+            view.interactor().UpdateSize(800, 600)
+            yield view
+            if render_interactive:
+                view.interactor().Start()  # blocks for `render_interactive` s
+            view.finalize()
+
+    See ADR-0008 §3 for the full pattern.
+    """
+    return float(pytestconfig.getoption("--render-interactive"))
+
+
+# --------------------------------------------------------------------------- #
+# Example application-boot fixture
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture(scope="session")
+def a_slicer_app():
+    """Session-scoped handle to Slicer-imported-as-a-library.
+
+    Per ADR-0004, the test discipline imports Slicer as a Python package
+    (``import slicer``) rather than launching the Slicer GUI binary.  Tests
+    that need an active MRML scene, the application logic singleton, or any
+    Slicer-registered Python utility consume this fixture.
+
+    When Slicer is unavailable (e.g. when running the unit-layer tests in a
+    plain Python environment without a built Slicer), the fixture
+    ``pytest.skip()``s the consuming test rather than erroring, so the
+    scaffold can be exercised in isolation during development of the
+    scaffold itself.
+
+    Returns
+    -------
+    The ``slicer`` module object.  Tests typically destructure ``mrmlScene``,
+    ``util``, or specific node classes from it.
+
+    TODO (follow-up PRs):
+      * Add fixtures ``a_mrml_scene`` (function-scoped, clears scene
+        between tests) and ``a_clean_scene`` (alias kept for trame-slicer
+        compatibility).
+      * Add ``a_resection_node`` (LiverResections module fixture).
+      * Add ``a_resectogram_view`` (LiverResections workflow fixture;
+        consumes ``render_interactive``).
+      * Add ``a_volumetry_node`` (LiverVolumetry module fixture).
+      * Add ``a_view_manager`` (LayerDM view-factory fixture).
+    """
+    try:
+        import slicer  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover — exercised only outside Slicer
+        pytest.skip(
+            f"slicer module not importable ({exc}); "
+            "run this test inside Slicer's Python or via "
+            "`Slicer --python-script $(which pytest) -- ...`."
+        )
+    return slicer
+
+
+# --------------------------------------------------------------------------- #
+# TODO (follow-up PRs) — fixture set to come
+# --------------------------------------------------------------------------- #
+#
+# Per ADR-0008 §2 ("Layered taxonomy") and the trame-slicer precedent,
+# the following fixtures land in subsequent PRs:
+#
+#   a_mrml_scene             — function-scoped clean scene
+#   a_view_manager           — LayerDM view factory (workflow layer)
+#   a_threed_view            — 3D view; consumes render_interactive
+#   a_slice_view             — 2D slice view; consumes render_interactive
+#   a_resection_node         — vtkMRMLLiverResectionNode + targets/markups
+#   a_resectogram_view       — resectogram widget; consumes render_interactive
+#   a_volumetry_node         — vtkMRMLLiverVolumetryNode + computed values
+#   a_segmentation_with_terminology
+#                            — SegmentationNode + SCT-coded segments
+#                              (per ADR-0011 dispatch policy)
+#   a_bezier_control_grid    — synthetic control grid for the algorithm
+#                              characterisation tests flagged in ADR-0008
+#                              §7 (bug-fix-PR pattern)
+#
+# Each landing PR also wires the module's tests under
+# ``Testing/Python/<layer>/`` and updates the layer-specific CMake entries
+# in ``Testing/Python/CMakeLists.txt``.

--- a/Testing/Python/unit/test_scaffold_smoke.py
+++ b/Testing/Python/unit/test_scaffold_smoke.py
@@ -1,0 +1,93 @@
+"""
+Unit-layer smoke test for the pytest scaffold.
+
+This test exists to prove three things about the scaffold introduced
+alongside ADR-0008:
+
+  1. The ``--render-interactive`` CLI option is registered with the
+     correct default (``0.0`` — CI-safe / offscreen).  ADR-0008 §6's CI
+     matrix relies on the bare-``pytest`` invocation being offscreen and
+     the brief-onscreen variant being an explicit override.
+  2. The ``render_interactive`` fixture always yields a non-negative float,
+     regardless of CLI override.
+  3. The unit layer (pure-Python, no slicer, no Qt) is runnable in a plain
+     Python environment with only ``pytest`` installed — confirming the
+     scaffold is not implicitly coupled to a built Slicer.
+
+When the per-module fixture set lands (see TODO list at the bottom of
+``conftest.py``), real unit tests for algorithmic code (Bezier basis
+evaluation on numpy arrays, distance-map math, etc.) replace this smoke
+test as the unit-layer signal.
+
+Per ADR-0008 §2:
+
+    | Unit | Pure algorithm/math | No slicer | No Qt | N/A | Bezier basis evaluation on numpy arrays |
+"""
+
+from __future__ import annotations
+
+
+def test_render_interactive_option_default_is_off(
+    pytestconfig,
+) -> None:
+    """The CLI option's *registered default* must be ``0.0``.
+
+    Inspecting ``pytestconfig._parser`` lets us assert against the
+    parser's recorded default independently of whatever value the current
+    invocation overrode it with.  This pins the "bare ``pytest`` is
+    offscreen / CI-safe" guarantee documented in ``conftest.py`` and
+    ADR-0008 §6.
+    """
+    # The Parser exposes options via the private ``_anonymous`` / group
+    # API; the public way to get a registered default is
+    # ``pytestconfig.getoption(name, default=<sentinel>)`` paired with
+    # checking the parser, but a simpler robust check is to inspect the
+    # parser's ``_groups`` directly.  However, the *most* stable public
+    # surface is just to look at the option's ``default`` attribute on
+    # the parser's recorded options.
+    parser = pytestconfig._parser
+    option = None
+    for group in parser._groups:
+        for opt in group.options:
+            if "--render-interactive" in opt.names():
+                option = opt
+                break
+        if option is not None:
+            break
+
+    assert option is not None, (
+        "--render-interactive option not registered; "
+        "check Testing/Python/conftest.py"
+    )
+    assert option.default == 0.0, (
+        "Default for --render-interactive must be 0.0 (offscreen / "
+        f"CI-safe); see ADR-0008 §6.  Got: {option.default!r}"
+    )
+
+
+def test_render_interactive_yields_a_nonnegative_float(
+    render_interactive: float,
+) -> None:
+    """The fixture must always yield a non-negative float.
+
+    Whether the user runs ``pytest`` (default 0.0), ``pytest
+    --render-interactive=0.1`` (CI's brief-onscreen pass), or ``pytest
+    --render-interactive=5`` (developer interactive), the fixture's
+    contract is the same: a non-negative float number of seconds.
+    """
+    assert isinstance(render_interactive, float)
+    assert render_interactive >= 0.0
+
+
+def test_scaffold_imports_without_slicer() -> None:
+    """The unit layer must be runnable without a built Slicer.
+
+    Sanity check: this file is the unit layer and consumes no fixture
+    that triggers ``import slicer``.  If a future refactor accidentally
+    couples the unit layer to a Slicer import (e.g. by adding a
+    top-level ``import slicer`` to ``conftest.py``), this test stops
+    being importable in a plain venv and the breakage is loud.
+    """
+    # No assertions needed — the fact that pytest collected and ran this
+    # test in a plain venv is the assertion.
+    assert True

--- a/Testing/Python/workflow/test_render_interactive_dispatch.py
+++ b/Testing/Python/workflow/test_render_interactive_dispatch.py
@@ -1,0 +1,69 @@
+"""
+Workflow-layer smoke test demonstrating the ``render_interactive`` dispatch.
+
+This test stands in for the (not-yet-landed) view-creating workflow tests
+that consume the fixture set described in ``conftest.py``'s TODO list
+(``a_threed_view``, ``a_resectogram_view``, ...).  Until those fixtures
+land, this test exercises the dispatch logic in isolation: it asserts
+that the ``render_interactive`` fixture is consumable, that the *pattern*
+a real view fixture would follow (branch on truthiness) is well-defined,
+and that the same test code adapts correctly to both modes.
+
+Per ADR-0008 §2:
+
+    | Workflow | Widget + scene + Qt | Yes | Yes | Yes (default-on) | Resectogram view shows tumor cross-section contours |
+
+The "Yes (default-on)" column entry refers to fixture *participation*
+(every view-creating workflow fixture consumes the option), not to the
+CLI default — the CLI default is ``0.0`` so that bare ``pytest`` stays
+CI-safe.  Developers opt in to the onscreen path explicitly.
+"""
+
+from __future__ import annotations
+
+
+def test_workflow_layer_consumes_render_interactive(
+    render_interactive: float,
+) -> None:
+    """A workflow test must be able to consume the fixture by name.
+
+    Mirrors the pattern documented in ADR-0008 §3 (the trame-slicer-style
+    view fixture).  We don't have a real view here yet, but we exercise
+    the same control flow a view fixture would.
+    """
+    # The dispatch pattern a real view fixture follows.
+    show_window = bool(render_interactive)
+    dwell_seconds = render_interactive
+
+    assert isinstance(show_window, bool)
+    assert dwell_seconds == render_interactive
+    assert dwell_seconds >= 0.0
+
+
+def test_render_interactive_pattern_adapts_to_both_modes(
+    render_interactive: float,
+) -> None:
+    """Pin the documented dispatch pattern from ADR-0008 §3.
+
+    A view-creating fixture branches on ``if render_interactive:`` to
+    decide whether to ``ShowWindowOn()`` and to ``Start()`` the
+    interactor for the given dwell time.  The same test body must work
+    correctly in both modes — that's the whole point of the dual-use
+    pattern.  This test simulates that branching and pins the expected
+    branch for each mode.
+    """
+    if render_interactive:
+        # Path that a real view fixture would take onscreen.
+        action = "show_window"
+        expected_dwell = render_interactive
+    else:
+        # Path the CI-default takes.
+        action = "offscreen"
+        expected_dwell = 0.0
+
+    if render_interactive == 0.0:
+        assert action == "offscreen"
+        assert expected_dwell == 0.0
+    else:
+        assert action == "show_window"
+        assert expected_dwell == render_interactive

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,24 @@
+; pytest configuration for Slicer-Liver
+; See Docs/adr/0008-testing-strategy.md for the canonical strategy.
+;
+; Tests live under Testing/Python/ (this scaffold) and, as the per-module
+; suites migrate to pytest, also under <Module>/Testing/Python/.  Both
+; roots are discovered.  The existing Slicer-self-test files
+; (``LiverSegmentsTest.py`` etc. under <Module>/Testing/Python/) are
+; **not** plain pytest tests — they run via ``slicer_add_python_unittest``
+; against the in-Slicer ``ScriptedLoadableModuleTest`` harness, and are
+; deliberately excluded from pytest collection via the ``python_files``
+; pattern below (they use the unprefixed ``<Module>Test.py`` naming;
+; pytest looks for ``test_*.py`` by default, so the exclusion is the
+; default behaviour rather than an explicit rule — documented here so a
+; future maintainer doesn't add ``*Test.py`` to ``python_files`` and break
+; the separation).
+
+[pytest]
+minversion = 7.0
+testpaths =
+    Testing/Python
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra


### PR DESCRIPTION
## Summary

- Lands the canonical pytest scaffold described in [ADR-0008](Docs/adr/0008-testing-strategy.md): shared `Testing/Python/` tree, `conftest.py`, `--render-interactive` CLI option, and the session-scoped `render_interactive` fixture.
- Adopts the trame-slicer / SlicerLayerDisplayableManager dual-use pattern — the same test code serves CI regression (offscreen) and developer interactive exploration (`pytest --render-interactive=5`).
- Two CTest entries (`pytest_scaffold` and `pytest_scaffold_render_interactive`) mirror the CI matrix in ADR-0008 §6.

## Default for `--render-interactive`

Default is **`0.0`** (offscreen).  Rationale:

- ADR-0008 §6 specifies that CI's brief-onscreen pass is an explicit *separate* invocation (`pytest --render-interactive=0.1`).  Bare `pytest` must therefore default to offscreen so the matrix's two invocations exercise distinct paths.
- GitHub Actions runners drive Qt via `QT_QPA_PLATFORM=offscreen` (`.github/workflows/ci.yml`); a default-on flag would hang on missing DISPLAY or burn wall-clock on invisible windows.
- Matches trame-slicer's convention.

## Implemented

- `Testing/Python/conftest.py` — `pytest_addoption`, `render_interactive` fixture (session-scoped, returns float seconds), `a_slicer_app` example fixture demonstrating the Slicer-imported-as-library pattern with graceful skip when Slicer is absent.
- `Testing/Python/unit/test_scaffold_smoke.py` — three unit-layer tests pinning the option's registered default (`0.0`), the fixture's contract (non-negative float), and Slicer-independence of the unit layer.
- `Testing/Python/workflow/test_render_interactive_dispatch.py` — two workflow-layer tests that exercise the dispatch pattern in both modes (no real view yet — that fixture lands in a follow-up).
- `pytest.ini` — `testpaths`, `python_files = test_*.py` (deliberately excludes the existing Slicer-self-test `*Test.py` files so they continue to run through `slicer_add_python_unittest` without colliding).
- `Testing/CMakeLists.txt` + `Testing/Python/CMakeLists.txt` — CTest registration gated on `BUILD_TESTING` and on `pytest` being importable from the configured Python.
- `CMakeLists.txt` top-level — `add_subdirectory(Testing)`.
- `.gitignore` — Python build artefacts (`__pycache__/`, `*.pyc`, `.pytest_cache/`).

## Stubbed (TODO in `conftest.py`, follow-up PRs)

The per-module fixture set is flagged but **not** implemented in this PR:

- `a_mrml_scene` — function-scoped clean scene
- `a_view_manager`, `a_threed_view`, `a_slice_view` — LayerDM view factory + view fixtures (consume `render_interactive`)
- `a_resection_node`, `a_resectogram_view` — `LiverResections` module/workflow fixtures
- `a_volumetry_node` — `LiverVolumetry` module fixture
- `a_segmentation_with_terminology` — SegmentationNode + SCT-coded segments (per ADR-0011)
- `a_bezier_control_grid` — synthetic control grid for the algorithm characterisation tests flagged in ADR-0008 §7

## Flagged

- **The CI image needs `pytest`.**  `ghcr.io/alive-research/slicer-build-ubuntu2404` does not currently ship pytest.  The CTest entries in `Testing/Python/CMakeLists.txt` skip cleanly at configure time when pytest is absent, so this PR doesn't break CI — but the new tests won't *run* on CI until the image is updated.  Tracked as a follow-up in `ALive-Docker` (out of scope here).
- **No existing test was migrated.**  Existing per-module Slicer self-tests (`LiverSegmentsTest.py` and friends, `ScriptedLoadableModuleTest`-based, registered via `slicer_add_python_unittest`) are untouched and continue to coexist.  Migration of those to pytest is a separate, per-module decision per ADR-0008 §1.

## Local verification

Scaffold tested with `pytest 9.0.2` in a clean Python environment (no Slicer):

```
$ pytest -v Testing/Python                  # default, offscreen
$ pytest -v --render-interactive=0.1 ...    # CI brief-onscreen variant
$ pytest -v --render-interactive=2.5 ...    # developer interactive
```

All five scaffold tests pass in all three modes; `pytest --help` exposes the `--render-interactive` option under a `slicer-liver` option group with the documented help text.

Closes #308.

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Plan and brief authored by the orchestrating Opus 4.7 session; conftest scaffold drafted by a Claude Code subagent under that plan. Opened for human review before merge.*