### PR TITLE
DOC: ADR-0015 — correct Eigen acquisition path (via ITK bundle, not Slicer superbuild)

### DIFF
--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -165,11 +165,25 @@ what the parent module already pulls in:
 - **Eigen** (MPL2, header-only) — linear algebra for the Bezier
   pseudo-inverse fit (`(N^T N)^{-1} N^T` style normal-equation
   solves on the 4×4 basis matrices and the per-axis matrix
-  multiply) and the EFD harmonic-integration sums.  Slicer's
-  superbuild ships Eigen (`Slicer_USE_Eigen` defaults on in
-  current Slicer main); enabled via `find_package(Eigen3 REQUIRED)`
-  from the new CMakeLists.  **No new external dep is introduced
-  beyond what Slicer's superbuild already provides.**
+  multiply) and the EFD harmonic-integration sums.  Slicer does
+  **not** ship Eigen as a top-level superbuild dependency; the
+  reachable Eigen3 `find_package(Eigen3 CONFIG REQUIRED)` target
+  comes from **ITK's bundled `ITKInternalEigen3` private tree**
+  (ITK is mandatory in any Slicer extension via `Slicer_USE_FILE`,
+  so `${ITK_DIR}` is in scope).  The new CMakeLists points
+  `find_package` at that bundled config via:
+
+  ```cmake
+  find_package(ITK REQUIRED)
+  find_package(Eigen3 REQUIRED CONFIG
+    HINTS
+      "${ITK_DIR}/ITKInternalEigen3-build"
+      "${ITK_DIR}/../ITK-build/ITKInternalEigen3-build"
+  )
+  ```
+
+  **No new external dep is introduced** — Eigen is reached
+  transitively through ITK, which is already mandatory.
 
 Deliberately **not** required:
 


### PR DESCRIPTION
## Summary

One-paragraph correction to ADR-0015 §2. The ADR claimed Eigen is reached via a `Slicer_USE_Eigen` superbuild toggle; that toggle does not exist on the public Slicer surface. Eigen ships privately inside ITK as the bundled `ITKInternalEigen3` header-only tree, and Slicer extensions reach a public `Eigen3::Eigen` target by pointing `find_package(Eigen3 CONFIG)` at `\${ITK_DIR}/ITKInternalEigen3-build`.

This misclaim caused the first CI failure on PR #334 (Stack 1 algorithm library) — the agent followed the ADR wording literally and `Eigen/Core` failed to resolve. Fix landed there in commits `9f4c715` + `a640f0b`. This PR updates the ADR so the next stack's agent does not retread the same misstep.

The conclusion of §2 — *"no new external dep is introduced"* — still holds: ITK is mandatory in any Slicer extension and Eigen comes through it transitively. Only the *mechanism* is corrected.

## Test plan

- [x] No code change, no CI gate beyond docs-lint.
- [x] Reproducible against PR #334's CMakeLists (`LiverResections/Algorithm/CMakeLists.txt:39-44`) which uses the same `HINTS \${ITK_DIR}/ITKInternalEigen3-build` form documented here.

## UX impact

N/A — non-UI change.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code. Opened for human review.*