### PR TITLE
DOC: ADR-0012 — amend scope to fold LiverMarkups dissolution into T2 LiverResections all-in

### DIFF
--- a/Docs/adr/0012-layerdm-migration-v2-scope.md
+++ b/Docs/adr/0012-layerdm-migration-v2-scope.md
@@ -55,7 +55,7 @@ custom widget subclassing `vtkAbstractWidget` directly.  The
 combined consequence: LiverMarkups dissolves entirely in v2.0.0, its
 three primitives relocate into LiverResections as non-Markups data
 nodes, and the v2.0.0 in-scope list shrinks to two phases.  Full
-rationale lives in [ADR-0014](0014-livermarkups-dissolution.md).
+rationale lives in ADR-0014 (forthcoming).
 
 ## Decision
 
@@ -69,14 +69,13 @@ Two phases, in order:
 
 - **T2 — LiverResections (all-in)** — pattern-setting migration.
   Absorbs the LiverMarkups dissolution per
-  [ADR-0014](0014-livermarkups-dissolution.md): the three Markups-
-  derived primitives (BezierSurface + SlicingContour + DistanceContour)
-  relocate into LiverResections as non-Markups data nodes, with a
-  single state-aware LayerDM Pipeline owning three state-conditional
-  Representations (per [ADR-0013](0013-layerdm-pipeline-pattern.md)
-  §4).  Bezier-fitting and ring-extraction algorithms lift to a C++
-  algorithm library per
-  [ADR-0015](0015-cpp-algorithm-library.md).  Resolves the structural
+  ADR-0014 (forthcoming): the three Markups-derived primitives
+  (BezierSurface + SlicingContour + DistanceContour) relocate into
+  LiverResections as non-Markups data nodes, with a single
+  state-aware LayerDM Pipeline owning three state-conditional
+  Representations (per ADR-0013 §4, forthcoming).  Bezier-fitting
+  and ring-extraction algorithms lift to a C++ algorithm library
+  per ADR-0015 (forthcoming).  Resolves the structural
   pains ADR-0002 §1–§5 enumerate (three-node assembly, six
   `std::map` members, leaked display fields, Markups
   interaction-model ceiling, DM boilerplate).  Delivers the real-view
@@ -234,13 +233,13 @@ These do not block adoption of this ADR:
 - ADR-0011 (terminology dispatch for LiverSegments) — the
   data-model work that lands in v2.0.0 for the
   display-migration-deferred LiverSegments module.
-- [ADR-0013](0013-layerdm-pipeline-pattern.md) — the canonical
-  LayerDM Pipeline pattern that the T2 LiverResections migration and
-  T3 Resectogram split both instantiate.
-- [ADR-0014](0014-livermarkups-dissolution.md) — the LiverMarkups
-  dissolution decision that this amendment folds into the T2 scope.
-- [ADR-0015](0015-cpp-algorithm-library.md) — the C++ algorithm
-  library decision (Bezier fitter, ring extractors, contour
-  parameterizer) supporting the T2 implementation.
+- ADR-0013 (forthcoming) — the canonical LayerDM Pipeline pattern
+  that the T2 LiverResections migration and T3 Resectogram split
+  both instantiate.
+- ADR-0014 (forthcoming) — the LiverMarkups dissolution decision
+  that this amendment folds into the T2 scope.
+- ADR-0015 (forthcoming) — the C++ algorithm library decision
+  (Bezier fitter, ring extractors, contour parameterizer)
+  supporting the T2 implementation.
 - [SlicerLayerDisplayableManager](https://github.com/KitwareMedical/SlicerLayerDisplayableManager)
   — the upstream framework adopted per ADR-0002.

--- a/Docs/adr/0012-layerdm-migration-v2-scope.md
+++ b/Docs/adr/0012-layerdm-migration-v2-scope.md
@@ -43,6 +43,20 @@ modules to v2.1.0 therefore does **not** force a v3.0.0 bump — the
 deferred migrations ship as a scene-compatible MINOR release on top
 of v2.0.0.
 
+A subsequent design discussion further collapsed the in-scope module
+list.  `vtkMRMLMarkupsSlicingContourNode` and
+`vtkMRMLMarkupsDistanceContourNode` are not independent annotations —
+they are **alternative initialisation affordances for the same Bezier
+surface** (each defines a ring on the target mesh that seeds the
+Bezier fit).  Two additional forces — ring-aware right-click on the
+4×4 Bezier control grid, and per-role control-point glyph rendering
+— require dropping the `vtkSlicerMarkupsWidget` base in favour of a
+custom widget subclassing `vtkAbstractWidget` directly.  The
+combined consequence: LiverMarkups dissolves entirely in v2.0.0, its
+three primitives relocate into LiverResections as non-Markups data
+nodes, and the v2.0.0 in-scope list shrinks to two phases.  Full
+rationale lives in [ADR-0014](0014-livermarkups-dissolution.md).
+
 ## Decision
 
 Narrow the v2.0.0 scope of ADR-0002's LayerDM migration to the
@@ -51,19 +65,29 @@ v2.1.0, where it ships as additive (no scene-breaking changes).
 
 ### In scope for v2.0.0 (display-side LayerDM migration)
 
-- **LiverMarkups** — pattern-setting first module (migration phase
-  T2 per the ADR-0002 ordering).  Establishes the LayerDM Pipeline
-  pattern that the other in-scope modules consume.
-- **LiverResections** — primary beneficiary; Bezier interaction is
-  LayerDM-native.  Resolves the structural pains ADR-0002 §1–§5
-  enumerate (three-node assembly, six `std::map` members, leaked
-  display fields, Markups interaction-model ceiling, DM
-  boilerplate).
-- **Resectogram** — split from LiverResections as its own SLDM
-  pipeline.  View-coupled rendering with locator crosshair; the
-  view-and-pipeline coupling is fundamentally a LayerDM concern.
-- **Distance maps** — entangled with resectogram texture
-  generation.  One-shot CPU compute, but the display path is
+Two phases, in order:
+
+- **T2 — LiverResections (all-in)** — pattern-setting migration.
+  Absorbs the LiverMarkups dissolution per
+  [ADR-0014](0014-livermarkups-dissolution.md): the three Markups-
+  derived primitives (BezierSurface + SlicingContour + DistanceContour)
+  relocate into LiverResections as non-Markups data nodes, with a
+  single state-aware LayerDM Pipeline owning three state-conditional
+  Representations (per [ADR-0013](0013-layerdm-pipeline-pattern.md)
+  §4).  Bezier-fitting and ring-extraction algorithms lift to a C++
+  algorithm library per
+  [ADR-0015](0015-cpp-algorithm-library.md).  Resolves the structural
+  pains ADR-0002 §1–§5 enumerate (three-node assembly, six
+  `std::map` members, leaked display fields, Markups
+  interaction-model ceiling, DM boilerplate).  Delivers the real-view
+  fixture deferred by PR #316 (the pytest scaffold from ADR-0008's
+  workflow layer); provides the worked example T3 reviews against.
+- **T3 — Resectogram + distance maps** — split from LiverResections
+  as its own SLDM pipeline.  View-coupled rendering with locator
+  crosshair; the view-and-pipeline coupling is fundamentally a
+  LayerDM concern.  Distance-map texture is a Representation inside
+  the resectogram Pipeline ("entangled with resectogram texture
+  generation"): one-shot CPU compute, but the display path is
   LayerDM-coupled and cannot be cleanly separated from the
   resectogram pipeline.
 
@@ -210,8 +234,13 @@ These do not block adoption of this ADR:
 - ADR-0011 (terminology dispatch for LiverSegments) — the
   data-model work that lands in v2.0.0 for the
   display-migration-deferred LiverSegments module.
-- ADR-0013 (LayerDM Pipeline pattern, drafted alongside the T2
-  LiverMarkups migration PR) — will document the implementation
-  pattern produced by the v2.0.0 in-scope migrations.
+- [ADR-0013](0013-layerdm-pipeline-pattern.md) — the canonical
+  LayerDM Pipeline pattern that the T2 LiverResections migration and
+  T3 Resectogram split both instantiate.
+- [ADR-0014](0014-livermarkups-dissolution.md) — the LiverMarkups
+  dissolution decision that this amendment folds into the T2 scope.
+- [ADR-0015](0015-cpp-algorithm-library.md) — the C++ algorithm
+  library decision (Bezier fitter, ring extractors, contour
+  parameterizer) supporting the T2 implementation.
 - [SlicerLayerDisplayableManager](https://github.com/KitwareMedical/SlicerLayerDisplayableManager)
   — the upstream framework adopted per ADR-0002.


### PR DESCRIPTION
## Summary
Amend ADR-0012 in light of a design discussion that surfaced after #304 merged. The v2.0.0 in-scope LayerDM-migration list collapses from four modules to two phases.

## What changed
- **In scope for v2.0.0** — replaced four bullets (LiverMarkups / LiverResections / Resectogram / distance maps) with two:
  - **T2 — LiverResections (all-in)** absorbing the LiverMarkups dissolution per the forthcoming ADR-0014
  - **T3 — Resectogram + distance maps**, renumbered down from T4
- **Context** — added a paragraph explaining *why* the collapse: SlicingContour + DistanceContour are alternative init affordances for the same Bezier surface (not independent annotations); ring-aware right-click + per-role glyph rendering both require moving off `vtkSlicerMarkupsWidget`. Full rationale in ADR-0014.
- **References** — added forward-refs to ADR-0014 (LiverMarkups dissolution) and ADR-0015 (C++ algorithm library).

## Not changed
- The v2.1.0 deferred list (LiverSegments / LiverVolumetry / Modeling LayerDM display nodes; cross-module locator unification). Those decisions stand.
- The Alternatives section. The rejection arguments for full migration / total deferral / patch-series / resectogram-only are unaffected.
- The Consequences section. The MRML-hierarchy-partial-migration and Easier/Harder bullets stand.

## Cross-refs
- Companion PRs landing this week: ADR-0013 (LayerDM Pipeline pattern, with the updated migration map), ADR-0014 (LiverMarkups dissolution), ADR-0015 (C++ algorithm library).
- Source of the design discussion: `.claude/handoff-2026-05-15-v2-architecture.md` (handoff from PKS-side conversation).

## UX impact
N/A — non-UI change (ADR amendment).

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Opened for human review before merge.*