### PR TITLE
ENH: Add edge-case stress tests for Algorithm library (#335)

### DIFF
--- a/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
@@ -12,6 +12,10 @@ set(KIT_TEST_SRCS
   vtkLiverContourParameterizerTest1.cxx
   vtkLiverPlaneRingExtractorTest1.cxx
   vtkLiverSpheroidRingExtractorTest1.cxx
+  vtkLiverBezierFitterEdgeCasesTest.cxx
+  vtkLiverContourParameterizerEdgeCasesTest.cxx
+  vtkLiverPlaneRingExtractorEdgeCasesTest.cxx
+  vtkLiverSpheroidRingExtractorEdgeCasesTest.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -30,3 +34,7 @@ SIMPLE_TEST(vtkLiverBezierFitterTest1)
 SIMPLE_TEST(vtkLiverContourParameterizerTest1)
 SIMPLE_TEST(vtkLiverPlaneRingExtractorTest1)
 SIMPLE_TEST(vtkLiverSpheroidRingExtractorTest1)
+SIMPLE_TEST(vtkLiverBezierFitterEdgeCasesTest)
+SIMPLE_TEST(vtkLiverContourParameterizerEdgeCasesTest)
+SIMPLE_TEST(vtkLiverPlaneRingExtractorEdgeCasesTest)
+SIMPLE_TEST(vtkLiverSpheroidRingExtractorEdgeCasesTest)

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverAlgorithmEdgeCaseHelpers.h
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverAlgorithmEdgeCaseHelpers.h
@@ -1,0 +1,406 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Shared helpers for the edge-case stress tests (issue #335).  These
+  are deliberately separate from vtkLiverAlgorithmTestFixtures.h so the
+  bit-equivalence pin against PR #342's Python characterisation stays
+  untouched: NEW fixtures + helpers live here; EXPECTED_* constants
+  there remain bit-frozen.
+
+  Provides:
+   - Sub-test bookkeeping helpers (PASS / FAIL counters, scoped report).
+   - Synthetic mesh constructors (sphere, cube, faceted-plate, NaN-poisoned).
+   - Synthetic-ring constructors (circle, spiral, degenerate).
+   - Condition-number estimator for small dense matrices via the ratio of
+     min/max diagonal magnitude after a Cholesky factorisation (sufficient
+     for flagging κ > 1e8 on Gram matrices; not a substitute for SVD).
+
+  ADR-0015 §Context (bug-discovery motivation), ADR-0003 (characterisation
+  discipline), ADR-0008 (testing strategy).
+
+==============================================================================*/
+
+#ifndef __vtkLiverAlgorithmEdgeCaseHelpers_h_
+#define __vtkLiverAlgorithmEdgeCaseHelpers_h_
+
+#include <vtkCellArray.h>
+#include <vtkDoubleArray.h>
+#include <vtkFloatArray.h>
+#include <vtkNew.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+#include <vtkSphereSource.h>
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace vtkLiverAlgorithmEdgeCaseHelpers
+{
+
+constexpr double PI = 3.141592653589793238462643383279502884197;
+
+//------------------------------------------------------------------------------
+// Sub-test bookkeeping.  Each edge-case file's entry point owns one of
+// these; sub-tests call PASS/FAIL on it and the entry point returns
+// EXIT_FAILURE if any FAIL was recorded.
+struct SubTestReport
+{
+  int passed = 0;
+  int failed = 0;
+  std::vector<std::string> failures;
+
+  void pass(const char* name)
+  {
+    ++passed;
+    std::fprintf(stderr, "  [PASS] %s\n", name);
+  }
+
+  void fail(const char* name, const std::string& why)
+  {
+    ++failed;
+    failures.emplace_back(std::string(name) + ": " + why);
+    std::fprintf(stderr, "  [FAIL] %s: %s\n", name, why.c_str());
+  }
+
+  int total() const { return passed + failed; }
+
+  void print(const char* suite) const
+  {
+    std::fprintf(stderr, "\n[%s] %d / %d sub-tests passed (%d failed)\n", suite, passed, total(), failed);
+    for (const auto& f : failures)
+    {
+      std::fprintf(stderr, "  - %s\n", f.c_str());
+    }
+  }
+};
+
+//------------------------------------------------------------------------------
+// Synthetic mesh: unit sphere with a configurable tessellation density.
+inline vtkSmartPointer<vtkPolyData> makeUnitSphere(int theta = 64, int phi = 64, double radius = 1.0)
+{
+  vtkNew<vtkSphereSource> sphere;
+  sphere->SetRadius(radius);
+  sphere->SetCenter(0.0, 0.0, 0.0);
+  sphere->SetThetaResolution(theta);
+  sphere->SetPhiResolution(phi);
+  sphere->Update();
+  vtkSmartPointer<vtkPolyData> out = vtkSmartPointer<vtkPolyData>::New();
+  out->DeepCopy(sphere->GetOutput());
+  return out;
+}
+
+//------------------------------------------------------------------------------
+// A unit cube made of 12 triangles (6 quad faces, 2 tris each), centred at
+// origin, side length 1.  Useful for "plane parallel to flat face" / "plane
+// through a vertex" tests where a smooth sphere doesn't have a sharp edge.
+inline vtkSmartPointer<vtkPolyData> makeUnitCube()
+{
+  vtkSmartPointer<vtkPolyData> poly = vtkSmartPointer<vtkPolyData>::New();
+  vtkNew<vtkPoints> pts;
+  pts->SetDataTypeToDouble();
+  const double s = 0.5;
+  // 8 corner vertices.
+  const double coords[8][3] = {
+    { -s, -s, -s }, { s, -s, -s }, { s, s, -s }, { -s, s, -s }, { -s, -s, s }, { s, -s, s }, { s, s, s }, { -s, s, s },
+  };
+  for (int i = 0; i < 8; ++i)
+  {
+    pts->InsertNextPoint(coords[i][0], coords[i][1], coords[i][2]);
+  }
+  poly->SetPoints(pts);
+  // 6 faces, 2 triangles each — outward normals.
+  const vtkIdType faces[12][3] = {
+    { 0, 2, 1 }, { 0, 3, 2 }, // z = -s
+    { 4, 5, 6 }, { 4, 6, 7 }, // z = +s
+    { 0, 1, 5 }, { 0, 5, 4 }, // y = -s
+    { 3, 7, 6 }, { 3, 6, 2 }, // y = +s
+    { 0, 4, 7 }, { 0, 7, 3 }, // x = -s
+    { 1, 2, 6 }, { 1, 6, 5 }, // x = +s
+  };
+  vtkNew<vtkCellArray> tris;
+  for (int i = 0; i < 12; ++i)
+  {
+    tris->InsertNextCell(3);
+    tris->InsertCellPoint(faces[i][0]);
+    tris->InsertCellPoint(faces[i][1]);
+    tris->InsertCellPoint(faces[i][2]);
+  }
+  poly->SetPolys(tris);
+  return poly;
+}
+
+//------------------------------------------------------------------------------
+// Wrap a flat (x, y, z) buffer into a vtkPolyData with points (no cells).
+// This is the input-port format the post-#349 algorithms accept.
+inline vtkSmartPointer<vtkPolyData> makePolyDataFromFlat(const std::vector<double>& flat)
+{
+  vtkSmartPointer<vtkPolyData> poly = vtkSmartPointer<vtkPolyData>::New();
+  vtkNew<vtkPoints> pts;
+  pts->SetDataTypeToDouble();
+  const int n = static_cast<int>(flat.size() / 3);
+  pts->SetNumberOfPoints(n);
+  for (int i = 0; i < n; ++i)
+  {
+    pts->SetPoint(i, flat[i * 3 + 0], flat[i * 3 + 1], flat[i * 3 + 2]);
+  }
+  poly->SetPoints(pts);
+  return poly;
+}
+
+//------------------------------------------------------------------------------
+// Same as makePolyDataFromFlat but uses a single-precision vtkFloatArray as
+// the points backend (cross-cutting #335 row "single-precision input").
+inline vtkSmartPointer<vtkPolyData> makePolyDataFromFlatFloat(const std::vector<double>& flat)
+{
+  vtkSmartPointer<vtkPolyData> poly = vtkSmartPointer<vtkPolyData>::New();
+  vtkNew<vtkPoints> pts;
+  pts->SetDataTypeToFloat();
+  const int n = static_cast<int>(flat.size() / 3);
+  pts->SetNumberOfPoints(n);
+  for (int i = 0; i < n; ++i)
+  {
+    pts->SetPoint(i, static_cast<float>(flat[i * 3 + 0]), static_cast<float>(flat[i * 3 + 1]), static_cast<float>(flat[i * 3 + 2]));
+  }
+  poly->SetPoints(pts);
+  return poly;
+}
+
+//------------------------------------------------------------------------------
+// Closed planar circle in z = 0 with N points (last duplicates first to
+// close the loop, matching the Kuhl-Giardina contour convention).
+inline std::vector<double> makePlanarCircle(int n, double radius = 1.0, double z = 0.0)
+{
+  std::vector<double> out(static_cast<size_t>(n + 1) * 3, 0.0);
+  for (int k = 0; k < n; ++k)
+  {
+    const double theta = (2.0 * PI * static_cast<double>(k)) / static_cast<double>(n);
+    out[k * 3 + 0] = radius * std::cos(theta);
+    out[k * 3 + 1] = radius * std::sin(theta);
+    out[k * 3 + 2] = z;
+  }
+  out[n * 3 + 0] = out[0];
+  out[n * 3 + 1] = out[1];
+  out[n * 3 + 2] = out[2];
+  return out;
+}
+
+//------------------------------------------------------------------------------
+// A closed contour that wobbles aggressively (high-frequency sine
+// modulation) along a base circle.  Sets up the "high-frequency
+// oscillation" / "FourierPower 0.9999 truncation" stress fixtures.
+inline std::vector<double> makeHighFrequencyContour(int n, int harmonic, double amp = 0.2)
+{
+  std::vector<double> out(static_cast<size_t>(n + 1) * 3, 0.0);
+  for (int k = 0; k < n; ++k)
+  {
+    const double theta = (2.0 * PI * static_cast<double>(k)) / static_cast<double>(n);
+    out[k * 3 + 0] = std::cos(theta) + amp * std::cos(harmonic * theta);
+    out[k * 3 + 1] = std::sin(theta) + amp * std::sin(harmonic * theta);
+    out[k * 3 + 2] = 0.0;
+  }
+  out[n * 3 + 0] = out[0];
+  out[n * 3 + 1] = out[1];
+  out[n * 3 + 2] = out[2];
+  return out;
+}
+
+//------------------------------------------------------------------------------
+// Estimate the 2-norm condition number of a symmetric positive-definite
+// matrix via the power iteration on (A) and (A^{-1}).  Returns NaN if
+// the matrix is too small or non-PD.  Only used as an *observable*
+// (per #335 numerical stability category); the threshold check picks
+// up degenerate Gram matrices that the LU inverse will resolve poorly.
+inline double conditionNumberSPD(const std::vector<double>& A, int n, int maxIter = 200, double tol = 1e-14)
+{
+  if (n < 1)
+  {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  // Power iteration for the largest eigenvalue.
+  std::vector<double> b(n, 1.0 / std::sqrt(static_cast<double>(n)));
+  double lambdaMax = 0.0;
+  for (int it = 0; it < maxIter; ++it)
+  {
+    std::vector<double> y(n, 0.0);
+    for (int i = 0; i < n; ++i)
+    {
+      for (int j = 0; j < n; ++j)
+      {
+        y[i] += A[i * n + j] * b[j];
+      }
+    }
+    double norm = 0.0;
+    for (int i = 0; i < n; ++i)
+    {
+      norm += y[i] * y[i];
+    }
+    norm = std::sqrt(norm);
+    if (norm == 0.0)
+    {
+      return std::numeric_limits<double>::infinity();
+    }
+    for (int i = 0; i < n; ++i)
+    {
+      y[i] /= norm;
+    }
+    const double diff = std::fabs(norm - lambdaMax);
+    lambdaMax = norm;
+    b = y;
+    if (diff < tol * lambdaMax)
+    {
+      break;
+    }
+  }
+  // Inverse power iteration for the smallest eigenvalue: solve A x = b
+  // via Cholesky.  Bail with infinity if the Cholesky factorisation
+  // breaks down (matrix not PD → "infinitely ill-conditioned" for our
+  // purposes).
+  std::vector<double> L(static_cast<size_t>(n) * n, 0.0);
+  for (int i = 0; i < n; ++i)
+  {
+    for (int j = 0; j <= i; ++j)
+    {
+      double sum = A[i * n + j];
+      for (int k = 0; k < j; ++k)
+      {
+        sum -= L[i * n + k] * L[j * n + k];
+      }
+      if (i == j)
+      {
+        if (sum <= 0.0)
+        {
+          return std::numeric_limits<double>::infinity();
+        }
+        L[i * n + i] = std::sqrt(sum);
+      }
+      else
+      {
+        L[i * n + j] = sum / L[j * n + j];
+      }
+    }
+  }
+  // Solve L y = b, then L^T x = y, iteratively.
+  std::vector<double> v(n, 1.0 / std::sqrt(static_cast<double>(n)));
+  double lambdaMin = 0.0;
+  for (int it = 0; it < maxIter; ++it)
+  {
+    // Forward sub: L y = v.
+    std::vector<double> y(n, 0.0);
+    for (int i = 0; i < n; ++i)
+    {
+      double s = v[i];
+      for (int k = 0; k < i; ++k)
+      {
+        s -= L[i * n + k] * y[k];
+      }
+      y[i] = s / L[i * n + i];
+    }
+    // Back sub: L^T x = y.
+    std::vector<double> x(n, 0.0);
+    for (int i = n - 1; i >= 0; --i)
+    {
+      double s = y[i];
+      for (int k = i + 1; k < n; ++k)
+      {
+        s -= L[k * n + i] * x[k];
+      }
+      x[i] = s / L[i * n + i];
+    }
+    double norm = 0.0;
+    for (int i = 0; i < n; ++i)
+    {
+      norm += x[i] * x[i];
+    }
+    norm = std::sqrt(norm);
+    if (norm == 0.0)
+    {
+      return std::numeric_limits<double>::infinity();
+    }
+    for (int i = 0; i < n; ++i)
+    {
+      x[i] /= norm;
+    }
+    const double diff = std::fabs(1.0 / norm - lambdaMin);
+    lambdaMin = 1.0 / norm;
+    v = x;
+    if (diff < tol * lambdaMin)
+    {
+      break;
+    }
+  }
+  if (lambdaMin <= 0.0)
+  {
+    return std::numeric_limits<double>::infinity();
+  }
+  return lambdaMax / lambdaMin;
+}
+
+//------------------------------------------------------------------------------
+// Build a uniform 4x4 sample fixture for the Bezier fitter at arbitrary
+// surface samples.  Bernstein degree 3.  Mirrors the saddle fixture in
+// vtkLiverAlgorithmTestFixtures.h but lets the caller supply a per-vertex
+// z(u, v) lambda for the surface profile.
+template <typename Fn>
+inline void makeBezierSample(int Nu, int Nv, Fn zFn, std::vector<double>& points, std::vector<double>& basisU, std::vector<double>& basisV)
+{
+  points.assign(static_cast<size_t>(Nu) * Nv * 3, 0.0);
+  basisU.assign(static_cast<size_t>(Nu) * 4, 0.0);
+  basisV.assign(static_cast<size_t>(Nv) * 4, 0.0);
+  std::vector<double> uSamples(Nu), vSamples(Nv);
+  for (int i = 0; i < Nu; ++i)
+  {
+    uSamples[i] = (Nu == 1) ? 0.0 : static_cast<double>(i) / static_cast<double>(Nu - 1);
+  }
+  for (int j = 0; j < Nv; ++j)
+  {
+    vSamples[j] = (Nv == 1) ? 0.0 : static_cast<double>(j) / static_cast<double>(Nv - 1);
+  }
+  auto bern = [](double t, double* out)
+  {
+    const double t1 = 1.0 - t;
+    out[0] = t1 * t1 * t1;
+    out[1] = 3.0 * t * t1 * t1;
+    out[2] = 3.0 * t * t * t1;
+    out[3] = t * t * t;
+  };
+  for (int i = 0; i < Nu; ++i)
+  {
+    double b[4];
+    bern(uSamples[i], b);
+    for (int k = 0; k < 4; ++k)
+    {
+      basisU[i * 4 + k] = b[k];
+    }
+  }
+  for (int j = 0; j < Nv; ++j)
+  {
+    double b[4];
+    bern(vSamples[j], b);
+    for (int k = 0; k < 4; ++k)
+    {
+      basisV[j * 4 + k] = b[k];
+    }
+  }
+  for (int i = 0; i < Nu; ++i)
+  {
+    for (int j = 0; j < Nv; ++j)
+    {
+      const double u = uSamples[i];
+      const double v = vSamples[j];
+      points[(i * Nv + j) * 3 + 0] = u;
+      points[(i * Nv + j) * 3 + 1] = v;
+      points[(i * Nv + j) * 3 + 2] = zFn(u, v);
+    }
+  }
+}
+
+} // namespace vtkLiverAlgorithmEdgeCaseHelpers
+
+#endif // __vtkLiverAlgorithmEdgeCaseHelpers_h_

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverBezierFitterEdgeCasesTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverBezierFitterEdgeCasesTest.cxx
@@ -1,0 +1,414 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Edge-case stress tests for vtkLiverBezierFitter (issue #335).
+  Probes:
+    - flat / collinear surface samples (degenerate)
+    - high-frequency-oscillation surface samples
+    - very few sample points (just enough for 4x4 basis)
+    - condition-number observable on the Gram matrix Bu^T Bu
+
+==============================================================================*/
+
+#include "vtkLiverAlgorithmEdgeCaseHelpers.h"
+#include "vtkLiverBezierFitter.h"
+
+#include <vtkDoubleArray.h>
+#include <vtkNew.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkTable.h>
+#include <vtkTestingOutputWindow.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+namespace
+{
+
+using vtkLiverAlgorithmEdgeCaseHelpers::conditionNumberSPD;
+using vtkLiverAlgorithmEdgeCaseHelpers::makeBezierSample;
+using vtkLiverAlgorithmEdgeCaseHelpers::SubTestReport;
+
+vtkSmartPointer<vtkPolyData> packPoints(const std::vector<double>& flat, int Nu, int Nv)
+{
+  vtkSmartPointer<vtkPolyData> poly = vtkSmartPointer<vtkPolyData>::New();
+  vtkNew<vtkPoints> pts;
+  pts->SetDataTypeToDouble();
+  pts->SetNumberOfPoints(static_cast<vtkIdType>(Nu) * Nv);
+  for (int i = 0; i < Nu; ++i)
+  {
+    for (int j = 0; j < Nv; ++j)
+    {
+      const size_t base = (static_cast<size_t>(i) * Nv + j) * 3;
+      pts->SetPoint(static_cast<vtkIdType>(i) * Nv + j, flat[base + 0], flat[base + 1], flat[base + 2]);
+    }
+  }
+  poly->SetPoints(pts);
+  return poly;
+}
+
+vtkSmartPointer<vtkTable> packBasis(const std::vector<double>& basis, int nRows, int M)
+{
+  vtkSmartPointer<vtkTable> table = vtkSmartPointer<vtkTable>::New();
+  for (int j = 0; j < M; ++j)
+  {
+    vtkNew<vtkDoubleArray> col;
+    col->SetNumberOfComponents(1);
+    col->SetNumberOfTuples(nRows);
+    for (int i = 0; i < nRows; ++i)
+    {
+      col->SetValue(i, basis[static_cast<size_t>(i) * M + j]);
+    }
+    table->AddColumn(col);
+  }
+  return table;
+}
+
+bool runFitter(int Nu, int Nv, const std::vector<double>& points, const std::vector<double>& basisU, const std::vector<double>& basisV, std::vector<double>& outCps)
+{
+  vtkNew<vtkLiverBezierFitter> fitter;
+  fitter->SetNumberOfSamples(Nu, Nv);
+  fitter->SetInputData(0, packPoints(points, Nu, Nv));
+  fitter->SetInputData(1, packBasis(basisU, Nu, 4));
+  fitter->SetInputData(2, packBasis(basisV, Nv, 4));
+  fitter->Update();
+  outCps = fitter->GetControlPoints();
+  return outCps.size() == 48;
+}
+
+// Compute Bu^T Bu as a row-major std::vector for condition-number probing.
+std::vector<double> gramMatrix(const std::vector<double>& basis, int nRows, int M)
+{
+  std::vector<double> G(static_cast<size_t>(M) * M, 0.0);
+  for (int i = 0; i < M; ++i)
+  {
+    for (int j = 0; j < M; ++j)
+    {
+      double s = 0.0;
+      for (int k = 0; k < nRows; ++k)
+      {
+        s += basis[static_cast<size_t>(k) * M + i] * basis[static_cast<size_t>(k) * M + j];
+      }
+      G[i * M + j] = s;
+    }
+  }
+  return G;
+}
+
+//----------------------------------------------------------------------------
+// FlatSurface — z(u, v) ≡ 0.  All control points should land on z = 0,
+// the planar fit is exact.  Acceptance: |cps[2]| < 1e-12 for every cp.
+void testFlatSurface(SubTestReport& r)
+{
+  std::vector<double> points, basisU, basisV;
+  makeBezierSample(4, 4, [](double, double) { return 0.0; }, points, basisU, basisV);
+  std::vector<double> cps;
+  if (!runFitter(4, 4, points, basisU, basisV, cps))
+  {
+    r.fail("FlatSurface", "fitter did not produce 48 control values");
+    return;
+  }
+  bool ok = true;
+  for (int i = 0; i < 16; ++i)
+  {
+    if (std::fabs(cps[i * 3 + 2]) > 1e-12)
+    {
+      ok = false;
+      break;
+    }
+  }
+  if (ok)
+  {
+    r.pass("FlatSurface");
+  }
+  else
+  {
+    r.fail("FlatSurface", "non-planar control points on flat input");
+  }
+}
+
+//----------------------------------------------------------------------------
+// CollinearXOnly — z(u, v) = u (depends only on u).  The fit collapses
+// to a 1-D Bezier curve along u; columns of the control grid should be
+// identical (within tolerance).
+void testCollinearXOnly(SubTestReport& r)
+{
+  std::vector<double> points, basisU, basisV;
+  makeBezierSample(4, 4, [](double u, double) { return u; }, points, basisU, basisV);
+  std::vector<double> cps;
+  if (!runFitter(4, 4, points, basisU, basisV, cps))
+  {
+    r.fail("CollinearXOnly", "fitter did not produce 48 control values");
+    return;
+  }
+  // For each row i, the z-coordinates of cps[i, 0..3, 2] should match.
+  bool ok = true;
+  for (int i = 0; i < 4 && ok; ++i)
+  {
+    const double z0 = cps[(i * 4 + 0) * 3 + 2];
+    for (int j = 1; j < 4; ++j)
+    {
+      if (std::fabs(cps[(i * 4 + j) * 3 + 2] - z0) > 1e-9)
+      {
+        ok = false;
+        break;
+      }
+    }
+  }
+  if (ok)
+  {
+    r.pass("CollinearXOnly");
+  }
+  else
+  {
+    r.fail("CollinearXOnly", "rows of z control points not constant");
+  }
+}
+
+//----------------------------------------------------------------------------
+// HighFrequencyOscillation — surface with rapid wiggle that exceeds the
+// 4x4 Bernstein basis capacity.  The fit will smooth it heavily;
+// acceptance: finite control points (no NaN / Inf), max z within
+// the input amplitude bounds.
+void testHighFrequencyOscillation(SubTestReport& r)
+{
+  std::vector<double> points, basisU, basisV;
+  const double amp = 0.5;
+  makeBezierSample(4, 4, [amp](double u, double v) { return amp * std::cos(20.0 * u) * std::cos(20.0 * v); }, points, basisU, basisV);
+  std::vector<double> cps;
+  if (!runFitter(4, 4, points, basisU, basisV, cps))
+  {
+    r.fail("HighFrequencyOscillation", "fitter did not produce 48 control values");
+    return;
+  }
+  bool ok = true;
+  for (int i = 0; i < 16; ++i)
+  {
+    const double z = cps[i * 3 + 2];
+    if (!std::isfinite(z) || std::fabs(z) > 10.0 * amp)
+    {
+      ok = false;
+      break;
+    }
+  }
+  if (ok)
+  {
+    r.pass("HighFrequencyOscillation");
+  }
+  else
+  {
+    r.fail("HighFrequencyOscillation", "control points exploded or non-finite");
+  }
+}
+
+//----------------------------------------------------------------------------
+// MinimumSampleCount — 4x4 = 16 samples is *exactly* the minimum for a
+// degree-3 Bernstein basis to be invertible.  Verify fit succeeds.
+void testMinimumSampleCount(SubTestReport& r)
+{
+  std::vector<double> points, basisU, basisV;
+  makeBezierSample(4, 4, [](double u, double v) { return u * v; }, points, basisU, basisV);
+  std::vector<double> cps;
+  if (runFitter(4, 4, points, basisU, basisV, cps))
+  {
+    r.pass("MinimumSampleCount");
+  }
+  else
+  {
+    r.fail("MinimumSampleCount", "fitter failed at minimum 4x4");
+  }
+}
+
+//----------------------------------------------------------------------------
+// ConditionNumberProbe — pass an oversampled 8x8 basis (well-conditioned)
+// AND a "collapsed" 4x4 basis where two adjacent rows are nearly
+// identical (so the Bernstein basis rows become near-linearly-dependent
+// → high κ on Bu^T Bu).
+//
+// Per #335 the current Eigen::MatrixXd::inverse() (PartialPivLU) is the
+// textbook unstable form.  The well-conditioned baseline must produce a
+// reasonable κ (< 1e6); the collapsed input is expected to flag κ above
+// the 1e8 alert threshold.  We DO NOT switch the algorithm to
+// JacobiSVD here — characterisation only, sub-issue filed for the fix.
+void testConditionNumberProbe(SubTestReport& r)
+{
+  // Baseline: 8x8 uniform sampling, well-conditioned.
+  std::vector<double> points8, basisU8, basisV8;
+  makeBezierSample(8, 8, [](double u, double v) { return u * v; }, points8, basisU8, basisV8);
+  const std::vector<double> Gu = gramMatrix(basisU8, 8, 4);
+  const double kappaBaseline = conditionNumberSPD(Gu, 4);
+  std::fprintf(stderr, "    note: baseline 8x8 Bu^T Bu condition number ≈ %.3e\n", kappaBaseline);
+  if (!(std::isfinite(kappaBaseline) && kappaBaseline < 1e6))
+  {
+    r.fail("ConditionNumberProbe", "baseline 8x8 unexpectedly ill-conditioned: κ=" + std::to_string(kappaBaseline));
+    return;
+  }
+
+  // Degenerate: 4x4 sampling with two collapsed rows.  Bernstein basis
+  // at (0, eps, 2*eps, 1) has near-identical first three rows → Gram
+  // matrix near-singular.  Build the basis manually.
+  std::vector<double> badBasis(4 * 4, 0.0);
+  const double samples[4] = { 0.0, 1e-8, 2e-8, 1.0 };
+  auto bern = [](double t, double* out)
+  {
+    const double t1 = 1.0 - t;
+    out[0] = t1 * t1 * t1;
+    out[1] = 3.0 * t * t1 * t1;
+    out[2] = 3.0 * t * t * t1;
+    out[3] = t * t * t;
+  };
+  for (int i = 0; i < 4; ++i)
+  {
+    double b[4];
+    bern(samples[i], b);
+    for (int k = 0; k < 4; ++k)
+    {
+      badBasis[i * 4 + k] = b[k];
+    }
+  }
+  const std::vector<double> Gbad = gramMatrix(badBasis, 4, 4);
+  const double kappaBad = conditionNumberSPD(Gbad, 4);
+  std::fprintf(stderr, "    note: collapsed-row Bu^T Bu condition number ≈ %.3e (>1e8 expected → sub-issue)\n", kappaBad);
+  // Acceptance: condition number flags above threshold OR is +inf.
+  // Either is the "this is degenerate; fix the inverse path" signal.
+  if (kappaBad > 1e8)
+  {
+    r.pass("ConditionNumberProbe");
+  }
+  else
+  {
+    r.fail("ConditionNumberProbe", "collapsed Gram unexpectedly well-conditioned: κ=" + std::to_string(kappaBad));
+  }
+}
+
+//----------------------------------------------------------------------------
+// SinglePrecisionPoints — drive the fitter with a vtkFloatArray-backed
+// vtkPoints; verify the GetPoint(i, p) into a double[3] conversion path
+// is clean (i.e. the produced control points match the double-input
+// case to within float precision).
+void testSinglePrecisionPoints(SubTestReport& r)
+{
+  std::vector<double> points, basisU, basisV;
+  makeBezierSample(4, 4, [](double u, double v) { return u * v; }, points, basisU, basisV);
+
+  // Reference: double pipeline.
+  std::vector<double> cpsRef;
+  runFitter(4, 4, points, basisU, basisV, cpsRef);
+
+  // Float-backed pipeline.
+  vtkSmartPointer<vtkPolyData> poly = vtkSmartPointer<vtkPolyData>::New();
+  vtkNew<vtkPoints> pts;
+  pts->SetDataTypeToFloat();
+  pts->SetNumberOfPoints(16);
+  for (int i = 0; i < 4; ++i)
+  {
+    for (int j = 0; j < 4; ++j)
+    {
+      const size_t base = (static_cast<size_t>(i) * 4 + j) * 3;
+      pts->SetPoint(static_cast<vtkIdType>(i) * 4 + j, static_cast<float>(points[base + 0]), static_cast<float>(points[base + 1]), static_cast<float>(points[base + 2]));
+    }
+  }
+  poly->SetPoints(pts);
+  vtkNew<vtkLiverBezierFitter> fitter;
+  fitter->SetNumberOfSamples(4, 4);
+  fitter->SetInputData(0, poly);
+  fitter->SetInputData(1, packBasis(basisU, 4, 4));
+  fitter->SetInputData(2, packBasis(basisV, 4, 4));
+  fitter->Update();
+  const auto& cpsFloat = fitter->GetControlPoints();
+  if (cpsFloat.size() != 48)
+  {
+    r.fail("SinglePrecisionPoints", "no fitted output");
+    return;
+  }
+  bool ok = true;
+  for (size_t i = 0; i < 48; ++i)
+  {
+    if (std::fabs(cpsFloat[i] - cpsRef[i]) > 1e-6)
+    {
+      ok = false;
+      break;
+    }
+  }
+  if (ok)
+  {
+    r.pass("SinglePrecisionPoints");
+  }
+  else
+  {
+    r.fail("SinglePrecisionPoints", "float vs double control points differ by > 1e-6");
+  }
+}
+
+//----------------------------------------------------------------------------
+// MissingBasisPort — call Update() without setting BasisU.  Must trigger
+// vtkErrorMacro and short-circuit.
+void testMissingBasisPort(SubTestReport& r)
+{
+  TESTING_OUTPUT_RESET();
+  std::vector<double> points, basisU, basisV;
+  makeBezierSample(4, 4, [](double u, double v) { return u * v; }, points, basisU, basisV);
+  vtkNew<vtkLiverBezierFitter> fitter;
+  fitter->SetNumberOfSamples(4, 4);
+  fitter->SetInputData(0, packPoints(points, 4, 4));
+  // Port 1 deliberately unset.
+  fitter->SetInputData(2, packBasis(basisV, 4, 4));
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  fitter->Update();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  r.pass("MissingBasisPort");
+}
+
+//----------------------------------------------------------------------------
+// MismatchedBasisColumns — BasisU has 4 columns, BasisV has 3 columns.
+// Must error and return 0.
+void testMismatchedBasisColumns(SubTestReport& r)
+{
+  TESTING_OUTPUT_RESET();
+  std::vector<double> points, basisU, basisV;
+  makeBezierSample(4, 4, [](double u, double v) { return u * v; }, points, basisU, basisV);
+  // Truncate basisV to 3 columns per row.
+  std::vector<double> basisV3(4 * 3, 0.0);
+  for (int i = 0; i < 4; ++i)
+  {
+    for (int k = 0; k < 3; ++k)
+    {
+      basisV3[i * 3 + k] = basisV[i * 4 + k];
+    }
+  }
+  vtkNew<vtkLiverBezierFitter> fitter;
+  fitter->SetNumberOfSamples(4, 4);
+  fitter->SetInputData(0, packPoints(points, 4, 4));
+  fitter->SetInputData(1, packBasis(basisU, 4, 4));
+  fitter->SetInputData(2, packBasis(basisV3, 4, 3));
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  fitter->Update();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  r.pass("MismatchedBasisColumns");
+}
+
+} // namespace
+
+int vtkLiverBezierFitterEdgeCasesTest(int, char*[])
+{
+  SubTestReport r;
+  std::fprintf(stderr, "[BezierFitter edge cases]\n");
+
+  testFlatSurface(r);
+  testCollinearXOnly(r);
+  testHighFrequencyOscillation(r);
+  testMinimumSampleCount(r);
+  testConditionNumberProbe(r);
+  testSinglePrecisionPoints(r);
+  testMissingBasisPort(r);
+  testMismatchedBasisColumns(r);
+
+  r.print("BezierFitter");
+  return r.failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverBezierFitterEdgeCasesTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverBezierFitterEdgeCasesTest.cxx
@@ -235,7 +235,9 @@ void testMinimumSampleCount(SubTestReport& r)
 // textbook unstable form.  The well-conditioned baseline must produce a
 // reasonable κ (< 1e6); the collapsed input is expected to flag κ above
 // the 1e8 alert threshold.  We DO NOT switch the algorithm to
-// JacobiSVD here — characterisation only, sub-issue filed for the fix.
+// JacobiSVD here — characterisation only, see issue #356
+// (https://github.com/ALive-research/Slicer-Liver/issues/356) for the
+// proposed fix path (LLT/ColPivHouseholderQR on the Gram matrix).
 void testConditionNumberProbe(SubTestReport& r)
 {
   // Baseline: 8x8 uniform sampling, well-conditioned.

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerEdgeCasesTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerEdgeCasesTest.cxx
@@ -1,0 +1,403 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Edge-case stress tests for vtkLiverContourParameterizer (issue #335).
+  Probes:
+    - very short rings (< 10 points; EFD order > Nyquist)
+    - rings with duplicated consecutive points (segment length 0)
+    - highly non-uniform sampling along the ring
+    - near-coplanar vs genuinely 3D rings (consistency between modes)
+    - corner-mapping mode vs EFD mode round-trip on a planar circle
+
+==============================================================================*/
+
+#include "vtkLiverAlgorithmEdgeCaseHelpers.h"
+#include "vtkLiverContourParameterizer.h"
+
+#include <vtkNew.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkTestingOutputWindow.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <vector>
+
+namespace
+{
+
+using vtkLiverAlgorithmEdgeCaseHelpers::makeHighFrequencyContour;
+using vtkLiverAlgorithmEdgeCaseHelpers::makePlanarCircle;
+using vtkLiverAlgorithmEdgeCaseHelpers::makePolyDataFromFlat;
+using vtkLiverAlgorithmEdgeCaseHelpers::makePolyDataFromFlatFloat;
+using vtkLiverAlgorithmEdgeCaseHelpers::SubTestReport;
+
+//----------------------------------------------------------------------------
+// ShortRingOrderAboveNyquist — 6-point closed ring with order 8.  Nyquist
+// here is 3 (n/2); order 8 is well above.  Acceptance: defined output
+// (48 EFD coefficients) — higher harmonics will be small but the routine
+// must not crash.
+void testShortRingOrderAboveNyquist(SubTestReport& r)
+{
+  auto ring = makePlanarCircle(6); // 6 + 1 closing point
+  const int nPts = static_cast<int>(ring.size() / 3);
+  auto coeffs = vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(ring.data(), nPts, 8);
+  if (coeffs.size() == 48)
+  {
+    bool finite = true;
+    for (double v : coeffs)
+    {
+      if (!std::isfinite(v))
+      {
+        finite = false;
+        break;
+      }
+    }
+    if (finite)
+    {
+      r.pass("ShortRingOrderAboveNyquist");
+    }
+    else
+    {
+      r.fail("ShortRingOrderAboveNyquist", "non-finite coefficients");
+    }
+  }
+  else
+  {
+    r.fail("ShortRingOrderAboveNyquist", "expected 48 coeffs");
+  }
+}
+
+//----------------------------------------------------------------------------
+// DuplicatedConsecutivePoints — segment length 0 between two points.  The
+// implementation divides by dt[i] for each segment; a zero-length segment
+// would produce NaN / Inf.  Acceptance: the routine documents whether it
+// guards or produces NaN.  CURRENT BEHAVIOUR (pinned for #335 follow-up):
+// the implementation does not guard, so NaN propagates.  We capture this
+// as a "known fragile" pin: assert NaN propagation so a future fix is
+// flagged.
+void testDuplicatedConsecutivePoints(SubTestReport& r)
+{
+  // Insert a duplicate of point 5 right after itself.
+  auto ring = makePlanarCircle(20);
+  // Splice in (ring[15], ring[16], ring[17]) again after itself.
+  std::vector<double> dup;
+  dup.reserve(ring.size() + 3);
+  const int N = static_cast<int>(ring.size() / 3);
+  for (int k = 0; k < N; ++k)
+  {
+    dup.push_back(ring[k * 3 + 0]);
+    dup.push_back(ring[k * 3 + 1]);
+    dup.push_back(ring[k * 3 + 2]);
+    if (k == 5)
+    {
+      // duplicate point 5
+      dup.push_back(ring[k * 3 + 0]);
+      dup.push_back(ring[k * 3 + 1]);
+      dup.push_back(ring[k * 3 + 2]);
+    }
+  }
+  const int nPts = static_cast<int>(dup.size() / 3);
+  auto coeffs = vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(dup.data(), nPts, 8);
+  // Look for NaN — known fragile pin.
+  bool hasNaN = false;
+  for (double v : coeffs)
+  {
+    if (std::isnan(v))
+    {
+      hasNaN = true;
+      break;
+    }
+  }
+  if (hasNaN)
+  {
+    // Document the current behaviour: NaN propagates from the zero-
+    // length segment.  Sub-issue filed; passing here pins the
+    // characterisation per ADR-0003.
+    std::fprintf(stderr,
+                 "    note: NaN propagation pinned (zero-length segment "
+                 "divide; see follow-up sub-issue).\n");
+    r.pass("DuplicatedConsecutivePoints");
+  }
+  else
+  {
+    // If implementation gets fixed to guard against zero-length, this
+    // branch becomes the new normal: still pass, but log the change.
+    std::fprintf(stderr,
+                 "    note: zero-length-segment path produced finite "
+                 "coefficients; behaviour has changed from NaN-propagating.\n");
+    r.pass("DuplicatedConsecutivePoints");
+  }
+}
+
+//----------------------------------------------------------------------------
+// NonUniformSampling — same closed circle but with one quadrant
+// densely sampled and another sparsely sampled.  The Kuhl-Giardina
+// parameterisation uses arc-length (cumulative |dxyz|), so the EFD
+// coefficients should depend only weakly on the sampling distribution.
+// Acceptance: coefficients are finite.
+void testNonUniformSampling(SubTestReport& r)
+{
+  std::vector<double> ring;
+  // Dense first quadrant (40 pts), sparse rest (8 pts each).
+  const int dense = 40;
+  for (int k = 0; k < dense; ++k)
+  {
+    const double theta = (0.5 * vtkLiverAlgorithmEdgeCaseHelpers::PI * static_cast<double>(k)) / static_cast<double>(dense);
+    ring.push_back(std::cos(theta));
+    ring.push_back(std::sin(theta));
+    ring.push_back(0.0);
+  }
+  for (int q = 1; q < 4; ++q)
+  {
+    for (int k = 0; k < 8; ++k)
+    {
+      const double base = 0.5 * vtkLiverAlgorithmEdgeCaseHelpers::PI * q;
+      const double theta = base + (0.5 * vtkLiverAlgorithmEdgeCaseHelpers::PI * static_cast<double>(k)) / static_cast<double>(8);
+      ring.push_back(std::cos(theta));
+      ring.push_back(std::sin(theta));
+      ring.push_back(0.0);
+    }
+  }
+  // close
+  ring.push_back(ring[0]);
+  ring.push_back(ring[1]);
+  ring.push_back(ring[2]);
+  const int nPts = static_cast<int>(ring.size() / 3);
+  auto coeffs = vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(ring.data(), nPts, 8);
+  bool ok = coeffs.size() == 48;
+  for (double v : coeffs)
+  {
+    if (!std::isfinite(v))
+    {
+      ok = false;
+      break;
+    }
+  }
+  if (ok)
+  {
+    r.pass("NonUniformSampling");
+  }
+  else
+  {
+    r.fail("NonUniformSampling", "non-finite EFD coefficients on non-uniform sampling");
+  }
+}
+
+//----------------------------------------------------------------------------
+// PlanarCircleConsistency — feed the same 30-point planar circle through
+// EFD mode and CornerMapping mode.  The reconstructed (12-point) EFD
+// contour should approximate the circle to good tolerance; CornerMapping
+// should preserve the input and tag 4 corners.
+void testPlanarCircleConsistency(SubTestReport& r)
+{
+  auto ring = makePlanarCircle(60);
+  const int nPts = static_cast<int>(ring.size() / 3);
+
+  // EFD pass with 12 reconstruction points.
+  auto coeffs = vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(ring.data(), nPts, 8);
+  auto dc = vtkLiverContourParameterizer::ComputeDCCoefficientsRaw(ring.data(), nPts);
+  const double locusArr[3] = { dc[0], dc[1], dc[2] };
+  auto recon = vtkLiverContourParameterizer::InverseTransformRaw(coeffs.data(), 8, locusArr, 24);
+  // Reconstructed points should sit on the unit circle (within ~1e-3).
+  bool ok = true;
+  for (int k = 0; k < 24; ++k)
+  {
+    const double x = recon[0 * 24 + k];
+    const double y = recon[1 * 24 + k];
+    const double rad = std::sqrt(x * x + y * y);
+    if (std::fabs(rad - 1.0) > 5e-3)
+    {
+      ok = false;
+      break;
+    }
+  }
+  if (ok)
+  {
+    r.pass("PlanarCircleConsistency");
+  }
+  else
+  {
+    r.fail("PlanarCircleConsistency", "EFD reconstruction of a unit circle deviates > 5e-3");
+  }
+}
+
+//----------------------------------------------------------------------------
+// FourierPower9999Probe — high-frequency oscillation.  Build a ring whose
+// 8th harmonic contributes ~10% energy.  After EFD-8 reconstruction at
+// 12 samples the harmonic content above N=8 is truncated by definition,
+// so reconstruction error is bounded by the harmonic-8 amplitude.  The
+// magic 0.9999 FourierPower threshold lives in the Python orchestration
+// (Liver/Liver.py); we verify here only that the C++ EFD reproduces the
+// energy distribution correctly enough that downstream truncation is
+// well-defined.
+void testFourierPower9999Probe(SubTestReport& r)
+{
+  auto ring = makeHighFrequencyContour(120, 8, 0.1);
+  const int nPts = static_cast<int>(ring.size() / 3);
+  auto coeffs = vtkLiverContourParameterizer::ComputeEFDCoefficientsRaw(ring.data(), nPts, 16);
+  if (coeffs.size() != 96)
+  {
+    r.fail("FourierPower9999Probe", "expected 96 coeffs");
+    return;
+  }
+  // Sum |coeff_n|^2 per harmonic.  Harmonic 1 should dominate; harmonic
+  // 8 should carry visible energy (amp 0.1 — the modulator).  Harmonic
+  // 9..16 should be near zero.
+  std::vector<double> power(16, 0.0);
+  for (int n = 0; n < 16; ++n)
+  {
+    double s = 0.0;
+    for (int k = 0; k < 6; ++k)
+    {
+      s += coeffs[n * 6 + k] * coeffs[n * 6 + k];
+    }
+    power[n] = s;
+  }
+  // Acceptance: power[7] (harmonic 8, 0-indexed n=7) > 1e-4 * power[0].
+  // Without that the EFD is not picking up the modulator at all.
+  if (power[0] > 0.0 && power[7] > 1e-4 * power[0])
+  {
+    r.pass("FourierPower9999Probe");
+  }
+  else
+  {
+    r.fail("FourierPower9999Probe",
+           "harmonic 8 energy below threshold: "
+           "p[7]="
+             + std::to_string(power[7]) + " p[0]=" + std::to_string(power[0]));
+  }
+}
+
+//----------------------------------------------------------------------------
+// SinglePrecisionInput — drive the parameterizer through the polydata
+// input port using a vtkFloatArray-backed vtkPoints.  Verifies the
+// input-conversion path (GetPoint() into a double[3]) is clean and
+// produces sensible EFD output for a single-precision ring.
+void testSinglePrecisionInput(SubTestReport& r)
+{
+  auto ring = makePlanarCircle(48);
+  auto poly = makePolyDataFromFlatFloat(ring);
+  vtkNew<vtkLiverContourParameterizer> param;
+  param->SetMode(vtkLiverContourParameterizer::MODE_EFD);
+  param->SetOrder(8);
+  param->SetNumberOfReconstructionPoints(12);
+  param->SetInputData(poly);
+  param->Update();
+  const auto& recon = param->GetReconstruction();
+  if (recon.size() != 36)
+  {
+    r.fail("SinglePrecisionInput", "expected 36 reconstruction values");
+    return;
+  }
+  // Same on-circle test as the consistency case, just looser tol for
+  // float input.
+  bool ok = true;
+  for (int k = 0; k < 12; ++k)
+  {
+    const double x = recon[0 * 12 + k];
+    const double y = recon[1 * 12 + k];
+    const double rad = std::sqrt(x * x + y * y);
+    if (std::fabs(rad - 1.0) > 1e-2)
+    {
+      ok = false;
+      break;
+    }
+  }
+  if (ok)
+  {
+    r.pass("SinglePrecisionInput");
+  }
+  else
+  {
+    r.fail("SinglePrecisionInput", "float-input reconstruction off the unit circle");
+  }
+}
+
+//----------------------------------------------------------------------------
+// SinglePointInput — pipeline-level error path.  A 1-point polydata
+// must produce a vtkErrorMacro from RequestData and not crash.
+void testSinglePointInput(SubTestReport& r)
+{
+  TESTING_OUTPUT_RESET();
+  std::vector<double> oneP = { 0.0, 0.0, 0.0 };
+  auto poly = makePolyDataFromFlat(oneP);
+  vtkNew<vtkLiverContourParameterizer> param;
+  param->SetMode(vtkLiverContourParameterizer::MODE_EFD);
+  param->SetOrder(8);
+  param->SetInputData(poly);
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  param->Update();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  r.pass("SinglePointInput");
+}
+
+//----------------------------------------------------------------------------
+// CornerMappingMode — 60-point planar circle → 4 corner indices should
+// land at 0, 15, 30, 45.  Output point count == input.
+void testCornerMappingMode(SubTestReport& r)
+{
+  auto ring = makePlanarCircle(60);
+  auto poly = makePolyDataFromFlat(ring);
+  vtkNew<vtkLiverContourParameterizer> param;
+  param->SetMode(vtkLiverContourParameterizer::MODE_CORNER_MAPPING);
+  param->SetInputData(poly);
+  param->Update();
+  vtkPolyData* out = param->GetOutput();
+  if (!out || !out->GetPoints())
+  {
+    r.fail("CornerMappingMode", "no output polydata");
+    return;
+  }
+  const int n = static_cast<int>(out->GetPoints()->GetNumberOfPoints());
+  if (n != 61)
+  {
+    r.fail("CornerMappingMode", "expected 61 points (60 + closure), got " + std::to_string(n));
+    return;
+  }
+  r.pass("CornerMappingMode");
+}
+
+//----------------------------------------------------------------------------
+// ZeroOrderError — Order == 0 must trigger vtkErrorMacro and short-
+// circuit.
+void testZeroOrderError(SubTestReport& r)
+{
+  TESTING_OUTPUT_RESET();
+  auto ring = makePlanarCircle(30);
+  auto poly = makePolyDataFromFlat(ring);
+  vtkNew<vtkLiverContourParameterizer> param;
+  param->SetMode(vtkLiverContourParameterizer::MODE_EFD);
+  param->SetOrder(0);
+  param->SetInputData(poly);
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  param->Update();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  r.pass("ZeroOrderError");
+}
+
+} // namespace
+
+int vtkLiverContourParameterizerEdgeCasesTest(int, char*[])
+{
+  SubTestReport r;
+  std::fprintf(stderr, "[ContourParameterizer edge cases]\n");
+
+  testShortRingOrderAboveNyquist(r);
+  testDuplicatedConsecutivePoints(r);
+  testNonUniformSampling(r);
+  testPlanarCircleConsistency(r);
+  testFourierPower9999Probe(r);
+  testSinglePrecisionInput(r);
+  testSinglePointInput(r);
+  testCornerMappingMode(r);
+  testZeroOrderError(r);
+
+  r.print("ContourParameterizer");
+  return r.failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerEdgeCasesTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerEdgeCasesTest.cxx
@@ -114,24 +114,25 @@ void testDuplicatedConsecutivePoints(SubTestReport& r)
       break;
     }
   }
+  // ADR-0003 characterisation pin for issue #355
+  // (https://github.com/ALive-research/Slicer-Liver/issues/355): the
+  // current implementation propagates NaN from the zero-length-segment
+  // divide.  Pinning hasNaN==true here gives CI a loud signal the day a
+  // future fix lands — the assertion inverts, the test fails, the
+  // fixer flips it to hasNaN==false plus a closing reference to #355.
+  // TODO(#355): invert this assertion to `if (!hasNaN)` when fixed.
   if (hasNaN)
   {
-    // Document the current behaviour: NaN propagates from the zero-
-    // length segment.  Sub-issue filed; passing here pins the
-    // characterisation per ADR-0003.
     std::fprintf(stderr,
-                 "    note: NaN propagation pinned (zero-length segment "
-                 "divide; see follow-up sub-issue).\n");
+                 "    note: NaN propagation pinned per ADR-0003 (issue #355).\n");
     r.pass("DuplicatedConsecutivePoints");
   }
   else
   {
-    // If implementation gets fixed to guard against zero-length, this
-    // branch becomes the new normal: still pass, but log the change.
-    std::fprintf(stderr,
-                 "    note: zero-length-segment path produced finite "
-                 "coefficients; behaviour has changed from NaN-propagating.\n");
-    r.pass("DuplicatedConsecutivePoints");
+    r.fail("DuplicatedConsecutivePoints: characterisation pin inverted — "
+           "zero-length-segment path no longer NaN-propagates.  "
+           "If this is intentional (issue #355 fixed), invert the assertion "
+           "and close #355.");
   }
 }
 

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerEdgeCasesTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverContourParameterizerEdgeCasesTest.cxx
@@ -123,16 +123,15 @@ void testDuplicatedConsecutivePoints(SubTestReport& r)
   // TODO(#355): invert this assertion to `if (!hasNaN)` when fixed.
   if (hasNaN)
   {
-    std::fprintf(stderr,
-                 "    note: NaN propagation pinned per ADR-0003 (issue #355).\n");
+    std::fprintf(stderr, "    note: NaN propagation pinned per ADR-0003 (issue #355).\n");
     r.pass("DuplicatedConsecutivePoints");
   }
   else
   {
-    r.fail("DuplicatedConsecutivePoints: characterisation pin inverted — "
-           "zero-length-segment path no longer NaN-propagates.  "
-           "If this is intentional (issue #355 fixed), invert the assertion "
-           "and close #355.");
+    r.fail("DuplicatedConsecutivePoints",
+           "characterisation pin inverted — zero-length-segment path no longer "
+           "NaN-propagates.  If this is intentional (issue #355 fixed), invert "
+           "the assertion and close #355.");
   }
 }
 

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverPlaneRingExtractorEdgeCasesTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverPlaneRingExtractorEdgeCasesTest.cxx
@@ -1,0 +1,210 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Edge-case stress tests for vtkLiverPlaneRingExtractor (issue #335).
+
+  This file is the bug-discovery counterpart to vtkLiverPlaneRingExtractorTest1
+  (which pins the well-conditioned z=0 great-circle smoke case).  Each
+  sub-test exercises one corner-case input the smoke test does not cover,
+  and asserts either a defined output (graceful handling) or a defined
+  failure mode (vtkErrorMacro + RequestData == 0).  See the SubTestReport
+  block at the bottom for the aggregate pass/fail line ctest will scrape.
+
+==============================================================================*/
+
+#include "vtkLiverAlgorithmEdgeCaseHelpers.h"
+#include "vtkLiverPlaneRingExtractor.h"
+
+#include <vtkCellArray.h>
+#include <vtkNew.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkSphereSource.h>
+#include <vtkTestingOutputWindow.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+
+namespace
+{
+
+using vtkLiverAlgorithmEdgeCaseHelpers::makeUnitCube;
+using vtkLiverAlgorithmEdgeCaseHelpers::makeUnitSphere;
+using vtkLiverAlgorithmEdgeCaseHelpers::SubTestReport;
+
+// Drive an extractor and return the number of output points.  Caller
+// handles the polydata if non-null.
+int runExtractor(vtkLiverPlaneRingExtractor* ex, vtkPolyData* target, double origin[3], double normal[3])
+{
+  ex->SetInputData(0, target);
+  ex->SetOrigin(origin);
+  ex->SetNormal(normal);
+  ex->Update();
+  vtkPolyData* out = ex->GetOutput();
+  return out && out->GetPoints() ? static_cast<int>(out->GetPoints()->GetNumberOfPoints()) : 0;
+}
+
+//----------------------------------------------------------------------------
+// PlaneOutsideMesh — plane sits 10 unit-radii above a unit sphere: no
+// intersection.  Expected: empty output, no warning, no error.
+void testPlaneOutsideMesh(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere();
+  vtkNew<vtkLiverPlaneRingExtractor> ex;
+  double origin[3] = { 0.0, 0.0, 10.0 };
+  double normal[3] = { 0.0, 0.0, 1.0 };
+  const int n = runExtractor(ex, sphere, origin, normal);
+  if (n == 0)
+  {
+    r.pass("PlaneOutsideMesh");
+  }
+  else
+  {
+    r.fail("PlaneOutsideMesh", "expected empty output but got " + std::to_string(n) + " points");
+  }
+}
+
+//----------------------------------------------------------------------------
+// PlaneTangentToSphere — z = 1.0 just grazes the unit sphere's north
+// pole.  vtkCutter typically emits a single point (degenerate cell) or
+// no cells; either is acceptable as long as nothing crashes.
+void testPlaneTangentToSphere(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere(128, 128);
+  vtkNew<vtkLiverPlaneRingExtractor> ex;
+  double origin[3] = { 0.0, 0.0, 1.0 };
+  double normal[3] = { 0.0, 0.0, 1.0 };
+  const int n = runExtractor(ex, sphere, origin, normal);
+  // Tangent cuts on a faceted sphere can produce up to a one-edge
+  // ring (a handful of points) along the discretised pole; demand
+  // small but allow non-empty.
+  if (n <= 8)
+  {
+    r.pass("PlaneTangentToSphere");
+  }
+  else
+  {
+    r.fail("PlaneTangentToSphere", "tangent cut produced " + std::to_string(n) + " points; expected <= 8");
+  }
+}
+
+//----------------------------------------------------------------------------
+// PlaneThroughVertex — cut a cube with z = 0.5 (exactly the +z face plane).
+// This plane passes through 4 vertices and is parallel to the face.  The
+// cut should still produce a well-defined output (either the face boundary
+// or empty), never crash.
+void testPlaneThroughVertex(SubTestReport& r)
+{
+  auto cube = makeUnitCube();
+  vtkNew<vtkLiverPlaneRingExtractor> ex;
+  double origin[3] = { 0.0, 0.0, 0.5 }; // top face of the cube
+  double normal[3] = { 0.0, 0.0, 1.0 };
+  const int n = runExtractor(ex, cube, origin, normal);
+  // Acceptable outcomes: 0 (no triangle straddles the plane) or 4-5
+  // (the four boundary vertices, possibly with the loop closed).
+  if (n == 0 || (n >= 3 && n <= 8))
+  {
+    r.pass("PlaneThroughVertex");
+  }
+  else
+  {
+    r.fail("PlaneThroughVertex", "expected 0 or 3-8 points, got " + std::to_string(n));
+  }
+}
+
+//----------------------------------------------------------------------------
+// PlaneParallelToFlatFace — cut a cube with z = 0.499, just below the +z
+// face.  Expected: a square ring of 4 (or 5 with closure) points along the
+// cube's vertical edges.
+void testPlaneParallelToFlatFace(SubTestReport& r)
+{
+  auto cube = makeUnitCube();
+  vtkNew<vtkLiverPlaneRingExtractor> ex;
+  double origin[3] = { 0.0, 0.0, 0.499 };
+  double normal[3] = { 0.0, 0.0, 1.0 };
+  const int n = runExtractor(ex, cube, origin, normal);
+  // Stripper emits the closed quad ring as either 4 unique points or
+  // 8 points where the loop is duplicated (a startpoint repeat at
+  // join boundaries between original cutter segments).  Either is
+  // acceptable; the invariant is "a closed 4-corner ring."
+  if (n == 4 || n == 5 || n == 8)
+  {
+    r.pass("PlaneParallelToFlatFace");
+  }
+  else
+  {
+    r.fail("PlaneParallelToFlatFace", "expected 4, 5, or 8 ring points, got " + std::to_string(n));
+  }
+}
+
+//----------------------------------------------------------------------------
+// NullInputMesh — calling Update() without an input polydata must report
+// an error (vtkErrorMacro) and return 0 from RequestData, not crash.
+void testNullInputMesh(SubTestReport& r)
+{
+  TESTING_OUTPUT_RESET();
+  vtkNew<vtkLiverPlaneRingExtractor> ex;
+  double origin[3] = { 0.0, 0.0, 0.0 };
+  double normal[3] = { 0.0, 0.0, 1.0 };
+  ex->SetOrigin(origin);
+  ex->SetNormal(normal);
+  // No SetInputData call → port 0 is empty.  vtkAlgorithm's contract
+  // produces a default-constructed input data object on the connection,
+  // so the algorithm will receive a vtkPolyData with zero points rather
+  // than nullptr.  Behaviour we assert: empty output, no crash.
+  TESTING_OUTPUT_IGNORE_WARNINGS_ERRORS_BEGIN();
+  ex->Update();
+  TESTING_OUTPUT_IGNORE_WARNINGS_ERRORS_END();
+  vtkPolyData* out = ex->GetOutput();
+  const int n = out && out->GetPoints() ? static_cast<int>(out->GetPoints()->GetNumberOfPoints()) : 0;
+  if (n == 0)
+  {
+    r.pass("NullInputMesh");
+  }
+  else
+  {
+    r.fail("NullInputMesh", "expected 0 points, got " + std::to_string(n));
+  }
+}
+
+//----------------------------------------------------------------------------
+// NaNNormal — a degenerate normal vector containing NaN.  vtkPlane should
+// short-circuit (no intersection); we mostly care that no crash occurs.
+void testNaNNormal(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere();
+  vtkNew<vtkLiverPlaneRingExtractor> ex;
+  double origin[3] = { 0.0, 0.0, 0.0 };
+  double normal[3] = { std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0 };
+  TESTING_OUTPUT_IGNORE_WARNINGS_ERRORS_BEGIN();
+  const int n = runExtractor(ex, sphere, origin, normal);
+  TESTING_OUTPUT_IGNORE_WARNINGS_ERRORS_END();
+  // No crash → pass.  Output content is implementation-defined for
+  // NaN normals; either empty or garbage is acceptable as long as
+  // RequestData returns.  Pin: must not segfault.
+  (void)n;
+  r.pass("NaNNormal");
+}
+
+} // namespace
+
+int vtkLiverPlaneRingExtractorEdgeCasesTest(int, char*[])
+{
+  SubTestReport r;
+  std::fprintf(stderr, "[PlaneRingExtractor edge cases]\n");
+
+  testPlaneOutsideMesh(r);
+  testPlaneTangentToSphere(r);
+  testPlaneThroughVertex(r);
+  testPlaneParallelToFlatFace(r);
+  testNullInputMesh(r);
+  testNaNNormal(r);
+
+  r.print("PlaneRingExtractor");
+  return r.failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverSpheroidRingExtractorEdgeCasesTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverSpheroidRingExtractorEdgeCasesTest.cxx
@@ -1,0 +1,228 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Edge-case stress tests for vtkLiverSpheroidRingExtractor (issue #335).
+
+  See vtkLiverPlaneRingExtractorEdgeCasesTest.cxx header for the
+  reporting / acceptance discipline (defined output OR defined failure
+  mode).
+
+==============================================================================*/
+
+#include "vtkLiverAlgorithmEdgeCaseHelpers.h"
+#include "vtkLiverSpheroidRingExtractor.h"
+
+#include <vtkCellArray.h>
+#include <vtkNew.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkTestingOutputWindow.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace
+{
+
+using vtkLiverAlgorithmEdgeCaseHelpers::makeUnitSphere;
+using vtkLiverAlgorithmEdgeCaseHelpers::SubTestReport;
+
+int runExtractor(vtkLiverSpheroidRingExtractor* ex, vtkPolyData* target, const double center[3], double rx, double ry, double rz)
+{
+  ex->SetInputData(0, target);
+  ex->SetCenter(center[0], center[1], center[2]);
+  ex->SetRadiusX(rx);
+  ex->SetRadiusY(ry);
+  ex->SetRadiusZ(rz);
+  ex->Update();
+  vtkPolyData* out = ex->GetOutput();
+  return out && out->GetPoints() ? static_cast<int>(out->GetPoints()->GetNumberOfPoints()) : 0;
+}
+
+//----------------------------------------------------------------------------
+// SpheroidEntirelyOutsideMesh — spheroid centred well above the sphere
+// with radius too small to reach.  Expected: empty output.
+void testSpheroidEntirelyOutsideMesh(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere();
+  vtkNew<vtkLiverSpheroidRingExtractor> ex;
+  const double center[3] = { 0.0, 0.0, 10.0 };
+  const int n = runExtractor(ex, sphere, center, 0.1, 0.1, 0.1);
+  if (n == 0)
+  {
+    r.pass("SpheroidEntirelyOutsideMesh");
+  }
+  else
+  {
+    r.fail("SpheroidEntirelyOutsideMesh", "expected empty, got " + std::to_string(n));
+  }
+}
+
+//----------------------------------------------------------------------------
+// SpheroidEntirelyInsideMesh — tiny spheroid completely inside the unit
+// sphere.  The quadric is negative everywhere on the sphere surface, so
+// the cutter produces no level-zero cells.
+void testSpheroidEntirelyInsideMesh(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere();
+  vtkNew<vtkLiverSpheroidRingExtractor> ex;
+  const double center[3] = { 0.0, 0.0, 0.0 };
+  const int n = runExtractor(ex, sphere, center, 0.1, 0.1, 0.1);
+  if (n == 0)
+  {
+    r.pass("SpheroidEntirelyInsideMesh");
+  }
+  else
+  {
+    r.fail("SpheroidEntirelyInsideMesh", "expected empty, got " + std::to_string(n));
+  }
+}
+
+//----------------------------------------------------------------------------
+// SpheroidTangentToSphere — radius 2.0 spheroid centred so the +x apex
+// just touches the unit sphere at (1, 0, 0).  Acceptance: small (or
+// zero) output but no crash.
+void testSpheroidTangentToSphere(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere(128, 128);
+  vtkNew<vtkLiverSpheroidRingExtractor> ex;
+  const double center[3] = { -1.0, 0.0, 0.0 }; // sphere of radius 2.0 from -1 → +1
+  const int n = runExtractor(ex, sphere, center, 2.0, 2.0, 2.0);
+  if (n <= 16)
+  {
+    r.pass("SpheroidTangentToSphere");
+  }
+  else
+  {
+    r.fail("SpheroidTangentToSphere", "tangent produced " + std::to_string(n) + " points; expected <= 16");
+  }
+}
+
+//----------------------------------------------------------------------------
+// VeryOblateSpheroid — aspect 100:1 (rx = 100, rz = 1).  At origin the
+// quadric F = (x² + y²)/10000 + z² - 1.  On the unit sphere x² + y² + z²
+// = 1, F reduces to z² − 1 + (1−z²)/10000 ≈ z² − 1, which is zero only
+// at z = ±1 (the poles).  vtkCutter picks up the two pole crossings as
+// two single-point cells.  Acceptance: extractor returns 0 or 2 points
+// (pole tangency on a faceted sphere is ambiguous; either is graceful).
+void testVeryOblateSpheroid(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere();
+  vtkNew<vtkLiverSpheroidRingExtractor> ex;
+  const double center[3] = { 0.0, 0.0, 0.0 };
+  const int n = runExtractor(ex, sphere, center, 100.0, 100.0, 1.0);
+  if (n <= 4)
+  {
+    r.pass("VeryOblateSpheroid");
+  }
+  else
+  {
+    r.fail("VeryOblateSpheroid", "100:1 oblate touched at " + std::to_string(n) + " points; expected pole tangency (<= 4)");
+  }
+}
+
+//----------------------------------------------------------------------------
+// VeryProlateSpheroid — aspect 1:100 (rz = 100, rx = ry = 0.01).  Long
+// thin needle along z.  Should produce a defined empty output (the
+// needle is too thin to touch the unit sphere unless centred inside).
+void testVeryProlateSpheroid(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere();
+  vtkNew<vtkLiverSpheroidRingExtractor> ex;
+  const double center[3] = { 5.0, 0.0, 0.0 }; // centre off the sphere
+  const int n = runExtractor(ex, sphere, center, 0.01, 0.01, 100.0);
+  if (n == 0)
+  {
+    r.pass("VeryProlateSpheroid");
+  }
+  else
+  {
+    r.fail("VeryProlateSpheroid", "thin needle off-sphere should be empty, got " + std::to_string(n));
+  }
+}
+
+//----------------------------------------------------------------------------
+// SpheroidExtremeAspect_0p1 — aspect 0.1 (rx = ry = 1.5, rz = 0.1)
+// centred on the sphere.  Implicit F = ((x² + y²)/2.25) + 100·z² − 1.
+// On a unit sphere where x² + y² = 1 − z², F reduces to
+// (1 − z²)/2.25 + 100 z² − 1 ≈ 99·z² − 0.55, which crosses zero near
+// z ≈ ±0.0745 — a real intersection ring.  Tests the squashed-spheroid
+// path produces a non-trivial output.
+void testSpheroidExtremeAspect0p1(SubTestReport& r)
+{
+  auto sphere = makeUnitSphere(128, 128);
+  vtkNew<vtkLiverSpheroidRingExtractor> ex;
+  const double center[3] = { 0.0, 0.0, 0.0 };
+  const int n = runExtractor(ex, sphere, center, 1.5, 1.5, 0.1);
+  if (n >= 10)
+  {
+    r.pass("SpheroidExtremeAspect_0p1");
+  }
+  else
+  {
+    r.fail("SpheroidExtremeAspect_0p1", "expected a non-trivial ring (>=10 pts), got " + std::to_string(n));
+  }
+}
+
+//----------------------------------------------------------------------------
+// NegativeRadius — invalid input.  RequestData must emit vtkErrorMacro
+// and return 0; output stays empty.
+void testNegativeRadius(SubTestReport& r)
+{
+  TESTING_OUTPUT_RESET();
+  auto sphere = makeUnitSphere();
+  vtkNew<vtkLiverSpheroidRingExtractor> ex;
+  ex->SetInputData(0, sphere);
+  ex->SetCenter(0.0, 0.0, 0.0);
+  ex->SetRadiusX(-1.0);
+  ex->SetRadiusY(1.0);
+  ex->SetRadiusZ(1.0);
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  ex->Update();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  r.pass("NegativeRadius");
+}
+
+//----------------------------------------------------------------------------
+// ZeroRadius — radius == 0 is invalid (would divide by zero in the
+// quadric coefficient inv2x).  RequestData must emit an error and
+// return early.
+void testZeroRadius(SubTestReport& r)
+{
+  TESTING_OUTPUT_RESET();
+  auto sphere = makeUnitSphere();
+  vtkNew<vtkLiverSpheroidRingExtractor> ex;
+  ex->SetInputData(0, sphere);
+  ex->SetCenter(0.0, 0.0, 0.0);
+  ex->SetRadiusX(0.0);
+  ex->SetRadiusY(1.0);
+  ex->SetRadiusZ(1.0);
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  ex->Update();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  r.pass("ZeroRadius");
+}
+
+} // namespace
+
+int vtkLiverSpheroidRingExtractorEdgeCasesTest(int, char*[])
+{
+  SubTestReport r;
+  std::fprintf(stderr, "[SpheroidRingExtractor edge cases]\n");
+
+  testSpheroidEntirelyOutsideMesh(r);
+  testSpheroidEntirelyInsideMesh(r);
+  testSpheroidTangentToSphere(r);
+  testVeryOblateSpheroid(r);
+  testVeryProlateSpheroid(r);
+  testSpheroidExtremeAspect0p1(r);
+  testNegativeRadius(r);
+  testZeroRadius(r);
+
+  r.print("SpheroidRingExtractor");
+  return r.failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/Testing/Python/unit/test_bezier_characterization.py
+++ b/Testing/Python/unit/test_bezier_characterization.py
@@ -640,3 +640,143 @@ def test_cxx_inverse_transform_matches_pinned_reconstruction(algorithm_module):
         rtol=_RTOL_TIGHT,
         atol=_ATOL_TIGHT,
     )
+
+
+# --------------------------------------------------------------------------- #
+# Edge-case stress tests — issue #335.
+#
+# Drive the C++ Algorithm wrapper with degenerate / extreme inputs and
+# assert either a defined output OR a defined failure mode (graceful
+# vtkErrorMacro return).  The fixtures are deliberately small Python
+# constructs so the test bodies stay readable and ctest output is
+# self-documenting.  All assertions live behind the same
+# ``algorithm_module`` fixture as the parity tests above, so the
+# whole block skips cleanly when the wrapped Algorithm library is
+# unavailable.
+#
+# Findings landed via this block are mirrored in the C++ ctkTest
+# driver under LiverResections/Algorithm/Testing/Cxx/*EdgeCasesTest.cxx
+# (same fixtures, same acceptance, same #335 traceability).  Whichever
+# stage is faster to iterate wins for the day-to-day add-a-fixture loop.
+# --------------------------------------------------------------------------- #
+
+
+def _planar_circle(n, radius=1.0):
+    """Return an (n+1) x 3 closed planar ring at z=0."""
+    theta = np.linspace(0.0, 2.0 * np.pi, n, endpoint=False)
+    pts = np.zeros((n + 1, 3), dtype=np.float64)
+    pts[:n, 0] = radius * np.cos(theta)
+    pts[:n, 1] = radius * np.sin(theta)
+    pts[n] = pts[0]
+    return pts
+
+
+def test_cxx_efd_short_ring_above_nyquist(algorithm_module):
+    """EFD with order > Nyquist on a 6-point ring: defined finite output."""
+    ring = _planar_circle(6)
+    coeffs_arr = (
+        algorithm_module.vtkLiverContourParameterizer.ComputeEFDCoefficients(
+            _to_double_array(ring.flatten().tolist()), 8
+        )
+    )
+    n = coeffs_arr.GetNumberOfTuples()
+    coeffs = np.array([coeffs_arr.GetValue(i) for i in range(n)]).reshape(8, 6)
+    assert coeffs.shape == (8, 6)
+    assert np.all(np.isfinite(coeffs)), (
+        "EFD coefficients on a 6-point ring must remain finite"
+    )
+
+
+def test_cxx_efd_duplicated_consecutive_points(algorithm_module):
+    """Zero-length segment -> NaN propagation (known fragile behaviour).
+
+    Pinned per ADR-0003: the current implementation divides each
+    segment displacement by its arc-length without guarding against
+    zero, so a duplicated consecutive point yields NaN coefficients.
+    The C++ test surfaces the same behaviour via a sub-issue; this
+    Python wrapper test is the dual-mode characterisation pin.
+    """
+    ring = _planar_circle(20)
+    # Splice a duplicate of row 5.
+    dup = np.insert(ring, 6, ring[5], axis=0)
+    coeffs_arr = (
+        algorithm_module.vtkLiverContourParameterizer.ComputeEFDCoefficients(
+            _to_double_array(dup.flatten().tolist()), 8
+        )
+    )
+    n = coeffs_arr.GetNumberOfTuples()
+    coeffs = np.array([coeffs_arr.GetValue(i) for i in range(n)])
+    # Either the implementation has been patched (no NaN) or it still
+    # propagates NaN -- both are accepted, but log which path we took
+    # so a reviewer sees the change instantly.
+    has_nan = bool(np.any(np.isnan(coeffs)))
+    print(
+        "\n    dup-segment NaN propagation: "
+        + ("YES (current pin)" if has_nan else "NO (behaviour changed)")
+    )
+
+
+def test_cxx_efd_planar_circle_round_trip(algorithm_module):
+    """EFD-8 reconstruction of a 60-point unit circle approximates it."""
+    ring = _planar_circle(60)
+    coeffs_arr = (
+        algorithm_module.vtkLiverContourParameterizer.ComputeEFDCoefficients(
+            _to_double_array(ring.flatten().tolist()), 8
+        )
+    )
+    dc_arr = (
+        algorithm_module.vtkLiverContourParameterizer.ComputeDCCoefficients(
+            _to_double_array(ring.flatten().tolist())
+        )
+    )
+    recon_arr = (
+        algorithm_module.vtkLiverContourParameterizer.InverseTransform(
+            coeffs_arr,
+            8,
+            dc_arr.GetValue(0),
+            dc_arr.GetValue(1),
+            dc_arr.GetValue(2),
+            24,
+        )
+    )
+    n = recon_arr.GetNumberOfTuples()
+    recon = np.array(
+        [recon_arr.GetValue(i) for i in range(n)], dtype=np.float64
+    ).reshape(3, 24)
+    radius = np.sqrt(recon[0] ** 2 + recon[1] ** 2)
+    np.testing.assert_allclose(radius, 1.0, atol=5e-3)
+
+
+def test_cxx_bezier_fitter_flat_surface(algorithm_module):
+    """Flat z=0 input: control points must all sit on z=0."""
+    u = np.linspace(0.0, 1.0, 4)
+    v = np.linspace(0.0, 1.0, 4)
+    points = np.zeros((4, 4, 3))
+    for i in range(4):
+        for j in range(4):
+            points[i, j] = (u[i], v[j], 0.0)
+
+    def bern3(t):
+        t1 = 1.0 - t
+        return np.array(
+            [t1**3, 3.0 * t * t1**2, 3.0 * t**2 * t1, t**3]
+        )
+
+    basis_u = np.stack([bern3(t) for t in u])
+    basis_v = np.stack([bern3(t) for t in v])
+
+    fitter = algorithm_module.vtkLiverBezierFitter()
+    fitter.SetNumberOfSamples(4, 4)
+    fitter.SetInputData(0, _points_polydata(points.flatten().tolist()))
+    fitter.SetInputData(1, _basis_table(basis_u))
+    fitter.SetInputData(2, _basis_table(basis_v))
+    fitter.Update()
+
+    out_points = fitter.GetOutput().GetPoints()
+    assert out_points.GetNumberOfPoints() == 16
+    z_max = 0.0
+    for k in range(16):
+        z_max = max(z_max, abs(out_points.GetPoint(k)[2]))
+    assert z_max < 1e-10, (
+        "flat-input control points off z=0: max |z| = " + str(z_max)
+    )

--- a/Testing/Python/unit/test_bezier_characterization.py
+++ b/Testing/Python/unit/test_bezier_characterization.py
@@ -706,14 +706,20 @@ def test_cxx_efd_duplicated_consecutive_points(algorithm_module):
     )
     n = coeffs_arr.GetNumberOfTuples()
     coeffs = np.array([coeffs_arr.GetValue(i) for i in range(n)])
-    # Either the implementation has been patched (no NaN) or it still
-    # propagates NaN -- both are accepted, but log which path we took
-    # so a reviewer sees the change instantly.
+    # ADR-0003 characterisation pin for issue #355
+    # (https://github.com/ALive-research/Slicer-Liver/issues/355): the
+    # current implementation divides each segment displacement by its
+    # arc-length without guarding against zero, so a duplicated point
+    # yields NaN coefficients.  Pinning has_nan == True gives CI a loud
+    # signal the day a future fix lands — the assertion fails, the
+    # fixer flips it to `assert not np.any(...)` and closes #355.
     has_nan = bool(np.any(np.isnan(coeffs)))
-    print(
-        "\n    dup-segment NaN propagation: "
-        + ("YES (current pin)" if has_nan else "NO (behaviour changed)")
+    assert has_nan, (
+        "Characterisation pin inverted: zero-length-segment path no longer "
+        "NaN-propagates.  If this is intentional (issue #355 fixed), invert "
+        "the assertion to `assert not np.any(np.isnan(coeffs))` and close #355."
     )
+    # TODO(#355): invert assertion to `assert not has_nan` when fixed.
 
 
 def test_cxx_efd_planar_circle_round_trip(algorithm_module):


### PR DESCRIPTION
## Summary

Bug-discovery half of ADR-0015 motivation — closes #335.

Adds **31 parametrised edge-case sub-tests** across the four C++ algorithm classes landed by PR #334 (`vtkLiverPlaneRingExtractor`, `vtkLiverSpheroidRingExtractor`, `vtkLiverContourParameterizer`, `vtkLiverBezierFitter`), plus four dual-mode parity tests in the Python wrapper layer.  Each sub-test asserts either a defined output (graceful handling) or a defined failure mode (`vtkErrorMacro` + `RequestData` returns 0), per ADR-0003 characterisation discipline.

This PR is **test-only**: no algorithm class is modified, `vtkLiverAlgorithmTestFixtures.h`'s `EXPECTED_*` bit-equivalence pins are untouched, and the post-#349 input-port API is used throughout.

## Categories covered

| Class | Sub-tests | Categories from #335 |
| --- | --- | --- |
| `vtkLiverPlaneRingExtractor` | 6 | plane outside / tangent / through-vertex / parallel-to-flat-face / null input / NaN normal |
| `vtkLiverSpheroidRingExtractor` | 8 | entirely outside / entirely inside / tangent / oblate-100:1 / prolate-1:100 / aspect-0.1 / negative-radius / zero-radius |
| `vtkLiverContourParameterizer` | 9 | order > Nyquist / duplicated consecutive points / non-uniform sampling / planar-circle round-trip / FourierPower 0.9999 probe / single-precision input / single-point error / corner mapping / order=0 error |
| `vtkLiverBezierFitter` | 8 | flat surface / collinear in u / high-frequency oscillation / minimum sample count / condition-number probe / single-precision points / missing basis port / mismatched basis columns |

The Python wrapper test file gains four parallel tests (short ring above Nyquist, duplicated consecutive points, planar circle round-trip, flat surface) so a single PR test run covers both C++ and Python entry points.

### Deliberately deferred

* Non-manifold geometry near the plane (issue #335 §`vtkLiverPlaneRingExtractor`) — would require fixture infrastructure (deliberately-broken cell ordering, edge sharing) that does not exist elsewhere in the repo yet; bigger scope than this PR.

## Sub-issues filed

* **#355** — `vtkLiverContourParameterizer` NaN-propagates on zero-length segments (no guard around `dxyz[i] / dt[i]`).
* **#356** — `vtkLiverBezierFitter` Gram matrix `Bu^T Bu` reaches κ ≈ 5e31 on degenerate inputs; `Eigen::MatrixXd::inverse()` (PartialPivLU) is the textbook-unstable form and `JacobiSVD` is the recommended swap.

Both findings are pinned as characterisation tests in this PR so the current behaviour is locked in until the dedicated fix PRs land (with re-pinned EXPECTED constants).

## Test plan

- [x] All 8 algorithm tests (4 existing characterisation + 4 new edge-case) build and pass locally against `preview` HEAD `639edf8`.
- [x] `ruff check --fix` clean on the modified Python file.
- [x] `clang-format` applied to all new `.cxx` / `.h` files.
- [x] Pre-commit checks pass for end-of-file / trailing-whitespace / mixed-line-ending / pyupgrade / commit-msg vocabulary.  (`clang-format`, `prettier`, `ruff-check` hooks skipped locally because their pinned environments were not available; CI re-checks them.)
- [x] Sub-issues #355 and #356 filed with citations to the failing fixtures.

## Notes

* The algorithm classes (`vtkLiverPlaneRingExtractor.cxx`, `vtkLiverSpheroidRingExtractor.cxx`, `vtkLiverContourParameterizer.cxx`, `vtkLiverBezierFitter.cxx`) and the bit-equivalence pin (`vtkLiverAlgorithmTestFixtures.h`) are **not modified**; the test-only invariant from ADR-0015 §Out-of-scope is preserved.
* The shared `vtkLiverAlgorithmEdgeCaseHelpers.h` adds synthetic-mesh / synthetic-ring constructors and a Cholesky-based condition-number estimator used as the observable for finding #356.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code.  Opened for human review.*