### PR TITLE
DOC: ADR-0002 — replace private-project reference with abstract phrasing

### DIFF
--- a/Docs/adr/0002-migrate-to-slicerlayerdm.md
+++ b/Docs/adr/0002-migrate-to-slicerlayerdm.md
@@ -86,7 +86,7 @@ addresses exactly these structural pains:
 - *Pipeline registration via factory + creator API* — replaces the
   string-based DM factory with typed registration.
 - *Internally validated*: the same LayerDM architecture has been
-  proven in our Hyperprobe project for resectogram-parallel
+  exercised in adjacent project work for resectogram-parallel
   functionalities — first-hand evidence that the framework scales
   past a single pipeline class and that we can build on it without
   hitting unforeseen ceilings.


### PR DESCRIPTION
## Summary
One-line scrub of a single phrase in ADR-0002 §Decision that named an internal private project ("our Hyperprobe project for resectogram-parallel functionalities"). External readers cannot follow the reference; replaced with "adjacent project work", which preserves the original claim (the LayerDM architecture has been exercised internally beyond a single pipeline class) without naming a non-public source.

## Why now
Surfaced while cross-checking ADR-0013 (PR #324 in flight) for the same issue. Same scrub applied there; this PR closes the gap for the already-merged ADR-0002.

## What does NOT change
- The technical claim — internal validation of the LayerDM architecture beyond a single pipeline class — stands.
- All other content in ADR-0002 is unchanged.
- This is not a re-decision; it is a public-readability cleanup.

## Test plan
- [ ] `grep -i hyperprobe Docs/` returns no hits after this and #324 merge

## UX impact
N/A — non-UI change (one-word ADR edit).

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. The reference was flagged during PR #324 review as inappropriate for a publicly-reachable ADR. Opened for human review before merge.*