### PR TITLE
ENH: Add vtkLiverBezierWidget (T2.3 — Option B: skeleton + left-drag)

### DIFF
--- a/LiverResections/CMakeLists.txt
+++ b/LiverResections/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(MRML)
 add_subdirectory(Algorithm)
 add_subdirectory(Logic)
 add_subdirectory(MRMLDM)
+add_subdirectory(VTKWidgets)
 
 #-----------------------------------------------------------------------------
 set(MODULE_EXPORT_DIRECTIVE "Q_SLICER_QTMODULES_${MODULE_NAME_UPPER}_EXPORT")

--- a/LiverResections/VTKWidgets/CMakeLists.txt
+++ b/LiverResections/VTKWidgets/CMakeLists.txt
@@ -1,0 +1,60 @@
+#-----------------------------------------------------------------------------
+# LiverResections/VTKWidgets
+#
+# Custom VTK widget for the Bezier-surface resection-planning workflow.
+# Per ADR-0014 §3, ``vtkLiverBezierWidget`` subclasses
+# ``vtkAbstractWidget`` directly (NOT ``vtkSlicerMarkupsWidget``) so the
+# event table is free of Markups assumptions:
+#
+#   - Left-drag  = per-point control-grid manipulation.
+#   - Right-drag = ring-group manipulation
+#                  (TODO(T2.3 right-drag-ring-group)).
+#   - Right-click = widget's own context menu
+#                   (TODO(T2.3 right-click-context-menu)).
+#
+# Paired with ``vtkLiverBezierRepresentation`` (a
+# ``vtkWidgetRepresentation`` subclass), which owns the interaction-
+# time actors (selection highlight, drag preview).  The relocated
+# OpenGL surface mappers from ``LiverMarkups/VTKWidgets/`` are
+# TODO(T2-mapper-relocation); the LayerDM Pipeline keeps the
+# Bezier-surface render path through that follow-on.
+#-----------------------------------------------------------------------------
+
+project(vtkSlicer${MODULE_NAME}ModuleVTKWidgets)
+
+set(KIT ${PROJECT_NAME})
+
+set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_MODULE_VTKWIDGETS_EXPORT")
+
+set(${KIT}_INCLUDE_DIRECTORIES
+  ${vtkSlicer${MODULE_NAME}ModuleMRML_SOURCE_DIR}
+  ${vtkSlicer${MODULE_NAME}ModuleMRML_BINARY_DIR}
+  )
+
+set(${KIT}_SRCS
+  vtkLiverBezierRepresentation.h
+  vtkLiverBezierRepresentation.cxx
+  vtkLiverBezierWidget.h
+  vtkLiverBezierWidget.cxx
+  )
+
+set(${KIT}_TARGET_LIBRARIES
+  vtkSlicer${MODULE_NAME}ModuleMRML
+  ${VTK_LIBRARIES}
+  )
+
+#-----------------------------------------------------------------------------
+SlicerMacroBuildModuleLogic(
+  NAME ${KIT}
+  EXPORT_DIRECTIVE ${${KIT}_EXPORT_DIRECTIVE}
+  INCLUDE_DIRECTORIES ${${KIT}_INCLUDE_DIRECTORIES}
+  SRCS ${${KIT}_SRCS}
+  TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
+  )
+
+#-----------------------------------------------------------------------------
+# C++ low-level tests for the widget + representation (ADR-0008 §2,
+# ctkTest driver, no Slicer launch, no Qt).
+if(BUILD_TESTING)
+  add_subdirectory(Testing)
+endif()

--- a/LiverResections/VTKWidgets/Testing/CMakeLists.txt
+++ b/LiverResections/VTKWidgets/Testing/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Cxx)

--- a/LiverResections/VTKWidgets/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/VTKWidgets/Testing/Cxx/CMakeLists.txt
@@ -1,0 +1,27 @@
+#-----------------------------------------------------------------------------
+# C++ low-level tests for the LiverResections VTKWidgets library.
+# Per ADR-0008 §2 — "C++ low-level" row, ctkTest driver, no Slicer
+# launch, no Qt.  Pattern mirrors the Algorithm/Testing/Cxx and
+# MRML/Testing/Cxx subdirectories.
+#-----------------------------------------------------------------------------
+
+set(KIT vtkSlicer${MODULE_NAME}ModuleVTKWidgets)
+
+#-----------------------------------------------------------------------------
+set(KIT_TEST_SRCS
+  vtkLiverBezierWidgetTest1.cxx
+  )
+
+#-----------------------------------------------------------------------------
+slicerMacroConfigureModuleCxxTestDriver(
+  NAME ${KIT}
+  SOURCES ${KIT_TEST_SRCS}
+  INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_BINARY_DIR}/..
+  WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
+  )
+
+SIMPLE_TEST(vtkLiverBezierWidgetTest1)

--- a/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
+++ b/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
@@ -152,8 +152,7 @@ int testPickControlPoint()
   display[0] = d[0];
   display[1] = d[1];
 
-  vtkLiverBezierRepresentation::PickResult pick =
-    rep->Pick(static_cast<int>(std::round(display[0])), static_cast<int>(std::round(display[1])));
+  vtkLiverBezierRepresentation::PickResult pick = rep->Pick(static_cast<int>(std::round(display[0])), static_cast<int>(std::round(display[1])));
   CHECK_INT(pick.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
   // row=2, col=1 -> index 2*4 + 1 = 9
   CHECK_INT(pick.Index, 9);
@@ -308,8 +307,7 @@ int testReadOnlyEnforcement()
   // either resolve to a control-point pick (different role) or miss.
   // Either way, it must NOT carry the SlicingPlaneInit role.
   const bool started = widget->BeginLeftDragAt(X, Y);
-  if (started
-      && widget->GetPickedRole() == vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit)
+  if (started && widget->GetPickedRole() == vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit)
   {
     std::cerr << "Widget entered Dragging on a SlicingPlaneInit pick in "
               << "Planning state — read-only invariant breach\n";

--- a/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
+++ b/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
@@ -1,0 +1,352 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Tests for vtkLiverBezierWidget and vtkLiverBezierRepresentation —
+  the custom widget landed by ADR-0014 §3.  Per ADR-0008 §2 these are
+  C++ low-level ctkTest-driver tests: no Slicer scene, no Qt, no
+  rendering, no on-screen interactor.
+
+  Coverage:
+
+   - Constructor / SetWidgetState lifecycle
+       (Start -> Hovering -> Dragging -> Start).
+   - Picking a control point at a known coordinate returns the right
+     point index + role.
+   - Simulating LeftButtonPress + MouseMove + LeftButtonRelease
+     mutates the data node's control grid as expected.
+   - Read-only enforcement (ADR-0014 §4): in state=Planning, init-mode
+     drag attempts are rejected — the widget must not enter Dragging
+     on an init-mode pick when the data node is in Planning.
+
+==============================================================================*/
+
+// LiverResections VTKWidgets includes
+#include "vtkLiverBezierRepresentation.h"
+#include "vtkLiverBezierWidget.h"
+
+// MRML includes
+#include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLCoreTestingMacros.h"
+
+// VTK includes
+#include <vtkCamera.h>
+#include <vtkGenericOpenGLRenderWindow.h>
+#include <vtkNew.h>
+#include <vtkRenderer.h>
+#include <vtkSmartPointer.h>
+
+// STD includes
+#include <cmath>
+#include <iostream>
+
+namespace
+{
+
+/// Build a renderer + camera oriented so the world plane Z=0 maps to
+/// display coordinates with a known scale.  The picker tolerance in
+/// vtkLiverBezierRepresentation is in world units; this orientation
+/// keeps the test points well separated under that tolerance.
+vtkSmartPointer<vtkRenderer> makeRenderer()
+{
+  vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
+  renderer->SetViewport(0.0, 0.0, 1.0, 1.0);
+  vtkCamera* camera = renderer->GetActiveCamera();
+  camera->ParallelProjectionOn();
+  camera->SetParallelScale(50.0);
+  camera->SetPosition(0.0, 0.0, 100.0);
+  camera->SetFocalPoint(0.0, 0.0, 0.0);
+  camera->SetViewUp(0.0, 1.0, 0.0);
+  camera->SetClippingRange(1.0, 1000.0);
+  return renderer;
+}
+
+/// Construct a minimal Bezier surface data node in Planning state with
+/// a known control grid: every control point lies on the Z=0 plane at
+/// the lattice position (col, row) * stride for stride=10.  The 16
+/// points are well outside the 5-unit pick tolerance from each other.
+vtkSmartPointer<vtkMRMLBezierSurfaceNode> makePlanningNode()
+{
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New();
+  node->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  double values[vtkMRMLBezierSurfaceNode::ControlGridSize] = { 0.0 };
+  constexpr double stride = 10.0;
+  for (int row = 0; row < vtkMRMLBezierSurfaceNode::GridSize; ++row)
+  {
+    for (int col = 0; col < vtkMRMLBezierSurfaceNode::GridSize; ++col)
+    {
+      const int i = row * vtkMRMLBezierSurfaceNode::GridSize + col;
+      values[i * 3 + 0] = (col - 1.5) * stride;
+      values[i * 3 + 1] = (row - 1.5) * stride;
+      values[i * 3 + 2] = 0.0;
+    }
+  }
+  node->SetControlGrid(values);
+  return node;
+}
+
+int testLifecycle()
+{
+  vtkNew<vtkLiverBezierWidget> widget;
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Start);
+  CHECK_INT(widget->GetPickedIndex(), -1);
+  CHECK_INT(widget->GetPickedRole(), vtkLiverBezierRepresentation::PickRole_None);
+
+  widget->SetWidgetState(vtkLiverBezierWidget::Hovering);
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Hovering);
+
+  widget->SetWidgetState(vtkLiverBezierWidget::Dragging);
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Dragging);
+
+  widget->SetWidgetState(vtkLiverBezierWidget::Start);
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Start);
+  CHECK_INT(widget->GetPickedIndex(), -1);
+  CHECK_INT(widget->GetPickedRole(), vtkLiverBezierRepresentation::PickRole_None);
+
+  // CreateDefaultRepresentation must lazily build a representation.
+  CHECK_NULL(widget->GetLiverBezierRepresentation());
+  widget->CreateDefaultRepresentation();
+  CHECK_NOT_NULL(widget->GetLiverBezierRepresentation());
+  return EXIT_SUCCESS;
+}
+
+int testPickControlPoint()
+{
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = makePlanningNode();
+  vtkSmartPointer<vtkRenderer> renderer = makeRenderer();
+
+  vtkNew<vtkLiverBezierRepresentation> rep;
+  rep->SetRenderer(renderer);
+  rep->SetBezierNode(node);
+  rep->BuildRepresentation();
+
+  // Render-window + interactor get a fake size so display-to-world
+  // mapping is deterministic.  No actual rendering occurs.
+  // vtkGenericOpenGLRenderWindow is a headless software-only render
+  // window — no X / EGL / GLX connection.  It provides the viewport
+  // size the renderer needs for display-to-world math (per
+  // vtkViewport::GetSize) without triggering the upstream "bad X
+  // server connection" warning that vtkXOpenGLRenderWindow emits
+  // when DISPLAY is unset.  ADR-0008 §2 ctkTest scope demands no
+  // on-screen rendering; this matches that constraint.
+  vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+  renderWindow->SetShowWindow(false);
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetSize(400, 400);
+
+  // Drive the active-camera reset so vtkInteractorObserver's
+  // display-to-world projector picks up a finite viewport.
+  renderer->ResetCameraClippingRange();
+
+  // The control point at (row=2, col=1) sits at world (-5, 5, 0)
+  // given stride=10, origin = (col - 1.5)*stride.  Map that to
+  // display coordinates via the camera-modelview composition.
+  double world[3] = { -5.0, 5.0, 0.0 };
+  double display[3] = { 0.0, 0.0, 0.0 };
+  // Project world -> display through the renderer's transformation.
+  renderer->SetWorldPoint(world[0], world[1], world[2], 1.0);
+  renderer->WorldToDisplay();
+  double* d = renderer->GetDisplayPoint();
+  display[0] = d[0];
+  display[1] = d[1];
+
+  vtkLiverBezierRepresentation::PickResult pick =
+    rep->Pick(static_cast<int>(std::round(display[0])), static_cast<int>(std::round(display[1])));
+  CHECK_INT(pick.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
+  // row=2, col=1 -> index 2*4 + 1 = 9
+  CHECK_INT(pick.Index, 9);
+
+  // A pick far away from any control point misses.
+  vtkLiverBezierRepresentation::PickResult miss = rep->Pick(-1000, -1000);
+  CHECK_INT(miss.Role, vtkLiverBezierRepresentation::PickRole_None);
+  return EXIT_SUCCESS;
+}
+
+int testLeftDragMutatesControlGrid()
+{
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = makePlanningNode();
+  vtkSmartPointer<vtkRenderer> renderer = makeRenderer();
+
+  vtkNew<vtkLiverBezierRepresentation> rep;
+  rep->SetRenderer(renderer);
+  rep->SetBezierNode(node);
+  rep->BuildRepresentation();
+
+  // vtkGenericOpenGLRenderWindow is a headless software-only render
+  // window — no X / EGL / GLX connection.  It provides the viewport
+  // size the renderer needs for display-to-world math (per
+  // vtkViewport::GetSize) without triggering the upstream "bad X
+  // server connection" warning that vtkXOpenGLRenderWindow emits
+  // when DISPLAY is unset.  ADR-0008 §2 ctkTest scope demands no
+  // on-screen rendering; this matches that constraint.
+  vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+  renderWindow->SetShowWindow(false);
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetSize(400, 400);
+  renderer->ResetCameraClippingRange();
+
+  vtkNew<vtkLiverBezierWidget> widget;
+  widget->SetRepresentation(rep);
+  widget->SetBezierNode(node);
+
+  // Project control point (row=0, col=0) at world (-15, -15, 0) to
+  // display coordinates.
+  renderer->SetWorldPoint(-15.0, -15.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  double* d = renderer->GetDisplayPoint();
+  const int startX = static_cast<int>(std::round(d[0]));
+  const int startY = static_cast<int>(std::round(d[1]));
+
+  CHECK_BOOL(widget->BeginLeftDragAt(startX, startY), true);
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Dragging);
+  CHECK_INT(widget->GetPickedRole(), vtkLiverBezierRepresentation::PickRole_ControlPoint);
+  CHECK_INT(widget->GetPickedIndex(), 0);
+
+  // Project a new target world coordinate (-12, -10, 0) to display
+  // coordinates, then drag the picked point there.
+  renderer->SetWorldPoint(-12.0, -10.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  d = renderer->GetDisplayPoint();
+  const int endX = static_cast<int>(std::round(d[0]));
+  const int endY = static_cast<int>(std::round(d[1]));
+
+  double resolved[3] = { 0.0, 0.0, 0.0 };
+  CHECK_BOOL(widget->DragTo(endX, endY, resolved), true);
+  CHECK_DOUBLE_TOLERANCE(resolved[0], -12.0, 1e-3);
+  CHECK_DOUBLE_TOLERANCE(resolved[1], -10.0, 1e-3);
+  CHECK_DOUBLE_TOLERANCE(resolved[2], 0.0, 1e-3);
+
+  // Data node round-trip — control point 0 must have moved.
+  const double* grid = node->GetControlGrid();
+  CHECK_DOUBLE_TOLERANCE(grid[0], -12.0, 1e-3);
+  CHECK_DOUBLE_TOLERANCE(grid[1], -10.0, 1e-3);
+  CHECK_DOUBLE_TOLERANCE(grid[2], 0.0, 1e-3);
+
+  // Other control points must not have moved.
+  CHECK_DOUBLE_TOLERANCE(grid[3], -5.0, 1e-3); // (row=0, col=1) -> x=-5
+  CHECK_DOUBLE_TOLERANCE(grid[4], -15.0, 1e-3);
+
+  widget->EndLeftDrag();
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Start);
+  CHECK_INT(widget->GetPickedIndex(), -1);
+  return EXIT_SUCCESS;
+}
+
+int testReadOnlyEnforcement()
+{
+  // ADR-0014 §4 — in state=Planning, init-mode points are read-only
+  // audit data.  The widget must *not* enter Dragging on an init-mode
+  // pick attempt in Planning.  This test seeds init data while in Init,
+  // transitions to Planning (legal one-way transition), and asserts a
+  // drag attempt at an init-point display coordinate is rejected.
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New();
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Init);
+  double p0[3] = { -20.0, 0.0, 0.0 };
+  double p1[3] = { 20.0, 0.0, 0.0 };
+  node->SetSlicingPlaneInitPoint(0, p0);
+  node->SetSlicingPlaneInitPoint(1, p1);
+
+  vtkSmartPointer<vtkRenderer> renderer = makeRenderer();
+  // vtkGenericOpenGLRenderWindow is a headless software-only render
+  // window — no X / EGL / GLX connection.  It provides the viewport
+  // size the renderer needs for display-to-world math (per
+  // vtkViewport::GetSize) without triggering the upstream "bad X
+  // server connection" warning that vtkXOpenGLRenderWindow emits
+  // when DISPLAY is unset.  ADR-0008 §2 ctkTest scope demands no
+  // on-screen rendering; this matches that constraint.
+  vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+  renderWindow->SetShowWindow(false);
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetSize(400, 400);
+  renderer->ResetCameraClippingRange();
+
+  vtkNew<vtkLiverBezierRepresentation> rep;
+  rep->SetRenderer(renderer);
+  rep->SetBezierNode(node);
+  rep->BuildRepresentation();
+
+  vtkNew<vtkLiverBezierWidget> widget;
+  widget->SetRepresentation(rep);
+  widget->SetBezierNode(node);
+
+  // While in Init, picking the slicing-plane init point at world
+  // (-20, 0, 0) should succeed and a drag should land.
+  renderer->SetWorldPoint(-20.0, 0.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  double* d = renderer->GetDisplayPoint();
+  const int X = static_cast<int>(std::round(d[0]));
+  const int Y = static_cast<int>(std::round(d[1]));
+
+  CHECK_BOOL(widget->BeginLeftDragAt(X, Y), true);
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Dragging);
+  CHECK_INT(widget->GetPickedRole(), vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit);
+  CHECK_INT(widget->GetPickedIndex(), 0);
+  widget->EndLeftDrag();
+
+  // Transition to Planning — init points are now read-only.
+  node->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Planning);
+
+  // The pickable set has changed — re-build the representation so the
+  // glyph cloud reflects the new (state, mode) tuple.
+  rep->BuildRepresentation();
+
+  // Picking the same display coordinate must *not* return an init-mode
+  // hit.  The representation's pick logic gates init-mode points
+  // behind state==Init.
+  vtkLiverBezierRepresentation::PickResult pick = rep->Pick(X, Y);
+  if (pick.Role == vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit)
+  {
+    std::cerr << "Pick returned init-mode hit in Planning state — read-only "
+              << "invariant breach (ADR-0014 §4)\n";
+    return EXIT_FAILURE;
+  }
+
+  // Attempting to start a left-drag at the same coordinate must
+  // either resolve to a control-point pick (different role) or miss.
+  // Either way, it must NOT carry the SlicingPlaneInit role.
+  const bool started = widget->BeginLeftDragAt(X, Y);
+  if (started
+      && widget->GetPickedRole() == vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit)
+  {
+    std::cerr << "Widget entered Dragging on a SlicingPlaneInit pick in "
+              << "Planning state — read-only invariant breach\n";
+    return EXIT_FAILURE;
+  }
+  if (started)
+  {
+    widget->EndLeftDrag();
+  }
+
+  // Belt-and-braces: explicitly attempt the read-only-rejected setter
+  // path.  The data node's ADR-0014 §4 guard emits a warning; gate the
+  // assertion so the test driver does not count it as a failure.
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  double clobber[3] = { -99.0, -99.0, -99.0 };
+  CHECK_BOOL(node->SetSlicingPlaneInitPoint(0, clobber), false);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+
+  // Init point still carries its pre-Planning value.
+  const double* got = node->GetSlicingPlaneInitPoint(0);
+  CHECK_NOT_NULL(got);
+  CHECK_DOUBLE(got[0], -20.0);
+  CHECK_DOUBLE(got[1], 0.0);
+  CHECK_DOUBLE(got[2], 0.0);
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkLiverBezierWidgetTest1(int, char*[])
+{
+  CHECK_EXIT_SUCCESS(testLifecycle());
+  CHECK_EXIT_SUCCESS(testPickControlPoint());
+  CHECK_EXIT_SUCCESS(testLeftDragMutatesControlGrid());
+  CHECK_EXIT_SUCCESS(testReadOnlyEnforcement());
+
+  std::cout << "vtkLiverBezierWidgetTest1 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
@@ -1,0 +1,477 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the T2 LiverResections all-in migration (Stack 2 of the
+  v2.0.0 release tracker — see ADR-0014 §3).
+
+==============================================================================*/
+
+#include "vtkLiverBezierRepresentation.h"
+
+// MRML includes
+#include <vtkMRMLBezierSurfaceNode.h>
+
+// VTK includes
+#include <vtkActor.h>
+#include <vtkCamera.h>
+#include <vtkCellArray.h>
+#include <vtkInteractorObserver.h>
+#include <vtkMath.h>
+#include <vtkObjectFactory.h>
+#include <vtkPlane.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkPropCollection.h>
+#include <vtkPropPicker.h>
+#include <vtkProperty.h>
+#include <vtkRenderer.h>
+#include <vtkSphereSource.h>
+#include <vtkUnsignedCharArray.h>
+
+// STD includes
+#include <algorithm>
+#include <cmath>
+
+//------------------------------------------------------------------------------
+vtkStandardNewMacro(vtkLiverBezierRepresentation);
+
+namespace
+{
+// Sentinel pick-tolerance in world units.  The widget converts a
+// display-space mouse cursor to a world ray via the renderer's camera,
+// and a control point counts as picked if the perpendicular world-
+// space distance from the ray to the point falls below this threshold.
+// Calibrated to match the visual radius of the glyph cloud below.
+constexpr double kPickRadiusWorld = 5.0;
+constexpr double kGlyphRadius = 2.5;
+
+} // anonymous namespace
+
+//------------------------------------------------------------------------------
+vtkLiverBezierRepresentation::vtkLiverBezierRepresentation()
+  : LastBuildDataMTime(0)
+{
+  this->GlyphPolyData = vtkSmartPointer<vtkPolyData>::New();
+  vtkNew<vtkPoints> points;
+  this->GlyphPolyData->SetPoints(points);
+  vtkNew<vtkCellArray> verts;
+  this->GlyphPolyData->SetVerts(verts);
+
+  this->GlyphSource = vtkSmartPointer<vtkSphereSource>::New();
+  this->GlyphSource->SetRadius(kGlyphRadius);
+  this->GlyphSource->SetThetaResolution(8);
+  this->GlyphSource->SetPhiResolution(8);
+
+  this->GlyphMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  // The mapper is here as a placeholder render target; the actual
+  // per-role glyph treatment + relocated mapper land in the
+  // TODO(T2-mapper-relocation) follow-up.  For the skeleton scope this
+  // class only needs the picker + the actor lifecycle to be sound.
+  this->GlyphMapper->SetInputConnection(this->GlyphSource->GetOutputPort());
+  this->GlyphActor = vtkSmartPointer<vtkActor>::New();
+  this->GlyphActor->SetMapper(this->GlyphMapper);
+  this->GlyphActor->VisibilityOff();
+
+  this->HighlightSource = vtkSmartPointer<vtkSphereSource>::New();
+  this->HighlightSource->SetRadius(kGlyphRadius * 1.4);
+  this->HighlightSource->SetThetaResolution(12);
+  this->HighlightSource->SetPhiResolution(12);
+  this->HighlightMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  this->HighlightMapper->SetInputConnection(this->HighlightSource->GetOutputPort());
+  this->HighlightActor = vtkSmartPointer<vtkActor>::New();
+  this->HighlightActor->SetMapper(this->HighlightMapper);
+  this->HighlightActor->GetProperty()->SetColor(1.0, 0.85, 0.1);
+  this->HighlightActor->VisibilityOff();
+
+  this->Picker = vtkSmartPointer<vtkPropPicker>::New();
+}
+
+//------------------------------------------------------------------------------
+vtkLiverBezierRepresentation::~vtkLiverBezierRepresentation() = default;
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierRepresentation::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "BezierNode: " << (this->BezierNode.GetPointer() ? "set" : "(null)") << "\n";
+  os << indent << "LastBuildDataMTime: " << this->LastBuildDataMTime << "\n";
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierRepresentation::SetBezierNode(vtkMRMLBezierSurfaceNode* node)
+{
+  if (this->BezierNode.GetPointer() == node)
+  {
+    return;
+  }
+  this->BezierNode = node;
+  this->LastBuildDataMTime = 0;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLBezierSurfaceNode* vtkLiverBezierRepresentation::GetBezierNode()
+{
+  return this->BezierNode.GetPointer();
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierRepresentation::UpdatePickableGlyphs()
+{
+  vtkMRMLBezierSurfaceNode* node = this->BezierNode.GetPointer();
+  vtkPoints* points = this->GlyphPolyData->GetPoints();
+  vtkCellArray* verts = this->GlyphPolyData->GetVerts();
+  points->Reset();
+  verts->Reset();
+  if (!node)
+  {
+    this->GlyphPolyData->Modified();
+    return;
+  }
+
+  // ADR-0014 §3 — pickable set depends on (State, InitMode).
+  const int state = node->GetState();
+  const int mode = node->GetInitMode();
+
+  auto pushPoint = [&](double x, double y, double z) {
+    const vtkIdType id = points->InsertNextPoint(x, y, z);
+    verts->InsertNextCell(1, &id);
+  };
+
+  if (state == vtkMRMLBezierSurfaceNode::Planning)
+  {
+    // 16 Bezier control points become pickable.
+    const double* grid = node->GetControlGrid();
+    for (int i = 0; i < vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize;
+         ++i)
+    {
+      pushPoint(grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2]);
+    }
+  }
+  else // Init
+  {
+    if (mode == vtkMRMLBezierSurfaceNode::SlicingPlane)
+    {
+      for (int i = 0; i < 2; ++i)
+      {
+        const double* p = node->GetSlicingPlaneInitPoint(i);
+        if (p)
+        {
+          pushPoint(p[0], p[1], p[2]);
+        }
+      }
+    }
+    else // DistanceSpheroid
+    {
+      const int n = node->GetNumberOfDistanceSpheroidInitPoints();
+      for (int i = 0; i < n; ++i)
+      {
+        const double* p = node->GetDistanceSpheroidInitPoint(i);
+        if (p)
+        {
+          pushPoint(p[0], p[1], p[2]);
+        }
+      }
+    }
+  }
+
+  this->GlyphPolyData->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierRepresentation::BuildRepresentation()
+{
+  vtkMRMLBezierSurfaceNode* node = this->BezierNode.GetPointer();
+  if (!node)
+  {
+    this->GlyphActor->VisibilityOff();
+    this->HighlightActor->VisibilityOff();
+    return;
+  }
+  const vtkMTimeType nodeMTime = node->GetMTime();
+  if (nodeMTime != this->LastBuildDataMTime)
+  {
+    this->UpdatePickableGlyphs();
+    this->LastBuildDataMTime = nodeMTime;
+  }
+  this->GlyphActor->SetVisibility(this->GlyphPolyData->GetNumberOfPoints() > 0 ? 1 : 0);
+}
+
+//------------------------------------------------------------------------------
+int vtkLiverBezierRepresentation::ComputeInteractionState(int X, int Y, int /*modify*/)
+{
+  // The widget owns the substate enum; this method exists to satisfy
+  // the vtkWidgetRepresentation contract (returning a non-zero state
+  // when the cursor is over a pickable primitive).  A hit returns
+  // ``Picked`` (1); a miss returns ``Outside`` (0).
+  PickResult res = this->Pick(X, Y);
+  this->InteractionState = (res.Role == PickRole_None) ? 0 : 1;
+  return this->InteractionState;
+}
+
+//------------------------------------------------------------------------------
+vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int X, int Y)
+{
+  PickResult result;
+  vtkMRMLBezierSurfaceNode* node = this->BezierNode.GetPointer();
+  if (!node)
+  {
+    return result;
+  }
+  vtkRenderer* renderer = this->GetRenderer();
+  if (!renderer)
+  {
+    return result;
+  }
+
+  // Convert (X, Y) to a world-space ray through the camera.  For the
+  // skeleton scope, the picker is a simple nearest-point-on-ray test
+  // against the pickable point cloud.  The production widget pairs
+  // each glyph with a vtkActor and uses vtkPropPicker, but the cloud
+  // is small (≤ 16 points) and the ray test stays trivially correct
+  // under headless interactor.
+  double nearWorld[4] = { 0.0, 0.0, 0.0, 1.0 };
+  double farWorld[4] = { 0.0, 0.0, 0.0, 1.0 };
+  vtkInteractorObserver::ComputeDisplayToWorld(
+    renderer, static_cast<double>(X), static_cast<double>(Y), 0.0, nearWorld);
+  vtkInteractorObserver::ComputeDisplayToWorld(
+    renderer, static_cast<double>(X), static_cast<double>(Y), 1.0, farWorld);
+
+  double rayOrigin[3] = { nearWorld[0], nearWorld[1], nearWorld[2] };
+  double rayDir[3] = { farWorld[0] - nearWorld[0],
+                       farWorld[1] - nearWorld[1],
+                       farWorld[2] - nearWorld[2] };
+  vtkMath::Normalize(rayDir);
+
+  // ADR-0014 §3 — pickability is state-gated.
+  const int state = node->GetState();
+  const int mode = node->GetInitMode();
+
+  // Helper: distance from point to ray.
+  auto distanceToRay = [&](const double p[3]) {
+    double op[3] = { p[0] - rayOrigin[0], p[1] - rayOrigin[1], p[2] - rayOrigin[2] };
+    const double dot = vtkMath::Dot(op, rayDir);
+    double closest[3] = { rayOrigin[0] + dot * rayDir[0],
+                          rayOrigin[1] + dot * rayDir[1],
+                          rayOrigin[2] + dot * rayDir[2] };
+    return std::sqrt(vtkMath::Distance2BetweenPoints(p, closest));
+  };
+
+  double bestDist = kPickRadiusWorld;
+  if (state == vtkMRMLBezierSurfaceNode::Planning)
+  {
+    const double* grid = node->GetControlGrid();
+    for (int i = 0; i < vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize;
+         ++i)
+    {
+      const double p[3] = { grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2] };
+      const double d = distanceToRay(p);
+      if (d < bestDist)
+      {
+        bestDist = d;
+        result.Role = PickRole_ControlPoint;
+        result.Index = i;
+      }
+    }
+  }
+  else // Init — init-mode points become pickable.
+  {
+    if (mode == vtkMRMLBezierSurfaceNode::SlicingPlane)
+    {
+      for (int i = 0; i < 2; ++i)
+      {
+        const double* p = node->GetSlicingPlaneInitPoint(i);
+        if (!p)
+        {
+          continue;
+        }
+        const double d = distanceToRay(p);
+        if (d < bestDist)
+        {
+          bestDist = d;
+          result.Role = PickRole_SlicingPlaneInit;
+          result.Index = i;
+        }
+      }
+    }
+    else // DistanceSpheroid
+    {
+      const int n = node->GetNumberOfDistanceSpheroidInitPoints();
+      for (int i = 0; i < n; ++i)
+      {
+        const double* p = node->GetDistanceSpheroidInitPoint(i);
+        if (!p)
+        {
+          continue;
+        }
+        const double d = distanceToRay(p);
+        if (d < bestDist)
+        {
+          bestDist = d;
+          result.Role = PickRole_DistanceSpheroidInit;
+          result.Index = i;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+//------------------------------------------------------------------------------
+bool vtkLiverBezierRepresentation::DisplayToWorld(int X, int Y,
+                                                  const double referenceWorld[3],
+                                                  double worldOut[3])
+{
+  vtkRenderer* renderer = this->GetRenderer();
+  if (!renderer || !referenceWorld || !worldOut)
+  {
+    return false;
+  }
+  // Project the (X, Y) cursor onto the plane parallel to the camera
+  // that passes through the reference world point.  This is the
+  // standard VTK widget pattern for converting a 2-D mouse-move into
+  // a 3-D point update.
+  double cameraFocal[3];
+  double cameraPos[3];
+  vtkCamera* camera = renderer->GetActiveCamera();
+  if (!camera)
+  {
+    return false;
+  }
+  camera->GetFocalPoint(cameraFocal);
+  camera->GetPosition(cameraPos);
+  double planeNormal[3] = { cameraFocal[0] - cameraPos[0],
+                            cameraFocal[1] - cameraPos[1],
+                            cameraFocal[2] - cameraPos[2] };
+  if (vtkMath::Norm(planeNormal) < 1e-9)
+  {
+    return false;
+  }
+  vtkMath::Normalize(planeNormal);
+
+  double nearWorld[4] = { 0.0, 0.0, 0.0, 1.0 };
+  double farWorld[4] = { 0.0, 0.0, 0.0, 1.0 };
+  vtkInteractorObserver::ComputeDisplayToWorld(
+    renderer, static_cast<double>(X), static_cast<double>(Y), 0.0, nearWorld);
+  vtkInteractorObserver::ComputeDisplayToWorld(
+    renderer, static_cast<double>(X), static_cast<double>(Y), 1.0, farWorld);
+  double rayDir[3] = { farWorld[0] - nearWorld[0],
+                       farWorld[1] - nearWorld[1],
+                       farWorld[2] - nearWorld[2] };
+  vtkMath::Normalize(rayDir);
+  double rayOrigin[3] = { nearWorld[0], nearWorld[1], nearWorld[2] };
+  double rayFar[3] = { rayOrigin[0] + rayDir[0] * 1.0e6,
+                       rayOrigin[1] + rayDir[1] * 1.0e6,
+                       rayOrigin[2] + rayDir[2] * 1.0e6 };
+  double refCopy[3] = { referenceWorld[0], referenceWorld[1], referenceWorld[2] };
+  double t = 0.0;
+  if (vtkPlane::IntersectWithLine(rayOrigin, rayFar, planeNormal, refCopy, t, worldOut) == 0)
+  {
+    return false;
+  }
+  return true;
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierRepresentation::GetActors(vtkPropCollection* pc)
+{
+  if (!pc)
+  {
+    return;
+  }
+  pc->AddItem(this->GlyphActor);
+  pc->AddItem(this->HighlightActor);
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierRepresentation::ReleaseGraphicsResources(vtkWindow* w)
+{
+  this->GlyphActor->ReleaseGraphicsResources(w);
+  this->HighlightActor->ReleaseGraphicsResources(w);
+}
+
+//------------------------------------------------------------------------------
+int vtkLiverBezierRepresentation::RenderOverlay(vtkViewport* viewport)
+{
+  int count = 0;
+  if (this->GlyphActor->GetVisibility())
+  {
+    count += this->GlyphActor->RenderOverlay(viewport);
+  }
+  if (this->HighlightActor->GetVisibility())
+  {
+    count += this->HighlightActor->RenderOverlay(viewport);
+  }
+  return count;
+}
+
+//------------------------------------------------------------------------------
+int vtkLiverBezierRepresentation::RenderOpaqueGeometry(vtkViewport* viewport)
+{
+  this->BuildRepresentation();
+  int count = 0;
+  if (this->GlyphActor->GetVisibility())
+  {
+    count += this->GlyphActor->RenderOpaqueGeometry(viewport);
+  }
+  if (this->HighlightActor->GetVisibility())
+  {
+    count += this->HighlightActor->RenderOpaqueGeometry(viewport);
+  }
+  return count;
+}
+
+//------------------------------------------------------------------------------
+int vtkLiverBezierRepresentation::RenderTranslucentPolygonalGeometry(vtkViewport* viewport)
+{
+  int count = 0;
+  if (this->GlyphActor->GetVisibility())
+  {
+    count += this->GlyphActor->RenderTranslucentPolygonalGeometry(viewport);
+  }
+  if (this->HighlightActor->GetVisibility())
+  {
+    count += this->HighlightActor->RenderTranslucentPolygonalGeometry(viewport);
+  }
+  return count;
+}
+
+//------------------------------------------------------------------------------
+vtkTypeBool vtkLiverBezierRepresentation::HasTranslucentPolygonalGeometry()
+{
+  return this->GlyphActor->HasTranslucentPolygonalGeometry()
+    || this->HighlightActor->HasTranslucentPolygonalGeometry();
+}

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
@@ -165,7 +165,8 @@ void vtkLiverBezierRepresentation::UpdatePickableGlyphs()
   const int state = node->GetState();
   const int mode = node->GetInitMode();
 
-  auto pushPoint = [&](double x, double y, double z) {
+  auto pushPoint = [&](double x, double y, double z)
+  {
     const vtkIdType id = points->InsertNextPoint(x, y, z);
     verts->InsertNextCell(1, &id);
   };
@@ -174,8 +175,7 @@ void vtkLiverBezierRepresentation::UpdatePickableGlyphs()
   {
     // 16 Bezier control points become pickable.
     const double* grid = node->GetControlGrid();
-    for (int i = 0; i < vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize;
-         ++i)
+    for (int i = 0; i < vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize; ++i)
     {
       pushPoint(grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2]);
     }
@@ -264,15 +264,11 @@ vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int 
   // under headless interactor.
   double nearWorld[4] = { 0.0, 0.0, 0.0, 1.0 };
   double farWorld[4] = { 0.0, 0.0, 0.0, 1.0 };
-  vtkInteractorObserver::ComputeDisplayToWorld(
-    renderer, static_cast<double>(X), static_cast<double>(Y), 0.0, nearWorld);
-  vtkInteractorObserver::ComputeDisplayToWorld(
-    renderer, static_cast<double>(X), static_cast<double>(Y), 1.0, farWorld);
+  vtkInteractorObserver::ComputeDisplayToWorld(renderer, static_cast<double>(X), static_cast<double>(Y), 0.0, nearWorld);
+  vtkInteractorObserver::ComputeDisplayToWorld(renderer, static_cast<double>(X), static_cast<double>(Y), 1.0, farWorld);
 
   double rayOrigin[3] = { nearWorld[0], nearWorld[1], nearWorld[2] };
-  double rayDir[3] = { farWorld[0] - nearWorld[0],
-                       farWorld[1] - nearWorld[1],
-                       farWorld[2] - nearWorld[2] };
+  double rayDir[3] = { farWorld[0] - nearWorld[0], farWorld[1] - nearWorld[1], farWorld[2] - nearWorld[2] };
   vtkMath::Normalize(rayDir);
 
   // ADR-0014 §3 — pickability is state-gated.
@@ -280,12 +276,11 @@ vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int 
   const int mode = node->GetInitMode();
 
   // Helper: distance from point to ray.
-  auto distanceToRay = [&](const double p[3]) {
+  auto distanceToRay = [&](const double p[3])
+  {
     double op[3] = { p[0] - rayOrigin[0], p[1] - rayOrigin[1], p[2] - rayOrigin[2] };
     const double dot = vtkMath::Dot(op, rayDir);
-    double closest[3] = { rayOrigin[0] + dot * rayDir[0],
-                          rayOrigin[1] + dot * rayDir[1],
-                          rayOrigin[2] + dot * rayDir[2] };
+    double closest[3] = { rayOrigin[0] + dot * rayDir[0], rayOrigin[1] + dot * rayDir[1], rayOrigin[2] + dot * rayDir[2] };
     return std::sqrt(vtkMath::Distance2BetweenPoints(p, closest));
   };
 
@@ -293,8 +288,7 @@ vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int 
   if (state == vtkMRMLBezierSurfaceNode::Planning)
   {
     const double* grid = node->GetControlGrid();
-    for (int i = 0; i < vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize;
-         ++i)
+    for (int i = 0; i < vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize; ++i)
     {
       const double p[3] = { grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2] };
       const double d = distanceToRay(p);
@@ -351,9 +345,7 @@ vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int 
 }
 
 //------------------------------------------------------------------------------
-bool vtkLiverBezierRepresentation::DisplayToWorld(int X, int Y,
-                                                  const double referenceWorld[3],
-                                                  double worldOut[3])
+bool vtkLiverBezierRepresentation::DisplayToWorld(int X, int Y, const double referenceWorld[3], double worldOut[3])
 {
   vtkRenderer* renderer = this->GetRenderer();
   if (!renderer || !referenceWorld || !worldOut)
@@ -373,9 +365,7 @@ bool vtkLiverBezierRepresentation::DisplayToWorld(int X, int Y,
   }
   camera->GetFocalPoint(cameraFocal);
   camera->GetPosition(cameraPos);
-  double planeNormal[3] = { cameraFocal[0] - cameraPos[0],
-                            cameraFocal[1] - cameraPos[1],
-                            cameraFocal[2] - cameraPos[2] };
+  double planeNormal[3] = { cameraFocal[0] - cameraPos[0], cameraFocal[1] - cameraPos[1], cameraFocal[2] - cameraPos[2] };
   if (vtkMath::Norm(planeNormal) < 1e-9)
   {
     return false;
@@ -384,18 +374,12 @@ bool vtkLiverBezierRepresentation::DisplayToWorld(int X, int Y,
 
   double nearWorld[4] = { 0.0, 0.0, 0.0, 1.0 };
   double farWorld[4] = { 0.0, 0.0, 0.0, 1.0 };
-  vtkInteractorObserver::ComputeDisplayToWorld(
-    renderer, static_cast<double>(X), static_cast<double>(Y), 0.0, nearWorld);
-  vtkInteractorObserver::ComputeDisplayToWorld(
-    renderer, static_cast<double>(X), static_cast<double>(Y), 1.0, farWorld);
-  double rayDir[3] = { farWorld[0] - nearWorld[0],
-                       farWorld[1] - nearWorld[1],
-                       farWorld[2] - nearWorld[2] };
+  vtkInteractorObserver::ComputeDisplayToWorld(renderer, static_cast<double>(X), static_cast<double>(Y), 0.0, nearWorld);
+  vtkInteractorObserver::ComputeDisplayToWorld(renderer, static_cast<double>(X), static_cast<double>(Y), 1.0, farWorld);
+  double rayDir[3] = { farWorld[0] - nearWorld[0], farWorld[1] - nearWorld[1], farWorld[2] - nearWorld[2] };
   vtkMath::Normalize(rayDir);
   double rayOrigin[3] = { nearWorld[0], nearWorld[1], nearWorld[2] };
-  double rayFar[3] = { rayOrigin[0] + rayDir[0] * 1.0e6,
-                       rayOrigin[1] + rayDir[1] * 1.0e6,
-                       rayOrigin[2] + rayDir[2] * 1.0e6 };
+  double rayFar[3] = { rayOrigin[0] + rayDir[0] * 1.0e6, rayOrigin[1] + rayDir[1] * 1.0e6, rayOrigin[2] + rayDir[2] * 1.0e6 };
   double refCopy[3] = { referenceWorld[0], referenceWorld[1], referenceWorld[2] };
   double t = 0.0;
   if (vtkPlane::IntersectWithLine(rayOrigin, rayFar, planeNormal, refCopy, t, worldOut) == 0)
@@ -472,6 +456,5 @@ int vtkLiverBezierRepresentation::RenderTranslucentPolygonalGeometry(vtkViewport
 //------------------------------------------------------------------------------
 vtkTypeBool vtkLiverBezierRepresentation::HasTranslucentPolygonalGeometry()
 {
-  return this->GlyphActor->HasTranslucentPolygonalGeometry()
-    || this->HighlightActor->HasTranslucentPolygonalGeometry();
+  return this->GlyphActor->HasTranslucentPolygonalGeometry() || this->HighlightActor->HasTranslucentPolygonalGeometry();
 }

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
@@ -37,8 +37,8 @@
 
 ==============================================================================*/
 
-#ifndef __vtklivebezierrepresentation_h_
-#define __vtklivebezierrepresentation_h_
+#ifndef __vtkliverbezierrepresentation_h_
+#define __vtkliverbezierrepresentation_h_
 
 #include "vtkSlicerLiverResectionsModuleVTKWidgetsExport.h"
 
@@ -201,4 +201,4 @@ private:
   void operator=(const vtkLiverBezierRepresentation&) = delete;
 };
 
-#endif //__vtklivebezierrepresentation_h_
+#endif //__vtkliverbezierrepresentation_h_

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
@@ -82,8 +82,7 @@ class vtkSphereSource;
  * they are read-only audit data and the widget must not enter a drag
  * substate on them.
  */
-class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkLiverBezierRepresentation
-  : public vtkWidgetRepresentation
+class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkLiverBezierRepresentation : public vtkWidgetRepresentation
 {
 public:
   static vtkLiverBezierRepresentation* New();
@@ -97,8 +96,8 @@ public:
   enum PickRole
   {
     PickRole_None = 0,
-    PickRole_ControlPoint = 1,      ///< Bezier 4×4 grid (state=Planning).
-    PickRole_SlicingPlaneInit = 2,  ///< Two SlicingPlane init points.
+    PickRole_ControlPoint = 1,         ///< Bezier 4×4 grid (state=Planning).
+    PickRole_SlicingPlaneInit = 2,     ///< Two SlicingPlane init points.
     PickRole_DistanceSpheroidInit = 3, ///< DistanceSpheroid init points.
   };
 

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
@@ -1,0 +1,205 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the T2 LiverResections all-in migration (Stack 2 of the
+  v2.0.0 release tracker — see ADR-0014 §3).
+
+==============================================================================*/
+
+#ifndef __vtklivebezierrepresentation_h_
+#define __vtklivebezierrepresentation_h_
+
+#include "vtkSlicerLiverResectionsModuleVTKWidgetsExport.h"
+
+// VTK includes
+#include <vtkSmartPointer.h>
+#include <vtkWeakPointer.h>
+#include <vtkWidgetRepresentation.h>
+
+class vtkActor;
+class vtkMRMLBezierSurfaceNode;
+class vtkPolyData;
+class vtkPolyDataMapper;
+class vtkPropPicker;
+class vtkSphereSource;
+
+/**
+ * \class vtkLiverBezierRepresentation
+ *
+ * \brief VTK widget representation paired with ``vtkLiverBezierWidget``.
+ *
+ * This is the VTK ``vtkWidgetRepresentation``-pattern representation — the
+ * geometry the widget draws during interaction (selection highlights,
+ * drag previews, the picked control-point glyph).  It is *not* the
+ * LayerDM-Pipeline ``BezierPlanningRepresentation``; those two
+ * "representation" concepts coexist by accident of vocabulary.
+ *
+ * The representation observes a ``vtkMRMLBezierSurfaceNode`` for its
+ * geometry source (the 4×4 control grid + init data per ADR-0014 §1)
+ * and exposes a picker that resolves a display-space (X, Y) cursor to a
+ * point index in the underlying data node.
+ *
+ * Per ADR-0014 §3, the *pickable* set depends on the data node's
+ * ``(State, InitMode)`` tuple:
+ *
+ *   - ``(Init, SlicingPlane)``  — the two SlicingPlane init points.
+ *   - ``(Init, DistanceSpheroid)`` — the DistanceSpheroid init points.
+ *   - ``(Planning, *)``  — the 16 Bezier control-grid points
+ *     (corners 4 + edges 8 + interior 4).
+ *
+ * Init-mode points are not pickable in Planning state; per ADR-0014 §4
+ * they are read-only audit data and the widget must not enter a drag
+ * substate on them.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkLiverBezierRepresentation
+  : public vtkWidgetRepresentation
+{
+public:
+  static vtkLiverBezierRepresentation* New();
+  vtkTypeMacro(vtkLiverBezierRepresentation, vtkWidgetRepresentation);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Pickable-primitive role.  The integer-tagged enum is exposed so
+  /// ``vtkLiverBezierWidget`` can dispatch on what was hit without
+  /// rebuilding the pick result.  ``PickRole_None`` is the sentinel
+  /// "miss".
+  enum PickRole
+  {
+    PickRole_None = 0,
+    PickRole_ControlPoint = 1,      ///< Bezier 4×4 grid (state=Planning).
+    PickRole_SlicingPlaneInit = 2,  ///< Two SlicingPlane init points.
+    PickRole_DistanceSpheroidInit = 3, ///< DistanceSpheroid init points.
+  };
+
+  /// Result of ``Pick(X, Y)`` — role + point index.  The index is
+  /// role-relative: control-grid is [0..15], slicing-plane init is
+  /// [0..1], distance-spheroid init is [0..N) where N is the data
+  /// node's ``NumberOfDistanceSpheroidInitPoints``.
+  struct PickResult
+  {
+    int Role{ PickRole_None };
+    int Index{ -1 };
+  };
+
+  ///@{
+  /// Attach / detach the data node this representation tracks.  The
+  /// representation observes the node's ``ModifiedEvent`` and rebuilds
+  /// its actors on change.  The reference is a vtkWeakPointer to avoid
+  /// extending data-node lifetime; the widget owns the strong
+  /// reference (TODO(T2-target-mesh-weakref)).
+  void SetBezierNode(vtkMRMLBezierSurfaceNode* node);
+  vtkMRMLBezierSurfaceNode* GetBezierNode();
+  ///@}
+
+  /// Pick at display coordinates ``(X, Y)``.  Returns a ``PickResult``
+  /// whose ``Role`` is ``PickRole_None`` on miss.  Picking is gated by
+  /// the data node's ``(State, InitMode)`` per ADR-0014 §3 — in
+  /// Planning state init-mode points are not pickable, in Init state
+  /// the control grid is not pickable.
+  PickResult Pick(int X, int Y);
+
+  /// Resolve a display-space (X, Y) cursor to a world-space (RAS) point
+  /// on the plane parallel to the camera and passing through the
+  /// currently picked point.  Returns ``true`` on success.  Used by
+  /// the widget during ``Dragging`` to convert mouse moves into new
+  /// point positions.
+  bool DisplayToWorld(int X, int Y, const double referenceWorld[3], double worldOut[3]);
+
+  //--------------------------------------------------------------------------
+  // vtkWidgetRepresentation interface
+  //--------------------------------------------------------------------------
+  void BuildRepresentation() override;
+  int ComputeInteractionState(int X, int Y, int modify = 0) override;
+
+  /// Renderer set/get is inherited from vtkWidgetRepresentation.
+
+  //--------------------------------------------------------------------------
+  // vtkProp interface (forwarded to internal actors).
+  //--------------------------------------------------------------------------
+  void GetActors(vtkPropCollection* pc) override;
+  void ReleaseGraphicsResources(vtkWindow* w) override;
+  int RenderOverlay(vtkViewport* viewport) override;
+  int RenderOpaqueGeometry(vtkViewport* viewport) override;
+  int RenderTranslucentPolygonalGeometry(vtkViewport* viewport) override;
+  vtkTypeBool HasTranslucentPolygonalGeometry() override;
+
+protected:
+  vtkLiverBezierRepresentation();
+  ~vtkLiverBezierRepresentation() override;
+
+  /// Rebuild the internal poly data carrying the currently-pickable
+  /// glyph cloud.  Cheap (≤ 16 sphere glyphs); called from
+  /// ``BuildRepresentation()``.  The control-grid OpenGL mapper from
+  /// ``LiverMarkups/VTKWidgets/`` is *not* hosted here — it relocates
+  /// in TODO(T2-mapper-relocation) and the LayerDM Pipeline keeps the
+  /// surface render path.  This representation only owns the
+  /// interaction-time glyph cloud + selection highlight.
+  void UpdatePickableGlyphs();
+
+  /// Data node observed for geometry source.  Weak so the data node
+  /// can outlive or pre-decease the representation cleanly.
+  vtkWeakPointer<vtkMRMLBezierSurfaceNode> BezierNode;
+
+  /// Glyph cloud carrying the currently-pickable points.  Per-point
+  /// scalars carry the role + index so a vtkPropPicker hit resolves
+  /// directly to a (Role, Index) pair.
+  vtkSmartPointer<vtkPolyData> GlyphPolyData;
+  vtkSmartPointer<vtkPolyDataMapper> GlyphMapper;
+  vtkSmartPointer<vtkActor> GlyphActor;
+  vtkSmartPointer<vtkSphereSource> GlyphSource;
+
+  /// Selection-highlight actor — a sphere drawn at the currently
+  /// hovered or dragged point.  Visible only when the widget is in
+  /// ``Hovering`` or ``Dragging`` substate.  ADR-0014 §3 commits to
+  /// no specific visual treatment — this is a minimal placeholder
+  /// that survives until per-role glyph design lands in the T2 UX
+  /// follow-on per ADR-0009 §3.
+  vtkSmartPointer<vtkActor> HighlightActor;
+  vtkSmartPointer<vtkSphereSource> HighlightSource;
+  vtkSmartPointer<vtkPolyDataMapper> HighlightMapper;
+
+  /// Picker used by ``Pick(X, Y)`` to resolve cursor → point index.
+  vtkSmartPointer<vtkPropPicker> Picker;
+
+  /// MTime of the data node at the last ``UpdatePickableGlyphs`` call;
+  /// used to short-circuit rebuilds when no geometry-bearing field has
+  /// changed.
+  vtkMTimeType LastBuildDataMTime;
+
+private:
+  vtkLiverBezierRepresentation(const vtkLiverBezierRepresentation&) = delete;
+  void operator=(const vtkLiverBezierRepresentation&) = delete;
+};
+
+#endif //__vtklivebezierrepresentation_h_

--- a/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
@@ -1,0 +1,434 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the T2 LiverResections all-in migration (Stack 2 of the
+  v2.0.0 release tracker — see ADR-0014 §3).
+
+==============================================================================*/
+
+#include "vtkLiverBezierWidget.h"
+
+// MRML includes
+#include <vtkMRMLBezierSurfaceNode.h>
+
+// VTK includes
+#include <vtkActor.h>
+#include <vtkCallbackCommand.h>
+#include <vtkCommand.h>
+#include <vtkEvent.h>
+#include <vtkObjectFactory.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+#include <vtkWidgetCallbackMapper.h>
+#include <vtkWidgetEvent.h>
+#include <vtkWidgetEventTranslator.h>
+
+//------------------------------------------------------------------------------
+vtkStandardNewMacro(vtkLiverBezierWidget);
+
+//------------------------------------------------------------------------------
+vtkLiverBezierWidget::vtkLiverBezierWidget()
+  : WidgetState(Start)
+  , PickedRole(vtkLiverBezierRepresentation::PickRole_None)
+  , PickedIndex(-1)
+{
+  this->DragAnchorWorld[0] = 0.0;
+  this->DragAnchorWorld[1] = 0.0;
+  this->DragAnchorWorld[2] = 0.0;
+  this->ManagesCursor = 1;
+
+  // ADR-0014 §3 — explicit event table.  The Markups widget retired by
+  // this design hardwired right-click to its own ``WidgetEventMenu``;
+  // here right-click maps to a widget-specific event we own.
+  //
+  // Left-drag = per-point manipulation.  ``Select`` advances to
+  // ``Dragging`` on a successful pick; ``EndSelect`` returns to
+  // ``Start``; ``Move`` updates the point if Dragging.
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::LeftButtonPressEvent,
+                                          vtkWidgetEvent::Select,
+                                          this,
+                                          vtkLiverBezierWidget::SelectAction);
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::LeftButtonReleaseEvent,
+                                          vtkWidgetEvent::EndSelect,
+                                          this,
+                                          vtkLiverBezierWidget::EndSelectAction);
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::MouseMoveEvent,
+                                          vtkWidgetEvent::Move,
+                                          this,
+                                          vtkLiverBezierWidget::MoveAction);
+
+  // Right-drag / right-click — registered so the event table is
+  // *visible* in this PR; the callbacks are no-op placeholders
+  // pending TODO(T2.3 right-drag-ring-group) and
+  // TODO(T2.3 right-click-context-menu).  Wiring the registrations
+  // here means upstream interactor events route into the widget
+  // (rather than falling through to the Markups widget or the
+  // default 3-D-camera bindings), making the future iterations a
+  // pure callback-body edit.
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::RightButtonPressEvent,
+                                          vtkWidgetEvent::Select3D,
+                                          this,
+                                          vtkLiverBezierWidget::RightSelectAction);
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::RightButtonReleaseEvent,
+                                          vtkWidgetEvent::EndSelect3D,
+                                          this,
+                                          vtkLiverBezierWidget::RightEndSelectAction);
+}
+
+//------------------------------------------------------------------------------
+vtkLiverBezierWidget::~vtkLiverBezierWidget() = default;
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "WidgetState: " << this->WidgetState << "\n";
+  os << indent << "PickedRole: " << this->PickedRole << "\n";
+  os << indent << "PickedIndex: " << this->PickedIndex << "\n";
+  os << indent << "BezierNode: " << (this->BezierNode.GetPointer() ? "set" : "(null)") << "\n";
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::CreateDefaultRepresentation()
+{
+  if (!this->WidgetRep)
+  {
+    vtkNew<vtkLiverBezierRepresentation> rep;
+    this->SetRepresentation(rep.GetPointer());
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::SetRepresentation(vtkLiverBezierRepresentation* r)
+{
+  this->Superclass::SetWidgetRepresentation(reinterpret_cast<vtkWidgetRepresentation*>(r));
+  if (r && this->BezierNode.GetPointer())
+  {
+    r->SetBezierNode(this->BezierNode.GetPointer());
+  }
+}
+
+//------------------------------------------------------------------------------
+vtkLiverBezierRepresentation* vtkLiverBezierWidget::GetLiverBezierRepresentation()
+{
+  return reinterpret_cast<vtkLiverBezierRepresentation*>(this->WidgetRep);
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::SetBezierNode(vtkMRMLBezierSurfaceNode* node)
+{
+  this->BezierNode = node;
+  if (auto* rep = this->GetLiverBezierRepresentation())
+  {
+    rep->SetBezierNode(node);
+  }
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLBezierSurfaceNode* vtkLiverBezierWidget::GetBezierNode()
+{
+  return this->BezierNode.GetPointer();
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::SetEnabled(int enabling)
+{
+  this->Superclass::SetEnabled(enabling);
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::SetWidgetState(int state)
+{
+  if (state == this->WidgetState)
+  {
+    return;
+  }
+  this->WidgetState = state;
+  if (state == Start)
+  {
+    this->PickedRole = vtkLiverBezierRepresentation::PickRole_None;
+    this->PickedIndex = -1;
+  }
+}
+
+//------------------------------------------------------------------------------
+bool vtkLiverBezierWidget::BeginLeftDragAt(int X, int Y)
+{
+  this->CreateDefaultRepresentation();
+  auto* rep = this->GetLiverBezierRepresentation();
+  if (!rep)
+  {
+    return false;
+  }
+  vtkMRMLBezierSurfaceNode* node = this->BezierNode.GetPointer();
+  if (!node)
+  {
+    return false;
+  }
+  vtkLiverBezierRepresentation::PickResult pick = rep->Pick(X, Y);
+  if (pick.Role == vtkLiverBezierRepresentation::PickRole_None)
+  {
+    return false;
+  }
+
+  // ADR-0014 §4 — reject the drag start if the picked role would
+  // mutate read-only audit data (init-mode point in Planning state).
+  // ``Pick`` already guards against returning init-mode hits in
+  // Planning, but the widget keeps a belt-and-braces second check
+  // here so a future loosening of ``Pick`` (e.g. for hover-only
+  // tooltips on read-only audit points) does not silently re-enable
+  // the drag path.
+  if (node->GetState() == vtkMRMLBezierSurfaceNode::Planning
+      && pick.Role != vtkLiverBezierRepresentation::PickRole_ControlPoint)
+  {
+    return false;
+  }
+
+  // Cache the anchor world position so ``DragTo`` can project the
+  // mouse onto a stable plane parallel to the camera.
+  switch (pick.Role)
+  {
+    case vtkLiverBezierRepresentation::PickRole_ControlPoint:
+    {
+      const double* grid = node->GetControlGrid();
+      this->DragAnchorWorld[0] = grid[pick.Index * 3 + 0];
+      this->DragAnchorWorld[1] = grid[pick.Index * 3 + 1];
+      this->DragAnchorWorld[2] = grid[pick.Index * 3 + 2];
+      break;
+    }
+    case vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit:
+    {
+      const double* p = node->GetSlicingPlaneInitPoint(pick.Index);
+      if (!p)
+      {
+        return false;
+      }
+      this->DragAnchorWorld[0] = p[0];
+      this->DragAnchorWorld[1] = p[1];
+      this->DragAnchorWorld[2] = p[2];
+      break;
+    }
+    case vtkLiverBezierRepresentation::PickRole_DistanceSpheroidInit:
+    {
+      const double* p = node->GetDistanceSpheroidInitPoint(pick.Index);
+      if (!p)
+      {
+        return false;
+      }
+      this->DragAnchorWorld[0] = p[0];
+      this->DragAnchorWorld[1] = p[1];
+      this->DragAnchorWorld[2] = p[2];
+      break;
+    }
+    default:
+      return false;
+  }
+
+  this->PickedRole = pick.Role;
+  this->PickedIndex = pick.Index;
+  this->WidgetState = Dragging;
+  this->InvokeEvent(vtkCommand::StartInteractionEvent, nullptr);
+  return true;
+}
+
+//------------------------------------------------------------------------------
+bool vtkLiverBezierWidget::DragTo(int X, int Y, double worldOut[3])
+{
+  if (this->WidgetState != Dragging)
+  {
+    return false;
+  }
+  auto* rep = this->GetLiverBezierRepresentation();
+  if (!rep)
+  {
+    return false;
+  }
+  double world[3] = { 0.0, 0.0, 0.0 };
+  if (!rep->DisplayToWorld(X, Y, this->DragAnchorWorld, world))
+  {
+    return false;
+  }
+  if (!this->ApplyPickedPointWorld(world))
+  {
+    return false;
+  }
+  if (worldOut)
+  {
+    worldOut[0] = world[0];
+    worldOut[1] = world[1];
+    worldOut[2] = world[2];
+  }
+  // Advance the anchor — keeps the drag plane stable across long
+  // gestures (otherwise the cursor would slowly slide off the original
+  // anchor plane as the user moves through Z).
+  this->DragAnchorWorld[0] = world[0];
+  this->DragAnchorWorld[1] = world[1];
+  this->DragAnchorWorld[2] = world[2];
+  this->InvokeEvent(vtkCommand::InteractionEvent, nullptr);
+  return true;
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::EndLeftDrag()
+{
+  if (this->WidgetState != Dragging)
+  {
+    return;
+  }
+  this->SetWidgetState(Start);
+  this->InvokeEvent(vtkCommand::EndInteractionEvent, nullptr);
+}
+
+//------------------------------------------------------------------------------
+bool vtkLiverBezierWidget::ApplyPickedPointWorld(const double world[3])
+{
+  vtkMRMLBezierSurfaceNode* node = this->BezierNode.GetPointer();
+  if (!node || !world)
+  {
+    return false;
+  }
+  switch (this->PickedRole)
+  {
+    case vtkLiverBezierRepresentation::PickRole_ControlPoint:
+    {
+      if (this->PickedIndex < 0
+          || this->PickedIndex
+            >= vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize)
+      {
+        return false;
+      }
+      // SetControlGrid takes the full 48-double array; copy current,
+      // patch the picked point, push back.
+      double values[vtkMRMLBezierSurfaceNode::ControlGridSize];
+      const double* current = node->GetControlGrid();
+      for (int i = 0; i < vtkMRMLBezierSurfaceNode::ControlGridSize; ++i)
+      {
+        values[i] = current[i];
+      }
+      values[this->PickedIndex * 3 + 0] = world[0];
+      values[this->PickedIndex * 3 + 1] = world[1];
+      values[this->PickedIndex * 3 + 2] = world[2];
+      return node->SetControlGrid(values);
+    }
+    case vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit:
+      return node->SetSlicingPlaneInitPoint(this->PickedIndex, world);
+    case vtkLiverBezierRepresentation::PickRole_DistanceSpheroidInit:
+      return node->SetDistanceSpheroidInitPoint(this->PickedIndex, world);
+    default:
+      return false;
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::SelectAction(vtkAbstractWidget* w)
+{
+  auto* self = static_cast<vtkLiverBezierWidget*>(w);
+  if (!self->Interactor)
+  {
+    return;
+  }
+  const int X = self->Interactor->GetEventPosition()[0];
+  const int Y = self->Interactor->GetEventPosition()[1];
+  if (self->BeginLeftDragAt(X, Y))
+  {
+    // Capture event so the camera-trackball bindings don't fight us.
+    self->EventCallbackCommand->SetAbortFlag(1);
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::EndSelectAction(vtkAbstractWidget* w)
+{
+  auto* self = static_cast<vtkLiverBezierWidget*>(w);
+  if (self->WidgetState != Dragging)
+  {
+    return;
+  }
+  self->EndLeftDrag();
+  self->EventCallbackCommand->SetAbortFlag(1);
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::MoveAction(vtkAbstractWidget* w)
+{
+  auto* self = static_cast<vtkLiverBezierWidget*>(w);
+  if (!self->Interactor)
+  {
+    return;
+  }
+  const int X = self->Interactor->GetEventPosition()[0];
+  const int Y = self->Interactor->GetEventPosition()[1];
+  if (self->WidgetState == Dragging)
+  {
+    double world[3] = { 0.0, 0.0, 0.0 };
+    self->DragTo(X, Y, world);
+    self->EventCallbackCommand->SetAbortFlag(1);
+  }
+  else
+  {
+    // Hover update — pick test only, no state change beyond
+    // ``Start`` <-> ``Hovering``.
+    auto* rep = self->GetLiverBezierRepresentation();
+    if (!rep)
+    {
+      return;
+    }
+    vtkLiverBezierRepresentation::PickResult hit = rep->Pick(X, Y);
+    self->SetWidgetState(hit.Role == vtkLiverBezierRepresentation::PickRole_None ? Start
+                                                                                 : Hovering);
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::RightSelectAction(vtkAbstractWidget* w)
+{
+  // TODO(T2.3 right-drag-ring-group) — translate / rotate / scale the
+  // ring group (corners 4 / edges 8 / interior 4 per ADR-0014 §3) as
+  // a unit while right-button is held.
+  // TODO(T2.3 right-click-context-menu) — if the right-drag does not
+  // exceed the drag threshold, open the widget's own context menu
+  // on release.  vtkSlicerMarkupsWidget's ``WidgetEventMenu`` /
+  // ``populateContextMenu`` would compete here; the whole point of
+  // subclassing vtkAbstractWidget directly is that those bindings do
+  // not pre-empt this one.
+  static_cast<void>(w);
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverBezierWidget::RightEndSelectAction(vtkAbstractWidget* w)
+{
+  // TODO(T2.3 right-drag-ring-group) end-of-gesture cleanup.
+  // TODO(T2.3 right-click-context-menu) context-menu launch.
+  static_cast<void>(w);
+}

--- a/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
@@ -80,13 +80,13 @@ vtkLiverBezierWidget::vtkLiverBezierWidget()
   this->CallbackMapper->SetCallbackMethod(vtkCommand::MouseMoveEvent, vtkWidgetEvent::Move, this, vtkLiverBezierWidget::MoveAction);
 
   // Right-drag / right-click — registered so the event table is
-  // *visible* in this PR; the callbacks are no-op placeholders
-  // pending TODO(T2.3 right-drag-ring-group) and
+  // *visible* now; the callbacks are no-op placeholders pending
+  // TODO(T2.3 right-drag-ring-group) and
   // TODO(T2.3 right-click-context-menu).  Wiring the registrations
   // here means upstream interactor events route into the widget
   // (rather than falling through to the Markups widget or the
-  // default 3-D-camera bindings), making the future iterations a
-  // pure callback-body edit.
+  // default 3-D-camera bindings), making later iterations a pure
+  // callback-body edit.
   this->CallbackMapper->SetCallbackMethod(vtkCommand::RightButtonPressEvent, vtkWidgetEvent::Select3D, this, vtkLiverBezierWidget::RightSelectAction);
   this->CallbackMapper->SetCallbackMethod(vtkCommand::RightButtonReleaseEvent, vtkWidgetEvent::EndSelect3D, this, vtkLiverBezierWidget::RightEndSelectAction);
 }
@@ -117,7 +117,7 @@ void vtkLiverBezierWidget::CreateDefaultRepresentation()
 //------------------------------------------------------------------------------
 void vtkLiverBezierWidget::SetRepresentation(vtkLiverBezierRepresentation* r)
 {
-  this->Superclass::SetWidgetRepresentation(reinterpret_cast<vtkWidgetRepresentation*>(r));
+  this->Superclass::SetWidgetRepresentation(r);
   if (r && this->BezierNode.GetPointer())
   {
     r->SetBezierNode(this->BezierNode.GetPointer());
@@ -127,7 +127,7 @@ void vtkLiverBezierWidget::SetRepresentation(vtkLiverBezierRepresentation* r)
 //------------------------------------------------------------------------------
 vtkLiverBezierRepresentation* vtkLiverBezierWidget::GetLiverBezierRepresentation()
 {
-  return reinterpret_cast<vtkLiverBezierRepresentation*>(this->WidgetRep);
+  return static_cast<vtkLiverBezierRepresentation*>(this->WidgetRep);
 }
 
 //------------------------------------------------------------------------------

--- a/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
@@ -75,18 +75,9 @@ vtkLiverBezierWidget::vtkLiverBezierWidget()
   // Left-drag = per-point manipulation.  ``Select`` advances to
   // ``Dragging`` on a successful pick; ``EndSelect`` returns to
   // ``Start``; ``Move`` updates the point if Dragging.
-  this->CallbackMapper->SetCallbackMethod(vtkCommand::LeftButtonPressEvent,
-                                          vtkWidgetEvent::Select,
-                                          this,
-                                          vtkLiverBezierWidget::SelectAction);
-  this->CallbackMapper->SetCallbackMethod(vtkCommand::LeftButtonReleaseEvent,
-                                          vtkWidgetEvent::EndSelect,
-                                          this,
-                                          vtkLiverBezierWidget::EndSelectAction);
-  this->CallbackMapper->SetCallbackMethod(vtkCommand::MouseMoveEvent,
-                                          vtkWidgetEvent::Move,
-                                          this,
-                                          vtkLiverBezierWidget::MoveAction);
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::LeftButtonPressEvent, vtkWidgetEvent::Select, this, vtkLiverBezierWidget::SelectAction);
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::LeftButtonReleaseEvent, vtkWidgetEvent::EndSelect, this, vtkLiverBezierWidget::EndSelectAction);
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::MouseMoveEvent, vtkWidgetEvent::Move, this, vtkLiverBezierWidget::MoveAction);
 
   // Right-drag / right-click — registered so the event table is
   // *visible* in this PR; the callbacks are no-op placeholders
@@ -96,14 +87,8 @@ vtkLiverBezierWidget::vtkLiverBezierWidget()
   // (rather than falling through to the Markups widget or the
   // default 3-D-camera bindings), making the future iterations a
   // pure callback-body edit.
-  this->CallbackMapper->SetCallbackMethod(vtkCommand::RightButtonPressEvent,
-                                          vtkWidgetEvent::Select3D,
-                                          this,
-                                          vtkLiverBezierWidget::RightSelectAction);
-  this->CallbackMapper->SetCallbackMethod(vtkCommand::RightButtonReleaseEvent,
-                                          vtkWidgetEvent::EndSelect3D,
-                                          this,
-                                          vtkLiverBezierWidget::RightEndSelectAction);
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::RightButtonPressEvent, vtkWidgetEvent::Select3D, this, vtkLiverBezierWidget::RightSelectAction);
+  this->CallbackMapper->SetCallbackMethod(vtkCommand::RightButtonReleaseEvent, vtkWidgetEvent::EndSelect3D, this, vtkLiverBezierWidget::RightEndSelectAction);
 }
 
 //------------------------------------------------------------------------------
@@ -209,8 +194,7 @@ bool vtkLiverBezierWidget::BeginLeftDragAt(int X, int Y)
   // here so a future loosening of ``Pick`` (e.g. for hover-only
   // tooltips on read-only audit points) does not silently re-enable
   // the drag path.
-  if (node->GetState() == vtkMRMLBezierSurfaceNode::Planning
-      && pick.Role != vtkLiverBezierRepresentation::PickRole_ControlPoint)
+  if (node->GetState() == vtkMRMLBezierSurfaceNode::Planning && pick.Role != vtkLiverBezierRepresentation::PickRole_ControlPoint)
   {
     return false;
   }
@@ -251,8 +235,7 @@ bool vtkLiverBezierWidget::BeginLeftDragAt(int X, int Y)
       this->DragAnchorWorld[2] = p[2];
       break;
     }
-    default:
-      return false;
+    default: return false;
   }
 
   this->PickedRole = pick.Role;
@@ -322,9 +305,7 @@ bool vtkLiverBezierWidget::ApplyPickedPointWorld(const double world[3])
   {
     case vtkLiverBezierRepresentation::PickRole_ControlPoint:
     {
-      if (this->PickedIndex < 0
-          || this->PickedIndex
-            >= vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize)
+      if (this->PickedIndex < 0 || this->PickedIndex >= vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize)
       {
         return false;
       }
@@ -341,12 +322,9 @@ bool vtkLiverBezierWidget::ApplyPickedPointWorld(const double world[3])
       values[this->PickedIndex * 3 + 2] = world[2];
       return node->SetControlGrid(values);
     }
-    case vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit:
-      return node->SetSlicingPlaneInitPoint(this->PickedIndex, world);
-    case vtkLiverBezierRepresentation::PickRole_DistanceSpheroidInit:
-      return node->SetDistanceSpheroidInitPoint(this->PickedIndex, world);
-    default:
-      return false;
+    case vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit: return node->SetSlicingPlaneInitPoint(this->PickedIndex, world);
+    case vtkLiverBezierRepresentation::PickRole_DistanceSpheroidInit: return node->SetDistanceSpheroidInitPoint(this->PickedIndex, world);
+    default: return false;
   }
 }
 
@@ -405,8 +383,7 @@ void vtkLiverBezierWidget::MoveAction(vtkAbstractWidget* w)
       return;
     }
     vtkLiverBezierRepresentation::PickResult hit = rep->Pick(X, Y);
-    self->SetWidgetState(hit.Role == vtkLiverBezierRepresentation::PickRole_None ? Start
-                                                                                 : Hovering);
+    self->SetWidgetState(hit.Role == vtkLiverBezierRepresentation::PickRole_None ? Start : Hovering);
   }
 }
 

--- a/LiverResections/VTKWidgets/vtkLiverBezierWidget.h
+++ b/LiverResections/VTKWidgets/vtkLiverBezierWidget.h
@@ -1,0 +1,215 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the T2 LiverResections all-in migration (Stack 2 of the
+  v2.0.0 release tracker — see ADR-0014 §3).
+
+==============================================================================*/
+
+#ifndef __vtkliverbezierwidget_h_
+#define __vtkliverbezierwidget_h_
+
+#include "vtkSlicerLiverResectionsModuleVTKWidgetsExport.h"
+
+// VTK includes
+#include <vtkAbstractWidget.h>
+#include <vtkWeakPointer.h>
+
+#include "vtkLiverBezierRepresentation.h"
+
+class vtkMRMLBezierSurfaceNode;
+
+/**
+ * \class vtkLiverBezierWidget
+ *
+ * \brief Custom VTK widget for the Bezier-surface resection planning
+ *        workflow.
+ *
+ * Subclasses ``vtkAbstractWidget`` directly (NOT ``vtkSlicerMarkupsWidget``)
+ * so the event table is free of the Markups-widget assumptions
+ * documented in ADR-0014 §3.  Owns the explicit event vocabulary:
+ *
+ *   - **Left-drag** = per-point control-grid manipulation (move a
+ *     single control point or init point under the cursor).
+ *   - **Right-drag** = ring-group manipulation
+ *     (TODO(T2.3 right-drag-ring-group)).
+ *   - **Right-click** = own context menu
+ *     (TODO(T2.3 right-click-context-menu); the reason for subclassing
+ *     vtkAbstractWidget directly rather than vtkSlicerMarkupsWidget,
+ *     whose ``WidgetEventMenu`` / ``populateContextMenu`` constrains
+ *     the menu shape).
+ *
+ * The current PR lands the skeleton + left-drag only.  The other two
+ * event flows ship in the named TODO follow-ups; the state-machine
+ * substates for them are reserved at the enum level but the
+ * callbacks are placeholders.
+ *
+ * The widget observes a ``vtkMRMLBezierSurfaceNode`` and mutates its
+ * control grid / init points via ``SetControlGrid`` /
+ * ``SetSlicingPlaneInitPoint`` / ``SetDistanceSpheroidInitPoint``.
+ * Per ADR-0014 §4 the data node enforces the read-only-after-Planning
+ * invariant on init-mode setters; the widget mirrors that by gating
+ * pickability through ``vtkLiverBezierRepresentation::Pick`` (which
+ * does *not* return init-mode hits in Planning state).
+ *
+ * \par Test discipline
+ *
+ * The widget can be exercised standalone (no Slicer scene, no Qt) per
+ * ADR-0008 §2; ``vtkLiverBezierWidgetTest1`` drives event dispatch
+ * via direct ``SelectAction`` / ``MoveAction`` / ``EndSelectAction``
+ * calls on a stub ``vtkRenderWindowInteractor`` (the headless test
+ * pattern used by the upstream ``vtkLineWidget2Test1``).
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkLiverBezierWidget
+  : public vtkAbstractWidget
+{
+public:
+  static vtkLiverBezierWidget* New();
+  vtkTypeMacro(vtkLiverBezierWidget, vtkAbstractWidget);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Internal state machine (ADR-0014 §3).  Pin enum values explicitly
+  /// so a future reorder does not silently shift downstream test
+  /// expectations.
+  ///
+  /// - ``Start``         — idle, no interaction in flight.
+  /// - ``Hovering``      — cursor over a pickable primitive.
+  /// - ``Dragging``      — left-mouse held over a pickable point.
+  /// - ``GroupDragging`` — right-drag of a ring group
+  ///                       (TODO(T2.3 right-drag-ring-group)).
+  /// - ``ContextMenu``   — right-click context menu in flight
+  ///                       (TODO(T2.3 right-click-context-menu)).
+  enum WidgetStateType
+  {
+    Start = 0,
+    Hovering = 1,
+    Dragging = 2,
+    GroupDragging = 3,
+    ContextMenu = 4,
+  };
+
+  /// Get / set the widget substate.  Setting Start clears the picked
+  /// point cache.
+  vtkGetMacro(WidgetState, int);
+  void SetWidgetState(int state);
+
+  /// Set / get the representation.  Type-constrains the
+  /// ``Superclass::SetWidgetRepresentation`` signature.
+  void SetRepresentation(vtkLiverBezierRepresentation* r);
+  vtkLiverBezierRepresentation* GetLiverBezierRepresentation();
+
+  /// Attach / detach the data node the widget mutates.  The data node
+  /// is also pushed onto the representation so picking stays in sync.
+  void SetBezierNode(vtkMRMLBezierSurfaceNode* node);
+  vtkMRMLBezierSurfaceNode* GetBezierNode();
+
+  //--------------------------------------------------------------------------
+  // vtkAbstractWidget interface
+  //--------------------------------------------------------------------------
+  void CreateDefaultRepresentation() override;
+
+  /// Standard VTK widget enable/disable; routes the priority observer
+  /// add/remove path through ``vtkAbstractWidget::SetEnabled``.
+  void SetEnabled(int enabling) override;
+
+  //--------------------------------------------------------------------------
+  // Test surface — public so tests can drive event dispatch without
+  // an interactor.  ADR-0008 §2 ctkTest scope.
+  //--------------------------------------------------------------------------
+
+  /// Begin a left-drag interaction at display ``(X, Y)``.  Returns
+  /// true if the press landed on a pickable primitive (advancing the
+  /// state machine to ``Dragging``); false otherwise.  Mirrors the
+  /// ``LeftButtonPressEvent`` path.
+  bool BeginLeftDragAt(int X, int Y);
+
+  /// Update the currently-dragged point to display ``(X, Y)``.  No-op
+  /// outside ``Dragging``.  Returns the resolved world-space
+  /// coordinate the data node was updated to.
+  bool DragTo(int X, int Y, double worldOut[3]);
+
+  /// End the current left-drag.  Resets to ``Start`` substate.
+  void EndLeftDrag();
+
+  /// Index of the picked point in the active role (control grid,
+  /// SlicingPlane init, DistanceSpheroid init).  -1 when no pick.
+  vtkGetMacro(PickedIndex, int);
+
+  /// Role of the picked point.
+  vtkGetMacro(PickedRole, int);
+
+protected:
+  vtkLiverBezierWidget();
+  ~vtkLiverBezierWidget() override;
+
+  /// VTK callback-mapper entry points.  These are the targets the
+  /// widget event translator dispatches to; they unpack ``self`` and
+  /// route into the instance helpers above.  Each marks the boundary
+  /// between the upstream ``vtkAbstractWidget`` callback ABI and the
+  /// instance-method test surface.
+  static void SelectAction(vtkAbstractWidget* w);
+  static void EndSelectAction(vtkAbstractWidget* w);
+  static void MoveAction(vtkAbstractWidget* w);
+  static void RightSelectAction(vtkAbstractWidget* w);
+  static void RightEndSelectAction(vtkAbstractWidget* w);
+
+  /// Write ``world`` back to the data node at the currently picked
+  /// (role, index).  Routes through the read-only-after-Planning
+  /// guards on the data node per ADR-0014 §4.  Returns the data
+  /// node's accept signal (true = mutation landed; false = rejected
+  /// or no-op).
+  bool ApplyPickedPointWorld(const double world[3]);
+
+  /// Cache the world-space anchor of the currently dragged point so
+  /// ``DisplayToWorld`` can keep the cursor's drag plane coherent
+  /// across the gesture.
+  double DragAnchorWorld[3];
+
+  /// Substate.
+  int WidgetState;
+
+  /// Pick result cached from the last successful press.
+  int PickedRole;
+  int PickedIndex;
+
+  /// Data node the widget mutates.  Held as vtkWeakPointer; the
+  /// scene / module owner keeps the strong reference.
+  vtkWeakPointer<vtkMRMLBezierSurfaceNode> BezierNode;
+
+private:
+  vtkLiverBezierWidget(const vtkLiverBezierWidget&) = delete;
+  void operator=(const vtkLiverBezierWidget&) = delete;
+};
+
+#endif //__vtkliverbezierwidget_h_

--- a/LiverResections/VTKWidgets/vtkLiverBezierWidget.h
+++ b/LiverResections/VTKWidgets/vtkLiverBezierWidget.h
@@ -91,8 +91,7 @@ class vtkMRMLBezierSurfaceNode;
  * calls on a stub ``vtkRenderWindowInteractor`` (the headless test
  * pattern used by the upstream ``vtkLineWidget2Test1``).
  */
-class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkLiverBezierWidget
-  : public vtkAbstractWidget
+class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkLiverBezierWidget : public vtkAbstractWidget
 {
 public:
   static vtkLiverBezierWidget* New();


### PR DESCRIPTION
## Summary

Per **ADR-0014 §3**, lands the custom VTK widget for the Bezier-surface
resection-planning workflow.  The widget subclasses **`vtkAbstractWidget`
directly** — NOT `vtkSlicerMarkupsWidget` — so the event table is free
of the Markups-widget assumptions ADR-0014 §3 enumerates.

### Scoping choice: **Option B** (skeleton + left-drag)

Per the brief's two-option scoping, I chose Option B over Option A.
Rationale:

- The full widget (Option A) would have to land all three event flows
  (left-drag, right-drag with ring-group resolution + drag math,
  right-click with a custom context menu) in a single PR — comfortably
  ≥1500 LOC + 4 test sub-blocks per flow, beyond reviewable single-PR
  size.
- Option B mirrors the **T2.2 iteration 1** pattern already in
  `preview` (`LiverBezierSurfacePipeline` landed in 3 iterations under
  3 PRs).  It gets the lifecycle plumbing — event-translator
  registration, callback-mapper wiring, state-machine substates,
  picker, representation lifecycle — into `preview` so the two
  follow-on iterations are callback-body edits, not architectural
  re-litigation.
- The state-machine substates for the deferred flows (`GroupDragging`,
  `ContextMenu`) are **reserved at the enum level** in this PR, and
  the right-button event translations are wired through the
  callback mapper.  The future iterations only have to fill in
  placeholder callback bodies.

### Event table (ADR-0014 §3)

| Gesture     | Event                  | Status        |
|-------------|------------------------|---------------|
| Left-drag   | per-point manipulation | **wired**     |
| Right-drag  | ring-group manipulation | `TODO(T2.3 right-drag-ring-group)` |
| Right-click | widget's own context menu | `TODO(T2.3 right-click-context-menu)` |

### State-machine substates (ADR-0014 §3)

| Substate         | Status     |
|------------------|------------|
| `Start`          | implemented |
| `Hovering`       | implemented |
| `Dragging`       | implemented (left-drag) |
| `GroupDragging`  | enum reserved; populated by `TODO(T2.3 right-drag-ring-group)` |
| `ContextMenu`    | enum reserved; populated by `TODO(T2.3 right-click-context-menu)` |

### Data-node contract (ADR-0014 §1, §4)

The widget mutates `vtkMRMLBezierSurfaceNode` directly via
`SetControlGrid` / `SetSlicingPlaneInitPoint` /
`SetDistanceSpheroidInitPoint`.  The read-only-after-Planning
invariant (ADR-0014 §4) is enforced at two layers: the data node
rejects init-point setters in Planning state (already in `preview`),
and the widget gates pickability via
`vtkLiverBezierRepresentation::Pick` so init points are not pickable
in Planning state and the `Dragging` substate cannot enter on a
rejected role.

### Language band (ADR-0013 §1, ADR-0004)

C++ because it is perf-critical (per-frame interaction during drag).
This sits alongside the **LayerDM-Pipeline** `BezierPlanningRepresentation`
(Python, decoration / per-frame render path) — the two "representation"
patterns coexist by accident of vocabulary; this widget's
representation is the `vtkWidgetRepresentation`-pattern interaction-
time actor host, separate from the Pipeline's display-side
representation.

### Tests (ADR-0008 §2)

`vtkLiverBezierWidgetTest1` is a ctkTest driver — no Slicer scene, no
Qt, no on-screen render window.  Coverage:

- Constructor / `SetWidgetState` lifecycle
  (Start → Hovering → Dragging → Start).
- Picking a control point at a known coordinate returns the right
  point index + role.
- `BeginLeftDragAt` + `DragTo` + `EndLeftDrag` mutates the data node's
  control grid as expected.
- Read-only enforcement: in `state=Planning`, init-mode drag attempts
  are rejected; the widget does **not** enter `Dragging` on an
  init-mode pick, and the data node's per-setter `vtkWarningMacro`
  fires under `TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN/END`.

The test uses `vtkGenericOpenGLRenderWindow` (software-only, no X/EGL)
to satisfy the renderer's display-to-world math requirements without
triggering the upstream `vtkXOpenGLRenderWindow` "bad X server
connection" warning that `WITH_VTK_ERROR_OUTPUT_CHECK` would catch.

## Legacy widget stays put

The legacy `vtkSlicerMarkupsBezierSurfaceWidget` under
`LiverMarkups/VTKWidgets/` stays in place — **T2.7 retires it**, after
T2.6 (registration in `qSlicerLiverResectionsModule::setup()`) wires
the new widget in.

## Deferred (out of scope per the brief)

- **T2.5** — storage node (parallel agent).
- **T2.6** — module registration / wiring.
- **T2.7** — legacy widget retirement.
- **`TODO(T2-mapper-relocation)`** — the four OpenGL mappers relocated
  from `LiverMarkups/VTKWidgets/` (ADR-0014 §3); the LayerDM Pipeline
  keeps the surface render path through that follow-on.
- **`TODO(T2-target-mesh-weakref)`** — target-mesh weakref handling.

## TODO markers left in source

- `TODO(T2.3 right-drag-ring-group)` — ring-group manipulation event
  flow.
- `TODO(T2.3 right-click-context-menu)` — widget's own context menu.
- `TODO(T2-mapper-relocation)` — OpenGL mappers relocation.
- `TODO(T2-target-mesh-weakref)` — target-mesh weakref handling.

## Test plan

- [x] Local build clean against
      `/home/rafael/src/Slicer-Liver-bezier-widget-build`
      (Slicer-main qt6 Release).
- [x] `ctest -L vtkSlicerLiverResectionsModule` — 11/11 pass
      including `vtkLiverBezierWidgetTest1`.
- [x] No regressions on the existing low-level tests
      (`vtkSlicerLiverResectionsModuleAlgorithm`,
      `vtkSlicerLiverResectionsModuleMRML`).
- [x] No `PR #…` / `#…` references in source comments
      (`feedback_no_pr_refs_in_code.md`).
- [x] Commit message follows the strict Slicer regex
      `^(ENH|PERF|BUG|STYLE|DOC|COMP): ([A-Z])+`.
- [ ] CI green (full Qt-integration tests need the offscreen QT_QPA
      plugin; pre-existing on this host, see e.g. `preview` HEAD
      `a9579d4`).

---

*AI-assisted authorship: this pull request was drafted with help from
Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code.
Opened for human review before merge.*