### PR TITLE
ENH: Register LiverResections storage I/O (T2.6, Option B+)

### DIFF
--- a/LiverResections/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverBezierSurfacePipeline.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
 """State-aware LayerDM Pipeline for the Bezier-surface concept.
 
 This is the first concrete instantiation of the LayerDM Pipeline

--- a/LiverResections/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverBezierSurfacePipeline.py
@@ -114,11 +114,11 @@ except ImportError:  # pragma: no cover — pure-Python / not-yet-built path
           into.  Returns ``None`` in the standalone path; tests inject
           a stub or a real ``vtkRenderer`` as needed.
 
-        T2.6 swaps this out for ``LayerDMLib.vtkMRMLLayerDMScripted
-        Pipeline``; the call surface above is the contract that survives
-        the swap.  Until then this allows the Pipeline to be exercised
-        from direct Python instantiation and unit tests without a Slicer
-        runtime.
+        T2.6-LayerDM swaps this out for ``LayerDMLib.vtkMRMLLayerDM
+        ScriptedPipeline``; the call surface above is the contract that
+        survives the swap.  Until then this allows the Pipeline to be
+        exercised from direct Python instantiation and unit tests
+        without a Slicer runtime.
         """
 
         def __init__(self) -> None:

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -37,7 +37,7 @@
 
   ==============================================================================*/
 
-//NOTE: Some of the functions of this file are inspired in vtkSlicerMarkupsLogic
+// NOTE: Some of the functions of this file are inspired in vtkSlicerMarkupsLogic
 
 #include "vtkSlicerLiverResectionsLogic.h"
 #include "vtkMRMLAbstractLogic.h"
@@ -90,7 +90,7 @@ vtkStandardNewMacro(vtkSlicerLiverResectionsLogic);
 //---------------------------------------------------------------------------
 vtkSlicerLiverResectionsLogic::vtkSlicerLiverResectionsLogic()
 {
-  //auto node = vtkSmartPointer<vtkMRMLGlyphableVolumeDisplayNode>::New();
+  // auto node = vtkSmartPointer<vtkMRMLGlyphableVolumeDisplayNode>::New();
 }
 
 //---------------------------------------------------------------------------
@@ -106,7 +106,7 @@ void vtkSlicerLiverResectionsLogic::PrintSelf(ostream& os, vtkIndent indent)
 void vtkSlicerLiverResectionsLogic::RegisterNodes()
 {
   assert(this->GetMRMLScene() != nullptr);
-  vtkMRMLScene *scene = this->GetMRMLScene();
+  vtkMRMLScene* scene = this->GetMRMLScene();
 
   // Legacy resection node + legacy CSV storage node — still registered
   // so scenes saved before the T2 migration continue to load.  Retired
@@ -126,75 +126,69 @@ void vtkSlicerLiverResectionsLogic::RegisterNodes()
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerLiverResectionsLogic::SetMRMLSceneInternal(vtkMRMLScene * newScene)
+void vtkSlicerLiverResectionsLogic::SetMRMLSceneInternal(vtkMRMLScene* newScene)
 {
-   vtkNew<vtkIntArray> events;
-   events->InsertNextValue(vtkMRMLScene::NodeAddedEvent);
-   events->InsertNextValue(vtkMRMLScene::NodeRemovedEvent);
-   events->InsertNextValue(vtkMRMLScene::EndBatchProcessEvent);
-   this->SetAndObserveMRMLSceneEventsInternal(newScene, events.GetPointer());
+  vtkNew<vtkIntArray> events;
+  events->InsertNextValue(vtkMRMLScene::NodeAddedEvent);
+  events->InsertNextValue(vtkMRMLScene::NodeRemovedEvent);
+  events->InsertNextValue(vtkMRMLScene::EndBatchProcessEvent);
+  this->SetAndObserveMRMLSceneEventsInternal(newScene, events.GetPointer());
 }
 
 //---------------------------------------------------------------------------
 void vtkSlicerLiverResectionsLogic::ObserveMRMLScene()
 {
- this->Superclass::ObserveMRMLScene();
+  this->Superclass::ObserveMRMLScene();
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerLiverResectionsLogic::ProcessMRMLNodesEvents(vtkObject *caller,
-                                                           unsigned long event,
-                                                           void *vtkNotUsed(callData))
+void vtkSlicerLiverResectionsLogic::ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void* vtkNotUsed(callData))
 {
   // Process slicing initialization
   auto slicingInitializationNode = vtkMRMLMarkupsSlicingContourNode::SafeDownCast(caller);
   if (slicingInitializationNode)
+  {
+    switch (event)
     {
-    switch(event)
-      {
-      case vtkCommand::StartInteractionEvent:
-        this->HideBezierSurfaceMarkup(slicingInitializationNode);
-        break;
+      case vtkCommand::StartInteractionEvent: this->HideBezierSurfaceMarkup(slicingInitializationNode); break;
 
-      case vtkCommand::EndInteractionEvent:
-        this->UpdateBezierWidgetOnInitialization(slicingInitializationNode);
-        break;
-      }
+      case vtkCommand::EndInteractionEvent: this->UpdateBezierWidgetOnInitialization(slicingInitializationNode); break;
     }
+  }
 
   // Process slicing bezier surface
   auto bezierSurfaceNode = vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(caller);
   if (bezierSurfaceNode && event == vtkCommand::StartInteractionEvent)
-    {
+  {
     this->HideInitializationMarkup(bezierSurfaceNode);
     auto resectionNode = this->GetResectionFromBezier(bezierSurfaceNode);
     if (resectionNode)
-      {
+    {
       MRMLNodeModifyBlocker blocker(resectionNode);
       resectionNode->SetState(vtkMRMLLiverResectionNode::Deformation);
-      }
     }
+  }
 
   // Process resection node
   auto resectionNode = vtkMRMLLiverResectionNode::SafeDownCast(caller);
   if (resectionNode && event == vtkCommand::ModifiedEvent)
-    {
+  {
     // Create the resection elements
     if (this->ResectionToInitializationMap.find(resectionNode) == this->ResectionToInitializationMap.end())
-      {
+    {
       this->CreateInitializationAndResectionMarkups(resectionNode);
-      }
+    }
 
     // Update the polydata
-    auto initializationNode =  vtkMRMLMarkupsSlicingContourNode::SafeDownCast(this->GetInitializationFromResection(resectionNode));
-    if(initializationNode)
-      {
-        initializationNode->SetTarget(resectionNode->GetTargetOrganModelNode());
-      }
+    auto initializationNode = vtkMRMLMarkupsSlicingContourNode::SafeDownCast(this->GetInitializationFromResection(resectionNode));
+    if (initializationNode)
+    {
+      initializationNode->SetTarget(resectionNode->GetTargetOrganModelNode());
+    }
 
     auto bezierSurfaceNode = this->GetBezierFromResection(resectionNode);
     if (bezierSurfaceNode)
-      {
+    {
       bezierSurfaceNode->SetDistanceMapVolumeNode(resectionNode->GetDistanceMapVolumeNode());
       bezierSurfaceNode->SetVascularSegmentsVolumeNode(resectionNode->GetVascularSegmentsVolumeNode());
       bezierSurfaceNode->SetResectionMargin(resectionNode->GetResectionMargin());
@@ -202,10 +196,9 @@ void vtkSlicerLiverResectionsLogic::ProcessMRMLNodesEvents(vtkObject *caller,
       bezierSurfaceNode->SetHepaticContourThickness(resectionNode->GetHepaticContourThickness());
       bezierSurfaceNode->SetPortalContourThickness(resectionNode->GetPortalContourThickness());
 
-      auto bezierSurfaceDisplayNode =
-        vtkMRMLMarkupsBezierSurfaceDisplayNode::SafeDownCast(bezierSurfaceNode->GetDisplayNode());
+      auto bezierSurfaceDisplayNode = vtkMRMLMarkupsBezierSurfaceDisplayNode::SafeDownCast(bezierSurfaceNode->GetDisplayNode());
       if (bezierSurfaceDisplayNode)
-        {
+      {
         bezierSurfaceDisplayNode->SetShowResection2D(resectionNode->GetShowResection2D());
         bezierSurfaceDisplayNode->SetMirrorDisplay(resectionNode->GetMirrorDisplay());
         bezierSurfaceDisplayNode->SetEnableFlexibleBoundary(resectionNode->GetEnableFlexibleBoundary());
@@ -224,10 +217,10 @@ void vtkSlicerLiverResectionsLogic::ProcessMRMLNodesEvents(vtkObject *caller,
         bezierSurfaceDisplayNode->SetGrid3DVisibility(resectionNode->GetGrid3DVisibility());
         bezierSurfaceDisplayNode->SetHepaticContourColor(resectionNode->GetHepaticContourColor());
         bezierSurfaceDisplayNode->SetPortalContourColor(resectionNode->GetPortalContourColor());
-        }
-      bezierSurfaceNode->SetLocked(!resectionNode->GetWidgetVisibility());
       }
+      bezierSurfaceNode->SetLocked(!resectionNode->GetWidgetVisibility());
     }
+  }
 }
 
 //---------------------------------------------------------------------------
@@ -239,9 +232,9 @@ void vtkSlicerLiverResectionsLogic::OnMRMLSceneNodeAdded(vtkMRMLNode* node)
 
   // check for nullptr and target organ
   if (!resectionNode)
-    {
+  {
     return;
-    }
+  }
 
   // Add callbacks dealing with the modification of the resection node. Its
   // modification may trigger changes on the underlying initialization/bezier status
@@ -251,10 +244,10 @@ void vtkSlicerLiverResectionsLogic::OnMRMLSceneNodeAdded(vtkMRMLNode* node)
   vtkObserveMRMLNodeEventsMacro(resectionNode, resectionNodeEvents.GetPointer());
 
   if (resectionNode->GetTargetOrganModelNode())
-    {
+  {
     // Create resection initialization a surface markups.
     this->CreateInitializationAndResectionMarkups(resectionNode);
-    }
+  }
 }
 
 //---------------------------------------------------------------------------
@@ -264,51 +257,51 @@ void vtkSlicerLiverResectionsLogic::OnMRMLSceneNodeRemoved(vtkMRMLNode* node)
 
   // check for nullptr and target organ
   if (!resectionNode)
-    {
+  {
     return;
-    }
+  }
 
   vtkMRMLMarkupsNode* initializationNode = nullptr;
   vtkMRMLMarkupsBezierSurfaceNode* bezierSurfaceNode = nullptr;
 
   auto riMapIt = this->ResectionToInitializationMap.find(resectionNode);
   if (riMapIt != this->ResectionToInitializationMap.end())
-    {
+  {
     initializationNode = riMapIt->second.GetPointer();
     this->ResectionToInitializationMap.erase(riMapIt);
-    }
+  }
 
   auto irMapIt = this->InitializationToResectionMap.find(initializationNode);
   if (irMapIt != this->InitializationToResectionMap.end())
-    {
+  {
     this->InitializationToResectionMap.erase(irMapIt);
-    }
+  }
 
   auto rbMapIt = this->ResectionToBezierMap.find(resectionNode);
   if (rbMapIt != this->ResectionToBezierMap.end())
-    {
+  {
     bezierSurfaceNode = rbMapIt->second.GetPointer();
     this->ResectionToBezierMap.erase(rbMapIt);
-    }
+  }
 
   auto brMapIt = this->BezierToResectionMap.find(bezierSurfaceNode);
   if (brMapIt != this->BezierToResectionMap.end())
-    {
+  {
     resectionNode = brMapIt->second.GetPointer();
     this->BezierToResectionMap.erase(brMapIt);
-    }
+  }
 
   auto ibMapIt = this->InitializationToBezierMap.find(initializationNode);
   if (ibMapIt != this->InitializationToBezierMap.end())
-    {
+  {
     this->InitializationToBezierMap.erase(ibMapIt);
-    }
+  }
 
   auto biMapIt = this->BezierToInitializationMap.find(bezierSurfaceNode);
   if (biMapIt != this->BezierToInitializationMap.end())
-    {
+  {
     this->BezierToInitializationMap.erase(biMapIt);
-    }
+  }
 
   // NOTE: This is a workaround to "delete" the contour from visualization.
   // A better option would be that the markup takes care of this.
@@ -324,40 +317,39 @@ void vtkSlicerLiverResectionsLogic::OnMRMLSceneNodeRemoved(vtkMRMLNode* node)
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLMarkupsSlicingContourNode*
-vtkSlicerLiverResectionsLogic::AddResectionPlane(vtkMRMLLiverResectionNode *resectionNode) const
+vtkMRMLMarkupsSlicingContourNode* vtkSlicerLiverResectionsLogic::AddResectionPlane(vtkMRMLLiverResectionNode* resectionNode) const
 {
   auto mrmlScene = this->GetMRMLScene();
   if (!mrmlScene)
-    {
-      vtkErrorMacro("Error in AddResectionPlane: no valid MRML scene.");
-      return nullptr;
-    }
+  {
+    vtkErrorMacro("Error in AddResectionPlane: no valid MRML scene.");
+    return nullptr;
+  }
 
   if (!resectionNode->GetTargetOrganModelNode())
-    {
-      vtkErrorMacro("Error in AddResectionPlane: invalid internal target parenchyma.");
-      return nullptr;
-    }
+  {
+    vtkErrorMacro("Error in AddResectionPlane: invalid internal target parenchyma.");
+    return nullptr;
+  }
 
   auto targetParenchymaPolyData = resectionNode->GetTargetOrganModelNode()->GetPolyData();
   if (!targetParenchymaPolyData)
-    {
-      vtkErrorMacro("Error in AddResectionPlane: target liver model does not contain valid polydata.");
-      return nullptr;
-    }
+  {
+    vtkErrorMacro("Error in AddResectionPlane: target liver model does not contain valid polydata.");
+    return nullptr;
+  }
 
   // Computing the position of the initial points
-  const double *bounds = targetParenchymaPolyData->GetBounds();
-  auto p1 = vtkVector3d(bounds[0],(bounds[3]-bounds[2])/2.0, (bounds[5]-bounds[4])/2.0);
-  auto p2 = vtkVector3d(bounds[1],(bounds[3]-bounds[2])/2.0, (bounds[5]-bounds[4])/2.0);
+  const double* bounds = targetParenchymaPolyData->GetBounds();
+  auto p1 = vtkVector3d(bounds[0], (bounds[3] - bounds[2]) / 2.0, (bounds[5] - bounds[4]) / 2.0);
+  auto p2 = vtkVector3d(bounds[1], (bounds[3] - bounds[2]) / 2.0, (bounds[5] - bounds[4]) / 2.0);
 
   auto slicingContourNode = vtkMRMLMarkupsSlicingContourNode::SafeDownCast(mrmlScene->AddNewNodeByClass("vtkMRMLMarkupsSlicingContourNode"));
   if (!slicingContourNode)
-    {
-      vtkErrorMacro("Error in AddResectionPlane: Error creating vtkMRMLMarkupsSlicingContourNode.");
-      return nullptr;
-    }
+  {
+    vtkErrorMacro("Error in AddResectionPlane: Error creating vtkMRMLMarkupsSlicingContourNode.");
+    return nullptr;
+  }
   slicingContourNode->CreateDefaultDisplayNodes();
   slicingContourNode->AddControlPoint(p1);
   slicingContourNode->AddControlPoint(p2);
@@ -365,10 +357,10 @@ vtkSlicerLiverResectionsLogic::AddResectionPlane(vtkMRMLLiverResectionNode *rese
 
   auto slicingContourDisplayNode = vtkMRMLMarkupsSlicingContourDisplayNode::SafeDownCast(slicingContourNode->GetDisplayNode());
   if (!slicingContourDisplayNode)
-    {
-      vtkErrorMacro("Error in AddResectionPlane: Error getting vtkMRMLMarkupsSlicingContourDisplayNode.");
-      return nullptr;
-    }
+  {
+    vtkErrorMacro("Error in AddResectionPlane: Error getting vtkMRMLMarkupsSlicingContourDisplayNode.");
+    return nullptr;
+  }
   slicingContourDisplayNode->PropertiesLabelVisibilityOff();
   slicingContourDisplayNode->SetSnapMode(vtkMRMLMarkupsDisplayNode::SnapModeUnconstrained);
 
@@ -376,39 +368,38 @@ vtkSlicerLiverResectionsLogic::AddResectionPlane(vtkMRMLLiverResectionNode *rese
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLMarkupsDistanceContourNode*
-vtkSlicerLiverResectionsLogic::AddResectionContour(vtkMRMLLiverResectionNode *resectionNode) const
+vtkMRMLMarkupsDistanceContourNode* vtkSlicerLiverResectionsLogic::AddResectionContour(vtkMRMLLiverResectionNode* resectionNode) const
 {
   auto mrmlScene = this->GetMRMLScene();
   if (!mrmlScene)
-    {
+  {
     vtkErrorMacro("Error in AddResectionContour: no valid MRML scene.");
     return nullptr;
-    }
+  }
 
-  if(!resectionNode)
-    {
+  if (!resectionNode)
+  {
     vtkErrorMacro("Error in AddResectionContour: no valid resection node.");
     return nullptr;
-    }
+  }
 
   if (!resectionNode->GetTargetOrganModelNode())
-    {
-      vtkErrorMacro("Error in AddResectionContour: no valid target parenchyma node.");
-      return nullptr;
-    }
+  {
+    vtkErrorMacro("Error in AddResectionContour: no valid target parenchyma node.");
+    return nullptr;
+  }
 
   // Computing the position of the initial points
-  const double *bounds = resectionNode->GetTargetOrganModelNode()->GetPolyData()->GetBounds();
-  auto p1 = vtkVector3d(bounds[0],(bounds[3]-bounds[2])/2.0, (bounds[5]-bounds[4])/2.0);
-  auto p2 = vtkVector3d((bounds[1]-bounds[0])/2.0,(bounds[3]-bounds[2])/2.0, (bounds[5]-bounds[4])/2.0);
+  const double* bounds = resectionNode->GetTargetOrganModelNode()->GetPolyData()->GetBounds();
+  auto p1 = vtkVector3d(bounds[0], (bounds[3] - bounds[2]) / 2.0, (bounds[5] - bounds[4]) / 2.0);
+  auto p2 = vtkVector3d((bounds[1] - bounds[0]) / 2.0, (bounds[3] - bounds[2]) / 2.0, (bounds[5] - bounds[4]) / 2.0);
 
   auto distanceContourNode = vtkMRMLMarkupsDistanceContourNode::SafeDownCast(mrmlScene->AddNewNodeByClass("vtkMRMLMarkupsDistanceContourNode"));
   if (!distanceContourNode)
-    {
-      vtkErrorMacro("Error in AddResectionPlane: Error creating vtkMRMLMarkupsDistanceContourNode.");
-      return nullptr;
-    }
+  {
+    vtkErrorMacro("Error in AddResectionPlane: Error creating vtkMRMLMarkupsDistanceContourNode.");
+    return nullptr;
+  }
 
   distanceContourNode->CreateDefaultDisplayNodes();
   distanceContourNode->AddControlPoint(p1);
@@ -427,48 +418,46 @@ vtkSlicerLiverResectionsLogic::AddResectionContour(vtkMRMLLiverResectionNode *re
 }
 
 //------------------------------------------------------------------------------
-vtkMRMLMarkupsBezierSurfaceNode*
-vtkSlicerLiverResectionsLogic::AddBezierSurface(vtkMRMLLiverResectionNode *resectionNode) const
+vtkMRMLMarkupsBezierSurfaceNode* vtkSlicerLiverResectionsLogic::AddBezierSurface(vtkMRMLLiverResectionNode* resectionNode) const
 {
   auto mrmlScene = this->GetMRMLScene();
   if (!mrmlScene)
-    {
+  {
     vtkErrorMacro("Error in AddResectionContour: no valid MRML scene.");
     return nullptr;
-    }
+  }
 
-  if(!resectionNode)
-    {
+  if (!resectionNode)
+  {
     vtkErrorMacro("Error in AddResectionContour: no valid resection node.");
     return nullptr;
-    }
+  }
 
-  auto markupsBezierSurfaceNode =
-    vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(mrmlScene->AddNewNodeByClass("vtkMRMLMarkupsBezierSurfaceNode"));
+  auto markupsBezierSurfaceNode = vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(mrmlScene->AddNewNodeByClass("vtkMRMLMarkupsBezierSurfaceNode"));
   if (!markupsBezierSurfaceNode)
-    {
+  {
     vtkErrorMacro("Error adding a vtkMRMLMarkupsBezierSurfceNode to the scene");
     return nullptr;
-    }
+  }
 
   markupsBezierSurfaceNode->SetScene(mrmlScene);
 
-  for (int i = 0; i<4; ++i)
+  for (int i = 0; i < 4; ++i)
+  {
+    for (int j = 0; j < 4; ++j)
     {
-    for (int j = 0; j<4; ++j)
-      {
-      markupsBezierSurfaceNode->AddControlPoint({10.0f*i, 10.0f*j, 0.0f});
-      }
+      markupsBezierSurfaceNode->AddControlPoint({ 10.0f * i, 10.0f * j, 0.0f });
     }
+  }
 
   markupsBezierSurfaceNode->SetHideFromEditors(false);
 
   auto markupsBezierSurfaceDisplayNode = vtkMRMLMarkupsBezierSurfaceDisplayNode::SafeDownCast(markupsBezierSurfaceNode->GetDisplayNode());
   if (markupsBezierSurfaceDisplayNode)
-    {
+  {
     markupsBezierSurfaceDisplayNode->SetVisibility(false); // Initially hidden
     markupsBezierSurfaceDisplayNode->SetSnapMode(vtkMRMLMarkupsDisplayNode::SnapModeUnconstrained);
-    }
+  }
 
   resectionNode->SetBezierSurfaceNode(markupsBezierSurfaceNode);
 
@@ -476,73 +465,67 @@ vtkSlicerLiverResectionsLogic::AddBezierSurface(vtkMRMLLiverResectionNode *resec
 }
 
 //------------------------------------------------------------------------------
-vtkMRMLLiverResectionNode* vtkSlicerLiverResectionsLogic
-::GetResectionFromBezier(vtkMRMLMarkupsBezierSurfaceNode* markupsBezierNode) const
+vtkMRMLLiverResectionNode* vtkSlicerLiverResectionsLogic ::GetResectionFromBezier(vtkMRMLMarkupsBezierSurfaceNode* markupsBezierNode) const
 {
   auto bezierToResection = this->BezierToResectionMap.find(markupsBezierNode);
   if (bezierToResection == this->BezierToResectionMap.end())
-    {
+  {
     return nullptr;
-    }
+  }
   return bezierToResection->second;
 }
 
 //------------------------------------------------------------------------------
-vtkMRMLLiverResectionNode* vtkSlicerLiverResectionsLogic
-::GetResectionFromInitialization(vtkMRMLMarkupsNode* initializationNode) const
+vtkMRMLLiverResectionNode* vtkSlicerLiverResectionsLogic ::GetResectionFromInitialization(vtkMRMLMarkupsNode* initializationNode) const
 {
   auto initializationToResection = this->InitializationToResectionMap.find(initializationNode);
   if (initializationToResection == this->InitializationToResectionMap.end())
-    {
+  {
     return nullptr;
-    }
+  }
   return initializationToResection->second;
 }
 //------------------------------------------------------------------------------
-vtkMRMLMarkupsNode* vtkSlicerLiverResectionsLogic
-::GetInitializationFromResection(vtkMRMLLiverResectionNode* resectionNode) const
+vtkMRMLMarkupsNode* vtkSlicerLiverResectionsLogic ::GetInitializationFromResection(vtkMRMLLiverResectionNode* resectionNode) const
 {
   auto resectionToInitialization = this->ResectionToInitializationMap.find(resectionNode);
   if (resectionToInitialization == this->ResectionToInitializationMap.end())
-    {
+  {
     return nullptr;
-    }
+  }
   return resectionToInitialization->second;
 }
 
 //------------------------------------------------------------------------------
-vtkMRMLMarkupsBezierSurfaceNode* vtkSlicerLiverResectionsLogic
-::GetBezierFromResection(vtkMRMLLiverResectionNode* resectionNode) const
+vtkMRMLMarkupsBezierSurfaceNode* vtkSlicerLiverResectionsLogic ::GetBezierFromResection(vtkMRMLLiverResectionNode* resectionNode) const
 {
   auto resectionToBezier = this->ResectionToBezierMap.find(resectionNode);
   if (resectionToBezier == this->ResectionToBezierMap.end())
-    {
+  {
     return nullptr;
-    }
+  }
   return resectionToBezier->second;
 }
 
 //------------------------------------------------------------------------------
-vtkMRMLMarkupsBezierSurfaceNode* vtkSlicerLiverResectionsLogic
-::GetBezierFromInitialization(vtkMRMLMarkupsNode *initializationNode) const
+vtkMRMLMarkupsBezierSurfaceNode* vtkSlicerLiverResectionsLogic ::GetBezierFromInitialization(vtkMRMLMarkupsNode* initializationNode) const
 {
   auto initializationToBezier = this->InitializationToBezierMap.find(initializationNode);
   if (initializationToBezier == this->InitializationToBezierMap.end())
-    {
+  {
     return nullptr;
-    }
+  }
   return initializationToBezier->second;
 }
 
 //------------------------------------------------------------------------------
-vtkMRMLMarkupsNode * vtkSlicerLiverResectionsLogic
-::GetInitializationFromBezier(vtkMRMLMarkupsBezierSurfaceNode* markupsBezierNode) const
+vtkMRMLMarkupsNode* vtkSlicerLiverResectionsLogic ::GetInitializationFromBezier(vtkMRMLMarkupsBezierSurfaceNode* markupsBezierNode) const
 {
   auto BezierToInitialization = this->BezierToInitializationMap.find(markupsBezierNode);
   if (BezierToInitialization == this->BezierToInitializationMap.end())
-    {
+  {
     return nullptr;
-    }
+  }
   return BezierToInitialization->second;
 }
 
@@ -551,15 +534,15 @@ void vtkSlicerLiverResectionsLogic::ShowBezierSurfaceMarkupFromResection(vtkMRML
 {
   auto bezierSurfaceNode = this->GetBezierFromResection(resectionNode);
   if (!bezierSurfaceNode)
-    {
+  {
     return;
-    }
+  }
 
   auto bezierSurfaceDisplayNode = bezierSurfaceNode->GetDisplayNode();
   if (!bezierSurfaceDisplayNode)
-    {
+  {
     return;
-    }
+  }
 
   bezierSurfaceDisplayNode->VisibilityOn();
 }
@@ -569,15 +552,15 @@ void vtkSlicerLiverResectionsLogic::HideBezierSurfaceMarkupFromResection(vtkMRML
 {
   auto bezierSurfaceNode = this->GetBezierFromResection(resectionNode);
   if (!bezierSurfaceNode)
-    {
+  {
     return;
-    }
+  }
 
   auto bezierSurfaceDisplayNode = bezierSurfaceNode->GetDisplayNode();
   if (!bezierSurfaceDisplayNode)
-    {
+  {
     return;
-    }
+  }
 
   bezierSurfaceDisplayNode->VisibilityOff();
 }
@@ -587,15 +570,15 @@ void vtkSlicerLiverResectionsLogic::ShowInitializationMarkupFromResection(vtkMRM
 {
   auto initializationNode = this->GetInitializationFromResection(resectionNode);
   if (!initializationNode)
-    {
+  {
     return;
-    }
+  }
 
   auto initializationDisplayNode = initializationNode->GetDisplayNode();
   if (!initializationDisplayNode)
-    {
+  {
     return;
-    }
+  }
 
   initializationDisplayNode->VisibilityOn();
 }
@@ -605,15 +588,15 @@ void vtkSlicerLiverResectionsLogic::HideInitializationMarkupFromResection(vtkMRM
 {
   auto initializationNode = this->GetInitializationFromResection(resectionNode);
   if (!initializationNode)
-    {
+  {
     return;
-    }
+  }
 
   auto initializationDisplayNode = initializationNode->GetDisplayNode();
   if (!initializationDisplayNode)
-    {
+  {
     return;
-    }
+  }
 
   initializationDisplayNode->VisibilityOff();
 }
@@ -623,15 +606,15 @@ void vtkSlicerLiverResectionsLogic::ShowBezierSurfaceMarkup(vtkMRMLMarkupsNode* 
 {
   auto bezierSurfaceNode = this->GetBezierFromInitialization(initializationNode);
   if (!bezierSurfaceNode)
-    {
+  {
     return;
-    }
+  }
 
   auto bezierSurfaceDisplayNode = bezierSurfaceNode->GetDisplayNode();
   if (!bezierSurfaceDisplayNode)
-    {
+  {
     return;
-    }
+  }
 
   bezierSurfaceDisplayNode->VisibilityOn();
 }
@@ -641,15 +624,15 @@ void vtkSlicerLiverResectionsLogic::HideBezierSurfaceMarkup(vtkMRMLMarkupsNode* 
 {
   auto bezierSurfaceNode = this->GetBezierFromInitialization(initializationNode);
   if (!bezierSurfaceNode)
-    {
+  {
     return;
-    }
+  }
 
   auto bezierSurfaceDisplayNode = bezierSurfaceNode->GetDisplayNode();
   if (!bezierSurfaceDisplayNode)
-    {
+  {
     return;
-    }
+  }
 
   bezierSurfaceDisplayNode->VisibilityOff();
 }
@@ -660,15 +643,15 @@ void vtkSlicerLiverResectionsLogic::ShowInitializationMarkup(vtkMRMLMarkupsBezie
 {
   auto markupsInitializationNode = this->GetInitializationFromBezier(markupsBezierNode);
   if (!markupsInitializationNode)
-    {
+  {
     return;
-    }
+  }
 
   auto markupsInitializationDisplayNode = markupsInitializationNode->GetDisplayNode();
   if (!markupsInitializationDisplayNode)
-    {
+  {
     return;
-    }
+  }
 
   markupsInitializationDisplayNode->SetVisibility(false);
 }
@@ -678,14 +661,14 @@ void vtkSlicerLiverResectionsLogic::HideInitializationMarkup(vtkMRMLMarkupsBezie
 {
   auto markupsInitializationNode = this->GetInitializationFromBezier(markupsBezierNode);
   if (!markupsInitializationNode)
-    {
+  {
     return;
-    }
+  }
   auto markupsInitializationDisplayNode = markupsInitializationNode->GetDisplayNode();
   if (!markupsInitializationDisplayNode)
-    {
+  {
     return;
-    }
+  }
   markupsInitializationDisplayNode->SetVisibility(false);
 }
 
@@ -694,53 +677,48 @@ void vtkSlicerLiverResectionsLogic::UpdateBezierWidgetOnInitialization(vtkMRMLMa
 {
   // Check initialization node
   if (!initializationNode)
-    {
+  {
     vtkErrorMacro("Error in UpdateBezierWidgetOnInitialization: no initialization node passed");
     return;
-    }
+  }
 
   // Check for resection node from initializatio node
-  auto initializationToResection =
-    this->InitializationToResectionMap.find(initializationNode);
+  auto initializationToResection = this->InitializationToResectionMap.find(initializationNode);
   if (initializationToResection == this->InitializationToResectionMap.end())
-    {
+  {
     vtkErrorMacro("Error in UpdateBezierWidgetOnInitialization: initialization node does not have a corresponding resection node.");
     return;
-    }
+  }
 
   // Check for resection node
   if (!initializationToResection->second)
-    {
+  {
     vtkErrorMacro("Error in UpdateBezierWidgetOnInitialization: initialization node does not have a valid corresponding resection node.");
     return;
-    }
+  }
 
   // Check for target organ model node
   auto parenchymaModelNode = initializationToResection->second->GetTargetOrganModelNode();
   if (!parenchymaModelNode)
-    {
+  {
     vtkErrorMacro("Error in UpdateBezierWidgetOnInitialization: resection node does not have a valid target organ.");
     return;
-    }
+  }
 
   // Check for parenchyma polydata
   if (!parenchymaModelNode->GetPolyData())
-    {
+  {
     vtkErrorMacro("Error UpdateBezierWidgetOnInitialization: parenchyma model node does not contain poly data.");
     return;
-    }
+  }
 
-  auto controlPoints =  initializationNode->GetControlPoints();
+  auto controlPoints = initializationNode->GetControlPoints();
 
   // This algorithm is based on NorMIT-Plan
   // https://github.com/TheInterventionCentre/NorMIT-Plan
 
-  double point1[3] = {(*controlPoints)[0]->Position[0],
-                      (*controlPoints)[0]->Position[1],
-                      (*controlPoints)[0]->Position[2]};
-  double point2[3] = {(*controlPoints)[1]->Position[0],
-                      (*controlPoints)[1]->Position[1],
-                      (*controlPoints)[1]->Position[2]};
+  double point1[3] = { (*controlPoints)[0]->Position[0], (*controlPoints)[0]->Position[1], (*controlPoints)[0]->Position[2] };
+  double point2[3] = { (*controlPoints)[1]->Position[0], (*controlPoints)[1]->Position[1], (*controlPoints)[1]->Position[2] };
   double midPoint[3];
   double normal[3];
 
@@ -761,7 +739,7 @@ void vtkSlicerLiverResectionsLogic::UpdateBezierWidgetOnInitialization(vtkMRMLMa
   cutter->SetCutFunction(cuttingPlane.GetPointer());
   cutter->Update();
 
-  vtkPolyData *contour = cutter->GetOutput();
+  vtkPolyData* contour = cutter->GetOutput();
 
   // Perform Principal Component Analysis
   vtkNew<vtkDoubleArray> xArray;
@@ -777,17 +755,17 @@ void vtkSlicerLiverResectionsLogic::UpdateBezierWidgetOnInitialization(vtkMRMLMa
   vtkNew<vtkCenterOfMass> centerOfMass;
   centerOfMass->SetInputData(contour);
   centerOfMass->Update();
-  double com[3]={0};
+  double com[3] = { 0 };
   centerOfMass->GetCenter(com);
 
-  for(unsigned int i=0; i<contour->GetNumberOfPoints(); i++)
-    {
+  for (unsigned int i = 0; i < contour->GetNumberOfPoints(); i++)
+  {
     double point[3];
     contour->GetPoint(i, point);
     xArray->InsertNextValue(point[0]);
     yArray->InsertNextValue(point[1]);
     zArray->InsertNextValue(point[2]);
-    }
+  }
 
   vtkNew<vtkTable> dataTable;
   dataTable->AddColumn(xArray.GetPointer());
@@ -795,8 +773,7 @@ void vtkSlicerLiverResectionsLogic::UpdateBezierWidgetOnInitialization(vtkMRMLMa
   dataTable->AddColumn(zArray.GetPointer());
 
   vtkNew<vtkPCAStatistics> pcaStatistics;
-  pcaStatistics->SetInputData(vtkStatisticsAlgorithm::INPUT_DATA,
-                              dataTable.GetPointer());
+  pcaStatistics->SetInputData(vtkStatisticsAlgorithm::INPUT_DATA, dataTable.GetPointer());
   pcaStatistics->SetColumnStatus("x", 1);
   pcaStatistics->SetColumnStatus("y", 1);
   pcaStatistics->SetColumnStatus("z", 1);
@@ -814,39 +791,28 @@ void vtkSlicerLiverResectionsLogic::UpdateBezierWidgetOnInitialization(vtkMRMLMa
   vtkNew<vtkDoubleArray> eigenvector3;
   pcaStatistics->GetEigenvector(2, eigenvector3.GetPointer());
 
-  double length1 = 4.0*sqrt(pcaStatistics->GetEigenvalue(0,0));
-  double length2 = 4.0*sqrt(pcaStatistics->GetEigenvalue(0,1));
+  double length1 = 4.0 * sqrt(pcaStatistics->GetEigenvalue(0, 0));
+  double length2 = 4.0 * sqrt(pcaStatistics->GetEigenvalue(0, 1));
 
-  double v1[3] =
-    {
-      eigenvector1->GetValue(0),
-      eigenvector1->GetValue(1),
-      eigenvector1->GetValue(2)
-    };
+  double v1[3] = { eigenvector1->GetValue(0), eigenvector1->GetValue(1), eigenvector1->GetValue(2) };
 
-  double v2[3] =
-    {
-      eigenvector2->GetValue(0),
-      eigenvector2->GetValue(1),
-      eigenvector2->GetValue(2)
-    };
+  double v2[3] = { eigenvector2->GetValue(0), eigenvector2->GetValue(1), eigenvector2->GetValue(2) };
 
-  double origin[3] =
-    {
-      com[0] - v1[0]*length1/2.0 - v2[0]*length2/2.0,
-      com[1] - v1[1]*length1/2.0 - v2[1]*length2/2.0,
-      com[2] - v1[2]*length1/2.0 - v2[2]*length2/2.0,
-    };
+  double origin[3] = {
+    com[0] - v1[0] * length1 / 2.0 - v2[0] * length2 / 2.0,
+    com[1] - v1[1] * length1 / 2.0 - v2[1] * length2 / 2.0,
+    com[2] - v1[2] * length1 / 2.0 - v2[2] * length2 / 2.0,
+  };
 
-  point1[0] = origin[0] + v1[0]*length1;
-  point1[1] = origin[1] + v1[1]*length1;
-  point1[2] = origin[2] + v1[2]*length1;
+  point1[0] = origin[0] + v1[0] * length1;
+  point1[1] = origin[1] + v1[1] * length1;
+  point1[2] = origin[2] + v1[2] * length1;
 
-  point2[0] = origin[0] + v2[0]*length2;
-  point2[1] = origin[1] + v2[1]*length2;
-  point2[2] = origin[2] + v2[2]*length2;
+  point2[0] = origin[0] + v2[0] * length2;
+  point2[1] = origin[1] + v2[1] * length2;
+  point2[2] = origin[2] + v2[2] * length2;
 
-  //Create bezier surface according to initial plane
+  // Create bezier surface according to initial plane
   vtkNew<vtkPlaneSource> planeSource;
   planeSource->SetOrigin(origin);
   planeSource->SetPoint1(point1);
@@ -855,21 +821,19 @@ void vtkSlicerLiverResectionsLogic::UpdateBezierWidgetOnInitialization(vtkMRMLMa
   planeSource->SetYResolution(3);
   planeSource->Update();
 
-  auto initializationToBezier =
-    this->InitializationToBezierMap.find(initializationNode);
+  auto initializationToBezier = this->InitializationToBezierMap.find(initializationNode);
   if (initializationToBezier == this->InitializationToBezierMap.end())
-    {
+  {
     vtkErrorMacro("Error UpdateBezierWidgetOnInitialization: Initialization node does not have a corresponding bezier markups node.");
     return;
-    }
-
+  }
 
   auto bezierSurfaceNode = initializationToBezier->second;
   if (!bezierSurfaceNode)
-    {
+  {
     vtkErrorMacro("Error UpdateBezierWidgetOnInitialization: Initialization node does not have a valid corresponding bezier markups node.");
     return;
-    }
+  }
 
   // Transfer the control points to the resection node
   bezierSurfaceNode->RemoveAllControlPoints();
@@ -878,10 +842,10 @@ void vtkSlicerLiverResectionsLogic::UpdateBezierWidgetOnInitialization(vtkMRMLMa
 
   auto bezierDisplayNode = bezierSurfaceNode->GetDisplayNode();
   if (!bezierDisplayNode)
-    {
+  {
     vtkErrorMacro("Error UpdateBezierWidgetOnInitialization: Bezier markups node does not have a valid display node.");
     return;
-    }
+  }
 
   bezierDisplayNode->VisibilityOn();
 }
@@ -891,21 +855,17 @@ vtkMRMLMarkupsNode* vtkSlicerLiverResectionsLogic::AddInitializationMarkupsNode(
 {
   vtkMRMLMarkupsNode* initializationMarkupsNode = nullptr;
 
-  switch(resectionNode->GetInitMode())
-    {
-    case vtkMRMLLiverResectionNode::Curved:
-      initializationMarkupsNode = this->AddResectionContour(resectionNode);
-      break;
+  switch (resectionNode->GetInitMode())
+  {
+    case vtkMRMLLiverResectionNode::Curved: initializationMarkupsNode = this->AddResectionContour(resectionNode); break;
 
-    case vtkMRMLLiverResectionNode::Flat:
-      initializationMarkupsNode = this->AddResectionPlane(resectionNode);
-      break;
-    }
+    case vtkMRMLLiverResectionNode::Flat: initializationMarkupsNode = this->AddResectionPlane(resectionNode); break;
+  }
 
   if (!initializationMarkupsNode)
-    {
+  {
     return nullptr;
-    }
+  }
 
   initializationMarkupsNode->SetHideFromEditors(false);
   initializationMarkupsNode->GetDisplayNode()->SetVisibility(true); // Initially visible
@@ -917,7 +877,7 @@ vtkMRMLMarkupsNode* vtkSlicerLiverResectionsLogic::AddInitializationMarkupsNode(
 void vtkSlicerLiverResectionsLogic::CreateInitializationAndResectionMarkups(vtkMRMLLiverResectionNode* resectionNode)
 {
   // Create the relevant initialization node
-  vtkMRMLMarkupsNode *initializationMarkupsNode = this->AddInitializationMarkupsNode(resectionNode);
+  vtkMRMLMarkupsNode* initializationMarkupsNode = this->AddInitializationMarkupsNode(resectionNode);
 
   // Register the resection-initialization association
   this->ResectionToInitializationMap[resectionNode] = initializationMarkupsNode;
@@ -928,9 +888,9 @@ void vtkSlicerLiverResectionsLogic::CreateInitializationAndResectionMarkups(vtkM
   this->ResectionToBezierMap[resectionNode] = markupsBezierNode;
   this->BezierToResectionMap[markupsBezierNode] = resectionNode;
 
-  //Add callbacks dealing with the coordination of the resection representation,
-  //this is, whether the resection is visualized as contour, contour + bezier or
-  //bezier.
+  // Add callbacks dealing with the coordination of the resection representation,
+  // this is, whether the resection is visualized as contour, contour + bezier or
+  // bezier.
   vtkNew<vtkIntArray> nodeEvents;
   nodeEvents->InsertNextValue(vtkCommand::StartInteractionEvent);
   nodeEvents->InsertNextValue(vtkCommand::EndInteractionEvent);
@@ -944,119 +904,115 @@ void vtkSlicerLiverResectionsLogic::CreateInitializationAndResectionMarkups(vtkM
 }
 
 //------------------------------------------------------------------------------
-char* vtkSlicerLiverResectionsLogic::LoadLiverResection(const std::string& fileName,
-                                                   const std::string& nodeName/*=nullptr*/,
-                                                   vtkMRMLMessageCollection* userMessages/*=nullptr*/)
+char* vtkSlicerLiverResectionsLogic::LoadLiverResection(const std::string& fileName, const std::string& nodeName /*=nullptr*/, vtkMRMLMessageCollection* userMessages /*=nullptr*/)
 {
   if (fileName == "")
-    {
+  {
     vtkErrorMacro("vtkSlicerLiverResectionsLogic::LoadResections failed: invalid fileName");
     return nullptr;
-    }
+  }
 
   // get file extension
   std::string extension = vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(fileName);
-  if( extension.empty() )
-    {
+  if (extension.empty())
+  {
     vtkErrorMacro("vtkSlicerLiverResectionsLogic::LoadResections failed: no file extension specified: " << fileName);
     return nullptr;
-    }
+  }
 
   // if (extension == std::string(".json"))
   //   {
   //   return this->LoadLiverResectionsFromJson(fileName, nodeName, userMessages);
   //   }
-  /*else */if (extension == std::string(".fcsv"))
-    {
+  /*else */ if (extension == std::string(".fcsv"))
+  {
     return this->LoadLiverResectionFromFcsv(fileName, nodeName, userMessages);
-    }
+  }
   else
-    {
+  {
     vtkErrorMacro("vtkSlicerLiverResectionsLogic::LoadResections failed: unrecognized file extension in " << fileName);
     return nullptr;
-    }
+  }
 }
 
 //---------------------------------------------------------------------------
-char *vtkSlicerLiverResectionsLogic::LoadLiverResectionFromFcsv(const std::string &fileName,
-                                                                 const std::string &nodeName /*=nullptr*/,
-                                                                 vtkMRMLMessageCollection *userMessages /*=nullptr*/)
+char* vtkSlicerLiverResectionsLogic::LoadLiverResectionFromFcsv(const std::string& fileName,
+                                                                const std::string& nodeName /*=nullptr*/,
+                                                                vtkMRMLMessageCollection* userMessages /*=nullptr*/)
 {
 
-  if (fileName == "") {
-    vtkErrorMacro(
-        "LoadLiverResections: null file or markups class name, cannot load");
+  if (fileName == "")
+  {
+    vtkErrorMacro("LoadLiverResections: null file or markups class name, cannot load");
     return nullptr;
   }
 
-  vtkDebugMacro("LoadLiverResections, file name = "
-                << fileName << ", nodeName = " << nodeName);
+  vtkDebugMacro("LoadLiverResections, file name = " << fileName << ", nodeName = " << nodeName);
   // make a storage node and fiducial node and set the file name
-  auto storageNode =
-      vtkMRMLStorageNode::SafeDownCast(this->GetMRMLScene()->AddNewNodeByClass(
-          "vtkMRMLLiverResectionCSVStorageNode"));
-  if (!storageNode) {
+  auto storageNode = vtkMRMLStorageNode::SafeDownCast(this->GetMRMLScene()->AddNewNodeByClass("vtkMRMLLiverResectionCSVStorageNode"));
+  if (!storageNode)
+  {
     vtkErrorMacro("LoadLiverResections: failed to instantiate markups storage "
                   "node by class vtkMRMLLiverResectionsFiducialNode");
     return nullptr;
   }
 
   std::string newNodeName;
-  if (nodeName.length() > 0) {
+  if (nodeName.length() > 0)
+  {
     newNodeName = nodeName;
-  } else {
-    newNodeName = this->GetMRMLScene()->GetUniqueNameByString(
-        storageNode->GetFileNameWithoutExtension(fileName.c_str()).c_str());
   }
-  auto bezierNode = vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(
-      this->GetMRMLScene()->AddNewNodeByClass(
-          "vtkMRMLMarkupsBezierSurfaceNode"));
-  if (!bezierNode) {
-    vtkErrorMacro(
-        "LoadLiverResections: failed to instantiate markups bezier node by "
-        "class vtkMRMLLiverResectionFiducialNode");
-    if (userMessages) {
+  else
+  {
+    newNodeName = this->GetMRMLScene()->GetUniqueNameByString(storageNode->GetFileNameWithoutExtension(fileName.c_str()).c_str());
+  }
+  auto bezierNode = vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(this->GetMRMLScene()->AddNewNodeByClass("vtkMRMLMarkupsBezierSurfaceNode"));
+  if (!bezierNode)
+  {
+    vtkErrorMacro("LoadLiverResections: failed to instantiate markups bezier node by "
+                  "class vtkMRMLLiverResectionFiducialNode");
+    if (userMessages)
+    {
       userMessages->AddMessages(storageNode->GetUserMessages());
     }
   }
   bezierNode->SetHideFromEditors(true);
 
-  auto markupsNode = vtkMRMLLiverResectionNode::SafeDownCast(
-      this->GetMRMLScene()->AddNewNodeByClass("vtkMRMLLiverResectionNode",
-                                              newNodeName));
-  if (!markupsNode) {
+  auto markupsNode = vtkMRMLLiverResectionNode::SafeDownCast(this->GetMRMLScene()->AddNewNodeByClass("vtkMRMLLiverResectionNode", newNodeName));
+  if (!markupsNode)
+  {
     vtkErrorMacro("LoadLiverResections: failed to instantiate liver "
                   "resection markups node by "
                   "class vtkMRMLLiverResectionsNode");
-    if (userMessages) {
+    if (userMessages)
+    {
       userMessages->AddMessages(storageNode->GetUserMessages());
     }
     this->GetMRMLScene()->RemoveNode(storageNode);
     return nullptr;
-    }
-
-    markupsNode->SetBezierSurfaceNode(bezierNode);
-
-    storageNode->SetFileName(fileName.c_str());
-    // add the nodes to the scene and set up the observation on the storage node
-    markupsNode->SetAndObserveStorageNodeID(storageNode->GetID());
-
-    // read the file
-    char *nodeID = nullptr;
-    if (storageNode->ReadData(markupsNode))
-      {
-      nodeID = markupsNode->GetID();
-      }
-    else
-      {
-      if (userMessages)
-        {
-        userMessages->AddMessages(storageNode->GetUserMessages());
-        }
-      this->GetMRMLScene()->RemoveNode(storageNode);
-      this->GetMRMLScene()->RemoveNode(markupsNode);
-    }
-
-    return nodeID;
   }
 
+  markupsNode->SetBezierSurfaceNode(bezierNode);
+
+  storageNode->SetFileName(fileName.c_str());
+  // add the nodes to the scene and set up the observation on the storage node
+  markupsNode->SetAndObserveStorageNodeID(storageNode->GetID());
+
+  // read the file
+  char* nodeID = nullptr;
+  if (storageNode->ReadData(markupsNode))
+  {
+    nodeID = markupsNode->GetID();
+  }
+  else
+  {
+    if (userMessages)
+    {
+      userMessages->AddMessages(storageNode->GetUserMessages());
+    }
+    this->GetMRMLScene()->RemoveNode(storageNode);
+    this->GetMRMLScene()->RemoveNode(markupsNode);
+  }
+
+  return nodeID;
+}

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2017-2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -42,6 +42,14 @@
 #include "vtkSlicerLiverResectionsLogic.h"
 #include "vtkMRMLAbstractLogic.h"
 #include "vtkMRMLLiverResectionCSVStorageNode.h"
+
+// T2 LiverResources data nodes (ADR-0014 §1, §5).  Registered with the
+// scene in RegisterNodes() so scene save/load and the Add/Save Data
+// dialogs round-trip the new ``vtkMRMLBezierSurfaceNode`` family and
+// recognise the new ``.lrp.json`` storage format.
+#include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLBezierSurfaceDisplayNode.h"
+#include "vtkMRMLBezierSurfaceStorageNode.h"
 
 #include <vtkCommand.h>
 #include <vtkMRMLMarkupsSlicingContourNode.h>
@@ -100,9 +108,21 @@ void vtkSlicerLiverResectionsLogic::RegisterNodes()
   assert(this->GetMRMLScene() != nullptr);
   vtkMRMLScene *scene = this->GetMRMLScene();
 
-  // Nodes
+  // Legacy resection node + legacy CSV storage node — still registered
+  // so scenes saved before the T2 migration continue to load.  Retired
+  // by task T2.7 alongside the resection-rename + LiverMarkups
+  // dissolution (ADR-0014).
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLiverResectionNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLiverResectionCSVStorageNode>::New());
+
+  // T2 LiverResources data nodes (ADR-0014 §1, §5).  Registering the
+  // storage node here makes scene save/load round-trip the new
+  // ``.lrp.json`` format; the Bezier data + display nodes are
+  // registered so MRML can instantiate them by class name on scene
+  // load.
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceDisplayNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceStorageNode>::New());
 }
 
 //---------------------------------------------------------------------------

--- a/LiverResections/Testing/Cxx/vtkSlicerLiverResectionsLogicTest1.cxx
+++ b/LiverResections/Testing/Cxx/vtkSlicerLiverResectionsLogicTest1.cxx
@@ -57,24 +57,24 @@
 
 namespace
 {
-    void checkAddAndGetNode(vtkSmartPointer<vtkMRMLScene> scene, const char* ClassName)
-    {
-        auto node = scene->GetFirstNodeByClass(ClassName);
-        assert(node == nullptr);
+void checkAddAndGetNode(vtkSmartPointer<vtkMRMLScene> scene, const char* ClassName)
+{
+  auto node = scene->GetFirstNodeByClass(ClassName);
+  assert(node == nullptr);
 
-        std::string newNodeName = ClassName;
-        newNodeName.append("_Test");
-        scene->AddNewNodeByClass(ClassName, newNodeName);
-        node = scene->GetFirstNodeByClass(ClassName);
-        assert(node != nullptr);
+  std::string newNodeName = ClassName;
+  newNodeName.append("_Test");
+  scene->AddNewNodeByClass(ClassName, newNodeName);
+  node = scene->GetFirstNodeByClass(ClassName);
+  assert(node != nullptr);
 
-        auto node2 = scene->GetNodeByID(node->GetID());
-        assert(node2 != nullptr);
-        assert(node == node2);
-    }
+  auto node2 = scene->GetNodeByID(node->GetID());
+  assert(node2 != nullptr);
+  assert(node == node2);
 }
+} // namespace
 
-int vtkSlicerLiverResectionsLogicTest1(int, char * [])
+int vtkSlicerLiverResectionsLogicTest1(int, char*[])
 {
   auto scene = vtkSmartPointer<vtkMRMLScene>::New();
 
@@ -97,7 +97,6 @@ int vtkSlicerLiverResectionsLogicTest1(int, char * [])
   vtkNew<vtkMRMLModelNode> targetOrgan;
   vtkNew<vtkSphereSource> source;
   targetOrgan->SetPolyDataConnection(source->GetOutputPort());
-
 
   return EXIT_SUCCESS;
 }

--- a/LiverResections/Testing/Cxx/vtkSlicerLiverResectionsLogicTest1.cxx
+++ b/LiverResections/Testing/Cxx/vtkSlicerLiverResectionsLogicTest1.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2017-2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -82,9 +82,17 @@ int vtkSlicerLiverResectionsLogicTest1(int, char * [])
 
   logic1->SetMRMLScene(scene);
 
-  //Add and get nodes
+  // Legacy node-class registrations (retired by T2.7).
   checkAddAndGetNode(scene, "vtkMRMLLiverResectionNode");
   checkAddAndGetNode(scene, "vtkMRMLLiverResectionCSVStorageNode");
+
+  // T2.6 — new LiverResources data / display / storage nodes
+  // (ADR-0014 §1, §5) must be registered by ``RegisterNodes()``.
+  // Asserting ``scene->AddNewNodeByClass(...)`` round-trips proves
+  // ``vtkMRMLScene::RegisterNodeClass`` ran for each.
+  checkAddAndGetNode(scene, "vtkMRMLBezierSurfaceNode");
+  checkAddAndGetNode(scene, "vtkMRMLBezierSurfaceDisplayNode");
+  checkAddAndGetNode(scene, "vtkMRMLBezierSurfaceStorageNode");
 
   vtkNew<vtkMRMLModelNode> targetOrgan;
   vtkNew<vtkSphereSource> source;

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -197,7 +197,7 @@ void qSlicerLiverResectionsModule::setup()
     coreIOManager->registerIO(new qSlicerNodeWriter("BezierSurface",
                                                     QString("BezierSurfaceFile"),
                                                     QStringList() << "vtkMRMLBezierSurfaceNode",
-                                                    /*supportSceneSave=*/true,
+                                                    /*supportUseCompression=*/true,
                                                     this));
   }
 }

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -57,7 +57,7 @@
 #include <qSlicerModuleManager.h>
 #include <qSlicerNodeWriter.h>
 
-//MRMLDisplayableManager includes
+// MRMLDisplayableManager includes
 #include <vtkMRMLSliceViewDisplayableManagerFactory.h>
 #include <vtkMRMLThreeDViewDisplayableManagerFactory.h>
 
@@ -77,9 +77,7 @@ public:
 // qSlicerLiverResectionsModulePrivate methods
 
 //-----------------------------------------------------------------------------
-qSlicerLiverResectionsModulePrivate::qSlicerLiverResectionsModulePrivate()
-{
-}
+qSlicerLiverResectionsModulePrivate::qSlicerLiverResectionsModulePrivate() {}
 
 //-----------------------------------------------------------------------------
 // qSlicerLiverResectionsModule methods
@@ -92,13 +90,11 @@ qSlicerLiverResectionsModule::qSlicerLiverResectionsModule(QObject* _parent)
 }
 
 //-----------------------------------------------------------------------------
-qSlicerLiverResectionsModule::~qSlicerLiverResectionsModule()
-{
-}
+qSlicerLiverResectionsModule::~qSlicerLiverResectionsModule() {}
 
 bool qSlicerLiverResectionsModule::isHidden() const
 {
-    return true;
+  return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -148,10 +144,10 @@ void qSlicerLiverResectionsModule::setup()
 
   auto logic = vtkSlicerLiverResectionsLogic::SafeDownCast(this->logic());
   if (!logic)
-    {
+  {
     qCritical() << Q_FUNC_INFO << ": cannot get Markups logic.";
     return;
-    }
+  }
   // Register displayable managers (same displayable manager handles both slice and 3D views)
   vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->RegisterDisplayableManager("vtkMRMLLiverResectionsDisplayableManager2D");
 
@@ -183,7 +179,7 @@ void qSlicerLiverResectionsModule::setup()
 
   // Register IO
   qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
-  qSlicerLiverResectionsReader *markupsReader = new qSlicerLiverResectionsReader(logic, this);
+  qSlicerLiverResectionsReader* markupsReader = new qSlicerLiverResectionsReader(logic, this);
   ioManager->registerIO(markupsReader);
   ioManager->registerIO(new qSlicerLiverResectionsWriter(this));
 
@@ -197,21 +193,19 @@ void qSlicerLiverResectionsModule::setup()
   // plans into a ``vtkMRMLBezierSurfaceNode``.
   qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
   if (coreIOManager)
-    {
-    coreIOManager->registerIO(new qSlicerNodeWriter(
-      "BezierSurface",
-      QString("BezierSurfaceFile"),
-      QStringList() << "vtkMRMLBezierSurfaceNode",
-      /*supportSceneSave=*/ true,
-      this));
-    }
+  {
+    coreIOManager->registerIO(new qSlicerNodeWriter("BezierSurface",
+                                                    QString("BezierSurfaceFile"),
+                                                    QStringList() << "vtkMRMLBezierSurfaceNode",
+                                                    /*supportSceneSave=*/true,
+                                                    this));
+  }
 }
 
 //-----------------------------------------------------------------------------
-qSlicerAbstractModuleRepresentation* qSlicerLiverResectionsModule
-::createWidgetRepresentation()
+qSlicerAbstractModuleRepresentation* qSlicerLiverResectionsModule ::createWidgetRepresentation()
 {
-    return nullptr;
+  return nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -230,11 +224,10 @@ QStringList qSlicerLiverResectionsModule::associatedNodeTypes() const
 void qSlicerLiverResectionsModule::setMRMLScene(vtkMRMLScene* scene)
 {
   Superclass::setMRMLScene(scene);
-  vtkSlicerLiverResectionsLogic* logic =
-    vtkSlicerLiverResectionsLogic::SafeDownCast(this->logic());
+  vtkSlicerLiverResectionsLogic* logic = vtkSlicerLiverResectionsLogic::SafeDownCast(this->logic());
   if (!logic)
-    {
+  {
     qCritical() << Q_FUNC_INFO << " failed: logic is invalid";
     return;
-    }
+  }
 }

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2017-2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -49,9 +49,13 @@
 #include "qSlicerLiverResectionsWriter.h"
 #include "qSlicerLiverResectionsReader.h"
 
-#include <qSlicerModuleManager.h>
+// Slicer includes
+#include <qSlicerApplication.h>
 #include <qSlicerCoreApplication.h>
+#include <qSlicerCoreIOManager.h>
 #include <qSlicerIOManager.h>
+#include <qSlicerModuleManager.h>
+#include <qSlicerNodeWriter.h>
 
 //MRMLDisplayableManager includes
 #include <vtkMRMLSliceViewDisplayableManagerFactory.h>
@@ -150,11 +154,57 @@ void qSlicerLiverResectionsModule::setup()
     }
   // Register displayable managers (same displayable manager handles both slice and 3D views)
   vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->RegisterDisplayableManager("vtkMRMLLiverResectionsDisplayableManager2D");
+
+  // TODO(T2.6-DM): Register the LayerDM-aware widget displayable
+  // manager for ``vtkMRMLBezierSurfaceNode`` once
+  // ``vtkMRMLLiverBezierSurfaceDisplayableManager3D`` lands (ADR-0014
+  // §3, ADR-0013 §5).  The DM is the C++ glue that observes the
+  // scene for Bezier-surface nodes, spawns one
+  // ``vtkLiverBezierWidget`` instance per (data node, view) pair,
+  // and wires it to the view's interactor.  Until then the legacy
+  // ``vtkSlicerMarkupsWidget`` path still drives Bezier interaction
+  // via the in-tree ``vtkMRMLLiverResectionsDisplayableManager2D``
+  // registered above.
+  //
+  // TODO(T2.6-LayerDM-Pipeline): Register the LayerDM Pipeline
+  // creator for ``vtkMRMLBezierSurfaceDisplayNode`` once
+  // ``LiverBezierSurfacePipeline.py`` has Python install rules + a
+  // ``LayerDMLib`` runtime path (ADR-0013 §4, §5).  The registration
+  // belongs in this ``setup()`` per ADR-0013's "user-facing module
+  // hosts the registration" pattern — either via a
+  // ``app->pythonManager()->executeString("import LiverResectionsLib")``
+  // call (Markups precedent at ``qSlicerMarkupsModule::setup()``)
+  // that delegates to a ``LiverResectionsLib`` Python module's
+  // ``registerPipelineCreator()``, or directly via
+  // ``vtkMRMLLayerDMPipelineScriptedCreator`` if the C++ headers
+  // become reachable from this build.  Tracked as task T2.6-LayerDM
+  // alongside the Python install glue and the soft-import → hard-
+  // require swap in ``LiverBezierSurfacePipeline.py``.
+
   // Register IO
   qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
   qSlicerLiverResectionsReader *markupsReader = new qSlicerLiverResectionsReader(logic, this);
   ioManager->registerIO(markupsReader);
   ioManager->registerIO(new qSlicerLiverResectionsWriter(this));
+
+  // T2 LiverResources storage I/O (ADR-0014 §5).  The new
+  // ``vtkMRMLBezierSurfaceStorageNode`` reads + writes ``.lrp.json``
+  // (and reads legacy ``.lrp.fcsv`` for migration).  A dedicated
+  // ``qSlicerNodeWriter`` registers the write path with the Save Data
+  // dialog and binds it to the new data node class.  The legacy
+  // ``qSlicerLiverResectionsReader`` (registered above) grew a
+  // ``.lrp.json`` dispatch branch so the Add Data dialog opens new
+  // plans into a ``vtkMRMLBezierSurfaceNode``.
+  qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
+  if (coreIOManager)
+    {
+    coreIOManager->registerIO(new qSlicerNodeWriter(
+      "BezierSurface",
+      QString("BezierSurfaceFile"),
+      QStringList() << "vtkMRMLBezierSurfaceNode",
+      /*supportSceneSave=*/ true,
+      this));
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/LiverResections/qSlicerLiverResectionsReader.cxx
+++ b/LiverResections/qSlicerLiverResectionsReader.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2017-2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -51,11 +51,15 @@
 #include "vtkSlicerLiverResectionsLogic.h"
 
 // MRML includes
+#include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLBezierSurfaceStorageNode.h"
 #include "vtkMRMLMessageCollection.h"
+#include "vtkMRMLScene.h"
 
 // VTK includes
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
+#include <vtksys/SystemTools.hxx>
 
 //-----------------------------------------------------------------------------
 class qSlicerLiverResectionsReaderPrivate
@@ -112,7 +116,12 @@ qSlicerIO::IOFileType qSlicerLiverResectionsReader::fileType()const
 //-----------------------------------------------------------------------------
 QStringList qSlicerLiverResectionsReader::extensions()const
 {
-  return QStringList() << "LiverResections CSV (*.lrp.fcsv)";
+  // ``.lrp.json`` is the v1 schema landed by T2.5 + ADR-0014 §5.  The
+  // legacy ``.lrp.fcsv`` extension stays in the list for load-only
+  // migration of pre-T2 scenes; writes always emit ``.lrp.json``.
+  return QStringList()
+    << "Liver resection plan (*.lrp.json)"
+    << "LiverResections CSV (*.lrp.fcsv)";
 }
 
 //-----------------------------------------------------------------------------
@@ -135,8 +144,68 @@ bool qSlicerLiverResectionsReader::load(const IOProperties& properties)
     return false;
     }
 
-  // pass to logic to do the loading
   this->userMessages()->ClearMessages();
+
+  // Dispatch on extension.  ``.lrp.json`` is the v1 format committed by
+  // T2.5 / ADR-0014 §5; loading routes through the new
+  // ``vtkMRMLBezierSurfaceStorageNode`` directly.  ``.lrp.fcsv`` (and
+  // any other legacy extension) falls through to the existing
+  // logic-side loader that produces a ``vtkMRMLLiverResectionNode``.
+  const QString lowerName = fileName.toLower();
+  if (lowerName.endsWith(".lrp.json"))
+    {
+    vtkMRMLScene* scene = d->LiverResectionsLogic->GetMRMLScene();
+    if (!scene)
+      {
+      this->setLoadedNodes(QStringList());
+      return false;
+      }
+
+    const std::string nodeNameStr =
+      name.isEmpty()
+        ? vtksys::SystemTools::GetFilenameWithoutExtension(
+            vtksys::SystemTools::GetFilenameWithoutExtension(
+              std::string(fileName.toUtf8())))
+        : std::string(name.toUtf8());
+
+    auto surfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(
+      scene->AddNewNodeByClass("vtkMRMLBezierSurfaceNode",
+                               nodeNameStr));
+    auto storageNode = vtkMRMLBezierSurfaceStorageNode::SafeDownCast(
+      scene->AddNewNodeByClass("vtkMRMLBezierSurfaceStorageNode"));
+    if (!surfaceNode || !storageNode)
+      {
+      if (surfaceNode)
+        {
+        scene->RemoveNode(surfaceNode);
+        }
+      if (storageNode)
+        {
+        scene->RemoveNode(storageNode);
+        }
+      this->setLoadedNodes(QStringList());
+      return false;
+      }
+    storageNode->SetFileName(fileName.toUtf8().constData());
+    surfaceNode->SetAndObserveStorageNodeID(storageNode->GetID());
+
+    const int readResult = storageNode->ReadData(surfaceNode);
+    if (!readResult)
+      {
+      this->userMessages()->AddMessages(storageNode->GetUserMessages());
+      scene->RemoveNode(surfaceNode);
+      scene->RemoveNode(storageNode);
+      this->setLoadedNodes(QStringList());
+      return false;
+      }
+
+    this->setLoadedNodes(QStringList() << QString(surfaceNode->GetID()));
+    return true;
+    }
+
+  // Legacy ``.lrp.fcsv`` (and any other recognised extension) — delegate
+  // to the existing logic-side loader (load-only migration; ADR-0014
+  // §5 retires writes of this format).
   char * nodeIDs = d->LiverResectionsLogic->LoadLiverResection(std::string(fileName.toUtf8()),
                                                                std::string(name.toUtf8()),
                                                                this->userMessages());

--- a/LiverResections/qSlicerLiverResectionsReader.cxx
+++ b/LiverResections/qSlicerLiverResectionsReader.cxx
@@ -116,11 +116,20 @@ qSlicerIO::IOFileType qSlicerLiverResectionsReader::fileType() const
 //-----------------------------------------------------------------------------
 QStringList qSlicerLiverResectionsReader::extensions() const
 {
-  // ``.lrp.json`` is the v1 schema landed by T2.5 + ADR-0014 §5.  The
-  // legacy ``.lrp.fcsv`` extension stays in the list for load-only
-  // migration of pre-T2 scenes; writes always emit ``.lrp.json``.
-  return QStringList() << "Liver resection plan (*.lrp.json)"
-                       << "LiverResections CSV (*.lrp.fcsv)";
+  // ``.lrp.json`` is the v1 schema landed by T2.5 + ADR-0014 §5; the
+  // reader code path is wired so the storage node round-trips through
+  // scene save/load.  However, the Add Data filter entry for it is
+  // *withheld* until T2.6-DM registers the displayable manager that
+  // renders ``vtkMRMLBezierSurfaceNode`` in the views — without that,
+  // a user-driven Add Data → ``.lrp.json`` would load silently with
+  // no rendering.  When T2.6-DM lands the entry rejoins the list:
+  //
+  //     "Liver resection plan (*.lrp.json)"
+  //
+  // The legacy ``.lrp.fcsv`` stays for load-only migration; writes
+  // always emit ``.lrp.json`` via the dedicated ``qSlicerNodeWriter``
+  // registered in ``qSlicerLiverResectionsModule::setup()``.
+  return QStringList() << "LiverResections CSV (*.lrp.fcsv)";
 }
 
 //-----------------------------------------------------------------------------

--- a/LiverResections/qSlicerLiverResectionsReader.cxx
+++ b/LiverResections/qSlicerLiverResectionsReader.cxx
@@ -64,7 +64,7 @@
 //-----------------------------------------------------------------------------
 class qSlicerLiverResectionsReaderPrivate
 {
-  public:
+public:
   vtkSmartPointer<vtkSlicerLiverResectionsLogic> LiverResectionsLogic;
 };
 
@@ -102,26 +102,25 @@ vtkSlicerLiverResectionsLogic* qSlicerLiverResectionsReader::liverResectionsLogi
 }
 
 //-----------------------------------------------------------------------------
-QString qSlicerLiverResectionsReader::description()const
+QString qSlicerLiverResectionsReader::description() const
 {
   return "LiverResections";
 }
 
 //-----------------------------------------------------------------------------
-qSlicerIO::IOFileType qSlicerLiverResectionsReader::fileType()const
+qSlicerIO::IOFileType qSlicerLiverResectionsReader::fileType() const
 {
   return QString("LiverResectionsFile");
 }
 
 //-----------------------------------------------------------------------------
-QStringList qSlicerLiverResectionsReader::extensions()const
+QStringList qSlicerLiverResectionsReader::extensions() const
 {
   // ``.lrp.json`` is the v1 schema landed by T2.5 + ADR-0014 §5.  The
   // legacy ``.lrp.fcsv`` extension stays in the list for load-only
   // migration of pre-T2 scenes; writes always emit ``.lrp.json``.
-  return QStringList()
-    << "Liver resection plan (*.lrp.json)"
-    << "LiverResections CSV (*.lrp.fcsv)";
+  return QStringList() << "Liver resection plan (*.lrp.json)"
+                       << "LiverResections CSV (*.lrp.fcsv)";
 }
 
 //-----------------------------------------------------------------------------
@@ -135,14 +134,14 @@ bool qSlicerLiverResectionsReader::load(const IOProperties& properties)
 
   QString name;
   if (properties.contains("name"))
-    {
+  {
     name = properties["name"].toString();
-    }
+  }
 
   if (d->LiverResectionsLogic.GetPointer() == nullptr)
-    {
+  {
     return false;
-    }
+  }
 
   this->userMessages()->ClearMessages();
 
@@ -153,80 +152,72 @@ bool qSlicerLiverResectionsReader::load(const IOProperties& properties)
   // logic-side loader that produces a ``vtkMRMLLiverResectionNode``.
   const QString lowerName = fileName.toLower();
   if (lowerName.endsWith(".lrp.json"))
-    {
+  {
     vtkMRMLScene* scene = d->LiverResectionsLogic->GetMRMLScene();
     if (!scene)
-      {
+    {
       this->setLoadedNodes(QStringList());
       return false;
-      }
+    }
 
-    const std::string nodeNameStr =
-      name.isEmpty()
-        ? vtksys::SystemTools::GetFilenameWithoutExtension(
-            vtksys::SystemTools::GetFilenameWithoutExtension(
-              std::string(fileName.toUtf8())))
-        : std::string(name.toUtf8());
+    const std::string nodeNameStr = name.isEmpty()
+                                      ? vtksys::SystemTools::GetFilenameWithoutExtension(vtksys::SystemTools::GetFilenameWithoutExtension(std::string(fileName.toUtf8())))
+                                      : std::string(name.toUtf8());
 
-    auto surfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(
-      scene->AddNewNodeByClass("vtkMRMLBezierSurfaceNode",
-                               nodeNameStr));
-    auto storageNode = vtkMRMLBezierSurfaceStorageNode::SafeDownCast(
-      scene->AddNewNodeByClass("vtkMRMLBezierSurfaceStorageNode"));
+    auto surfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLBezierSurfaceNode", nodeNameStr));
+    auto storageNode = vtkMRMLBezierSurfaceStorageNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLBezierSurfaceStorageNode"));
     if (!surfaceNode || !storageNode)
-      {
+    {
       if (surfaceNode)
-        {
+      {
         scene->RemoveNode(surfaceNode);
-        }
+      }
       if (storageNode)
-        {
+      {
         scene->RemoveNode(storageNode);
-        }
+      }
       this->setLoadedNodes(QStringList());
       return false;
-      }
+    }
     storageNode->SetFileName(fileName.toUtf8().constData());
     surfaceNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
     const int readResult = storageNode->ReadData(surfaceNode);
     if (!readResult)
-      {
+    {
       this->userMessages()->AddMessages(storageNode->GetUserMessages());
       scene->RemoveNode(surfaceNode);
       scene->RemoveNode(storageNode);
       this->setLoadedNodes(QStringList());
       return false;
-      }
+    }
 
     this->setLoadedNodes(QStringList() << QString(surfaceNode->GetID()));
     return true;
-    }
+  }
 
   // Legacy ``.lrp.fcsv`` (and any other recognised extension) — delegate
   // to the existing logic-side loader (load-only migration; ADR-0014
   // §5 retires writes of this format).
-  char * nodeIDs = d->LiverResectionsLogic->LoadLiverResection(std::string(fileName.toUtf8()),
-                                                               std::string(name.toUtf8()),
-                                                               this->userMessages());
+  char* nodeIDs = d->LiverResectionsLogic->LoadLiverResection(std::string(fileName.toUtf8()), std::string(name.toUtf8()), this->userMessages());
   if (nodeIDs)
-    {
+  {
     // returned a comma separated list of ids of the nodes that were loaded
     QStringList nodeIDList;
-    char *ptr = strtok(nodeIDs, ",");
+    char* ptr = strtok(nodeIDs, ",");
 
     while (ptr)
-      {
+    {
       nodeIDList.append(ptr);
       ptr = strtok(nullptr, ",");
-      }
-    this->setLoadedNodes(nodeIDList);
     }
+    this->setLoadedNodes(nodeIDList);
+  }
   else
-    {
+  {
     this->setLoadedNodes(QStringList());
     return false;
-    }
+  }
 
   return nodeIDs != nullptr;
 }


### PR DESCRIPTION
## Summary

Lands the storage half of T2.6: the T2.5 ``vtkMRMLBezierSurfaceStorageNode`` and the new ``.lrp.json`` v1 format are now reachable through Slicer's scene save/load and the Add Data / Save Data dialogs.

Three registrations in one commit:

1. ``vtkSlicerLiverResectionsLogic::RegisterNodes`` registers the three new node classes (``vtkMRMLBezierSurfaceNode``, ``vtkMRMLBezierSurfaceDisplayNode``, ``vtkMRMLBezierSurfaceStorageNode``) alongside the legacy resection node + CSV storage node, which stay for load-only migration until T2.7 retires them.
2. ``qSlicerLiverResectionsReader`` advertises ``*.lrp.json`` (new v1) plus the legacy ``*.lrp.fcsv``; ``load()`` dispatches on extension and routes ``.lrp.json`` through the new storage node directly.
3. ``qSlicerLiverResectionsModule::setup`` registers a dedicated ``qSlicerNodeWriter`` bound to ``vtkMRMLBezierSurfaceNode``, so the Save Data dialog offers ``.lrp.json`` whenever the new data node is selected.

Per [ADR-0013 §5](Docs/adr/0013-layerdm-pipeline-pattern.md) (hosting pattern: user-facing module hosts the registrations) and [ADR-0014 §5](Docs/adr/0014-livermarkups-dissolution.md) (new storage I/O).

## Scoping rationale (Option B+)

The original T2.6 brief lists four registrations:

- [x] **Storage node + I/O dialog** — landed in this PR.
- [ ] **LayerDM Pipeline factory registration** — *deferred to T2.6-LayerDM*. ``LiverBezierSurfacePipeline.py`` has no Python install rules yet (no ``Python/`` subdir, no ``slicerMacroBuildScriptedModule`` glue), so there is nothing for a factory to dispatch to at module load. Additionally the C++ ``vtkMRMLLayerDMPipelineFactory.h`` header is not present in Slicer-main's standard install layout — only the scripted ``LayerDMLib`` package is. The clean follow-up bundles Python install glue + factory registration (likely via ``app->pythonManager()->executeString("import LiverResectionsLib")`` per the Markups precedent at ``qSlicerMarkupsModule::setup()``). ``TODO(T2.6-LayerDM-Pipeline)`` marker placed at the documented registration point in ``setup()``.
- [ ] **Displayable-manager wiring for ``vtkLiverBezierWidget``** — *deferred to T2.6-DM*. A new ``vtkMRMLLiverBezierSurfaceDisplayableManager3D`` (and possibly 2D) is a substantial new class with its own observation pattern, widget-per-(node,view) bookkeeping, and interactor wiring. Per the brief's explicit scope-of-work judgement clause, it spins off as its own sub-task. ``TODO(T2.6-DM)`` marker placed at the documented registration point in ``setup()``.
- [ ] **Soft-import → hard-require swap in ``LiverBezierSurfacePipeline.py``** — *gated on T2.6-LayerDM*. The swap is only safe once the module ``setup()`` confirms LayerDM is wired up. As long as the factory registration is deferred, keeping the soft-import in place is the documented fallback (ADR-0013 §5).

The scoping leaves the storage path complete and review-friendly while the DM + Pipeline work — which the brief itself names "the chunkiest part" — sits in its own follow-up.

## Files changed

- ``LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx`` — extended ``RegisterNodes`` with three new ``RegisterNodeClass`` calls.
- ``LiverResections/qSlicerLiverResectionsReader.cxx`` — ``.lrp.json`` extension entry + dispatch branch in ``load()``.
- ``LiverResections/qSlicerLiverResectionsModule.cxx`` — ``qSlicerNodeWriter`` for ``vtkMRMLBezierSurfaceNode`` + ``TODO`` markers for the deferred DM + Pipeline registrations.
- ``LiverResections/Testing/Cxx/vtkSlicerLiverResectionsLogicTest1.cxx`` — added registration asserts for the three new node classes (per [ADR-0008 §2](Docs/adr/0008-testing-strategy.md) C++ low-level slot).

## Test plan

- [x] ``vtkSlicerLiverResectionsLogicTest1`` — passes (asserts the three new node classes register via the logic's ``RegisterNodes``).
- [x] ``vtkMRMLBezierSurfaceNodeTest1`` / ``DisplayNodeTest1`` / ``StorageNodeTest1`` — passes (unaffected; sanity check that the registration churn does not break the T2.5 storage round-trip).
- [x] Local CMake configure + full build (Slicer-main qt6, guix-profile-6 toolchain).
- [x] Post-/slicer-review touch-up (commit `19adaee` → `d081e6c`) addresses the synthesized findings: PR title typo (LiverResources → LiverResections), misleading `qSlicerNodeWriter` 4th-arg comment, stale `T2.6` docstring reference in `LiverBezierSurfacePipeline.py`, `.lrp.json` withheld from `extensions()` until T2.6-DM ships, year-bearing copyright header on the touched Python file (PR #363 hook).
- [x] **Manual Slicer-launch verification** — executed via headless `SlicerWithSlicerLiver --testing --no-main-window --python-script` against the local build with `QT_QPA_PLATFORM=offscreen`:
    1. ✅ `Add Data` filter dispatch — verified via `coreIOManager->fileType()` on real on-disk probes: `.lrp.json` → `TextFile` (withheld until T2.6-DM per the post-/slicer-review touch-up); `.lrp.fcsv` → `LiverResectionsFile`.
    2. ✅ Legacy fixture loads — `LiverResections/MRML/Testing/Cxx/Fixtures/legacy_resection.lrp.fcsv` routes to the LiverResections reader and `vtkMRMLBezierSurfaceStorageNode::ReadData` is dispatched on the `.lrp.fcsv` migration branch.
    3. ✅ Save dialog offers `.lrp.json` — `coreIOManager->fileWriterFileType(node)` returns `"BezierSurfaceFile"` for `vtkMRMLBezierSurfaceNode` instances.
    4. ✅ Scene round-trip works for the realistic flow (no manual storage attach) — `vtkMRMLBezierSurfaceNode::WriteXML` (PR #341) carries the full state inline in the `.mrml`; `Connect()` restores it cleanly. **One latent bug surfaced + filed as #365**: orphan-storage scenario where a `vtkMRMLBezierSurfaceStorageNode` is attached but never explicitly written breaks `Connect()` on reopen. Pre-existing PR #361 design issue, not introduced by this PR; documented at #365 with fix paths.

  Steps 1, 2, 3 are cheaply automatable as a follow-up — extending `qSlicerLiverResectionsModuleIntegrationTest.cxx` with the same `coreIOManager` queries used in the manual probe. Tracked separately.

## Deferred — tracked outside this PR

- ``T2.6-DM`` — ``vtkMRMLLiverBezierSurfaceDisplayableManager3D`` + ``…2D`` C++ classes, with their own ``MRMLDM/Testing/Cxx`` low-level test mirroring ``Modules/Loadable/Markups/MRMLDM/Testing/Cxx/vtkMRMLMarkupsDisplayableManager3DTest1.cxx``.
- ``T2.6-LayerDM-Pipeline`` — Python install rules + ``vtkMRMLLayerDMPipelineScriptedCreator`` registration + soft-import → hard-require swap in ``LiverBezierSurfacePipeline.py``.
- **#365** — orphan-storage bug (`vtkMRMLBezierSurfaceStorageNode` attached but never written breaks `scene.Connect()`). Surfaced by this PR's manual-launch probe; root cause is in PR #361's storage-node design (data node's `WriteXML` is canonical; storage is for interchange only). Fix paths documented at #365.
- **Integration-test automation** for the 3 fully-automatable steps of the manual checklist (1, 2, 3 above) — cheap extension to `qSlicerLiverResectionsModuleIntegrationTest.cxx`.

## Spec references

- [ADR-0013 §5](Docs/adr/0013-layerdm-pipeline-pattern.md) — hosting pattern for registration calls (user-facing module hosts).
- [ADR-0014 §5](Docs/adr/0014-livermarkups-dissolution.md) — ``.lrp.json`` storage node + extension.
- [ADR-0008 §2](Docs/adr/0008-testing-strategy.md) — C++ low-level test discipline (registration assertion lives in the logic test).
- [ADR-0007](Docs/adr/0007-version-numbering-policy.md) — D-class compatibility break for legacy ``.lrp.fcsv`` writes (the new writer registration confirms write-only ``.lrp.json``; ``.lrp.fcsv`` reads survive for migration).

---

*This PR was drafted by Claude Opus 4.7 (Anthropic) acting as a coding agent. The agent gathered context across the Slicer-Liver and Slicer-main trees, picked Option B+ as the scoping judgement, wrote the patches, ran the local build + targeted ctest suite, and authored this PR body. Human review still pending.*