### PR TITLE
FIX: docs-only paths filter — single brace-expanded pattern (PR #327 regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,13 @@ jobs:
       # Filter is PR-scoped — push events (merge to preview, direct push,
       # workflow_dispatch) always run the full build to catch any drift.
       # ---------------------------------------------------------------------
+      # dorny/paths-filter@v3 with `predicate-quantifier: every` matches
+      # *every* changed file against *every* pattern in the filter list
+      # (rather than the union of patterns), so listing the docs paths as
+      # separate list entries fails for any single file that doesn't satisfy
+      # all of them simultaneously — surfaced by PR #340 (one ADR change,
+      # didn't skip).  Consolidate to a single brace-expanded pattern so the
+      # quantifier sees one alternation that each file must match.
       - name: Detect docs-only change
         id: changes
         if: github.event_name == 'pull_request'
@@ -167,13 +174,7 @@ jobs:
           predicate-quantifier: every
           filters: |
             docs-only:
-              - 'Docs/**'
-              - '*.md'
-              - '.github/pull_request_template.md'
-              - '.github/CODEOWNERS'
-              - 'CITATION.cff'
-              - 'License.txt'
-              - 'COPYRIGHT.txt'
+              - '{Docs/**,*.md,.github/pull_request_template.md,.github/CODEOWNERS,CITATION.cff,License.txt,COPYRIGHT.txt}'
 
       - name: Report skip (docs-only PR)
         if: github.event_name == 'pull_request' && steps.changes.outputs.docs-only == 'true'


### PR DESCRIPTION
## Summary

PR #327 added a docs-only skip on the `build-test (slicer-main, Linux)` job using `dorny/paths-filter@v3` with `predicate-quantifier: every` and a list of glob patterns. The intent was *"every changed file matches at least one of these patterns"* — i.e. the union. But `every` in `dorny/paths-filter@v3` actually means *"every changed file matches every pattern in the list"*, which is impossible for any single file (it can be under `Docs/` or be a root `*.md`, never both).

**Surfaced by PR #340** (the ADR-0015 Eigen amendment): one file change at `Docs/adr/0015-cpp-algorithm-library.md`; action log reported `Filter docs-only = false / Matching files: none`; the full ~7-min Slicer build ran on a docs-only PR.

Fix: consolidate the list into a single brace-expanded pattern. Under `every` this becomes *"every changed file matches this one (alternation) pattern"* — the intended semantic. Brace expansion is flattened to a single level to dodge picomatch nested-brace edge cases.

## Test plan

- [x] Workflow YAML lints OK locally.
- [ ] This PR itself touches only `.github/workflows/ci.yml` — once the fix lands on `preview`, **the next docs-only PR self-tests** that the build is skipped.
- [ ] This PR is *not* docs-only (it edits the workflow), so it correctly runs the full build. Confirms the negative case still works.

## UX impact

N/A — non-UI change.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code. Opened for human review.*