### PR TITLE
CI: make CTest output verbose to surface pytest_scaffold's per-test count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,5 +219,13 @@ jobs:
           # itself rather than fail.  Tracked as a follow-up; until
           # then, the CTest-level exclude keeps CI honestly green for
           # what it actually covers.
-          ctest --output-on-failure --no-tests=error \
+          # `-V` (verbose) dumps each test's stdout/stderr in the CI log
+          # regardless of pass/fail.  Replaces the prior `--output-on-failure`
+          # so that aggregated pytest entries (e.g. `pytest_scaffold` from
+          # ADR-0008's scaffold) reveal the per-pytest-test breakdown instead
+          # of just the CTest pass/fail line.  Trade-off: more noisy log
+          # (the native C++ tests also dump on success), accepted because
+          # CI logs are append-mostly archives and one-glance pytest
+          # visibility outweighs the line count.
+          ctest -V --no-tests=error \
                 --exclude-regex '^py_LiverSegmentsTest$'


### PR DESCRIPTION
## Summary
Replace `ctest --output-on-failure` with `ctest -V` (verbose) in the `build-test (slicer-main, Linux)` job. CI log will now include pytest's per-test breakdown inside `pytest_scaffold` (and any other aggregated CTest entries).

## Background
PR #316's pytest scaffold registers two CTest entries (`pytest_scaffold` + `pytest_scaffold_render_interactive`) that each invoke pytest on `Testing/Python/`. On preview today there are **23 pytest tests** inside those entries (3 scaffold smoke + 14 terminology + 4 bezier characterisation + 2 workflow dispatch), but the CI log shows only:
```
14/15 Test #14: pytest_scaffold .........................................   Passed    2.04 sec
```
The pytest summary is swallowed by `--output-on-failure` because the CTest entry passed. Reviewers cannot see the per-pytest-test pass/fail/skip count.

Verified locally with `PythonSlicer -m pytest Testing/Python/` against PR #330's tree:
```
============================== 23 passed, 1 skipped, 68 warnings in 8.47s ==============================
```
The single skip is `test_main_terminology_loads_in_slicer` — that one needs `slicer.modules.terminologies` which only resolves when Slicer's *app* is running (not just `PythonSlicer -m pytest`). Expected.

## What changes
- `.github/workflows/ci.yml` — single-line swap: `--output-on-failure` → `-V`. Inline comment explains the tradeoff.

## Tradeoff
The native C++ CTest entries (`qSlicerLiverMarkupsModule*Test` etc.) also dump their output on success now — more lines in the CI log. Acceptable because CI logs are append-mostly archives and one-glance pytest visibility is the higher-value end of the tradeoff for the v2.0.0 cycle.

## Cross-refs
- ADR-0005 (CI architecture)
- ADR-0008 (test layering — pytest is the primary)
- PR #316 (pytest scaffold + the two `pytest_scaffold` CTest entries)
- PR #330 (T1-A characterisation — first PR where the invisibility surfaced as a reviewer concern)

## UX impact
N/A — non-UI change (CI workflow).

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Reviewer flagged invisibility of pytest test counts in PR #330's CI; this PR addresses that visibility gap. Opened for human review before merge.*