### PR TITLE
FIX: remove dead developerMode reference in LiverSegmentsWidget

### DIFF
--- a/LiverSegments/LiverSegments.py
+++ b/LiverSegments/LiverSegments.py
@@ -669,10 +669,6 @@ class LiverSegmentsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     return combinedPolyData.GetOutput()
 
   def onCalculateVascularTerritoryMapButton(self):
-    if self.developerMode is True:
-      import time
-      startTime = time.time()
-
     segmentationNode = self.ui.inputSurfaceSelector.currentNode()
     vascTerrSegmentationId = int(self.ui.selectedVascularTerritorySegmId.currentNode().GetAttribute("LiverSegments.SegmentationId"))
     centerlineModel = self.logic.build_centerline_model(self.colormap, vascTerrSegmentationId)
@@ -696,10 +692,6 @@ class LiverSegmentsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     slicer.app.resumeRender()
     qt.QApplication.restoreOverrideCursor()
-
-    if self.developerMode is True:
-      stopTime = time.time()
-      logging.info(f'Vascular Segments processing completed in {stopTime-startTime:.2f} seconds')
 
 # LiverSegmentsLogic
 #


### PR DESCRIPTION
## Summary

`LiverSegmentsWidget.onCalculateVascularTerritoryMapButton` guarded
two timing blocks on `self.developerMode`, an attribute that is never
assigned anywhere on the class. Both branches were therefore
unreachable — had either ever executed, it would have raised
`AttributeError`. This PR removes both dead branches; no other code
referenced the locals (`startTime`, `stopTime`) or the `import time`
that lived inside them.

This is **not** the `DeveloperMode` flag in
`vtkSlicerLiverMarkupsLogic`, which is intentional and gates the
`SlicingContour` / `DistanceContour` registration. That flag is
untouched.

## Diff

`LiverSegments/LiverSegments.py`, two hunks inside
`onCalculateVascularTerritoryMapButton`:

- Method head (was lines 672-675): removed
  `if self.developerMode is True: import time; startTime = time.time()`
- Method tail (was lines 700-703): removed
  `if self.developerMode is True: stopTime = time.time(); logging.info(...)`

Net: 8 deletions, 0 insertions. `python3 -m py_compile` clean.
`grep -rn 'developerMode' LiverSegments/` now returns no hits.

## Follow-ups surfaced

None within the LiverSegments tree. The only other in-repo hits for
`developerMode` are two already-commented-out lines in
`Liver/Liver.py` (lines 141, 153), which are out of scope per the
"do not touch files outside the LiverSegments module's source tree"
constraint on this task.

Closes #319

## Test plan

- [x] `python3 -m py_compile LiverSegments/LiverSegments.py`
- [x] `grep -rn 'developerMode' LiverSegments/` returns no hits
- [ ] CI runs the existing test suite on `preview`-base PRs
- [ ] Reviewer eyeballs the diff (8 lines, single method)

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Cleanup task drafted by a Claude Code subagent under the orchestrating Opus 4.7 session's plan. Opened for human review before merge.*