### PR TITLE
BUG: Lint workflow needs fetch-depth: 0 for pre-commit --from-ref

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 is required by the pre-commit/action --from-ref step
+      # below — pre-commit invokes `git diff --name-only <base>..<head>` to
+      # build the PR-touched file list, and the default shallow clone
+      # (fetch-depth: 1) doesn't have the base commit reachable.  Surfaced
+      # by PR #345 (ADR-0014 amendment) when PR #344's cutover became
+      # live: lint failed with `CalledProcessError: git diff …<base>..<head>`
+      # because the base commit was not in the local clone.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:


### PR DESCRIPTION
## Summary

PR #344 added a ternary that passes `--from-ref <base> --to-ref <head>` to `pre-commit/action` on `pull_request` events, restricting hooks to PR-touched files per ADR-0016 §"Cutover discipline". But pre-commit implements `--from-ref` by shelling out to `git diff --name-only <base>..<head>` to compute the file list, and `actions/checkout`'s default shallow clone (`fetch-depth: 1`) doesn't include the base commit in the local clone — `git diff` errors out.

**Surfaced by PR #345** (ADR-0014 Bezier rename amendment) after it was force-push-rebased onto post-#344 preview: the lint run reported

```
CalledProcessError: command: ('git', 'diff', '--name-only', '--no-ext-diff', '-z',
  'eff1bdfa...<head>')
```

and exited code 3.

## Fix

Set `fetch-depth: 0` on the `actions/checkout` step in `.github/workflows/lint.yml`. Full history adds a few seconds to the clone but makes the pre-commit `--from-ref` path reliable across any base/head pair.

## Test plan

- [x] **Self-testing**: this PR's own Lint check fetches deeper history; pre-commit sees only the workflow file in the diff (clean YAML), hook chain should pass.
- [ ] **After merge**: PR #345's Lint, when re-triggered against post-this-merge preview, should pass cleanly on the single touched ADR file.

## UX impact

N/A — non-UI change.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code. Opened for human review.*