### PR TITLE
BUG: Restrict pre-commit lint to PR-touched files (ADR-0016 cutover fix)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      # ADR-0016 §"Cutover discipline" commits to "run hooks only on
+      # PR-touched files" so existing un-reformatted code is grandfathered
+      # until something touches it.  The pre-commit/action default is
+      # `extra_args: --all-files`, which checks every file in the repo —
+      # surfaced by PR #341 (T2 Stack 2) where Lint failed on ~19 unrelated
+      # files (`Paper/`, `LiverSegments/`, `LiverVolumetry/`, etc.).
+      # Restrict to PR-diff on pull_request events; push events to preview
+      # still run --all-files to catch any drift on the trunk.
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: ${{ github.event_name == 'pull_request' && format('--from-ref {0} --to-ref {1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || '--all-files' }}


### PR DESCRIPTION
## Summary

PR #336 copied Slicer's `lint.yml` verbatim, but `pre-commit/action@v3.0.1`'s default `extra_args: --all-files` makes the action check every file in the repository. That's incompatible with ADR-0016 §"Cutover discipline":

> "The `pre-commit/action`'s default behaviour — run hooks only on PR-touched files — gives us automatic gradual cutover: new code is enforced from this ADR forward, existing un-reformatted code is grandfathered until something touches it."

That promise was based on a misreading of the action's defaults. **Surfaced by PR #341 (T2 Stack 2)** — its Lint check failed on ~19 pre-existing files (`Paper/`, `LiverSegments/`, `LiverVolumetry/`, `LiverMarkups/MRMLDM/`, `LiverResections/MRMLDM/`, `README.md`, `.github/pull_request_template.md`) that the PR itself never modified.

## Fix

Pass `--from-ref <base> --to-ref <head>` to the action for `pull_request` events so pre-commit only runs hooks against files changed in the PR. Push events to `preview` continue running `--all-files` to catch any drift on the trunk.

```yaml
- uses: pre-commit/action@v3.0.1
  with:
    extra_args: \${{ github.event_name == 'pull_request' && format('--from-ref {0} --to-ref {1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || '--all-files' }}
```

## Test plan

- [x] **Self-testing**: this PR touches only the workflow file, so its own Lint check exercises the fix on a 1-file diff (the workflow YAML itself). Expected: Lint passes.
- [ ] **After merge**: PR #341's next Lint re-run (after rebase or empty-commit push) will only check the files #341 actually modifies. Expected: only modifications #341 introduces are flagged.

## What this PR does NOT do

The bulk-reformat that retires the pre-existing whitespace debt is still expected per ADR-0016 §"Cutover discipline" — at T2 Stack 7 for `LiverResections/` + `Algorithm/`, and at the matching v2.1.0 cascade for each deferred module. This PR is the predicate that lets those land gradually rather than as a single big-bang.

## UX impact

N/A — non-UI change.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code. Opened for human review.*