### PR TITLE
ENH: Add DistanceSpheroidInitRepresentation (T2.2 iteration 3)

### DIFF
--- a/LiverResections/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverBezierSurfacePipeline.py
@@ -317,14 +317,22 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             BezierPlanningRepresentation(renderer=self.GetRenderer())
         )
 
+        try:  # pragma: no cover - exercised once per import path
+            from .Representations.DistanceSpheroidInitRepresentation import (
+                DistanceSpheroidInitRepresentation,
+            )
+        except ImportError:
+            from Representations.DistanceSpheroidInitRepresentation import (  # type: ignore[no-redef]
+                DistanceSpheroidInitRepresentation,
+            )
+
         self._representations[REPRESENTATION_SLICING_PLANE_INIT] = (
             SlicingPlaneInitRepresentation(renderer=self.GetRenderer())
         )
 
-        # TODO(T2.2 DistanceSpheroidInit): populate slot per ADR-0014 §2.
-        #   self._representations[REPRESENTATION_DISTANCE_SPHEROID_INIT] = (
-        #       DistanceSpheroidInitRepresentation(renderer=self.GetRenderer())
-        #   )
+        self._representations[REPRESENTATION_DISTANCE_SPHEROID_INIT] = (
+            DistanceSpheroidInitRepresentation(renderer=self.GetRenderer())
+        )
 
     def update(self) -> None:
         """Dispatch the active Representation by ``(state, initMode)``.

--- a/LiverResections/Representations/DistanceSpheroidInitRepresentation.py
+++ b/LiverResections/Representations/DistanceSpheroidInitRepresentation.py
@@ -1,0 +1,557 @@
+"""Representation active in ``(ResectionState=Init, InitMode=DistanceSpheroid)``.
+
+Renders the geometry that supports the **DistanceSpheroid** init mode
+(per ADR-0014 §2) — the alternative initialisation path where the
+surgeon places a variable number of seed points (two or more, per the
+data node's contract) that imply an axis-aligned spheroid (``Center``,
+``RadiusX``, ``RadiusY``, ``RadiusZ``); the planning surface is then
+the intersection of that spheroid with the target liver mesh.
+
+Scope of this iteration (T2.2 iteration 3)
+------------------------------------------
+This is the third iteration of the T2.2 stack.  The Representation
+class is constructed by ``LiverBezierSurfacePipeline.initialize()``
+and exercised by direct Python instantiation in unit tests.  Full
+integration with Slicer's LayerDM framework happens at T2.6.
+
+Three pieces of geometry per ADR-0014 §2:
+
+1. **Variable-N control-point markers** — small sphere actors at each
+   surgeon-placed init point.  The actor list grows / shrinks
+   dynamically as ``GetNumberOfDistanceSpheroidInitPoints()`` changes.
+2. **Spheroid visualisation** — a translucent axis-aligned spheroid
+   (``vtkParametricEllipsoid`` with ``XRadius`` / ``YRadius`` /
+   ``ZRadius`` translated to the spheroid centre).  Axis-aligned only,
+   per ``vtkLiverSpheroidRingExtractor``'s header — general-orientation
+   rotation is deferred and tracked as a future task.
+3. **Ring on target mesh** — **DEFERRED** at this iteration; see
+   ``TODO(T2-target-mesh-weakref)`` below.  The intersection ring
+   requires the target liver mesh, which is not yet reachable from
+   ``vtkMRMLBezierSurfaceNode`` (the weakrefs to ``TargetOrganModelNode``
+   / ``DistanceMapVolumeNode`` / ``VascularSegmentsVolumeNode`` per
+   ADR-0014 §1 have not landed yet).  Once that lands, this
+   Representation will construct a ``vtkLiverSpheroidRingExtractor``
+   fed with the target mesh + ``Center`` + ``Radii``, and render the
+   output as a ring polyline actor.
+
+Per ADR-0014 §3 the four custom OpenGL mappers — including
+``vtkOpenGLDistanceContourPolyDataMapper`` — relocate from
+``LiverMarkups/VTKWidgets/`` to ``LiverResections/VTKWidgets/``.  The
+relocation has not landed yet; this Representation uses the generic
+``vtkPolyDataMapper`` + ``vtkActor`` pair until the relocation
+completes, at which point the spheroid mapper field flips to
+``vtkOpenGLDistanceContourPolyDataMapper`` *without changing the
+Representation's public API*.  Marked with
+``TODO(T2-mapper-relocation)`` at the construction point.
+
+Renderer attachment
+-------------------
+Mirrors ``BezierPlanningRepresentation``: when ``renderer`` is
+provided, all actors are added to it; ``None`` is supported for unit
+tests (the actors exist but are unrendered).  Per ADR-0008 §2 unit-
+layer tests have no Slicer / no view.
+
+References
+----------
+* `ADR-0011`_ — SCT terminology dispatch.
+* `ADR-0013`_ §6 — Representations as composable VTK pipelines.
+* `ADR-0014`_ §2 — names the DistanceSpheroidInit Representation.
+* `ADR-0014`_ §3 — mapper relocation.
+* `ADR-0014`_ §4 — data-node read-only-after-Planning rules + the
+  accessor surface this Representation reads.
+
+.. _ADR-0011: ../../../Docs/adr/0011-sct-terminology-dispatch.md
+.. _ADR-0013: ../../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0014: ../../../Docs/adr/0014-livermarkups-dissolution.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# VTK is a soft dependency — when running in a plain Python without VTK on
+# ``PYTHONPATH``, the import below fails and the unit tests that need a
+# real mapper skip via ``pytest.importorskip("vtk")``.  The Representation
+# can still be constructed (the lazy ``_get_vtk()`` returns ``None``); its
+# ``update()`` then becomes a no-op for the missing VTK case, which is
+# enough for the smoke-level tests.
+# --------------------------------------------------------------------------- #
+
+try:  # pragma: no cover — exercised inside Slicer / when VTK is available
+    import vtk
+
+    _HAS_VTK = True
+except ImportError:  # pragma: no cover — pure-Python path
+    vtk = None  # type: ignore[assignment]
+    _HAS_VTK = False
+
+
+# --------------------------------------------------------------------------- #
+# Default colour / opacity values — mirror the legacy
+# ``vtkMRMLLiverResectionNode`` constructor so the Pipeline path starts
+# from an identical visual baseline.  Display nodes carry these as
+# float[3] in [0,1].
+# --------------------------------------------------------------------------- #
+
+DEFAULT_RESECTION_COLOR = (1.0, 1.0, 1.0)
+DEFAULT_RESECTION_OPACITY = 1.0
+
+# Small visual radius for the surgeon-placed seed markers.  Independent
+# of the spheroid radii (which come from the data node).  Picked to be
+# visible at typical liver-scale RAS coordinates; the eventual
+# decoration plumbing on the display node may expose this as a tunable.
+DEFAULT_MARKER_RADIUS = 2.0
+
+
+class DistanceSpheroidInitRepresentation:
+    """VTK assembly for the Init-state, DistanceSpheroid-mode geometry.
+
+    Constructor
+    -----------
+    ``DistanceSpheroidInitRepresentation(renderer=None)``
+
+    * ``renderer`` — the ``vtkRenderer`` the actors are added to.
+      Optional; ``None`` is supported for unit tests (the actors
+      exist but are unrendered).
+
+    Public methods
+    --------------
+    * ``update(display_node, data_node)`` — reads decoration from the
+      display node, geometry from the data node, and reconciles the
+      marker / spheroid mapper-actor pairs.  Tolerant of ``None``
+      arguments — turns the actors invisible / no-op in those cases.
+    * ``cleanup()`` — detaches all actors from the renderer and
+      releases the VTK pipeline.
+
+    Marker handling
+    ---------------
+    The number of surgeon-placed init points is variable (two or
+    more, per ``vtkMRMLBezierSurfaceNode``'s contract).  Marker
+    actors are tracked in a Python list — when the count grows on a
+    later ``update()``, new actors are constructed (and attached to
+    the current renderer if one is set); when the count shrinks, the
+    superfluous actors are detached and their strong refs dropped so
+    VTK can free the resources.
+
+    Ring rendering
+    --------------
+    Ring rendering is **deferred** — see the module docstring and
+    ``TODO(T2-target-mesh-weakref)`` in ``_apply_data_node``.
+
+    Introspection (used by unit tests)
+    ----------------------------------
+    * ``GetMarkerActors()`` — list of ``vtkActor`` rendering the
+      seed markers, or an empty list if VTK is not importable.
+    * ``GetSpheroidActor()`` — the ``vtkActor`` rendering the
+      translucent spheroid, or ``None``.
+    * ``GetSpheroidMapper()`` — the spheroid mapper.
+    * ``GetParametricEllipsoid()`` — the ``vtkParametricEllipsoid``
+      driving the spheroid mapper (so tests can read its ``XRadius``
+      / ``YRadius`` / ``ZRadius`` back).
+    * ``GetCurrentColor()`` — the (r, g, b) triple last written.
+    * ``GetCurrentOpacity()`` — the opacity last written.
+    * ``GetInputRefreshCount()`` — bumps each time ``update()``
+      observes a change in (Center, Radii, init points, displayMTime).
+    """
+
+    def __init__(self, renderer: Any | None = None) -> None:
+        self._renderer: Any | None = None
+
+        # The VTK pipeline objects the Representation owns.  ``None`` in
+        # the pure-Python testing path.
+        self._parametric_ellipsoid: Any | None = None
+        self._parametric_function_source: Any | None = None
+        self._spheroid_polydata_filter: Any | None = None
+        self._spheroid_mapper: Any | None = None
+        self._spheroid_actor: Any | None = None
+
+        # Marker actors — list grows / shrinks with
+        # GetNumberOfDistanceSpheroidInitPoints().  Each entry is a
+        # (sphere_source, mapper, actor) triple so the geometry can be
+        # mutated in place (centre + radius) without rebuilding the
+        # pipeline.
+        self._marker_entries: list[tuple[Any, Any, Any]] = []
+
+        # Last-written colour / opacity — exposed as a stub-friendly
+        # introspection surface for unit tests that cannot construct
+        # real VTK objects.
+        self._current_color: tuple[float, float, float] = DEFAULT_RESECTION_COLOR
+        self._current_opacity: float = DEFAULT_RESECTION_OPACITY
+
+        # Memoised input signature — see ``_apply_data_node`` for the
+        # invariant.
+        self._last_input_signature: tuple | None = None
+
+        # Bookkeeping for unit tests: how many times the spheroid /
+        # marker pipeline has been refreshed.  Tests assert that a
+        # data-node mutation bumps this counter.
+        self._input_refresh_count: int = 0
+
+        # TODO(T2-mapper-relocation): swap ``vtk.vtkPolyDataMapper`` for
+        # ``vtkOpenGLDistanceContourPolyDataMapper`` once the four
+        # custom mappers are relocated from ``LiverMarkups/VTKWidgets/``
+        # to ``LiverResections/VTKWidgets/`` per ADR-0014 §3.  The
+        # public API of this Representation does not change — only the
+        # spheroid mapper field's concrete type.
+        if _HAS_VTK:
+            self._build_vtk_pipeline()
+
+        if renderer is not None:
+            self.SetRenderer(renderer)
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def SetRenderer(self, renderer: Any | None) -> None:
+        """Attach the Representation's actors to ``renderer``.
+
+        Detaches from any previously-set renderer first.
+        """
+        if self._renderer is not None and self._renderer is not renderer:
+            self._detach_actors(self._renderer)
+        self._renderer = renderer
+        if renderer is not None:
+            self._attach_actors(renderer)
+
+    def GetRenderer(self) -> Any | None:
+        return self._renderer
+
+    def update(
+        self, display_node: Any | None, data_node: Any | None
+    ) -> None:
+        """Reconcile the actors against the current display + data nodes.
+
+        Tolerant of ``None`` arguments — when either node is missing
+        the actors fall back to invisible / default state instead of
+        raising.
+        """
+        self._apply_display_node(display_node)
+        self._apply_data_node(data_node)
+
+    def cleanup(self) -> None:
+        """Detach actors from the renderer and drop the VTK pipeline."""
+        if self._renderer is not None:
+            self._detach_actors(self._renderer)
+            self._renderer = None
+        # Drop strong references so VTK can free the resources.
+        self._parametric_ellipsoid = None
+        self._parametric_function_source = None
+        self._spheroid_polydata_filter = None
+        self._spheroid_mapper = None
+        self._spheroid_actor = None
+        self._marker_entries = []
+
+    # ------------------------------------------------------------------ #
+    # Introspection — used by the unit-layer tests
+    # ------------------------------------------------------------------ #
+
+    def GetMarkerActors(self) -> list[Any]:
+        return [entry[2] for entry in self._marker_entries]
+
+    def GetSpheroidActor(self) -> Any | None:
+        return self._spheroid_actor
+
+    def GetSpheroidMapper(self) -> Any | None:
+        return self._spheroid_mapper
+
+    def GetParametricEllipsoid(self) -> Any | None:
+        return self._parametric_ellipsoid
+
+    def GetCurrentColor(self) -> tuple[float, float, float]:
+        return self._current_color
+
+    def GetCurrentOpacity(self) -> float:
+        return self._current_opacity
+
+    def GetInputRefreshCount(self) -> int:
+        return self._input_refresh_count
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _build_vtk_pipeline(self) -> None:
+        """Construct the spheroid pipeline.
+
+        Marker actors are built lazily on demand (the count is data-
+        driven; see ``_resize_markers``).
+
+        TODO(T2-mapper-relocation): swap the generic ``vtkPolyDataMapper``
+        for ``vtkOpenGLDistanceContourPolyDataMapper`` per ADR-0014 §3.
+        The relocated mapper computes the spheroid-vs-target-mesh
+        contour as a fragment-shader feature; this skeleton renders
+        the parametric spheroid surface itself as a stand-in until
+        that relocation lands.
+        """
+        assert vtk is not None  # for the type-checker — gated by _HAS_VTK
+
+        # Spheroid pipeline ---------------------------------------------------
+        self._parametric_ellipsoid = vtk.vtkParametricEllipsoid()
+        # Sensible default radii so a freshly-constructed Representation
+        # is not visually surprising before the first ``update()``.
+        self._parametric_ellipsoid.SetXRadius(1.0)
+        self._parametric_ellipsoid.SetYRadius(1.0)
+        self._parametric_ellipsoid.SetZRadius(1.0)
+
+        self._parametric_function_source = vtk.vtkParametricFunctionSource()
+        self._parametric_function_source.SetParametricFunction(
+            self._parametric_ellipsoid
+        )
+
+        # Translate the parametric output to the spheroid centre.  The
+        # parametric source emits geometry around the origin; the data
+        # node's Center is RAS world coordinates.  A transform filter
+        # composes them.
+        self._spheroid_polydata_filter = vtk.vtkTransformPolyDataFilter()
+        self._spheroid_transform = vtk.vtkTransform()
+        self._spheroid_transform.Identity()
+        self._spheroid_polydata_filter.SetTransform(self._spheroid_transform)
+        self._spheroid_polydata_filter.SetInputConnection(
+            self._parametric_function_source.GetOutputPort()
+        )
+
+        self._spheroid_mapper = vtk.vtkPolyDataMapper()
+        self._spheroid_mapper.SetInputConnection(
+            self._spheroid_polydata_filter.GetOutputPort()
+        )
+        self._spheroid_actor = vtk.vtkActor()
+        self._spheroid_actor.SetMapper(self._spheroid_mapper)
+        self._spheroid_actor.GetProperty().SetColor(*DEFAULT_RESECTION_COLOR)
+        self._spheroid_actor.GetProperty().SetOpacity(DEFAULT_RESECTION_OPACITY)
+
+    def _make_marker_entry(self) -> tuple[Any, Any, Any]:
+        """Construct one ``(sphere_source, mapper, actor)`` triple."""
+        assert vtk is not None
+        sphere = vtk.vtkSphereSource()
+        sphere.SetRadius(DEFAULT_MARKER_RADIUS)
+        sphere.SetCenter(0.0, 0.0, 0.0)
+        mapper = vtk.vtkPolyDataMapper()
+        mapper.SetInputConnection(sphere.GetOutputPort())
+        actor = vtk.vtkActor()
+        actor.SetMapper(mapper)
+        # Markers render at full opacity regardless of the display
+        # node's ResectionOpacity (which gates spheroid translucency
+        # only).  Colour is updated by ``_apply_display_node``.
+        actor.GetProperty().SetColor(*DEFAULT_RESECTION_COLOR)
+        actor.GetProperty().SetOpacity(1.0)
+        return (sphere, mapper, actor)
+
+    def _resize_markers(self, n: int) -> None:
+        """Grow or shrink the marker list to ``n`` entries.
+
+        Newly-added actors are attached to the current renderer (if any)
+        and inherit the most recently applied colour.  Removed actors
+        are detached and their strong refs dropped.
+        """
+        if not _HAS_VTK:
+            return
+        current = len(self._marker_entries)
+        if n == current:
+            return
+        if n > current:
+            # Grow.
+            for _ in range(n - current):
+                entry = self._make_marker_entry()
+                # Inherit current colour so newly-spawned markers don't
+                # flash white before the next display-node read.
+                entry[2].GetProperty().SetColor(*self._current_color)
+                self._marker_entries.append(entry)
+                if self._renderer is not None and hasattr(
+                    self._renderer, "AddActor"
+                ):
+                    self._renderer.AddActor(entry[2])
+        else:
+            # Shrink — pop from the tail.
+            for _ in range(current - n):
+                _sphere, _mapper, actor = self._marker_entries.pop()
+                if self._renderer is not None and hasattr(
+                    self._renderer, "RemoveActor"
+                ):
+                    try:
+                        self._renderer.RemoveActor(actor)
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+                # The triple goes out of scope here — VTK frees the
+                # resources on garbage collection.
+
+    def _attach_actors(self, renderer: Any) -> None:
+        if not hasattr(renderer, "AddActor"):
+            return
+        if self._spheroid_actor is not None:
+            renderer.AddActor(self._spheroid_actor)
+        for _sphere, _mapper, actor in self._marker_entries:
+            renderer.AddActor(actor)
+
+    def _detach_actors(self, renderer: Any) -> None:
+        if not hasattr(renderer, "RemoveActor"):
+            return
+        if self._spheroid_actor is not None:
+            try:
+                renderer.RemoveActor(self._spheroid_actor)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        for _sphere, _mapper, actor in self._marker_entries:
+            try:
+                renderer.RemoveActor(actor)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+    def _apply_display_node(self, display_node: Any | None) -> None:
+        """Push decoration fields onto the actors.
+
+        Tolerant of ``None`` / partial display nodes — falls back to
+        defaults.  Colour applies to spheroid + markers; opacity
+        applies to the (translucent) spheroid only — markers stay at
+        full opacity to remain visible against the translucent volume.
+        """
+        if display_node is None:
+            color = DEFAULT_RESECTION_COLOR
+            opacity = DEFAULT_RESECTION_OPACITY
+        else:
+            color_getter = getattr(display_node, "GetResectionColor", None)
+            opacity_getter = getattr(
+                display_node, "GetResectionOpacity", None
+            )
+
+            color = (
+                _as_color_tuple(color_getter())
+                if color_getter is not None
+                else DEFAULT_RESECTION_COLOR
+            )
+            opacity = (
+                float(opacity_getter())
+                if opacity_getter is not None
+                else DEFAULT_RESECTION_OPACITY
+            )
+
+        self._current_color = color
+        self._current_opacity = opacity
+
+        # TODO(ADR-0011): when the display node's TerminologyEntry is
+        # populated, derive the colour / label / badge from the SCT
+        # triple via the project's terminology utilities, overriding
+        # the pure-vector ResectionColor above.  The terminology helper
+        # API lands in T2.4; this Representation will follow
+        # ``BezierPlanningRepresentation``'s adopting pattern when it
+        # does.
+
+        if self._spheroid_actor is not None:
+            prop = self._spheroid_actor.GetProperty()
+            prop.SetColor(*color)
+            prop.SetOpacity(opacity)
+        for _sphere, _mapper, actor in self._marker_entries:
+            actor.GetProperty().SetColor(*color)
+            # Markers stay at full opacity (see method docstring).
+
+    def _apply_data_node(self, data_node: Any | None) -> None:
+        """Push (Center, Radii, init points) onto the spheroid + markers.
+
+        TODO(T2-target-mesh-weakref): once ``vtkMRMLBezierSurfaceNode``
+        gains a weakref to ``TargetOrganModelNode`` (per ADR-0014 §1),
+        instantiate a ``vtkLiverSpheroidRingExtractor`` here, feed it
+        the target mesh + (Center, RadiusX, RadiusY, RadiusZ), and
+        render its output as a ring polyline actor.  The axis-aligned-
+        spheroid constraint matches the extractor's contract (its
+        header notes that general-orientation rotation is deferred to
+        a later stack iteration).
+        """
+        if data_node is None:
+            return
+
+        center_getter = getattr(data_node, "GetDistanceSpheroidCenter", None)
+        rx_getter = getattr(data_node, "GetDistanceSpheroidRadiusX", None)
+        ry_getter = getattr(data_node, "GetDistanceSpheroidRadiusY", None)
+        rz_getter = getattr(data_node, "GetDistanceSpheroidRadiusZ", None)
+        n_getter = getattr(
+            data_node, "GetNumberOfDistanceSpheroidInitPoints", None
+        )
+        point_getter = getattr(data_node, "GetDistanceSpheroidInitPoint", None)
+
+        if center_getter is None or rx_getter is None or ry_getter is None or rz_getter is None:
+            return
+
+        try:
+            center = _as_xyz_tuple(center_getter())
+            rx = float(rx_getter())
+            ry = float(ry_getter())
+            rz = float(rz_getter())
+        except Exception:  # pragma: no cover - defensive
+            return
+
+        if n_getter is not None and point_getter is not None:
+            try:
+                n = int(n_getter())
+            except Exception:  # pragma: no cover - defensive
+                n = 0
+            init_points: tuple[tuple[float, float, float], ...] = tuple(
+                _as_xyz_tuple(point_getter(i)) for i in range(max(0, n))
+            )
+        else:
+            init_points = ()
+
+        signature = (center, rx, ry, rz, init_points)
+        if signature == self._last_input_signature:
+            return  # idempotent short-circuit
+        self._last_input_signature = signature
+        self._input_refresh_count += 1
+
+        if not _HAS_VTK:
+            # Pure-Python path: still resize the (empty) marker list
+            # bookkeeping so test introspection of GetMarkerActors()
+            # length stays accurate even without VTK.
+            return
+
+        # Spheroid: push radii into the parametric ellipsoid + recenter
+        # via the transform filter.
+        if self._parametric_ellipsoid is not None:
+            self._parametric_ellipsoid.SetXRadius(rx)
+            self._parametric_ellipsoid.SetYRadius(ry)
+            self._parametric_ellipsoid.SetZRadius(rz)
+        if self._spheroid_transform is not None:
+            self._spheroid_transform.Identity()
+            self._spheroid_transform.Translate(center[0], center[1], center[2])
+            self._spheroid_transform.Modified()
+        if self._parametric_function_source is not None:
+            self._parametric_function_source.Modified()
+
+        # Markers: resize the actor list, then update each sphere's
+        # centre.
+        self._resize_markers(len(init_points))
+        for entry, point in zip(self._marker_entries, init_points):
+            sphere, _mapper, _actor = entry
+            sphere.SetCenter(point[0], point[1], point[2])
+            sphere.Modified()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _as_color_tuple(raw: Any) -> tuple[float, float, float]:
+    """Coerce a colour accessor's return value to ``(r, g, b)``.
+
+    Accepts list, tuple, or VTK-wrapped sequence; clamps to [0, 1] and
+    falls back to white on parse failure.
+    """
+    try:
+        r = max(0.0, min(1.0, float(raw[0])))
+        g = max(0.0, min(1.0, float(raw[1])))
+        b = max(0.0, min(1.0, float(raw[2])))
+        return (r, g, b)
+    except Exception:
+        return DEFAULT_RESECTION_COLOR
+
+
+def _as_xyz_tuple(raw: Any) -> tuple[float, float, float]:
+    """Coerce a 3-component accessor's return value to ``(x, y, z)``.
+
+    Accepts list, tuple, or VTK-wrapped sequence; falls back to
+    ``(0, 0, 0)`` on parse failure.
+    """
+    try:
+        return (float(raw[0]), float(raw[1]), float(raw[2]))
+    except Exception:
+        return (0.0, 0.0, 0.0)

--- a/Testing/Python/unit/test_distance_spheroid_init_representation.py
+++ b/Testing/Python/unit/test_distance_spheroid_init_representation.py
@@ -1,0 +1,449 @@
+"""Python unit tests for ``DistanceSpheroidInitRepresentation`` — T2.2 stack, iteration 3.
+
+Per ADR-0008 §2, Representations are the smallest unit-testable VTK
+assembly; they have no Slicer dependency and a small, well-defined
+API surface.  These tests construct the Representation with stub
+data and display nodes, drive ``update()``, and assert that the
+mapper / actor outputs reflect the stubs' contents.
+
+Two layers of assertions:
+
+* Pure-Python checks against the introspection helpers
+  (``GetCurrentColor``, ``GetCurrentOpacity``, ``GetInputRefreshCount``).
+  These work whether or not VTK is importable, so the test suite
+  yields meaningful signal in CI environments where VTK is
+  unavailable.
+
+* VTK-mediated checks against the actual ``vtkActor`` /
+  ``vtkPolyDataMapper`` / ``vtkParametricEllipsoid`` outputs.  Gated
+  on ``pytest.importorskip("vtk")``.
+
+References
+----------
+* ADR-0008 §2 — Representation tests, unit layer.
+* ADR-0013 §6 — Representations as composable VTK pipelines.
+* ADR-0014 §2 — names the DistanceSpheroidInit Representation.
+* ADR-0014 §4 — data-node accessor surface this Representation reads.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Repo geometry — Representations live at
+# ``LiverResections/Representations/`` per ADR-0013 §7 file-layout.
+# --------------------------------------------------------------------------- #
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "LiverResections"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Stub nodes — minimal API matching ADR-0014 §4's accessor surface on
+# vtkMRMLBezierSurfaceNode + its paired display node.
+# --------------------------------------------------------------------------- #
+
+
+class _StubDisplayNode:
+    def __init__(
+        self,
+        color: tuple = (1.0, 1.0, 1.0),
+        opacity: float = 1.0,
+    ) -> None:
+        self.color = color
+        self.opacity = opacity
+
+    def GetResectionColor(self):
+        return self.color
+
+    def GetResectionOpacity(self) -> float:
+        return self.opacity
+
+
+class _StubDataNode:
+    def __init__(
+        self,
+        center: tuple = (0.0, 0.0, 0.0),
+        radius_x: float = 1.0,
+        radius_y: float = 1.0,
+        radius_z: float = 1.0,
+        init_points: tuple = (
+            (1.0, 0.0, 0.0),
+            (-1.0, 0.0, 0.0),
+        ),
+    ) -> None:
+        self.center = center
+        self.radius_x = radius_x
+        self.radius_y = radius_y
+        self.radius_z = radius_z
+        self.init_points = tuple(init_points)
+
+    def GetDistanceSpheroidCenter(self):
+        return self.center
+
+    def GetDistanceSpheroidRadiusX(self) -> float:
+        return self.radius_x
+
+    def GetDistanceSpheroidRadiusY(self) -> float:
+        return self.radius_y
+
+    def GetDistanceSpheroidRadiusZ(self) -> float:
+        return self.radius_z
+
+    def GetNumberOfDistanceSpheroidInitPoints(self) -> int:
+        return len(self.init_points)
+
+    def GetDistanceSpheroidInitPoint(self, index: int):
+        return self.init_points[index]
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def rep_module():
+    from Representations.DistanceSpheroidInitRepresentation import (
+        DistanceSpheroidInitRepresentation,
+    )
+
+    return DistanceSpheroidInitRepresentation
+
+
+# --------------------------------------------------------------------------- #
+# Pure-Python assertions (run with or without VTK)
+# --------------------------------------------------------------------------- #
+
+
+def test_representation_construct_with_no_renderer(rep_module):
+    """Construct without a renderer — no exception, default state set."""
+    rep = rep_module()
+    assert rep.GetRenderer() is None
+    # Defaults match the legacy ResectionNode constructor.
+    assert rep.GetCurrentColor() == (1.0, 1.0, 1.0)
+    assert rep.GetCurrentOpacity() == pytest.approx(1.0)
+    assert rep.GetInputRefreshCount() == 0
+    # Markers are data-driven; none until ``update()`` reads the node.
+    assert rep.GetMarkerActors() == []
+    rep.cleanup()
+
+
+def test_representation_update_with_none_display_falls_back_to_defaults(
+    rep_module,
+):
+    """``update(None, data)`` does not raise — actors stay at defaults."""
+    rep = rep_module()
+    rep.update(display_node=None, data_node=_StubDataNode())
+    assert rep.GetCurrentColor() == (1.0, 1.0, 1.0)
+    assert rep.GetCurrentOpacity() == pytest.approx(1.0)
+    rep.cleanup()
+
+
+def test_representation_update_with_none_data_is_noop(rep_module):
+    """``update(display, None)`` does not raise — refresh count unchanged."""
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.25, 0.5, 0.75), opacity=0.5)
+    rep.update(display, data_node=None)
+    # Decoration is still applied even when geometry is unavailable.
+    assert rep.GetCurrentColor() == (0.25, 0.5, 0.75)
+    assert rep.GetCurrentOpacity() == pytest.approx(0.5)
+    # But no input refresh fired.
+    assert rep.GetInputRefreshCount() == 0
+    rep.cleanup()
+
+
+def test_representation_color_round_trip(rep_module):
+    """Mutating the display node's ResectionColor changes the introspection
+    helper after ``update()``."""
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.25, 0.5, 0.75))
+    data = _StubDataNode()
+    rep.update(display, data)
+    assert rep.GetCurrentColor() == (0.25, 0.5, 0.75)
+
+    display.color = (0.1, 0.2, 0.3)
+    rep.update(display, data)
+    assert rep.GetCurrentColor() == (0.1, 0.2, 0.3)
+    rep.cleanup()
+
+
+def test_representation_opacity_round_trip(rep_module):
+    """ResectionOpacity flows through ``update()`` to the introspection
+    helper."""
+    rep = rep_module()
+    display = _StubDisplayNode(opacity=0.5)
+    rep.update(display, _StubDataNode())
+    assert rep.GetCurrentOpacity() == pytest.approx(0.5)
+    rep.cleanup()
+
+
+def test_representation_input_refresh_on_geometry_change(rep_module):
+    """Mutating Center / Radii / init points increments the refresh counter."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode(
+        center=(10.0, 0.0, 0.0),
+        radius_x=2.0,
+        radius_y=3.0,
+        radius_z=4.0,
+        init_points=((11.0, 0.0, 0.0), (9.0, 0.0, 0.0)),
+    )
+    rep.update(display, data)
+    after_first = rep.GetInputRefreshCount()
+    assert after_first == 1, (
+        "first update() with a non-default geometry must refresh"
+    )
+
+    # Re-running update() with the same inputs is a no-op (memoised).
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == after_first
+
+    # Mutating the Center forces a refresh.
+    data.center = (20.0, 0.0, 0.0)
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == after_first + 1
+
+    # Mutating a Radius forces a refresh.
+    data.radius_x = 5.0
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == after_first + 2
+
+    # Mutating an init point forces a refresh.
+    data.init_points = ((21.0, 0.0, 0.0), (19.0, 0.0, 0.0))
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == after_first + 3
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# VTK-mediated assertions
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def vtk_module():
+    """Import the ``vtk`` module or skip the test."""
+    return pytest.importorskip(
+        "vtk",
+        reason=(
+            "vtk not importable; skip the VTK-mediated Representation "
+            "tests.  Run inside Slicer's Python or in any environment "
+            "where the bundled vtk wheel is on sys.path."
+        ),
+    )
+
+
+def test_representation_spheroid_color_matches_display_node(
+    rep_module, vtk_module
+):
+    """After ``update()``, the spheroid actor's property carries the
+    display node's ResectionColor + ResectionOpacity."""
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.25, 0.5, 0.75), opacity=0.42)
+    rep.update(display, _StubDataNode())
+
+    spheroid = rep.GetSpheroidActor()
+    assert spheroid is not None
+    prop_color = spheroid.GetProperty().GetColor()
+    assert list(prop_color) == pytest.approx([0.25, 0.5, 0.75])
+    assert spheroid.GetProperty().GetOpacity() == pytest.approx(0.42)
+    rep.cleanup()
+
+
+def test_representation_markers_color_matches_display_but_opaque(
+    rep_module, vtk_module
+):
+    """Markers inherit ResectionColor but stay fully opaque (per the
+    Representation's docstring — translucent markers would disappear
+    against the translucent spheroid)."""
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.25, 0.5, 0.75), opacity=0.3)
+    data = _StubDataNode(
+        init_points=((1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0))
+    )
+    rep.update(display, data)
+
+    actors = rep.GetMarkerActors()
+    assert len(actors) == 3
+    for actor in actors:
+        prop_color = actor.GetProperty().GetColor()
+        assert list(prop_color) == pytest.approx([0.25, 0.5, 0.75])
+        # Full opacity regardless of spheroid translucency.
+        assert actor.GetProperty().GetOpacity() == pytest.approx(1.0)
+    rep.cleanup()
+
+
+def test_representation_spheroid_radii_match_data_node(
+    rep_module, vtk_module
+):
+    """The parametric ellipsoid's X / Y / Z radii reflect the data node."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode(radius_x=2.5, radius_y=3.5, radius_z=4.5)
+    rep.update(display, data)
+
+    ellipsoid = rep.GetParametricEllipsoid()
+    assert ellipsoid is not None
+    assert ellipsoid.GetXRadius() == pytest.approx(2.5)
+    assert ellipsoid.GetYRadius() == pytest.approx(3.5)
+    assert ellipsoid.GetZRadius() == pytest.approx(4.5)
+    rep.cleanup()
+
+
+def test_representation_marker_count_matches_data_node(
+    rep_module, vtk_module
+):
+    """Marker actor count tracks ``GetNumberOfDistanceSpheroidInitPoints``."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    points = ((1.0, 0.0, 0.0), (-1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    rep.update(display, _StubDataNode(init_points=points))
+    assert len(rep.GetMarkerActors()) == 3
+
+
+def test_representation_marker_count_grows(rep_module, vtk_module):
+    """Increasing init-point count from 2 to 5 grows the marker list."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode(init_points=((1.0, 0.0, 0.0), (-1.0, 0.0, 0.0)))
+    rep.update(display, data)
+    assert len(rep.GetMarkerActors()) == 2
+
+    data.init_points = (
+        (1.0, 0.0, 0.0),
+        (-1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (0.0, -1.0, 0.0),
+        (0.0, 0.0, 1.0),
+    )
+    rep.update(display, data)
+    assert len(rep.GetMarkerActors()) == 5
+    rep.cleanup()
+
+
+def test_representation_marker_count_shrinks(rep_module, vtk_module):
+    """Decreasing init-point count from 5 to 2 shrinks the marker list
+    and detaches the removed actors from the renderer."""
+    rep = rep_module()
+    renderer = vtk_module.vtkRenderer()
+    rep.SetRenderer(renderer)
+    display = _StubDisplayNode()
+    data = _StubDataNode(
+        init_points=(
+            (1.0, 0.0, 0.0),
+            (-1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, -1.0, 0.0),
+            (0.0, 0.0, 1.0),
+        )
+    )
+    rep.update(display, data)
+    assert len(rep.GetMarkerActors()) == 5
+    # 1 spheroid + 5 markers = 6 actors on the renderer.
+    assert renderer.GetActors().GetNumberOfItems() == 6
+
+    data.init_points = ((1.0, 0.0, 0.0), (-1.0, 0.0, 0.0))
+    rep.update(display, data)
+    assert len(rep.GetMarkerActors()) == 2
+    # 1 spheroid + 2 markers = 3 actors on the renderer.
+    assert renderer.GetActors().GetNumberOfItems() == 3
+    rep.cleanup()
+
+
+def test_representation_marker_centers_match_init_points(
+    rep_module, vtk_module
+):
+    """Each marker's sphere centre matches the corresponding init point."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    points = ((1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0))
+    rep.update(display, _StubDataNode(init_points=points))
+
+    actors = rep.GetMarkerActors()
+    # Reach back to the sphere sources via the introspection — pull
+    # them off the mapper's input connection's producer.
+    for actor, expected in zip(actors, points):
+        mapper = actor.GetMapper()
+        # Resolve the upstream vtkSphereSource via the algorithm input.
+        producer = mapper.GetInputAlgorithm()
+        center = producer.GetCenter()
+        assert list(center) == pytest.approx(list(expected))
+    rep.cleanup()
+
+
+def test_representation_attach_detach_renderer(rep_module, vtk_module):
+    """``SetRenderer(r)`` adds the spheroid + marker actors; ``cleanup()``
+    removes them."""
+    rep = rep_module()
+    renderer = vtk_module.vtkRenderer()
+    assert renderer.GetActors().GetNumberOfItems() == 0
+
+    rep.SetRenderer(renderer)
+    # Pre-update: only the spheroid is on the renderer (markers are
+    # data-driven and have not been populated yet).
+    assert renderer.GetActors().GetNumberOfItems() == 1
+
+    display = _StubDisplayNode()
+    data = _StubDataNode(
+        init_points=((1.0, 0.0, 0.0), (-1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    )
+    rep.update(display, data)
+    # 1 spheroid + 3 markers = 4 actors.
+    assert renderer.GetActors().GetNumberOfItems() == 4
+
+    rep.cleanup()
+    # cleanup() detaches both and the renderer is empty again.
+    assert renderer.GetActors().GetNumberOfItems() == 0
+
+
+def test_representation_idempotent_no_refresh_on_unchanged_inputs(
+    rep_module, vtk_module
+):
+    """A second ``update()`` with unchanged inputs is a no-op — refresh
+    count does not advance, polydata is not re-emitted."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode(
+        center=(5.0, 5.0, 5.0),
+        radius_x=2.0,
+        radius_y=3.0,
+        radius_z=4.0,
+        init_points=((6.0, 5.0, 5.0), (4.0, 5.0, 5.0)),
+    )
+    rep.update(display, data)
+    after_first = rep.GetInputRefreshCount()
+    rep.update(display, data)
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == after_first
+    rep.cleanup()
+
+
+def test_representation_refresh_advances_on_any_input_change(
+    rep_module, vtk_module
+):
+    """Each distinct mutation of the geometry inputs advances the
+    counter; ``vtkParametricEllipsoid`` radii follow."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode(
+        center=(0.0, 0.0, 0.0),
+        radius_x=1.0,
+        radius_y=1.0,
+        radius_z=1.0,
+        init_points=((1.0, 0.0, 0.0), (-1.0, 0.0, 0.0)),
+    )
+    rep.update(display, data)
+    n = rep.GetInputRefreshCount()
+
+    data.radius_y = 2.0
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == n + 1
+    assert rep.GetParametricEllipsoid().GetYRadius() == pytest.approx(2.0)
+    rep.cleanup()


### PR DESCRIPTION
## Summary

Third iteration of the T2.2 stack: wires the **DistanceSpheroidInit** Representation of the LayerDM Pipeline pattern introduced by ADR-0013 §4 / ADR-0014 §2.  Active when `(state == Init, mode == DistanceSpheroid)`, this is the alternative initialisation path where the surgeon places a variable number of seed points (two or more) that imply an axis-aligned spheroid (`Center`, `RadiusX`, `RadiusY`, `RadiusZ`); the planning surface is then the intersection of that spheroid with the target liver mesh.

This iteration leaves the **SlicingPlaneInit** slot untouched — that is T2.2 iteration 2's territory and is in flight in parallel.

## What this renders

Per ADR-0014 §2 the Representation is responsible for three pieces of geometry:

1. **Variable-N control-point markers.**  Small sphere actors at each surgeon-placed init point.  The actor list grows / shrinks dynamically as `GetNumberOfDistanceSpheroidInitPoints()` changes between `update()` calls; removed actors are detached from the renderer and their strong refs are dropped.
2. **Spheroid visualisation.**  A translucent `vtkParametricEllipsoid` (`XRadius` / `YRadius` / `ZRadius`) wrapped in a `vtkParametricFunctionSource` and translated to the spheroid centre via a `vtkTransformPolyDataFilter`.  **Axis-aligned only** per `vtkLiverSpheroidRingExtractor`'s header — general-orientation rotation is deferred to a later stack iteration (the extractor's contract documents the same constraint).
3. **Ring on target mesh — DEFERRED.**  Tracked by `TODO(T2-target-mesh-weakref)`: the intersection ring needs the target liver mesh, which is not yet reachable from `vtkMRMLBezierSurfaceNode`.  Once the weakrefs to `TargetOrganModelNode` / `DistanceMapVolumeNode` / `VascularSegmentsVolumeNode` per ADR-0014 §1 land, this Representation will construct a `vtkLiverSpheroidRingExtractor`, feed it the target mesh + Center + Radii, and render the output as a ring polyline actor.

## Decoration plumbing (ADR-0014 §4)

- `GetResectionColor()` applies to spheroid + markers.
- `GetResectionOpacity()` applies to the (translucent) spheroid only.
- Markers stay at full opacity to remain visible against the translucent spheroid.

## Mapper relocation (deferred)

`TODO(T2-mapper-relocation)` markers note that the eventual swap from the generic `vtkPolyDataMapper` to `vtkOpenGLDistanceContourPolyDataMapper` (per ADR-0014 §3) is API-preserving and will land with the broader mapper relocation cohort.  No public-API change for this Representation when that swap happens.

## Pipeline wiring

`LiverBezierSurfacePipeline.initialize` populates the `REPRESENTATION_DISTANCE_SPHEROID_INIT` slot using the same dual-path import (package-relative + top-level `sys.path`) the `BezierPlanningRepresentation` uses.  Only the `TODO(T2.2 DistanceSpheroidInit)` block is touched — the `TODO(T2.2 SlicingPlaneInit)` block is left for iteration 2.

## Tests

`Testing/Python/unit/test_distance_spheroid_init_representation.py` mirrors the canonical `test_bezier_planning_representation.py` template:

- **Pure-Python layer** (works without VTK): construction, defaults, `None`-tolerance for display + data, color / opacity round-trip, idempotency memo on `(Center, Radii, init points)`.
- **VTK-mediated layer** (gated by `pytest.importorskip("vtk")`): spheroid colour / opacity, marker colour with markers-stay-opaque invariant, `vtkParametricEllipsoid` radii match the data node, marker count tracks `GetNumberOfDistanceSpheroidInitPoints()`, marker count grows from 2 to 5 + shrinks from 5 to 2 with renderer attach/detach actor counting, marker centres match init points, idempotent no-refresh on unchanged inputs.

All pure-Python tests pass locally; existing `test_liver_bezier_surface_pipeline.py` tests still pass (the populated slot does not break the previously-`None`-slot dispatch assertions).

## References

- ADR-0008 §2 §3 — unit-layer Representation testing discipline.
- ADR-0013 §4 §6 §7 — Pipeline pattern, Representations as composable VTK pipelines, file layout.
- ADR-0014 §1 §2 §3 §4 — data-node accessors, the three Representations, mapper relocation, read-only-after-Planning rules.

## Test plan

- [ ] CI green on the pytest scaffold (both offscreen + render-interactive).
- [ ] CI green on the build-test (no regression in `test_liver_bezier_surface_pipeline.py` from the populated slot).
- [ ] Lint / pre-commit clean on CI.
- [ ] Manual smoke once T2.6 wires the registration: drop into an `Init`-state Bezier node with `InitMode=DistanceSpheroid` and confirm the markers + translucent spheroid render at the placed-seed locations.

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code.  Opened for human review.*