### PR TITLE
ENH: Add SlicingPlaneInitRepresentation (T2.2 iteration 2)

### DIFF
--- a/LiverResections/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverBezierSurfacePipeline.py
@@ -11,13 +11,14 @@ The Pipeline owns three Representations keyed on the
 ``(state, initMode)`` tuple; ``update()`` activates whichever
 Representation matches the current tuple.
 
-Scope of this skeleton — first T2.2 stack iteration
----------------------------------------------------
-This is the **first iteration of the T2.2 stack** (Path B scoping;
-see the v2.0.0 release tracker).  Only the ``BezierPlanning``
-Representation is wired up; the two ``Init``-state Representations
-(``SlicingPlaneInit`` and ``DistanceSpheroidInit``) are placeholder
-slots with TODO markers and land in the remaining T2.2 iterations.
+Scope of this skeleton — T2.2 stack iterations
+----------------------------------------------
+This Pipeline is built incrementally across the T2.2 stack
+iterations (Path B scoping; see the v2.0.0 release tracker).  As of
+iteration 2 the ``BezierPlanning`` and ``SlicingPlaneInit``
+Representations are wired up; the ``DistanceSpheroidInit`` slot
+remains a placeholder with a TODO marker and lands in the remaining
+T2.2 iteration.
 
 Out of scope here, per the brief:
 
@@ -274,9 +275,10 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         across state transitions — no add/remove churn on the MRML scene
         as the surgeon moves through the workflow.
 
-        This iteration wires only ``BezierPlanningRepresentation``.
-        The two Init-state Representations land in later T2.2 stack
-        iterations.
+        As of T2.2 iteration 2 this wires ``BezierPlanningRepresentation``
+        and ``SlicingPlaneInitRepresentation``.  The
+        ``DistanceSpheroidInit`` slot lands in the remaining T2.2 stack
+        iteration.
         """
         # Local import to avoid a circular import when the Representations
         # package grows.  The Representation classes themselves are small
@@ -302,14 +304,23 @@ class LiverBezierSurfacePipeline(_PipelineBase):
                 BezierPlanningRepresentation,
             )
 
+        try:  # pragma: no cover - exercised once per import path
+            from .Representations.SlicingPlaneInitRepresentation import (
+                SlicingPlaneInitRepresentation,
+            )
+        except ImportError:
+            from Representations.SlicingPlaneInitRepresentation import (  # type: ignore[no-redef]
+                SlicingPlaneInitRepresentation,
+            )
+
         self._representations[REPRESENTATION_BEZIER_PLANNING] = (
             BezierPlanningRepresentation(renderer=self.GetRenderer())
         )
 
-        # TODO(T2.2 SlicingPlaneInit): populate slot per ADR-0014 §2.
-        #   self._representations[REPRESENTATION_SLICING_PLANE_INIT] = (
-        #       SlicingPlaneInitRepresentation(renderer=self.GetRenderer())
-        #   )
+        self._representations[REPRESENTATION_SLICING_PLANE_INIT] = (
+            SlicingPlaneInitRepresentation(renderer=self.GetRenderer())
+        )
+
         # TODO(T2.2 DistanceSpheroidInit): populate slot per ADR-0014 §2.
         #   self._representations[REPRESENTATION_DISTANCE_SPHEROID_INIT] = (
         #       DistanceSpheroidInitRepresentation(renderer=self.GetRenderer())

--- a/LiverResections/Representations/SlicingPlaneInitRepresentation.py
+++ b/LiverResections/Representations/SlicingPlaneInitRepresentation.py
@@ -1,0 +1,618 @@
+"""Representation active in ``(ResectionState=Init, InitMode=SlicingPlane)``.
+
+Renders the surgeon-placed *SlicingPlane* initialisation geometry per
+ADR-0014 §2: the two init points that seed the plane and the plane
+visualisation itself.  Driven by the ``vtkMRMLBezierSurfaceNode`` data
+node (geometry: ``GetSlicingPlaneOrigin``, ``GetSlicingPlaneNormal``,
+``GetSlicingPlaneInitPoint(0|1)``) and the paired
+``vtkMRMLBezierSurfaceDisplayNode`` (decoration: ``GetResectionColor``,
+``GetResectionOpacity``).
+
+Scope of this skeleton — T2.2 stack iteration 2
+-----------------------------------------------
+This is the second T2.2 iteration: the *SlicingPlaneInit*
+Representation slot on ``LiverBezierSurfacePipeline``.  The first
+iteration landed ``BezierPlanningRepresentation``; this iteration
+mirrors its pattern (soft VTK gate, ``update`` /
+``cleanup`` lifecycle, idempotency memo, introspection helpers for
+unit tests).
+
+Three pieces of geometry per ADR-0014 §2
+----------------------------------------
+1. **Two control-point markers** — small ``vtkSphereSource`` glyphs,
+   transformed to ``GetSlicingPlaneInitPoint(0)`` and
+   ``GetSlicingPlaneInitPoint(1)``.  Full opacity, takes the display
+   node's ``ResectionColor``.
+2. **The plane visualisation** — a ``vtkPlaneSource`` driven by
+   ``GetSlicingPlaneOrigin`` (centre) + ``GetSlicingPlaneNormal``
+   (orientation).  Sized to a square ~2× the distance between the two
+   init points, centred on the plane origin.  Reduced opacity (the
+   display node's ``ResectionOpacity`` is multiplied by
+   ``PLANE_OPACITY_FACTOR`` so the plane reads as a transparent
+   reference surface and does not occlude the underlying liver).
+3. **Ring on the target liver mesh** — DEFERRED.  The
+   ``vtkLiverPlaneRingExtractor`` consumer needs the target liver
+   mesh, which is reached through a (not-yet-landed) weakref on
+   ``vtkMRMLBezierSurfaceNode``.  See
+   ``TODO(T2-target-mesh-weakref)`` in ``_build_vtk_pipeline`` for
+   the exact wiring once the data node gains a
+   ``TargetOrganModelNode`` reference per ADR-0014 §1.
+
+Mapper relocation
+-----------------
+Per ADR-0014 §3 the relocated ``vtkOpenGLSlicingContourPolyDataMapper``
+is the eventual replacement for the plane visualisation mapper used
+here.  Today the relocation has not landed; this skeleton uses the
+generic ``vtkPolyDataMapper`` + ``vtkActor`` pair.  Marked with
+``TODO(T2-mapper-relocation)`` at the construction point so the swap
+is mechanical.
+
+Renderer attachment
+-------------------
+Same discipline as ``BezierPlanningRepresentation``: all actors are
+created on ``__init__`` (when VTK is importable); ``SetRenderer``
+attaches them; ``cleanup`` detaches and drops strong refs.  When
+``renderer`` is ``None`` (the unit-test path) the actors exist but
+are unrendered.  Per ADR-0008 §2 unit-layer tests have no Slicer /
+no view.
+
+No grid actor
+-------------
+Unlike ``BezierPlanningRepresentation`` (which lives in
+``state=Planning``), this Representation does NOT render the Bezier
+4×4 control grid.  In ``state=Init`` there is no fitted surface yet —
+only the plane definition.  The grid is a shader feature on the
+Planning surface mapper per ADR-0014 §3 and is irrelevant here.
+
+References
+----------
+* `ADR-0013`_ §4 — Pipeline pattern, state-conditional dispatch.
+* `ADR-0013`_ §6 — Representations as composable VTK pipelines.
+* `ADR-0014`_ §2 — names this Representation.
+* `ADR-0014`_ §4 — init data persists as read-only audit data after
+  Init→Planning; the data node's
+  ``GetSlicingPlaneOrigin`` / ``GetSlicingPlaneNormal`` /
+  ``GetSlicingPlaneInitPoint(i)`` accessors honour that contract.
+
+.. _ADR-0013: ../../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0014: ../../../Docs/adr/0014-livermarkups-dissolution.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# VTK is a soft dependency — mirrors the pattern in
+# ``BezierPlanningRepresentation``.  When ``vtk`` is not importable the
+# Representation can still be constructed; ``update()`` then writes the
+# colour / opacity stubs without building any VTK pipeline, which is
+# enough for the smoke-level unit tests.  See ADR-0008 §2.
+# --------------------------------------------------------------------------- #
+
+try:  # pragma: no cover — exercised inside Slicer / when VTK is available
+    import vtk
+
+    _HAS_VTK = True
+except ImportError:  # pragma: no cover — pure-Python path
+    vtk = None  # type: ignore[assignment]
+    _HAS_VTK = False
+
+
+# --------------------------------------------------------------------------- #
+# Default colour / opacity values — mirror the legacy
+# ``vtkMRMLLiverResectionNode`` constructor so the Init-state visual
+# baseline matches the Planning Representation's defaults.
+# --------------------------------------------------------------------------- #
+
+DEFAULT_RESECTION_COLOR = (1.0, 1.0, 1.0)
+DEFAULT_RESECTION_OPACITY = 1.0
+
+# Marker-sphere radius (world units).  Sized for the typical liver
+# bounding box (~150 mm) so the markers are visible without occluding
+# the plane.  A perceptual rather than physical choice; refine when
+# the design rationale of ADR-0009 §3 is applied.
+MARKER_RADIUS = 1.5
+
+# The plane is drawn at a reduced opacity relative to the display
+# node's ``ResectionOpacity`` so it reads as a transparent reference
+# surface and does not occlude the underlying liver in 3D views.
+PLANE_OPACITY_FACTOR = 0.35
+
+# Size factor — the plane is rendered as a square whose side length is
+# ``PLANE_SIZE_FACTOR`` × the distance between the two init points,
+# centred on the plane origin.  Provides a "sensible size" per the
+# T2.2 iteration-2 brief.  Refined when ADR-0009 §3's UX rationale is
+# applied to this Representation.
+PLANE_SIZE_FACTOR = 2.0
+
+# Fallback plane half-extent (world units) used when the two init
+# points are coincident — without it the plane visualisation would
+# collapse to a degenerate point.
+PLANE_FALLBACK_HALF_EXTENT = 25.0
+
+
+class SlicingPlaneInitRepresentation:
+    """VTK assembly for the (Init, SlicingPlane) state.
+
+    Constructor
+    -----------
+    ``SlicingPlaneInitRepresentation(renderer=None)``
+
+    * ``renderer`` — the ``vtkRenderer`` the actors are added to.
+      Optional; ``None`` is supported for unit tests (the actors
+      exist but are unrendered).
+
+    Public methods
+    --------------
+    * ``update(display_node, data_node)`` — reads decoration from the
+      display node, plane / init-point geometry from the data node,
+      and reconciles mappers / actors.  Tolerant of ``None`` arguments.
+    * ``cleanup()`` — detaches actors from the renderer and releases
+      the VTK pipeline.
+
+    Introspection (used by unit tests)
+    ----------------------------------
+    * ``GetMarkerActor(i)`` — the ``vtkActor`` rendering init point
+      ``i`` (0 or 1).  ``None`` when VTK is not importable.
+    * ``GetPlaneActor()`` — the ``vtkActor`` rendering the plane
+      visualisation.
+    * ``GetPlaneSource()`` — the underlying ``vtkPlaneSource``.
+    * ``GetCurrentColor()`` — last colour written.
+    * ``GetCurrentOpacity()`` — last opacity written.
+    * ``GetInputRefreshCount()`` — counter bumped each time the plane
+      / marker geometry is rebuilt from a *changed* data node.
+    """
+
+    def __init__(self, renderer: Any | None = None) -> None:
+        self._renderer: Any | None = None
+
+        # VTK objects owned by the Representation.  ``None`` in the
+        # pure-Python testing path.
+        self._marker_sources: list[Any] = []  # vtkSphereSource × 2
+        self._marker_mappers: list[Any] = []  # vtkPolyDataMapper × 2
+        self._marker_actors: list[Any] = []  # vtkActor × 2
+
+        self._plane_source: Any | None = None
+        self._plane_mapper: Any | None = None
+        self._plane_actor: Any | None = None
+
+        # Last-written colour / opacity — exposed for stub-friendly
+        # introspection.
+        self._current_color: tuple[float, float, float] = DEFAULT_RESECTION_COLOR
+        self._current_opacity: float = DEFAULT_RESECTION_OPACITY
+
+        # Idempotency memo on (origin, normal, init0, init1, displayMTime).
+        # The Pipeline already memoises (state, initMode, dataMTime,
+        # displayMTime); this second memo guards against redundant VTK
+        # pipeline rebuilds when the Pipeline's coarse-grained key
+        # changes but the SlicingPlane subset of the data node is
+        # unchanged.
+        self._last_input_signature: tuple | None = None
+
+        # Bookkeeping for unit tests — bumped on a real refresh.
+        self._input_refresh_count: int = 0
+
+        # TODO(T2-mapper-relocation): swap the generic
+        # ``vtk.vtkPolyDataMapper`` used for the plane visualisation
+        # with ``vtkOpenGLSlicingContourPolyDataMapper`` once the four
+        # custom mappers are relocated from ``LiverMarkups/VTKWidgets/``
+        # to ``LiverResections/VTKWidgets/`` per ADR-0014 §3.  The
+        # public API of this Representation does not change — only
+        # the plane mapper's concrete type.
+        #
+        # TODO(T2-target-mesh-weakref): once ``vtkMRMLBezierSurfaceNode``
+        # gains a weakref to its ``TargetOrganModelNode`` (per ADR-0014
+        # §1's data-node design), construct a ``vtkLiverPlaneRing
+        # Extractor``, feed it the target mesh + origin + normal, and
+        # render its polyline output as a ring actor here.  The
+        # extractor already exists at
+        # ``LiverResections/Algorithm/vtkLiverPlaneRingExtractor.{h,cxx}``;
+        # only the data-node hook is missing.  Without the target
+        # mesh, this Representation cannot construct the ring; the
+        # ring slot is therefore omitted entirely in this iteration
+        # rather than left as a dangling empty actor.
+        if _HAS_VTK:
+            self._build_vtk_pipeline()
+
+        if renderer is not None:
+            self.SetRenderer(renderer)
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def SetRenderer(self, renderer: Any | None) -> None:
+        """Attach the Representation's actors to ``renderer``."""
+        if self._renderer is not None and self._renderer is not renderer:
+            self._detach_actors(self._renderer)
+        self._renderer = renderer
+        if renderer is not None:
+            self._attach_actors(renderer)
+
+    def GetRenderer(self) -> Any | None:
+        return self._renderer
+
+    def update(
+        self, display_node: Any | None, data_node: Any | None
+    ) -> None:
+        """Reconcile the actors against the current display + data nodes.
+
+        Tolerant of ``None`` arguments — falls back to default colour /
+        opacity without raising.
+        """
+        self._apply_display_node(display_node)
+        self._apply_data_node(data_node)
+
+    def cleanup(self) -> None:
+        """Detach actors from the renderer and drop the VTK pipeline."""
+        if self._renderer is not None:
+            self._detach_actors(self._renderer)
+            self._renderer = None
+        # Drop strong refs so VTK can free the resources.
+        self._marker_sources = []
+        self._marker_mappers = []
+        self._marker_actors = []
+        self._plane_source = None
+        self._plane_mapper = None
+        self._plane_actor = None
+
+    # ------------------------------------------------------------------ #
+    # Introspection — used by the unit-layer tests
+    # ------------------------------------------------------------------ #
+
+    def GetMarkerActor(self, index: int) -> Any | None:
+        if 0 <= index < len(self._marker_actors):
+            return self._marker_actors[index]
+        return None
+
+    def GetMarkerSource(self, index: int) -> Any | None:
+        if 0 <= index < len(self._marker_sources):
+            return self._marker_sources[index]
+        return None
+
+    def GetPlaneActor(self) -> Any | None:
+        return self._plane_actor
+
+    def GetPlaneMapper(self) -> Any | None:
+        return self._plane_mapper
+
+    def GetPlaneSource(self) -> Any | None:
+        return self._plane_source
+
+    def GetCurrentColor(self) -> tuple[float, float, float]:
+        return self._current_color
+
+    def GetCurrentOpacity(self) -> float:
+        return self._current_opacity
+
+    def GetInputRefreshCount(self) -> int:
+        return self._input_refresh_count
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _build_vtk_pipeline(self) -> None:
+        """Construct the marker + plane actors.
+
+        Called from ``__init__`` only when ``vtk`` is importable.
+        """
+        assert vtk is not None  # for the type-checker — gated by _HAS_VTK
+
+        # Two marker spheres — one per init point.
+        for _ in range(2):
+            sphere = vtk.vtkSphereSource()
+            sphere.SetRadius(MARKER_RADIUS)
+            sphere.SetPhiResolution(12)
+            sphere.SetThetaResolution(12)
+            sphere.SetCenter(0.0, 0.0, 0.0)
+            mapper = vtk.vtkPolyDataMapper()
+            mapper.SetInputConnection(sphere.GetOutputPort())
+            actor = vtk.vtkActor()
+            actor.SetMapper(mapper)
+            actor.GetProperty().SetColor(*DEFAULT_RESECTION_COLOR)
+            actor.GetProperty().SetOpacity(DEFAULT_RESECTION_OPACITY)
+            self._marker_sources.append(sphere)
+            self._marker_mappers.append(mapper)
+            self._marker_actors.append(actor)
+
+        # Plane visualisation.
+        #
+        # TODO(T2-mapper-relocation): once the four custom mappers land
+        # in ``LiverResections/VTKWidgets/`` per ADR-0014 §3, swap the
+        # ``vtk.vtkPolyDataMapper`` below for
+        # ``vtkOpenGLSlicingContourPolyDataMapper``.  That mapper carries
+        # the slicing-contour shader treatment that the legacy
+        # LiverMarkups path used; today we use the generic mapper so
+        # the Representation remains independent of the mapper
+        # relocation work.
+        self._plane_source = vtk.vtkPlaneSource()
+        self._plane_mapper = vtk.vtkPolyDataMapper()
+        self._plane_mapper.SetInputConnection(
+            self._plane_source.GetOutputPort()
+        )
+        self._plane_actor = vtk.vtkActor()
+        self._plane_actor.SetMapper(self._plane_mapper)
+        self._plane_actor.GetProperty().SetColor(*DEFAULT_RESECTION_COLOR)
+        self._plane_actor.GetProperty().SetOpacity(
+            DEFAULT_RESECTION_OPACITY * PLANE_OPACITY_FACTOR
+        )
+
+    def _attach_actors(self, renderer: Any) -> None:
+        if not hasattr(renderer, "AddActor"):
+            return
+        for actor in self._marker_actors:
+            renderer.AddActor(actor)
+        if self._plane_actor is not None:
+            renderer.AddActor(self._plane_actor)
+
+    def _detach_actors(self, renderer: Any) -> None:
+        if not hasattr(renderer, "RemoveActor"):
+            return
+        for actor in self._marker_actors:
+            try:
+                renderer.RemoveActor(actor)
+            except Exception:  # pragma: no cover — defensive
+                pass
+        if self._plane_actor is not None:
+            try:
+                renderer.RemoveActor(self._plane_actor)
+            except Exception:  # pragma: no cover — defensive
+                pass
+
+    def _apply_display_node(self, display_node: Any | None) -> None:
+        """Push decoration fields onto the actors.
+
+        Marker actors take the colour at full opacity; the plane actor
+        takes the colour at reduced opacity (``PLANE_OPACITY_FACTOR``).
+        """
+        if display_node is None:
+            color = DEFAULT_RESECTION_COLOR
+            opacity = DEFAULT_RESECTION_OPACITY
+        else:
+            color_getter = getattr(display_node, "GetResectionColor", None)
+            opacity_getter = getattr(
+                display_node, "GetResectionOpacity", None
+            )
+            color = (
+                _as_color_tuple(color_getter())
+                if color_getter is not None
+                else DEFAULT_RESECTION_COLOR
+            )
+            opacity = (
+                float(opacity_getter())
+                if opacity_getter is not None
+                else DEFAULT_RESECTION_OPACITY
+            )
+
+        self._current_color = color
+        self._current_opacity = opacity
+
+        # TODO(ADR-0011): when the display node's TerminologyEntry is
+        # populated, derive the colour from the SCT triple via the
+        # project's terminology utilities (overriding the pure-vector
+        # ResectionColor above).  The terminology helper API lands in
+        # T2.4; this Representation is among its first consumers.
+
+        for actor in self._marker_actors:
+            prop = actor.GetProperty()
+            prop.SetColor(*color)
+            prop.SetOpacity(opacity)
+        if self._plane_actor is not None:
+            prop = self._plane_actor.GetProperty()
+            prop.SetColor(*color)
+            prop.SetOpacity(opacity * PLANE_OPACITY_FACTOR)
+
+    def _apply_data_node(self, data_node: Any | None) -> None:
+        """Pull plane + init-point geometry off the data node and
+        push it through the marker sphere centres + plane source.
+        """
+        if data_node is None:
+            return
+
+        origin = _read_vec3(data_node, "GetSlicingPlaneOrigin")
+        normal = _read_vec3(data_node, "GetSlicingPlaneNormal")
+        init0 = _read_init_point(data_node, 0)
+        init1 = _read_init_point(data_node, 1)
+
+        if origin is None or normal is None or init0 is None or init1 is None:
+            # Any missing field is treated as "not enough geometry to
+            # render yet" — the actors retain their previous geometry
+            # (so a transient ``Modified()`` mid-update doesn't blank
+            # the view) and the refresh counter does not advance.
+            return
+
+        signature = (origin, normal, init0, init1)
+        if signature == self._last_input_signature:
+            return  # no geometry change, no refresh
+        self._last_input_signature = signature
+        self._input_refresh_count += 1
+
+        if not _HAS_VTK:
+            return
+
+        self._refresh_marker_positions(init0, init1)
+        self._refresh_plane(origin, normal, init0, init1)
+
+    def _refresh_marker_positions(
+        self,
+        init0: tuple[float, float, float],
+        init1: tuple[float, float, float],
+    ) -> None:
+        if len(self._marker_sources) < 2:
+            return
+        self._marker_sources[0].SetCenter(*init0)
+        self._marker_sources[1].SetCenter(*init1)
+
+    def _refresh_plane(
+        self,
+        origin: tuple[float, float, float],
+        normal: tuple[float, float, float],
+        init0: tuple[float, float, float],
+        init1: tuple[float, float, float],
+    ) -> None:
+        """Drive the ``vtkPlaneSource`` from origin + normal.
+
+        Builds a square plane of side ``PLANE_SIZE_FACTOR × |init0 -
+        init1|``, centred on ``origin``, oriented to ``normal``.
+        Falls back to ``PLANE_FALLBACK_HALF_EXTENT`` when the two init
+        points are coincident (would otherwise yield a degenerate
+        plane).
+        """
+        if self._plane_source is None:
+            return
+        assert vtk is not None
+
+        plane = self._plane_source
+
+        # Half-extent: half the side length.
+        d = _distance(init0, init1)
+        half = max(
+            0.5 * PLANE_SIZE_FACTOR * d, PLANE_FALLBACK_HALF_EXTENT
+        )
+
+        # Construct a basis (u, v) in the plane.  vtkMath::Perpendiculars
+        # returns two unit vectors perpendicular to ``normal`` and to
+        # each other.  Falls back to a manual orthonormal pair if the
+        # helper is unavailable.
+        n = _normalise(normal)
+        if n is None:
+            return
+        u, v = _plane_basis(n)
+
+        cx, cy, cz = origin
+        plane.SetOrigin(
+            cx - half * u[0] - half * v[0],
+            cy - half * u[1] - half * v[1],
+            cz - half * u[2] - half * v[2],
+        )
+        plane.SetPoint1(
+            cx + half * u[0] - half * v[0],
+            cy + half * u[1] - half * v[1],
+            cz + half * u[2] - half * v[2],
+        )
+        plane.SetPoint2(
+            cx - half * u[0] + half * v[0],
+            cy - half * u[1] + half * v[1],
+            cz - half * u[2] + half * v[2],
+        )
+        plane.SetCenter(cx, cy, cz)
+        plane.SetNormal(n[0], n[1], n[2])
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _as_color_tuple(raw: Any) -> tuple[float, float, float]:
+    """Coerce a colour accessor's return value to ``(r, g, b)``.
+
+    Accepts list, tuple, or VTK-wrapped sequence; clamps to [0, 1] and
+    falls back to white on parse failure.
+    """
+    try:
+        r = max(0.0, min(1.0, float(raw[0])))
+        g = max(0.0, min(1.0, float(raw[1])))
+        b = max(0.0, min(1.0, float(raw[2])))
+        return (r, g, b)
+    except Exception:
+        return DEFAULT_RESECTION_COLOR
+
+
+def _read_vec3(
+    node: Any, getter_name: str
+) -> tuple[float, float, float] | None:
+    """Read a 3-tuple accessor (e.g. ``GetSlicingPlaneOrigin``) off ``node``.
+
+    Returns ``None`` when the accessor is missing or its return value
+    cannot be coerced to three floats.
+    """
+    getter = getattr(node, getter_name, None)
+    if getter is None:
+        return None
+    try:
+        raw = getter()
+    except Exception:  # pragma: no cover — defensive
+        return None
+    if raw is None:
+        return None
+    try:
+        return (float(raw[0]), float(raw[1]), float(raw[2]))
+    except Exception:
+        return None
+
+
+def _read_init_point(
+    node: Any, index: int
+) -> tuple[float, float, float] | None:
+    """Read ``GetSlicingPlaneInitPoint(index)`` off ``node``."""
+    getter = getattr(node, "GetSlicingPlaneInitPoint", None)
+    if getter is None:
+        return None
+    try:
+        raw = getter(index)
+    except Exception:  # pragma: no cover — defensive
+        return None
+    if raw is None:
+        return None
+    try:
+        return (float(raw[0]), float(raw[1]), float(raw[2]))
+    except Exception:
+        return None
+
+
+def _distance(
+    a: tuple[float, float, float], b: tuple[float, float, float]
+) -> float:
+    dx = a[0] - b[0]
+    dy = a[1] - b[1]
+    dz = a[2] - b[2]
+    return (dx * dx + dy * dy + dz * dz) ** 0.5
+
+
+def _normalise(
+    v: tuple[float, float, float],
+) -> tuple[float, float, float] | None:
+    n = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]) ** 0.5
+    if n == 0.0:
+        return None
+    return (v[0] / n, v[1] / n, v[2] / n)
+
+
+def _plane_basis(
+    n: tuple[float, float, float],
+) -> tuple[
+    tuple[float, float, float], tuple[float, float, float]
+]:
+    """Return two unit vectors (u, v) perpendicular to ``n`` and to each other.
+
+    Used to lay out the ``vtkPlaneSource`` corners around the plane
+    origin.  Pure Python (no VTK dependency) so the basis is
+    computable in the no-VTK testing path.
+    """
+    # Pick a non-parallel reference axis.
+    ax, ay, az = abs(n[0]), abs(n[1]), abs(n[2])
+    if ax <= ay and ax <= az:
+        ref = (1.0, 0.0, 0.0)
+    elif ay <= ax and ay <= az:
+        ref = (0.0, 1.0, 0.0)
+    else:
+        ref = (0.0, 0.0, 1.0)
+
+    # u = normalise(ref × n)
+    u_raw = (
+        ref[1] * n[2] - ref[2] * n[1],
+        ref[2] * n[0] - ref[0] * n[2],
+        ref[0] * n[1] - ref[1] * n[0],
+    )
+    u = _normalise(u_raw) or (1.0, 0.0, 0.0)
+
+    # v = n × u (already unit by construction)
+    v = (
+        n[1] * u[2] - n[2] * u[1],
+        n[2] * u[0] - n[0] * u[2],
+        n[0] * u[1] - n[1] * u[0],
+    )
+    return u, v

--- a/LiverResections/Representations/__init__.py
+++ b/LiverResections/Representations/__init__.py
@@ -11,13 +11,15 @@
 #
 # * ``BezierPlanningRepresentation`` — active in (state=Planning, *);
 #   renders the 4×4 Bezier control surface.
-#
-# Reserved for the remaining T2.2 stack iterations (slot names defined
-# as constants on ``LiverBezierSurfacePipeline``):
-#
 # * ``SlicingPlaneInitRepresentation`` — active in
 #   (state=Init, mode=SlicingPlane); renders two control points + the
-#   plane + the ring on the target liver surface.
+#   plane (ring on the target liver surface deferred per
+#   TODO(T2-target-mesh-weakref) until the data node gains a target
+#   mesh reference).
+#
+# Reserved for the remaining T2.2 stack iteration (slot name defined
+# as a constant on ``LiverBezierSurfacePipeline``):
+#
 # * ``DistanceSpheroidInitRepresentation`` — active in
 #   (state=Init, mode=DistanceSpheroid); renders the spheroid control
 #   points + the spheroid + the ring.

--- a/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
+++ b/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
@@ -240,8 +240,8 @@ def test_pipeline_dispatches_to_bezier_planning_on_state_planning(
     )
 
     # Before Init→Planning, dispatch resolves to the SlicingPlaneInit
-    # slot — which is None at this stack iteration.  ``update()`` runs
-    # but no active Representation is set.
+    # slot.  ``update()`` runs and the active Representation name is
+    # set on the Pipeline.
     pipeline.update()
     assert pipeline.GetCurrentRepresentationName() == (
         pipeline_module.REPRESENTATION_SLICING_PLANE_INIT

--- a/Testing/Python/unit/test_slicing_plane_init_representation.py
+++ b/Testing/Python/unit/test_slicing_plane_init_representation.py
@@ -1,0 +1,373 @@
+"""Python unit tests for ``SlicingPlaneInitRepresentation`` — T2.2 stack, iteration 2.
+
+Mirrors ``test_bezier_planning_representation.py``: per ADR-0008 §2
+Representations are the smallest unit-testable VTK assembly and have
+no Slicer dependency.  Two layers of assertions:
+
+* Pure-Python checks against the introspection helpers
+  (``GetCurrentColor``, ``GetCurrentOpacity``, ``GetInputRefreshCount``).
+  These run with or without VTK on ``PYTHONPATH``.
+
+* VTK-mediated checks against the real ``vtkActor`` /
+  ``vtkPlaneSource`` / ``vtkSphereSource`` outputs, gated by
+  ``pytest.importorskip("vtk")``.
+
+References
+----------
+* ADR-0008 §2 — Representation tests, unit layer.
+* ADR-0013 §6 — Representations as composable VTK pipelines.
+* ADR-0014 §2 — names this Representation.
+* ADR-0014 §4 — init data accessors on the data node.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Repo geometry — Representations live at
+# ``LiverResections/Representations/`` per ADR-0013 §7 file-layout.
+# --------------------------------------------------------------------------- #
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "LiverResections"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Stub nodes — same minimal-API approach as ``test_bezier_planning_
+# representation.py``.  Kept local to avoid cross-test coupling.
+# --------------------------------------------------------------------------- #
+
+
+class _StubDisplayNode:
+    def __init__(
+        self,
+        color: tuple = (1.0, 1.0, 1.0),
+        opacity: float = 1.0,
+    ) -> None:
+        self.color = color
+        self.opacity = opacity
+
+    def GetResectionColor(self):
+        return self.color
+
+    def GetResectionOpacity(self) -> float:
+        return self.opacity
+
+
+class _StubDataNode:
+    def __init__(
+        self,
+        origin: tuple = (0.0, 0.0, 0.0),
+        normal: tuple = (0.0, 0.0, 1.0),
+        init0: tuple = (-5.0, 0.0, 0.0),
+        init1: tuple = (5.0, 0.0, 0.0),
+    ) -> None:
+        self.origin = origin
+        self.normal = normal
+        self.init0 = init0
+        self.init1 = init1
+
+    def GetSlicingPlaneOrigin(self):
+        return self.origin
+
+    def GetSlicingPlaneNormal(self):
+        return self.normal
+
+    def GetSlicingPlaneInitPoint(self, index: int):
+        if index == 0:
+            return self.init0
+        if index == 1:
+            return self.init1
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def rep_module():
+    from Representations.SlicingPlaneInitRepresentation import (
+        SlicingPlaneInitRepresentation,
+    )
+
+    return SlicingPlaneInitRepresentation
+
+
+# --------------------------------------------------------------------------- #
+# Pure-Python assertions (run with or without VTK)
+# --------------------------------------------------------------------------- #
+
+
+def test_representation_construct_with_no_renderer(rep_module):
+    """Construct without a renderer — no exception, default state set."""
+    rep = rep_module()
+    assert rep.GetRenderer() is None
+    assert rep.GetCurrentColor() == (1.0, 1.0, 1.0)
+    assert rep.GetCurrentOpacity() == pytest.approx(1.0)
+    assert rep.GetInputRefreshCount() == 0
+    rep.cleanup()
+
+
+def test_representation_update_with_none_display_falls_back_to_defaults(
+    rep_module,
+):
+    """``update(None, data)`` does not raise — actors stay at defaults."""
+    rep = rep_module()
+    rep.update(display_node=None, data_node=_StubDataNode())
+    assert rep.GetCurrentColor() == (1.0, 1.0, 1.0)
+    assert rep.GetCurrentOpacity() == pytest.approx(1.0)
+    rep.cleanup()
+
+
+def test_representation_update_with_none_data_does_not_refresh(rep_module):
+    """``update(display, None)`` — colour still applied, refresh counter
+    does not advance because there is no geometry to push."""
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.2, 0.4, 0.6), opacity=0.8)
+    rep.update(display, None)
+    assert rep.GetCurrentColor() == pytest.approx((0.2, 0.4, 0.6))
+    assert rep.GetInputRefreshCount() == 0
+    rep.cleanup()
+
+
+def test_representation_color_round_trip(rep_module):
+    """Mutating the display node's ResectionColor flows through update()."""
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.25, 0.5, 0.75))
+    data = _StubDataNode()
+    rep.update(display, data)
+    assert rep.GetCurrentColor() == (0.25, 0.5, 0.75)
+
+    display.color = (0.1, 0.2, 0.3)
+    rep.update(display, data)
+    assert rep.GetCurrentColor() == (0.1, 0.2, 0.3)
+    rep.cleanup()
+
+
+def test_representation_opacity_round_trip(rep_module):
+    """ResectionOpacity flows through update() to the introspection helper."""
+    rep = rep_module()
+    display = _StubDisplayNode(opacity=0.5)
+    rep.update(display, _StubDataNode())
+    assert rep.GetCurrentOpacity() == pytest.approx(0.5)
+    rep.cleanup()
+
+
+def test_representation_input_refresh_idempotency(rep_module):
+    """The idempotency memo on (origin, normal, init0, init1) skips a
+    redundant refresh; mutating any of those inputs advances the counter.
+    """
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode(
+        origin=(1.0, 2.0, 3.0),
+        normal=(0.0, 0.0, 1.0),
+        init0=(0.0, 0.0, 0.0),
+        init1=(10.0, 0.0, 0.0),
+    )
+    rep.update(display, data)
+    first = rep.GetInputRefreshCount()
+    assert first == 1, "first update() with valid geometry must refresh"
+
+    # Re-running update() with the same inputs is a no-op (memoised).
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == first
+
+    # Mutating the origin forces a refresh.
+    data.origin = (4.0, 5.0, 6.0)
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == first + 1
+
+    # Mutating the normal forces a refresh.
+    data.normal = (1.0, 0.0, 0.0)
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == first + 2
+
+    # Mutating init0 forces a refresh.
+    data.init0 = (-1.0, -1.0, -1.0)
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == first + 3
+
+    # Mutating init1 forces a refresh.
+    data.init1 = (8.0, 0.0, 0.0)
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == first + 4
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# VTK-mediated assertions
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def vtk_module():
+    """Import the ``vtk`` module or skip the test."""
+    return pytest.importorskip(
+        "vtk",
+        reason=(
+            "vtk not importable; skip the VTK-mediated Representation "
+            "tests.  Run inside Slicer's Python or in any environment "
+            "where the bundled vtk wheel is on sys.path."
+        ),
+    )
+
+
+def test_representation_construct_builds_actors(rep_module, vtk_module):
+    """With VTK available, construction yields two marker actors and one
+    plane actor."""
+    rep = rep_module()
+    assert rep.GetMarkerActor(0) is not None
+    assert rep.GetMarkerActor(1) is not None
+    # Only two marker actors — index 2 is out of range.
+    assert rep.GetMarkerActor(2) is None
+    assert rep.GetPlaneActor() is not None
+    assert rep.GetPlaneSource() is not None
+    rep.cleanup()
+    # After cleanup() actors are released.
+    assert rep.GetMarkerActor(0) is None
+    assert rep.GetPlaneActor() is None
+
+
+def test_representation_marker_positions_match_init_points(
+    rep_module, vtk_module
+):
+    """After ``update()`` the marker sphere sources sit at the two init
+    points reported by the data node."""
+    rep = rep_module()
+    data = _StubDataNode(
+        origin=(0.0, 0.0, 0.0),
+        normal=(0.0, 0.0, 1.0),
+        init0=(-7.0, 1.0, 2.0),
+        init1=(7.0, -1.0, -2.0),
+    )
+    rep.update(_StubDisplayNode(), data)
+
+    s0 = rep.GetMarkerSource(0)
+    s1 = rep.GetMarkerSource(1)
+    assert list(s0.GetCenter()) == pytest.approx([-7.0, 1.0, 2.0])
+    assert list(s1.GetCenter()) == pytest.approx([7.0, -1.0, -2.0])
+    rep.cleanup()
+
+
+def test_representation_plane_source_driven_by_origin_and_normal(
+    rep_module, vtk_module
+):
+    """The ``vtkPlaneSource`` centre lands on the data node's
+    ``GetSlicingPlaneOrigin`` and its normal lines up with
+    ``GetSlicingPlaneNormal``."""
+    rep = rep_module()
+    data = _StubDataNode(
+        origin=(3.0, 4.0, 5.0),
+        normal=(0.0, 1.0, 0.0),
+        init0=(-2.0, 4.0, 5.0),
+        init1=(2.0, 4.0, 5.0),
+    )
+    rep.update(_StubDisplayNode(), data)
+
+    plane = rep.GetPlaneSource()
+    centre = plane.GetCenter()
+    assert list(centre) == pytest.approx([3.0, 4.0, 5.0])
+
+    n = plane.GetNormal()
+    # Allow either sign — ``vtkPlaneSource`` may flip the normal
+    # depending on the corner ordering vtkMath::Perpendiculars produced.
+    assert (
+        list(n) == pytest.approx([0.0, 1.0, 0.0])
+        or list(n) == pytest.approx([0.0, -1.0, 0.0])
+    )
+    rep.cleanup()
+
+
+def test_representation_mapper_color_matches_display_node(
+    rep_module, vtk_module
+):
+    """After ``update()`` the actor properties carry the display node's
+    ResectionColor.  Plane opacity is reduced relative to the markers."""
+    from Representations.SlicingPlaneInitRepresentation import (
+        PLANE_OPACITY_FACTOR,
+    )
+
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.25, 0.5, 0.75), opacity=0.8)
+    rep.update(display, _StubDataNode())
+
+    # Markers — full opacity, display node's colour.
+    for i in (0, 1):
+        actor = rep.GetMarkerActor(i)
+        assert list(actor.GetProperty().GetColor()) == pytest.approx(
+            [0.25, 0.5, 0.75]
+        )
+        assert actor.GetProperty().GetOpacity() == pytest.approx(0.8)
+
+    # Plane — same colour, reduced opacity.
+    plane_actor = rep.GetPlaneActor()
+    assert list(plane_actor.GetProperty().GetColor()) == pytest.approx(
+        [0.25, 0.5, 0.75]
+    )
+    assert plane_actor.GetProperty().GetOpacity() == pytest.approx(
+        0.8 * PLANE_OPACITY_FACTOR
+    )
+    rep.cleanup()
+
+
+def test_representation_attach_detach_renderer(rep_module, vtk_module):
+    """``SetRenderer(r)`` adds two marker actors + one plane actor = 3;
+    ``cleanup()`` removes them all."""
+    rep = rep_module()
+    renderer = vtk_module.vtkRenderer()
+    assert renderer.GetActors().GetNumberOfItems() == 0
+
+    rep.SetRenderer(renderer)
+    # Three actors expected: two markers + one plane.  No grid actor
+    # (the grid is a Planning-state shader feature per ADR-0014 §3;
+    # irrelevant in Init).  No ring actor (deferred per
+    # TODO(T2-target-mesh-weakref)).
+    assert renderer.GetActors().GetNumberOfItems() == 3
+
+    rep.cleanup()
+    assert renderer.GetActors().GetNumberOfItems() == 0
+
+
+def test_representation_plane_size_scales_with_init_point_distance(
+    rep_module, vtk_module
+):
+    """The plane's side length scales with the distance between the two
+    init points (per ``PLANE_SIZE_FACTOR`` in the Representation)."""
+    from Representations.SlicingPlaneInitRepresentation import (
+        PLANE_SIZE_FACTOR,
+    )
+
+    rep = rep_module()
+    # Far-apart init points so we exceed PLANE_FALLBACK_HALF_EXTENT and
+    # the distance-driven sizing dominates.
+    d = 100.0
+    data = _StubDataNode(
+        origin=(0.0, 0.0, 0.0),
+        normal=(0.0, 0.0, 1.0),
+        init0=(-d / 2, 0.0, 0.0),
+        init1=(d / 2, 0.0, 0.0),
+    )
+    rep.update(_StubDisplayNode(), data)
+
+    plane = rep.GetPlaneSource()
+    # Plane corners are at ``origin ± half × u`` (and ± half × v).  We
+    # only check the magnitude — the basis direction can vary.
+    expected_half = 0.5 * PLANE_SIZE_FACTOR * d
+    p1 = plane.GetPoint1()
+    origin = plane.GetOrigin()
+    side = (
+        (p1[0] - origin[0]) ** 2
+        + (p1[1] - origin[1]) ** 2
+        + (p1[2] - origin[2]) ** 2
+    ) ** 0.5
+    assert side == pytest.approx(2.0 * expected_half, rel=1e-6)
+    rep.cleanup()


### PR DESCRIPTION
## Summary

This PR is **iteration 2 of the T2.2 stack** and lands the
`SlicingPlaneInitRepresentation` — the Representation active when
`(ResectionState=Init, InitializationMode=SlicingPlane)` on the
state-aware `LiverBezierSurfacePipeline` per **ADR-0013 §4 / §6** and
**ADR-0014 §2**.

The Representation is driven by `vtkMRMLBezierSurfaceNode` (geometry)
and `vtkMRMLBezierSurfaceDisplayNode` (decoration) per ADR-0014 §4's
read-only init-data contract.

### Three pieces of geometry per ADR-0014 §2

| Piece | Status | Notes |
| --- | --- | --- |
| **Two control-point markers** | ✅ Rendered | `vtkSphereSource` glyphs at `GetSlicingPlaneInitPoint(0)` / `(1)`. Take the display node's `ResectionColor` at full opacity. |
| **Plane visualisation** | ✅ Rendered | `vtkPlaneSource` driven by `GetSlicingPlaneOrigin` + `GetSlicingPlaneNormal`. Sized as a square of side `PLANE_SIZE_FACTOR × distance(init0, init1)` centred on the origin (with a fallback half-extent for coincident init points). Rendered at `ResectionOpacity × PLANE_OPACITY_FACTOR` so the plane reads as a transparent reference surface. |
| **Ring on target mesh** | ⏸ Deferred | `TODO(T2-target-mesh-weakref)` — see below. |

### Why the ring is deferred

`vtkLiverPlaneRingExtractor` (already shipped at
`LiverResections/Algorithm/vtkLiverPlaneRingExtractor.{h,cxx}`) needs
the target liver mesh as input.  Per ADR-0014 §1 the data node will
gain a weakref to its `TargetOrganModelNode` (and to
`DistanceMapVolumeNode` / `VascularSegmentsVolumeNode`).  That
weakref has not landed yet; without it, the Representation has no
way to reach the target mesh.

Rather than register a dangling empty actor, this iteration omits
the ring entirely and pins the wiring point with a
`TODO(T2-target-mesh-weakref)` comment in `_build_vtk_pipeline`.
Once the data node gains the reference, the ring lights up
without any API change on the Representation.

### Mapper relocation marker

Per **ADR-0014 §3** the four custom OpenGL mappers in
`LiverMarkups/VTKWidgets/` relocate to
`LiverResections/VTKWidgets/`.  The plane visualisation will use
the relocated `vtkOpenGLSlicingContourPolyDataMapper` once that
relocation lands.  Today the relocation has not landed; the
Representation uses the generic `vtk.vtkPolyDataMapper` and pins
the swap with a `TODO(T2-mapper-relocation)` marker.  The public
API is invariant under the swap.

### No grid actor

Unlike `BezierPlanningRepresentation`, this Representation does
*not* render the Bezier 4×4 control grid.  In `state=Init` there is
no fitted surface yet; the grid is a fragment-shader feature on the
Planning surface mapper per ADR-0014 §3 and is irrelevant in Init.

### Pipeline slot

`LiverBezierSurfacePipeline.initialize()` now populates the
`REPRESENTATION_SLICING_PLANE_INIT` slot.  The
`REPRESENTATION_DISTANCE_SPHEROID_INIT` slot remains a placeholder
for iteration 3 (running in parallel) — the two `TODO` blocks are
disjoint to avoid merge conflicts.

## Files added / modified

- **new** `LiverResections/Representations/SlicingPlaneInitRepresentation.py`
  — the Representation class (mirrors `BezierPlanningRepresentation`
  pattern: soft VTK gate, `update`/`cleanup` lifecycle, idempotency
  memo, introspection helpers).
- **new** `Testing/Python/unit/test_slicing_plane_init_representation.py`
  — 12 unit tests (6 pure-Python, 6 VTK-mediated via
  `pytest.importorskip("vtk")`).
- **mod** `LiverResections/LiverBezierSurfacePipeline.py` — populates
  the `REPRESENTATION_SLICING_PLANE_INIT` slot only.  The
  `TODO(T2.2 DistanceSpheroidInit)` block is intentionally untouched.
- **mod** `LiverResections/Representations/__init__.py` — module
  docstring updated to reflect the populated slot.
- **mod** `Testing/Python/unit/test_liver_bezier_surface_pipeline.py`
  — single-line comment refresh; the existing assertion that
  dispatch resolves to `REPRESENTATION_SLICING_PLANE_INIT` for
  `(Init, SlicingPlane)` continues to pass.

## Test plan

- [x] Pure-Python tests pass without VTK on `PYTHONPATH` (6/12 run,
  6 VTK-gated tests skip cleanly).
- [x] VTK-mediated tests pass with VTK available (12/12 run).
- [x] Existing pipeline + planning-representation tests still pass
  (no regression: 16/16).
- [x] `ruff check` clean on the touched files.
- [ ] CI green on push.

## ADR / spec references

- `Docs/adr/0013-layerdm-pipeline-pattern.md` §4 (state-conditional
  dispatch), §6 (Representations as composable VTK pipelines), §7
  (file layout — Representations live directly under the module dir).
- `Docs/adr/0014-livermarkups-dissolution.md` §2 (names the three
  state-conditional Representations), §3 (mapper relocation rationale),
  §4 (init data persists as read-only audit after Init→Planning).
- `Docs/adr/0008-testing-strategy.md` §2 / §3 — unit-layer
  Representation tests.

---

*AI-assisted authorship: this PR was drafted with help from
Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code.
Opened for human review.*
