### PR TITLE
STYLE: neutralise Guix-specific reference in Slicer host accessibility survey

### DIFF
--- a/Docs/architecture/slicer-host-accessibility-survey.md
+++ b/Docs/architecture/slicer-host-accessibility-survey.md
@@ -2,9 +2,8 @@
 
 - **Status:** Findings draft
 - **Date:** 2026-05-15
-- **Reference Slicer revision:** 5.8.1 source tree
-  (`slicer-source-5.8`, content-addressed via the guix-systole `slicer-skill`
-  package; commit hashes preserved by Guix).
+- **Reference Slicer revision:** Slicer 5.8.1 source tree
+  ([github.com/Slicer/Slicer @ `v5.8.1`](https://github.com/Slicer/Slicer/tree/v5.8.1)).
 - **Gates:** [ADR-0010 — Accessibility and i18n stance](../adr/0010-accessibility-and-i18n.md),
   Tier-2 commitments §§4–6 and the open-questions list.
 


### PR DESCRIPTION
## Summary
One-line scrub of `Docs/architecture/slicer-host-accessibility-survey.md` (lines 6–7). Replaces the Guix-specific provenance phrasing with a neutral pointer to the upstream Slicer git tag.

## What changed
- **Was**: `5.8.1 source tree (slicer-source-5.8, content-addressed via the guix-systole slicer-skill package; commit hashes preserved by Guix)`
- **Now**: `Slicer 5.8.1 source tree ([github.com/Slicer/Slicer @ v5.8.1](https://github.com/Slicer/Slicer/tree/v5.8.1))`

The reproducibility intent is preserved — readers can still pin the exact Slicer revision the survey was conducted against. Just without naming a specific Linux distribution / package manager that Slicer-Liver as a project is neutral to.

## Why
Following the convention from commit `c77ebf1` ("STYLE: Neutralise personal-environment leaks in arch scaffolding"). Slicer-Liver is platform-neutral; references to specific OS or package-manager tooling in repo content would confuse external contributors on Linux distributions other than the author's, or on macOS / Windows.

## Cross-refs
- PR #318 (where this survey originally landed)
- Companion: PR #330 has been amended to scrub a parallel Guix reference from its test docstring + PR body.

## UX impact
N/A — non-UI change (doc neutralisation).

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Personal-environment leakage was flagged by the maintainer; this PR applies the project's existing neutralisation convention. Opened for human review before merge.*