### PR TITLE
ENH: Add SetupForDevelopment.sh + local commit-msg hook (Slicer style)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,16 @@ repos:
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
+
+  # Slicer-Liver-specific commit-message validator.  Mirrors the regex
+  # used by Slicer's slicer-check-commit-message-action so the local
+  # commit-msg hook fails the same input that CI would reject.  Run
+  # `./Utilities/SetupForDevelopment.sh` to install the commit-msg
+  # stage hook (`pre-commit install --hook-type commit-msg`).
+  - repo: local
+    hooks:
+      - id: slicer-liver-commit-message
+        name: Slicer-Liver strict commit-message vocabulary
+        entry: Utilities/Hooks/check-commit-message.sh
+        language: script
+        stages: [commit-msg]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,94 @@ We encourage you to submit pull requests as the preferred method for proposing c
 
 - Fork the [source code](https://github.com/ALive-research/Slicer-Liver)
 - Build Slicer-Liver from the source code following [instructions](https://github.com/ALive-research/Slicer-Liver?tab=readme-ov-file#developers)
+- **Run the development setup script once after cloning** — installs the local git hooks that enforce project style + commit-message conventions (see [Development setup](#development-setup) below).
 - **Branch off `preview`** (the repository's default branch).  See [ADR-0006](Docs/adr/0006-branch-model.md) for the full branch model; the short version: new work targets `preview`; stable releases live on `main` and receive backports from `preview` periodically.
 - Implement your changes, ensuring they adhere to the Python and C++ coding standards used in the project.
-- Commit and push your changes with clear and descriptive messages.
+- Commit and push your changes with clear and descriptive messages (see [Commit message format](#commit-message-format)).
 - Open a pull request **against `preview`**, clearly describing the changes you made and their purpose.
 
 We look forward to reviewing your contributions!
+
+### Development setup
+
+After cloning, install `pre-commit` (once per machine) and run the
+setup script (once per clone):
+
+```bash
+# Install pre-commit if you don't have it:
+pipx install pre-commit        # recommended (isolates pre-commit + deps)
+# or: pip install --user pre-commit
+# or: brew install pre-commit
+# or: sudo apt install pre-commit
+
+# Install Slicer-Liver's git hooks into this clone:
+./Utilities/SetupForDevelopment.sh
+```
+
+This installs two hook chains via `pre-commit`:
+
+- **pre-commit stage** — clang-format, ruff, pyupgrade, trailing-whitespace, end-of-file-fixer, mixed-line-ending, JSON-schema validators, prettier (YAML), etc.  Enforced on the files you've touched.
+- **commit-msg stage** — Slicer's strict commit-subject regex (see below).  Rejects non-conforming subjects at `git commit` time, before push, so you don't have to wait for CI to discover them.
+
+Both chains are re-checked by CI (`Lint` and `check-commit-message` workflows) regardless — the local hooks just shorten the feedback loop.
+
+To run the pre-commit chain ad-hoc against every file (e.g. before opening a PR):
+
+```bash
+pre-commit run --all-files
+```
+
+To bypass the hooks for an exceptional commit (rare; CI will still re-check on push):
+
+```bash
+git commit --no-verify
+```
+
+### Commit message format
+
+Slicer-Liver follows Slicer's strict commit-subject format (see [ADR-0016](Docs/adr/0016-code-style-and-lint.md) and the upstream [Slicer style guide][slicer-style]):
+
+```
+<PREFIX>: <Uppercase-First-Word> <rest of subject>
+```
+
+Where `<PREFIX>` is one of:
+
+| Prefix  | Use for                                                  |
+|---------|----------------------------------------------------------|
+| `ENH:`  | Enhancement / new feature / additive improvement         |
+| `PERF:` | Performance improvement                                  |
+| `BUG:`  | Bug fix / correctness fix                                |
+| `STYLE:`| Mechanical reformat / lint cleanup                       |
+| `DOC:`  | Documentation / ADR / comment changes                    |
+| `COMP:` | Compilation / build-system fix                           |
+
+**Two common mistakes the local commit-msg hook catches:**
+
+1. **Wrong prefix**: `FIX:`, `TEST:`, `CI:` are **not** in the vocabulary.
+   - `FIX: <bug>` → `BUG: ...`
+   - `FIX: <build>` → `COMP: ...`
+   - `TEST: <new test>` → `ENH: Add ...`
+   - `TEST: <test fix>` → `BUG: ...`
+   - `CI: <workflow>` → `ENH:` or `BUG:` depending on intent
+
+2. **Lowercase first word after the colon**:
+   - Bad:  `STYLE: clang-format apply on touched files` (lowercase `c`)
+   - Good: `STYLE: Apply clang-format on touched files`
+   - Bad:  `ENH: vtkMRMLBezierSurfaceNode reparented to ...` (lowercase `v`)
+   - Good: `ENH: Reparent vtkMRMLBezierSurfaceNode to ...`
+
+Examples (good):
+
+```
+ENH: Add display-node TerminologyEntry field (ADR-0011 + ADR-0013 §3)
+BUG: Restrict pre-commit lint to PR-touched files
+STYLE: Apply clang-format to touched files (lint cutover)
+DOC: ADR-0014 — rename vtkMRMLLiverBezierSurface*
+COMP: Resolve Eigen via ITK's bundled config
+```
+
+[slicer-style]: https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits
 
 ### Report bugs
 

--- a/Utilities/Hooks/check-commit-message.sh
+++ b/Utilities/Hooks/check-commit-message.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Validate commit-message subject against Slicer-Liver's strict
+# commit-message convention (mirrors Slicer's slicer-check-commit-
+# message-action regex per ADR-0016).
+#
+# Regex:  ^(ENH|PERF|BUG|STYLE|DOC|COMP): ([A-Z])+
+#
+# Installed as a pre-commit "commit-msg" stage hook by
+#   ./Utilities/SetupForDevelopment.sh
+# which runs `pre-commit install --hook-type commit-msg`.
+#
+# Pre-commit invokes this script with the path to the commit-message
+# file (.git/COMMIT_EDITMSG) as the only argument.
+#
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <path-to-commit-message-file>" >&2
+  exit 2
+fi
+
+msg_file="$1"
+subject="$(head -1 "$msg_file")"
+
+# Allow fixup, squash, revert, and merge commits to pass without prefix
+# check — these have well-known auto-generated subjects.
+case "$subject" in
+  fixup\!*|squash\!*|"Revert "*|"Merge "*)
+    exit 0
+    ;;
+esac
+
+# Slicer-strict regex.
+if [[ ! "$subject" =~ ^(ENH|PERF|BUG|STYLE|DOC|COMP):\ [A-Z] ]]; then
+  cat >&2 <<EOF
+
+✗ Commit subject does not match the Slicer-Liver strict format.
+
+Got:
+    ${subject}
+
+Expected:
+    <PREFIX>: <Uppercase-First-Word> <rest of subject>
+
+Where <PREFIX> is one of:
+    ENH    Enhancement / new feature / additive improvement
+    PERF   Performance improvement
+    BUG    Bug fix / correctness fix
+    STYLE  Mechanical reformat / lint cleanup
+    DOC    Documentation / ADR / comment changes
+    COMP   Compilation / build-system fix
+
+Examples (good):
+    ENH: Add display-node terminology field
+    BUG: Restrict pre-commit lint to PR-touched files
+    STYLE: Apply clang-format to touched files (lint cutover)
+    DOC: ADR-0014 — rename vtkMRMLLiverBezierSurface*
+
+Common mistakes:
+- FIX: / TEST: / CI: are NOT in the strict vocabulary.
+  - FIX: <bug>     -> BUG: ...
+  - FIX: <build>   -> COMP: ...
+  - TEST: <new>    -> ENH: Add ...
+  - TEST: <fix>    -> BUG: ...
+  - CI: <change>   -> ENH: / BUG: depending on intent
+- The first non-space word after the colon MUST start with an
+  uppercase letter.  Lowercase tool / class names trip the check:
+    Bad:   STYLE: clang-format apply on touched files
+    Good:  STYLE: Apply clang-format on touched files
+    Bad:   ENH: vtkMRMLBezierSurfaceNode reparented
+    Good:  ENH: Reparent vtkMRMLBezierSurfaceNode to vtkMRMLDisplayableNode
+
+See CONTRIBUTING.md ("Commit message format") and
+https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits
+
+If you really need to bypass this check (rare):
+    git commit --no-verify
+But: PR CI will re-run check-commit-message on every commit, so the
+bypass only delays the failure.
+
+EOF
+  exit 1
+fi
+
+exit 0

--- a/Utilities/SetupForDevelopment.sh
+++ b/Utilities/SetupForDevelopment.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Set up local git hooks for Slicer-Liver development.
+#
+# Mirrors Slicer's developer-setup pattern (per ADR-0016) but builds
+# on top of the modern pre-commit framework rather than Slicer-core's
+# legacy `hooks` branch.  All hook chains — pre-commit (clang-format,
+# ruff, trailing-whitespace, …) and commit-msg (Slicer-strict subject
+# regex) — are owned by `pre-commit` and configured in
+# .pre-commit-config.yaml at the repo root.
+#
+# Usage:
+#   ./Utilities/SetupForDevelopment.sh
+#
+# After running, every `git commit` in this clone runs the hook chain
+# locally — catching style + commit-subject issues BEFORE push instead
+# of on the CI gate.  CI re-checks regardless.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+printErrorAndExit() {
+  echo "✗ Setup failed: $*" 1>&2
+  echo "  See https://pre-commit.com/#install" 1>&2
+  exit 1
+}
+
+# 1. Verify pre-commit is installed.
+if ! command -v pre-commit >/dev/null 2>&1; then
+  cat <<'EOF' 1>&2
+✗ pre-commit is not installed.
+
+Install before running this script:
+
+  # pipx (recommended, isolates pre-commit + its deps):
+  pipx install pre-commit
+
+  # or pip --user:
+  pip install --user pre-commit
+
+  # or a system package manager that ships it:
+  #   apt:    sudo apt install pre-commit
+  #   brew:   brew install pre-commit
+  #   guix:   guix install python-pre-commit
+
+Then re-run:
+  ./Utilities/SetupForDevelopment.sh
+EOF
+  exit 1
+fi
+
+# 2. Confirm we're inside the Slicer-Liver clone.
+if [ ! -f .pre-commit-config.yaml ]; then
+  printErrorAndExit ".pre-commit-config.yaml not found in $ROOT (are you inside the Slicer-Liver clone?)"
+fi
+
+# 3. Make sure the commit-message validator is executable
+#    (git mv / fresh clones may strip the +x bit on some filesystems).
+chmod +x Utilities/Hooks/check-commit-message.sh
+
+# 4. Install hooks (pre-commit + commit-msg stages).
+echo "Installing pre-commit hooks (pre-commit + commit-msg stages)..."
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+
+# 5. Record the setup version so we can prompt the developer to re-run
+#    if this script (or the hook list) materially changes.  Mirrors
+#    Slicer-core's `git config hooks.SetupForDevelopment` pattern.
+SetupForDevelopment_VERSION=1
+git config hooks.SetupForDevelopment "${SetupForDevelopment_VERSION}"
+
+cat <<'EOF'
+
+✓ Done.  Future `git commit` runs:
+  - pre-commit hooks (clang-format, ruff, trailing-whitespace,
+    end-of-file-fixer, mixed-line-ending, jsonschema, prettier, …)
+  - commit-msg hook (Slicer-strict subject regex
+    ^(ENH|PERF|BUG|STYLE|DOC|COMP): ([A-Z])+)
+
+Run all hooks against every file ad-hoc (e.g. before a PR):
+  pre-commit run --all-files
+
+Run hooks against only the staged change set:
+  pre-commit run
+
+Bypass hooks for an exceptional commit (rare; CI re-checks):
+  git commit --no-verify
+
+See CONTRIBUTING.md → "Development setup" for the full convention
+decoder ring (prefix mapping, first-word rule, etc.).
+EOF


### PR DESCRIPTION
## Summary

Mirrors Slicer's developer-setup pattern (`Utilities/SetupForDevelopment.sh` → git hooks owned by `pre-commit` framework) so the strict commit-message regex and the per-file lint chain fail at `git commit` time on the contributor's machine, not at PR-CI time.

Today's PRs **#341 / #348 / #349 / #350** each ate a `check-commit-message` failure because contributors / agents typed subjects like:

- `STYLE: clang-format apply on touched files` — lowercase `c`
- `ENH: vtkMRMLBezierSurfaceNode reparented to ...` — lowercase `v`

Slicer's regex is `^(ENH|PERF|BUG|STYLE|DOC|COMP): ([A-Z])+`. The local commit-msg hook installed by this PR rejects both at `git commit` time with a friendly error message + decoder ring, so the contributor fixes in place rather than after a CI round-trip and admin-bypass merge.

## What's added

| File | Purpose |
|---|---|
| `Utilities/SetupForDevelopment.sh` | Idempotent setup entry-point. Verifies `pre-commit` is installed, runs `pre-commit install --hook-type pre-commit --hook-type commit-msg`, records `hooks.SetupForDevelopment` version on the local clone (mirrors Slicer-core's pattern). |
| `Utilities/Hooks/check-commit-message.sh` | Bash validator for the commit subject. Allows `fixup!`/`squash!`/`Revert `/`Merge ` to pass without check. Friendly error message with worked good/bad examples and the prefix decoder ring. |

## What's modified

- **`.pre-commit-config.yaml`** — adds a `repo: local` entry hooking the commit-msg stage to the validator script. No change to the existing pre-commit-stage hooks (clang-format, ruff, etc.).
- **`CONTRIBUTING.md`** — adds two new sections: "Development setup" (run `SetupForDevelopment.sh` after cloning) and "Commit message format" (prefix decoder ring with worked good/bad examples). Closes one of ADR-0016's "open questions".

## Strictness decision

The local hook regex matches Slicer's upstream-action regex **verbatim** — strict capitalization included. The user's call (see PR discussion thread on \[the relevant chat\] today): keep Slicer's standard rather than relax to a more permissive form. ADR-0016 §"Decision" already commits Slicer-Liver to mirroring Slicer's commit-message-action verbatim; this PR aligns the local enforcement with that decision.

## Test plan

- [x] `pre-commit run --files Utilities/SetupForDevelopment.sh Utilities/Hooks/check-commit-message.sh .pre-commit-config.yaml CONTRIBUTING.md` passes locally (Guix-shell, prettier-skipped). Seven hooks (large-files, case-conflict, merge-conflict, yaml, end-of-file-fixer, mixed-line-ending, trailing-whitespace) all green.
- [x] Self-test against good + bad subjects: `ENH: Add new field` → exit 0; `STYLE: clang-format ...` → exit 1 with error; `FIX: something` → exit 1; `BUG: Restrict pre-commit lint` → exit 0; `STYLE: Apply clang-format` → exit 0.
- [ ] CI lint + check-commit-message should both pass on the PR itself (the PR's own commit subject `ENH: Add SetupForDevelopment.sh + local commit-msg hook (Slicer style)` matches the strict regex).
- [ ] After merge, contributors run `./Utilities/SetupForDevelopment.sh` once and future `git commit` invocations enforce the chain locally.

## UX impact

N/A — non-UI change.

## References

- ADR-0016 — Slicer-Liver mirrors Slicer's style enforcement infrastructure verbatim.
- Slicer-core: `Utilities/SetupForDevelopment.sh`, `Utilities/Scripts/SetupHooks.sh` — the pattern this mirrors.
- `slicer-check-commit-message-action` — the upstream CI counterpart of the local hook.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code. Opened for human review.*