### PR TITLE
ENH: Add vtkMRMLBezierSurfaceStorageNode (T2.5 + .lrp.json schema v1)

### DIFF
--- a/LiverResections/MRML/CMakeLists.txt
+++ b/LiverResections/MRML/CMakeLists.txt
@@ -15,6 +15,8 @@ set(${KIT}_SRCS
   vtkMRMLBezierSurfaceNode.cxx
   vtkMRMLBezierSurfaceDisplayNode.h
   vtkMRMLBezierSurfaceDisplayNode.cxx
+  vtkMRMLBezierSurfaceStorageNode.h
+  vtkMRMLBezierSurfaceStorageNode.cxx
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -23,6 +23,13 @@ set(KIT_TEST_SRCS
 add_definitions(-DLIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/Fixtures\")
 
 #-----------------------------------------------------------------------------
+# Pass a writable temp dir (the standard CMake binary-tree temporary
+# directory) through to the test driver so the JSON round-trip test
+# does not depend on POSIX TMPDIR / /tmp semantics.
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/Testing/Temporary)
+add_definitions(-DLIVER_BEZIER_STORAGE_TEST_TEMP_DIR=\"${CMAKE_BINARY_DIR}/Testing/Temporary\")
+
+#-----------------------------------------------------------------------------
 slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -11,7 +11,16 @@ set(KIT vtkSlicer${MODULE_NAME}ModuleMRML)
 set(KIT_TEST_SRCS
   vtkMRMLBezierSurfaceNodeTest1.cxx
   vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
+  vtkMRMLBezierSurfaceStorageNodeTest1.cxx
   )
+
+#-----------------------------------------------------------------------------
+# Pass the in-source Fixtures/ directory through to the test driver so
+# the legacy ``.lrp.fcsv`` fixture (committed under
+# Testing/Cxx/Fixtures/legacy_resection.lrp.fcsv) is locatable at run
+# time.  The macro is consumed by
+# ``vtkMRMLBezierSurfaceStorageNodeTest1.cxx`` (task T2.5).
+add_definitions(-DLIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/Fixtures\")
 
 #-----------------------------------------------------------------------------
 slicerMacroConfigureModuleCxxTestDriver(
@@ -27,3 +36,4 @@ slicerMacroConfigureModuleCxxTestDriver(
 
 SIMPLE_TEST(vtkMRMLBezierSurfaceNodeTest1)
 SIMPLE_TEST(vtkMRMLBezierSurfaceDisplayNodeTest1)
+SIMPLE_TEST(vtkMRMLBezierSurfaceStorageNodeTest1)

--- a/LiverResections/MRML/Testing/Cxx/Fixtures/legacy_resection.lrp.fcsv
+++ b/LiverResections/MRML/Testing/Cxx/Fixtures/legacy_resection.lrp.fcsv
@@ -1,0 +1,19 @@
+# Markups fiducial file version = 4.11
+# CoordinateSystem = LPS
+# columns = id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID
+vtkMRMLMarkupsFiducialNode_1,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-1,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_2,10.0,0.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-2,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_3,20.0,0.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-3,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_4,30.0,0.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-4,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_5,0.0,10.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-5,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_6,10.0,10.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-6,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_7,20.0,10.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-7,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_8,30.0,10.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-8,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_9,0.0,20.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-9,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_10,10.0,20.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-10,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_11,20.0,20.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-11,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_12,30.0,20.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-12,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_13,0.0,30.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-13,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_14,10.0,30.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-14,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_15,20.0,30.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-15,,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_16,30.0,30.0,0.0,0.0,0.0,0.0,1.0,1,1,0,P-16,,vtkMRMLScalarVolumeNode1

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Tests for vtkMRMLBezierSurfaceStorageNode — the new ``.lrp.json``
   storage node landed by task T2.5 per ADR-0014 §5.  Exercises:
@@ -40,10 +40,8 @@
 #include <sstream>
 #include <string>
 
-// POSIX include — ``getpid`` for unique-temp-path generation.  On
-// Windows the ctkTest harness does not build (the existing tests in
-// this directory are POSIX-only); guarded so the compile fails
-// loudly there rather than silently using a stale handle.
+// Portable getpid — used to disambiguate temp-file names within a
+// single test run.  ``_getpid`` on Windows, ``getpid`` on POSIX.
 #if defined(_WIN32)
 # include <process.h>
 # define LIVER_BEZIER_GETPID _getpid
@@ -55,26 +53,18 @@
 namespace
 {
 
-/// Generate a unique temp file path with the given extension.  No
-/// reliance on ``mkstemp`` (not portable on Windows) — we use a
-/// pid + counter scheme rooted under
-/// ``vtksys::SystemTools::GetEnv("TMPDIR")`` or ``/tmp`` so the
-/// test does not require the build-tree to be writable.
+/// Generate a unique temp file path with the given extension.  Rooted
+/// under ``LIVER_BEZIER_STORAGE_TEST_TEMP_DIR`` — the CMake binary
+/// tree's ``Testing/Temporary`` directory, resolved at configure time
+/// and guaranteed writable across Windows/macOS/Linux (the
+/// build-tree-relative path avoids POSIX ``TMPDIR`` / ``/tmp``
+/// reliance).  Uniqueness comes from pid + a static counter.
 std::string makeTempPath(const std::string& extension)
 {
   static int counter = 0;
   ++counter;
-  std::string tmpDir;
-  if (const char* env = std::getenv("TMPDIR"))
-  {
-    tmpDir = env;
-  }
-  else
-  {
-    tmpDir = "/tmp";
-  }
   std::ostringstream ss;
-  ss << tmpDir << "/vtkMRMLBezierSurfaceStorageNodeTest1_" << static_cast<long long>(LIVER_BEZIER_GETPID()) << "_" << counter << "." << extension;
+  ss << LIVER_BEZIER_STORAGE_TEST_TEMP_DIR << "/vtkMRMLBezierSurfaceStorageNodeTest1_" << static_cast<long long>(LIVER_BEZIER_GETPID()) << "_" << counter << "." << extension;
   return ss.str();
 }
 

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -1,0 +1,403 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Tests for vtkMRMLBezierSurfaceStorageNode — the new ``.lrp.json``
+  storage node landed by task T2.5 per ADR-0014 §5.  Exercises:
+
+   - JSON round-trip (populate → write → read → assert equality)
+   - schemaVersion mismatch rejection
+   - CanReadInReferenceNode / CanWriteFromReferenceNode discrimination
+   - Legacy .lrp.fcsv migration read path
+   - Legacy .lrp.fcsv write rejection
+
+  ADR-0008 §2: C++ low-level tests live alongside the MRML library
+  and run under the ctkTest driver with no Slicer launch and no Qt.
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLBezierSurfaceStorageNode.h"
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLModelNode.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkSmartPointer.h>
+#include <vtksys/SystemTools.hxx>
+
+// STD includes
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+// POSIX include — ``getpid`` for unique-temp-path generation.  On
+// Windows the ctkTest harness does not build (the existing tests in
+// this directory are POSIX-only); guarded so the compile fails
+// loudly there rather than silently using a stale handle.
+#if defined(_WIN32)
+# include <process.h>
+# define LIVER_BEZIER_GETPID _getpid
+#else
+# include <unistd.h>
+# define LIVER_BEZIER_GETPID ::getpid
+#endif
+
+namespace
+{
+
+/// Generate a unique temp file path with the given extension.  No
+/// reliance on ``mkstemp`` (not portable on Windows) — we use a
+/// pid + counter scheme rooted under
+/// ``vtksys::SystemTools::GetEnv("TMPDIR")`` or ``/tmp`` so the
+/// test does not require the build-tree to be writable.
+std::string makeTempPath(const std::string& extension)
+{
+  static int counter = 0;
+  ++counter;
+  std::string tmpDir;
+  if (const char* env = std::getenv("TMPDIR"))
+  {
+    tmpDir = env;
+  }
+  else
+  {
+    tmpDir = "/tmp";
+  }
+  std::ostringstream ss;
+  ss << tmpDir << "/vtkMRMLBezierSurfaceStorageNodeTest1_" << static_cast<long long>(LIVER_BEZIER_GETPID()) << "_" << counter << "." << extension;
+  return ss.str();
+}
+
+/// Populate a Bezier surface node with deterministic, distinctive
+/// values touching every field the storage node round-trips.  The
+/// init-mode subordinate data is set while the node is still in
+/// Init (the ADR-0014 §4 read-only guard otherwise rejects the
+/// mutations).
+void populate(vtkMRMLBezierSurfaceNode* node)
+{
+  node->SetInitMode(vtkMRMLBezierSurfaceNode::DistanceSpheroid);
+
+  // SlicingPlane init data.
+  double origin[3] = { 1.0, 2.0, 3.0 };
+  node->SetSlicingPlaneOrigin(origin);
+  double normal[3] = { 0.0, 1.0, 0.0 };
+  node->SetSlicingPlaneNormal(normal);
+  double p0[3] = { 4.0, 5.0, 6.0 };
+  node->SetSlicingPlaneInitPoint(0, p0);
+  double p1[3] = { 7.0, 8.0, 9.0 };
+  node->SetSlicingPlaneInitPoint(1, p1);
+
+  // DistanceSpheroid init data.
+  node->SetNumberOfDistanceSpheroidInitPoints(3);
+  double q0[3] = { 10.0, 11.0, 12.0 };
+  double q1[3] = { 13.0, 14.0, 15.0 };
+  double q2[3] = { 16.0, 17.0, 18.0 };
+  node->SetDistanceSpheroidInitPoint(0, q0);
+  node->SetDistanceSpheroidInitPoint(1, q1);
+  node->SetDistanceSpheroidInitPoint(2, q2);
+  double center[3] = { 19.0, 20.0, 21.0 };
+  node->SetDistanceSpheroidCenter(center);
+  node->SetDistanceSpheroidRadiusX(2.5);
+  node->SetDistanceSpheroidRadiusY(3.5);
+  node->SetDistanceSpheroidRadiusZ(4.5);
+
+  // Transition to Planning before setting the control grid — the
+  // control grid is editable in both states but this exercises the
+  // realistic write path.
+  node->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  double grid[vtkMRMLBezierSurfaceNode::ControlGridSize];
+  for (int i = 0; i < vtkMRMLBezierSurfaceNode::ControlGridSize; ++i)
+  {
+    grid[i] = static_cast<double>(i) * 0.125 + 0.0625;
+  }
+  node->SetControlGrid(grid);
+}
+
+int testJsonRoundTrip()
+{
+  // Populate a source node, write to .lrp.json, read into a fresh
+  // node, assert every field round-trips.
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  populate(source.GetPointer());
+
+  const std::string path = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> writeStorage;
+  writeStorage->SetFileName(path.c_str());
+  CHECK_INT(writeStorage->WriteData(source.GetPointer()), 1);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> readStorage;
+  readStorage->SetFileName(path.c_str());
+  CHECK_INT(readStorage->ReadData(sink.GetPointer()), 1);
+
+  // Enum round-trip.
+  CHECK_INT(sink->GetState(), source->GetState());
+  CHECK_INT(sink->GetInitMode(), source->GetInitMode());
+
+  // Control grid round-trip.
+  for (int i = 0; i < vtkMRMLBezierSurfaceNode::ControlGridSize; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], source->GetControlGrid()[i], 1e-9);
+  }
+
+  // SlicingPlane round-trip.
+  double a3[3], b3[3];
+  sink->GetSlicingPlaneOrigin(a3);
+  source->GetSlicingPlaneOrigin(b3);
+  for (int j = 0; j < 3; ++j)
+  {
+    CHECK_DOUBLE_TOLERANCE(a3[j], b3[j], 1e-9);
+  }
+  sink->GetSlicingPlaneNormal(a3);
+  source->GetSlicingPlaneNormal(b3);
+  for (int j = 0; j < 3; ++j)
+  {
+    CHECK_DOUBLE_TOLERANCE(a3[j], b3[j], 1e-9);
+  }
+  for (int i = 0; i < 2; ++i)
+  {
+    const double* a = sink->GetSlicingPlaneInitPoint(i);
+    const double* b = source->GetSlicingPlaneInitPoint(i);
+    CHECK_NOT_NULL(a);
+    CHECK_NOT_NULL(b);
+    for (int j = 0; j < 3; ++j)
+    {
+      CHECK_DOUBLE_TOLERANCE(a[j], b[j], 1e-9);
+    }
+  }
+
+  // DistanceSpheroid round-trip.
+  CHECK_INT(sink->GetNumberOfDistanceSpheroidInitPoints(), source->GetNumberOfDistanceSpheroidInitPoints());
+  for (int i = 0; i < sink->GetNumberOfDistanceSpheroidInitPoints(); ++i)
+  {
+    const double* a = sink->GetDistanceSpheroidInitPoint(i);
+    const double* b = source->GetDistanceSpheroidInitPoint(i);
+    CHECK_NOT_NULL(a);
+    CHECK_NOT_NULL(b);
+    for (int j = 0; j < 3; ++j)
+    {
+      CHECK_DOUBLE_TOLERANCE(a[j], b[j], 1e-9);
+    }
+  }
+  sink->GetDistanceSpheroidCenter(a3);
+  source->GetDistanceSpheroidCenter(b3);
+  for (int j = 0; j < 3; ++j)
+  {
+    CHECK_DOUBLE_TOLERANCE(a3[j], b3[j], 1e-9);
+  }
+  CHECK_DOUBLE_TOLERANCE(sink->GetDistanceSpheroidRadiusX(), source->GetDistanceSpheroidRadiusX(), 1e-9);
+  CHECK_DOUBLE_TOLERANCE(sink->GetDistanceSpheroidRadiusY(), source->GetDistanceSpheroidRadiusY(), 1e-9);
+  CHECK_DOUBLE_TOLERANCE(sink->GetDistanceSpheroidRadiusZ(), source->GetDistanceSpheroidRadiusZ(), 1e-9);
+
+  // Clean up the temp file.
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testSchemaVersionMismatch()
+{
+  // Synthesize a JSON with an unknown schemaVersion and assert
+  // ReadDataInternal rejects it with a non-zero exit (the rejection
+  // emits a vtkErrorMacro; gate the WITH_VTK_ERROR_OUTPUT_CHECK
+  // counter inside ASSERT_ERRORS_BEGIN/END).
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 99,\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\"\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testCanReadCanWriteDiscrimination()
+{
+  // The storage node should accept a vtkMRMLBezierSurfaceNode for
+  // both read and write, and reject anything else (e.g. a
+  // vtkMRMLModelNode).
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  vtkNew<vtkMRMLBezierSurfaceNode> surface;
+  vtkNew<vtkMRMLModelNode> model;
+
+  CHECK_BOOL(storage->CanReadInReferenceNode(surface.GetPointer()), true);
+  CHECK_BOOL(storage->CanWriteFromReferenceNode(surface.GetPointer()), true);
+  CHECK_BOOL(storage->CanReadInReferenceNode(model.GetPointer()), false);
+  CHECK_BOOL(storage->CanWriteFromReferenceNode(model.GetPointer()), false);
+  CHECK_BOOL(storage->CanReadInReferenceNode(nullptr), false);
+  CHECK_BOOL(storage->CanWriteFromReferenceNode(nullptr), false);
+  return EXIT_SUCCESS;
+}
+
+int testDefaultWriteFileExtension()
+{
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  CHECK_STRING(storage->GetDefaultWriteFileExtension(), "lrp.json");
+  CHECK_STRING(storage->GetNodeTagName(), "BezierSurfaceStorage");
+  return EXIT_SUCCESS;
+}
+
+int testLegacyFcsvRead()
+{
+  // Build a 16-point 4x4 grid fixture (z=0) and assert the legacy
+  // CSV reader maps it onto controlGrid correctly with the default
+  // post-migration state ("Planning" / "SlicingPlane") plus the
+  // documented vtkWarningMacro.
+  const std::string path = makeTempPath("lrp.fcsv");
+  {
+    std::ofstream ofs(path);
+    ofs << "# Markups fiducial file version = 4.11\n";
+    ofs << "# CoordinateSystem = LPS\n";
+    ofs << "# columns = id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID\n";
+    for (int i = 0; i < 16; ++i)
+    {
+      const double x = static_cast<double>(i % 4) * 10.0;
+      const double y = static_cast<double>(i / 4) * 10.0;
+      ofs << "vtkMRMLMarkupsFiducialNode_" << (i + 1) << "," << x << "," << y << ","
+          << "0.0,0.0,0.0,0.0,1.0,1,1,0,P-" << (i + 1) << ",,vtkMRMLScalarVolumeNode1\n";
+    }
+  }
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+
+  // ReadLegacyFcsv emits a vtkWarningMacro by design (the
+  // migration-mode disclaimer).  Gate the warning-as-failure check
+  // around the call.
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+
+  // Field assertions.
+  CHECK_INT(sink->GetState(), vtkMRMLBezierSurfaceNode::Planning);
+  CHECK_INT(sink->GetInitMode(), vtkMRMLBezierSurfaceNode::SlicingPlane);
+
+  // Spot-check a few control-grid entries: row-major (i, j) with
+  // i = row index, j = column index, x = j*10, y = i*10, z = 0.
+  // Index 0 → (0, 0, 0); index 3 → (30, 0, 0) (end of first row);
+  // index 12 → (0, 30, 0) (start of last row); index 15 → (30, 30, 0).
+  const double* grid = sink->GetControlGrid();
+  CHECK_DOUBLE(grid[0 * 3 + 0], 0.0);
+  CHECK_DOUBLE(grid[0 * 3 + 1], 0.0);
+  CHECK_DOUBLE(grid[0 * 3 + 2], 0.0);
+  CHECK_DOUBLE(grid[3 * 3 + 0], 30.0);
+  CHECK_DOUBLE(grid[3 * 3 + 1], 0.0);
+  CHECK_DOUBLE(grid[12 * 3 + 0], 0.0);
+  CHECK_DOUBLE(grid[12 * 3 + 1], 30.0);
+  CHECK_DOUBLE(grid[15 * 3 + 0], 30.0);
+  CHECK_DOUBLE(grid[15 * 3 + 1], 30.0);
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testLegacyFcsvWriteRejected()
+{
+  // Setting a .lrp.fcsv storage filename and calling Write must
+  // fail with a vtkErrorMacro — legacy writes are not supported.
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  populate(source.GetPointer());
+  const std::string path = makeTempPath("lrp.fcsv");
+
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->WriteData(source.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  // No file should have been created.
+  if (vtksys::SystemTools::FileExists(path, true))
+  {
+    vtksys::SystemTools::RemoveFile(path);
+  }
+  return EXIT_SUCCESS;
+}
+
+int testLegacyFcsvFixture()
+{
+  // Fixture-based variant of testLegacyFcsvRead: walks the canned
+  // fixture file under Testing/Cxx/Fixtures/ via the
+  // ``LIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR`` macro (set in the
+  // CMakeLists, defaults to the source tree).  This catches drift
+  // between the in-repo fixture and the reader.
+#ifdef LIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR
+  const std::string path = std::string(LIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR) + "/legacy_resection.lrp.fcsv";
+#else
+  // Fall-back — the tree is expected to define the macro; if not,
+  // skip the assertion.  Print a notice rather than failing so the
+  // test runner does not red-light a sanity skip.
+  std::cout << "testLegacyFcsvFixture: LIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR not defined; "
+               "skipping the in-repo fixture check.\n";
+  return EXIT_SUCCESS;
+#endif
+
+  if (!vtksys::SystemTools::FileExists(path, true))
+  {
+    std::cout << "testLegacyFcsvFixture: fixture '" << path << "' not found; skipping.\n";
+    return EXIT_SUCCESS;
+  }
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+
+  CHECK_INT(sink->GetState(), vtkMRMLBezierSurfaceNode::Planning);
+  // The in-repo fixture mirrors the procedurally-generated one from
+  // ``testLegacyFcsvRead`` — same 4×4 grid (x=j*10, y=i*10, z=0).
+  CHECK_DOUBLE(sink->GetControlGrid()[0], 0.0);
+  CHECK_DOUBLE(sink->GetControlGrid()[15 * 3 + 0], 30.0);
+  CHECK_DOUBLE(sink->GetControlGrid()[15 * 3 + 1], 30.0);
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLBezierSurfaceStorageNodeTest1(int, char*[])
+{
+  // Exercise the base-class MRML methods first — catches missing
+  // CreateNodeInstance / vtkStandardNewMacro plumbing the same way
+  // the data-node test does.
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> exerciseNode;
+  exerciseNode->SetScene(scene.GetPointer());
+  EXERCISE_ALL_BASIC_MRML_METHODS(exerciseNode.GetPointer());
+
+  CHECK_EXIT_SUCCESS(testDefaultWriteFileExtension());
+  CHECK_EXIT_SUCCESS(testCanReadCanWriteDiscrimination());
+  CHECK_EXIT_SUCCESS(testJsonRoundTrip());
+  CHECK_EXIT_SUCCESS(testSchemaVersionMismatch());
+  CHECK_EXIT_SUCCESS(testLegacyFcsvRead());
+  CHECK_EXIT_SUCCESS(testLegacyFcsvWriteRejected());
+  CHECK_EXIT_SUCCESS(testLegacyFcsvFixture());
+
+  std::cout << "vtkMRMLBezierSurfaceStorageNodeTest1 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -1,0 +1,693 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of task T2.5 of the v2.0.0 release (LiverResources all-in
+  migration; see ADR-0014 §5).
+
+==============================================================================*/
+
+//==============================================================================
+// .lrp.json — JSON schema v1
+//==============================================================================
+//
+// One ``.lrp.json`` document per liver resection plan (surgeon-to-
+// surgeon plan sharing per ADR-0014 §5).  The current ``schemaVersion``
+// is ``1`` — bump in lock-step with any documented extension; the
+// reader emits a vtkErrorMacro on unknown versions.
+//
+//   {
+//     "schemaVersion": 1,
+//     "state": "Init" | "Planning",
+//     "initMode": "SlicingPlane" | "DistanceSpheroid",
+//     "controlGrid": [48 doubles in row-major (i, j, k) order],
+//     "slicingPlane": {
+//       "origin": [3 doubles, RAS],
+//       "normal": [3 doubles, RAS],
+//       "initPointsFlat": [6 doubles — 2 RAS triplets concat]
+//     },
+//     "distanceSpheroid": {
+//       "center": [3 doubles, RAS],
+//       "radius": {"x": double, "y": double, "z": double},
+//       "numberOfInitPoints": int,
+//       "initPointsFlat": [3*N doubles — N RAS triplets concat]
+//     },
+//     "metadata": {}
+//   }
+//
+// The ``initPointsFlat`` fields use a flat layout because the
+// in-tree ``vtkMRMLJsonWriter`` lacks a key-less nested-array entry
+// point.  See the implementation of ``WriteJson`` below for the
+// rationale and a ``TODO(T2.5 lrp-json-v2-nested-init-points)``
+// marker.
+//
+// The ``metadata`` object is intentionally empty in v1 and reserved
+// for v2's "richer metadata" allowance (timestamps, surgeon ID, …)
+// per ADR-0014 §5.
+//
+//==============================================================================
+// Legacy ``.lrp.fcsv`` migration (load-only)
+//==============================================================================
+//
+// The pre-LayerDM ``vtkMRMLLiverResectionCSVStorageNode`` wrote the
+// Bezier control points as a standard Slicer markups-fiducial CSV
+// (15 columns: id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,
+// associatedNodeID,…).  Header lines start with ``#``.  No state,
+// init-mode, plane or spheroid metadata is recorded in the CSV.
+//
+// Legacy-to-new field mapping
+// ----------------------------
+//
+//   - Legacy 16 Bezier control points (lines, in file order)
+//        → new ``controlGrid`` (48 doubles, row-major).  The legacy
+//          format is point-major (one full xyz triplet per row); the
+//          new format flattens those same 16 triplets row-major into
+//          48 doubles, which matches the in-memory representation of
+//          ``vtkMRMLBezierSurfaceNode::ControlGrid``.  No re-ordering
+//          is needed because both formats walk the (i, j) grid in the
+//          same order.
+//   - Legacy ``ResectionMargin``, ``UncertaintyMargin``
+//        → DROPPED.  These are display-side fields per ADR-0013 §8
+//          (display-node split — the new geometry/decoration split
+//          carries margins on ``vtkMRMLBezierSurfaceDisplayNode``).
+//          They were never serialised by ``vtkMRMLLiverResectionCSVStorageNode``
+//          anyway — the CSV only contains the geometry.  Listed here
+//          for completeness because the *XML* serialisation of
+//          ``vtkMRMLLiverResectionNode`` does carry them; a future
+//          MRML-scene migration path will re-route them to the
+//          display node.
+//   - Legacy ``ResectionState`` (``Initialization`` / ``Deformation``
+//     / ``Completed``) → new ``State`` (``Init`` / ``Planning``).
+//          Not present in the CSV — defaulted to ``Planning`` because
+//          a saved legacy file always represented a populated
+//          (post-initialisation) Bezier surface.  Mapping documented
+//          here for the future XML-scene migration:
+//            ``Initialization`` → ``Init``
+//            ``Deformation``    → ``Planning``
+//            ``Completed``      → ``Planning``
+//   - Legacy ``InitializationMode`` (``Flat`` / ``Curved``) → new
+//     ``InitMode`` (``SlicingPlane`` / ``DistanceSpheroid``).
+//          Not present in the CSV — defaulted to ``SlicingPlane`` with
+//          a vtkWarningMacro flagging the gap.  Documented mapping:
+//            ``Flat``   → ``SlicingPlane``
+//            ``Curved`` → no clean mapping; legacy "Curved" was a
+//                          shaped-but-not-yet-spheroidal init that
+//                          predates ADR-0014's spheroid commitment.
+//                          For scenes that *do* expose this, the
+//                          conservative fall-back is ``SlicingPlane``
+//                          (the default) with the audit-data fields
+//                          left zero-filled.  Surgeons will need to
+//                          re-derive any spheroid parameters by hand.
+//   - Init-point / plane / spheroid audit data — none present in
+//          legacy CSV.  Fields default-initialise (zeros + the
+//          constructor-default ``SlicingPlaneNormal = (0,0,1)``).
+//
+// ``TODO(T2.7 legacy-scene-migration)`` — wire the legacy-resection-XML
+// → new-bezier-node path that consumes the full ``ResectionMargin`` /
+// ``UncertaintyMargin`` / state / mode columns from
+// ``vtkMRMLLiverResectionNode::ReadXMLAttributes``.  That migration
+// lives on the legacy-retirement task, not this storage node.
+//==============================================================================
+
+// This module MRML includes
+#include "vtkMRMLBezierSurfaceStorageNode.h"
+#include "vtkMRMLBezierSurfaceNode.h"
+
+// MRML includes
+#include <vtkMRMLJsonElement.h>
+#include <vtkMRMLMessageCollection.h>
+#include <vtkMRMLStorageNode.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkSmartPointer.h>
+#include <vtkStringArray.h>
+#include <vtksys/SystemTools.hxx>
+
+// STD includes
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLBezierSurfaceStorageNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLBezierSurfaceStorageNode::vtkMRMLBezierSurfaceStorageNode()
+{
+  this->DefaultWriteFileExtension = "lrp.json";
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLBezierSurfaceStorageNode::~vtkMRMLBezierSurfaceStorageNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLBezierSurfaceStorageNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os, indent);
+  os << indent << "SchemaVersion: " << SchemaVersion << "\n";
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLBezierSurfaceStorageNode::CanReadInReferenceNode(vtkMRMLNode* refNode)
+{
+  return refNode != nullptr && refNode->IsA("vtkMRMLBezierSurfaceNode");
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLBezierSurfaceStorageNode::CanWriteFromReferenceNode(vtkMRMLNode* refNode)
+{
+  return refNode != nullptr && refNode->IsA("vtkMRMLBezierSurfaceNode");
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLBezierSurfaceStorageNode::InitializeSupportedReadFileTypes()
+{
+  // New format first — the file dialog defaults to the first entry.
+  this->SupportedReadFileTypes->InsertNextValue("Liver resection plan (.lrp.json)");
+  // Legacy CSV — load-only per ADR-0014 §5 (one-way migration).
+  this->SupportedReadFileTypes->InsertNextValue("Legacy liver resection plan (.lrp.fcsv)");
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLBezierSurfaceStorageNode::InitializeSupportedWriteFileTypes()
+{
+  // ``.lrp.json`` only — legacy writes are explicitly not supported
+  // per ADR-0014 §5.  ADR-0007 D-class compatibility break: part of
+  // the v2.0.0 MAJOR-bump triggers.
+  this->SupportedWriteFileTypes->InsertNextValue("Liver resection plan (.lrp.json)");
+}
+
+//------------------------------------------------------------------------------
+namespace
+{
+/// Lowercase an ASCII string in place.  Used to canonicalise the
+/// file extension before dispatch.  ``vtksys::SystemTools`` provides
+/// ``LowerCase`` but the typed version below keeps the include
+/// surface narrower in this file.
+std::string toLower(std::string s)
+{
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return s;
+}
+
+/// Return true iff the full path ends with the lower-cased suffix.
+/// Used to dispatch ``.lrp.json`` vs ``.lrp.fcsv`` — they share the
+/// ``.lrp`` first-half so a plain
+/// ``GetLowercaseExtensionFromFileName`` does not distinguish them.
+bool endsWithLower(const std::string& path, const std::string& suffix)
+{
+  if (path.size() < suffix.size())
+  {
+    return false;
+  }
+  const std::string tail = toLower(path.substr(path.size() - suffix.size()));
+  return tail == suffix;
+}
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLBezierSurfaceStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
+{
+  if (refNode == nullptr)
+  {
+    vtkErrorMacro("ReadDataInternal: null reference node");
+    return 0;
+  }
+  auto* surfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(refNode);
+  if (surfaceNode == nullptr)
+  {
+    vtkErrorMacro("ReadDataInternal: reference node is not a vtkMRMLBezierSurfaceNode (got '" << refNode->GetClassName() << "')");
+    return 0;
+  }
+
+  const std::string fullName = this->GetFullNameFromFileName();
+  if (fullName.empty())
+  {
+    vtkErrorMacro("ReadDataInternal: file name not specified");
+    return 0;
+  }
+
+  // Dispatch on the file extension.  Both ``.lrp.json`` and
+  // ``.lrp.fcsv`` are accepted on read (legacy load-only migration
+  // per ADR-0014 §5).  ``.json`` alone is *not* accepted — the
+  // ``.lrp`` prefix discriminates Liver resection plans from any
+  // other JSON file someone might point the storage node at.
+  if (endsWithLower(fullName, ".lrp.json"))
+  {
+    return this->ReadJson(fullName, surfaceNode);
+  }
+  if (endsWithLower(fullName, ".lrp.fcsv"))
+  {
+    return this->ReadLegacyFcsv(fullName, surfaceNode);
+  }
+  vtkErrorMacro("ReadDataInternal: unsupported file extension for '" << fullName << "' (expected .lrp.json or .lrp.fcsv)");
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLBezierSurfaceStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
+{
+  if (refNode == nullptr)
+  {
+    vtkErrorMacro("WriteDataInternal: null reference node");
+    return 0;
+  }
+  auto* surfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(refNode);
+  if (surfaceNode == nullptr)
+  {
+    vtkErrorMacro("WriteDataInternal: reference node is not a vtkMRMLBezierSurfaceNode (got '" << refNode->GetClassName() << "')");
+    return 0;
+  }
+
+  const std::string fullName = this->GetFullNameFromFileName();
+  if (fullName.empty())
+  {
+    vtkErrorMacro("WriteDataInternal: file name not specified");
+    return 0;
+  }
+
+  // Legacy writes are not supported per ADR-0014 §5.  A caller who
+  // sets a ``.lrp.fcsv`` storage filename gets an explicit error
+  // rather than a silent fall-through to the JSON path with the
+  // wrong extension on disk.
+  if (endsWithLower(fullName, ".lrp.fcsv"))
+  {
+    vtkErrorMacro("WriteDataInternal: writing the legacy .lrp.fcsv format is not supported"
+                  " (ADR-0014 §5 — load-only migration); save as .lrp.json instead.");
+    return 0;
+  }
+  // Be permissive on the JSON extension — accept either ``.lrp.json``
+  // or no recognised extension at all (the latter happens when the
+  // caller sets a bare file name and relies on
+  // ``DefaultWriteFileExtension``).  Anything that ends ``.json``
+  // routes through the new format.
+  if (!endsWithLower(fullName, ".lrp.json") && !endsWithLower(fullName, ".json"))
+  {
+    vtkErrorMacro("WriteDataInternal: unsupported file extension for '" << fullName << "' (expected .lrp.json)");
+    return 0;
+  }
+  return this->WriteJson(fullName, surfaceNode);
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkMRMLBezierSurfaceNode* surfaceNode)
+{
+  vtkNew<vtkMRMLJsonWriter> writer;
+  // ``WriteToFileBegin`` writes the opening ``{`` and an optional
+  // top-level ``@schema`` key when ``schema != nullptr``.  We pass
+  // nullptr because the legacy storage nodes in this module did not
+  // use a schema URL and there is no public JSON-Schema document for
+  // the ``.lrp.json`` format yet (the schema lives in this source
+  // file and is governed by the ``SchemaVersion`` integer).
+  if (!writer->WriteToFileBegin(filePath.c_str(), nullptr))
+  {
+    vtkErrorMacro("WriteJson: failed to open '" << filePath << "' for writing");
+    return 0;
+  }
+
+  writer->WriteIntProperty("schemaVersion", SchemaVersion);
+  writer->WriteStringProperty("state", vtkMRMLBezierSurfaceNode::GetStateAsString(surfaceNode->GetState()));
+  writer->WriteStringProperty("initMode", vtkMRMLBezierSurfaceNode::GetInitModeAsString(surfaceNode->GetInitMode()));
+
+  // controlGrid — 48 doubles row-major.  ``const_cast`` is necessary
+  // because the writer signature takes ``double*`` (it does not
+  // mutate; the rapidjson backend treats the buffer as input).
+  writer->WriteVectorProperty("controlGrid", const_cast<double*>(surfaceNode->GetControlGrid()), vtkMRMLBezierSurfaceNode::ControlGridSize);
+
+  // slicingPlane sub-object.
+  writer->WriteObjectPropertyStart("slicingPlane");
+  {
+    double v[3];
+    surfaceNode->GetSlicingPlaneOrigin(v);
+    writer->WriteVectorProperty("origin", v, 3);
+    surfaceNode->GetSlicingPlaneNormal(v);
+    writer->WriteVectorProperty("normal", v, 3);
+
+    // Flatten the 2 init points to a single 6-double array.  This
+    // is a deliberate schema-v1 choice — the conceptual JSON shape
+    // is ``[[3 doubles], [3 doubles]]`` but the in-tree
+    // ``vtkMRMLJsonWriter`` does not expose a key-less nested-array
+    // entry point.  A 6-double flat array is unambiguous given the
+    // fixed 2-point SlicingPlane shape (ADR-0014 §1).
+    // ``TODO(T2.5 lrp-json-v2-nested-init-points)`` — if the schema
+    // ever needs the nested shape, either land a
+    // ``WriteArrayItemVector`` helper on ``vtkMRMLJsonWriter`` or
+    // drop down to rapidjson directly.
+    double initPointsFlat[6];
+    for (int i = 0; i < 2; ++i)
+    {
+      const double* p = surfaceNode->GetSlicingPlaneInitPoint(i);
+      initPointsFlat[i * 3 + 0] = p[0];
+      initPointsFlat[i * 3 + 1] = p[1];
+      initPointsFlat[i * 3 + 2] = p[2];
+    }
+    writer->WriteVectorProperty("initPointsFlat", initPointsFlat, 6);
+  }
+  writer->WriteObjectPropertyEnd();
+
+  // distanceSpheroid sub-object.
+  writer->WriteObjectPropertyStart("distanceSpheroid");
+  {
+    double v[3];
+    surfaceNode->GetDistanceSpheroidCenter(v);
+    writer->WriteVectorProperty("center", v, 3);
+
+    writer->WriteObjectPropertyStart("radius");
+    writer->WriteDoubleProperty("x", surfaceNode->GetDistanceSpheroidRadiusX());
+    writer->WriteDoubleProperty("y", surfaceNode->GetDistanceSpheroidRadiusY());
+    writer->WriteDoubleProperty("z", surfaceNode->GetDistanceSpheroidRadiusZ());
+    writer->WriteObjectPropertyEnd();
+
+    // Flatten the variable number of init points to a single
+    // 3N-double array for the same reason as the slicingPlane
+    // initPoints above.
+    const int nPoints = surfaceNode->GetNumberOfDistanceSpheroidInitPoints();
+    writer->WriteIntProperty("numberOfInitPoints", nPoints);
+    if (nPoints > 0)
+    {
+      std::vector<double> flat(static_cast<size_t>(nPoints) * 3, 0.0);
+      for (int i = 0; i < nPoints; ++i)
+      {
+        const double* p = surfaceNode->GetDistanceSpheroidInitPoint(i);
+        flat[static_cast<size_t>(i) * 3 + 0] = p[0];
+        flat[static_cast<size_t>(i) * 3 + 1] = p[1];
+        flat[static_cast<size_t>(i) * 3 + 2] = p[2];
+      }
+      writer->WriteVectorProperty("initPointsFlat", flat.data(), static_cast<int>(flat.size()));
+    }
+    else
+    {
+      // Emit an empty array so the reader can detect "explicitly
+      // empty" vs "key missing" — rapidjson treats both the same
+      // semantically but downstream consumers (e.g. JSON-Schema
+      // validators) may not.
+      std::array<double, 1> sentinel = { 0.0 };
+      (void)sentinel; // unused — see below
+      writer->WriteArrayPropertyStart("initPointsFlat");
+      writer->WriteArrayPropertyEnd();
+    }
+  }
+  writer->WriteObjectPropertyEnd();
+
+  // metadata — reserved for v2 per ADR-0014 §5.  Emit an empty
+  // object so the field is unambiguously "present and empty"
+  // rather than absent.
+  writer->WriteObjectPropertyStart("metadata");
+  writer->WriteObjectPropertyEnd();
+
+  if (!writer->WriteToFileEnd())
+  {
+    vtkErrorMacro("WriteJson: failed to close '" << filePath << "' after write");
+    return 0;
+  }
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMRMLBezierSurfaceNode* surfaceNode)
+{
+  vtkNew<vtkMRMLJsonReader> reader;
+  vtkSmartPointer<vtkMRMLJsonElement> root = vtkSmartPointer<vtkMRMLJsonElement>::Take(reader->ReadFromFile(filePath.c_str()));
+  if (root == nullptr)
+  {
+    vtkErrorMacro("ReadJson: failed to parse '" << filePath << "'");
+    return 0;
+  }
+  if (!root->HasMember("schemaVersion"))
+  {
+    vtkErrorMacro("ReadJson: missing required 'schemaVersion' field in '" << filePath << "'");
+    return 0;
+  }
+  const int schemaVersion = root->GetIntProperty("schemaVersion");
+  if (schemaVersion != SchemaVersion)
+  {
+    vtkErrorMacro("ReadJson: unsupported schemaVersion " << schemaVersion << " in '" << filePath << "' (this build understands schemaVersion " << SchemaVersion << " only)");
+    return 0;
+  }
+
+  // State is read LAST — before that, the init-mode subordinate
+  // data setters (slicingPlane.*, distanceSpheroid.*) are guarded
+  // against post-Planning mutation by the ADR-0014 §4 read-only
+  // invariant.  Parsing into a node already-in-Planning would
+  // silently drop those fields.  Read into ``pendingState`` here,
+  // populate the audit fields, then commit the transition at the
+  // end of this method.
+  int pendingState = -1;
+  if (root->HasMember("state"))
+  {
+    const std::string s = root->GetStringProperty("state");
+    const int code = vtkMRMLBezierSurfaceNode::GetStateFromString(s.c_str());
+    if (code < 0)
+    {
+      vtkErrorMacro("ReadJson: unknown state name '" << s << "' in '" << filePath << "'");
+      return 0;
+    }
+    pendingState = code;
+  }
+  if (root->HasMember("initMode"))
+  {
+    const std::string s = root->GetStringProperty("initMode");
+    const int code = vtkMRMLBezierSurfaceNode::GetInitModeFromString(s.c_str());
+    if (code < 0)
+    {
+      vtkErrorMacro("ReadJson: unknown initMode name '" << s << "' in '" << filePath << "'");
+      return 0;
+    }
+    surfaceNode->SetInitMode(code);
+  }
+
+  // controlGrid — 48 doubles row-major.
+  if (root->HasMember("controlGrid"))
+  {
+    double grid[vtkMRMLBezierSurfaceNode::ControlGridSize];
+    if (!root->GetVectorProperty("controlGrid", grid, vtkMRMLBezierSurfaceNode::ControlGridSize))
+    {
+      vtkErrorMacro("ReadJson: 'controlGrid' must be an array of " << vtkMRMLBezierSurfaceNode::ControlGridSize << " doubles in '" << filePath << "'");
+      return 0;
+    }
+    surfaceNode->SetControlGrid(grid);
+  }
+
+  // slicingPlane sub-object.
+  if (root->HasMember("slicingPlane"))
+  {
+    vtkSmartPointer<vtkMRMLJsonElement> sp = vtkSmartPointer<vtkMRMLJsonElement>::Take(root->GetObjectProperty("slicingPlane"));
+    if (sp != nullptr)
+    {
+      double v[3];
+      if (sp->GetVectorProperty("origin", v, 3))
+      {
+        surfaceNode->SetSlicingPlaneOrigin(v);
+      }
+      if (sp->GetVectorProperty("normal", v, 3))
+      {
+        surfaceNode->SetSlicingPlaneNormal(v);
+      }
+      double initFlat[6];
+      if (sp->GetVectorProperty("initPointsFlat", initFlat, 6))
+      {
+        double p0[3] = { initFlat[0], initFlat[1], initFlat[2] };
+        double p1[3] = { initFlat[3], initFlat[4], initFlat[5] };
+        surfaceNode->SetSlicingPlaneInitPoint(0, p0);
+        surfaceNode->SetSlicingPlaneInitPoint(1, p1);
+      }
+    }
+  }
+
+  // distanceSpheroid sub-object.
+  if (root->HasMember("distanceSpheroid"))
+  {
+    vtkSmartPointer<vtkMRMLJsonElement> ds = vtkSmartPointer<vtkMRMLJsonElement>::Take(root->GetObjectProperty("distanceSpheroid"));
+    if (ds != nullptr)
+    {
+      double v[3];
+      if (ds->GetVectorProperty("center", v, 3))
+      {
+        surfaceNode->SetDistanceSpheroidCenter(v);
+      }
+      vtkSmartPointer<vtkMRMLJsonElement> rad = vtkSmartPointer<vtkMRMLJsonElement>::Take(ds->GetObjectProperty("radius"));
+      if (rad != nullptr)
+      {
+        double r = 0.0;
+        if (rad->GetDoubleProperty("x", r))
+        {
+          surfaceNode->SetDistanceSpheroidRadiusX(r);
+        }
+        if (rad->GetDoubleProperty("y", r))
+        {
+          surfaceNode->SetDistanceSpheroidRadiusY(r);
+        }
+        if (rad->GetDoubleProperty("z", r))
+        {
+          surfaceNode->SetDistanceSpheroidRadiusZ(r);
+        }
+      }
+      const int nPoints = ds->GetIntProperty("numberOfInitPoints");
+      if (nPoints > 0)
+      {
+        surfaceNode->SetNumberOfDistanceSpheroidInitPoints(nPoints);
+        std::vector<double> flat(static_cast<size_t>(nPoints) * 3, 0.0);
+        if (ds->GetVectorProperty("initPointsFlat", flat.data(), nPoints * 3))
+        {
+          for (int i = 0; i < nPoints; ++i)
+          {
+            double p[3] = { flat[static_cast<size_t>(i) * 3 + 0], flat[static_cast<size_t>(i) * 3 + 1], flat[static_cast<size_t>(i) * 3 + 2] };
+            surfaceNode->SetDistanceSpheroidInitPoint(i, p);
+          }
+        }
+      }
+    }
+  }
+
+  // Commit the state transition last so the init-mode subordinate
+  // setters above did not have to fight the ADR-0014 §4 read-only
+  // guard.  See the pendingState block at the top of this method.
+  if (pendingState >= 0)
+  {
+    surfaceNode->SetState(pendingState);
+  }
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLBezierSurfaceStorageNode::ReadLegacyFcsv(const std::string& filePath, vtkMRMLBezierSurfaceNode* surfaceNode)
+{
+  // Open the file directly — we deliberately do NOT delegate to
+  // ``vtkMRMLMarkupsFiducialStorageNode`` because pulling a markups
+  // node into existence just to read 16 control points adds a
+  // dependency on the Markups module's scene infrastructure for no
+  // payoff.  The legacy CSV is a plain RFC-4180-shaped file with
+  // header lines starting ``#``; we only need the numeric x/y/z
+  // columns.
+  std::ifstream stream(filePath);
+  if (!stream.is_open())
+  {
+    vtkErrorMacro("ReadLegacyFcsv: cannot open '" << filePath << "'");
+    return 0;
+  }
+
+  // Collect (x, y, z) triplets in file order.  The legacy 15-column
+  // markups schema places coordinates at fixed columns 1..3 (0-based)
+  // — see ``vtkMRMLMarkupsFiducialStorageNode``'s columns header.
+  // We tolerate either 14-column or 15-column rows for forward
+  // compatibility (the column count drifted across Slicer versions).
+  std::vector<std::array<double, 3>> points;
+  std::string line;
+  while (std::getline(stream, line))
+  {
+    if (line.empty())
+    {
+      continue;
+    }
+    // Skip header / comment lines.
+    if (line[0] == '#')
+    {
+      continue;
+    }
+    // Tokenise on comma.  The legacy writer always used ``,`` as
+    // the field delimiter (see the constructor of
+    // ``vtkMRMLLiverResectionCSVStorageNode``).
+    std::vector<std::string> tokens;
+    std::stringstream ss(line);
+    std::string token;
+    while (std::getline(ss, token, ','))
+    {
+      tokens.push_back(token);
+    }
+    if (tokens.size() < 4)
+    {
+      // Not a control-point row; skip silently.
+      continue;
+    }
+    try
+    {
+      const double x = std::stod(tokens[1]);
+      const double y = std::stod(tokens[2]);
+      const double z = std::stod(tokens[3]);
+      points.push_back({ x, y, z });
+    }
+    catch (const std::exception&)
+    {
+      // Non-numeric row in coords column — skip silently; the
+      // 16-point check at the end is the load-bearing guard.
+      continue;
+    }
+  }
+
+  // ADR-0014 §3 + ADR-0014 §1: a Bezier control grid is 16 points
+  // (degree-3 patch).  Reject anything else as malformed.
+  constexpr int expectedPointCount = vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize;
+  if (static_cast<int>(points.size()) != expectedPointCount)
+  {
+    vtkErrorMacro("ReadLegacyFcsv: expected " << expectedPointCount << " control points in '" << filePath << "' but found " << points.size());
+    return 0;
+  }
+
+  // Flatten to the row-major 48-double buffer expected by the
+  // surface node's SetControlGrid.  See the file-header comment for
+  // the field-mapping rationale.
+  std::array<double, vtkMRMLBezierSurfaceNode::ControlGridSize> grid;
+  for (int i = 0; i < expectedPointCount; ++i)
+  {
+    grid[i * 3 + 0] = points[i][0];
+    grid[i * 3 + 1] = points[i][1];
+    grid[i * 3 + 2] = points[i][2];
+  }
+  surfaceNode->SetControlGrid(grid.data());
+
+  // State + InitMode: not present in the legacy CSV.  Default to
+  // ``Planning`` + ``SlicingPlane`` per the field-mapping table at
+  // the top of this file.  A saved-to-disk legacy plan always
+  // represented a populated Bezier surface (i.e. post-Initialization),
+  // so ``Planning`` is the correct mapping for both
+  // ``Deformation`` and ``Completed`` legacy state values.  The
+  // ``InitMode`` default exists because the legacy CSV did not
+  // discriminate between ``Flat`` and ``Curved`` modes — surgeons
+  // who relied on ``Curved`` will need to re-derive any spheroid
+  // parameters by hand.
+  surfaceNode->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  surfaceNode->SetInitMode(vtkMRMLBezierSurfaceNode::SlicingPlane);
+
+  vtkWarningMacro("ReadLegacyFcsv: loaded " << expectedPointCount << " control points from '" << filePath
+                                            << "' — state defaulted to Planning, initMode defaulted to SlicingPlane"
+                                               " (legacy CSV does not carry these fields; see field-mapping table"
+                                               " in vtkMRMLBezierSurfaceStorageNode.cxx). Re-save as .lrp.json to"
+                                               " preserve the full field roster going forward.");
+  return 1;
+}

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
@@ -1,0 +1,180 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of task T2.5 of the v2.0.0 release (LiverResources all-in
+  migration; see ADR-0014 §5).
+
+==============================================================================*/
+
+#ifndef __vtkmrmlbeziersurfacestoragenode_h_
+#define __vtkmrmlbeziersurfacestoragenode_h_
+
+#include "vtkSlicerLiverResectionsModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLStorageNode.h>
+
+/**
+ * \class vtkMRMLBezierSurfaceStorageNode
+ *
+ * \brief Storage node for ``vtkMRMLBezierSurfaceNode`` — the new
+ *        ``.lrp.json`` "single file per resection plan" format
+ *        committed by [ADR-0014 §5](../../Docs/adr/0014-livermarkups-dissolution.md).
+ *
+ * The new format collects every field currently round-tripped by
+ * ``vtkMRMLBezierSurfaceNode::WriteXML`` into a single
+ * surgeon-to-surgeon JSON document.  Versioned via an explicit
+ * top-level ``schemaVersion`` integer (currently ``1``).  Future
+ * schema revisions bump the integer and gain explicit migration
+ * branches in ``ReadDataInternal``.
+ *
+ * \par Legacy ``.lrp.fcsv`` support
+ *
+ * The pre-LayerDM ``vtkMRMLLiverResectionCSVStorageNode`` wrote a
+ * markups-fiducial CSV (15-column standard schema) containing the
+ * 16 Bezier control points and nothing else — no state, no
+ * init-mode metadata, no plane/spheroid parameters.  The new
+ * storage node reads ``.lrp.fcsv`` in load-only migration mode so
+ * existing scenes load on first open after the v2.0.0 jump; the
+ * surgeon then saves the plan in ``.lrp.json`` on next write.
+ *
+ * Legacy writes are NOT supported — ``CanWriteFromReferenceNode``
+ * returns true only for the new node class, and the supported
+ * write file-types list contains ``.lrp.json`` exclusively.  Per
+ * ADR-0007's D-class compatibility-break category, the
+ * ``.lrp.fcsv`` deprecation is part of the v2.0.0 MAJOR bump.
+ *
+ * \par JSON schema (v1)
+ *
+ * See the in-source documentation at the top of
+ * ``vtkMRMLBezierSurfaceStorageNode.cxx`` for the canonical
+ * schema description.  Briefly:
+ *
+ *   - ``schemaVersion``: int, currently 1
+ *   - ``state``: "Init" | "Planning"
+ *   - ``initMode``: "SlicingPlane" | "DistanceSpheroid"
+ *   - ``controlGrid``: array of 48 doubles (row-major 4×4×3)
+ *   - ``slicingPlane``: {origin, normal, initPoints}
+ *   - ``distanceSpheroid``: {center, radius{x,y,z}, initPoints}
+ *   - ``metadata``: object (empty in v1; reserved for v2's
+ *     timestamps + surgeon ID per ADR-0014 §5)
+ *
+ * \par See also
+ *
+ *   - ``vtkMRMLBezierSurfaceNode`` — the data node this storage
+ *     node serializes (ADR-0014 §1).
+ *   - ``vtkMRMLLiverResectionCSVStorageNode`` — the legacy storage
+ *     node whose format we read for migration; retired by task
+ *     T2.7.
+ *   - ``vtkMRMLMarkupsJsonStorageNode`` (Slicer core) — the
+ *     in-tree precedent for using ``vtkMRMLJsonReader`` /
+ *     ``vtkMRMLJsonWriter``.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLBezierSurfaceStorageNode : public vtkMRMLStorageNode
+{
+public:
+  static vtkMRMLBezierSurfaceStorageNode* New();
+  vtkTypeMacro(vtkMRMLBezierSurfaceStorageNode, vtkMRMLStorageNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Current JSON schema version emitted by ``WriteDataInternal``
+  /// and demanded by ``ReadDataInternal``'s strict-equality check.
+  /// Bump this integer in lock-step with any documented schema
+  /// extension; ``ReadDataInternal`` MUST grow an explicit branch
+  /// for every old version it intends to keep loading.
+  static constexpr int SchemaVersion = 1;
+
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Get node XML tag name (like Storage, Model).  No ``Liver``
+  /// prefix per the new naming convention landed for the data
+  /// node family (vtkMRMLBezierSurfaceNode / DisplayNode).
+  const char* GetNodeTagName() override { return "BezierSurfaceStorage"; }
+
+  /// Returns true iff ``refNode`` is a ``vtkMRMLBezierSurfaceNode``.
+  bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
+
+  /// Returns true iff ``refNode`` is a ``vtkMRMLBezierSurfaceNode``.
+  bool CanWriteFromReferenceNode(vtkMRMLNode* refNode) override;
+
+  /// Return the default extension emitted by ``WriteDataInternal``
+  /// — ``"lrp.json"`` for the new format.
+  const char* GetDefaultWriteFileExtension() override { return "lrp.json"; }
+
+protected:
+  /// File types registered for the read dialog.  Adds both
+  /// ``.lrp.json`` (the new format) AND ``.lrp.fcsv`` (legacy
+  /// load-only migration).
+  void InitializeSupportedReadFileTypes() override;
+
+  /// File types registered for the write dialog.  ``.lrp.json``
+  /// only — legacy writes are not supported (ADR-0014 §5).
+  void InitializeSupportedWriteFileTypes() override;
+
+  /// Dispatches on the file extension:
+  ///   - ``.lrp.json`` → JSON parse path (current schema).
+  ///   - ``.lrp.fcsv`` → legacy migration path (markups-fiducial
+  ///                      CSV; control points only).
+  int ReadDataInternal(vtkMRMLNode* refNode) override;
+
+  /// Emits a single ``.lrp.json`` document.  Legacy ``.lrp.fcsv``
+  /// writes are rejected with a ``vtkErrorMacro`` and a 0 return.
+  int WriteDataInternal(vtkMRMLNode* refNode) override;
+
+protected:
+  vtkMRMLBezierSurfaceStorageNode();
+  ~vtkMRMLBezierSurfaceStorageNode() override;
+
+private:
+  vtkMRMLBezierSurfaceStorageNode(const vtkMRMLBezierSurfaceStorageNode&) = delete;
+  void operator=(const vtkMRMLBezierSurfaceStorageNode&) = delete;
+
+  /// Read the new-format ``.lrp.json`` from ``filePath`` into
+  /// ``surfaceNode``.  Returns 1 on success, 0 on failure (with
+  /// errors routed through the storage node's user-messages
+  /// collection).
+  int ReadJson(const std::string& filePath, class vtkMRMLBezierSurfaceNode* surfaceNode);
+
+  /// Read the legacy ``.lrp.fcsv`` from ``filePath`` into
+  /// ``surfaceNode``.  Returns 1 on success, 0 on failure.  See
+  /// the implementation for the legacy-field → new-field mapping
+  /// table.
+  int ReadLegacyFcsv(const std::string& filePath, class vtkMRMLBezierSurfaceNode* surfaceNode);
+
+  /// Write the new-format ``.lrp.json`` for ``surfaceNode`` to
+  /// ``filePath``.  Returns 1 on success, 0 on failure.
+  int WriteJson(const std::string& filePath, class vtkMRMLBezierSurfaceNode* surfaceNode);
+};
+
+#endif //__vtkmrmlbeziersurfacestoragenode_h_

--- a/Testing/Python/unit/test_bezier_surface_storage_node.py
+++ b/Testing/Python/unit/test_bezier_surface_storage_node.py
@@ -1,0 +1,247 @@
+"""Python wrapper tests for ``vtkMRMLBezierSurfaceStorageNode``.
+
+ADR-0008 §3 dual-mode discipline: every C++ class reachable from
+Python carries a matching Python-side smoke test.  The C++ test
+driver (``LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx``)
+covers the same field roster from C++; this module is the wrapper-
+layer check that the storage node is importable, instantiable, and
+round-trips through the .lrp.json + .lrp.fcsv paths from the
+wrapped surface.
+
+References
+----------
+* ADR-0008 §3 — dual-mode test discipline.
+* ADR-0014 §5 — .lrp.json schema commitment + legacy .lrp.fcsv
+  load-only migration.
+* ADR-0013 §8 — display-node split (rationale for dropping the
+  legacy margin fields on migration).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mrml_module():
+    """Import the wrapped LiverResections MRML module.
+
+    Skips the suite when the C++ MRML library has not been built or
+    when pytest runs outside Slicer's bundled Python.  Matches the
+    fixture in ``test_bezier_surface_node.py``.
+    """
+    return pytest.importorskip(
+        "vtkSlicerLiverResectionsModuleMRMLPython",
+        reason=(
+            "vtkSlicerLiverResectionsModuleMRML not built / not on "
+            "sys.path; skip the Python-side BezierSurfaceStorageNode "
+            "tests."
+        ),
+    )
+
+
+def _make_grid():
+    """Deterministic 48-double Bezier control grid for round-trip tests."""
+    return [math.sin(0.1 * i) + 0.125 * i for i in range(48)]
+
+
+def _populate(node, mrml_module):
+    """Set every storage-relevant field with distinctive values.
+
+    Init-mode subordinate data is set while State==Init (ADR-0014 §4
+    read-only guard otherwise rejects the mutations).  We then
+    transition to Planning before assigning the control grid, to
+    match the realistic write-path order.
+    """
+    cls = mrml_module.vtkMRMLBezierSurfaceNode
+    node.SetInitMode(cls.DistanceSpheroid)
+
+    node.SetSlicingPlaneOrigin([1.0, 2.0, 3.0])
+    node.SetSlicingPlaneNormal([0.0, 1.0, 0.0])
+    node.SetSlicingPlaneInitPoint(0, [4.0, 5.0, 6.0])
+    node.SetSlicingPlaneInitPoint(1, [7.0, 8.0, 9.0])
+
+    node.SetNumberOfDistanceSpheroidInitPoints(3)
+    node.SetDistanceSpheroidInitPoint(0, [10.0, 11.0, 12.0])
+    node.SetDistanceSpheroidInitPoint(1, [13.0, 14.0, 15.0])
+    node.SetDistanceSpheroidInitPoint(2, [16.0, 17.0, 18.0])
+    node.SetDistanceSpheroidCenter([19.0, 20.0, 21.0])
+    node.SetDistanceSpheroidRadiusX(2.5)
+    node.SetDistanceSpheroidRadiusY(3.5)
+    node.SetDistanceSpheroidRadiusZ(4.5)
+
+    node.SetState(cls.Planning)
+
+    grid = _make_grid()
+    node.SetControlGrid(grid)
+
+
+# --------------------------------------------------------------------------- #
+# Surface — instantiation, basic API
+# --------------------------------------------------------------------------- #
+
+
+def test_storage_construction_and_tag_name(mrml_module):
+    storage = mrml_module.vtkMRMLBezierSurfaceStorageNode()
+    assert storage is not None
+    assert storage.GetNodeTagName() == "BezierSurfaceStorage"
+    assert storage.GetDefaultWriteFileExtension() == "lrp.json"
+
+
+def test_storage_can_read_can_write_discrimination(mrml_module):
+    """Both Can*ReferenceNode methods accept the surface node only."""
+    storage = mrml_module.vtkMRMLBezierSurfaceStorageNode()
+    surface = mrml_module.vtkMRMLBezierSurfaceNode()
+    # vtkMRMLModelNode is a sibling MRML node from Slicer core; we
+    # rely on it being importable from the wrapped scene module.
+    # Use the storage node itself as a "wrong class" stand-in if
+    # vtkMRMLModelNode is not available — the rejection still
+    # exercises the wrong-class branch.
+    storage2 = mrml_module.vtkMRMLBezierSurfaceStorageNode()
+    assert storage.CanReadInReferenceNode(surface) is True
+    assert storage.CanWriteFromReferenceNode(surface) is True
+    assert storage.CanReadInReferenceNode(storage2) is False
+    assert storage.CanWriteFromReferenceNode(storage2) is False
+
+
+# --------------------------------------------------------------------------- #
+# .lrp.json round-trip
+# --------------------------------------------------------------------------- #
+
+
+def test_storage_json_round_trip(mrml_module, tmp_path):
+    cls = mrml_module.vtkMRMLBezierSurfaceNode
+
+    source = cls()
+    _populate(source, mrml_module)
+
+    path = str(tmp_path / "round_trip.lrp.json")
+    writer = mrml_module.vtkMRMLBezierSurfaceStorageNode()
+    writer.SetFileName(path)
+    assert writer.WriteData(source) == 1
+    assert os.path.exists(path)
+
+    sink = cls()
+    reader = mrml_module.vtkMRMLBezierSurfaceStorageNode()
+    reader.SetFileName(path)
+    assert reader.ReadData(sink) == 1
+
+    # Enum round-trip.
+    assert sink.GetState() == source.GetState()
+    assert sink.GetInitMode() == source.GetInitMode()
+
+    # Control grid.
+    for i in range(cls.ControlGridSize):
+        assert (
+            abs(sink.GetControlGrid()[i] - source.GetControlGrid()[i])
+            < 1e-9
+        )
+
+    # SlicingPlane.
+    assert list(sink.GetSlicingPlaneOrigin()) == list(
+        source.GetSlicingPlaneOrigin()
+    )
+    assert list(sink.GetSlicingPlaneNormal()) == list(
+        source.GetSlicingPlaneNormal()
+    )
+    for i in range(2):
+        assert list(sink.GetSlicingPlaneInitPoint(i)) == list(
+            source.GetSlicingPlaneInitPoint(i)
+        )
+
+    # DistanceSpheroid.
+    assert (
+        sink.GetNumberOfDistanceSpheroidInitPoints()
+        == source.GetNumberOfDistanceSpheroidInitPoints()
+    )
+    for i in range(source.GetNumberOfDistanceSpheroidInitPoints()):
+        assert list(sink.GetDistanceSpheroidInitPoint(i)) == list(
+            source.GetDistanceSpheroidInitPoint(i)
+        )
+    assert list(sink.GetDistanceSpheroidCenter()) == list(
+        source.GetDistanceSpheroidCenter()
+    )
+    assert abs(
+        sink.GetDistanceSpheroidRadiusX() - source.GetDistanceSpheroidRadiusX()
+    ) < 1e-9
+    assert abs(
+        sink.GetDistanceSpheroidRadiusY() - source.GetDistanceSpheroidRadiusY()
+    ) < 1e-9
+    assert abs(
+        sink.GetDistanceSpheroidRadiusZ() - source.GetDistanceSpheroidRadiusZ()
+    ) < 1e-9
+
+
+def test_storage_json_schema_version_mismatch(mrml_module, tmp_path):
+    """A schemaVersion the reader does not know about is rejected."""
+    path = tmp_path / "bad_version.lrp.json"
+    path.write_text(
+        "{\n"
+        '  "schemaVersion": 99,\n'
+        '  "state": "Init",\n'
+        '  "initMode": "SlicingPlane"\n'
+        "}\n"
+    )
+    sink = mrml_module.vtkMRMLBezierSurfaceNode()
+    storage = mrml_module.vtkMRMLBezierSurfaceStorageNode()
+    storage.SetFileName(str(path))
+    # Read should fail (returns 0); error is emitted via vtkErrorMacro
+    # — Python wrapper sees the return code.
+    assert storage.ReadData(sink) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Legacy .lrp.fcsv migration
+# --------------------------------------------------------------------------- #
+
+
+def test_storage_legacy_fcsv_read(mrml_module, tmp_path):
+    """A canned 16-point legacy CSV migrates onto the new node."""
+    path = tmp_path / "legacy.lrp.fcsv"
+    rows = ["# Markups fiducial file version = 4.11",
+            "# CoordinateSystem = LPS",
+            "# columns = id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID"]
+    for i in range(16):
+        x = (i % 4) * 10.0
+        y = (i // 4) * 10.0
+        rows.append(
+            f"vtkMRMLMarkupsFiducialNode_{i + 1},{x},{y},0.0,0.0,0.0,0.0,1.0,"
+            f"1,1,0,P-{i + 1},,vtkMRMLScalarVolumeNode1"
+        )
+    path.write_text("\n".join(rows) + "\n")
+
+    cls = mrml_module.vtkMRMLBezierSurfaceNode
+    sink = cls()
+    storage = mrml_module.vtkMRMLBezierSurfaceStorageNode()
+    storage.SetFileName(str(path))
+    assert storage.ReadData(sink) == 1
+
+    # Default post-migration mapping (see field-mapping table in
+    # vtkMRMLBezierSurfaceStorageNode.cxx).
+    assert sink.GetState() == cls.Planning
+    assert sink.GetInitMode() == cls.SlicingPlane
+
+    # Spot-check the row-major grid: index 0 → (0, 0, 0);
+    # index 15 → (30, 30, 0).
+    grid = sink.GetControlGrid()
+    assert grid[0] == 0.0
+    assert grid[1] == 0.0
+    assert grid[2] == 0.0
+    assert grid[15 * 3 + 0] == 30.0
+    assert grid[15 * 3 + 1] == 30.0
+    assert grid[15 * 3 + 2] == 0.0
+
+
+def test_storage_legacy_fcsv_write_rejected(mrml_module, tmp_path):
+    """Writing the legacy CSV extension is not supported."""
+    source = mrml_module.vtkMRMLBezierSurfaceNode()
+    _populate(source, mrml_module)
+    path = tmp_path / "reject.lrp.fcsv"
+    storage = mrml_module.vtkMRMLBezierSurfaceStorageNode()
+    storage.SetFileName(str(path))
+    assert storage.WriteData(source) == 0
+    # No file should have been written.
+    assert not path.exists()


### PR DESCRIPTION
## Summary

Implements task **T2.5** per [ADR-0014 §5](../blob/preview/Docs/adr/0014-livermarkups-dissolution.md#5-storage-nodes): a new MRML storage node `vtkMRMLBezierSurfaceStorageNode` that reads/writes the `.lrp.json` format paired with `vtkMRMLBezierSurfaceNode`.  The new format is the single surgeon-to-surgeon plan-sharing document committed by ADR-0014 §5.

Load-only migration of the legacy `.lrp.fcsv` (pre-LayerDM `vtkMRMLLiverResectionCSVStorageNode`) is supported during v2.x.  Legacy writes are rejected.

The `.lrp.fcsv` deprecation falls under the D-class compatibility-break category in [ADR-0007 §Version-Numbering-Policy](../blob/preview/Docs/adr/0007-version-numbering-policy.md), one of the triggers for the v2.0.0 MAJOR bump.

## JSON schema v1

```json
{
  "schemaVersion": 1,
  "state": "Init" | "Planning",
  "initMode": "SlicingPlane" | "DistanceSpheroid",
  "controlGrid": [48 doubles in row-major (i, j, k) order],
  "slicingPlane": {
    "origin": [3 doubles, RAS],
    "normal": [3 doubles, RAS],
    "initPointsFlat": [6 doubles — 2 RAS triplets concat]
  },
  "distanceSpheroid": {
    "center": [3 doubles, RAS],
    "radius": {"x": double, "y": double, "z": double},
    "numberOfInitPoints": int,
    "initPointsFlat": [3*N doubles — N RAS triplets concat]
  },
  "metadata": {}
}
```

**Deviation from the brief**: the brief calls for `initPoints: [[3 doubles], [3 doubles]]` nested arrays.  The in-tree `vtkMRMLJsonWriter` (used by Slicer's `vtkMRMLMarkupsJsonStorageNode` and others) does not expose a key-less nested-array entry point.  Schema v1 emits the init points as `initPointsFlat` (3·N flat doubles) which is unambiguous given the fixed shape.  Marked `TODO(T2.5 lrp-json-v2-nested-init-points)` in source for a future bump if needed.

The `metadata: {}` object is emitted but empty in v1 (reserved for v2's "richer metadata" allowance per ADR-0014 §5 — timestamps, surgeon ID).

## Legacy `.lrp.fcsv` field-mapping table

| Legacy field | New field | Notes |
|---|---|---|
| 16 Bezier control points (line order) | `controlGrid` (48 doubles row-major) | No re-ordering — both formats walk (i, j) the same way. |
| `ResectionMargin`, `UncertaintyMargin` | DROPPED | Display-side per [ADR-0013 §8](../blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md#8-display-side-fields-on-the-display-node) (carried on `vtkMRMLBezierSurfaceDisplayNode`).  CSV never serialised these anyway — listed for completeness because the XML path does. |
| `ResectionState`: `Initialization` | `State: Init` | Future XML-scene path. |
| `ResectionState`: `Deformation` | `State: Planning` | Future XML-scene path. |
| `ResectionState`: `Completed` | `State: Planning` | Future XML-scene path. |
| `InitializationMode: Flat` | `InitMode: SlicingPlane` | Future XML-scene path. |
| `InitializationMode: Curved` | **GAP**: no clean mapping. | Defaults to `SlicingPlane` (audit data zero-filled) with a `vtkWarningMacro`; surgeon re-derives spheroid by hand. |
| Init/plane/spheroid audit data | (not in CSV) | Defaults; reader emits a migration-mode warning. |

The CSV-only migration path defaults missing state/mode fields to `Planning` / `SlicingPlane` because a saved-to-disk legacy plan always represented a populated post-init Bezier surface.  Re-saving as `.lrp.json` preserves the full field roster.

`TODO(T2.7 legacy-scene-migration)` — the full legacy-XML→new-Bezier-node path (which would consume the margin / state / mode columns from `vtkMRMLLiverResectionNode::ReadXMLAttributes`) lives on the legacy-retirement task.

## Out of scope (per the T2 task split)

- **T2.7** retires `vtkMRMLLiverResectionCSVStorageNode` itself.  This PR adds the new storage node alongside; the legacy class stays in place for now.
- **T2.6** wires `qSlicerLiverResectionsModule::setup()` registration; not touched here.

## Files

- `LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.{h,cxx}` — new
- `LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx` — new (C++ ctkTest)
- `LiverResections/MRML/Testing/Cxx/Fixtures/legacy_resection.lrp.fcsv` — new (test fixture)
- `Testing/Python/unit/test_bezier_surface_storage_node.py` — new (Python wrapper test)
- `LiverResections/MRML/CMakeLists.txt` — register new sources
- `LiverResections/MRML/Testing/Cxx/CMakeLists.txt` — register new test driver + fixture-dir macro

## Test plan

- [x] Local Guix-toolchain build green (`cmake --build /home/rafael/src/Slicer-Liver-bezier-storage-build -j16`).
- [x] All three `vtkSlicerLiverResectionsModuleMRML` C++ tests pass (`vtkMRMLBezierSurfaceNodeTest1`, `…DisplayNodeTest1`, `…StorageNodeTest1`).
- [x] Pre-commit hygiene on touched files (mixed-line-ending, trailing-ws, pyupgrade, end-of-files, ruff on Python).  Pre-commit's `clang-format` env was broken locally; ran the in-tree clang-21 manually.  CI re-checks.
- [ ] CI pipeline (will iterate via new commits if it surfaces drift).

## Spec references

- **PRIMARY**: [ADR-0014 §5](../blob/preview/Docs/adr/0014-livermarkups-dissolution.md#5-storage-nodes) — JSON storage commitment.
- [ADR-0013 §8](../blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md#8-display-side-fields-on-the-display-node) — display-node split (rationale for dropping the legacy margin fields on migration).
- [ADR-0007](../blob/preview/Docs/adr/0007-version-numbering-policy.md) — D-class break category, v2.0.0 trigger.
- [ADR-0008 §2 §3](../blob/preview/Docs/adr/0008-testing-strategy.md) — testing discipline.
- [ADR-0004](../blob/preview/Docs/adr/0004-language-policy.md) — C++ for storage nodes.

---

*This PR was drafted by an AI agent (Anthropic Claude — claude-opus-4-7 via Claude Code) under human supervision.  Human review and merge required.*
