### PR TITLE
ENH: Add TerminologyEntry field to vtkMRMLBezierSurfaceDisplayNode (ADR-0011 + ADR-0013 §3)

### DIFF
--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
@@ -240,30 +240,38 @@ int testXMLRoundTrip()
   float ra[3], rb[3];
   source->GetResectionColor(rb);
   sink->GetResectionColor(ra);
-  for (int j = 0; j < 3; ++j) { CHECK_DOUBLE_TOLERANCE(ra[j], rb[j], 1e-5); }
+  for (int j = 0; j < 3; ++j)
+  {
+    CHECK_DOUBLE_TOLERANCE(ra[j], rb[j], 1e-5);
+  }
   source->GetResectionGridColor(rb);
   sink->GetResectionGridColor(ra);
-  for (int j = 0; j < 3; ++j) { CHECK_DOUBLE_TOLERANCE(ra[j], rb[j], 1e-5); }
+  for (int j = 0; j < 3; ++j)
+  {
+    CHECK_DOUBLE_TOLERANCE(ra[j], rb[j], 1e-5);
+  }
   source->GetResectionMarginColor(rb);
   sink->GetResectionMarginColor(ra);
-  for (int j = 0; j < 3; ++j) { CHECK_DOUBLE_TOLERANCE(ra[j], rb[j], 1e-5); }
+  for (int j = 0; j < 3; ++j)
+  {
+    CHECK_DOUBLE_TOLERANCE(ra[j], rb[j], 1e-5);
+  }
   source->GetUncertaintyMarginColor(rb);
   sink->GetUncertaintyMarginColor(ra);
-  for (int j = 0; j < 3; ++j) { CHECK_DOUBLE_TOLERANCE(ra[j], rb[j], 1e-5); }
+  for (int j = 0; j < 3; ++j)
+  {
+    CHECK_DOUBLE_TOLERANCE(ra[j], rb[j], 1e-5);
+  }
 
-  CHECK_DOUBLE_TOLERANCE(sink->GetResectionOpacity(),
-                         source->GetResectionOpacity(), 1e-5);
+  CHECK_DOUBLE_TOLERANCE(sink->GetResectionOpacity(), source->GetResectionOpacity(), 1e-5);
   CHECK_BOOL(sink->GetGridVisibility(), source->GetGridVisibility());
-  CHECK_DOUBLE_TOLERANCE(sink->GetGridDivisions(),
-                         source->GetGridDivisions(), 1e-5);
-  CHECK_DOUBLE_TOLERANCE(sink->GetGridThickness(),
-                         source->GetGridThickness(), 1e-5);
+  CHECK_DOUBLE_TOLERANCE(sink->GetGridDivisions(), source->GetGridDivisions(), 1e-5);
+  CHECK_DOUBLE_TOLERANCE(sink->GetGridThickness(), source->GetGridThickness(), 1e-5);
   CHECK_BOOL(sink->GetGrid3DVisibility(), source->GetGrid3DVisibility());
   CHECK_BOOL(sink->GetGrid2DVisibility(), source->GetGrid2DVisibility());
   CHECK_BOOL(sink->GetWidgetVisibility(), source->GetWidgetVisibility());
   CHECK_BOOL(sink->GetClipOut(), source->GetClipOut());
-  CHECK_BOOL(sink->GetInterpolatedMargins(),
-             source->GetInterpolatedMargins());
+  CHECK_BOOL(sink->GetInterpolatedMargins(), source->GetInterpolatedMargins());
   CHECK_BOOL(sink->GetShowResection2D(), source->GetShowResection2D());
   CHECK_BOOL(sink->GetMirrorDisplay(), source->GetMirrorDisplay());
   return EXIT_SUCCESS;
@@ -271,18 +279,16 @@ int testXMLRoundTrip()
 
 /// Assert that calling ``setter()`` advances ``node->GetMTime()``.
 /// Helper macro so the per-setter scaffolding stays terse.
-#define EXPECT_MTIME_ADVANCES(NODE, SETTER_CALL)                              \
-  do                                                                         \
-  {                                                                          \
-    const vtkMTimeType _baseline = (NODE)->GetMTime();                       \
-    SETTER_CALL;                                                             \
-    if ((NODE)->GetMTime() <= _baseline)                                     \
-    {                                                                        \
-      std::cerr << "Expected MTime to advance after " #SETTER_CALL           \
-                << " (baseline=" << _baseline                                \
-                << ", post=" << (NODE)->GetMTime() << ")\n";                 \
-      return EXIT_FAILURE;                                                   \
-    }                                                                        \
+#define EXPECT_MTIME_ADVANCES(NODE, SETTER_CALL)                                                                                              \
+  do                                                                                                                                          \
+  {                                                                                                                                           \
+    const vtkMTimeType _baseline = (NODE)->GetMTime();                                                                                        \
+    SETTER_CALL;                                                                                                                              \
+    if ((NODE)->GetMTime() <= _baseline)                                                                                                      \
+    {                                                                                                                                         \
+      std::cerr << "Expected MTime to advance after " #SETTER_CALL << " (baseline=" << _baseline << ", post=" << (NODE)->GetMTime() << ")\n"; \
+      return EXIT_FAILURE;                                                                                                                    \
+    }                                                                                                                                         \
   } while (0)
 
 int testModifiedEventsOnSetters()
@@ -340,16 +346,14 @@ int testTerminologyEntryRoundTrip()
 
   // Realistic SCT triple — Liver, anatomical structure category, no
   // modifier.  The canonical format is documented on the field.
-  const std::string sct =
-    "SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^";
+  const std::string sct = "SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^";
   const vtkMTimeType baseline = node->GetMTime();
   node->SetTerminologyEntry(sct);
   CHECK_STRING(node->GetTerminologyEntry().c_str(), sct.c_str());
   if (node->GetMTime() <= baseline)
   {
     std::cerr << "Expected MTime to advance after SetTerminologyEntry"
-              << " (baseline=" << baseline
-              << ", post=" << node->GetMTime() << ")\n";
+              << " (baseline=" << baseline << ", post=" << node->GetMTime() << ")\n";
     return EXIT_FAILURE;
   }
 
@@ -358,8 +362,7 @@ int testTerminologyEntryRoundTrip()
   // commit 07474f2 — project discipline) and the parser decodes
   // them on read.  The triple format itself uses ``^`` and ``~``
   // which are XML-safe, but ``&`` and ``<`` must round-trip too.
-  const std::string hostile =
-    "SCT^123037004^Cat & <Type>~SCT^10200004^Liver~^^";
+  const std::string hostile = "SCT^123037004^Cat & <Type>~SCT^10200004^Liver~^^";
   vtkNew<vtkMRMLBezierSurfaceDisplayNode> source;
   vtkNew<vtkMRMLScene> scene;
   source->SetScene(scene.GetPointer());
@@ -372,16 +375,14 @@ int testTerminologyEntryRoundTrip()
   // The terminologyEntry attribute must be present.
   if (xml.find("terminologyEntry=\"") == std::string::npos)
   {
-    std::cerr << "WriteXML output missing terminologyEntry attribute:\n"
-              << xml << "\n";
+    std::cerr << "WriteXML output missing terminologyEntry attribute:\n" << xml << "\n";
     return EXIT_FAILURE;
   }
   // Hostile chars must be XML-encoded in the on-wire form (else
   // the resulting XML would be malformed).
   if (xml.find("Cat & <Type>") != std::string::npos)
   {
-    std::cerr << "WriteXML output contains unencoded hostile chars:\n"
-              << xml << "\n";
+    std::cerr << "WriteXML output contains unencoded hostile chars:\n" << xml << "\n";
     return EXIT_FAILURE;
   }
 
@@ -420,8 +421,7 @@ int testTerminologyEntryRoundTrip()
     }
     std::string value = xml.substr(valStart, valEnd - valStart);
     // Manually decode the two XML entities relevant here.
-    auto replaceAll = [](std::string& s, const std::string& from,
-                         const std::string& to)
+    auto replaceAll = [](std::string& s, const std::string& from, const std::string& to)
     {
       std::size_t p = 0;
       while ((p = s.find(from, p)) != std::string::npos)
@@ -494,7 +494,7 @@ int testCopyContent()
   return EXIT_SUCCESS;
 }
 
-}  // namespace
+} // namespace
 
 //------------------------------------------------------------------------------
 int vtkMRMLBezierSurfaceDisplayNodeTest1(int, char*[])
@@ -511,7 +511,6 @@ int vtkMRMLBezierSurfaceDisplayNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testModifiedEventsOnSetters());
   CHECK_EXIT_SUCCESS(testTerminologyEntryRoundTrip());
 
-  std::cout << "vtkMRMLBezierSurfaceDisplayNodeTest1 completed successfully"
-            << std::endl;
+  std::cout << "vtkMRMLBezierSurfaceDisplayNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
@@ -12,6 +12,7 @@
    - ResectionOpacity clamp to [0, 1]
    - XML serialize/deserialize via WriteXML+ReadXMLAttributes
    - CopyContent / DeepCopy
+   - SCT TerminologyEntry round-trip (ADR-0011 + ADR-0013 §3)
 
 ==============================================================================*/
 
@@ -80,6 +81,11 @@ int testDefaults()
   CHECK_BOOL(node->GetInterpolatedMargins(), false);
   CHECK_BOOL(node->GetShowResection2D(), false);
   CHECK_BOOL(node->GetMirrorDisplay(), false);
+
+  // ADR-0011 + ADR-0013 §3 — TerminologyEntry defaults to empty
+  // (no terminology assigned; Pipeline uses pure-vector colour
+  // defaults rather than dispatching off the SCT triple).
+  CHECK_STRING(node->GetTerminologyEntry().c_str(), "");
 
   CHECK_STRING(node->GetNodeTagName(), "BezierSurfaceDisplay");
   return EXIT_SUCCESS;
@@ -319,6 +325,143 @@ int testModifiedEventsOnSetters()
 
 #undef EXPECT_MTIME_ADVANCES
 
+int testTerminologyEntryRoundTrip()
+{
+  // ADR-0011 + ADR-0013 §3 / §8 — the display node carries a
+  // serialised SCT triple.  This sub-test pins:
+  //   - default is empty
+  //   - get/set round-trip
+  //   - MTime advances on set
+  //   - WriteXML emits a ``terminologyEntry="..."`` attribute that
+  //     survives XMLAttributeEncodeString on hostile XML chars
+  //   - ReadXMLAttributes recovers the original value bit-exactly
+  vtkNew<vtkMRMLBezierSurfaceDisplayNode> node;
+  CHECK_STRING(node->GetTerminologyEntry().c_str(), "");
+
+  // Realistic SCT triple — Liver, anatomical structure category, no
+  // modifier.  The canonical format is documented on the field.
+  const std::string sct =
+    "SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^";
+  const vtkMTimeType baseline = node->GetMTime();
+  node->SetTerminologyEntry(sct);
+  CHECK_STRING(node->GetTerminologyEntry().c_str(), sct.c_str());
+  if (node->GetMTime() <= baseline)
+  {
+    std::cerr << "Expected MTime to advance after SetTerminologyEntry"
+              << " (baseline=" << baseline
+              << ", post=" << node->GetMTime() << ")\n";
+    return EXIT_FAILURE;
+  }
+
+  // XML round-trip with hostile characters to confirm
+  // XMLAttributeEncodeString is in the write path (per PR #341
+  // commit 07474f2 — project discipline) and the parser decodes
+  // them on read.  The triple format itself uses ``^`` and ``~``
+  // which are XML-safe, but ``&`` and ``<`` must round-trip too.
+  const std::string hostile =
+    "SCT^123037004^Cat & <Type>~SCT^10200004^Liver~^^";
+  vtkNew<vtkMRMLBezierSurfaceDisplayNode> source;
+  vtkNew<vtkMRMLScene> scene;
+  source->SetScene(scene.GetPointer());
+  source->SetTerminologyEntry(hostile);
+
+  std::ostringstream out;
+  source->WriteXML(out, 0);
+  const std::string xml = out.str();
+
+  // The terminologyEntry attribute must be present.
+  if (xml.find("terminologyEntry=\"") == std::string::npos)
+  {
+    std::cerr << "WriteXML output missing terminologyEntry attribute:\n"
+              << xml << "\n";
+    return EXIT_FAILURE;
+  }
+  // Hostile chars must be XML-encoded in the on-wire form (else
+  // the resulting XML would be malformed).
+  if (xml.find("Cat & <Type>") != std::string::npos)
+  {
+    std::cerr << "WriteXML output contains unencoded hostile chars:\n"
+              << xml << "\n";
+    return EXIT_FAILURE;
+  }
+
+  // Hand-parse name="value" pairs (vtkXMLDataParser would decode the
+  // entities for us; here we mimic the parser by replacing the
+  // entities back to their literal form before handing to
+  // ReadXMLAttributes, which expects already-decoded values per
+  // vtkMRMLNodePropertyMacros.h:193).
+  std::vector<std::string> storage;
+  std::size_t pos = 0;
+  while (pos < xml.size())
+  {
+    while (pos < xml.size() && std::isspace(static_cast<unsigned char>(xml[pos])))
+    {
+      ++pos;
+    }
+    if (pos >= xml.size())
+    {
+      break;
+    }
+    const std::size_t eq = xml.find('=', pos);
+    if (eq == std::string::npos)
+    {
+      break;
+    }
+    std::string name = xml.substr(pos, eq - pos);
+    if (eq + 1 >= xml.size() || xml[eq + 1] != '"')
+    {
+      break;
+    }
+    const std::size_t valStart = eq + 2;
+    const std::size_t valEnd = xml.find('"', valStart);
+    if (valEnd == std::string::npos)
+    {
+      break;
+    }
+    std::string value = xml.substr(valStart, valEnd - valStart);
+    // Manually decode the two XML entities relevant here.
+    auto replaceAll = [](std::string& s, const std::string& from,
+                         const std::string& to)
+    {
+      std::size_t p = 0;
+      while ((p = s.find(from, p)) != std::string::npos)
+      {
+        s.replace(p, from.size(), to);
+        p += to.size();
+      }
+    };
+    replaceAll(value, "&lt;", "<");
+    replaceAll(value, "&gt;", ">");
+    replaceAll(value, "&quot;", "\"");
+    replaceAll(value, "&apos;", "'");
+    replaceAll(value, "&amp;", "&");
+    storage.push_back(name);
+    storage.push_back(value);
+    pos = valEnd + 1;
+  }
+
+  std::vector<const char*> atts;
+  atts.reserve(storage.size() + 1);
+  for (const auto& s : storage)
+  {
+    atts.push_back(s.c_str());
+  }
+  atts.push_back(nullptr);
+
+  vtkNew<vtkMRMLBezierSurfaceDisplayNode> sink;
+  sink->SetScene(scene.GetPointer());
+  sink->ReadXMLAttributes(atts.data());
+  CHECK_STRING(sink->GetTerminologyEntry().c_str(), hostile.c_str());
+
+  // CopyContent must deep-copy the string.
+  vtkNew<vtkMRMLBezierSurfaceDisplayNode> copySink;
+  copySink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
+  CHECK_STRING(copySink->GetTerminologyEntry().c_str(), hostile.c_str());
+  source->SetTerminologyEntry("");
+  CHECK_STRING(copySink->GetTerminologyEntry().c_str(), hostile.c_str());
+  return EXIT_SUCCESS;
+}
+
 int testCopyContent()
 {
   vtkNew<vtkMRMLBezierSurfaceDisplayNode> source;
@@ -366,6 +509,7 @@ int vtkMRMLBezierSurfaceDisplayNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testXMLRoundTrip());
   CHECK_EXIT_SUCCESS(testCopyContent());
   CHECK_EXIT_SUCCESS(testModifiedEventsOnSetters());
+  CHECK_EXIT_SUCCESS(testTerminologyEntryRoundTrip());
 
   std::cout << "vtkMRMLBezierSurfaceDisplayNodeTest1 completed successfully"
             << std::endl;

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.cxx
@@ -67,6 +67,7 @@ vtkMRMLBezierSurfaceDisplayNode::vtkMRMLBezierSurfaceDisplayNode()
   , InterpolatedMargins(false)
   , ShowResection2D(false)
   , MirrorDisplay(false)
+  , TerminologyEntry()
 {
 }
 
@@ -94,6 +95,7 @@ void vtkMRMLBezierSurfaceDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(interpolatedMargins, InterpolatedMargins);
   vtkMRMLWriteXMLBooleanMacro(showResection2D, ShowResection2D);
   vtkMRMLWriteXMLBooleanMacro(mirrorDisplay, MirrorDisplay);
+  vtkMRMLWriteXMLStdStringMacro(terminologyEntry, TerminologyEntry);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -120,6 +122,7 @@ void vtkMRMLBezierSurfaceDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(interpolatedMargins, InterpolatedMargins);
   vtkMRMLReadXMLBooleanMacro(showResection2D, ShowResection2D);
   vtkMRMLReadXMLBooleanMacro(mirrorDisplay, MirrorDisplay);
+  vtkMRMLReadXMLStdStringMacro(terminologyEntry, TerminologyEntry);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -148,6 +151,7 @@ void vtkMRMLBezierSurfaceDisplayNode::CopyContent(vtkMRMLNode* anode,
   vtkMRMLCopyBooleanMacro(InterpolatedMargins);
   vtkMRMLCopyBooleanMacro(ShowResection2D);
   vtkMRMLCopyBooleanMacro(MirrorDisplay);
+  vtkMRMLCopyStdStringMacro(TerminologyEntry);
   vtkMRMLCopyEndMacro();
 }
 
@@ -172,5 +176,6 @@ void vtkMRMLBezierSurfaceDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(InterpolatedMargins);
   vtkMRMLPrintBooleanMacro(ShowResection2D);
   vtkMRMLPrintBooleanMacro(MirrorDisplay);
+  vtkMRMLPrintStdStringMacro(TerminologyEntry);
   vtkMRMLPrintEndMacro();
 }

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.cxx
@@ -129,8 +129,7 @@ void vtkMRMLBezierSurfaceDisplayNode::ReadXMLAttributes(const char** atts)
 }
 
 //------------------------------------------------------------------------------
-void vtkMRMLBezierSurfaceDisplayNode::CopyContent(vtkMRMLNode* anode,
-                                                       bool deepCopy /*=true*/)
+void vtkMRMLBezierSurfaceDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/)
 {
   MRMLNodeModifyBlocker blocker(this);
   Superclass::CopyContent(anode, deepCopy);

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.h
@@ -93,10 +93,9 @@
  * which retains its display fields (T2 is *additive*).  T2.7 will
  * collapse the legacy node and retire its display fields.
  */
-class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLBezierSurfaceDisplayNode
-  : public vtkMRMLDisplayNode
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLBezierSurfaceDisplayNode : public vtkMRMLDisplayNode
 {
- public:
+public:
   static vtkMRMLBezierSurfaceDisplayNode* New();
   vtkTypeMacro(vtkMRMLBezierSurfaceDisplayNode, vtkMRMLDisplayNode);
   void PrintSelf(ostream& os, vtkIndent indent) override;
@@ -224,13 +223,12 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLBezierSurfaceDisplayN
   vtkSetMacro(TerminologyEntry, std::string);
   vtkGetMacro(TerminologyEntry, std::string);
 
- protected:
+protected:
   vtkMRMLBezierSurfaceDisplayNode();
   ~vtkMRMLBezierSurfaceDisplayNode() override;
 
- private:
-  vtkMRMLBezierSurfaceDisplayNode(
-    const vtkMRMLBezierSurfaceDisplayNode&) = delete;
+private:
+  vtkMRMLBezierSurfaceDisplayNode(const vtkMRMLBezierSurfaceDisplayNode&) = delete;
   void operator=(const vtkMRMLBezierSurfaceDisplayNode&) = delete;
 
   float ResectionColor[3];

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.h
@@ -48,6 +48,9 @@
 // VTK includes
 #include <vtkSetGet.h>
 
+// STD includes
+#include <string>
+
 /**
  * \class vtkMRMLBezierSurfaceDisplayNode
  *
@@ -196,6 +199,31 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLBezierSurfaceDisplayN
   vtkSetMacro(MirrorDisplay, bool);
   vtkGetMacro(MirrorDisplay, bool);
 
+  //--------------------------------------------------------------------------
+  // SCT terminology reference (ADR-0011 + ADR-0013 §3)
+  //--------------------------------------------------------------------------
+
+  /// Serialised SNOMED-CT terminology triple (Category, Type,
+  /// optional Modifier) describing the clinical concept this display
+  /// node decorates.  The canonical wire format is Slicer's standard
+  /// terminology-entry string,
+  /// ``{CategoryCodingScheme}^{CategoryCode}^{CategoryMeaning}~``
+  /// ``{TypeCodingScheme}^{TypeCode}^{TypeMeaning}~``
+  /// ``{ModifierCodingScheme}^{ModifierCode}^{ModifierMeaning}``
+  /// (e.g. ``SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^``
+  /// for the liver anatomical concept).
+  ///
+  /// Empty string = no terminology assigned; rendering uses pure-vector
+  /// defaults (``ResectionColor`` etc.).  When set, the LayerDM
+  /// Pipeline (T2.2, out of scope here) uses the SCT triple to derive
+  /// colour, label, and badge presentation per
+  /// [ADR-0011](../../Docs/adr/0011-sct-terminology-dispatch.md) and
+  /// [ADR-0013 §3](../../Docs/adr/0013-layerdm-pipeline-pattern.md);
+  /// this node only stores the string — it does not depend on the
+  /// Terminologies module for parsing.
+  vtkSetMacro(TerminologyEntry, std::string);
+  vtkGetMacro(TerminologyEntry, std::string);
+
  protected:
   vtkMRMLBezierSurfaceDisplayNode();
   ~vtkMRMLBezierSurfaceDisplayNode() override;
@@ -220,6 +248,7 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLBezierSurfaceDisplayN
   bool InterpolatedMargins;
   bool ShowResection2D;
   bool MirrorDisplay;
+  std::string TerminologyEntry;
 };
 
 #endif //__vtkmrmlbeziersurfacedisplaynode_h_

--- a/Testing/Python/unit/test_bezier_surface_node.py
+++ b/Testing/Python/unit/test_bezier_surface_node.py
@@ -416,3 +416,40 @@ def test_display_copy_content(mrml_module):
 
     source.SetResectionColor([0.0, 0.0, 0.0])
     assert list(sink.GetResectionColor()) == pytest.approx([0.25, 0.5, 0.75])
+
+
+def test_display_terminology_entry_round_trip(mrml_module):
+    """SCT terminology field defaults empty and round-trips through set/get.
+
+    Pins the ADR-0011 + ADR-0013 §3 contract from the Python-wrapped
+    surface: the display node stores a serialised SCT triple as a
+    ``std::string``, defaults to empty (meaning "no terminology
+    assigned — Pipeline uses pure-vector defaults"), and round-trips
+    via the wrapped setter / getter without mangling separator chars
+    (``^``, ``~``).  The CopyContent path must deep-copy so source
+    mutation does not leak into a previously-copied sink.
+
+    The XML round-trip is covered by the C++ driver
+    (``vtkMRMLBezierSurfaceDisplayNodeTest1.cxx``); we keep this
+    Python-side check focused on the wrapped Python surface.
+    """
+    node = mrml_module.vtkMRMLBezierSurfaceDisplayNode()
+    assert node.GetTerminologyEntry() == ""
+
+    sct = "SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^"
+    baseline = node.GetMTime()
+    node.SetTerminologyEntry(sct)
+    assert node.GetTerminologyEntry() == sct
+    assert node.GetMTime() > baseline
+
+    # Separator chars round-trip through the wrapped std::string.
+    assert "^" in node.GetTerminologyEntry()
+    assert "~" in node.GetTerminologyEntry()
+
+    # CopyContent: deep-copy means later source edits do not bleed
+    # into the previously-copied sink.
+    sink = mrml_module.vtkMRMLBezierSurfaceDisplayNode()
+    sink.CopyContent(node, True)
+    assert sink.GetTerminologyEntry() == sct
+    node.SetTerminologyEntry("")
+    assert sink.GetTerminologyEntry() == sct


### PR DESCRIPTION
## Summary

Adds a serialised SNOMED-CT terminology-entry string to
`vtkMRMLBezierSurfaceDisplayNode` as a plain `std::string` field
exposed via `vtkSetMacro` / `vtkGetMacro`.  The wire format is
Slicer's standard terminology-entry string:

```
{CategoryCodingScheme}^{CategoryCode}^{CategoryMeaning}~{TypeCodingScheme}^{TypeCode}^{TypeMeaning}~{ModifierCodingScheme}^{ModifierCode}^{ModifierMeaning}
```

e.g. `SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^` for
the liver.

* Per [ADR-0011](Docs/adr/0011-sct-terminology-dispatch.md), SCT
  triples are the canonical dispatch key for terminology-driven
  presentation.
* Per [ADR-0013 §3](Docs/adr/0013-layerdm-pipeline-pattern.md), the
  LayerDM Pipeline derives colour, label, and badge from this triple.
* Per [ADR-0013 §8](Docs/adr/0013-layerdm-pipeline-pattern.md), the
  field lives on the display node, not the data node.

This PR is a **T2.2 Pipeline prerequisite** — landing only the field
plus characterisation tests so the Pipeline can read it without an
additional MRML schema change.

### Out of scope

* Pipeline / Logic / Widget integration (T2.2).
* Dependency on the Terminologies module — the field is stored as a
  raw string and downstream consumers parse it via
  `vtkSlicerTerminologyEntry` separately.
* Mirror field on `vtkMRMLLiverResectionNode` — additive stack;
  legacy retirement is T2.7.

### Files modified

* `LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.{h,cxx}` —
  add `TerminologyEntry` field, WriteXML / ReadXMLAttributes /
  CopyContent / PrintSelf entries (`vtkMRMLWriteXMLStdStringMacro`
  encodes via `XMLAttributeEncodeString`, per PR #341 commit
  `07474f2`).
* `LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceDisplayNodeTest1.cxx`
  — new `testTerminologyEntryRoundTrip()` sub-test.
* `Testing/Python/unit/test_bezier_surface_node.py` — new
  `test_display_terminology_entry_round_trip()` exercising the
  wrapped Python surface under `pytest.importorskip`.

### CI note

The post-cutover lint pass on the touched C++ files surfaced pre-
existing format drift in the display node header / cxx / test driver
(class-line wrapping, access-specifier indentation, line-break
choices in the existing `testXMLRoundTrip` / `EXPECT_MTIME_ADVANCES`
helper).  A follow-up `STYLE:` commit applies clang-format to the
three touched files; no semantic changes.

The `STYLE:` commit's subject begins with lowercase `clang-format`,
which trips `check-commit-message` (regex requires the first
non-space word after the colon to be uppercase).  Per the project's
no-force-push / no-amend rule, the failing check is left in place
for review override rather than rewriting history.  All other CI
checks (Lint, build-test, docs-lint, Paper Draft) pass.

## Test plan

- [x] CI: `Lint` passes on the four touched files.
- [x] CI: `build-test (slicer-main, Linux)` passes; this exercises
      `vtkMRMLBezierSurfaceDisplayNodeTest1` including the new
      `testTerminologyEntryRoundTrip()` sub-test that covers default
      value, get/set, MTime advance, WriteXML attribute presence,
      hostile-character XML encoding, ReadXMLAttributes round-trip,
      and CopyContent deep-copy.
- [x] CI: `docs-lint`, `Paper Draft` pass.
- [ ] CI: `check-commit-message` failing on commit `363b99e`'s
      lowercase first word — see "CI note" above.

---

Authored with the assistance of an AI agent (Claude Opus 4.7).