### PR TITLE
STYLE: Add 2026 year to copyright headers on T2.3 widget files

### DIFF
--- a/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
+++ b/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Tests for vtkLiverBezierWidget and vtkLiverBezierRepresentation —
   the custom widget landed by ADR-0014 §3.  Per ADR-0008 §2 these are

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/LiverResections/VTKWidgets/vtkLiverBezierWidget.h
+++ b/LiverResections/VTKWidgets/vtkLiverBezierWidget.h
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions


### PR DESCRIPTION
## Summary

Follow-up to merged PR #360 (T2.3 widget skeleton).  The five new files landed without a year in the copyright header — match the legacy in-project precedent on `vtkMRMLLiverResectionNode.cxx` (2017):

```
Copyright (c) YYYY, The Intervention Centre, Oslo University Hospital. All rights reserved.
```

Files touched:

- `LiverResections/VTKWidgets/vtkLiverBezierWidget.{h,cxx}`
- `LiverResections/VTKWidgets/vtkLiverBezierRepresentation.{h,cxx}`
- `LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx`

## Context

Most files in this repo still carry the year-less form `Copyright (c) Oslo University Hospital. All rights reserved.` — issue #338 is the deferred bulk-reformat that will normalise the older files in one sweep.  This PR only fixes the **new** files added by #360; older files unchanged.

A follow-up to wire year enforcement into a pre-commit hook + CI gate is queued separately.

## Test plan

- [x] Local: `grep -L 'Copyright (c) [12][0-9][0-9][0-9]' LiverResections/VTKWidgets/**/*.{h,cxx}` returns empty.
- [ ] CI: lint + commit-message hooks pass.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code.  Opened for human review.*