### PR TITLE
DOC: ADR-0014 + ADR-0015 — LiverMarkups dissolution and C++ algorithm library

### DIFF
--- a/Docs/adr/0014-livermarkups-dissolution.md
+++ b/Docs/adr/0014-livermarkups-dissolution.md
@@ -69,7 +69,7 @@ lived **implicitly in scene contents**: "if a `SlicingContour` node
 exists, we are in Initialization with SlicingPlane mode; if a
 `DistanceContour` node exists, we are in Initialization with
 DistanceSpheroid mode; if a `BezierSurface` node exists, we are in
-Planning".  [ADR-0013](0013-layerdm-pipeline-pattern.md) §4 documents
+Planning".  ADR-0013 §4 documents
 the brittleness of that pattern: ambiguous scene round-trip mid-
 transition, undo/redo crossing node boundaries, every state check is a
 scene query.  PR #317's UI baseline at
@@ -85,7 +85,7 @@ scene-contents pattern altogether.
 The `LiverMarkups` module is dissolved in v2.0.0.  Its three
 interactive primitives relocate into `LiverResections` as **non-Markups
 data nodes**, driven by a single state-aware LayerDM Pipeline with
-three Representations (per [ADR-0013](0013-layerdm-pipeline-pattern.md)
+three Representations (per ADR-0013
 §4 and §6) and a single custom widget that subclasses
 `vtkAbstractWidget` directly.
 
@@ -115,7 +115,7 @@ Planning→Init drop-back recovers them losslessly.
 
 ### 2. One LayerDM Pipeline; three state-conditional Representations
 
-Per [ADR-0013](0013-layerdm-pipeline-pattern.md) §4, a single
+Per ADR-0013 §4, a single
 `LiverBezierSurfacePipeline` observes its display node *and* the
 parent `vtkMRMLLiverResectionNode`'s `ResectionState` /
 `InitializationMode` enums.  The Pipeline owns three Representations,
@@ -214,7 +214,7 @@ LiverResections/
 
 Migrate the three Markups-derived nodes' *display* path to LayerDM
 per [ADR-0002](0002-migrate-to-slicerlayerdm.md) and
-[ADR-0013](0013-layerdm-pipeline-pattern.md), but leave the data
+ADR-0013, but leave the data
 nodes inheriting from `vtkMRMLMarkupsNode` and the interaction layer
 on `vtkSlicerMarkupsWidget`.
 
@@ -241,7 +241,7 @@ target liver mesh that seeds the same Bezier fit.  Keeping them in
 LiverMarkups would preserve a module that exists only to host two
 data carriers whose entire lifecycle is governed by the resection
 workflow — re-entrenching the implicit-state-via-scene-contents
-pattern [ADR-0013](0013-layerdm-pipeline-pattern.md) §4 retires.
+pattern ADR-0013 §4 retires.
 
 ### C. Three separate modules for the three primitives
 
@@ -274,7 +274,7 @@ the workflow they share.
   workflow.  T2 reviewers and `/slicer-review` evaluate the
   interactive surface against a single yardstick instead of three
   separate Markups subclasses.
-- **First concrete instantiation of [ADR-0013](0013-layerdm-pipeline-pattern.md)
+- **First concrete instantiation of ADR-0013
   and [ADR-0011](0011-sct-terminology-dispatch.md).**  The Pipeline
   consumes SCT triples for colour and label decoration (replacing the
   hardcoded `HepaticContourColor` / `PortalContourColor` constants in
@@ -337,7 +337,7 @@ The T2 LiverResections (all-in) phase lands in this order:
    `Set/Get` accessors, `WriteXML`/`ReadXMLAttributes` plumbing,
    and `Modified()` events on transition.
 4. **LiverBezierSurfacePipeline + three Representations** per
-   [ADR-0013](0013-layerdm-pipeline-pattern.md) — Python, observing
+   ADR-0013 — Python, observing
    both the display node and `vtkMRMLLiverResectionNode`'s state
    machine.  Ships with the three-tier test set (module test,
    per-Representation unit tests, workflow test using the
@@ -395,7 +395,7 @@ The T2 LiverResections (all-in) phase lands in this order:
     the current `LiverMarkups` constructors.
   - [ADR-0012](0012-layerdm-migration-v2-scope.md) (amended) — the
     v2.0.0 migration map collapses to T2 + T3 in light of this ADR.
-  - [ADR-0013](0013-layerdm-pipeline-pattern.md) — the canonical
+  - ADR-0013 — the canonical
     Pipeline + Representation shape this ADR instantiates; §4 is
     the state-aware-Pipeline pattern.
   - [ADR-0015](0015-cpp-algorithm-library.md) — the C++ algorithm

--- a/Docs/adr/0014-livermarkups-dissolution.md
+++ b/Docs/adr/0014-livermarkups-dissolution.md
@@ -148,9 +148,8 @@ directly — *not* `vtkSlicerMarkupsWidget`.  Free design space:
   init-mode drop-back), free of `vtkSlicerMarkupsWidget::WidgetEvent
   Menu` / `populateContextMenu` constraints.
 
-Per-role glyph rendering wires through the four existing custom OpenGL
-mappers in `LiverMarkups/VTKWidgets/` (relocated to `LiverResections/
-VTKWidgets/` alongside the widget):
+The four existing custom OpenGL mappers in `LiverMarkups/VTKWidgets/`
+relocate to `LiverResections/VTKWidgets/` alongside the widget:
 
 - `vtkOpenGLBezierResectionPolyDataMapper` — the surface.
 - `vtkOpenGLSlicingContourPolyDataMapper`,
@@ -159,34 +158,87 @@ VTKWidgets/` alongside the widget):
   surface (carried over into the T3 Resectogram migration; relocated
   here only to keep the migration map clean).
 
-### 4. Init control points persist across Init→Planning
+This ADR commits to **relocating** these mappers, **not** to any
+specific visual treatment for selected / ring-grouped / per-role
+control points.  The selection-feedback design (per-role glyph shapes,
+halo overlays around selected points, outline accents, colour
+modulation, …) is a UX choice deferred to the T2 implementation
+per [ADR-0009](0009-ux-and-design-discipline.md) §3 (design rationale
+on every UI-touching PR).  The widget's right-click / right-drag
+event-table semantics decided in §3 above are unaffected by that
+deferred visual choice.
 
-After the Init→Planning transition, the two (SlicingPlane) or
-two-or-more (DistanceSpheroid) init control points **persist** on the
-parent resection's data.  A Planning→Init drop-back recovers them
-losslessly; a save/load round-trip in either state captures the
-surgeon's intent across the state boundary.  Cost on the data node is
-negligible (a handful of `double[3]` arrays per resection); the
-alternative — discarding the init control points at the state
-transition — gives up recoverable workflow intent for no payoff.
+### 4. Init control-point lifecycle across Init→Planning — OPEN
 
-### 5. Storage rides through LiverResections' .lrp.fcsv with a schema bump
+**Open question, to be settled before the T2 PR lands.**
 
-The existing `.lrp.fcsv` storage class (per
-[ADR-0001](0001-resection-three-node-assembly.md) §3 and the round-trip
-test added in PR #294) absorbs the new fields:
+A previous draft of this ADR committed to persisting the init control
+points on the resection's data so a Planning→Init drop-back would be
+lossless.  Review surfaced a prior question: should the surgeon be
+able to drop back to Init at all?  Once Planning has moved the
+Bezier-grid geometry away from the original init ring, the init
+control points may no longer describe anything clinically meaningful;
+the drop-back would mostly be undo-style behaviour better served by
+Slicer's scene-state undo.
 
-- Ring-role metadata on the 16 Bezier control points (corner / edge /
-  interior).
+Two paths under discussion:
+
+- *No drop-back.*  Init→Planning is one-way for v2.0.0.  Init control
+  points are discarded at the transition; the Bezier 4×4 grid is the
+  sole persisted representation thereafter.  Save/load round-trip
+  captures only the Bezier grid + state-machine fields.  Simplest
+  workflow; loses recoverable intent for the surgeon who wants to
+  return to "before the fit".
+- *Drop-back with persistence.*  Init control points persist on the
+  resection's data node (handful of `double[3]` per resection — cheap)
+  so Planning→Init recovers them losslessly.  Captures intent across
+  the state boundary at the cost of slightly more storage and one more
+  state transition to validate.
+
+This ADR no longer commits to either path.  The decision feeds the
+schema design for §5 (storage) and the state-machine in ADR-0013 §4.
+Resolution by separate discussion before the T2 PR lands; outcome
+captured by amendment to this ADR.
+
+### 5. Storage — D-class break committed; format mechanism OPEN
+
+A **D-class break** per [ADR-0007](0007-version-numbering-policy.md)
+is committed: symmetric round-trip with v1 `.lrp.fcsv` files is no
+longer clean.  Already on the v1→v2 ticket and contributes to the (D)
+trigger ADR-0007 §"Mapping the v1 → v2 jump" enumerates.
+
+**The storage format itself is OPEN.**  The existing `.lrp.fcsv`
+format was driven by Markups as a base; the LiverMarkups dissolution
+in this ADR retires that base and reopens the format question.
+Candidates under discussion:
+
+- *Extended `.lrp.fcsv`.*  Schema bump in place; minimal migration
+  cost; carries legacy-format baggage.
+- *New MRML storage node.*  A
+  `vtkMRMLLiverBezierSurfaceStorageNode` purpose-built for the new
+  data model.  Cleaner schema; standard MRML scene-XML for the
+  geometry plus a sidecar (JSON or similar) for the high-volume
+  control-point payload.
+- *JSON sidecar to the scene MRML.*  Lightweight and inspection-
+  friendly; closer to the Segmentations-module convention.
+
+Fields the format must carry (regardless of mechanism):
+
+- The 16 Bezier control points with ring-role metadata (corner /
+  edge / interior).
 - Init-mode control points (2 for SlicingPlane, ≥2 for
-  DistanceSpheroid).
+  DistanceSpheroid) — quantity and persistence conditional on §4's
+  drop-back resolution.
 - State-machine fields (`ResectionState`, `InitializationMode`) as
   typed enums.
+- Margins and other decoration that previously lived on the data
+  node (per ADR-0013 §8, those move to the new display node — not
+  the storage node — though both go through the same save/load
+  path).
 
-This is a **D-class break** per [ADR-0007](0007-version-numbering-policy.md)
-(symmetric round-trip with v1 `.lrp.fcsv` files is no longer clean);
-it is already on the v1→v2 ticket and contributes to the (D) trigger
-ADR-0007 §"Mapping the v1 → v2 jump" enumerates.
+Resolution by separate discussion before the T2 PR lands; outcome
+captured by amendment to this ADR or by a follow-on ADR if the
+format choice is substantial enough to warrant its own.
 
 ### 6. Illustrative file layout
 

--- a/Docs/adr/0014-livermarkups-dissolution.md
+++ b/Docs/adr/0014-livermarkups-dissolution.md
@@ -1,0 +1,415 @@
+# 0014. Dissolve LiverMarkups; fold interactive resection primitives into LiverResections
+
+- **Status:** Proposed
+- **Date:** 2026-05-15
+- **Deciders:** Rafael Palomar
+- **Diagrams:** N/A (target MRML diagram and per-module UI diagrams land
+  alongside the T2 LiverResections migration PR per
+  [ADR-0009](0009-ux-and-design-discipline.md); this ADR fixes the
+  *shape* those diagrams will record.)
+- **PR:** _filled in on merge_
+
+## Context
+
+`LiverMarkups` today is a Markups-derived satellite module that hosts the
+interactive primitives the resection-planning workflow uses.  Per the
+inventory recorded in the v2.0.0 architecture handoff and visible in
+`LiverMarkups/MRML/`, it ships three node pairs:
+
+- `vtkMRMLMarkupsBezierSurfaceNode` (+ display) — the 4×4 control grid
+  the surgeon edits in the Planning state; weakrefs the target model,
+  distance map, and vascular segments; carries margin/thickness
+  doubles.
+- `vtkMRMLMarkupsSlicingContourNode` (+ display) — two control points
+  defining a plane; the plane ∩ target model produces a ring that
+  seeds the Bezier fit.
+- `vtkMRMLMarkupsDistanceContourNode` (+ display) — two-or-more
+  control points defining a spheroid (position + orientation +
+  convexity); the spheroid ∩ target model produces the ring; richer
+  parameterisation apparatus required (Elliptic Fourier Descriptors or
+  similar).
+
+The two contour nodes register with `SelectionNode` only when
+`DeveloperMode` is true (see `vtkSlicerLiverMarkupsLogic::Observe
+MRMLScene`); the Bezier surface always registers.  That registration
+asymmetry already hints at the workflow-specific role of the contour
+nodes — they are **not** independent annotations.  They are **two
+alternative initialisation affordances for the same Bezier surface**,
+each producing a ring that seeds the same downstream fit.  Calling
+them "Markups" obscures that relationship in the data model and forces
+each through Markups' point-list-centric machinery.
+
+Two forces push the Bezier surface itself off the `vtkMRMLMarkupsNode`
+base:
+
+- **Ring-aware right-click.**  Surgically meaningful operations on the
+  4×4 control grid group the points by ring role: corners (4), edges
+  (8), interior (4).  Right-clicking any interior point should let the
+  surgeon translate the inner ring as a unit; right-clicking a corner
+  should grip the outer ring.  Markups' `vtkSlicerMarkupsWidget` is
+  built around per-point semantics, owns its own right-click menu via
+  `WidgetEventMenu` / `populateContextMenu`, and has no first-class
+  concept of point groups.  Expressing the ring grouping on top of
+  Markups is brittle and contorts the upstream event vocabulary —
+  exactly the constraint catalogued in [ADR-0002](0002-migrate-to-slicerlayerdm.md)
+  §4.
+- **Per-role glyph rendering.**  The four corner, eight edge, and four
+  interior control points each want their own glyph (size, shape,
+  colour) so the surgeon can see at a glance which ring they are
+  manipulating.  Markups' standard sphere glyph machinery is one
+  glyph per node; per-role rendering on top of it is a continuous
+  fight against upstream rendering assumptions.  The reusable
+  ingredient already lives in the repo: `vtkOpenGLBezierResection
+  PolyDataMapper`, `vtkOpenGLSlicingContourPolyDataMapper`,
+  `vtkOpenGLDistanceContourPolyDataMapper`, and
+  `vtkOpenGLResection2DPolyDataMapper` in `LiverMarkups/VTKWidgets/`.
+
+The state machine that ties these primitives together has, until now,
+lived **implicitly in scene contents**: "if a `SlicingContour` node
+exists, we are in Initialization with SlicingPlane mode; if a
+`DistanceContour` node exists, we are in Initialization with
+DistanceSpheroid mode; if a `BezierSurface` node exists, we are in
+Planning".  [ADR-0013](0013-layerdm-pipeline-pattern.md) §4 documents
+the brittleness of that pattern: ambiguous scene round-trip mid-
+transition, undo/redo crossing node boundaries, every state check is a
+scene query.  PR #317's UI baseline at
+`Docs/architecture/ui/liver-resections.md` already names the explicit
+state machine: `vtkMRMLLiverResectionNode.ResectionState` (`Init` /
+`Planning`) and `.InitializationMode` (`SlicingPlane` /
+`DistanceSpheroid`).  The migration is the moment to make that
+state machine first-class and dispense with the implicit-state-via-
+scene-contents pattern altogether.
+
+## Decision
+
+The `LiverMarkups` module is dissolved in v2.0.0.  Its three
+interactive primitives relocate into `LiverResections` as **non-Markups
+data nodes**, driven by a single state-aware LayerDM Pipeline with
+three Representations (per [ADR-0013](0013-layerdm-pipeline-pattern.md)
+§4 and §6) and a single custom widget that subclasses
+`vtkAbstractWidget` directly.
+
+### 1. Three primitives become non-Markups MRML data nodes in LiverResections
+
+The three Markups-derived nodes relocate as plain `vtkMRMLDisplayable
+Node` subclasses (no `vtkMRMLMarkupsNode` inheritance):
+
+- `vtkMRMLLiverBezierSurfaceNode` (+ `vtkMRMLLiverBezierSurfaceDisplay
+  Node`) — the 4×4 control grid plus ring-role metadata (which
+  control points are corner / edge / interior); weakrefs to target
+  model, distance map, vascular segments; the margin/thickness
+  doubles previously hosted by `vtkMRMLMarkupsBezierSurfaceNode`.
+- `vtkMRMLLiverSlicingPlaneInitNode` (no separate display node — its
+  decoration lives on `vtkMRMLLiverBezierSurfaceDisplayNode`'s
+  state-conditional Representation) — two control points + plane
+  parameters; persisted on the parent resection's data, not a
+  separate scene node.
+- `vtkMRMLLiverDistanceSpheroidInitNode` (same pattern) — two-or-more
+  control points + spheroid parameters.
+
+The two init-mode "nodes" are conceptually struct-shaped subordinate
+data carried by the parent `vtkMRMLLiverResectionNode`, not free
+MRML nodes.  Their control points persist on the resection's
+`.lrp.fcsv` payload with explicit `init_mode` metadata, so a
+Planning→Init drop-back recovers them losslessly.
+
+### 2. One LayerDM Pipeline; three state-conditional Representations
+
+Per [ADR-0013](0013-layerdm-pipeline-pattern.md) §4, a single
+`LiverBezierSurfacePipeline` observes its display node *and* the
+parent `vtkMRMLLiverResectionNode`'s `ResectionState` /
+`InitializationMode` enums.  The Pipeline owns three Representations,
+constructed once and reused across state transitions:
+
+- `SlicingPlaneInitRepresentation` — active when `(ResectionState=Init,
+  InitializationMode=SlicingPlane)`; renders the two control points,
+  the plane, and the ring on the target liver surface.
+- `DistanceSpheroidInitRepresentation` — active when `(ResectionState=
+  Init, InitializationMode=DistanceSpheroid)`; renders the spheroid
+  control points, the spheroid, and the ring.
+- `BezierPlanningRepresentation` — active when `(ResectionState=
+  Planning, *)`; renders the 4×4 grid with per-role glyphs and the
+  fitted Bezier surface.
+
+The Pipeline's `update()` selects the active Representation by the
+`(state, mode)` tuple; no add/remove churn on the MRML scene as the
+surgeon moves through the workflow.
+
+### 3. Custom widget subclassing vtkAbstractWidget directly
+
+A single `vtkLiverBezierWidget` subclasses `vtkAbstractWidget`
+directly — *not* `vtkSlicerMarkupsWidget`.  Free design space:
+
+- **Left-drag** = per-point manipulation (the Markups-equivalent
+  semantics).
+- **Right-drag** = ring-group translation (corner / edge / interior
+  ring of the 4×4 grid moves as a unit).
+- **Right-click** = own context menu (ring selection, mode switches,
+  init-mode drop-back), free of `vtkSlicerMarkupsWidget::WidgetEvent
+  Menu` / `populateContextMenu` constraints.
+
+Per-role glyph rendering wires through the four existing custom OpenGL
+mappers in `LiverMarkups/VTKWidgets/` (relocated to `LiverResections/
+VTKWidgets/` alongside the widget):
+
+- `vtkOpenGLBezierResectionPolyDataMapper` — the surface.
+- `vtkOpenGLSlicingContourPolyDataMapper`,
+  `vtkOpenGLDistanceContourPolyDataMapper` — the init-mode rings.
+- `vtkOpenGLResection2DPolyDataMapper` — the resectogram-flattened
+  surface (carried over into the T3 Resectogram migration; relocated
+  here only to keep the migration map clean).
+
+### 4. Init control points persist across Init→Planning
+
+After the Init→Planning transition, the two (SlicingPlane) or
+two-or-more (DistanceSpheroid) init control points **persist** on the
+parent resection's data.  A Planning→Init drop-back recovers them
+losslessly; a save/load round-trip in either state captures the
+surgeon's intent across the state boundary.  Cost on the data node is
+negligible (a handful of `double[3]` arrays per resection); the
+alternative — discarding the init control points at the state
+transition — gives up recoverable workflow intent for no payoff.
+
+### 5. Storage rides through LiverResections' .lrp.fcsv with a schema bump
+
+The existing `.lrp.fcsv` storage class (per
+[ADR-0001](0001-resection-three-node-assembly.md) §3 and the round-trip
+test added in PR #294) absorbs the new fields:
+
+- Ring-role metadata on the 16 Bezier control points (corner / edge /
+  interior).
+- Init-mode control points (2 for SlicingPlane, ≥2 for
+  DistanceSpheroid).
+- State-machine fields (`ResectionState`, `InitializationMode`) as
+  typed enums.
+
+This is a **D-class break** per [ADR-0007](0007-version-numbering-policy.md)
+(symmetric round-trip with v1 `.lrp.fcsv` files is no longer clean);
+it is already on the v1→v2 ticket and contributes to the (D) trigger
+ADR-0007 §"Mapping the v1 → v2 jump" enumerates.
+
+### 6. Illustrative file layout
+
+```
+LiverResections/
+  MRML/
+    vtkMRMLLiverBezierSurfaceNode.{h,cxx}        # data; 4×4 grid + ring-role + weakrefs
+    vtkMRMLLiverBezierSurfaceDisplayNode.{h,cxx} # visibility, opacity, terminology (ADR-0011)
+  LiverBezierSurfacePipeline.py                   # LayerDM Pipeline (ADR-0013)
+  Representations/
+    SlicingPlaneInitRepresentation.py
+    DistanceSpheroidInitRepresentation.py
+    BezierPlanningRepresentation.py
+  VTKWidgets/
+    vtkLiverBezierWidget.{h,cxx}                  # subclasses vtkAbstractWidget directly
+    vtkOpenGLBezierResectionPolyDataMapper.{h,cxx}    # relocated from LiverMarkups/
+  Algorithm/                                      # per ADR-0015
+```
+
+`LiverMarkups/` disappears from the v2.0.0 module list entirely.
+
+## Alternatives considered
+
+### A. Keep LiverMarkups; LayerDM display migration only
+
+Migrate the three Markups-derived nodes' *display* path to LayerDM
+per [ADR-0002](0002-migrate-to-slicerlayerdm.md) and
+[ADR-0013](0013-layerdm-pipeline-pattern.md), but leave the data
+nodes inheriting from `vtkMRMLMarkupsNode` and the interaction layer
+on `vtkSlicerMarkupsWidget`.
+
+**Rejected** because ring-aware right-click on the 4×4 grid and
+per-role control-point rendering are blocked at the Markups widget
+base.  `vtkSlicerMarkupsWidget` owns its right-click menu through
+`WidgetEventMenu` / `populateContextMenu` and treats control points
+as independent atoms; expressing point groups on top of it is the
+same fight ADR-0002 §4 already loses.  The Markups inheritance is the
+specific constraint that needs to come off; migrating only the
+display path leaves the load-bearing constraint in place.
+
+### B. Move only BezierSurface; keep contours in LiverMarkups
+
+Relocate `vtkMRMLMarkupsBezierSurfaceNode` into LiverResections as a
+non-Markups data node (resolving the widget constraint), but keep
+`vtkMRMLMarkupsSlicingContourNode` and `vtkMRMLMarkupsDistanceContour
+Node` in LiverMarkups as Markups-derived annotation nodes.
+
+**Rejected** because SlicingContour and DistanceContour are not
+independent annotations.  They are two alternative initialisation
+affordances for the same Bezier surface; both produce a ring on the
+target liver mesh that seeds the same Bezier fit.  Keeping them in
+LiverMarkups would preserve a module that exists only to host two
+data carriers whose entire lifecycle is governed by the resection
+workflow — re-entrenching the implicit-state-via-scene-contents
+pattern [ADR-0013](0013-layerdm-pipeline-pattern.md) §4 retires.
+
+### C. Three separate modules for the three primitives
+
+Promote each of the three primitives to its own module
+(`LiverBezierSurface`, `LiverSlicingPlaneInit`,
+`LiverDistanceSpheroidInit`), each with its own MRML nodes, its own
+Pipeline, its own custom widget.
+
+**Rejected** because the three primitives are stations of a single
+workflow (Init→Planning for the same resection), not independent
+features.  Splitting them across modules multiplies the registration
+boilerplate (three module classes, three `Logic` classes, three CMake
+targets) for no separation-of-concerns benefit, and forces inter-
+module references for what is conceptually one Pipeline with three
+state-conditional Representations.  The dissolution of LiverMarkups
+into LiverResections is the *opposite* direction: fewer modules for
+the workflow they share.
+
+## Consequences
+
+### Easier
+
+- **State machine becomes first-class.**  `ResectionState` and
+  `InitializationMode` are typed enums on
+  `vtkMRMLLiverResectionNode`, readable in one node access; the
+  implicit-state-via-scene-contents pattern (and its undo/redo
+  ambiguity) retires.  Scene round-trip in any intermediate state is
+  unambiguous.
+- **One Pipeline, one widget, one storage class** for the resection
+  workflow.  T2 reviewers and `/slicer-review` evaluate the
+  interactive surface against a single yardstick instead of three
+  separate Markups subclasses.
+- **First concrete instantiation of [ADR-0013](0013-layerdm-pipeline-pattern.md)
+  and [ADR-0011](0011-sct-terminology-dispatch.md).**  The Pipeline
+  consumes SCT triples for colour and label decoration (replacing the
+  hardcoded `HepaticContourColor` / `PortalContourColor` constants in
+  the current `LiverMarkups` node constructors).  Sets the worked
+  example T3 Resectogram reviews against.
+- **The migration map simplifies to T2 + T3** per the
+  [ADR-0012](0012-layerdm-migration-v2-scope.md) amendment.  One
+  fewer migration phase; one fewer module's worth of LayerDM
+  pattern-setting; the LiverMarkups → LiverResections cross-reference
+  chain disappears.
+
+### Harder
+
+- **D-class compatibility break** per
+  [ADR-0007](0007-version-numbering-policy.md): `.lrp.fcsv` schema
+  bump for ring-role metadata, init-mode control points, and state-
+  machine fields.  Already on the v1→v2 ticket; contributes to the
+  (D) trigger ADR-0007 §"Mapping the v1 → v2 jump" enumerates.  The
+  storage class detects the v1 layout and dispatches a one-way read
+  migration into the v2 layout; v2 writes the v2 layout only.
+- **N-class compatibility break** per ADR-0007: the
+  `vtkMRMLMarkupsBezierSurfaceNode`, `vtkMRMLMarkupsSlicingContour
+  Node`, and `vtkMRMLMarkupsDistanceContourNode` classes go away;
+  the `LiverMarkups` module itself goes away.  Three node-class
+  renames + one module removal.  Already on the v1→v2 ticket;
+  contributes to the (N) trigger.
+- **Custom widget infrastructure cost.**  Subclassing
+  `vtkAbstractWidget` directly means re-implementing the parts of
+  `vtkSlicerMarkupsWidget` Slicer-Liver actually uses (event
+  routing, handle representation, picking).  The four custom OpenGL
+  mappers relocate intact, but the widget itself is new code in T2.
+- **Characterisation tests come first.**  Per
+  [ADR-0008](0008-testing-strategy.md) and
+  [ADR-0003](0003-testability-invariant.md), the migration is gated
+  on characterisation tests pinning current LiverMarkups behaviour:
+  display-node lifecycle on scene load, the `DeveloperMode`-
+  conditional `SelectionNode` registration filter, `Logic::OnMRML
+  SceneNodeAdded` invariants (`SnapMode=Unconstrained`,
+  `PropertiesLabelVisibilityOff`), target/distance-map/vascular-
+  segments weakref preservation across save/load, and representation
+  actor lifetime under display-flag toggles.  Extends the PR #294
+  characterisation harness.
+
+## Migration steps
+
+The T2 LiverResections (all-in) phase lands in this order:
+
+1. **Characterisation tests first.**  Extend PR #294's harness to
+   cover the five fragile-path candidates enumerated under
+   "Harder" above.  These tests pin current `LiverMarkups`
+   behaviour and are the regression yardstick for everything
+   downstream.
+2. **New MRML node types** in `LiverResections/MRML/`:
+   `vtkMRMLLiverBezierSurfaceNode`, `vtkMRMLLiverBezierSurfaceDisplay
+   Node`.  Data-only C++ per [ADR-0004](0004-python-cpp-boundary.md)
+   §1.
+3. **State-machine fields** on `vtkMRMLLiverResectionNode`:
+   `ResectionState` (`Init`/`Planning`) and `InitializationMode`
+   (`SlicingPlane`/`DistanceSpheroid`) as typed enums with
+   `Set/Get` accessors, `WriteXML`/`ReadXMLAttributes` plumbing,
+   and `Modified()` events on transition.
+4. **LiverBezierSurfacePipeline + three Representations** per
+   [ADR-0013](0013-layerdm-pipeline-pattern.md) — Python, observing
+   both the display node and `vtkMRMLLiverResectionNode`'s state
+   machine.  Ships with the three-tier test set (module test,
+   per-Representation unit tests, workflow test using the
+   `render_interactive` fixture).
+5. **Custom widget** `vtkLiverBezierWidget` (C++, subclasses
+   `vtkAbstractWidget` directly) plus relocation of the four custom
+   OpenGL mappers from `LiverMarkups/VTKWidgets/` to
+   `LiverResections/VTKWidgets/`.
+6. **`.lrp.fcsv` schema bump** in the LiverResections storage class:
+   v1-format read migration (detect by absence of state-machine
+   fields), v2-format read/write, plus a v1→v2 read-migration test
+   against curated v1 sample files.
+7. **Liver scripted-module "Place resection" button** wires through
+   the new state machine: clicking Place creates a
+   `vtkMRMLLiverResectionNode` with `ResectionState=Init,
+   InitializationMode=SlicingPlane` (default) and activates the
+   Pipeline's `SlicingPlaneInitRepresentation`.  Replaces the
+   current Markups-toolbar Place flow.
+8. **LiverMarkups module removal**: delete `LiverMarkups/`, the
+   `qSlicerLiverMarkupsModule` registration, the `add_subdirectory`
+   call in the top-level `CMakeLists.txt`, and all inbound
+   references in `LiverResections/` and the `Liver/` scripted
+   module.  Confirmed clean by a full `ctest` plus a
+   `pytest -k livermarkups` sweep returning zero collected tests.
+9. **Diagram refresh** per [ADR-0009](0009-ux-and-design-discipline.md):
+   the target-MRML-node-hierarchy diagram and the
+   `Docs/architecture/ui/liver-resections.md` baseline (landed in
+   PR #317) update to reflect the dissolved module and the
+   state-aware Pipeline.
+
+## References
+
+- Related ADRs:
+  - [ADR-0001](0001-resection-three-node-assembly.md) — the
+    descriptive record of the three-node assembly this ADR
+    supersedes for the interactive primitives.
+  - [ADR-0002](0002-migrate-to-slicerlayerdm.md) — the canonical
+    LayerDM migration direction; §4 documents the Markups
+    interaction-model ceiling that ADR-0014 finally clears.
+  - [ADR-0004](0004-python-cpp-boundary.md) — fixes the language
+    band for the new node classes (C++ data-only) and the Pipeline +
+    Representations (Python).
+  - [ADR-0007](0007-version-numbering-policy.md) — governs the
+    D-class (`.lrp.fcsv` schema bump) and N-class (module + node
+    removal) breaks under the v1→v2 jump.
+  - [ADR-0008](0008-testing-strategy.md) — the characterisation
+    discipline and the three-tier test layering applied to the new
+    Pipeline.
+  - [ADR-0009](0009-ux-and-design-discipline.md) — UI-diagram
+    obligation for the migration; the `liver-resections.md`
+    baseline lands in PR #317 and updates with this work.
+  - [ADR-0011](0011-sct-terminology-dispatch.md) — terminology
+    dispatch wires into the new display node for colour, label, and
+    badge presentation; replaces the hardcoded contour colours in
+    the current `LiverMarkups` constructors.
+  - [ADR-0012](0012-layerdm-migration-v2-scope.md) (amended) — the
+    v2.0.0 migration map collapses to T2 + T3 in light of this ADR.
+  - [ADR-0013](0013-layerdm-pipeline-pattern.md) — the canonical
+    Pipeline + Representation shape this ADR instantiates; §4 is
+    the state-aware-Pipeline pattern.
+  - [ADR-0015](0015-cpp-algorithm-library.md) — the C++ algorithm
+    library under `LiverResections/Algorithm/` that the Init→Planning
+    transition consumes.
+- Implementation-relevant PRs:
+  - PR #294 — `.lrp.fcsv` round-trip characterisation harness;
+    extended in step 1 of the migration.
+  - PR #315 — SCT terminology assets the new display node consumes.
+  - PR #316 — pytest scaffold the three-tier test set lands on.
+  - PR #317 — workflow-diagram baseline; this ADR's PR refreshes
+    `Docs/architecture/ui/liver-resections.md` against the
+    state-aware Pipeline.
+
+---
+
+*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Plan and brief from the orchestrating Opus 4.7 session per the handoff at `.claude/handoff-2026-05-15-v2-architecture.md`; prose drafted by a Claude Code subagent. Opened for human review before merge.*

--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -50,8 +50,26 @@ Today's implementation lives in three Python functions in
 
 (These line numbers are approximate; the project-log entries flagged
 this trio as a suspected-buggy hotspot multiple times during the
-2024–2026 development of the module.)  Three pains motivate the lift:
+2024–2026 development of the module.)  The current Python
+implementations are **known to be not very stable** — surgeons and
+maintainers have reported corner-case failures across the EFD
+parameterisation path and the fitting tolerance behaviour, with the
+combination of Slicer's event loop and the scene-state coupling making
+the failures hard to reproduce in isolation.  Four pains motivate the
+lift:
 
+- **Bug discovery.**  The lift is also a deliberate bug-hunt
+  opportunity.  Each lifted function gets a focused C++ unit-test
+  surface; corner cases that the Python implementation silently
+  mishandled (degenerate rings, near-coincident control points, EFD
+  reconstructions that diverge at high harmonic orders) become
+  individually reproducible.  Characterisation-first per
+  [ADR-0003](0003-testability-invariant.md) pins current behaviour
+  including its bugs; the lift then either inverts the assertion for
+  the corrected C++ behaviour or documents the divergence — in either
+  case the bug is now visible and triaged.  This is paired motivation
+  with the testability pain below: testability *and* discoverability
+  improve together.
 - **Testability.**  The functions run inside Slicer's event loop with
   implicit dependencies on the scene state and the active widget.
   Unit-testing them today requires either standing up a Slicer app

--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -23,7 +23,7 @@ introduced by [ADR-0014](0014-livermarkups-dissolution.md)) and lifts
 them from `Liver/Liver.py` into a new C++ algorithm library.
 
 The Init→Planning transition (per ADR-0014 §2 and
-[ADR-0013](0013-layerdm-pipeline-pattern.md) §4) needs a Bezier fit
+ADR-0013 §4) needs a Bezier fit
 from a ring on the target liver mesh.  Two flavours, both required for
 v2.0.0:
 
@@ -318,7 +318,7 @@ the path of least friction.
   - [ADR-0008](0008-testing-strategy.md) — the C++ low-level test
     layer the new library plugs into; §2 enumerates the four-layer
     taxonomy.
-  - [ADR-0013](0013-layerdm-pipeline-pattern.md) — the Pipeline
+  - ADR-0013 — the Pipeline
     pattern that consumes the library; §4 is the state-aware-
     Pipeline pattern the Init→Planning transition rides on.
   - [ADR-0014](0014-livermarkups-dissolution.md) — the LiverMarkups

--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -1,0 +1,331 @@
+# 0015. Lift parameterisation and fitting algorithms from Python to a C++ algorithm library under LiverResections
+
+- **Status:** Proposed
+- **Date:** 2026-05-15
+- **Deciders:** Rafael Palomar
+- **Diagrams:** N/A
+- **PR:** _filled in on merge_
+
+## Context
+
+[ADR-0004](0004-python-cpp-boundary.md) commits Slicer-Liver to a sharp
+Python/C++ boundary: Python is the default; C++ is reserved for
+data-only MRML node classes and for **performance-critical algorithm
+libraries** with a profile-justified native-speed need.  ADR-0004 §2
+explicitly enumerates the candidate workloads — "Bezier-surface
+evaluation, distance-map computation, slicing-contour interpolation,
+volumetry integrators, and any custom VTK filters with a demonstrated
+per-frame or inner-loop budget" — but does not commit a specific
+release to lifting any of them.  This ADR is the first concrete
+realisation of that boundary: it picks the resection-surface-fitting
+machinery (the algorithms behind the Init→Planning state transition
+introduced by [ADR-0014](0014-livermarkups-dissolution.md)) and lifts
+them from `Liver/Liver.py` into a new C++ algorithm library.
+
+The Init→Planning transition (per ADR-0014 §2 and
+[ADR-0013](0013-layerdm-pipeline-pattern.md) §4) needs a Bezier fit
+from a ring on the target liver mesh.  Two flavours, both required for
+v2.0.0:
+
+- **SlicingPlane init** — closed planar curve on the liver surface,
+  produced by intersecting a user-specified plane with the target
+  mesh.  The ring has 4-fold reflective symmetry under the plane;
+  the Bezier fit is mostly a corner-correspondence + interpolation
+  problem.
+- **DistanceSpheroid init** — closed (generally non-planar) curve on
+  the liver surface, produced by intersecting a user-specified
+  spheroid with the target mesh.  The ring is not symmetric; the
+  Bezier fit requires a richer parameterisation step (Elliptic
+  Fourier Descriptors or an equivalent harmonic apparatus) before
+  the corner correspondence is well-posed.
+
+Today's implementation lives in three Python functions in
+`Liver/Liver.py`:
+
+- `fit_bezier_surface` (≈ line 1914) — top-level dispatcher; takes a
+  ring + mode and returns the 4×4 control grid.
+- `runSurfacefromCurve` (≈ line 1961) — the SlicingPlane path.
+- `runSurfacefromEFD` (≈ line 2042) — the DistanceSpheroid path, with
+  the EFD parameterisation inlined.
+
+(These line numbers are approximate; the project-log entries flagged
+this trio as a suspected-buggy hotspot multiple times during the
+2024–2026 development of the module.)  Three pains motivate the lift:
+
+- **Testability.**  The functions run inside Slicer's event loop with
+  implicit dependencies on the scene state and the active widget.
+  Unit-testing them today requires either standing up a Slicer app
+  (slow, flaky, gives up the inner-loop on every iteration) or
+  mocking out enough Slicer machinery that the mock surface dwarfs
+  the function under test.  Neither matches
+  [ADR-0008](0008-testing-strategy.md)'s Unit-layer ambition
+  ("Bezier basis evaluation on numpy arrays" — no Slicer, no Qt).
+- **Suspected bugs in numerical paths.**  The EFD parameterisation
+  and the corner-correspondence step are the most-flagged hotspots
+  in the project log; they need to be unit-testable in isolation
+  before fixes can land with confidence.  Per
+  [ADR-0003](0003-testability-invariant.md), behaviour-changing PRs
+  in this area need characterisation tests; the current shape makes
+  characterisation expensive.
+- **Reuse across the v2.0.0 surface.**  The ring-extraction step
+  (plane ∩ mesh, spheroid ∩ mesh) and the Bezier fitter are both
+  consumed by the new state-aware Pipeline's three Representations
+  (per ADR-0014 §2) and by the T3 Resectogram pipeline downstream.
+  A C++ algorithm library with stable VTK-typed inputs and outputs
+  is the natural shared surface.
+
+Per ADR-0004 §2, the default for new compute is "Python VTK filter
+unless a profile says otherwise".  The fitting algorithms qualify for
+the C++ band on **testability** rather than profile-justified speed:
+they need to be exercisable in seconds against synthetic input
+without Slicer or Qt in the picture, and the C++ + `ctkTest` layer
+([ADR-0008](0008-testing-strategy.md) §2's "C++ low-level" row)
+provides exactly that.  Native-speed payoff is a secondary benefit;
+testability is the load-bearing reason.
+
+## Decision
+
+Slicer-Liver creates a new `LiverResections/Algorithm/` subdirectory
+hosting a C++ algorithm library with four `vtkAlgorithm`-style
+classes.  The library is pure VTK with **no MRML dependency**, is
+Python-wrapped via Slicer's existing VTK wrapping, ships its own C++
+test set under `Algorithm/Testing/Cxx/`, and is consumed by the
+state-aware LiverResections Pipeline introduced in
+[ADR-0014](0014-livermarkups-dissolution.md).  Subdirectory name is
+singular `Algorithm/` to match the sibling-directory convention
+elsewhere in `LiverResections/` (`Logic/`, `MRML/`, `MRMLDM/`,
+`Testing/`).
+
+### 1. Class roster
+
+| Class | Inputs | Output | Used by |
+|---|---|---|---|
+| `vtkLiverPlaneRingExtractor` | target `vtkPolyData` + plane | ordered ring `vtkPolyData` | `SlicingPlaneInitRepresentation` |
+| `vtkLiverSpheroidRingExtractor` | target `vtkPolyData` + spheroid | ordered ring `vtkPolyData` | `DistanceSpheroidInitRepresentation` |
+| `vtkLiverContourParameterizer` | ring + mode (corner-mapping / EFD) | parameterised curve | `vtkLiverBezierFitter` |
+| `vtkLiverBezierFitter` | parameterised curve | 4×4 grid + ring roles | Init→Planning transition |
+
+All four subclass `vtkPolyDataAlgorithm` (or `vtkAlgorithm` where the
+output is not a `vtkPolyData`).  Inputs come in through the standard
+VTK pipeline input ports; parameters come in through `Set/Get`
+accessors.  No `vtkMRMLNode` reference appears in any of these
+classes — MRML lives entirely in the Python orchestration layer
+(`LiverBezierSurfacePipeline` and its Representations) that consumes
+the algorithm outputs.
+
+The two ring-extractors are **new code**.  The contour parameteriser
+and Bezier fitter are **lifts** of the three Python functions
+catalogued above:
+
+- `fit_bezier_surface` (top-level dispatcher) → `vtkLiverBezierFitter`.
+- `runSurfacefromCurve` (SlicingPlane path) → folded into
+  `vtkLiverBezierFitter` via the parameterisation-mode parameter on
+  `vtkLiverContourParameterizer` (corner-mapping mode).
+- `runSurfacefromEFD` (DistanceSpheroid path) → folded into
+  `vtkLiverContourParameterizer` (EFD mode) feeding
+  `vtkLiverBezierFitter`.
+
+### 2. Build-system addition
+
+A new `LiverResections/Algorithm/CMakeLists.txt` declares an
+`add_library` target (`LiverResectionsAlgorithm` or similar) that
+links into `vtkSlicerLiverResectionsModuleLogic` via the existing
+module-library wiring.  VTK wrapping is enabled on the new library
+so Python consumers reach the classes through the standard
+`import vtkSlicerLiverResectionsModuleLogicPython`-style import (or
+the module's Python facade, per the scripted-module convention).
+
+### 3. Test layering — C++ low-level plus Python wrapper
+
+Per [ADR-0008](0008-testing-strategy.md) §2:
+
+- **C++ low-level tests** under `LiverResections/Algorithm/Testing/
+  Cxx/` exercise each class against synthetic `vtkPolyData` inputs.
+  No Slicer import, no Qt, no MRML scene.  These form the *fast
+  subset* of CI that a developer can re-run in seconds with
+  `ctest -R BezierFitter` for one-shot bug-repro.
+- **Python wrapper tests** under `LiverResections/Testing/Python/`
+  exercise the wrapping surface — that the parameter setters survive
+  Python type-coercion, that the output `vtkPolyData` round-trips
+  through `numpy_support` cleanly, and that the four classes compose
+  in the pipeline order the Init→Planning transition needs.  These
+  run under the pytest scaffold introduced by PR #316.
+- **Workflow-layer integration** is owned by the Pipeline tests per
+  ADR-0014 step 4, not by this library.  The algorithm library is a
+  pure VTK surface; the integration test belongs with the consumer.
+
+### 4. Migration discipline for the three lifted Python functions
+
+Per [ADR-0003](0003-testability-invariant.md), the lift is gated on
+characterisation tests of current Python behaviour.  Sequence:
+
+1. **Characterisation first.**  Add pytest cases under
+   `LiverResections/Testing/Python/` that drive `fit_bezier_surface`,
+   `runSurfacefromCurve`, and `runSurfacefromEFD` against curated
+   ring inputs (planar rings for SlicingPlane, synthetic non-planar
+   rings for DistanceSpheroid) and assert on the 4×4 control grids
+   they return.  Tolerances documented per case.
+2. **Lift.**  Implement the C++ classes; invert each characterisation
+   test's assertion target from the Python function to the C++ class
+   output, requiring bit-equivalence where the numerical apparatus
+   permits and a documented numerical tolerance otherwise.
+3. **Retire the Python paths.**  Once the C++ paths pass the
+   inverted characterisation tests, the three Python functions are
+   removed from `Liver/Liver.py` and the Pipeline consumes the C++
+   classes directly.  Suspected-bug fixes follow in *separate* PRs
+   on the lifted C++ code, each with its own regression test per
+   [ADR-0003](0003-testability-invariant.md) §3.
+
+## Alternatives considered
+
+### A. Keep the algorithms in Python
+
+Leave `fit_bezier_surface`, `runSurfacefromCurve`, and
+`runSurfacefromEFD` in `Liver/Liver.py`.  Refactor for testability
+in-place: extract the math into a pure-Python module, expose a
+seam for `numpy`-only unit tests, leave the orchestration in the
+scripted module.
+
+**Rejected** because testability is the load-bearing driver of this
+ADR, and Python alone does not deliver the full ambition.
+[ADR-0008](0008-testing-strategy.md)'s C++ low-level layer (`ctkTest`,
+no Slicer import) catches a class of regression — custom VTK
+mapper / observer / filter correctness — that pure-Python tests do
+not reach.  Lifting the algorithms to C++ puts them in the same test
+layer as the custom mappers they feed
+([ADR-0014](0014-livermarkups-dissolution.md) §3), which means one
+fast `ctest -R Bezier` invocation covers the whole numerical-plus-
+rendering path.  The native-speed dividend is also nonzero; it is
+just not the primary reason.
+
+### B. External C++ algorithm package (CGAL, libigl)
+
+Adopt CGAL or libigl as the home for the ring extraction, contour
+parameterisation, and Bezier fit.  Both libraries are mature,
+widely used in geometry processing, and would absorb the EFD-flavour
+apparatus naturally.
+
+**Rejected** for two reasons.  First, the algorithms are
+liver-specific: the ring extraction's contract is "what the liver
+surface looks like under the user's chosen init plane/spheroid",
+and the Bezier fit's contract is "what a surgically meaningful
+4×4 grid looks like over that ring with ring-role metadata
+preserved".  Neither contract sits naturally on a general-purpose
+geometry library's API.  Second, adopting CGAL or libigl adds a
+required external dependency to the Slicer-Liver build, which is an
+(E)-class trigger per [ADR-0007](0007-version-numbering-policy.md);
+the dependency cost for a liver-specific algorithm catalogue
+outweighs the (modest) code reuse.  The classes belong in-tree.
+
+### C. NumPy/SciPy hybrid (Python orchestration calling vectorised math)
+
+Keep the orchestration in Python but rewrite the math against
+NumPy/SciPy: `scipy.interpolate.BSpline` or equivalent for the
+Bezier evaluation, NumPy FFT for the EFD path, vectorised ring
+operations under NumPy slicing.
+
+**Rejected** because the consumer side is `vtkPolyData` (the
+Representations render `vtkActor`s over `vtkPolyDataMapper`s feeding
+on the algorithm outputs).  A NumPy/SciPy hybrid forces a
+`vtkPolyData ↔ numpy.ndarray` conversion at every pipeline boundary
+— either via `vtk.util.numpy_support` (cheap but adds boilerplate at
+every consumer) or via a custom marshalling layer (re-introduces the
+abstraction the lift is meant to retire).  Staying in the VTK
+pipeline (`vtkAlgorithm` style end-to-end) means the algorithm
+outputs flow into the Representations' mappers with no marshalling
+seam.
+
+### D. ITK filter library
+
+Express the four classes as `itk::ImageToImageFilter` / `itk::Mesh
+ToMeshFilter` subclasses, hosted under an `LiverResections/ITK/`
+subdirectory and built against the Slicer-bundled ITK.
+
+**Rejected** because ITK is image-centric: its mesh pipeline is a
+secondary concern with less maturity than its image-processing core,
+and the ring-extraction and Bezier-fitting work is fundamentally a
+mesh-and-curve workload.  VTK's `vtkPolyDataAlgorithm` pipeline is
+the natural substrate; using ITK here would mean fighting against
+ITK's image-first abstractions to express mesh-first operations.
+The custom OpenGL mappers ADR-0014 relocates also consume
+`vtkPolyData`; keeping the algorithm outputs in the same world is
+the path of least friction.
+
+## Consequences
+
+### Easier
+
+- **First concrete realisation of [ADR-0004](0004-python-cpp-boundary.md).**
+  The Python/C++ boundary that ADR-0004 commits in principle becomes a
+  worked example: four algorithm classes, one CMake target, one
+  Python-wrapper test set, one C++ low-level test set.  Future
+  C++ algorithm-library work in v2.1.0 (volumetry integrators,
+  distance maps for the resectogram texture path) follows the
+  template this ADR establishes — same directory shape, same test
+  layering, same wrapping convention.
+- **`ctest -R BezierFitter` is a one-line bug-repro.**  When a
+  surgeon reports an Init→Planning transition that produces a wrong
+  resection surface, the C++ low-level tests are the first stop:
+  build the curated ring input as a synthetic `vtkPolyData`, drive
+  it through `vtkLiverBezierFitter`, assert on the 4×4 grid.  No
+  Slicer launch, no event loop, no GUI in the picture; the
+  characterisation discipline ADR-0003 mandates becomes cheap
+  enough to apply systematically.
+- **The four classes compose with the rest of the resection
+  Pipeline.**  Per ADR-0014 §2, the three Representations consume
+  the algorithm outputs through standard VTK pipeline ports; the
+  Pipeline's `update()` re-runs only the algorithm stages whose
+  inputs have changed.  No bespoke marshalling between Python and
+  the rendering surface.
+
+### Harder
+
+- **Build-system addition: one new `CMakeLists.txt`.**  The
+  `LiverResections/Algorithm/CMakeLists.txt` file is new; its
+  `add_library` target links into the module logic and is registered
+  with the VTK wrapping pipeline.  Small one-time cost, paid in the
+  same PR that lands the classes.
+- **Regression risk on the three lifted functions.**  The lift
+  inverts the characterisation tests from "Python function returns
+  this output" to "C++ class returns the same output (within
+  documented tolerance)".  Mitigated by the ADR-0003 discipline of
+  landing the characterisation tests **first**, in their own commit
+  or PR, before the lift commit modifies them.  Numerical tolerance
+  is documented per test case where bit-equivalence is not
+  achievable (notably the EFD path, where the C++ FFT implementation
+  may differ in last-bit accuracy from the Python reference).
+- **C++ build-cost for iteration on the algorithm layer.**  Changes
+  to the algorithm classes require a Slicer rebuild (10–60 min per
+  [ADR-0004](0004-python-cpp-boundary.md)'s catalogue).  Acceptable
+  because the algorithms are expected to stabilise after the lift
+  and post-lift bug-fixes; the iteration loop for the *consumers*
+  (the Pipeline and Representations) stays in Python where ADR-0004
+  puts it.
+
+## References
+
+- Related ADRs:
+  - [ADR-0001](0001-resection-three-node-assembly.md) — the
+    descriptive record of the resection workflow these algorithms
+    serve; the Init→Planning transition is the workflow step the
+    library exists for.
+  - [ADR-0003](0003-testability-invariant.md) — the characterisation
+    discipline gating the lift of the three Python functions.
+  - [ADR-0004](0004-python-cpp-boundary.md) — the Python/C++
+    boundary this ADR is the first concrete realisation of.
+  - [ADR-0007](0007-version-numbering-policy.md) — the (E)-class
+    trigger considered (and avoided) in Alternative B.
+  - [ADR-0008](0008-testing-strategy.md) — the C++ low-level test
+    layer the new library plugs into; §2 enumerates the four-layer
+    taxonomy.
+  - [ADR-0013](0013-layerdm-pipeline-pattern.md) — the Pipeline
+    pattern that consumes the library; §4 is the state-aware-
+    Pipeline pattern the Init→Planning transition rides on.
+  - [ADR-0014](0014-livermarkups-dissolution.md) — the LiverMarkups
+    dissolution that this library supports; the three
+    Representations consume the four algorithm classes catalogued
+    here.
+
+---
+
+*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Plan and brief from the orchestrating Opus 4.7 session per the handoff at `.claude/handoff-2026-05-15-v2-architecture.md`; prose drafted by a Claude Code subagent. Opened for human review before merge.*

--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -135,6 +135,46 @@ so Python consumers reach the classes through the standard
 `import vtkSlicerLiverResectionsModuleLogicPython`-style import (or
 the module's Python facade, per the scripted-module convention).
 
+The new CMakeLists declares **two library dependencies** beyond
+what the parent module already pulls in:
+
+- **VTK** — already mandatory; the algorithm library re-uses VTK's
+  mesh ops (`vtkCutter` for plane intersection,
+  `vtkImplicitFunction` for spheroid cutting) and statistics
+  (`vtkPCAStatistics` is already used in
+  `vtkSlicerLiverResectionsLogic.cxx`).  No VTK-component
+  additions beyond the standard wrapping.
+- **Eigen** (MPL2, header-only) — linear algebra for the Bezier
+  pseudo-inverse fit (`(N^T N)^{-1} N^T` style normal-equation
+  solves on the 4×4 basis matrices and the per-axis matrix
+  multiply) and the EFD harmonic-integration sums.  Slicer's
+  superbuild ships Eigen (`Slicer_USE_Eigen` defaults on in
+  current Slicer main); enabled via `find_package(Eigen3 REQUIRED)`
+  from the new CMakeLists.  **No new external dep is introduced
+  beyond what Slicer's superbuild already provides.**
+
+Deliberately **not** required:
+
+- **FFT library** (FFTW, kissfft, pocketfft, …).  The Python
+  implementation in `Liver/Liver.py` computes elliptic Fourier
+  descriptors via direct closed-form harmonic integration
+  (pyefd-derived sums of `cos(n φ)` / `sin(n φ)` weighted by
+  segment differentials), not via FFT.  The C++ port reproduces
+  the same algebra in plain loops over Eigen vectors; neither
+  side uses an FFT library.
+- **External mesh / geometry library** (CGAL, libigl, OpenMesh).
+  Per Alternatives §B, VTK's mesh facilities suffice for ring
+  extraction and Bezier evaluation; adding one of these would
+  introduce a build dep with no clear payoff for liver-specific
+  algorithms.
+- **ITK** (image-filter library).  Per Alternatives §D, this
+  workload is mesh-centric.
+
+License posture for the introduced deps: BSD-3-Clause (VTK) and
+MPL2 (Eigen — less restrictive than LGPL; commonly used in
+closed-source contexts; compatible with Slicer-Liver's
+BSD-3-Clause release).
+
 ### 3. Test layering — C++ low-level plus Python wrapper
 
 Per [ADR-0008](0008-testing-strategy.md) §2:
@@ -221,7 +261,10 @@ outweighs the (modest) code reuse.  The classes belong in-tree.
 
 Keep the orchestration in Python but rewrite the math against
 NumPy/SciPy: `scipy.interpolate.BSpline` or equivalent for the
-Bezier evaluation, NumPy FFT for the EFD path, vectorised ring
+Bezier evaluation, vectorised NumPy array math for the EFD
+harmonic-integration path (the existing Python implementation
+computes Fourier coefficients via direct closed-form sums of
+`cos(n φ)` / `sin(n φ)` rather than FFT), and vectorised ring
 operations under NumPy slicing.
 
 **Rejected** because the consumer side is `vtkPolyData` (the
@@ -292,8 +335,12 @@ the path of least friction.
   landing the characterisation tests **first**, in their own commit
   or PR, before the lift commit modifies them.  Numerical tolerance
   is documented per test case where bit-equivalence is not
-  achievable (notably the EFD path, where the C++ FFT implementation
-  may differ in last-bit accuracy from the Python reference).
+  achievable — e.g. floating-point operation ordering in the EFD
+  harmonic-integration sums may differ between Python's NumPy
+  reduction order and the C++ `Eigen::VectorXd::sum()` reduction
+  order, producing last-bit-of-double differences.  Neither
+  implementation uses FFT (both are direct closed-form sums per
+  the existing Python reference in `Liver/Liver.py`).
 - **C++ build-cost for iteration on the algorithm layer.**  Changes
   to the algorithm classes require a Slicer rebuild (10–60 min per
   [ADR-0004](0004-python-cpp-boundary.md)'s catalogue).  Acceptable


### PR DESCRIPTION
## Summary

Two co-dependent ADRs landing together to fix the v2.0.0 architecture for the
resection-planning workflow.  Both `Status: Proposed`; status flips to
`Accepted` on merge per `Docs/adr/README.md`.

### ADR-0014 — Dissolve LiverMarkups; fold interactive resection primitives into LiverResections

The `LiverMarkups` module disappears entirely in v2.0.0.  Its three
Markups-derived node pairs (`vtkMRMLMarkupsBezierSurfaceNode`,
`vtkMRMLMarkupsSlicingContourNode`, `vtkMRMLMarkupsDistanceContourNode`)
relocate into `LiverResections` as **non-Markups data nodes**, driven by a
single state-aware LayerDM Pipeline (per [ADR-0013](../blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md) §4)
that owns three state-conditional Representations:

- `SlicingPlaneInitRepresentation` when `(ResectionState=Init, InitializationMode=SlicingPlane)`,
- `DistanceSpheroidInitRepresentation` when `(ResectionState=Init, InitializationMode=DistanceSpheroid)`,
- `BezierPlanningRepresentation` when `(ResectionState=Planning, *)`.

The reframing is that `SlicingContour` and `DistanceContour` are **alternative
initialisation affordances** for the same Bezier surface — not independent
annotations.  Two forces push the Bezier surface off `vtkMRMLMarkupsNode`:
ring-aware right-click on the 4×4 control grid (interior / edge / corner
groups), and per-role glyph rendering through the existing
`vtkOpenGLBezierResectionPolyDataMapper` family in `LiverMarkups/VTKWidgets/`.
The dissolution lets a single `vtkLiverBezierWidget` subclass `vtkAbstractWidget`
directly with a clean left-drag / right-drag / right-click event table, and
makes the state machine first-class on `vtkMRMLLiverResectionNode`
(`ResectionState`, `InitializationMode`) instead of implicit in scene
contents.

Init control points persist across the Init→Planning transition (recoverable
Planning→Init drop-back).  Storage rides through `LiverResections`'
`.lrp.fcsv` with a schema bump.  This is a **D-class + N-class** break per
[ADR-0007](../blob/preview/Docs/adr/0007-version-numbering-policy.md), already
on the v1→v2 ticket.

### ADR-0015 — Lift parameterisation and fitting algorithms from Python to a C++ algorithm library under LiverResections

The Init→Planning transition's Bezier fit lifts out of three suspected-buggy
Python functions in `Liver/Liver.py` (`fit_bezier_surface`,
`runSurfacefromCurve`, `runSurfacefromEFD`) into a new
`LiverResections/Algorithm/` subdirectory housing four
`vtkPolyDataAlgorithm`-style classes:

| Class | Used by |
|---|---|
| `vtkLiverPlaneRingExtractor` | `SlicingPlaneInitRepresentation` |
| `vtkLiverSpheroidRingExtractor` | `DistanceSpheroidInitRepresentation` |
| `vtkLiverContourParameterizer` | `vtkLiverBezierFitter` |
| `vtkLiverBezierFitter` | Init→Planning transition |

Pure VTK, **no MRML dependency**, Python-wrapped via standard VTK wrapping,
tested under `Algorithm/Testing/Cxx/` with no Slicer import (the
[ADR-0008](../blob/preview/Docs/adr/0008-testing-strategy.md) C++ low-level
test layer — `ctest -R BezierFitter` is a one-line bug-repro).  Migration of
the three Python functions follows [ADR-0003](../blob/preview/Docs/adr/0003-testability-invariant.md)
characterisation discipline: characterisation tests on current Python
behaviour land first, then the lift inverts the assertion for bit-equivalence
(or documented numerical tolerance, e.g. on the EFD path).

This is the **first concrete realisation of [ADR-0004](../blob/preview/Docs/adr/0004-python-cpp-boundary.md)**'s
Python/C++ boundary; v2.1.0 work (volumetry, distance maps) follows the
same in-tree pattern.

## Cross-references

- **[ADR-0013](../blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md)
  §4 (state-aware Pipelines)** — ADR-0014 is its first concrete
  instantiation; the three Representations are owned by one Pipeline
  observing both its display node and `vtkMRMLLiverResectionNode`'s
  state-machine enums.
- **[ADR-0012](../blob/preview/Docs/adr/0012-layerdm-migration-v2-scope.md)
  amendment (sibling PR)** — the v2.0.0 migration map collapses to
  **T2 LiverResections all-in + T3 Resectogram**.  This PR documents the
  decision; the ADR-0012 amendment PR records it in the scope ADR.
- **[ADR-0011](../blob/preview/Docs/adr/0011-sct-terminology-dispatch.md)** —
  the new `vtkMRMLLiverBezierSurfaceDisplayNode` consumes SCT triples for
  colour / label decoration, replacing the hardcoded `HepaticContourColor` /
  `PortalContourColor` constants in the current `LiverMarkups` node
  constructors.
- **[ADR-0007](../blob/preview/Docs/adr/0007-version-numbering-policy.md)** —
  ADR-0014 carries the (D) and (N) MAJOR triggers under the v1→v2 jump;
  ADR-0015 deliberately avoids an (E) trigger by hosting the algorithms
  in-tree rather than depending on CGAL/libigl.
- **[ADR-0008](../blob/preview/Docs/adr/0008-testing-strategy.md)** —
  ADR-0014's Pipeline ships the three-tier test set (module +
  Representations + workflow with `render_interactive`); ADR-0015's library
  ships the C++ low-level test set.
- **PR #294** (characterisation harness) — extended by ADR-0014 step 1.
- **PR #315** (SCT terminology assets) — consumed by the new display node.
- **PR #316** (pytest scaffold) — hosts the Python wrapper tests for the
  ADR-0015 algorithm library.
- **PR #317** (workflow-diagram baseline) — `Docs/architecture/ui/liver-resections.md`
  refreshes against the state-aware Pipeline.

## Verification

- [x] Both files match `Docs/adr/0000-template.md` structure (Status,
      Date, Deciders, Diagrams, PR, Context, Decision, Alternatives
      considered, Consequences, References).
- [x] All forward references resolve (ADR-0014 ↔ ADR-0015 cross-link
      cleanly; both forward-reference the ADR-0012 amendment landing in a
      sibling PR and the ADR-0013 §4 amendment).
- [x] Code block in ADR-0014 §6 stays at 13 lines (under the ≤15-line
      ceiling).
- [x] ADR-0014 ships 3 Alternatives (A/B/C) and 4 Consequences as the
      brief specifies; ADR-0015 ships 4 Alternatives (A/B/C/D) and 4
      Consequences.
- [x] No source-code or build-system changes touched; this PR is
      `Docs/adr/` only.

## Test plan

- [ ] Human review of the two ADRs for prose register, decision
      precision, and alternative-rejection rationale.
- [ ] Confirm sibling ADR-0012 amendment and ADR-0013 §4 amendment PRs
      land before this one (or co-stack cleanly) so the cross-references
      resolve to `Accepted` ADRs on merge.
- [ ] On merge: flip both ADRs to `Status: Accepted` and fill the PR link
      per `Docs/adr/README.md`'s lifecycle convention.

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Plan and brief from the orchestrating Opus 4.7 session per the handoff at `.claude/handoff-2026-05-15-v2-architecture.md`; prose drafted by a Claude Code subagent. Opened for human review before merge.*