### PR TITLE
CI: skip Slicer build/test on docs-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # ---------------------------------------------------------------------
+      # Skip the ~6 min Slicer build + CTest run when a PR touches only
+      # documentation / ADRs / architecture diagrams / repo-level meta files.
+      #
+      # The job itself still spawns and reports success on docs-only PRs —
+      # this preserves the "build-test (slicer-main, Linux)" check name so
+      # future branch-protection rules requiring it continue to pass without
+      # needing to be reconfigured (a skipped *job* would block merges; a
+      # job whose steps no-op does not).
+      #
+      # Filter scope:
+      #   - Docs/**                       (ADRs, architecture diagrams, surveys)
+      #   - root-level *.md               (README, CONTRIBUTING, SECURITY, …)
+      #   - .github/pull_request_template.md and CODEOWNERS
+      #   - CITATION.cff / License.txt / COPYRIGHT.txt
+      #
+      # Filter is PR-scoped — push events (merge to preview, direct push,
+      # workflow_dispatch) always run the full build to catch any drift.
+      # ---------------------------------------------------------------------
+      - name: Detect docs-only change
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          predicate-quantifier: every
+          filters: |
+            docs-only:
+              - 'Docs/**'
+              - '*.md'
+              - '.github/pull_request_template.md'
+              - '.github/CODEOWNERS'
+              - 'CITATION.cff'
+              - 'License.txt'
+              - 'COPYRIGHT.txt'
+
+      - name: Report skip (docs-only PR)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.docs-only == 'true'
+        run: |
+          echo "::notice::Skipping Slicer build/test — this PR only touches documentation, ADRs, or repo-meta files."
+          echo "Filtered paths matched every changed file; build-test job reports success."
+
       - name: Verify Slicer build tree
+        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
         run: |
           set -euo pipefail
           test -f "${Slicer_DIR}/SlicerConfig.cmake" \
@@ -148,6 +190,7 @@ jobs:
           echo "Slicer_DIR=${Slicer_DIR}"
 
       - name: Configure
+        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
         run: |
           set -euo pipefail
           mkdir -p build
@@ -157,9 +200,11 @@ jobs:
             -DSlicer_DIR="${Slicer_DIR}"
 
       - name: Build
+        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
         run: cmake --build build --config Release -j "$(nproc)"
 
       - name: Test (CTest)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
         run: |
           set -euo pipefail
           cd build


### PR DESCRIPTION
## Summary
Save the ~6 min Slicer build + CTest run on PRs that touch only documentation. The `build-test (slicer-main, Linux)` job still spawns and reports `success` — only the inner build/test steps are gated.

## Why now
- Slicer build is ~6 min per PR. The last week's wave of ADR PRs (#301, #302, #303, #304, #314, #317, #318, plus the in-flight #323, #324, #326) were all pure documentation. Each ran the full Slicer build for zero verification value. The savings compound.
- This is the right time before T2 begins — once code PRs are flowing, the savings shift to the new docs-only ADR amendments that will accompany them.

## Approach
**Step-level conditionals inside the `build-test` job** rather than workflow-level `paths-ignore`. Reason: preserves the check name `build-test (slicer-main, Linux)` reporting `success`. If `preview` later gets `required_status_checks` (currently `null` — verified) the rule still passes for docs-only PRs, no reconfiguration needed.

Uses [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter) with `predicate-quantifier: every` — the filter satisfies only when *every* changed file matches the pattern (i.e. truly docs-only). A single non-docs change brings the full build back.

## Filter scope (what counts as docs-only)
- `Docs/**` — ADRs, architecture diagrams, surveys, UI workflows
- root-level `*.md` — README, CONTRIBUTING, SECURITY, NOTICE
- `.github/pull_request_template.md` and `.github/CODEOWNERS`
- `CITATION.cff`, `License.txt`, `COPYRIGHT.txt`

Notably **not** in the filter (i.e. still trigger build-test):
- `.github/workflows/**` — workflow changes can affect CI behaviour
- `Resources/**` — terminology JSONs are runtime assets
- `Testing/**`, `CMakeLists.txt`, `conftest.py`, `pytest.ini`
- any module-source tree (`Liver*/**`)

## Push events
The detect step is PR-scoped (`if: github.event_name == 'pull_request'`). Push events to `preview` (merges, direct pushes, `workflow_dispatch`) always run the full build — defensive against any drift between PR-time and merge-time state.

## Worked example
PRs #314 (PR template), #317 (workflow diagrams), #318 (a11y survey) would all have skipped. ~18 min of runner time saved across that trio alone.

## Test plan
- [ ] On a docs-only PR (this PR itself is *not* docs-only — it touches `.github/workflows/`), the detect step runs and the build/test steps skip with the `::notice::` message
- [ ] On a code-touching PR, behaviour is unchanged (verify by reviewing this PR's own CI run: it touches a workflow file, so build-test runs fully)
- [ ] On a push to `preview` after merging a docs-only PR, build-test still runs the full build

## UX impact
N/A — non-UI change (CI infrastructure).

## Cross-refs
- ADR-0005 (GitHub Actions CI)

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Opened for human review before merge.*