### PR TITLE
ENH: Rewire vtkLiverContourParameterizer + vtkLiverBezierFitter to real VTK input ports (#339)

### DIFF
--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverBezierFitterTest1.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverBezierFitterTest1.cxx
@@ -28,7 +28,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-int vtkLiverBezierFitterTest1(int, char *[])
+int vtkLiverBezierFitterTest1(int, char*[])
 {
   using namespace vtkLiverAlgorithmTestFixtures;
 
@@ -54,46 +54,43 @@ int vtkLiverBezierFitterTest1(int, char *[])
   samplePoints->SetDataTypeToDouble();
   samplePoints->SetNumberOfPoints(static_cast<vtkIdType>(Nu) * Nv);
   for (int i = 0; i < Nu; ++i)
-    {
+  {
     for (int j = 0; j < Nv; ++j)
-      {
+    {
       const size_t base = (static_cast<size_t>(i) * Nv + j) * 3;
-      samplePoints->SetPoint(static_cast<vtkIdType>(i) * Nv + j,
-                             fx.points[base + 0],
-                             fx.points[base + 1],
-                             fx.points[base + 2]);
-      }
+      samplePoints->SetPoint(static_cast<vtkIdType>(i) * Nv + j, fx.points[base + 0], fx.points[base + 1], fx.points[base + 2]);
     }
+  }
   vtkNew<vtkPolyData> pointsPolyData;
   pointsPolyData->SetPoints(samplePoints);
 
   // Port 1 — BasisU as vtkTable (Nu rows, M columns).
   vtkNew<vtkTable> basisUTable;
   for (int j = 0; j < M; ++j)
-    {
+  {
     vtkNew<vtkDoubleArray> col;
     col->SetNumberOfComponents(1);
     col->SetNumberOfTuples(Nu);
     for (int i = 0; i < Nu; ++i)
-      {
+    {
       col->SetValue(i, fx.basisU[static_cast<size_t>(i) * M + j]);
-      }
-    basisUTable->AddColumn(col);
     }
+    basisUTable->AddColumn(col);
+  }
 
   // Port 2 — BasisV as vtkTable (Nv rows, M columns).
   vtkNew<vtkTable> basisVTable;
   for (int j = 0; j < M; ++j)
-    {
+  {
     vtkNew<vtkDoubleArray> col;
     col->SetNumberOfComponents(1);
     col->SetNumberOfTuples(Nv);
     for (int i = 0; i < Nv; ++i)
-      {
+    {
       col->SetValue(i, fx.basisV[static_cast<size_t>(i) * M + j]);
-      }
-    basisVTable->AddColumn(col);
     }
+    basisVTable->AddColumn(col);
+  }
 
   vtkNew<vtkLiverBezierFitter> fitter;
   fitter->SetNumberOfSamples(Nu, Nv);
@@ -102,52 +99,51 @@ int vtkLiverBezierFitterTest1(int, char *[])
   fitter->SetInputData(2, basisVTable);
   fitter->Update();
 
-  const auto &cps = fitter->GetControlPoints();
+  const auto& cps = fitter->GetControlPoints();
   if (cps.size() != static_cast<size_t>(4) * 4 * 3)
-    {
+  {
     std::fprintf(stderr, "[BezierFitter] FAIL: size %zu != 48\n", cps.size());
     return EXIT_FAILURE;
-    }
+  }
   if (fitter->GetGridSize() != 4)
-    {
-    std::fprintf(stderr, "[BezierFitter] FAIL: GridSize %d != 4\n",
-                 fitter->GetGridSize());
+  {
+    std::fprintf(stderr, "[BezierFitter] FAIL: GridSize %d != 4\n", fitter->GetGridSize());
     return EXIT_FAILURE;
-    }
+  }
 
-  const auto &expected = expectedBezierControlPoints();
+  const auto& expected = expectedBezierControlPoints();
   size_t failIdx = 0;
   if (!allClose(cps.data(), expected.data(), cps.size(), rtol, atol, &failIdx))
-    {
-    printFailure("BezierFitter", cps.data(), expected.data(), cps.size(),
-                 failIdx, rtol, atol);
+  {
+    printFailure("BezierFitter", cps.data(), expected.data(), cps.size(), failIdx, rtol, atol);
     return EXIT_FAILURE;
-    }
+  }
 
   // Verify the polydata output round-trips the same control points.
-  vtkPolyData *out = fitter->GetOutput();
+  vtkPolyData* out = fitter->GetOutput();
   if (!out || !out->GetPoints() || out->GetPoints()->GetNumberOfPoints() != 16)
-    {
-    std::fprintf(stderr,
-                 "[BezierFitter] FAIL: output polydata missing or wrong size\n");
+  {
+    std::fprintf(stderr, "[BezierFitter] FAIL: output polydata missing or wrong size\n");
     return EXIT_FAILURE;
-    }
+  }
   for (int i = 0; i < 4; ++i)
-    {
+  {
     for (int j = 0; j < 4; ++j)
-      {
+    {
       double p[3];
       out->GetPoints()->GetPoint(i * 4 + j, p);
       const size_t base = (i * 4 + j) * 3;
       if (p[0] != cps[base + 0] || p[1] != cps[base + 1] || p[2] != cps[base + 2])
-        {
+      {
         std::fprintf(stderr,
                      "[BezierFitter] FAIL: polydata point (%d,%d) does not "
-                     "match raw control-points vector\n", i, j);
+                     "match raw control-points vector\n",
+                     i,
+                     j);
         return EXIT_FAILURE;
-        }
       }
     }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverBezierFitterTest1.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverBezierFitterTest1.cxx
@@ -23,6 +23,7 @@
 #include <vtkNew.h>
 #include <vtkPoints.h>
 #include <vtkPolyData.h>
+#include <vtkTable.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -44,36 +45,61 @@ int vtkLiverBezierFitterTest1(int, char *[])
   constexpr double atol = 1e-12;
 
   auto fx = makeBezierFixture();
+  constexpr int Nu = 4;
+  constexpr int Nv = 4;
+  constexpr int M = 4;
 
-  vtkNew<vtkDoubleArray> pointsArr;
-  pointsArr->SetNumberOfComponents(1);
-  pointsArr->SetNumberOfTuples(static_cast<vtkIdType>(fx.points.size()));
-  for (size_t i = 0; i < fx.points.size(); ++i)
+  // Port 0 — Nu*Nv samples as vtkPolyData (row-major u, v).
+  vtkNew<vtkPoints> samplePoints;
+  samplePoints->SetDataTypeToDouble();
+  samplePoints->SetNumberOfPoints(static_cast<vtkIdType>(Nu) * Nv);
+  for (int i = 0; i < Nu; ++i)
     {
-    pointsArr->SetValue(static_cast<vtkIdType>(i), fx.points[i]);
+    for (int j = 0; j < Nv; ++j)
+      {
+      const size_t base = (static_cast<size_t>(i) * Nv + j) * 3;
+      samplePoints->SetPoint(static_cast<vtkIdType>(i) * Nv + j,
+                             fx.points[base + 0],
+                             fx.points[base + 1],
+                             fx.points[base + 2]);
+      }
+    }
+  vtkNew<vtkPolyData> pointsPolyData;
+  pointsPolyData->SetPoints(samplePoints);
+
+  // Port 1 — BasisU as vtkTable (Nu rows, M columns).
+  vtkNew<vtkTable> basisUTable;
+  for (int j = 0; j < M; ++j)
+    {
+    vtkNew<vtkDoubleArray> col;
+    col->SetNumberOfComponents(1);
+    col->SetNumberOfTuples(Nu);
+    for (int i = 0; i < Nu; ++i)
+      {
+      col->SetValue(i, fx.basisU[static_cast<size_t>(i) * M + j]);
+      }
+    basisUTable->AddColumn(col);
     }
 
-  vtkNew<vtkDoubleArray> basisU;
-  basisU->SetNumberOfComponents(1);
-  basisU->SetNumberOfTuples(static_cast<vtkIdType>(fx.basisU.size()));
-  for (size_t i = 0; i < fx.basisU.size(); ++i)
+  // Port 2 — BasisV as vtkTable (Nv rows, M columns).
+  vtkNew<vtkTable> basisVTable;
+  for (int j = 0; j < M; ++j)
     {
-    basisU->SetValue(static_cast<vtkIdType>(i), fx.basisU[i]);
-    }
-
-  vtkNew<vtkDoubleArray> basisV;
-  basisV->SetNumberOfComponents(1);
-  basisV->SetNumberOfTuples(static_cast<vtkIdType>(fx.basisV.size()));
-  for (size_t i = 0; i < fx.basisV.size(); ++i)
-    {
-    basisV->SetValue(static_cast<vtkIdType>(i), fx.basisV[i]);
+    vtkNew<vtkDoubleArray> col;
+    col->SetNumberOfComponents(1);
+    col->SetNumberOfTuples(Nv);
+    for (int i = 0; i < Nv; ++i)
+      {
+      col->SetValue(i, fx.basisV[static_cast<size_t>(i) * M + j]);
+      }
+    basisVTable->AddColumn(col);
     }
 
   vtkNew<vtkLiverBezierFitter> fitter;
-  fitter->SetNumberOfSamples(4, 4);
-  fitter->SetInputPoints(pointsArr);
-  fitter->SetBasisU(basisU);
-  fitter->SetBasisV(basisV);
+  fitter->SetNumberOfSamples(Nu, Nv);
+  fitter->SetInputData(0, pointsPolyData);
+  fitter->SetInputData(1, basisUTable);
+  fitter->SetInputData(2, basisVTable);
   fitter->Update();
 
   const auto &cps = fitter->GetControlPoints();

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerTest1.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerTest1.cxx
@@ -31,20 +31,19 @@ int testEFDCoefficients(double rtol, double atol)
   using namespace vtkLiverAlgorithmTestFixtures;
   auto contour = makeContourFixture();
   const int nPts = static_cast<int>(contour.size() / 3);
-  auto coeffs = vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(
-    contour.data(), nPts, 8);
+  auto coeffs = vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(contour.data(), nPts, 8);
   if (coeffs.size() != 48)
-    {
+  {
     std::fprintf(stderr, "[EFD] FAIL: size %zu != 48\n", coeffs.size());
     return EXIT_FAILURE;
-    }
-  const auto &expected = expectedEFDCoeffs();
+  }
+  const auto& expected = expectedEFDCoeffs();
   size_t failIdx = 0;
   if (!allClose(coeffs.data(), expected.data(), 48, rtol, atol, &failIdx))
-    {
+  {
     printFailure("EFD", coeffs.data(), expected.data(), 48, failIdx, rtol, atol);
     return EXIT_FAILURE;
-    }
+  }
   return EXIT_SUCCESS;
 }
 
@@ -53,20 +52,19 @@ int testDC(double rtol, double atol)
   using namespace vtkLiverAlgorithmTestFixtures;
   auto contour = makeContourFixture();
   const int nPts = static_cast<int>(contour.size() / 3);
-  auto dc = vtkLiverContourParameterizer::ComputeDCCoefficientsRaw(
-    contour.data(), nPts);
+  auto dc = vtkLiverContourParameterizer::ComputeDCCoefficientsRaw(contour.data(), nPts);
   if (dc.size() != 3)
-    {
+  {
     std::fprintf(stderr, "[DC] FAIL: size %zu != 3\n", dc.size());
     return EXIT_FAILURE;
-    }
+  }
   auto expected = expectedDC();
   size_t failIdx = 0;
   if (!allClose(dc.data(), expected.data(), 3, rtol, atol, &failIdx))
-    {
+  {
     printFailure("DC", dc.data(), expected.data(), 3, failIdx, rtol, atol);
     return EXIT_FAILURE;
-    }
+  }
   return EXIT_SUCCESS;
 }
 
@@ -75,24 +73,21 @@ int testInverseTransform(double rtol, double atol)
   using namespace vtkLiverAlgorithmTestFixtures;
   // Use the *pinned* EFD coefficients so this test isolates the
   // inverse-transform code path from any drift in the forward EFD.
-  const auto &coeffs = expectedEFDCoeffs();
+  const auto& coeffs = expectedEFDCoeffs();
   const double locus[3] = { 0.1, 0.2, 0.3 };
-  auto recon = vtkLiverContourParameterizer::InverseTransformRaw(
-    coeffs.data(), /*harmonic=*/8, locus, /*nCoords=*/12);
+  auto recon = vtkLiverContourParameterizer::InverseTransformRaw(coeffs.data(), /*harmonic=*/8, locus, /*nCoords=*/12);
   if (recon.size() != 36)
-    {
-    std::fprintf(stderr, "[InverseTransform] FAIL: size %zu != 36\n",
-                 recon.size());
+  {
+    std::fprintf(stderr, "[InverseTransform] FAIL: size %zu != 36\n", recon.size());
     return EXIT_FAILURE;
-    }
-  const auto &expected = expectedInverseTransform();
+  }
+  const auto& expected = expectedInverseTransform();
   size_t failIdx = 0;
   if (!allClose(recon.data(), expected.data(), 36, rtol, atol, &failIdx))
-    {
-    printFailure("InverseTransform", recon.data(), expected.data(), 36,
-                 failIdx, rtol, atol);
+  {
+    printFailure("InverseTransform", recon.data(), expected.data(), 36, failIdx, rtol, atol);
     return EXIT_FAILURE;
-    }
+  }
   return EXIT_SUCCESS;
 }
 
@@ -109,12 +104,9 @@ int testPipelineEFDMode()
   contourPoints->SetDataTypeToDouble();
   contourPoints->SetNumberOfPoints(nPts);
   for (int i = 0; i < nPts; ++i)
-    {
-    contourPoints->SetPoint(i,
-                            contour[i * 3 + 0],
-                            contour[i * 3 + 1],
-                            contour[i * 3 + 2]);
-    }
+  {
+    contourPoints->SetPoint(i, contour[i * 3 + 0], contour[i * 3 + 1], contour[i * 3 + 2]);
+  }
   vtkNew<vtkPolyData> contourPolyData;
   contourPolyData->SetPoints(contourPoints);
 
@@ -128,25 +120,21 @@ int testPipelineEFDMode()
   param->Update();
 
   if (param->GetReconstruction().size() != 36)
-    {
-    std::fprintf(stderr,
-                 "[Pipeline] FAIL: reconstruction size %zu != 36\n",
-                 param->GetReconstruction().size());
+  {
+    std::fprintf(stderr, "[Pipeline] FAIL: reconstruction size %zu != 36\n", param->GetReconstruction().size());
     return EXIT_FAILURE;
-    }
-  if (!param->GetOutput() || !param->GetOutput()->GetPoints()
-      || param->GetOutput()->GetPoints()->GetNumberOfPoints() != 12)
-    {
-    std::fprintf(stderr,
-                 "[Pipeline] FAIL: output polydata missing or wrong size\n");
+  }
+  if (!param->GetOutput() || !param->GetOutput()->GetPoints() || param->GetOutput()->GetPoints()->GetNumberOfPoints() != 12)
+  {
+    std::fprintf(stderr, "[Pipeline] FAIL: output polydata missing or wrong size\n");
     return EXIT_FAILURE;
-    }
+  }
   return EXIT_SUCCESS;
 }
 
-}  // namespace
+} // namespace
 
-int vtkLiverContourParameterizerTest1(int, char *[])
+int vtkLiverContourParameterizerTest1(int, char*[])
 {
   // EFD math is direct closed-form harmonic sums; bit-equivalent to
   // the Python implementation up to last-bit-of-double on the per-segment
@@ -156,9 +144,21 @@ int vtkLiverContourParameterizerTest1(int, char *[])
   constexpr double rtol = 1e-12;
   constexpr double atol = 1e-12;
 
-  if (testEFDCoefficients(rtol, atol) != EXIT_SUCCESS) return EXIT_FAILURE;
-  if (testDC(rtol, atol) != EXIT_SUCCESS) return EXIT_FAILURE;
-  if (testInverseTransform(rtol, atol) != EXIT_SUCCESS) return EXIT_FAILURE;
-  if (testPipelineEFDMode() != EXIT_SUCCESS) return EXIT_FAILURE;
+  if (testEFDCoefficients(rtol, atol) != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (testDC(rtol, atol) != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (testInverseTransform(rtol, atol) != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (testPipelineEFDMode() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
   return EXIT_SUCCESS;
 }

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerTest1.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerTest1.cxx
@@ -17,6 +17,7 @@
 // VTK includes
 #include <vtkDoubleArray.h>
 #include <vtkNew.h>
+#include <vtkPoints.h>
 #include <vtkPolyData.h>
 
 #include <cstdio>
@@ -99,15 +100,23 @@ int testPipelineEFDMode()
 {
   using namespace vtkLiverAlgorithmTestFixtures;
   // Drive the parameterizer through the algorithm pipeline and verify
-  // the polydata output contains nCoords points.
+  // the polydata output contains nCoords points.  The contour is now
+  // supplied through the real port-0 vtkPolyData input per ADR-0015 §1
+  // (issue #339 rewire) rather than via a member vtkDoubleArray setter.
   auto contour = makeContourFixture();
-  vtkNew<vtkDoubleArray> contourArr;
-  contourArr->SetNumberOfComponents(1);
-  contourArr->SetNumberOfTuples(static_cast<vtkIdType>(contour.size()));
-  for (size_t i = 0; i < contour.size(); ++i)
+  const int nPts = static_cast<int>(contour.size() / 3);
+  vtkNew<vtkPoints> contourPoints;
+  contourPoints->SetDataTypeToDouble();
+  contourPoints->SetNumberOfPoints(nPts);
+  for (int i = 0; i < nPts; ++i)
     {
-    contourArr->SetValue(static_cast<vtkIdType>(i), contour[i]);
+    contourPoints->SetPoint(i,
+                            contour[i * 3 + 0],
+                            contour[i * 3 + 1],
+                            contour[i * 3 + 2]);
     }
+  vtkNew<vtkPolyData> contourPolyData;
+  contourPolyData->SetPoints(contourPoints);
 
   vtkNew<vtkLiverContourParameterizer> param;
   param->SetMode(vtkLiverContourParameterizer::MODE_EFD);
@@ -115,7 +124,7 @@ int testPipelineEFDMode()
   param->SetNumberOfReconstructionPoints(12);
   param->UseComputedLocusOff();
   param->SetLocus(0.1, 0.2, 0.3);
-  param->SetInputContour(contourArr);
+  param->SetInputData(contourPolyData);
   param->Update();
 
   if (param->GetReconstruction().size() != 36)

--- a/LiverResections/Algorithm/vtkLiverBezierFitter.cxx
+++ b/LiverResections/Algorithm/vtkLiverBezierFitter.cxx
@@ -44,19 +44,18 @@ vtkLiverBezierFitter::vtkLiverBezierFitter()
 }
 
 //------------------------------------------------------------------------------
-int vtkLiverBezierFitter::FillInputPortInformation(int port,
-                                                    vtkInformation *info)
+int vtkLiverBezierFitter::FillInputPortInformation(int port, vtkInformation* info)
 {
   if (port == 0)
-    {
+  {
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
     return 1;
-    }
+  }
   if (port == 1 || port == 2)
-    {
+  {
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
     return 1;
-    }
+  }
   return 0;
 }
 
@@ -64,11 +63,10 @@ int vtkLiverBezierFitter::FillInputPortInformation(int port,
 vtkLiverBezierFitter::~vtkLiverBezierFitter() = default;
 
 //------------------------------------------------------------------------------
-void vtkLiverBezierFitter::PrintSelf(ostream &os, vtkIndent indent)
+void vtkLiverBezierFitter::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os, indent);
-  os << indent << "NumberOfSamples: (" << this->NumberOfSamples[0] << ", "
-     << this->NumberOfSamples[1] << ")\n";
+  os << indent << "NumberOfSamples: (" << this->NumberOfSamples[0] << ", " << this->NumberOfSamples[1] << ")\n";
   os << indent << "GridSize: " << this->GridSize << "\n";
 }
 
@@ -76,9 +74,9 @@ void vtkLiverBezierFitter::PrintSelf(ostream &os, vtkIndent indent)
 void vtkLiverBezierFitter::SetNumberOfSamples(int nu, int nv)
 {
   if (this->NumberOfSamples[0] == nu && this->NumberOfSamples[1] == nv)
-    {
+  {
     return;
-    }
+  }
   this->NumberOfSamples[0] = nu;
   this->NumberOfSamples[1] = nv;
   this->Modified();
@@ -92,72 +90,67 @@ void vtkLiverBezierFitter::SetNumberOfSamples(int nu, int nv)
 //------------------------------------------------------------------------------
 namespace
 {
-void evaluateBernstein(double t, int degree, double *out)
+void evaluateBernstein(double t, int degree, double* out)
 {
   // Initialise to (1, 0, ..., 0); deBoor up-sweep.
   for (int k = 0; k <= degree; ++k)
-    {
+  {
     out[k] = 0.0;
-    }
+  }
   out[0] = 1.0;
   const double t1 = 1.0 - t;
   for (int j = 1; j <= degree; ++j)
-    {
+  {
     double saved = 0.0;
     for (int k = 0; k < j; ++k)
-      {
+    {
       const double tmp = out[k];
       out[k] = saved + t1 * tmp;
       saved = t * tmp;
-      }
-    out[j] = saved;
     }
+    out[j] = saved;
+  }
 }
-}  // namespace
+} // namespace
 
 //------------------------------------------------------------------------------
-void vtkLiverBezierFitter::BuildBernsteinBasisRaw(const double *samples,
-                                                    int nSamples,
-                                                    int degree,
-                                                    std::vector<double> &out)
+void vtkLiverBezierFitter::BuildBernsteinBasisRaw(const double* samples, int nSamples, int degree, std::vector<double>& out)
 {
   const int cols = degree + 1;
   out.assign(static_cast<size_t>(nSamples) * cols, 0.0);
   std::vector<double> row(cols);
   for (int i = 0; i < nSamples; ++i)
-    {
+  {
     evaluateBernstein(samples[i], degree, row.data());
     for (int k = 0; k < cols; ++k)
-      {
+    {
       out[static_cast<size_t>(i) * cols + k] = row[k];
-      }
     }
+  }
 }
 
 //------------------------------------------------------------------------------
-vtkSmartPointer<vtkDoubleArray>
-vtkLiverBezierFitter::BuildBernsteinBasis(vtkDoubleArray *samples, int degree)
+vtkSmartPointer<vtkDoubleArray> vtkLiverBezierFitter::BuildBernsteinBasis(vtkDoubleArray* samples, int degree)
 {
   vtkSmartPointer<vtkDoubleArray> result = vtkSmartPointer<vtkDoubleArray>::New();
   if (!samples)
-    {
+  {
     return result;
-    }
-  const int n = static_cast<int>(samples->GetNumberOfTuples()
-                                 * samples->GetNumberOfComponents());
+  }
+  const int n = static_cast<int>(samples->GetNumberOfTuples() * samples->GetNumberOfComponents());
   std::vector<double> flat(n);
   for (int i = 0; i < n; ++i)
-    {
+  {
     flat[i] = samples->GetValue(i);
-    }
+  }
   std::vector<double> out;
   BuildBernsteinBasisRaw(flat.data(), n, degree, out);
   result->SetNumberOfComponents(1);
   result->SetNumberOfTuples(static_cast<vtkIdType>(out.size()));
   for (size_t i = 0; i < out.size(); ++i)
-    {
+  {
     result->SetValue(static_cast<vtkIdType>(i), out[i]);
-    }
+  }
   return result;
 }
 
@@ -168,50 +161,46 @@ namespace
 // column order.  Returns false (and emits an error via vtkErrorMacro on
 // the caller) if the row count does not match the configured Nrows or
 // if columns are non-numeric.
-bool decodeBasisTable(vtkTable *table, int nRows, Eigen::MatrixXd &out,
-                      int &outCols, std::string &err)
+bool decodeBasisTable(vtkTable* table, int nRows, Eigen::MatrixXd& out, int& outCols, std::string& err)
 {
   if (!table)
-    {
+  {
     err = "basis table is null";
     return false;
-    }
+  }
   const vtkIdType actualRows = table->GetNumberOfRows();
   const vtkIdType nCols = table->GetNumberOfColumns();
   if (actualRows != nRows)
-    {
+  {
     err = "basis table row count mismatch";
     return false;
-    }
+  }
   if (nCols < 1)
-    {
+  {
     err = "basis table has no columns";
     return false;
-    }
+  }
   outCols = static_cast<int>(nCols);
   out.resize(nRows, outCols);
   for (vtkIdType j = 0; j < nCols; ++j)
-    {
-    vtkAbstractArray *col = table->GetColumn(j);
+  {
+    vtkAbstractArray* col = table->GetColumn(j);
     if (!col || col->GetNumberOfTuples() != actualRows)
-      {
+    {
       err = "basis table column has wrong tuple count";
       return false;
-      }
-    for (vtkIdType i = 0; i < actualRows; ++i)
-      {
-      out(static_cast<int>(i), static_cast<int>(j)) =
-        col->GetVariantValue(i).ToDouble();
-      }
     }
+    for (vtkIdType i = 0; i < actualRows; ++i)
+    {
+      out(static_cast<int>(i), static_cast<int>(j)) = col->GetVariantValue(i).ToDouble();
+    }
+  }
   return true;
 }
-}  // namespace
+} // namespace
 
 //------------------------------------------------------------------------------
-int vtkLiverBezierFitter::RequestData(vtkInformation *,
-                                       vtkInformationVector **inputVector,
-                                       vtkInformationVector *outputVector)
+int vtkLiverBezierFitter::RequestData(vtkInformation*, vtkInformationVector** inputVector, vtkInformationVector* outputVector)
 {
   using Matrix = Eigen::MatrixXd;
 
@@ -219,48 +208,38 @@ int vtkLiverBezierFitter::RequestData(vtkInformation *,
   const int nv = this->NumberOfSamples[1];
 
   if (nu <= 0 || nv <= 0)
-    {
-    vtkErrorMacro(<< "NumberOfSamples must be positive; got ("
-                  << nu << ", " << nv << ").");
+  {
+    vtkErrorMacro(<< "NumberOfSamples must be positive; got (" << nu << ", " << nv << ").");
     return 0;
-    }
+  }
 
   // Port 0 — Points: vtkPolyData carrying Nu*Nv samples (row-major u, v).
-  vtkInformation *pointsInfo = inputVector[0]->GetInformationObject(0);
-  vtkPolyData *pointsInput = pointsInfo
-    ? vtkPolyData::SafeDownCast(pointsInfo->Get(vtkDataObject::DATA_OBJECT()))
-    : nullptr;
+  vtkInformation* pointsInfo = inputVector[0]->GetInformationObject(0);
+  vtkPolyData* pointsInput = pointsInfo ? vtkPolyData::SafeDownCast(pointsInfo->Get(vtkDataObject::DATA_OBJECT())) : nullptr;
   if (!pointsInput || !pointsInput->GetPoints())
-    {
+  {
     vtkErrorMacro(<< "Input points polydata (port 0) is required.");
     return 0;
-    }
-  vtkPoints *samplePoints = pointsInput->GetPoints();
+  }
+  vtkPoints* samplePoints = pointsInput->GetPoints();
   if (samplePoints->GetNumberOfPoints() < static_cast<vtkIdType>(nu) * nv)
-    {
-    vtkErrorMacro(<< "Input points has "
-                  << samplePoints->GetNumberOfPoints()
-                  << " entries, expected at least " << (nu * nv)
-                  << " for a " << nu << "x" << nv << " grid.");
+  {
+    vtkErrorMacro(<< "Input points has " << samplePoints->GetNumberOfPoints() << " entries, expected at least " << (nu * nv) << " for a " << nu << "x" << nv << " grid.");
     return 0;
-    }
+  }
 
   // Port 1 — BasisU as vtkTable (Nu rows, M columns).
-  vtkInformation *buInfo = inputVector[1]->GetInformationObject(0);
-  vtkTable *basisUInput = buInfo
-    ? vtkTable::SafeDownCast(buInfo->Get(vtkDataObject::DATA_OBJECT()))
-    : nullptr;
+  vtkInformation* buInfo = inputVector[1]->GetInformationObject(0);
+  vtkTable* basisUInput = buInfo ? vtkTable::SafeDownCast(buInfo->Get(vtkDataObject::DATA_OBJECT())) : nullptr;
   // Port 2 — BasisV as vtkTable (Nv rows, M columns).
-  vtkInformation *bvInfo = inputVector[2]->GetInformationObject(0);
-  vtkTable *basisVInput = bvInfo
-    ? vtkTable::SafeDownCast(bvInfo->Get(vtkDataObject::DATA_OBJECT()))
-    : nullptr;
+  vtkInformation* bvInfo = inputVector[2]->GetInformationObject(0);
+  vtkTable* basisVInput = bvInfo ? vtkTable::SafeDownCast(bvInfo->Get(vtkDataObject::DATA_OBJECT())) : nullptr;
   if (!basisUInput || !basisVInput)
-    {
+  {
     vtkErrorMacro(<< "BasisU (port 1) and BasisV (port 2) must be set "
                   << "before Update().");
     return 0;
-    }
+  }
 
   Matrix Bu;
   Matrix Bv;
@@ -268,43 +247,41 @@ int vtkLiverBezierFitter::RequestData(vtkInformation *,
   int mV = 0;
   std::string err;
   if (!decodeBasisTable(basisUInput, nu, Bu, mU, err))
-    {
-    vtkErrorMacro(<< "BasisU (port 1): " << err << " (expected "
-                  << nu << " rows).");
+  {
+    vtkErrorMacro(<< "BasisU (port 1): " << err << " (expected " << nu << " rows).");
     return 0;
-    }
+  }
   if (!decodeBasisTable(basisVInput, nv, Bv, mV, err))
-    {
-    vtkErrorMacro(<< "BasisV (port 2): " << err << " (expected "
-                  << nv << " rows).");
+  {
+    vtkErrorMacro(<< "BasisV (port 2): " << err << " (expected " << nv << " rows).");
     return 0;
-    }
+  }
   if (mU != mV)
-    {
+  {
     vtkErrorMacro(<< "BasisU and BasisV must have the same number of columns "
                   << "(got " << mU << " vs " << mV << ").");
     return 0;
-    }
+  }
   const int M = mU;
   this->GridSize = M;
 
   // Per-axis points matrix (Nu x Nv).
   std::array<Matrix, 3> P;
   for (int axis = 0; axis < 3; ++axis)
-    {
+  {
     P[axis].resize(nu, nv);
-    }
+  }
   for (int i = 0; i < nu; ++i)
-    {
+  {
     for (int j = 0; j < nv; ++j)
-      {
+    {
       double p[3];
       samplePoints->GetPoint(static_cast<vtkIdType>(i) * nv + j, p);
       P[0](i, j) = p[0];
       P[1](i, j) = p[1];
       P[2](i, j) = p[2];
-      }
     }
+  }
 
   // Compute the pseudo-inverse normal-equation matrices, in the same
   // order as the Python reference (LiverLogic.fit_bezier_surface):
@@ -327,36 +304,32 @@ int vtkLiverBezierFitter::RequestData(vtkInformation *,
   // Allocate the flat control-points buffer (M*M*3, row-major (i,j) x axis).
   this->ControlPoints.assign(static_cast<size_t>(M) * M * 3, 0.0);
   for (int axis = 0; axis < 3; ++axis)
-    {
+  {
     const Matrix cp = utUInvU * P[axis] * vtVInvV;
     assert(cp.rows() == M && cp.cols() == M);
     for (int i = 0; i < M; ++i)
-      {
+    {
       for (int j = 0; j < M; ++j)
-        {
+      {
         this->ControlPoints[(static_cast<size_t>(i) * M + j) * 3 + axis] = cp(i, j);
-        }
       }
     }
+  }
 
   // Pack into vtkPolyData output.
-  vtkInformation *outInfo = outputVector->GetInformationObject(0);
-  vtkPolyData *out = vtkPolyData::SafeDownCast(
-    outInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+  vtkPolyData* out = vtkPolyData::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
   vtkNew<vtkPoints> outPoints;
   outPoints->SetDataTypeToDouble();
   outPoints->SetNumberOfPoints(static_cast<vtkIdType>(M) * M);
   for (int i = 0; i < M; ++i)
-    {
+  {
     for (int j = 0; j < M; ++j)
-      {
+    {
       const size_t base = (static_cast<size_t>(i) * M + j) * 3;
-      outPoints->SetPoint(static_cast<vtkIdType>(i) * M + j,
-                          this->ControlPoints[base + 0],
-                          this->ControlPoints[base + 1],
-                          this->ControlPoints[base + 2]);
-      }
+      outPoints->SetPoint(static_cast<vtkIdType>(i) * M + j, this->ControlPoints[base + 0], this->ControlPoints[base + 1], this->ControlPoints[base + 2]);
     }
+  }
   out->SetPoints(outPoints);
   return 1;
 }

--- a/LiverResections/Algorithm/vtkLiverBezierFitter.cxx
+++ b/LiverResections/Algorithm/vtkLiverBezierFitter.cxx
@@ -9,6 +9,7 @@
 #include "vtkLiverBezierFitter.h"
 
 // VTK includes
+#include <vtkAbstractArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
@@ -16,6 +17,8 @@
 #include <vtkObjectFactory.h>
 #include <vtkPoints.h>
 #include <vtkPolyData.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
+#include <vtkTable.h>
 
 // Eigen
 #include <Eigen/Core>
@@ -34,8 +37,27 @@ vtkLiverBezierFitter::vtkLiverBezierFitter()
 {
   this->NumberOfSamples[0] = 0;
   this->NumberOfSamples[1] = 0;
-  this->SetNumberOfInputPorts(0);
+  // Three real input ports per ADR-0015 §1: points (port 0), basisU
+  // (port 1), basisV (port 2).  See header for the data-type contract.
+  this->SetNumberOfInputPorts(3);
   this->SetNumberOfOutputPorts(1);
+}
+
+//------------------------------------------------------------------------------
+int vtkLiverBezierFitter::FillInputPortInformation(int port,
+                                                    vtkInformation *info)
+{
+  if (port == 0)
+    {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+    return 1;
+    }
+  if (port == 1 || port == 2)
+    {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
+    return 1;
+    }
+  return 0;
 }
 
 //------------------------------------------------------------------------------
@@ -60,57 +82,6 @@ void vtkLiverBezierFitter::SetNumberOfSamples(int nu, int nv)
   this->NumberOfSamples[0] = nu;
   this->NumberOfSamples[1] = nv;
   this->Modified();
-}
-
-//------------------------------------------------------------------------------
-void vtkLiverBezierFitter::SetInputPoints(vtkDoubleArray *points)
-{
-  if (this->Points.GetPointer() == points)
-    {
-    return;
-    }
-  this->Points = points;
-  this->Modified();
-}
-
-//------------------------------------------------------------------------------
-vtkDoubleArray *vtkLiverBezierFitter::GetInputPoints() const
-{
-  return this->Points;
-}
-
-//------------------------------------------------------------------------------
-void vtkLiverBezierFitter::SetBasisU(vtkDoubleArray *basisU)
-{
-  if (this->BasisU.GetPointer() == basisU)
-    {
-    return;
-    }
-  this->BasisU = basisU;
-  this->Modified();
-}
-
-//------------------------------------------------------------------------------
-vtkDoubleArray *vtkLiverBezierFitter::GetBasisU() const
-{
-  return this->BasisU;
-}
-
-//------------------------------------------------------------------------------
-void vtkLiverBezierFitter::SetBasisV(vtkDoubleArray *basisV)
-{
-  if (this->BasisV.GetPointer() == basisV)
-    {
-    return;
-    }
-  this->BasisV = basisV;
-  this->Modified();
-}
-
-//------------------------------------------------------------------------------
-vtkDoubleArray *vtkLiverBezierFitter::GetBasisV() const
-{
-  return this->BasisV;
 }
 
 //------------------------------------------------------------------------------
@@ -191,8 +162,55 @@ vtkLiverBezierFitter::BuildBernsteinBasis(vtkDoubleArray *samples, int degree)
 }
 
 //------------------------------------------------------------------------------
+namespace
+{
+// Decode an Nrows x M vtkTable into an Eigen matrix in the same row /
+// column order.  Returns false (and emits an error via vtkErrorMacro on
+// the caller) if the row count does not match the configured Nrows or
+// if columns are non-numeric.
+bool decodeBasisTable(vtkTable *table, int nRows, Eigen::MatrixXd &out,
+                      int &outCols, std::string &err)
+{
+  if (!table)
+    {
+    err = "basis table is null";
+    return false;
+    }
+  const vtkIdType actualRows = table->GetNumberOfRows();
+  const vtkIdType nCols = table->GetNumberOfColumns();
+  if (actualRows != nRows)
+    {
+    err = "basis table row count mismatch";
+    return false;
+    }
+  if (nCols < 1)
+    {
+    err = "basis table has no columns";
+    return false;
+    }
+  outCols = static_cast<int>(nCols);
+  out.resize(nRows, outCols);
+  for (vtkIdType j = 0; j < nCols; ++j)
+    {
+    vtkAbstractArray *col = table->GetColumn(j);
+    if (!col || col->GetNumberOfTuples() != actualRows)
+      {
+      err = "basis table column has wrong tuple count";
+      return false;
+      }
+    for (vtkIdType i = 0; i < actualRows; ++i)
+      {
+      out(static_cast<int>(i), static_cast<int>(j)) =
+        col->GetVariantValue(i).ToDouble();
+      }
+    }
+  return true;
+}
+}  // namespace
+
+//------------------------------------------------------------------------------
 int vtkLiverBezierFitter::RequestData(vtkInformation *,
-                                       vtkInformationVector **,
+                                       vtkInformationVector **inputVector,
                                        vtkInformationVector *outputVector)
 {
   using Matrix = Eigen::MatrixXd;
@@ -206,33 +224,61 @@ int vtkLiverBezierFitter::RequestData(vtkInformation *,
                   << nu << ", " << nv << ").");
     return 0;
     }
-  if (!this->Points || this->Points->GetNumberOfTuples() * this->Points->GetNumberOfComponents()
-      < static_cast<vtkIdType>(nu) * nv * 3)
+
+  // Port 0 — Points: vtkPolyData carrying Nu*Nv samples (row-major u, v).
+  vtkInformation *pointsInfo = inputVector[0]->GetInformationObject(0);
+  vtkPolyData *pointsInput = pointsInfo
+    ? vtkPolyData::SafeDownCast(pointsInfo->Get(vtkDataObject::DATA_OBJECT()))
+    : nullptr;
+  if (!pointsInput || !pointsInput->GetPoints())
     {
-    vtkErrorMacro(<< "InputPoints array too small for "
-                  << nu << "x" << nv << " grid.");
+    vtkErrorMacro(<< "Input points polydata (port 0) is required.");
     return 0;
     }
-  if (!this->BasisU || !this->BasisV)
+  vtkPoints *samplePoints = pointsInput->GetPoints();
+  if (samplePoints->GetNumberOfPoints() < static_cast<vtkIdType>(nu) * nv)
     {
-    vtkErrorMacro(<< "BasisU and BasisV must be set before Update().");
+    vtkErrorMacro(<< "Input points has "
+                  << samplePoints->GetNumberOfPoints()
+                  << " entries, expected at least " << (nu * nv)
+                  << " for a " << nu << "x" << nv << " grid.");
     return 0;
     }
 
-  // Decode BasisU / BasisV row counts from NumberOfSamples; derive the
-  // column count M from the array length.  This matches the Python
-  // contract where basis_u has shape (Nu, M) and basis_v has shape (Nv, M).
-  const vtkIdType totalU = this->BasisU->GetNumberOfTuples()
-                           * this->BasisU->GetNumberOfComponents();
-  const vtkIdType totalV = this->BasisV->GetNumberOfTuples()
-                           * this->BasisV->GetNumberOfComponents();
-  if (totalU % nu != 0 || totalV % nv != 0)
+  // Port 1 — BasisU as vtkTable (Nu rows, M columns).
+  vtkInformation *buInfo = inputVector[1]->GetInformationObject(0);
+  vtkTable *basisUInput = buInfo
+    ? vtkTable::SafeDownCast(buInfo->Get(vtkDataObject::DATA_OBJECT()))
+    : nullptr;
+  // Port 2 — BasisV as vtkTable (Nv rows, M columns).
+  vtkInformation *bvInfo = inputVector[2]->GetInformationObject(0);
+  vtkTable *basisVInput = bvInfo
+    ? vtkTable::SafeDownCast(bvInfo->Get(vtkDataObject::DATA_OBJECT()))
+    : nullptr;
+  if (!basisUInput || !basisVInput)
     {
-    vtkErrorMacro(<< "BasisU/BasisV size not divisible by Nu/Nv.");
+    vtkErrorMacro(<< "BasisU (port 1) and BasisV (port 2) must be set "
+                  << "before Update().");
     return 0;
     }
-  const int mU = static_cast<int>(totalU / nu);
-  const int mV = static_cast<int>(totalV / nv);
+
+  Matrix Bu;
+  Matrix Bv;
+  int mU = 0;
+  int mV = 0;
+  std::string err;
+  if (!decodeBasisTable(basisUInput, nu, Bu, mU, err))
+    {
+    vtkErrorMacro(<< "BasisU (port 1): " << err << " (expected "
+                  << nu << " rows).");
+    return 0;
+    }
+  if (!decodeBasisTable(basisVInput, nv, Bv, mV, err))
+    {
+    vtkErrorMacro(<< "BasisV (port 2): " << err << " (expected "
+                  << nv << " rows).");
+    return 0;
+    }
   if (mU != mV)
     {
     vtkErrorMacro(<< "BasisU and BasisV must have the same number of columns "
@@ -241,24 +287,6 @@ int vtkLiverBezierFitter::RequestData(vtkInformation *,
     }
   const int M = mU;
   this->GridSize = M;
-
-  // Build Eigen matrices from the flat VTK arrays (row-major decode).
-  Matrix Bu(nu, M);
-  for (int i = 0; i < nu; ++i)
-    {
-    for (int j = 0; j < M; ++j)
-      {
-      Bu(i, j) = this->BasisU->GetValue(i * M + j);
-      }
-    }
-  Matrix Bv(nv, M);
-  for (int i = 0; i < nv; ++i)
-    {
-    for (int j = 0; j < M; ++j)
-      {
-      Bv(i, j) = this->BasisV->GetValue(i * M + j);
-      }
-    }
 
   // Per-axis points matrix (Nu x Nv).
   std::array<Matrix, 3> P;
@@ -270,10 +298,11 @@ int vtkLiverBezierFitter::RequestData(vtkInformation *,
     {
     for (int j = 0; j < nv; ++j)
       {
-      const vtkIdType base = (static_cast<vtkIdType>(i) * nv + j) * 3;
-      P[0](i, j) = this->Points->GetValue(base + 0);
-      P[1](i, j) = this->Points->GetValue(base + 1);
-      P[2](i, j) = this->Points->GetValue(base + 2);
+      double p[3];
+      samplePoints->GetPoint(static_cast<vtkIdType>(i) * nv + j, p);
+      P[0](i, j) = p[0];
+      P[1](i, j) = p[1];
+      P[2](i, j) = p[2];
       }
     }
 

--- a/LiverResections/Algorithm/vtkLiverBezierFitter.h
+++ b/LiverResections/Algorithm/vtkLiverBezierFitter.h
@@ -66,19 +66,29 @@ class vtkDoubleArray;
  * ``Testing/Python/unit/test_bezier_characterization.py`` continue to
  * hold against the C++ output at ``rtol=1e-12, atol=1e-12``.
  *
- * \par Inputs
- *  - **Points** (``Set/GetInputPoints``) — Nu * Nv samples of a surface in
- *    3-D, laid out as a flat array of length 3 * Nu * Nv (row-major: each
- *    consecutive triple is the (x,y,z) of a sample, samples grouped by
- *    increasing v within fixed u).  Sized via ``SetNumberOfSamples(Nu, Nv)``.
- *  - **BasisU** (``SetBasisU``) — the Nu x M matrix evaluating the
- *    Bernstein basis at each of the Nu u-samples, laid out row-major in a
- *    ``vtkDoubleArray`` of length Nu * M.  For the canonical 4x4 lift,
- *    M = 4 (Bernstein degree 3 — matches the production callers
+ * \par Inputs (real VTK input ports per ADR-0015 §1)
+ *  Three explicit input ports — option A from issue #339.  The
+ *  alternative (1 port + 2 parameter arrays) was rejected because the
+ *  Bernstein-basis matrices are *data* — they're a function of the
+ *  sample positions (an input), not a function of the algorithm's
+ *  fixed parameters.  Treating them as data on ports lets T2 Stack 4
+ *  Representations compose this fitter via ``SetInputConnection`` from
+ *  a basis-builder upstream (or supply a static
+ *  ``BuildBernsteinBasis``-produced table directly).
+ *
+ *  - **Port 0 — Points** as ``vtkPolyData``.  ``GetPoints()`` carries
+ *    Nu * Nv samples of a surface in 3-D, ordered row-major in u then v
+ *    (i.e. point index ``i * Nv + j`` holds sample ``(u_i, v_j)``).
+ *    Sized via ``SetNumberOfSamples(Nu, Nv)``.
+ *  - **Port 1 — BasisU** as ``vtkTable``.  Nu rows, M columns; row i is
+ *    the Bernstein basis evaluated at u-sample i.  M (= Bernstein order
+ *    + 1) determines the control-grid side length.  For the canonical
+ *    4x4 lift used by the production callers
  *    ``LiverLogic.runSurfacefromCurve`` / ``runSurfacefromEFD`` in
- *    ``Liver/Liver.py``, which evaluate ``evaluate_basis_bezier(t, 3)``).
- *  - **BasisV** (``SetBasisV``) — the Nv x M matrix evaluating the
- *    Bernstein basis at each of the Nv v-samples (row-major).
+ *    ``Liver/Liver.py``, M = 4 (Bernstein degree 3).
+ *  - **Port 2 — BasisV** as ``vtkTable``.  Nv rows, M columns; row i is
+ *    the Bernstein basis evaluated at v-sample i.  Must have the same
+ *    column count M as BasisU.
  *
  * \par Output
  *  - On port 0, a ``vtkPolyData`` whose ``GetPoints()`` array holds the
@@ -123,24 +133,12 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverBezierFitter
   void PrintSelf(ostream &os, vtkIndent indent) override;
 
   /// Set the dimensions of the gridded sample (Nu rows, Nv columns).
-  /// The Points array must contain 3*Nu*Nv values; BasisU must have
-  /// Nu rows and BasisV must have Nv rows.
+  /// The points input must contain Nu*Nv points; BasisU (table on port 1)
+  /// must have Nu rows and BasisV (table on port 2) must have Nv rows.
+  /// Setter only — gridded sample shape is a parameter per ADR-0015 §1
+  /// (an explicit declaration of what shape the input data carries).
   void SetNumberOfSamples(int nu, int nv);
   vtkGetVector2Macro(NumberOfSamples, int);
-
-  /// Set the gridded input points as a flat (Nu*Nv*3) array.  Layout:
-  /// ``[x00, y00, z00, x01, y01, z01, ..., x_{Nu-1,Nv-1}, y_..., z_...]``
-  /// (row-major in u then v).
-  void SetInputPoints(vtkDoubleArray *points);
-  vtkDoubleArray *GetInputPoints() const;
-
-  /// Set the Nu x M Bernstein-basis matrix (row-major).
-  void SetBasisU(vtkDoubleArray *basisU);
-  vtkDoubleArray *GetBasisU() const;
-
-  /// Set the Nv x M Bernstein-basis matrix (row-major).
-  void SetBasisV(vtkDoubleArray *basisV);
-  vtkDoubleArray *GetBasisV() const;
 
   /// Fetch the fitted M*M*3 control points as a flat std::vector.
   /// Valid after ``Update()``.  Layout matches the polydata output:
@@ -176,6 +174,7 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverBezierFitter
   vtkLiverBezierFitter();
   ~vtkLiverBezierFitter() override;
 
+  int FillInputPortInformation(int port, vtkInformation *info) override;
   int RequestData(vtkInformation *,
                   vtkInformationVector **,
                   vtkInformationVector *) override;
@@ -186,9 +185,6 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverBezierFitter
 
   int NumberOfSamples[2];
   int GridSize;
-  vtkSmartPointer<vtkDoubleArray> Points;
-  vtkSmartPointer<vtkDoubleArray> BasisU;
-  vtkSmartPointer<vtkDoubleArray> BasisV;
   std::vector<double> ControlPoints;
 };
 

--- a/LiverResections/Algorithm/vtkLiverBezierFitter.h
+++ b/LiverResections/Algorithm/vtkLiverBezierFitter.h
@@ -124,13 +124,12 @@ class vtkDoubleArray;
  *  the algorithm library is pure VTK; MRML lives in the Python
  *  orchestration layer that consumes the output.
  */
-class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverBezierFitter
-  : public vtkPolyDataAlgorithm
+class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverBezierFitter : public vtkPolyDataAlgorithm
 {
- public:
-  static vtkLiverBezierFitter *New();
+public:
+  static vtkLiverBezierFitter* New();
   vtkTypeMacro(vtkLiverBezierFitter, vtkPolyDataAlgorithm);
-  void PrintSelf(ostream &os, vtkIndent indent) override;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Set the dimensions of the gridded sample (Nu rows, Nv columns).
   /// The points input must contain Nu*Nv points; BasisU (table on port 1)
@@ -143,8 +142,7 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverBezierFitter
   /// Fetch the fitted M*M*3 control points as a flat std::vector.
   /// Valid after ``Update()``.  Layout matches the polydata output:
   /// row-major (i, j) order with 3 floats per control point.
-  const std::vector<double> &GetControlPoints() const
-  { return this->ControlPoints; }
+  const std::vector<double>& GetControlPoints() const { return this->ControlPoints; }
 
   /// Convenience: control-grid side length M (= BasisU/BasisV column count).
   /// Zero until ``Update()`` has been called.
@@ -160,32 +158,26 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverBezierFitter
   /// ``nSamples * (degree + 1)`` (1 component per value).
   ///
   /// Wrappable from Python via the VTK array surface.
-  static vtkSmartPointer<vtkDoubleArray>
-  BuildBernsteinBasis(vtkDoubleArray *samples, int degree);
+  static vtkSmartPointer<vtkDoubleArray> BuildBernsteinBasis(vtkDoubleArray* samples, int degree);
 
   /// C++-friendly overload — fill ``out`` (resized to nSamples *
   /// (degree+1)) with the same row-major Bernstein basis.
-  static void BuildBernsteinBasisRaw(const double *samples,
-                                      int nSamples,
-                                      int degree,
-                                      std::vector<double> &out);
+  static void BuildBernsteinBasisRaw(const double* samples, int nSamples, int degree, std::vector<double>& out);
 
- protected:
+protected:
   vtkLiverBezierFitter();
   ~vtkLiverBezierFitter() override;
 
-  int FillInputPortInformation(int port, vtkInformation *info) override;
-  int RequestData(vtkInformation *,
-                  vtkInformationVector **,
-                  vtkInformationVector *) override;
+  int FillInputPortInformation(int port, vtkInformation* info) override;
+  int RequestData(vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
 
- private:
-  vtkLiverBezierFitter(const vtkLiverBezierFitter &) = delete;
-  void operator=(const vtkLiverBezierFitter &) = delete;
+private:
+  vtkLiverBezierFitter(const vtkLiverBezierFitter&) = delete;
+  void operator=(const vtkLiverBezierFitter&) = delete;
 
   int NumberOfSamples[2];
   int GridSize;
   std::vector<double> ControlPoints;
 };
 
-#endif  // __vtkLiverBezierFitter_h_
+#endif // __vtkLiverBezierFitter_h_

--- a/LiverResections/Algorithm/vtkLiverContourParameterizer.cxx
+++ b/LiverResections/Algorithm/vtkLiverContourParameterizer.cxx
@@ -30,7 +30,7 @@ namespace
 {
 constexpr double TWO_PI = 6.283185307179586476925286766559005768394;
 constexpr double PI = 3.141592653589793238462643383279502884197;
-}
+} // namespace
 
 //------------------------------------------------------------------------------
 vtkLiverContourParameterizer::vtkLiverContourParameterizer()
@@ -50,19 +50,17 @@ vtkLiverContourParameterizer::vtkLiverContourParameterizer()
 vtkLiverContourParameterizer::~vtkLiverContourParameterizer() = default;
 
 //------------------------------------------------------------------------------
-void vtkLiverContourParameterizer::PrintSelf(ostream &os, vtkIndent indent)
+void vtkLiverContourParameterizer::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os, indent);
   os << indent << "Mode: " << this->Mode << "\n";
   os << indent << "Order: " << this->Order << "\n";
-  os << indent << "NumberOfReconstructionPoints: "
-     << this->NumberOfReconstructionPoints << "\n";
+  os << indent << "NumberOfReconstructionPoints: " << this->NumberOfReconstructionPoints << "\n";
   os << indent << "UseComputedLocus: " << this->UseComputedLocus << "\n";
 }
 
 //------------------------------------------------------------------------------
-int vtkLiverContourParameterizer::FillInputPortInformation(int /*port*/,
-                                                            vtkInformation *info)
+int vtkLiverContourParameterizer::FillInputPortInformation(int /*port*/, vtkInformation* info)
 {
   info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
   return 1;
@@ -72,9 +70,9 @@ int vtkLiverContourParameterizer::FillInputPortInformation(int /*port*/,
 void vtkLiverContourParameterizer::SetLocus(double x, double y, double z)
 {
   if (this->Locus[0] == x && this->Locus[1] == y && this->Locus[2] == z)
-    {
+  {
     return;
-    }
+  }
   this->Locus[0] = x;
   this->Locus[1] = y;
   this->Locus[2] = z;
@@ -104,50 +102,47 @@ void vtkLiverContourParameterizer::SetLocus(double x, double y, double z)
 // six sums in a single pass per harmonic, preserving the (over-segments)
 // reduction order so the floating-point reduction matches NumPy's.
 //------------------------------------------------------------------------------
-std::vector<double>
-vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(const double *contour,
-                                                        int nPoints,
-                                                        int order)
+std::vector<double> vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(const double* contour, int nPoints, int order)
 {
   std::vector<double> result(static_cast<size_t>(order) * 6, 0.0);
   if (nPoints < 2 || order < 1)
-    {
+  {
     return result;
-    }
+  }
 
   // Segment-wise differentials and parameter t.
   const int nSeg = nPoints - 1;
   std::vector<double> dx(nSeg), dy(nSeg), dz(nSeg), dt(nSeg);
   std::vector<double> t(nPoints, 0.0);
   for (int i = 0; i < nSeg; ++i)
-    {
+  {
     dx[i] = contour[(i + 1) * 3 + 0] - contour[i * 3 + 0];
     dy[i] = contour[(i + 1) * 3 + 1] - contour[i * 3 + 1];
     dz[i] = contour[(i + 1) * 3 + 2] - contour[i * 3 + 2];
     dt[i] = std::sqrt(dx[i] * dx[i] + dy[i] * dy[i] + dz[i] * dz[i]);
     t[i + 1] = t[i] + dt[i];
-    }
+  }
   const double T = t[nSeg];
   if (T == 0.0)
-    {
+  {
     return result;
-    }
+  }
 
   // phi[k] = 2 * pi * t[k] / T, evaluated per-segment endpoint.
   std::vector<double> phiBase(nPoints);
   for (int k = 0; k < nPoints; ++k)
-    {
+  {
     phiBase[k] = TWO_PI * t[k] / T;
-    }
+  }
 
   // Per-harmonic accumulation.  Per-harmonic constant matches Python:
   //   const_n = T / (2 * n^2 * pi^2)
   for (int n = 1; n <= order; ++n)
-    {
+  {
     const double cn = T / (2.0 * static_cast<double>(n) * n * PI * PI);
     double a = 0.0, b = 0.0, c = 0.0, d = 0.0, e = 0.0, f = 0.0;
     for (int i = 0; i < nSeg; ++i)
-      {
+    {
       const double phi0 = n * phiBase[i];
       const double phi1 = n * phiBase[i + 1];
       const double dCos = std::cos(phi1) - std::cos(phi0);
@@ -163,7 +158,7 @@ vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(const double *contour,
       d += (dy[i] / dt[i]) * dSin;
       e += (dz[i] / dt[i]) * dCos;
       f += (dz[i] / dt[i]) * dSin;
-      }
+    }
     const int row = n - 1;
     result[row * 6 + 0] = cn * a;
     result[row * 6 + 1] = cn * b;
@@ -171,7 +166,7 @@ vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(const double *contour,
     result[row * 6 + 3] = cn * d;
     result[row * 6 + 4] = cn * e;
     result[row * 6 + 5] = cn * f;
-    }
+  }
   return result;
 }
 
@@ -187,39 +182,38 @@ vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(const double *contour,
 // preserving the same per-segment reduction order so the result matches
 // NumPy's sum reduction to within last-bit-of-double.
 //------------------------------------------------------------------------------
-std::vector<double>
-vtkLiverContourParameterizer::ComputeDCCoefficientsRaw(const double *contour, int nPoints)
+std::vector<double> vtkLiverContourParameterizer::ComputeDCCoefficientsRaw(const double* contour, int nPoints)
 {
   std::vector<double> result(3, 0.0);
   if (nPoints < 2)
-    {
+  {
     return result;
-    }
+  }
   const int nSeg = nPoints - 1;
   std::vector<double> dx(nSeg), dy(nSeg), dz(nSeg), dt(nSeg);
   std::vector<double> t(nPoints, 0.0);
   for (int i = 0; i < nSeg; ++i)
-    {
+  {
     dx[i] = contour[(i + 1) * 3 + 0] - contour[i * 3 + 0];
     dy[i] = contour[(i + 1) * 3 + 1] - contour[i * 3 + 1];
     dz[i] = contour[(i + 1) * 3 + 2] - contour[i * 3 + 2];
     dt[i] = std::sqrt(dx[i] * dx[i] + dy[i] * dy[i] + dz[i] * dz[i]);
     t[i + 1] = t[i] + dt[i];
-    }
+  }
   const double T = t[nSeg];
   if (T == 0.0)
-    {
+  {
     result[0] = contour[0];
     result[1] = contour[1];
     result[2] = contour[2];
     return result;
-    }
+  }
   // diff(t**2): segment i contributes t[i+1]^2 - t[i]^2.
   // cumsum of dx/dy/dz: prefix sum along segments.
   double cumDx = 0.0, cumDy = 0.0, cumDz = 0.0;
   double sumX = 0.0, sumY = 0.0, sumZ = 0.0;
   for (int i = 0; i < nSeg; ++i)
-    {
+  {
     cumDx += dx[i];
     cumDy += dy[i];
     cumDz += dz[i];
@@ -231,7 +225,7 @@ vtkLiverContourParameterizer::ComputeDCCoefficientsRaw(const double *contour, in
     sumX += (dx[i] / (2.0 * dt[i])) * diffT2 + xi * dt[i];
     sumY += (dy[i] / (2.0 * dt[i])) * diffT2 + delta * dt[i];
     sumZ += (dz[i] / (2.0 * dt[i])) * diffT2 + zi * dt[i];
-    }
+  }
   const double invT = 1.0 / T;
   result[0] = contour[0] + sumX * invT;
   result[1] = contour[1] + sumY * invT;
@@ -257,48 +251,44 @@ vtkLiverContourParameterizer::ComputeDCCoefficientsRaw(const double *contour, in
 // t_k, sum over harmonics n.  This matches NumPy's matmul-of-row-vector
 // reduction direction.
 //------------------------------------------------------------------------------
-std::vector<double>
-vtkLiverContourParameterizer::InverseTransformRaw(const double *coeffs,
-                                                   int harmonic,
-                                                   const double locus[3],
-                                                   int nCoords)
+std::vector<double> vtkLiverContourParameterizer::InverseTransformRaw(const double* coeffs, int harmonic, const double locus[3], int nCoords)
 {
   std::vector<double> result(static_cast<size_t>(3) * nCoords, 0.0);
   if (harmonic < 1 || nCoords < 1)
-    {
+  {
     return result;
-    }
+  }
   // t = linspace(0, 1, nCoords) — NumPy default endpoint=True.
   std::vector<double> ts(nCoords);
   if (nCoords == 1)
-    {
+  {
     ts[0] = 0.0;
-    }
+  }
   else
-    {
+  {
     const double step = 1.0 / static_cast<double>(nCoords - 1);
     for (int k = 0; k < nCoords; ++k)
-      {
-      ts[k] = step * k;
-      }
-    }
-  for (int k = 0; k < nCoords; ++k)
     {
+      ts[k] = step * k;
+    }
+  }
+  for (int k = 0; k < nCoords; ++k)
+  {
     double xt = 0.0, yt = 0.0, zt = 0.0;
     const double t = ts[k];
     for (int n = 0; n < harmonic; ++n)
-      {
+    {
       const double phase = TWO_PI * static_cast<double>(n + 1) * t;
       const double cp = std::cos(phase);
       const double sp = std::sin(phase);
       xt += coeffs[n * 6 + 0] * cp + coeffs[n * 6 + 1] * sp;
       yt += coeffs[n * 6 + 2] * cp + coeffs[n * 6 + 3] * sp;
       zt += coeffs[n * 6 + 4] * cp + coeffs[n * 6 + 5] * sp;
-      }
+    }
     result[0 * nCoords + k] = xt + locus[0];
     result[1 * nCoords + k] = yt + locus[1];
     result[2 * nCoords + k] = zt + locus[2];
-    }
+  }
   return result;
 }
 
@@ -309,37 +299,36 @@ vtkLiverContourParameterizer::InverseTransformRaw(const double *coeffs,
 //------------------------------------------------------------------------------
 namespace
 {
-vtkSmartPointer<vtkDoubleArray> wrap(const std::vector<double> &values)
+vtkSmartPointer<vtkDoubleArray> wrap(const std::vector<double>& values)
 {
   vtkSmartPointer<vtkDoubleArray> arr = vtkSmartPointer<vtkDoubleArray>::New();
   arr->SetNumberOfComponents(1);
   arr->SetNumberOfTuples(static_cast<vtkIdType>(values.size()));
   for (size_t i = 0; i < values.size(); ++i)
-    {
+  {
     arr->SetValue(static_cast<vtkIdType>(i), values[i]);
-    }
+  }
   return arr;
 }
-std::vector<double> unwrap(vtkDoubleArray *arr)
+std::vector<double> unwrap(vtkDoubleArray* arr)
 {
   std::vector<double> out;
   if (!arr)
-    {
+  {
     return out;
-    }
+  }
   const vtkIdType n = arr->GetNumberOfTuples() * arr->GetNumberOfComponents();
   out.reserve(static_cast<size_t>(n));
   for (vtkIdType i = 0; i < n; ++i)
-    {
+  {
     out.push_back(arr->GetValue(i));
-    }
+  }
   return out;
 }
-}  // namespace
+} // namespace
 
 //------------------------------------------------------------------------------
-vtkSmartPointer<vtkDoubleArray>
-vtkLiverContourParameterizer::ComputeEFDCoefficients(vtkDoubleArray *contour, int order)
+vtkSmartPointer<vtkDoubleArray> vtkLiverContourParameterizer::ComputeEFDCoefficients(vtkDoubleArray* contour, int order)
 {
   auto flat = unwrap(contour);
   const int n = static_cast<int>(flat.size() / 3);
@@ -347,8 +336,7 @@ vtkLiverContourParameterizer::ComputeEFDCoefficients(vtkDoubleArray *contour, in
 }
 
 //------------------------------------------------------------------------------
-vtkSmartPointer<vtkDoubleArray>
-vtkLiverContourParameterizer::ComputeDCCoefficients(vtkDoubleArray *contour)
+vtkSmartPointer<vtkDoubleArray> vtkLiverContourParameterizer::ComputeDCCoefficients(vtkDoubleArray* contour)
 {
   auto flat = unwrap(contour);
   const int n = static_cast<int>(flat.size() / 3);
@@ -356,13 +344,7 @@ vtkLiverContourParameterizer::ComputeDCCoefficients(vtkDoubleArray *contour)
 }
 
 //------------------------------------------------------------------------------
-vtkSmartPointer<vtkDoubleArray>
-vtkLiverContourParameterizer::InverseTransform(vtkDoubleArray *coeffs,
-                                                int harmonic,
-                                                double locusX,
-                                                double locusY,
-                                                double locusZ,
-                                                int nCoords)
+vtkSmartPointer<vtkDoubleArray> vtkLiverContourParameterizer::InverseTransform(vtkDoubleArray* coeffs, int harmonic, double locusX, double locusY, double locusZ, int nCoords)
 {
   auto flat = unwrap(coeffs);
   const double locus[3] = { locusX, locusY, locusZ };
@@ -370,26 +352,22 @@ vtkLiverContourParameterizer::InverseTransform(vtkDoubleArray *coeffs,
 }
 
 //------------------------------------------------------------------------------
-int vtkLiverContourParameterizer::RequestData(vtkInformation *,
-                                                vtkInformationVector **inputVector,
-                                                vtkInformationVector *outputVector)
+int vtkLiverContourParameterizer::RequestData(vtkInformation*, vtkInformationVector** inputVector, vtkInformationVector* outputVector)
 {
-  vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
-  vtkPolyData *inputContour = vtkPolyData::SafeDownCast(
-    inInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
+  vtkPolyData* inputContour = vtkPolyData::SafeDownCast(inInfo->Get(vtkDataObject::DATA_OBJECT()));
   if (!inputContour || !inputContour->GetPoints())
-    {
+  {
     vtkErrorMacro(<< "Input contour polydata with points is required on port 0.");
     return 0;
-    }
-  vtkPoints *inputPoints = inputContour->GetPoints();
+  }
+  vtkPoints* inputPoints = inputContour->GetPoints();
   const vtkIdType n64 = inputPoints->GetNumberOfPoints();
   if (n64 < 2)
-    {
-    vtkErrorMacro(<< "Input contour must contain at least two 3D points; got "
-                  << n64 << ".");
+  {
+    vtkErrorMacro(<< "Input contour must contain at least two 3D points; got " << n64 << ".");
     return 0;
-    }
+  }
   const int n = static_cast<int>(n64);
   const vtkIdType total = static_cast<vtkIdType>(n) * 3;
 
@@ -398,43 +376,39 @@ int vtkLiverContourParameterizer::RequestData(vtkInformation *,
   // order: row i = (x_i, y_i, z_i).
   std::vector<double> contour(static_cast<size_t>(total));
   for (int i = 0; i < n; ++i)
-    {
+  {
     double p[3];
     inputPoints->GetPoint(i, p);
     contour[i * 3 + 0] = p[0];
     contour[i * 3 + 1] = p[1];
     contour[i * 3 + 2] = p[2];
-    }
+  }
 
-  vtkInformation *outInfo = outputVector->GetInformationObject(0);
-  vtkPolyData *out = vtkPolyData::SafeDownCast(
-    outInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+  vtkPolyData* out = vtkPolyData::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
 
   this->Coefficients.clear();
   this->DC.clear();
   this->Reconstruction.clear();
 
   if (this->Mode == MODE_EFD)
-    {
+  {
     if (this->Order < 1)
-      {
+    {
       vtkErrorMacro(<< "Order must be >= 1 in EFD mode; got " << this->Order << ".");
       return 0;
-      }
+    }
     this->Coefficients = ComputeEFDCoefficientsRaw(contour.data(), n, this->Order);
     if (this->UseComputedLocus)
-      {
+    {
       this->DC = ComputeDCCoefficientsRaw(contour.data(), n);
-      }
+    }
     else
-      {
+    {
       this->DC = { this->Locus[0], this->Locus[1], this->Locus[2] };
-      }
+    }
     const double locusArr[3] = { this->DC[0], this->DC[1], this->DC[2] };
-    this->Reconstruction = InverseTransformRaw(this->Coefficients.data(),
-                                                this->Order,
-                                                locusArr,
-                                                this->NumberOfReconstructionPoints);
+    this->Reconstruction = InverseTransformRaw(this->Coefficients.data(), this->Order, locusArr, this->NumberOfReconstructionPoints);
 
     // Pack into output polydata: nCoords reconstructed points.
     vtkNew<vtkPoints> outPoints;
@@ -442,15 +416,12 @@ int vtkLiverContourParameterizer::RequestData(vtkInformation *,
     const int nc = this->NumberOfReconstructionPoints;
     outPoints->SetNumberOfPoints(nc);
     for (int k = 0; k < nc; ++k)
-      {
-      outPoints->SetPoint(k,
-                          this->Reconstruction[0 * nc + k],
-                          this->Reconstruction[1 * nc + k],
-                          this->Reconstruction[2 * nc + k]);
-      }
+    {
+      outPoints->SetPoint(k, this->Reconstruction[0 * nc + k], this->Reconstruction[1 * nc + k], this->Reconstruction[2 * nc + k]);
+    }
     out->SetPoints(outPoints);
     return 1;
-    }
+  }
 
   // CornerMapping mode: choose 4 equally spaced corner indices around
   // the ring and surface them via point-data scalars.
@@ -458,12 +429,9 @@ int vtkLiverContourParameterizer::RequestData(vtkInformation *,
   outPoints->SetDataTypeToDouble();
   outPoints->SetNumberOfPoints(n);
   for (int i = 0; i < n; ++i)
-    {
-    outPoints->SetPoint(i,
-                        contour[i * 3 + 0],
-                        contour[i * 3 + 1],
-                        contour[i * 3 + 2]);
-    }
+  {
+    outPoints->SetPoint(i, contour[i * 3 + 0], contour[i * 3 + 1], contour[i * 3 + 2]);
+  }
   out->SetPoints(outPoints);
 
   vtkNew<vtkIntArray> cornerFlags;
@@ -471,16 +439,16 @@ int vtkLiverContourParameterizer::RequestData(vtkInformation *,
   cornerFlags->SetNumberOfComponents(1);
   cornerFlags->SetNumberOfTuples(n);
   for (int i = 0; i < n; ++i)
-    {
+  {
     cornerFlags->SetValue(i, 0);
-    }
+  }
   // Four corners at indices 0, n/4, n/2, 3n/4 (mod n).  Same convention
   // used by the SlicingPlane init path's existing Python helper.
   for (int k = 0; k < 4; ++k)
-    {
+  {
     const int idx = (k * n) / 4;
     cornerFlags->SetValue(idx, k + 1);
-    }
+  }
   out->GetPointData()->AddArray(cornerFlags);
   return 1;
 }

--- a/LiverResections/Algorithm/vtkLiverContourParameterizer.cxx
+++ b/LiverResections/Algorithm/vtkLiverContourParameterizer.cxx
@@ -42,7 +42,7 @@ vtkLiverContourParameterizer::vtkLiverContourParameterizer()
   this->Locus[0] = 0.0;
   this->Locus[1] = 0.0;
   this->Locus[2] = 0.0;
-  this->SetNumberOfInputPorts(0);
+  this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(1);
 }
 
@@ -61,20 +61,11 @@ void vtkLiverContourParameterizer::PrintSelf(ostream &os, vtkIndent indent)
 }
 
 //------------------------------------------------------------------------------
-void vtkLiverContourParameterizer::SetInputContour(vtkDoubleArray *contour)
+int vtkLiverContourParameterizer::FillInputPortInformation(int /*port*/,
+                                                            vtkInformation *info)
 {
-  if (this->Contour.GetPointer() == contour)
-    {
-    return;
-    }
-  this->Contour = contour;
-  this->Modified();
-}
-
-//------------------------------------------------------------------------------
-vtkDoubleArray *vtkLiverContourParameterizer::GetInputContour() const
-{
-  return this->Contour;
+  info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+  return 1;
 }
 
 //------------------------------------------------------------------------------
@@ -380,28 +371,39 @@ vtkLiverContourParameterizer::InverseTransform(vtkDoubleArray *coeffs,
 
 //------------------------------------------------------------------------------
 int vtkLiverContourParameterizer::RequestData(vtkInformation *,
-                                                vtkInformationVector **,
+                                                vtkInformationVector **inputVector,
                                                 vtkInformationVector *outputVector)
 {
-  if (!this->Contour)
+  vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
+  vtkPolyData *inputContour = vtkPolyData::SafeDownCast(
+    inInfo->Get(vtkDataObject::DATA_OBJECT()));
+  if (!inputContour || !inputContour->GetPoints())
     {
-    vtkErrorMacro(<< "InputContour must be set before Update().");
+    vtkErrorMacro(<< "Input contour polydata with points is required on port 0.");
     return 0;
     }
-  const vtkIdType total = this->Contour->GetNumberOfTuples()
-                          * this->Contour->GetNumberOfComponents();
-  if (total < 6 || total % 3 != 0)
+  vtkPoints *inputPoints = inputContour->GetPoints();
+  const vtkIdType n64 = inputPoints->GetNumberOfPoints();
+  if (n64 < 2)
     {
-    vtkErrorMacro(<< "InputContour must contain at least two 3D points and "
-                  << "be a multiple of three values; got " << total << ".");
+    vtkErrorMacro(<< "Input contour must contain at least two 3D points; got "
+                  << n64 << ".");
     return 0;
     }
-  const int n = static_cast<int>(total / 3);
+  const int n = static_cast<int>(n64);
+  const vtkIdType total = static_cast<vtkIdType>(n) * 3;
 
-  std::vector<double> contour(total);
-  for (vtkIdType i = 0; i < total; ++i)
+  // Decode the input ring point-by-point into the flat (x, y, z) buffer
+  // the EFD / corner-mapping algorithms operate on.  Preserves traversal
+  // order: row i = (x_i, y_i, z_i).
+  std::vector<double> contour(static_cast<size_t>(total));
+  for (int i = 0; i < n; ++i)
     {
-    contour[i] = this->Contour->GetValue(i);
+    double p[3];
+    inputPoints->GetPoint(i, p);
+    contour[i * 3 + 0] = p[0];
+    contour[i * 3 + 1] = p[1];
+    contour[i * 3 + 2] = p[2];
     }
 
   vtkInformation *outInfo = outputVector->GetInformationObject(0);

--- a/LiverResections/Algorithm/vtkLiverContourParameterizer.h
+++ b/LiverResections/Algorithm/vtkLiverContourParameterizer.h
@@ -49,11 +49,15 @@ class vtkDoubleArray;
  *  direct sum, matching the Python reference.
  *
  * \par Inputs
- *  - **Contour** (``SetInputContour``) — N closed ring points as a flat
- *    ``vtkDoubleArray`` of length 3*N.  The caller is responsible for
- *    closing the loop (i.e. either the last point repeats the first,
- *    or the test fixture handles that explicitly as in the Python
- *    characterisation tests).
+ *  - **Port 0** — closed ring as ``vtkPolyData``; the points array carries
+ *    N (x, y, z) triples in traversal order.  This is the natural output
+ *    type of the upstream ring extractors
+ *    (``vtkLiverPlaneRingExtractor`` / ``vtkLiverSpheroidRingExtractor``)
+ *    so the three classes compose with
+ *    ``parameterizer->SetInputConnection(extractor->GetOutputPort())``
+ *    per ADR-0015 §1.  The caller is responsible for closing the loop
+ *    (i.e. either the last point repeats the first, or the test fixture
+ *    handles that explicitly as in the Python characterisation tests).
  *
  * \par Parameters
  *  - ``Mode`` — ``MODE_CORNER_MAPPING`` (0) or ``MODE_EFD`` (1).
@@ -104,10 +108,6 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverContourParamete
 
   vtkSetMacro(NumberOfReconstructionPoints, int);
   vtkGetMacro(NumberOfReconstructionPoints, int);
-
-  /// Set the input contour as a flat 3*N array (row-major xyz).
-  void SetInputContour(vtkDoubleArray *contour);
-  vtkDoubleArray *GetInputContour() const;
 
   /// Use a caller-supplied locus for EFD reconstruction.  After
   /// ``UseComputedLocusOn`` (the default) the parameteriser computes
@@ -169,6 +169,7 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverContourParamete
   vtkLiverContourParameterizer();
   ~vtkLiverContourParameterizer() override;
 
+  int FillInputPortInformation(int port, vtkInformation *info) override;
   int RequestData(vtkInformation *,
                   vtkInformationVector **,
                   vtkInformationVector *) override;
@@ -183,7 +184,6 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverContourParamete
   double Locus[3];
   bool UseComputedLocus;
 
-  vtkSmartPointer<vtkDoubleArray> Contour;
   std::vector<double> Coefficients;
   std::vector<double> DC;
   std::vector<double> Reconstruction;

--- a/LiverResections/Algorithm/vtkLiverContourParameterizer.h
+++ b/LiverResections/Algorithm/vtkLiverContourParameterizer.h
@@ -86,13 +86,12 @@ class vtkDoubleArray;
  * \par MRML invariant
  *  No ``vtkMRMLNode`` references.  Per ADR-0015.
  */
-class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverContourParameterizer
-  : public vtkPolyDataAlgorithm
+class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverContourParameterizer : public vtkPolyDataAlgorithm
 {
- public:
-  static vtkLiverContourParameterizer *New();
+public:
+  static vtkLiverContourParameterizer* New();
   vtkTypeMacro(vtkLiverContourParameterizer, vtkPolyDataAlgorithm);
-  void PrintSelf(ostream &os, vtkIndent indent) override;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   enum Mode
   {
@@ -119,12 +118,12 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverContourParamete
   vtkBooleanMacro(UseComputedLocus, bool);
 
   /// Flat (Order * 6) row-major array of EFD coefficients.
-  const std::vector<double> &GetCoefficients() const { return this->Coefficients; }
+  const std::vector<double>& GetCoefficients() const { return this->Coefficients; }
   /// (A0, C0, E0) DC offsets actually used for the reconstruction.
-  const std::vector<double> &GetDCCoefficients() const { return this->DC; }
+  const std::vector<double>& GetDCCoefficients() const { return this->DC; }
   /// Reconstructed contour: 3*NumberOfReconstructionPoints values (x's,
   /// y's, z's in that order — matching the Python (1, 3, n_coords) shape).
-  const std::vector<double> &GetReconstruction() const { return this->Reconstruction; }
+  const std::vector<double>& GetReconstruction() const { return this->Reconstruction; }
 
   /// Compute EFD coefficients of an arbitrary closed 3D contour.
   /// Exposed as a static helper so callers (and tests) can drive the
@@ -134,49 +133,35 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverContourParamete
   /// vtkDoubleArray (1 component per value).
   ///
   /// `contour` must be a 3*n vtkDoubleArray of (x, y, z) triples.
-  static vtkSmartPointer<vtkDoubleArray>
-  ComputeEFDCoefficients(vtkDoubleArray *contour, int order);
+  static vtkSmartPointer<vtkDoubleArray> ComputeEFDCoefficients(vtkDoubleArray* contour, int order);
 
   /// Compute the Kuhl-Giardina (A_0, C_0, E_0) DC triple for a closed
   /// 3D contour.  Returns 3 values in a vtkDoubleArray.
-  static vtkSmartPointer<vtkDoubleArray>
-  ComputeDCCoefficients(vtkDoubleArray *contour);
+  static vtkSmartPointer<vtkDoubleArray> ComputeDCCoefficients(vtkDoubleArray* contour);
 
   /// Inverse EFD transform: reconstruct a contour from coefficients.
   /// Returns 3*nCoords values in the (1, 3, n_coords) layout used by
   /// the Python reference (i.e. all x's, then all y's, then all z's),
   /// packed into a vtkDoubleArray.
-  static vtkSmartPointer<vtkDoubleArray>
-  InverseTransform(vtkDoubleArray *coeffs,
-                   int harmonic,
-                   double locusX, double locusY, double locusZ,
-                   int nCoords);
+  static vtkSmartPointer<vtkDoubleArray> InverseTransform(vtkDoubleArray* coeffs, int harmonic, double locusX, double locusY, double locusZ, int nCoords);
 
   /// C++-friendly overloads on raw pointers — used by the in-process
   /// pipeline and the C++ tests, which need pointer arithmetic over
   /// pre-existing std::vector buffers.
-  static std::vector<double>
-  ComputeEFDCoefficientsRaw(const double *contour, int nPoints, int order);
-  static std::vector<double>
-  ComputeDCCoefficientsRaw(const double *contour, int nPoints);
-  static std::vector<double>
-  InverseTransformRaw(const double *coeffs,
-                      int harmonic,
-                      const double locus[3],
-                      int nCoords);
+  static std::vector<double> ComputeEFDCoefficientsRaw(const double* contour, int nPoints, int order);
+  static std::vector<double> ComputeDCCoefficientsRaw(const double* contour, int nPoints);
+  static std::vector<double> InverseTransformRaw(const double* coeffs, int harmonic, const double locus[3], int nCoords);
 
- protected:
+protected:
   vtkLiverContourParameterizer();
   ~vtkLiverContourParameterizer() override;
 
-  int FillInputPortInformation(int port, vtkInformation *info) override;
-  int RequestData(vtkInformation *,
-                  vtkInformationVector **,
-                  vtkInformationVector *) override;
+  int FillInputPortInformation(int port, vtkInformation* info) override;
+  int RequestData(vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
 
- private:
-  vtkLiverContourParameterizer(const vtkLiverContourParameterizer &) = delete;
-  void operator=(const vtkLiverContourParameterizer &) = delete;
+private:
+  vtkLiverContourParameterizer(const vtkLiverContourParameterizer&) = delete;
+  void operator=(const vtkLiverContourParameterizer&) = delete;
 
   int Mode;
   int Order;
@@ -189,4 +174,4 @@ class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverContourParamete
   std::vector<double> Reconstruction;
 };
 
-#endif  // __vtkLiverContourParameterizer_h_
+#endif // __vtkLiverContourParameterizer_h_

--- a/Testing/Python/unit/test_bezier_characterization.py
+++ b/Testing/Python/unit/test_bezier_characterization.py
@@ -504,6 +504,42 @@ def _to_double_array(flat):
     return arr
 
 
+def _points_polydata(points_flat_nu_nv_3):
+    """Pack an iterable of Nu*Nv*3 floats into a vtkPolyData with points.
+
+    Row-major (u, v) ordering, matching the C++ contour parameterizer +
+    Bezier fitter port-0 input contract introduced by issue #339.
+    """
+    import vtk
+
+    flat = list(points_flat_nu_nv_3)
+    n_points = len(flat) // 3
+    pts = vtk.vtkPoints()
+    pts.SetDataTypeToDouble()
+    pts.SetNumberOfPoints(n_points)
+    for i in range(n_points):
+        pts.SetPoint(i, flat[i * 3 + 0], flat[i * 3 + 1], flat[i * 3 + 2])
+    pd = vtk.vtkPolyData()
+    pd.SetPoints(pts)
+    return pd
+
+
+def _basis_table(basis_2d):
+    """Pack a 2D numpy array (n_rows x M) into a vtkTable with M columns."""
+    import vtk
+
+    n_rows, n_cols = basis_2d.shape
+    table = vtk.vtkTable()
+    for j in range(n_cols):
+        col = vtk.vtkDoubleArray()
+        col.SetNumberOfComponents(1)
+        col.SetNumberOfTuples(n_rows)
+        for i in range(n_rows):
+            col.SetValue(i, float(basis_2d[i, j]))
+        table.AddColumn(col)
+    return table
+
+
 def test_cxx_bezier_fitter_matches_pinned_control_points(algorithm_module):
     """C++ ``vtkLiverBezierFitter`` against the same EXPECTED control points.
 
@@ -514,13 +550,16 @@ def test_cxx_bezier_fitter_matches_pinned_control_points(algorithm_module):
     Reads the fitted grid back through the polydata output (which is the
     Python-wrappable surface) rather than ``GetControlPoints()`` (which
     returns a const std::vector reference VTK does not wrap).
+
+    Uses the post-#339 input-port surface: points on port 0 as a
+    ``vtkPolyData``, BasisU/BasisV on ports 1/2 as ``vtkTable``.
     """
     points, basis_u, basis_v = _make_bezier_fixture()
     fitter = algorithm_module.vtkLiverBezierFitter()
     fitter.SetNumberOfSamples(4, 4)
-    fitter.SetInputPoints(_to_double_array(points.flatten().tolist()))
-    fitter.SetBasisU(_to_double_array(basis_u.flatten().tolist()))
-    fitter.SetBasisV(_to_double_array(basis_v.flatten().tolist()))
+    fitter.SetInputData(0, _points_polydata(points.flatten().tolist()))
+    fitter.SetInputData(1, _basis_table(basis_u))
+    fitter.SetInputData(2, _basis_table(basis_v))
     fitter.Update()
 
     out_points = fitter.GetOutput().GetPoints()


### PR DESCRIPTION
## Summary

Closes #339.  Two of the four algorithm classes that landed in PR #334 bypass the VTK pipeline contract from ADR-0015 §1 (*"Inputs come in through the standard VTK pipeline input ports; parameters come in through Set/Get accessors"*) — they declare `SetNumberOfInputPorts(0)` and feed their bulk data inputs through `vtkSmartPointer<vtkDoubleArray>` member setters.  This PR rewires both to real input ports so T2 Stack 4 Representations (ADR-0013 §6) can compose `extractor -> parameterizer -> fitter` via `SetInputConnection` instead of a hand-rolled `Update + GetOutput + Set*` loop.

### `vtkLiverContourParameterizer`
- `SetNumberOfInputPorts(1)` + `FillInputPortInformation` requires `vtkPolyData` on port 0 — matches the upstream ring extractors' output type.
- `RequestData` decodes the ring from `GetPoints()` on the input polydata.
- `SetInputContour` / `GetInputContour` and the `Contour` member removed.
- Static helper overloads (`ComputeEFDCoefficients`, `ComputeDCCoefficients`, `InverseTransform`) keep their `vtkDoubleArray` signatures — they're stateless math, not the pipeline input surface.

### `vtkLiverBezierFitter` — option A (3 input ports)
- Port 0: points as `vtkPolyData` (Nu*Nv samples, row-major u then v).
- Port 1: BasisU as `vtkTable` (Nu rows, M columns).
- Port 2: BasisV as `vtkTable` (Nv rows, M columns).

**Why option A over option B (1 port + 2 parameter arrays)?**  The Bernstein basis matrices are a function of the sample positions (an input), not of the algorithm's fixed parameters.  Treating them as data on ports lets a downstream basis-builder Representation supply them via `SetInputConnection` rather than precomputing and shoving them through a parameter setter.  Header documents the trade-off.

`SetNumberOfSamples(Nu, Nv)` stays as a parameter setter — that's an explicit declaration of the gridded sample shape (which row-major dimensions the port-0 polydata carries), not data.

### Tests
- `vtkLiverContourParameterizerTest1` builds a `vtkPolyData` ring from the existing flat-array fixture and feeds it through `SetInputData`.
- `vtkLiverBezierFitterTest1` builds a `vtkPolyData` of Nu*Nv samples and two `vtkTable`s for BasisU/BasisV, then calls `SetInputData(port, ...)` for each of the three ports.
- Python C++-wrapper parity test (`test_bezier_characterization.py`) mirrors the wiring through `vtk.vtkPolyData` + `vtk.vtkTable` helpers.
- `EXPECTED_*` constants are untouched — the rewire is bit-equivalent to the pre-rewire input-acquisition path; the math is preserved.

### Numerical invariant
The four characterisation-pinned outputs are unchanged:
- EFD coefficients @ `rtol=1e-12`.
- DC triple @ `rtol=1e-12`.
- Inverse-transform reconstruction @ `rtol=1e-12`.
- Bezier control-points grid @ `rtol=1e-10` (Eigen-vs-LAPACK dispatch noise on the 4x4 inverse, per ADR-0015 §Consequences).

### Out of scope
Issue #339 mentions an optional `Eigen::MatrixXd::inverse()` -> `.llt().solve(.)` swap on the SPD Gram matrix `BᵀB`.  Deferred: the current `inverse()` matches `np.linalg.inv` to within last-bit-of-double, which is what the `rtol=1e-10` Bezier characterisation pin was captured against.  A separate PR coordinated with #335 (degenerate-input stress fixtures) is the right place for that.

`vtkLiverPlaneRingExtractor` / `vtkLiverSpheroidRingExtractor` already honour the pipeline contract and are untouched.

## Spec references
- `Docs/adr/0015-cpp-algorithm-library.md` §1 (input-port vs parameter-setter convention) — primary spec.
- `Docs/adr/0013-layerdm-pipeline-pattern.md` §6 (Representations as composable VTK pipelines) — why this matters for T2.2.

## Test plan
- [x] Local configure + build under Slicer-main Release-qt6 + ITK's bundled Eigen3 against preview HEAD `21a12d1`.
- [x] `vtkLiverContourParameterizerTest1` passes.
- [x] `vtkLiverBezierFitterTest1` passes.
- [x] `vtkLiverPlaneRingExtractorTest1` + `vtkLiverSpheroidRingExtractorTest1` remain green (no regression on the untouched classes).
- [ ] CI build-test pipeline against `ghcr.io/alive-research/slicer-build-ubuntu2404`.

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code.  Plan and brief from the orchestrating Opus 4.7 session; code + prose drafted by a Claude Code subagent.  Opened for human review before merge.*