### PR TITLE
BUG: Use canonical 7-component TerminologyEntry format (Slicer parser compat)

### DIFF
--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
@@ -344,9 +344,14 @@ int testTerminologyEntryRoundTrip()
   vtkNew<vtkMRMLBezierSurfaceDisplayNode> node;
   CHECK_STRING(node->GetTerminologyEntry().c_str(), "");
 
-  // Realistic SCT triple — Liver, anatomical structure category, no
-  // modifier.  The canonical format is documented on the field.
-  const std::string sct = "SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^";
+  // Realistic SCT terminology entry in Slicer's canonical 7-component
+  // form (terminologyContextName ~ category ~ type ~ typeModifier ~
+  // anatomicContextName ~ anatomicRegion ~ anatomicRegionModifier).
+  // Liver, anatomical structure category, no modifier, no anatomic
+  // region.  Matches the format consumed by
+  // vtkSlicerTerminologiesModuleLogic::DeserializeTerminologyEntry
+  // (which hard-rejects entries with fewer than 7 components).
+  const std::string sct = "SlicerLiver-Terminology~SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^~~^^~^^";
   const vtkMTimeType baseline = node->GetMTime();
   node->SetTerminologyEntry(sct);
   CHECK_STRING(node->GetTerminologyEntry().c_str(), sct.c_str());
@@ -362,7 +367,8 @@ int testTerminologyEntryRoundTrip()
   // commit 07474f2 — project discipline) and the parser decodes
   // them on read.  The triple format itself uses ``^`` and ``~``
   // which are XML-safe, but ``&`` and ``<`` must round-trip too.
-  const std::string hostile = "SCT^123037004^Cat & <Type>~SCT^10200004^Liver~^^";
+  // Hostile-character payload in the same 7-component form.
+  const std::string hostile = "SlicerLiver-Terminology~SCT^123037004^Cat & <Type>~SCT^10200004^Liver~^^~~^^~^^";
   vtkNew<vtkMRMLBezierSurfaceDisplayNode> source;
   vtkNew<vtkMRMLScene> scene;
   source->SetScene(scene.GetPointer());

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceDisplayNode.h
@@ -202,20 +202,32 @@ public:
   // SCT terminology reference (ADR-0011 + ADR-0013 §3)
   //--------------------------------------------------------------------------
 
-  /// Serialised SNOMED-CT terminology triple (Category, Type,
-  /// optional Modifier) describing the clinical concept this display
-  /// node decorates.  The canonical wire format is Slicer's standard
-  /// terminology-entry string,
-  /// ``{CategoryCodingScheme}^{CategoryCode}^{CategoryMeaning}~``
-  /// ``{TypeCodingScheme}^{TypeCode}^{TypeMeaning}~``
-  /// ``{ModifierCodingScheme}^{ModifierCode}^{ModifierMeaning}``
-  /// (e.g. ``SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^``
-  /// for the liver anatomical concept).
+  /// Serialised SNOMED-CT terminology entry describing the clinical
+  /// concept this display node decorates.  The wire format is Slicer's
+  /// canonical 7-component terminology-entry string as produced by
+  /// ``vtkSlicerTerminologiesModuleLogic::SerializeTerminologyEntry``
+  /// and consumed by ``DeserializeTerminologyEntry`` (which hard-rejects
+  /// anything other than exactly 7 ``~``-separated components):
   ///
-  /// Empty string = no terminology assigned; rendering uses pure-vector
+  /// ``{terminologyContextName}~``
+  /// ``{CategoryScheme}^{CategoryCode}^{CategoryMeaning}~``
+  /// ``{TypeScheme}^{TypeCode}^{TypeMeaning}~``
+  /// ``{TypeModifierScheme}^{TypeModifierCode}^{TypeModifierMeaning}~``
+  /// ``{anatomicContextName}~``
+  /// ``{AnatomicRegionScheme}^{AnatomicRegionCode}^{AnatomicRegionMeaning}~``
+  /// ``{AnatomicRegionModifierScheme}^{AnatomicRegionModifierCode}^{AnatomicRegionModifierMeaning}``
+  ///
+  /// Example (liver, anatomical structure category, no modifiers,
+  /// referencing the Slicer-Liver terminology JSON shipped by PR #315):
+  ///
+  /// ``SlicerLiver-Terminology~SCT^123037004^Anatomical Structure~``
+  /// ``SCT^10200004^Liver~^^~~^^~^^``
+  ///
+  /// Empty string = no terminology assigned; the current renderer
+  /// (v2.0.0 alpha) ignores this field entirely and uses pure-vector
   /// defaults (``ResectionColor`` etc.).  When set, the LayerDM
-  /// Pipeline (T2.2, out of scope here) uses the SCT triple to derive
-  /// colour, label, and badge presentation per
+  /// Pipeline (T2.2 — first consumer; out of scope here) uses the SCT
+  /// triple to derive colour, label, and badge presentation per
   /// [ADR-0011](../../Docs/adr/0011-sct-terminology-dispatch.md) and
   /// [ADR-0013 §3](../../Docs/adr/0013-layerdm-pipeline-pattern.md);
   /// this node only stores the string — it does not depend on the

--- a/Testing/Python/unit/test_bezier_surface_node.py
+++ b/Testing/Python/unit/test_bezier_surface_node.py
@@ -436,7 +436,11 @@ def test_display_terminology_entry_round_trip(mrml_module):
     node = mrml_module.vtkMRMLBezierSurfaceDisplayNode()
     assert node.GetTerminologyEntry() == ""
 
-    sct = "SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^"
+    # Slicer's canonical 7-component terminology-entry format
+    # (terminologyContextName ~ category ~ type ~ typeModifier ~
+    # anatomicContextName ~ anatomicRegion ~ anatomicRegionModifier) —
+    # matches what vtkSlicerTerminologiesModuleLogic emits/consumes.
+    sct = "SlicerLiver-Terminology~SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^~~^^~^^"
     baseline = node.GetMTime()
     node.SetTerminologyEntry(sct)
     assert node.GetTerminologyEntry() == sct


### PR DESCRIPTION
## Summary

Follow-up to merged PR #348. The `/slicer-review` of #348 — completed just after the merge — surfaced that the documented + tested `TerminologyEntry` string format was **3-component** (category ~ type ~ typeModifier), but Slicer's canonical format from `vtkSlicerTerminologiesModuleLogic::SerializeTerminologyEntry` is **7-component**:

```
terminologyContextName ~
  category(scheme^code^meaning) ~
  type(scheme^code^meaning) ~
  typeModifier(scheme^code^meaning) ~
  anatomicContextName ~
  anatomicRegion(scheme^code^meaning) ~
  anatomicRegionModifier(scheme^code^meaning)
```

`DeserializeTerminologyEntry` hard-rejects `entryComponents.size() != 7`. Original 3-component example would be rejected by Slicer's parser when T2.2 Pipeline tries to decode the SCT triple.

## Fix

Three string changes (docstring + 2 test strings) to canonical 7-component form, using `SlicerLiver-Terminology` as the terminology-context name with empty anatomic-region components.

**No code change, no on-disk format change, no behavioural change.** The macro plumbing was right; only the *expected content* needed to align with Slicer's parser.

## Supersedes

This PR supersedes **#351**, which had the same intent but was opened from a stale branch (still carried #348's original commits, causing a merge conflict). #351 will be closed.

## Test plan

- [x] `vtkMRMLBezierSurfaceDisplayNodeTest1` still passes — test asserts string round-trip; format is opaque to macro plumbing.
- [x] `test_bezier_surface_node.py` still passes.
- [x] New 7-component string would deserialise cleanly through Slicer's `DeserializeTerminologyEntry`.

## References

- PR #348 — original `TerminologyEntry` field landing.
- Slicer-core: `Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx:1998-2102`.
- ADR-0011 + ADR-0013 §3.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code. Opened for human review.*