### PR TITLE
DOC: workflow diagrams for current-state Liver modules (T1-F)

### DIFF
--- a/Docs/architecture/ui/liver-resections.md
+++ b/Docs/architecture/ui/liver-resections.md
@@ -1,0 +1,205 @@
+# LiverResections — current-state user workflow
+
+Snapshot of the resection-planning user workflow as it exists today on
+`preview`.  Documents *what is*, not what should be.  See
+[`adr/0009-ux-and-design-discipline.md`](../../adr/0009-ux-and-design-discipline.md)
+for why these diagrams matter and the gate they sit behind from v2.0.0
+onward.
+
+The resection-planning UI is not a single module — the LiverResections
+C++ module contributes MRML nodes (`vtkMRMLLiverResectionNode` and its
+storage / displayable managers) and logic, while the user-facing widget
+is hosted in the **Liver** scripted module (`Liver.py`), which loads
+three Qt Designer panels in sequence: `DistanceMapsWidget`,
+`ResectionsWidget`, `ResectogramWidget`.  This file documents that
+combined surface as the user experiences it.
+
+## What this module does for the user
+
+The user plans a liver resection by (1) computing distance maps from a
+multi-label segmentation that encodes tumor, parenchyma, hepatic vein
+and portal vein, (2) creating a resection node and shaping a cutting
+surface with one of three initialisation modes (Flat, Curved,
+MarkupClosedCurve), then (3) inspecting the planned cut interactively
+in 3D and — optionally — in a 2D "resectogram" view that flattens the
+cutting surface and overlays vascular contours.  The user adjusts
+resection and uncertainty margins, grid visualisation, and per-resection
+colours; the resection node persists the choice so it survives scene
+save/load.
+
+## Workflow diagram
+
+```mermaid
+flowchart TD
+    start([User opens Liver module])
+
+    subgraph DM [DistanceMapsWidget — preprocessing]
+        dmInputs[Select Segmentation<br/>+ Reference Volume]
+        dmAssign[Assign per-segment IDs:<br/>Tumor / Parenchyma /<br/>Hepatic / Portal]
+        dmOut[Select / create Output<br/>Distance Map volume]
+        dmCompute[/Compute Distance Maps<br/>push-button/]
+        dmInputs --> dmAssign --> dmOut --> dmCompute
+    end
+
+    subgraph RES [ResectionsWidget — shape the cut]
+        resSelect[Select / add<br/>Resection node]
+        resLiver[Pick liver Segmentation<br/>+ parenchyma segment]
+        resMode{Initialization mode}
+        modeFlat[Flat]
+        modeCurved[Curved]
+        modeClosedCurve[MarkupClosedCurve]
+        resFlat[Drag plane control points<br/>in 3D view]
+        resCurved[Place / edit Distance Contour;<br/>optionally Initial Contour<br/>Position button auto-seeds<br/>from tumor + liver geometry]
+        resClosedCurve[Pick / place closed curve;<br/>tick MarkupsResection<br/>checkbox to convert curve<br/>to a Bezier surface]
+        resBezier[Drag Bezier surface<br/>control points in 3D]
+        resDistanceMap[Pick Distance Map node<br/>computed earlier]
+        resParams[Adjust resection / uncertainty<br/>margins, opacity, colours,<br/>grid divisions and thickness,<br/>interpolated margins]
+        resLock[Lock Resection<br/>checkbox]
+
+        resMode --> modeFlat --> resFlat --> resBezier
+        resMode --> modeCurved --> resCurved --> resBezier
+        resMode --> modeClosedCurve --> resClosedCurve --> resBezier
+    end
+
+    subgraph REG [ResectogramWidget — 2D + vascular contour overlay]
+        regToggle[Resection2D checkbox]
+        regOpts[Mirror display,<br/>Flexible boundary,<br/>2D grid visibility,<br/>resectogram size]
+        regVasc[Select Vascular Segments<br/>volume; set hepatic / portal<br/>contour thickness + colour]
+    end
+
+    start --> dmInputs
+    dmCompute --> resSelect
+    resSelect --> resLiver --> resMode
+    resBezier --> resDistanceMap --> resParams --> resLock
+    resLock --> regToggle --> regOpts --> regVasc
+    regVasc --> done([Plan saved with scene<br/>via CSV storage node])
+
+    classDef pre fill:#eef,stroke:#446
+    classDef cut fill:#efe,stroke:#464
+    classDef view fill:#fee,stroke:#644
+    class DM pre
+    class RES cut
+    class REG view
+```
+
+Notes on the flow:
+
+- The three sub-panels are visually stacked in a single module panel;
+  the diagram orders them by the path a *first-time* user typically
+  follows.  An experienced user may revisit panels out of order — the
+  UI does not enforce a sequence.
+- `Compute Distance Maps` becomes enabled only when the tumor,
+  parenchyma, and output-distance-map selectors are all set.  Hepatic
+  and portal selectors are optional inputs (their presence sets
+  `TextureNumComps` on the resection node so the shader can render
+  vascular contours).
+- The `Initial Contour Position` push-button in the Curved branch
+  auto-seeds the two control points of a `vtkMRMLMarkupsDistanceContourNode`
+  from the centres of mass of the tumor and liver and a camera-cross
+  vector — this is the only place in the workflow where the camera
+  orientation feeds back into the model state.
+- The `MarkupsResection` checkbox is a one-shot conversion from a
+  generic Slicer closed curve into a Bezier resection surface; it
+  reports completion via a modal `QMessageBox.information` dialog.
+
+## Resection state machine
+
+`vtkMRMLLiverResectionNode` exposes two enums that the widget reacts to:
+
+- `ResectionState` ∈ {`Initialization`, `Deformation`, `Completed`}
+  (declared in `vtkMRMLLiverResectionNode.h`).
+- `InitializationMode` ∈ {`Flat`, `Curved`} (the `ClosedCurveButton`
+  radio is a third UI mode but reuses the Curved/MarkupClosedCurve
+  code paths rather than introducing a new enum value).
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoNode : module opens
+
+    NoNode --> Initialization : user picks a Resection node
+
+    state Initialization {
+        [*] --> ModeUnset
+        ModeUnset --> Flat : Flat radio
+        ModeUnset --> Curved : Curved radio
+        ModeUnset --> ClosedCurve : MarkupClosedCurve radio
+        Flat --> Flat : drag plane handles
+        Curved --> Curved : edit distance contour
+        ClosedCurve --> ClosedCurve : edit closed curve
+    }
+
+    Initialization --> Deformation : user drags Bezier handles
+    Deformation --> Deformation : drag Bezier handles
+    Deformation --> Locked : Lock Resection checkbox
+
+    Locked --> Deformation : un-tick Lock Resection
+    Locked --> Completed : TBD (no explicit UI affordance)
+
+    Completed --> [*]
+```
+
+Reading guide:
+
+- The transition into `Deformation` is implicit: there is no "Done with
+  initialisation" button.  The widget hides the initialisation markup
+  and shows the Bezier markup when the user clicks into the Bezier
+  control points, driven by `ShowBezierSurfaceMarkupFromResection` and
+  `HideInitializationMarkupFromResection` calls in
+  `onResectionNodeChanged` / `onRadioButtonState`.
+- `Locked` is not a distinct enum value — it is the conjunction of
+  `WidgetVisibility == false` and `ClipOut == true`, both driven by the
+  `ResectionLockCheckBox` and `Resection2DCheckBox`.
+- The `Completed` state in the enum is declared but the path from
+  `Locked` / `Deformation` to `Completed` is not surfaced by the
+  current Liver.py widget; persistence happens implicitly when the
+  scene is saved via `vtkMRMLLiverResectionCSVStorageNode`.
+
+## Known gaps / pain points observed during survey
+
+- **No explicit completion step.**  The `Completed` ResectionState
+  exists in the enum but no widget control transitions into it; users
+  cannot tell from the UI whether the current plan is "draft" or
+  "final".
+- **Mode-radio overlap.**  Three radio buttons (Flat, Curved,
+  MarkupClosedCurve) map to two `InitializationMode` enum values plus
+  a third path that mutates the Bezier surface directly from a Slicer
+  closed curve.  The relationship between radio label and underlying
+  enum is non-obvious.
+- **`ClosedCurveButton` is disabled in the .ui file** (`enabled=false`
+  property) but the handler `onRadioButtonState` still branches on
+  `rdbutton.text == "MarkupClosedCurve"`.  Whether the mode is meant
+  to be reachable today is unclear — TBD — clarify with maintainer.
+- **Auto-seed couples model to view.**  `onDefiningStartingContourPosition`
+  reads camera `ViewUp` / `ViewPlaneNormal` to place the distance
+  contour.  This conflates view state with model state — the same
+  scene saved and re-opened from a different camera angle would
+  produce a different seed contour if the user re-clicked the button.
+- **Repeated UI-state mirroring.**  `onResectionNodeChanged` updates
+  ~15 widgets under `blockSignals(True/False)` guards; every checkbox
+  that mirrors a resection-node bool (`ResectionLockCheckBox`,
+  `Resection2DCheckBox`, `FlexibleBoundaryCheckBox`) is set three or
+  four times in the same handler.  The redundancy is harmless but
+  signals the absence of a parameter-node-driven binding pattern.
+- **`onResection2DChanged` has a fall-through `else` that calls
+  `SetShowResection2D` on a `None` resection node** — would raise an
+  AttributeError if reached.  The code path is guarded by the surrounding
+  `if self._currentResectionNode is not None` so it appears unreachable;
+  flagging because the structure is suspicious.
+- **Modal confirmation dialogs after long-running operations.**
+  `Compute Distance Maps` and the Bezier conversion both pop a
+  `QMessageBox.information` modal on completion; on a 4-panel surgical
+  workstation this can land on a different monitor than the module
+  panel and block the workflow until dismissed.
+- **Hidden side effect on render-window renderers.**  The widget
+  inspects `renderWindow().GetRenderers()` and assumes the 5th renderer
+  (index 4) is the 2D resectogram overlay; it removes that renderer
+  directly when the user un-ticks Resection2D.  This couples UI state
+  to layout-manager internals.
+- **`Grid2DVisibility` / `Grid3DVisibility` styled with raw stylesheet
+  strings** point at PNG assets via `format()`-built paths; no fallback
+  if the icons are missing.
+- **No undo for resection edits.**  Dragging Bezier handles mutates the
+  resection node directly; the scene undo stack is not engaged.
+- **Typo `VsacularSegmentsGroupBox`** in `ResectogramWidget.ui` — the
+  group-box object name is misspelled (and the Python handler matches
+  the typo).  Cosmetic but ossifies into the API.

--- a/Docs/architecture/ui/liver-segments.md
+++ b/Docs/architecture/ui/liver-segments.md
@@ -1,0 +1,191 @@
+# LiverSegments — current-state user workflow
+
+Snapshot of the vascular-territory-segmentation user workflow as it
+exists today on `preview`.  Documents *what is*, not what should be.
+See [`adr/0009-ux-and-design-discipline.md`](../../adr/0009-ux-and-design-discipline.md)
+for why these diagrams matter.
+
+LiverSegments is a *hidden* scripted module (`parent.hidden = True`) —
+it does not appear standalone in the Slicer module menu and is loaded
+only from inside the **Liver** module's setup, wrapped in a
+`qMRMLWidget` container.  The module title shown in code metadata is
+"Extract Vascular segments" but the visible collapsible button reads
+"Liver Vascular Territories".
+
+## What this module does for the user
+
+The user partitions a liver into vascular territories by selecting an
+input liver-surface segmentation, picking the parenchyma segment, then
+iteratively building per-territory centerlines.  For each territory
+the user (1) picks or creates a "Vascular Territory" identifier in a
+combo box, (2) places vessel-endpoint fiducials inside the liver,
+(3) clicks **Add Vessel Centerline** (which calls into SlicerVMTK's
+`ExtractCenterline` to compute a centerline polyline) or **Add whole
+segment** (which uses the entire input vessel-segment polydata
+directly).  When all territories are seeded, **Calculate Vascular
+Territory Segmentation** runs a nearest-centerline labelling pass that
+writes a labelmap-backed multi-segment vascular-territory segmentation.
+The resulting segmentation is what `LiverVolumetry` and the Resectogram
+later consume.
+
+## Workflow diagram
+
+```mermaid
+flowchart TD
+    start([User opens Liver module —<br/>scroll to Liver Vascular Territories])
+
+    pre[Select Vascular Territory<br/>Segmentation node<br/>selectedVascularTerritorySegmId combo]
+    inputSurface[Select input liver<br/>Segmentation surface<br/>inputSurfaceSelector]
+    inputSeg[Select parenchyma segment<br/>inputSegmentSelectorWidget]
+
+    territory{Vascular Territory<br/>combo box}
+    newTerr[Create new territory ID<br/>auto-generates a Vascular<br/>Territory ID N name<br/>and adds empty segment]
+    existing[Pick existing<br/>territory entry]
+
+    color[Adjust territory colour<br/>ColorPickerButton]
+
+    vesselPoints[endPointsMarkupsSelector +<br/>endPointsMarkupsPlaceWidget:<br/>place fiducials on vessel<br/>endpoints inside the liver]
+
+    addBranch{Centerline source}
+    addLine[/Add Vessel Centerline<br/>push-button — runs VMTK<br/>ExtractCenterline on fiducials/]
+    addWhole[/Add whole segment<br/>push-button — uses entire<br/>vessel polydata as centerline/]
+
+    showHide[Show/Hide button —<br/>toggles segment visibility<br/>on display node]
+
+    repeat{More territories?}
+
+    calc[/Calculate Vascular Territory<br/>Segmentation push-button —<br/>nearest-centerline labelling<br/>over reference volume/]
+
+    done([Vascular territory<br/>segmentation node populated<br/>with one segment per ID])
+
+    start --> pre --> inputSurface --> inputSeg
+    inputSeg --> territory
+    territory --> newTerr --> color --> vesselPoints
+    territory --> existing --> vesselPoints
+    vesselPoints --> addBranch
+    addBranch --> addLine --> showHide
+    addBranch --> addWhole --> showHide
+    showHide --> repeat
+    repeat -->|yes| territory
+    repeat -->|no| calc --> done
+
+    classDef setup fill:#eef,stroke:#446
+    classDef territoryGroup fill:#efe,stroke:#464
+    classDef compute fill:#fee,stroke:#644
+    class pre,inputSurface,inputSeg setup
+    class territory,newTerr,existing,color,vesselPoints,addBranch,addLine,addWhole,showHide,repeat territoryGroup
+    class calc,done compute
+```
+
+Notes on the flow:
+
+- The Vascular Territory combo box uses index 0 as a sentinel labelled
+  "Create new territory ID"; selecting index 0 triggers
+  `onVascularTerritoryIdChanged` which appends a new combo entry and a
+  new empty segment to the segmentation, then leaves the user with the
+  fiducial-place widget already in place-mode.  The same code path
+  re-fires `onSegmentChanged` to attach the right attributes
+  (`LiverSegments.SegmentationId`, `LiverSegments.VascTerrId`) to a
+  freshly-allocated `vtkMRMLMarkupsFiducialNode`.
+- `Add Vessel Centerline` requires the **SlicerVMTK** extension's
+  `ExtractCenterline` module; the handler checks
+  `check_module_Extract_Centerline_installed()` and pops a
+  `slicer.util.errorDisplay` modal if absent.
+- `Calculate Vascular Territory Segmentation` requires at least two
+  centerline points and the *first* `vtkMRMLScalarVolumeNode` in the
+  scene as a reference grid — picked by
+  `slicer.mrmlScene.GetFirstNodeByClass(...)`, not a user-selectable
+  combo.
+- The widget owns a colour table (`SlicerLiverColorMap.ctbl`) loaded
+  on setup; territory colours map to that table by combo-box index.
+
+## State machine
+
+LiverSegments does not own a state-machine-style enum on any MRML node;
+its user-visible state is the conjunction of:
+
+- whether a vascular-territory segmentation has been picked
+  (`vascular_territory_segmentationNodeSelected` enables / disables the
+  whole control block via `enableWidgetButtons`),
+- which territory index is currently selected in the combo box, and
+- whether fiducial place-mode is active.
+
+A coarse state diagram captures the gating behaviour:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Disabled : module loaded
+    Disabled --> Idle : pick a Vascular_Territory_Segmentation
+    Idle --> Placing : pick or create a territory ID
+    Placing --> Placing : click vessel endpoints
+    Placing --> CenterlineReady : Add Vessel Centerline / Add whole segment
+    CenterlineReady --> Idle : pick another territory
+    Idle --> Computed : Calculate Vascular Territory Segmentation
+    CenterlineReady --> Computed : Calculate Vascular Territory Segmentation
+    Computed --> Idle : revise / extend territories
+```
+
+Reading guide:
+
+- The `enableWidgetButtons(False/True)` call at the top of
+  `vascular_territory_segmentationNodeSelected` is the only gate
+  between `Disabled` and the rest of the graph.  A subtle additional
+  guard: the function checks that `'Vascular_Territory_Segmentation'`
+  is a substring of the picked segmentation node's name — otherwise
+  it disables the controls again.  This baked-in name is not surfaced
+  in the .ui or in user-visible tooltips.
+- The transition Placing → CenterlineReady can fail silently if VMTK
+  is not installed (an error modal pops and the state stays in
+  Placing).
+
+## Known gaps / pain points observed during survey
+
+- **Hidden module + nested wrapper.**  `LiverSegments` is set
+  `parent.hidden = True` and surfaces only when the Liver module
+  embeds it inside a `qMRMLWidget` wrapper.  A user who imports the
+  Liver module from a Python console will not see this widget unless
+  they call `Liver.LiverWidget.setup()` end-to-end.
+- **Magic node-name gate.**  `enableWidgetButtons` requires the
+  selected segmentation's name to contain the literal substring
+  `'Vascular_Territory_Segmentation'`; otherwise the buttons silently
+  disable.  No tooltip explains this.
+- **`Reference Volume` is implicit.**  Vascular-territory computation
+  uses `slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLScalarVolumeNode')`
+  to find a grid — there is no UI for the user to choose which volume
+  serves as the reference.  Surprising when a scene holds multiple
+  scalar volumes.
+- **`SlicerVMTK` dependency is run-time-only.**  The
+  `ExtractCenterline` module is checked for at click-time; nothing in
+  the module's `parent.dependencies` advertises it.  A clean install
+  without SlicerVMTK will not warn the user until they click "Add
+  Vessel Centerline".
+- **"Create new territory ID" combo sentinel.**  Index 0 of the
+  combo-box is a creation affordance, not a real selection; clicking
+  it has a side effect (adds a row).  A user expecting a passive
+  drop-down will trigger node creation unintentionally.
+- **`firstSegmentName` hard-coded to `'Vascular Territory ID 1'`.**
+  If the user renames the first segment outside this widget, the
+  initialisation branch in
+  `vascular_territory_segmentationNodeSelected` treats it as missing
+  and re-adds an empty segment with that exact name.
+- **Show/Hide button text uses raw QIcon paths** (`Icons/VisibleOn.png`)
+  evaluated relative to the working directory, not the module
+  resource path.  Visual icons therefore do not render in practice;
+  only the text toggles.
+- **`updateGUIFromParameterNode` is double-guarded incorrectly.**  Two
+  consecutive `if self._parameterNode is None or self._updatingGUIFromParameterNode:`
+  checks straddle the parameter-node-bound assignment block, then the
+  function exits without removing its own re-entrancy flag if the
+  scene was just torn down.  Cosmetic but confusing.
+- **`vtkMRMLSegmentationNode` colour-map coupling.**  Territory colours
+  live in a side-table (`SlicerLiverColorMap.ctbl`) keyed by combo-box
+  index, not in the segmentation node's own per-segment colour.  The
+  two can drift if the user edits colours in the segmentation editor.
+- **No undo affordance.**  Adding centerlines and territories mutates
+  the scene directly; Slicer's scene-undo stack is not engaged.
+- **`self.developerMode` referenced without being defined.**
+  `onCalculateVascularTerritoryMapButton` wraps timing measurements in
+  `if self.developerMode is True:` but no `developerMode` attribute is
+  set on `LiverSegmentsWidget`; the access would raise
+  `AttributeError` if the branch ever evaluated.  Currently dead code
+  but fragile.

--- a/Docs/architecture/ui/liver-volumetry.md
+++ b/Docs/architecture/ui/liver-volumetry.md
@@ -1,0 +1,164 @@
+# LiverVolumetry — current-state user workflow
+
+Snapshot of the volumetry user workflow as it exists today on
+`preview`.  Documents *what is*, not what should be.  See
+[`adr/0009-ux-and-design-discipline.md`](../../adr/0009-ux-and-design-discipline.md)
+for why these diagrams matter.
+
+LiverVolumetry, like LiverSegments, is a *hidden* scripted module
+(`parent.hidden = True`) that surfaces only when the **Liver** module
+embeds its widget at the bottom of the resection-planning panel.  The
+collapsible button label reads "Resection Volumetry".
+
+## What this module does for the user
+
+The user computes liver volumes — total, per-segment, per-territory,
+and (most importantly) the resection *remnant* / *resected* volumes
+implied by a planned resection.  A typical session: (1) pick the
+parenchyma segmentation, (2) pick the reference scalar volume that
+defines the voxel grid, (3) select which segments contribute to the
+total volume in the multi-select widget, (4) optionally tick one or
+more `vtkMRMLLiverResectionNode`s in the checkable combo box to use
+their Bezier surfaces as cutting boundaries, (5) optionally place ROI
+fiducial markers to drive per-region accounting, and (6) click
+**Calculate Volume**.  The results land in a user-selectable
+`vtkMRMLTableNode` and the application layout switches to a
+table-visible layout so the user sees the result immediately.  A
+second push-button, **Generate segments based on selected resections
+and ROI markers**, takes the same inputs but writes the per-region
+labelmap out as a new segmentation node ("Remnant" + one segment per
+ROI marker) instead of (or in addition to) the table.
+
+## Workflow diagram
+
+```mermaid
+flowchart TD
+    start([User opens Liver module —<br/>scroll to Resection Volumetry])
+
+    inputSeg[Select parenchyma<br/>Segmentation<br/>InputSegmentationSelector]
+    refVol[Select Reference Volume<br/>ReferenceVolumeSelector]
+    inputSegs[Select segments that<br/>contribute to total volume<br/>InputSegmentSelectorWidget<br/>multi-select]
+    targetSegs[Optional: select target<br/>segments for percentage<br/>denominator<br/>TargetSegmentationSelectorWidget]
+
+    resectionPick[Optional: tick resections<br/>to use as cutting boundaries<br/>ResectionTargetNodeComboBox<br/>checkable]
+    roiPlace[Optional: place ROI fiducial<br/>markers per region of interest<br/>ROIMarkersListSelector +<br/>ROIMarkersListPlaceWidget]
+    outTable[Pick / create output<br/>Volume Table node<br/>VolumeTableSelectorWidget]
+
+    branch{Which action?}
+    calc[/Calculate Volume push-button —<br/>enabled when reference volume,<br/>segmentation, and at least one<br/>input segment are set/]
+    gen[/Generate segments push-button —<br/>enabled when ROI markers,<br/>reference volume, segmentation,<br/>and selected segments are all set/]
+
+    showTable[Switch to table layout;<br/>show result via<br/>SelectionNode.SetActiveTableID]
+    newSeg[New segmentation node:<br/>Remnant + one segment<br/>per ROI marker label]
+    infoModal[Modal info dialog —<br/>targeted liver volumetry<br/>was computed]
+
+    done([User reviews volumes /<br/>per-region breakdown])
+
+    start --> inputSeg --> refVol --> inputSegs
+    inputSegs --> targetSegs
+    inputSegs --> resectionPick
+    inputSegs --> roiPlace
+    targetSegs --> outTable
+    resectionPick --> outTable
+    roiPlace --> outTable
+    outTable --> branch
+    branch --> calc --> infoModal --> showTable --> done
+    branch --> gen --> newSeg --> done
+
+    classDef setup fill:#eef,stroke:#446
+    classDef opt fill:#ffd,stroke:#660
+    classDef compute fill:#efe,stroke:#464
+    class inputSeg,refVol,inputSegs,outTable setup
+    class targetSegs,resectionPick,roiPlace opt
+    class calc,gen,showTable,newSeg,infoModal compute
+```
+
+Notes on the flow:
+
+- The branching at *Which action?* is not a UI element — both push
+  buttons live next to each other and either can be clicked from the
+  same configured state.  The diagram splits the path to surface that
+  the two outputs (table vs. new segmentation node) are distinct.
+- The set of inputs that gate each button is asymmetric:
+  `Calculate Volume` requires reference volume + segmentation + at
+  least one input segment; `Generate segments` additionally requires
+  ROI markers and a (visible) resection list.  Both checks live in
+  separate handlers (`onVolumetryParameterChanged`,
+  `onGenerateSegmentsParameterChanged`).
+- Resections are read from the checkable combo box via
+  `noneChecked()` / `checkedNodes()`; when nothing is checked the
+  volumetry path falls through to the simpler
+  `SegmentStatistics`-based code that just sums segment volumes
+  without using cutting surfaces.
+- `Calculate Volume` builds two transient labelmap nodes
+  (`segmentVolumeNode`, `targetSegmentVolumeNode`) by exporting
+  segments to a labelmap against the reference volume, then deletes
+  them at the end of the handler.
+
+## State machine
+
+LiverVolumetry has no MRML-node-level state machine; user state is
+the cross-product of {*has parameter node*, *has segmentation*, *has
+segments selected*, *has reference volume*, *has resections checked*,
+*has ROI markers*}.  Because there are no mode transitions — only
+gating of the two action buttons — a state-machine diagram does not
+add information beyond the gating notes above.  Following ADR-0009
+§1 this section is therefore intentionally minimal:
+
+> **No multi-state interactive widget present.**  The two action
+> buttons are stateless push-buttons whose `enabled` flag is computed
+> from the current selectors.
+
+If a future refactor adds a "preview vs. commit" flow or any
+progressive disclosure (e.g. an explicit "configure → run → review"
+wizard) this section becomes review-blocked content per ADR-0009.
+
+## Known gaps / pain points observed during survey
+
+- **Two buttons, overlapping inputs.**  `Calculate Volume` and
+  `Generate segments based on selected resections and ROI markers`
+  consume nearly the same input set but produce different outputs
+  (table vs. new segmentation node).  Their relationship is not
+  surfaced in the UI — a first-time user cannot tell which to click
+  to "get the volume of my plan".
+- **Implicit layout takeover.**  `Calculate Volume` calls
+  `setLayout(layoutWithTable)` on success, rearranging the user's
+  workspace without confirmation.  Users mid-edit on a 3D view lose
+  that view until they switch the layout back.
+- **Modal confirmation dialog.**  `QMessageBox.information(None,
+  "Information", "The targeted liver volumetry was computed.")` blocks
+  on completion; same surgical-workstation multi-monitor concern as in
+  LiverResections.
+- **Hidden side-effect on segmentation display.**  Selecting an input
+  segmentation iterates *all* currently-visible segments on its
+  display node and turns them off via
+  `SetSegmentVisibility(..., False)` (in `segmentationNodeSelected`).
+  The user-driven visibility of unrelated segments is silently
+  modified.
+- **`segmentVolumeNode` / `targetSegmentVolumeNode` naming reuse.**
+  Both transient labelmaps are created with hard-coded names
+  (`segmentVolumeNode`, `targetSegmentVolumeNode`).  A second invocation
+  picks up the *first existing* node with that name via
+  `GetFirstNodeByName`, *and skips re-exporting the labelmap*
+  (`if not segmentsVolumeNode:` guards the export).  Result: stale
+  labelmaps from a previous run silently feed into the next
+  computation.  TBD — confirm with maintainer whether this is
+  intentional caching.
+- **`Total Volume:` label exists in the .ui but is never written
+  to.**  The widget exposes a label captioned "Total Volume:" but no
+  Python handler updates a sibling value label; the output goes
+  exclusively to the volume table.
+- **Resection list is checkable but unsorted.**  When multiple
+  resections exist they appear in MRML insertion order; no display of
+  which resection corresponds to which physical plan.
+- **`InputSegmentSelectorWidget` and `TargetSegmentationSelectorWidget`
+  both reference the same `inputSegmentation` parameter-node key.**
+  The `updateGUIFromParameterNode` handler sets both selectors to the
+  same `InputSegmentID` value — meaning the "target" denominator
+  cannot in practice be set independently via parameter-node
+  round-trip, only through direct UI interaction.  TBD — clarify with
+  maintainer whether this is the intended coupling.
+- **No undo for "Generate segments".**  The new segmentation node is
+  added directly to the scene.  Repeat invocations accumulate
+  duplicate "Remnant" segmentation nodes with appended numeric
+  suffixes.


### PR DESCRIPTION
## Summary

Adds Mermaid workflow diagrams for the three end-to-end Liver modules
under a new `Docs/architecture/ui/` directory, per ADR-0009 §2.  These
are the **current-state** baseline — the *before* picture that
ADR-0009-compliant PRs amend from v2.0.0 onward.

Each diagram file contains:

1. One opening paragraph on what the module does for the user.
2. A `flowchart TD` of the user's path (clicks, panel order, gates).
3. A `stateDiagram-v2` where the module exposes interactive state
   (LiverResections only; the other two are gate-driven push-button
   flows and are flagged as such).
4. A `Known gaps / pain points` bullet list — observations only, no
   recommendations.

## Modules covered

- `Docs/architecture/ui/liver-resections.md` — the resection-planning
  surface hosted in the Liver scripted module
  (DistanceMaps + Resections + Resectogram sub-panels), plus the
  `ResectionState` / `InitializationMode` enum-driven state machine
  on `vtkMRMLLiverResectionNode`.
- `Docs/architecture/ui/liver-segments.md` — the
  vascular-territory-segmentation workflow (hidden module surfaced
  inside Liver), with a coarse Disabled / Idle / Placing /
  CenterlineReady / Computed state diagram derived from the widget's
  gating behaviour.
- `Docs/architecture/ui/liver-volumetry.md` — the resection-volumetry
  workflow (hidden module surfaced inside Liver).  No multi-state
  widget present; the state-machine section is intentionally
  minimal per ADR-0009 §1.

## Out of scope

- No source-code edits.  Only files under `Docs/architecture/ui/`
  touched.
- Observations are surfaced as "Known gaps / pain points" without
  recommendations or fixes — they exist to inform later
  ADR-0009-compliant PRs.

Closes #312.

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Plan and brief authored by the orchestrating Opus 4.7 session; workflow diagrams drafted by a Claude Code subagent under that plan. Opened for human review before merge.*