### PR TITLE
FIX: SCT terminology — replace invented Couinaud codes with authoritative SCT triples

### DIFF
--- a/Resources/Terminology/SlicerLiver-Terminology.json
+++ b/Resources/Terminology/SlicerLiver-Terminology.json
@@ -56,79 +56,90 @@
       },
       {
         "CodeMeaning": "Liver segment",
-        "CodingSchemeDesignator": "99SLIVER",
-        "CodeValue": "LIVER-SEG-CATEGORY",
+        "CodingSchemeDesignator": "SCT",
+        "SNOMEDCTConceptID": "245553001",
+        "CodeValue": "245553001",
         "showAnatomy": false,
         "Type": [
           {
             "recommendedDisplayRGBValue": [218, 165, 32],
-            "CodeMeaning": "Liver segment I (caudate)",
-            "CodingSchemeDesignator": "99SLIVER",
+            "CodeMeaning": "Caudate lobe of liver",
+            "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "couinaud_I",
-            "CodeValue": "LIVER-SEG-I"
+            "SNOMEDCTConceptID": "71133005",
+            "CodeValue": "71133005"
           },
           {
             "recommendedDisplayRGBValue": [135, 206, 250],
             "CodeMeaning": "Liver segment II",
-            "CodingSchemeDesignator": "99SLIVER",
+            "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "couinaud_II",
-            "CodeValue": "LIVER-SEG-II"
+            "SNOMEDCTConceptID": "277956007",
+            "CodeValue": "277956007"
           },
           {
             "recommendedDisplayRGBValue": [250, 128, 114],
             "CodeMeaning": "Liver segment III",
-            "CodingSchemeDesignator": "99SLIVER",
+            "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "couinaud_III",
-            "CodeValue": "LIVER-SEG-III"
+            "SNOMEDCTConceptID": "277957003",
+            "CodeValue": "277957003"
           },
           {
             "recommendedDisplayRGBValue": [255, 182, 193],
             "CodeMeaning": "Liver segment IV",
-            "CodingSchemeDesignator": "99SLIVER",
+            "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "couinaud_IV",
-            "CodeValue": "LIVER-SEG-IV"
+            "SNOMEDCTConceptID": "277958008",
+            "CodeValue": "277958008"
+          },
+          {
+            "recommendedDisplayRGBValue": [255, 192, 203],
+            "CodeMeaning": "Liver segment IVa",
+            "CodingSchemeDesignator": "SCT",
+            "3dSlicerLabel": "couinaud_IVa",
+            "SNOMEDCTConceptID": "871688003",
+            "CodeValue": "871688003"
+          },
+          {
+            "recommendedDisplayRGBValue": [255, 105, 180],
+            "CodeMeaning": "Liver segment IVb",
+            "CodingSchemeDesignator": "SCT",
+            "3dSlicerLabel": "couinaud_IVb",
+            "SNOMEDCTConceptID": "871689006",
+            "CodeValue": "871689006"
           },
           {
             "recommendedDisplayRGBValue": [144, 238, 144],
             "CodeMeaning": "Liver segment V",
-            "CodingSchemeDesignator": "99SLIVER",
+            "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "couinaud_V",
-            "CodeValue": "LIVER-SEG-V"
+            "SNOMEDCTConceptID": "277959000",
+            "CodeValue": "277959000"
           },
           {
             "recommendedDisplayRGBValue": [255, 255, 102],
             "CodeMeaning": "Liver segment VI",
-            "CodingSchemeDesignator": "99SLIVER",
+            "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "couinaud_VI",
-            "CodeValue": "LIVER-SEG-VI"
+            "SNOMEDCTConceptID": "277960005",
+            "CodeValue": "277960005"
           },
           {
             "recommendedDisplayRGBValue": [186, 85, 211],
             "CodeMeaning": "Liver segment VII",
-            "CodingSchemeDesignator": "99SLIVER",
+            "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "couinaud_VII",
-            "CodeValue": "LIVER-SEG-VII"
+            "SNOMEDCTConceptID": "277961009",
+            "CodeValue": "277961009"
           },
           {
             "recommendedDisplayRGBValue": [255, 140, 0],
             "CodeMeaning": "Liver segment VIII",
-            "CodingSchemeDesignator": "99SLIVER",
+            "CodingSchemeDesignator": "SCT",
             "3dSlicerLabel": "couinaud_VIII",
-            "CodeValue": "LIVER-SEG-VIII"
-          },
-          {
-            "recommendedDisplayRGBValue": [139, 0, 0],
-            "CodeMeaning": "Right hemiliver (Couinaud V-VIII)",
-            "CodingSchemeDesignator": "99SLIVER",
-            "3dSlicerLabel": "hemiliver_right",
-            "CodeValue": "LIVER-HEMI-RIGHT"
-          },
-          {
-            "recommendedDisplayRGBValue": [0, 0, 139],
-            "CodeMeaning": "Left hemiliver (Couinaud II-IV)",
-            "CodingSchemeDesignator": "99SLIVER",
-            "3dSlicerLabel": "hemiliver_left",
-            "CodeValue": "LIVER-HEMI-LEFT"
+            "SNOMEDCTConceptID": "277962002",
+            "CodeValue": "277962002"
           }
         ]
       }

--- a/Testing/Python/unit/test_terminology_assets.py
+++ b/Testing/Python/unit/test_terminology_assets.py
@@ -98,3 +98,92 @@ def test_label_bridge_contract(bridge):
                 assert key in sct, (
                     f"{bridge.name}: mapping '{entry['label']}' missing sct.{key}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# Couinaud-specific assertions.
+#
+# The ten Couinaud codes carried by `SlicerLiver-Terminology.json` MUST be
+# the authoritative SNOMED-CT triples — not project-private placeholders.
+# Absence from Slicer's bundled `DICOM-Master.json` is the reason this file
+# ships at all; the codes themselves are real and must not drift.
+# ---------------------------------------------------------------------------
+
+# CodeMeaning -> CodeValue, verified against the SNOMED-CT browser.
+EXPECTED_COUINAUD_TYPES = {
+    "Caudate lobe of liver":  "71133005",
+    "Liver segment II":       "277956007",
+    "Liver segment III":      "277957003",
+    "Liver segment IV":       "277958008",
+    "Liver segment IVa":      "871688003",
+    "Liver segment IVb":      "871689006",
+    "Liver segment V":        "277959000",
+    "Liver segment VI":       "277960005",
+    "Liver segment VII":      "277961009",
+    "Liver segment VIII":     "277962002",
+}
+
+LIVER_SEGMENT_CATEGORY_CODE = "245553001"
+
+
+def _liver_segment_category():
+    """Locate the 'Liver segment' category, asserting it is present."""
+    data = json.loads(MAIN_FILE.read_text())
+    cats = [
+        c for c in data["SegmentationCodes"]["Category"]
+        if c.get("CodeMeaning") == "Liver segment"
+    ]
+    assert len(cats) == 1, (
+        f"expected exactly one 'Liver segment' category, found {len(cats)}"
+    )
+    return cats[0]
+
+
+def test_liver_segment_category_uses_authoritative_sct():
+    """The category itself is SNOMED-CT 245553001 'Liver segment',
+    not a project-private namespace."""
+    cat = _liver_segment_category()
+    assert cat["CodingSchemeDesignator"] == "SCT", (
+        f"category scheme must be SCT, got {cat['CodingSchemeDesignator']!r} — "
+        "private-scheme placeholders are not acceptable"
+    )
+    assert cat["CodeValue"] == LIVER_SEGMENT_CATEGORY_CODE, (
+        f"category code must be {LIVER_SEGMENT_CATEGORY_CODE}, "
+        f"got {cat['CodeValue']!r}"
+    )
+
+
+def test_couinaud_types_all_use_sct():
+    """Regression test against placeholder-scheme leakage: every Couinaud
+    segment type must declare CodingSchemeDesignator='SCT'."""
+    cat = _liver_segment_category()
+    wrong_scheme = [
+        (t["CodeMeaning"], t["CodingSchemeDesignator"])
+        for t in cat["Type"]
+        if t["CodingSchemeDesignator"] != "SCT"
+    ]
+    assert not wrong_scheme, (
+        f"Couinaud types using non-SCT scheme: {wrong_scheme}"
+    )
+
+
+def test_couinaud_codes_match_authoritative_set():
+    """Every Couinaud segment must carry the verified SNOMED-CT triple.
+    The mapping is authoritative for v2.0.0 and a drift here is either a
+    typo or a regression to placeholder codes."""
+    cat = _liver_segment_category()
+    actual = {t["CodeMeaning"]: t["CodeValue"] for t in cat["Type"]}
+    assert actual == EXPECTED_COUINAUD_TYPES, (
+        f"Couinaud CodeMeaning→CodeValue mismatch.\n"
+        f"  expected: {EXPECTED_COUINAUD_TYPES}\n"
+        f"  actual:   {actual}"
+    )
+
+
+def test_couinaud_types_count_is_ten():
+    """Sanity check — eight standard Couinaud segments (I–VIII) plus the
+    two clinically meaningful IVa/IVb subdivisions = ten types."""
+    cat = _liver_segment_category()
+    assert len(cat["Type"]) == 10, (
+        f"expected 10 Couinaud types (I–VIII + IVa + IVb), got {len(cat['Type'])}"
+    )


### PR DESCRIPTION
## Summary
Replaces the project-private Couinaud codes shipped in PR #315 with the **authoritative SNOMED-CT triples** verified against the public SNOMED-CT browser.

## Background
PR #315 shipped Couinaud segment codes under a project-private `99SLIVER` scheme (`LIVER-SEG-I` through `LIVER-SEG-VIII` plus two hemiliver compounds) because Slicer's bundled `DICOM-Master.json` does not include Couinaud codes and the team had no verified SCT triples on hand at PR-time.

Subsequent verification against the public SNOMED-CT browser established that **authoritative SCT codes exist** for Couinaud liver segments. They are absent from `DICOM-Master.json` (so a SlicerLiver-private terminology file is still required) but the codes themselves are real SNOMED-CT, not values to invent.

## Code mapping

| Segment | Was (invented) | Now (authoritative SCT) |
|---|---|---|
| I (Caudate) | `99SLIVER:LIVER-SEG-I` | `SCT:71133005` "Caudate lobe of liver" |
| II | `99SLIVER:LIVER-SEG-II` | `SCT:277956007` |
| III | `99SLIVER:LIVER-SEG-III` | `SCT:277957003` |
| IV | `99SLIVER:LIVER-SEG-IV` | `SCT:277958008` |
| IVa | (absent — was hemiliver compound instead) | `SCT:871688003` |
| IVb | (absent — was hemiliver compound instead) | `SCT:871689006` |
| V | `99SLIVER:LIVER-SEG-V` | `SCT:277959000` |
| VI | `99SLIVER:LIVER-SEG-VI` | `SCT:277960005` |
| VII | `99SLIVER:LIVER-SEG-VII` | `SCT:277961009` |
| VIII | `99SLIVER:LIVER-SEG-VIII` | `SCT:277962002` |
| Category | `99SLIVER:LIVER-SEG-CATEGORY` | `SCT:245553001` "Liver segment" |

Codes are independently verifiable via any public SNOMED-CT browser (e.g. <https://browser.ihtsdotools.org/>).

The two `LIVER-HEMI-RIGHT` / `LIVER-HEMI-LEFT` author-invented compound codes are removed. The `IVa` / `IVb` subdivisions take their place — they are on the verified list and are the clinically meaningful subdivisions used in anatomic-resection workflows.

The `99SLIVER` scheme is no longer referenced anywhere in this file. The "Liver segment" category is now purely SCT-coded.

## Why this matters
ADR-0011 dispatches on the full `(CodingSchemeDesignator, CodeValue, CodeMeaning)` triple. Invented codes mean any future consumer (DICOM SEG export, Segment Editor terminology selector, downstream extensions) that knows the real SCT codes will not recognise our segments. The fix is interop-positive.

## Tests
Adds four Couinaud-specific assertions to `Testing/Python/unit/test_terminology_assets.py`:

- `test_liver_segment_category_uses_authoritative_sct` — category scheme is SCT, value `245553001`
- `test_couinaud_types_all_use_sct` — regression check that no segment leaked back to a project-private scheme
- `test_couinaud_codes_match_authoritative_set` — every `CodeMeaning` → `CodeValue` matches the verified SNOMED-CT triple
- `test_couinaud_types_count_is_ten` — eight standard Couinaud segments (I–VIII) plus IVa + IVb

Local run: **15 passed, 1 skipped** (Slicer-load layer; runs on CI once the image picks up the latest `PythonSlicer` rebuild).

## Behaviour break?
Yes — anything that depended on the `99SLIVER` codes from #315 breaks. **Nothing in v2.0.0 has shipped consumers yet**, so the break has zero downstream cost. If anyone has built local tooling against the placeholder codes, this PR's merge is the cutover.

## UX impact
N/A — non-UI change (data asset + tests).

## Cross-refs
- ADR-0011 (SCT-as-dispatch-key)
- ADR-0007 (private-scheme renumbering would have been a MAJOR-N break — by removing the private scheme entirely we sidestep that hazard for the Couinaud case)
- PR #315 (the original terminology PR that shipped the now-superseded codes)

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. The Couinaud-code discrepancy was surfaced during review; this PR applies the verified-authoritative codes that should have shipped in PR #315 and adds explicit regression coverage. Opened for human review before merge.*