### PR TITLE
ENH: ADR-0016 — adopt Slicer's style enforcement infrastructure verbatim

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,57 @@
+---
+ColumnLimit: 180
+Language: Cpp
+Standard: c++17
+
+BasedOnStyle: Mozilla # Based on LLVM
+# LLVM: https://github.com/llvm/llvm-project/blob/llvmorg-20.1.7/clang/lib/Format/Format.cpp#L1472-L1693
+# Mozilla: https://github.com/llvm/llvm-project/blob/llvmorg-20.1.7/clang/lib/Format/Format.cpp#L1897-L1921
+
+# LLVM-style overides
+AlignEscapedNewlines: Left
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBinaryOperators: NonAssignment
+ConstructorInitializerIndentWidth: 2
+IndentPPDirectives: AfterHash
+InsertBraces: true
+PackConstructorInitializers: Never
+PPIndentWidth: 1
+
+# Mozilla-style overides
+AllowShortFunctionsOnASingleLine: Inline
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+BreakBeforeBraces: Allman
+FixNamespaceComments: true
+SpaceAfterTemplateKeyword: true
+
+# A list of macros that should be interpreted as foreach loops instead of as
+# function calls.
+ForEachMacros:
+  - BOOST_FOREACH
+  - foreach
+  - forever
+  - QBENCHMARK
+  - QBENCHMARK_ONCE
+  - Q_FOREACH
+  - Q_FOREVER
+
+QualifierAlignment: Custom
+QualifierOrder:
+  - friend
+  - static
+  - inline
+  - constexpr
+  - const
+  - type
+SortIncludes: false
+
+---
+Language: JavaScript
+DisableFormat: true
+
+---
+Language: Json
+DisableFormat: true

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,17 @@
+# Commits listed here are skipped by `git blame` when a developer runs
+# `git config blame.ignoreRevsFile .git-blame-ignore-revs` (or uses an
+# editor / tool that respects this file by default — most modern ones do).
+#
+# This file follows Slicer's convention: list bulk-reformat / mechanical
+# style commits so that `git blame` for a line skips past the reformat and
+# reports the substantive author who last touched the logic.
+#
+# Add a new entry when landing a `STYLE:` commit that mechanically
+# reformats more than ~50 lines without changing behaviour.  Format:
+#
+#   # Brief description (date or PR #)
+#   <full SHA of the commit>
+#
+# References:
+#   - Slicer's .git-blame-ignore-revs (the upstream pattern this mirrors)
+#   - ADR-0016 — Code style discipline and CI enforcement

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,23 @@
+name: "Commit Message Check"
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - preview
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Slicer/slicer-check-commit-message-action@26db1d4a0580194025a00bff6f5c24a88c0efb9f # v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: CI (Lint)
+
+on:
+  # Triggers the workflow on push or pull request events
+  push:
+    branches: [preview]
+  pull_request:
+    branches:
+      - "*"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,57 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v6.0.0"
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+        exclude: ^\.clang-format$ # check-yaml do not support multi-document file
+      - id: debug-statements
+        exclude: "Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTestWidget.py|Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTest.py"
+      - id: end-of-file-fixer
+        exclude: "\\.(md5|svg|vtk|vtp)$|^Resources\\/[^\\/]+\\.h$|\\/ColorFiles\\/.+\\.txt$|Data\\/Input\\/.+$"
+      - id: mixed-line-ending
+        exclude: "\\.(svg|vtk|vtp)$"
+      - id: trailing-whitespace
+        exclude: "\\.(svg|vtk|vtp)$"
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.9
+    hooks:
+      - id: ruff-check
+        args: ["--fix", "--show-fixes"]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: "v22.1.2"
+    hooks:
+      - id: clang-format
+        # For support of legacy code.  The Slicer core no longer has files with .txx extensions.
+        # Explicitly include ".txx" files, which are not recognized as source files
+        # by the "identify" package used by pre-commit. To work around this,
+        # we manually specify file matching via the "files" regex and set "types_or"
+        # to allow formatting of files treated as plain text.
+        #
+        # Reference: https://github.com/pre-commit/identify/blob/main/identify/extensions.py
+        types_or: [file, text]
+        files: \.(cpp|cxx|h|hpp|hxx|txx)$
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
+    hooks:
+      - id: pyupgrade
+        args: [--py312-plus]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v4.0.0-alpha.8"
+    hooks:
+      - id: prettier
+        types_or: [yaml]
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: "0.37.1"
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows

--- a/Docs/adr/0016-code-style-and-lint.md
+++ b/Docs/adr/0016-code-style-and-lint.md
@@ -1,0 +1,246 @@
+# 0016. Code style discipline and CI enforcement (adopt Slicer's infrastructure)
+
+- **Status:** Proposed
+- **Date:** 2026-05-16
+- **Deciders:** Rafael Palomar
+- **Diagrams:** N/A
+- **PR:** _filled in on merge_
+
+## Context
+
+Slicer-Liver v2.0.0 work has shifted to an agentic-development pattern
+(see PRs #301–#334, T1-A through T2 Stack 1).  Agents produce code
+that compiles and tests pass but often diverges from project
+conventions — brace style, header guards, naming, indentation,
+trailing whitespace, line endings, Python idiom drift.  Each
+divergence is small; aggregated across a release cycle they shift
+human-reviewer load from *"is this architecturally right?"* to
+*"are these braces in the wrong place?"*.  Style noise drowns out
+substance feedback exactly when substance review matters most.
+
+Slicer itself solved this problem.  Upstream
+[`Slicer/Slicer`](https://github.com/Slicer/Slicer) ships:
+
+- `.clang-format` (Mozilla-based with overrides — Allman braces,
+  `ColumnLimit: 180`, sorted includes, `BreakBeforeBraces: Allman`,
+  templates always broken, etc.).
+- `.pre-commit-config.yaml` orchestrating:
+  - `pre-commit/pre-commit-hooks` general checks (large files, merge
+    conflict markers, end-of-file fixer, mixed-line-ending, trailing
+    whitespace, YAML syntax, debug-statement detection).
+  - `astral-sh/ruff-pre-commit` for Python lint + autofix.
+  - `pre-commit/mirrors-clang-format` for C++ formatting.
+  - `asottile/pyupgrade` to keep Python idioms current (`--py312-plus`).
+  - `pre-commit/mirrors-prettier` for YAML.
+  - `python-jsonschema/check-jsonschema` for Dependabot + workflow
+    schema validation.
+- `.github/workflows/lint.yml` running `pre-commit/action@v3.0.1` on
+  every PR.  The action's default behaviour is to run hooks only on
+  PR-touched files — built-in gradual cutover; existing un-reformatted
+  files are grandfathered until something touches them.
+- `.github/workflows/commit-message.yml` running Slicer's own
+  `slicer-check-commit-message-action` so commit subjects follow the
+  project's `STYLE:` / `BUG:` / `ENH:` / `DOC:` / `FIX:` / `COMP:` /
+  `TEST:` prefix convention.
+- `.git-blame-ignore-revs` listing bulk-reformat commits so
+  `git blame` skips past mechanical changes.
+
+The conventions and tools are stable, well-tested across years of
+upstream Slicer development, and applied uniformly to extensions
+maintained inside the Slicer organization.  Re-deriving any of this
+from first principles would duplicate upstream maintenance for zero
+project-specific value.
+
+## Decision
+
+Slicer-Liver **mirrors Slicer's style enforcement infrastructure
+verbatim**, adapted only for repository-specific paths (branch refs).
+Specifically:
+
+1. **`.clang-format`** — copied verbatim from upstream Slicer.
+2. **`.pre-commit-config.yaml`** — copied verbatim from upstream
+   Slicer (same hooks, same versions, same exclusions).
+3. **`.github/workflows/lint.yml`** — copied from upstream Slicer with
+   one adaptation: branch references changed from `main` to `preview`
+   to match Slicer-Liver's branch model (per
+   [ADR-0006](0006-branch-model.md)).
+4. **`.github/workflows/commit-message.yml`** — same: branch ref
+   adaptation only.  Uses upstream's
+   `Slicer/slicer-check-commit-message-action` directly.
+5. **`.git-blame-ignore-revs`** — initially empty (or carrying only a
+   header note); entries appended when bulk-reformat commits land.
+
+### Cutover discipline
+
+The `pre-commit/action`'s default behaviour — run hooks only on
+PR-touched files — gives us automatic gradual cutover: new code is
+enforced from this ADR forward, existing un-reformatted code is
+grandfathered until something touches it.
+
+Per-module **bulk-reformat commits** are expected to land as part of
+the LayerDM migration cascade:
+
+- **T2 Stack 7** (LiverMarkups retirement + LiverResections rewrite)
+  ships a `STYLE:` commit reformatting all of `LiverResections/` and
+  the new `Algorithm/` subdirectory in one shot.
+- **v2.1.0 LayerDM expansions** (per ADR-0012's deferred modules)
+  reformat their target module the same way.
+
+Each bulk-reformat commit is appended to `.git-blame-ignore-revs` so
+`git blame` for the affected lines reports the substantive author who
+last touched the logic, not the mechanical reformat.
+
+### Upstream-tracking discipline
+
+When Slicer updates its `.clang-format` or `.pre-commit-config.yaml`,
+Slicer-Liver mirrors the change within a reasonable cadence
+(target: within one release cycle, or sooner if the change fixes a
+correctness bug).  Mirroring is a mechanical diff-and-apply, not a
+re-design discussion.  Significant divergence from upstream is itself
+a decision warranting a follow-on ADR.
+
+### For agentic development specifically
+
+Agents producing Slicer-Liver code:
+
+1. **Locally**: run `pre-commit run --all-files` before pushing.  The
+   pre-commit hook surfaces and (where possible) auto-fixes style
+   issues *before* the CI gate sees them.
+2. **On the CI gate**: the `lint.yml` workflow re-runs the hooks on
+   PR-touched files.  If the agent's push omitted the local
+   pre-commit run, CI fails with a clear diff showing what's wrong;
+   the agent (or a follow-on agent) re-runs the formatter and pushes
+   a fixup commit.
+3. **In agent prompts**: the orchestrating session should mention
+   "run `pre-commit run --all-files` before opening the PR" in the
+   standard agent brief.  Future iteration may bake this into a
+   pre-PR-push checklist captured in `~/.claude/projects/<…>/memory/`.
+
+## Alternatives considered
+
+### A. Roll our own style configuration
+
+Pick `.clang-format` knobs from first principles, adopt only the
+subset of pre-commit hooks Slicer-Liver "needs", maintain the lint
+workflow independently of upstream.
+
+**Rejected** because the upstream Slicer infrastructure is the
+working answer to a problem the Slicer ecosystem has already solved.
+Duplicating it means signing up to track upstream's improvements
+manually, drift from upstream conventions, and surface a different
+style "feel" to contributors who also work on Slicer core or other
+Slicer extensions.  No project-specific value justifies the
+divergence.
+
+### B. Defer until v2.1.0
+
+Keep style enforcement informal for v2.0.0 (relying on reviewer
+attention), introduce the tooling in v2.1.0 after T2 settles.
+
+**Rejected** because the cost of setting it up now is small (one ADR
++ one tooling PR) and the cost-savings compound across every agent-
+produced PR from this ADR forward.  The longer we wait, the more
+un-reformatted code accumulates and the larger the eventual
+reformat cost.
+
+### C. Lint-on-all-files instead of lint-on-PR-touched-files
+
+Configure the CI workflow to run `pre-commit run --all-files`
+unconditionally, forcing the entire codebase to conform at the
+moment this ADR lands.
+
+**Rejected** because the existing C++ in `Liver/`, `LiverMarkups/`,
+`LiverResections/`, `LiverSegments/`, `LiverVolumetry/` doesn't yet
+conform to Slicer's `.clang-format`.  A big-bang reformat would
+either gate this ADR on doing the reformat first (delaying the
+benefit for unrelated PRs) or generate a wall of CI failures on
+every PR that touches existing files.  The `pre-commit/action`
+default — touch-list-only — is the gradual-cutover path that
+sidesteps both pains.
+
+### D. Pre-commit only, no CI gate
+
+Install the pre-commit hook locally; trust contributors to run it
+before push; no CI enforcement.
+
+**Rejected** because agentic development weakens the trust premise.
+Local pre-commit hooks only fire if the contributor's environment is
+configured for them; an agent running in a fresh worktree does not
+have the hook installed unless its prompt arranges it.  The CI gate
+is the load-bearing enforcement.  Local pre-commit is the developer-
+ergonomics layer on top.
+
+## Consequences
+
+### Easier
+
+- **Review load shifts from style to substance.**  Reviewers stop
+  flagging brace placement and start engaging with architecture.
+- **Agentic-PR review becomes mechanical at the style layer.**  An
+  agent's PR either passes the lint gate (style is conformant by
+  definition — the formatter ran) or it doesn't (the agent or a
+  follow-up agent runs `pre-commit run --all-files`, commits the
+  result, re-pushes).
+- **Upstream-aligned developer experience.**  Anyone who has worked
+  on Slicer core or another Slicer-org extension finds the same
+  conventions, the same hook list, the same commit-message
+  expectations.
+- **`git blame` stays useful** across the bulk-reformat commits
+  because of `.git-blame-ignore-revs`.
+
+### Harder
+
+- **One more required CI check** (`lint`).  Branch protection on
+  `preview` may need to add it to its required-status-checks list
+  once configured.
+- **First-time contributor setup** requires installing pre-commit
+  (`pip install pre-commit; pre-commit install`).  Document in
+  CONTRIBUTING.md (separate small PR) and in agent briefs.
+- **Bulk-reformat commits disrupt `git blame`** at the line-history
+  level, but `.git-blame-ignore-revs` mitigates this for any tool
+  that respects it (GitHub's blame UI does; most editors do).
+- **Upstream-tracking discipline** is a recurring small task — when
+  Slicer bumps `clang-format` version or adds a hook, this project
+  needs to mirror within a reasonable cadence.  Schedule as a
+  quarterly mirror review at the start; revisit cadence if it
+  becomes friction.
+
+## Open questions
+
+These do not block adoption:
+
+- **Branch protection** — should `lint` join `build-test` as a
+  required status check on `preview`?  Deferred to a separate
+  branch-protection PR (independent of this ADR).
+- **CONTRIBUTING.md update** — adding a "First-time setup: install
+  pre-commit" line is a separate small PR.
+- **Commit-message format strictness** — the upstream
+  `slicer-check-commit-message-action` enforces a specific prefix
+  vocabulary (`STYLE:`, `BUG:`, `ENH:`, etc.).  Existing
+  Slicer-Liver commit history is mostly conformant but not
+  universally; the action may flag historical-style commits when
+  PRs include them.  Tolerable; the action operates on commits
+  in the PR, not on `preview`'s entire history.
+
+## References
+
+- [Slicer's style guide](https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html)
+  — narrative documentation of the conventions enforced by the
+  tooling adopted in this ADR.
+- [`Slicer/Slicer` `.clang-format`](https://github.com/Slicer/Slicer/blob/main/.clang-format)
+  — the source-of-truth file copied verbatim.
+- [`Slicer/Slicer` `.pre-commit-config.yaml`](https://github.com/Slicer/Slicer/blob/main/.pre-commit-config.yaml)
+  — the source-of-truth hook orchestration.
+- [`pre-commit/action`](https://github.com/pre-commit/action) — the
+  GitHub Action used by `lint.yml`.
+- [`Slicer/slicer-check-commit-message-action`](https://github.com/Slicer/slicer-check-commit-message-action)
+  — the commit-message action.
+- [ADR-0005](0005-github-actions-ci.md) — establishes the GitHub
+  Actions CI workflow this lint job joins.
+- [ADR-0006](0006-branch-model.md) — the branch model
+  (`main` / `preview`) the workflow's branch refs adapt to.
+- [ADR-0008](0008-testing-strategy.md) — test discipline parallel
+  to this ADR's style discipline.
+- [ADR-0009](0009-ux-and-design-discipline.md) — review-blocking
+  discipline ancestor; this ADR is the analogous discipline for
+  *style*, just as ADR-0003 is for *behaviour testability*.


### PR DESCRIPTION
## Summary
Mirrors Slicer's style enforcement infrastructure into Slicer-Liver — same `.clang-format`, same pre-commit hook list, same lint workflow, same commit-message check. Adapted only branch refs (`main` → `preview` per ADR-0006).

## Files added
- `.clang-format` — verbatim from upstream Slicer (Mozilla-based with overrides: Allman braces, `ColumnLimit: 180`, etc.)
- `.pre-commit-config.yaml` — verbatim: orchestrates `pre-commit-hooks` + `ruff-pre-commit` + `mirrors-clang-format` + `pyupgrade` + `mirrors-prettier` + `check-jsonschema`
- `.github/workflows/lint.yml` — runs `pre-commit/action@v3.0.1` on PR / `preview` push
- `.github/workflows/commit-message.yml` — runs `Slicer/slicer-check-commit-message-action`
- `.git-blame-ignore-revs` — initially header-only; populated when bulk-reformat commits land
- `Docs/adr/0016-code-style-and-lint.md` — ADR capturing the decision

## Cutover discipline
`pre-commit/action`'s default behaviour is to run hooks only on PR-touched files — built-in gradual cutover. New code is enforced from this ADR forward; existing un-reformatted code is grandfathered until something touches it. Per-module bulk-reformat commits land with the LayerDM migration cascade (T2 Stack 7 reformats `LiverResections/`; v2.1.0 expansions reformat their target modules). Each bulk-reformat commit appends to `.git-blame-ignore-revs`.

## What does NOT change
- No existing source code is reformatted in this PR. The first lint run after merge will only enforce on subsequent PRs' touched files.
- No new required-status-check rule is added; that's a separate branch-protection decision.

## Why mirror, not roll our own
- Upstream Slicer has already solved this problem with a stable, well-tested setup applied across the Slicer ecosystem.
- Slicer-Liver developers / agents who also work on Slicer core or other Slicer-org extensions encounter the same conventions — no context-switching tax.
- Mirroring is a mechanical diff-and-apply when upstream updates; rolling our own would sign us up for independent maintenance forever.

## For agentic development
Agents are expected to run `pre-commit run --all-files` before pushing. If they forget, CI lints the PR-touched files and reports a clear diff; the agent (or a follow-on agent) re-runs the formatter and pushes a fixup commit. The CI gate is the load-bearing enforcement; local pre-commit is the developer-ergonomics layer.

## Test plan
- [ ] On merge, `lint` and `commit-message` jobs appear in the CI matrix.
- [ ] A trivially-style-broken PR (e.g. trailing whitespace) against `preview` fails the `lint` job.
- [ ] A subsequent PR that touches a file matching the project's style conventions passes the `lint` job without action.
- [ ] The `commit-message` job accepts the existing `STYLE:` / `BUG:` / `ENH:` / `DOC:` / `FIX:` / `COMP:` / `TEST:` prefix vocabulary.

## UX impact
N/A — non-UI change (infrastructure).

## Cross-refs
- ADR-0005 (GitHub Actions CI) — the workflow this lint job joins
- ADR-0006 (branch model) — explains the `main` → `preview` adaptation
- ADR-0008 (testing strategy) — parallel discipline for behaviour testability; this ADR is the parallel discipline for style
- ADR-0009 (UX discipline) — analogous review-blocking discipline ancestor

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. ADR + tooling mirroring drafted by the orchestrating Opus 4.7 session at the maintainer's direction to mirror upstream rather than reinvent. Opened for human review before merge.*