### PR TITLE
ENH: Add vtkMRMLLiverBezierSurfaceDisplayableManager (T2.6-DM)

### DIFF
--- a/LiverResections/CMakeLists.txt
+++ b/LiverResections/CMakeLists.txt
@@ -9,8 +9,14 @@ string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 add_subdirectory(MRML)
 add_subdirectory(Algorithm)
 add_subdirectory(Logic)
-add_subdirectory(MRMLDM)
+# VTKWidgets must precede MRMLDM — the displayable manager
+# ``vtkMRMLLiverBezierSurfaceDisplayableManager3D`` (T2.6-DM) spawns
+# ``vtkLiverBezierWidget`` instances from the VTKWidgets kit, so the
+# kit's include directories must already be in
+# ``vtkSlicer${MODULE_NAME}ModuleVTKWidgets_{SOURCE,BINARY}_DIR``
+# variables when MRMLDM/CMakeLists.txt runs.
 add_subdirectory(VTKWidgets)
+add_subdirectory(MRMLDM)
 
 #-----------------------------------------------------------------------------
 set(MODULE_EXPORT_DIRECTIVE "Q_SLICER_QTMODULES_${MODULE_NAME_UPPER}_EXPORT")

--- a/LiverResections/MRMLDM/CMakeLists.txt
+++ b/LiverResections/MRMLDM/CMakeLists.txt
@@ -9,12 +9,20 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${vtkSlicer${MODULE_NAME}ModuleLogic_BINARY_DIR}
   ${vtkSlicer${MODULE_NAME}ModuleMRML_SOURCE_DIR}
   ${vtkSlicer${MODULE_NAME}ModuleMRML_BINARY_DIR}
+  ${vtkSlicer${MODULE_NAME}ModuleVTKWidgets_SOURCE_DIR}
+  ${vtkSlicer${MODULE_NAME}ModuleVTKWidgets_BINARY_DIR}
   ${vtkSlicerLiverMarkupsModuleVTKWidgets_SOURCE_DIR}
   ${vtkSlicerLiverMarkupsModuleVTKWidgets_BINARY_DIR}
   )
 
+# Per ADR-0014 §6 — the new ``vtkMRMLLiverBezierSurfaceDisplayableManager3D``
+# (T2.6-DM) joins the legacy ``vtkMRMLLiverResectionsDisplayableManager2D``
+# in this kit.  Both register through the standard
+# ``SlicerConfigureDisplayableManagerObjectFactory`` macro so they appear
+# in the displayable-manager group for every view they target.
 set(displayable_manager_SRCS
-  vtkMRML${MODULE_NAME}DisplayableManager2D.cpp
+  vtkMRMLLiverResectionsDisplayableManager2D.cpp
+  vtkMRMLLiverBezierSurfaceDisplayableManager3D.cxx
   )
 
 SlicerConfigureDisplayableManagerObjectFactory(
@@ -28,13 +36,17 @@ SlicerConfigureDisplayableManagerObjectFactory(
 set(${KIT}_SRCS
   ${displayable_manager_instantiator_SRCS}
   ${displayable_manager_SRCS}
-  vtkMRML${MODULE_NAME}DisplayableManagerHelper2D.cpp
+  vtkMRMLLiverResectionsDisplayableManagerHelper2D.cpp
   )
 
+# T2.6-DM links against the in-module VTKWidgets kit to spawn
+# ``vtkLiverBezierWidget`` / ``vtkLiverBezierRepresentation`` instances
+# per (data node, view) pair.
 set(${KIT}_TARGET_LIBRARIES
   ${MRML_LIBRARIES}
   vtkSlicer${MODULE_NAME}ModuleLogic
   vtkSlicer${MODULE_NAME}ModuleMRML
+  vtkSlicer${MODULE_NAME}ModuleVTKWidgets
   )
 
 #-----------------------------------------------------------------------------
@@ -45,3 +57,10 @@ SlicerMacroBuildModuleLogic(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
 )
+
+#-----------------------------------------------------------------------------
+# C++ low-level tests for the MRMLDM kit (ADR-0008 §2, ctkTest driver,
+# no Slicer launch, no Qt).
+if(BUILD_TESTING)
+  add_subdirectory(Testing)
+endif()

--- a/LiverResections/MRMLDM/Testing/CMakeLists.txt
+++ b/LiverResections/MRMLDM/Testing/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Cxx)

--- a/LiverResections/MRMLDM/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRMLDM/Testing/Cxx/CMakeLists.txt
@@ -1,0 +1,31 @@
+#-----------------------------------------------------------------------------
+# C++ low-level tests for the LiverResections MRMLDM library.
+# Per ADR-0008 §2 — "C++ low-level" row, ctkTest driver, no Slicer
+# launch, no Qt.  Mirrors the VTKWidgets/Testing/Cxx pattern used by
+# vtkLiverBezierWidgetTest1.
+#-----------------------------------------------------------------------------
+
+set(KIT vtkSlicer${MODULE_NAME}ModuleMRMLDisplayableManager)
+
+#-----------------------------------------------------------------------------
+set(KIT_TEST_SRCS
+  vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1.cxx
+  )
+
+#-----------------------------------------------------------------------------
+slicerMacroConfigureModuleCxxTestDriver(
+  NAME ${KIT}
+  SOURCES ${KIT_TEST_SRCS}
+  INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_BINARY_DIR}/..
+    ${vtkSlicer${MODULE_NAME}ModuleMRML_SOURCE_DIR}
+    ${vtkSlicer${MODULE_NAME}ModuleMRML_BINARY_DIR}
+    ${vtkSlicer${MODULE_NAME}ModuleVTKWidgets_SOURCE_DIR}
+    ${vtkSlicer${MODULE_NAME}ModuleVTKWidgets_BINARY_DIR}
+  WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
+  )
+
+SIMPLE_TEST(vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1)

--- a/LiverResections/MRMLDM/Testing/Cxx/vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1.cxx
+++ b/LiverResections/MRMLDM/Testing/Cxx/vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1.cxx
@@ -1,0 +1,153 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Tests for vtkMRMLLiverBezierSurfaceDisplayableManager3D — the C++
+  displayable manager landed by T2.6-DM (ADR-0014 §3).  Per ADR-0008 §2
+  these are ctkTest-driver tests: no Slicer launch, no Qt, no real
+  view, no interactor binding (the DM constructs widgets headlessly;
+  SetInteractor is only invoked if the renderer + interactor are
+  non-null, which they are not in this headless harness).
+
+  Coverage:
+
+   - NodeAdded spawn: adding a vtkMRMLBezierSurfaceNode causes the DM
+     registry to gain exactly one entry.
+   - NodeRemoved teardown: removing the node empties the registry.
+   - Scene swap rebuild: clearing the scene + re-importing rebuilds
+     the registry (OnMRMLSceneEndImport reconcile path).
+   - Multiple nodes: adding three nodes yields three registry entries.
+
+==============================================================================*/
+
+// LiverResections MRMLDM includes
+#include "vtkMRMLLiverBezierSurfaceDisplayableManager3D.h"
+
+// LiverResections VTKWidgets includes
+#include "vtkLiverBezierWidget.h"
+
+// LiverResections MRML includes
+#include "vtkMRMLBezierSurfaceNode.h"
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkSmartPointer.h>
+
+// STD includes
+#include <iostream>
+
+namespace
+{
+
+/// Build a minimal scene + DM pair.  The DM observes the scene via
+/// SetMRMLScene — the same code path the displayable-manager group
+/// drives in a real view.
+vtkSmartPointer<vtkMRMLLiverBezierSurfaceDisplayableManager3D> makeDM(vtkMRMLScene* scene)
+{
+  vtkSmartPointer<vtkMRMLLiverBezierSurfaceDisplayableManager3D> dm = vtkSmartPointer<vtkMRMLLiverBezierSurfaceDisplayableManager3D>::New();
+  dm->SetMRMLScene(scene);
+  return dm;
+}
+
+int testNodeAddedSpawn()
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkSmartPointer<vtkMRMLLiverBezierSurfaceDisplayableManager3D> dm = makeDM(scene);
+  CHECK_INT(static_cast<int>(dm->GetNumberOfWidgets()), 0);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> node;
+  scene->AddNode(node);
+
+  CHECK_INT(static_cast<int>(dm->GetNumberOfWidgets()), 1);
+  vtkLiverBezierWidget* widget = dm->GetWidget(node);
+  CHECK_NOT_NULL(widget);
+  CHECK_POINTER(widget->GetBezierNode(), node.GetPointer());
+  return EXIT_SUCCESS;
+}
+
+int testNodeRemovedTeardown()
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkSmartPointer<vtkMRMLLiverBezierSurfaceDisplayableManager3D> dm = makeDM(scene);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> node;
+  scene->AddNode(node);
+  CHECK_INT(static_cast<int>(dm->GetNumberOfWidgets()), 1);
+
+  scene->RemoveNode(node);
+  CHECK_INT(static_cast<int>(dm->GetNumberOfWidgets()), 0);
+  CHECK_NULL(dm->GetWidget(node));
+  return EXIT_SUCCESS;
+}
+
+int testSceneSwapRebuild()
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkSmartPointer<vtkMRMLLiverBezierSurfaceDisplayableManager3D> dm = makeDM(scene);
+
+  // Seed the scene with two Bezier-surface nodes outside of the
+  // DM's normal NodeAdded path — emulate a fresh scene populated
+  // by an importer that fired EndImport at the end.
+  scene->StartState(vtkMRMLScene::ImportState);
+  vtkNew<vtkMRMLBezierSurfaceNode> nodeA;
+  vtkNew<vtkMRMLBezierSurfaceNode> nodeB;
+  scene->AddNode(nodeA);
+  scene->AddNode(nodeB);
+  scene->EndState(vtkMRMLScene::ImportState);
+
+  // After EndImport reconcile, both nodes must have widgets.
+  CHECK_INT(static_cast<int>(dm->GetNumberOfWidgets()), 2);
+  CHECK_NOT_NULL(dm->GetWidget(nodeA));
+  CHECK_NOT_NULL(dm->GetWidget(nodeB));
+
+  // Clear the scene — every widget tears down via EndClose.
+  scene->StartState(vtkMRMLScene::CloseState);
+  scene->Clear(1);
+  scene->EndState(vtkMRMLScene::CloseState);
+  CHECK_INT(static_cast<int>(dm->GetNumberOfWidgets()), 0);
+  return EXIT_SUCCESS;
+}
+
+int testMultipleNodes()
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkSmartPointer<vtkMRMLLiverBezierSurfaceDisplayableManager3D> dm = makeDM(scene);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> nodeA;
+  vtkNew<vtkMRMLBezierSurfaceNode> nodeB;
+  vtkNew<vtkMRMLBezierSurfaceNode> nodeC;
+  scene->AddNode(nodeA);
+  scene->AddNode(nodeB);
+  scene->AddNode(nodeC);
+
+  CHECK_INT(static_cast<int>(dm->GetNumberOfWidgets()), 3);
+  CHECK_NOT_NULL(dm->GetWidget(nodeA));
+  CHECK_NOT_NULL(dm->GetWidget(nodeB));
+  CHECK_NOT_NULL(dm->GetWidget(nodeC));
+
+  // Each widget must reference its own data node.
+  CHECK_POINTER(dm->GetWidget(nodeA)->GetBezierNode(), nodeA.GetPointer());
+  CHECK_POINTER(dm->GetWidget(nodeB)->GetBezierNode(), nodeB.GetPointer());
+  CHECK_POINTER(dm->GetWidget(nodeC)->GetBezierNode(), nodeC.GetPointer());
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1(int, char*[])
+{
+  CHECK_EXIT_SUCCESS(testNodeAddedSpawn());
+  CHECK_EXIT_SUCCESS(testNodeRemovedTeardown());
+  CHECK_EXIT_SUCCESS(testSceneSwapRebuild());
+  CHECK_EXIT_SUCCESS(testMultipleNodes());
+
+  std::cout << "vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRMLDM/vtkMRMLLiverBezierSurfaceDisplayableManager3D.cxx
+++ b/LiverResections/MRMLDM/vtkMRMLLiverBezierSurfaceDisplayableManager3D.cxx
@@ -1,0 +1,232 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the T2 LiverResections all-in migration (Stack 2 of the
+  v2.0.0 release tracker — see ADR-0014 §3).
+
+==============================================================================*/
+
+#include "vtkMRMLLiverBezierSurfaceDisplayableManager3D.h"
+
+// LiverResections includes
+#include "vtkLiverBezierRepresentation.h"
+#include "vtkLiverBezierWidget.h"
+#include "vtkMRMLBezierSurfaceNode.h"
+
+// MRML includes
+#include <vtkMRMLScene.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+
+//-----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkMRMLLiverBezierSurfaceDisplayableManager3D);
+
+//-----------------------------------------------------------------------------
+vtkMRMLLiverBezierSurfaceDisplayableManager3D::vtkMRMLLiverBezierSurfaceDisplayableManager3D() = default;
+
+//-----------------------------------------------------------------------------
+vtkMRMLLiverBezierSurfaceDisplayableManager3D::~vtkMRMLLiverBezierSurfaceDisplayableManager3D()
+{
+  this->RemoveAllWidgets();
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLLiverBezierSurfaceDisplayableManager3D::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "NumberOfWidgets: " << this->Widgets.size() << "\n";
+}
+
+//-----------------------------------------------------------------------------
+vtkLiverBezierWidget* vtkMRMLLiverBezierSurfaceDisplayableManager3D::GetWidget(vtkMRMLBezierSurfaceNode* node)
+{
+  if (!node || !node->GetID())
+  {
+    return nullptr;
+  }
+  const auto it = this->Widgets.find(node->GetID());
+  if (it == this->Widgets.end())
+  {
+    return nullptr;
+  }
+  return it->second.GetPointer();
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLLiverBezierSurfaceDisplayableManager3D::SetMRMLSceneInternal(vtkMRMLScene* newScene)
+{
+  // Tear every widget down before swapping the scene observer chain.
+  // The superclass handles the Modified-event observation; the
+  // node-level observation runs through OnMRMLSceneNodeAdded /
+  // OnMRMLSceneNodeRemoved already provided by the base class via
+  // vtkMRMLAbstractLogic.
+  this->RemoveAllWidgets();
+  this->Superclass::SetMRMLSceneInternal(newScene);
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLLiverBezierSurfaceDisplayableManager3D::OnMRMLSceneNodeAdded(vtkMRMLNode* node)
+{
+  this->Superclass::OnMRMLSceneNodeAdded(node);
+  vtkMRMLBezierSurfaceNode* bezierNode = vtkMRMLBezierSurfaceNode::SafeDownCast(node);
+  if (!bezierNode)
+  {
+    return;
+  }
+  this->AddBezierSurfaceNode(bezierNode);
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLLiverBezierSurfaceDisplayableManager3D::OnMRMLSceneNodeRemoved(vtkMRMLNode* node)
+{
+  vtkMRMLBezierSurfaceNode* bezierNode = vtkMRMLBezierSurfaceNode::SafeDownCast(node);
+  if (bezierNode)
+  {
+    this->RemoveBezierSurfaceNode(bezierNode);
+  }
+  this->Superclass::OnMRMLSceneNodeRemoved(node);
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLLiverBezierSurfaceDisplayableManager3D::OnMRMLSceneEndImport()
+{
+  // After scene import, the registry may be stale (nodes loaded from
+  // disk did not pass through OnMRMLSceneNodeAdded in BatchProcessing
+  // mode for some scene swaps).  Walk the scene and reconcile.
+  this->RemoveAllWidgets();
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (!scene)
+  {
+    return;
+  }
+  std::vector<vtkMRMLNode*> nodes;
+  scene->GetNodesByClass("vtkMRMLBezierSurfaceNode", nodes);
+  for (vtkMRMLNode* node : nodes)
+  {
+    if (vtkMRMLBezierSurfaceNode* bezierNode = vtkMRMLBezierSurfaceNode::SafeDownCast(node))
+    {
+      this->AddBezierSurfaceNode(bezierNode);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLLiverBezierSurfaceDisplayableManager3D::OnMRMLSceneEndClose()
+{
+  this->RemoveAllWidgets();
+}
+
+//-----------------------------------------------------------------------------
+bool vtkMRMLLiverBezierSurfaceDisplayableManager3D::AddBezierSurfaceNode(vtkMRMLBezierSurfaceNode* node)
+{
+  if (!node || !node->GetID())
+  {
+    return false;
+  }
+  const std::string key(node->GetID());
+
+  // Idempotency: drop any existing widget for this ID first.  Common
+  // during EndImport reconcile.
+  const auto existing = this->Widgets.find(key);
+  if (existing != this->Widgets.end())
+  {
+    if (existing->second)
+    {
+      existing->second->SetEnabled(0);
+      existing->second->SetRepresentation(nullptr);
+      existing->second->SetBezierNode(nullptr);
+    }
+    this->Widgets.erase(existing);
+  }
+
+  vtkRenderer* renderer = this->GetRenderer();
+  vtkRenderWindowInteractor* interactor = this->GetInteractor();
+
+  vtkNew<vtkLiverBezierWidget> widget;
+  vtkNew<vtkLiverBezierRepresentation> rep;
+  if (renderer)
+  {
+    rep->SetRenderer(renderer);
+  }
+  widget->SetRepresentation(rep);
+  widget->SetBezierNode(node);
+  if (interactor)
+  {
+    widget->SetInteractor(interactor);
+    widget->SetEnabled(1);
+  }
+
+  this->Widgets[key] = widget;
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLLiverBezierSurfaceDisplayableManager3D::RemoveBezierSurfaceNode(vtkMRMLBezierSurfaceNode* node)
+{
+  if (!node || !node->GetID())
+  {
+    return;
+  }
+  const auto it = this->Widgets.find(node->GetID());
+  if (it == this->Widgets.end())
+  {
+    return;
+  }
+  if (it->second)
+  {
+    it->second->SetEnabled(0);
+    it->second->SetRepresentation(nullptr);
+    it->second->SetBezierNode(nullptr);
+  }
+  this->Widgets.erase(it);
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLLiverBezierSurfaceDisplayableManager3D::RemoveAllWidgets()
+{
+  for (auto& entry : this->Widgets)
+  {
+    if (entry.second)
+    {
+      entry.second->SetEnabled(0);
+      entry.second->SetRepresentation(nullptr);
+      entry.second->SetBezierNode(nullptr);
+    }
+  }
+  this->Widgets.clear();
+}

--- a/LiverResections/MRMLDM/vtkMRMLLiverBezierSurfaceDisplayableManager3D.cxx
+++ b/LiverResections/MRMLDM/vtkMRMLLiverBezierSurfaceDisplayableManager3D.cxx
@@ -97,12 +97,49 @@ void vtkMRMLLiverBezierSurfaceDisplayableManager3D::SetMRMLSceneInternal(vtkMRML
   // vtkMRMLAbstractLogic.
   this->RemoveAllWidgets();
   this->Superclass::SetMRMLSceneInternal(newScene);
+
+  // Late-attach reconcile: if the DM is wired into a view AFTER the
+  // scene is already populated (e.g., second-view attach, late module
+  // load), the existing vtkMRMLBezierSurfaceNode instances will not
+  // re-fire NodeAddedEvent and OnMRMLSceneEndImport / EndClose will
+  // not fire either.  Walk the new scene and create widgets for any
+  // pre-existing Bezier surface nodes.  Same loop as
+  // OnMRMLSceneEndImport.
+  if (!newScene)
+  {
+    return;
+  }
+  std::vector<vtkMRMLNode*> existingNodes;
+  newScene->GetNodesByClass("vtkMRMLBezierSurfaceNode", existingNodes);
+  for (vtkMRMLNode* node : existingNodes)
+  {
+    if (vtkMRMLBezierSurfaceNode* bezierNode = vtkMRMLBezierSurfaceNode::SafeDownCast(node))
+    {
+      this->AddBezierSurfaceNode(bezierNode);
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
 void vtkMRMLLiverBezierSurfaceDisplayableManager3D::OnMRMLSceneNodeAdded(vtkMRMLNode* node)
 {
   this->Superclass::OnMRMLSceneNodeAdded(node);
+
+  // Match the established Slicer-core DM pattern: during batch
+  // processing (scene import / restore) skip per-node widget
+  // construction and let OnMRMLSceneEndImport do a single reconcile
+  // pass.  Without this guard each imported node creates a widget
+  // that EndImport then tears down and re-creates — functionally
+  // correct due to ``AddBezierSurfaceNode`` idempotency, but wasteful.
+  // Cf. vtkMRMLCameraDisplayableManager, vtkMRMLModelSliceDisplayable
+  // Manager, vtkMRMLThreeDReformatDisplayableManager — all guard
+  // OnMRMLSceneNodeAdded with this exact check.
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (scene && scene->IsBatchProcessing())
+  {
+    return;
+  }
+
   vtkMRMLBezierSurfaceNode* bezierNode = vtkMRMLBezierSurfaceNode::SafeDownCast(node);
   if (!bezierNode)
   {

--- a/LiverResections/MRMLDM/vtkMRMLLiverBezierSurfaceDisplayableManager3D.h
+++ b/LiverResections/MRMLDM/vtkMRMLLiverBezierSurfaceDisplayableManager3D.h
@@ -1,0 +1,163 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the T2 LiverResections all-in migration (Stack 2 of the
+  v2.0.0 release tracker — see ADR-0014 §3).
+
+==============================================================================*/
+
+#ifndef __vtkMRMLLiverBezierSurfaceDisplayableManager3D_h
+#define __vtkMRMLLiverBezierSurfaceDisplayableManager3D_h
+
+// LiverResections MRMLDM includes
+#include "vtkSlicerLiverResectionsModuleMRMLDisplayableManagerExport.h"
+
+// MRMLDisplayableManager includes
+#include <vtkMRMLAbstractThreeDViewDisplayableManager.h>
+
+// VTK includes
+#include <vtkSmartPointer.h>
+#include <vtkWeakPointer.h>
+
+// STD includes
+#include <map>
+#include <string>
+
+class vtkLiverBezierWidget;
+class vtkMRMLBezierSurfaceNode;
+class vtkMRMLNode;
+
+/**
+ * \class vtkMRMLLiverBezierSurfaceDisplayableManager3D
+ *
+ * \brief Displayable manager for ``vtkMRMLBezierSurfaceNode`` in 3D
+ *        views.
+ *
+ * Observes ``vtkMRMLScene`` and spawns one ``vtkLiverBezierWidget``
+ * (+ ``vtkLiverBezierRepresentation``) per (data node, view) pair so
+ * the Bezier-surface resection plan is interactive in every 3D view
+ * registered with the displayable-manager factory.
+ *
+ * Architectural role (ADR-0013 / ADR-0014):
+ *
+ *   - The **LayerDM Pipeline** (Python, per-view actor pipeline —
+ *     ``LiverBezierSurfacePipeline.py``) draws the surface +
+ *     decorations *passively*: it consumes display-node fields and
+ *     produces actors.  It does NOT own interactive state.
+ *   - This **displayable manager** is the C++ glue that owns the
+ *     *interactive* widget per view.  It observes the scene for
+ *     ``vtkMRMLBezierSurfaceNode`` add / remove, builds the widget,
+ *     wires it to the view's renderer + interactor, and tears it down
+ *     on remove / scene close.
+ *
+ * Both layers are needed: a passive LayerDM Pipeline alone cannot
+ * mutate the data node from picks / drags (no interactor binding);
+ * a DM-spawned widget alone cannot share the surface-decoration
+ * pipeline across views (no per-view actor cache).
+ *
+ * Slice-view (2D) coverage is out of scope for this stack iteration —
+ * see ``TODO(T2.6-DM-2D)`` in ``qSlicerLiverResectionsModule::setup()``.
+ * The existing ``vtkLiverBezierRepresentation`` is 3D-only and a
+ * slice-intersection contour requires a separate representation class.
+ *
+ * \par Widget registry
+ *
+ * Keyed by the data node's MRML ID (``std::string``) — not by raw
+ * pointer — so the registry survives a scene swap (``EndImportEvent``
+ * fires AFTER all nodes have new addresses but stable IDs).
+ *
+ * \par Test discipline (ADR-0008 §2)
+ *
+ * Lifecycle is exercised headlessly by
+ * ``vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1``: construct
+ * the DM, attach a scene, add / remove / re-import Bezier-surface
+ * nodes, assert the registry tracks each transition.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRMLDISPLAYABLEMANAGER_EXPORT vtkMRMLLiverBezierSurfaceDisplayableManager3D : public vtkMRMLAbstractThreeDViewDisplayableManager
+{
+public:
+  static vtkMRMLLiverBezierSurfaceDisplayableManager3D* New();
+  vtkTypeMacro(vtkMRMLLiverBezierSurfaceDisplayableManager3D, vtkMRMLAbstractThreeDViewDisplayableManager);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Number of widgets currently tracked.  Provided primarily for the
+  /// ctkTest driver — the production code path uses ``GetWidget``.
+  std::size_t GetNumberOfWidgets() const { return this->Widgets.size(); }
+
+  /// Look up the widget associated with a data node, or nullptr if
+  /// none.  Used by tests and by the registration-point probe in
+  /// ``qSlicerLiverResectionsModule::setup()``.
+  vtkLiverBezierWidget* GetWidget(vtkMRMLBezierSurfaceNode* node);
+
+protected:
+  vtkMRMLLiverBezierSurfaceDisplayableManager3D();
+  ~vtkMRMLLiverBezierSurfaceDisplayableManager3D() override;
+
+  /// Hook scene observation: wire ``NodeAddedEvent``,
+  /// ``NodeRemovedEvent``, ``EndImportEvent``, ``EndCloseEvent``.
+  void SetMRMLSceneInternal(vtkMRMLScene* newScene) override;
+
+  /// Per-node lifecycle.  ``OnMRMLSceneNodeAdded`` filters to
+  /// ``vtkMRMLBezierSurfaceNode``; ``OnMRMLSceneNodeRemoved`` symmetric.
+  void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
+
+  /// Scene-level lifecycle.  EndImport rebuilds the registry from
+  /// scratch (the scene may carry pre-existing Bezier-surface nodes
+  /// loaded from disk); EndClose tears every widget down.
+  void OnMRMLSceneEndImport() override;
+  void OnMRMLSceneEndClose() override;
+
+  /// Build the widget for a freshly-tracked node.  Idempotent —
+  /// re-registering an already-tracked node tears the old widget down
+  /// first.  Returns true on success.
+  bool AddBezierSurfaceNode(vtkMRMLBezierSurfaceNode* node);
+
+  /// Drop the widget for a node.  No-op if the node is not tracked.
+  void RemoveBezierSurfaceNode(vtkMRMLBezierSurfaceNode* node);
+
+  /// Drop every widget.  Called from ``OnMRMLSceneEndClose`` and from
+  /// the destructor.
+  void RemoveAllWidgets();
+
+  /// Widget registry.  Keyed by MRML node ID — survives a scene swap
+  /// where node addresses change but IDs are preserved.
+  std::map<std::string, vtkSmartPointer<vtkLiverBezierWidget>> Widgets;
+
+private:
+  vtkMRMLLiverBezierSurfaceDisplayableManager3D(const vtkMRMLLiverBezierSurfaceDisplayableManager3D&) = delete;
+  void operator=(const vtkMRMLLiverBezierSurfaceDisplayableManager3D&) = delete;
+};
+
+#endif

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -151,16 +151,22 @@ void qSlicerLiverResectionsModule::setup()
   // Register displayable managers (same displayable manager handles both slice and 3D views)
   vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->RegisterDisplayableManager("vtkMRMLLiverResectionsDisplayableManager2D");
 
-  // TODO(T2.6-DM): Register the LayerDM-aware widget displayable
-  // manager for ``vtkMRMLBezierSurfaceNode`` once
-  // ``vtkMRMLLiverBezierSurfaceDisplayableManager3D`` lands (ADR-0014
-  // §3, ADR-0013 §5).  The DM is the C++ glue that observes the
-  // scene for Bezier-surface nodes, spawns one
-  // ``vtkLiverBezierWidget`` instance per (data node, view) pair,
-  // and wires it to the view's interactor.  Until then the legacy
-  // ``vtkSlicerMarkupsWidget`` path still drives Bezier interaction
-  // via the in-tree ``vtkMRMLLiverResectionsDisplayableManager2D``
-  // registered above.
+  // T2.6-DM — register the C++ displayable manager that spawns one
+  // ``vtkLiverBezierWidget`` instance per (``vtkMRMLBezierSurfaceNode``,
+  // 3D view) pair.  The DM is the interactive companion of the
+  // LayerDM Pipeline registered below: the Pipeline draws the surface
+  // + decorations passively per view; the DM owns the interactive
+  // widget binding to the renderer + interactor (ADR-0014 §3,
+  // ADR-0013 §5, ADR-0004 — DM is C++ for the perf-critical observer
+  // chain).
+  vtkMRMLThreeDViewDisplayableManagerFactory::GetInstance()->RegisterDisplayableManager("vtkMRMLLiverBezierSurfaceDisplayableManager3D");
+
+  // TODO(T2.6-DM-2D): Register a slice-view variant of the Bezier-
+  // surface DM once a 2D representation that renders the surface ∩
+  // slice-plane intersection contour exists (``vtkLiverBezierRepre
+  // sentation`` is 3D-only as of T2.6-DM).  Tracked alongside the T3
+  // Resectogram migration that needs the same slice-intersection
+  // primitive.
   //
   // TODO(T2.6-LayerDM-Pipeline): Register the LayerDM Pipeline
   // creator for ``vtkMRMLBezierSurfaceDisplayNode`` once

--- a/LiverResections/qSlicerLiverResectionsReader.cxx
+++ b/LiverResections/qSlicerLiverResectionsReader.cxx
@@ -117,19 +117,18 @@ qSlicerIO::IOFileType qSlicerLiverResectionsReader::fileType() const
 QStringList qSlicerLiverResectionsReader::extensions() const
 {
   // ``.lrp.json`` is the v1 schema landed by T2.5 + ADR-0014 §5; the
-  // reader code path is wired so the storage node round-trips through
-  // scene save/load.  However, the Add Data filter entry for it is
-  // *withheld* until T2.6-DM registers the displayable manager that
-  // renders ``vtkMRMLBezierSurfaceNode`` in the views — without that,
-  // a user-driven Add Data → ``.lrp.json`` would load silently with
-  // no rendering.  When T2.6-DM lands the entry rejoins the list:
-  //
-  //     "Liver resection plan (*.lrp.json)"
+  // reader code path round-trips through ``vtkMRMLBezierSurfaceStorage
+  // Node``.  The Add Data filter entry rejoins the list now that
+  // T2.6-DM has landed ``vtkMRMLLiverBezierSurfaceDisplayableManager3D``
+  // — the silent-no-render trap closes when the DM spawns a
+  // ``vtkLiverBezierWidget`` per (data node, 3D view) pair on
+  // ``NodeAddedEvent``.
   //
   // The legacy ``.lrp.fcsv`` stays for load-only migration; writes
   // always emit ``.lrp.json`` via the dedicated ``qSlicerNodeWriter``
   // registered in ``qSlicerLiverResectionsModule::setup()``.
-  return QStringList() << "LiverResections CSV (*.lrp.fcsv)";
+  return QStringList() << "Liver resection plan (*.lrp.json)"
+                       << "LiverResections CSV (*.lrp.fcsv)";
 }
 
 //-----------------------------------------------------------------------------

--- a/LiverResections/qSlicerLiverResectionsReader.cxx
+++ b/LiverResections/qSlicerLiverResectionsReader.cxx
@@ -200,6 +200,16 @@ bool qSlicerLiverResectionsReader::load(const IOProperties& properties)
       return false;
     }
 
+    // ADR-0013 §8 — the display-side decoration (margin / grid / colour)
+    // lives on a separate display node.  ``vtkMRMLStorageNode::ReadData``
+    // does not create it; without an explicit call here the loaded
+    // surface would have no display node attached and the T2.6-DM
+    // rendering chain (vtkMRMLLiverBezierSurfaceDisplayableManager3D ->
+    // LayerDM Pipeline) would receive a surface with no decoration
+    // target, reopening the silent-no-render trap the DM is meant to
+    // close.
+    surfaceNode->CreateDefaultDisplayNodes();
+
     this->setLoadedNodes(QStringList() << QString(surfaceNode->GetID()));
     return true;
   }


### PR DESCRIPTION
## Summary

Adds **`vtkMRMLLiverBezierSurfaceDisplayableManager3D`** — the C++
displayable manager that observes the MRML scene for
`vtkMRMLBezierSurfaceNode` instances and spawns one
`vtkLiverBezierWidget` + representation pair per (data node, 3D
view) pair.  Without this, T2.6's Add Data → `.lrp.json` path would
load silently with no rendering — exactly why PR #364 withheld the
`.lrp.json` filter entry from `qSlicerLiverResectionsReader::extensions()`.

This PR closes that trap and re-enables the filter.

### Scoping choice — 3D only

This PR ships the 3D variant only; 2D slice-view coverage is
deferred to a follow-up `T2.6-DM-2D`.  Rationale:

- The existing `vtkLiverBezierRepresentation` is 3D-only as
  landed by T2.6 / PR #361.
- Slice-view coverage requires a representation class that
  renders the Bezier-surface ∩ slice-plane intersection contour —
  a non-trivial new representation, not a copy of the 3D path.
- Implementing it would push this PR past review-friendly size.

A `TODO(T2.6-DM-2D)` marker in
`qSlicerLiverResectionsModule::setup()` names the follow-up.

### Architectural fit

- **ADR-0014 §3** (PRIMARY — DM dispatch) — the DM is what
  spawns one `vtkLiverBezierWidget` per (data node, view) pair.
- **ADR-0014 §6** — file layout, `LiverResections/MRMLDM/`.
- **ADR-0013 §1, §5** — Python/C++ boundary; the LayerDM Pipeline
  (Python, passive per-view actor pipeline) and this DM (C++,
  interactive widget per view) coexist by design.
- **ADR-0004** — DM is C++ for the perf-critical observer chain.
- **ADR-0008 §2** — ctkTest discipline, no Slicer launch, no Qt.

### Widget registry shape

- `std::map<std::string, vtkSmartPointer<vtkLiverBezierWidget>>`,
  keyed by MRML **node ID** (not raw pointer) so the registry
  survives a scene swap (`EndImportEvent` fires after node
  addresses change but IDs stay stable).
- Lifecycle hooks: `OnMRMLSceneNodeAdded` (filtered to
  `vtkMRMLBezierSurfaceNode`), `OnMRMLSceneNodeRemoved`,
  `OnMRMLSceneEndImport` (reconcile against scene contents),
  `OnMRMLSceneEndClose` (tear down all), plus
  `SetMRMLSceneInternal` for the scene-swap entry/exit.
- Per-widget teardown chains `SetEnabled(0)` →
  `SetRepresentation(nullptr)` → `SetBezierNode(nullptr)` before
  dropping the smart-pointer reference.

### `.lrp.json` filter rejoins the Reader

`qSlicerLiverResectionsReader::extensions()` now advertises both:

```cpp
return QStringList() << "Liver resection plan (*.lrp.json)"
                     << "LiverResections CSV (*.lrp.fcsv)";
```

The silent-no-render trap closes: a user-driven Add Data →
`.lrp.json` now lands a `vtkMRMLBezierSurfaceNode` *and* sees
the widget spawn in every 3D view via the new DM.

### Manual-launch probe

```
QT_QPA_PLATFORM=offscreen \
  /home/rafael/src/Slicer-Liver-t2-6-dm-build/SlicerWithSlicerLiver \
    --testing --python-script /tmp/t2-6-dm-verify.py
```

Probe output:

```
[t2-6-dm-verify] starting
[t2-6-dm-verify] added node ID=vtkMRMLBezierSurfaceNode1
[t2-6-dm-verify] viewNode=vtkMRMLViewNode1
[t2-6-dm-verify] DM found: vtkMRMLLiverBezierSurfaceDisplayableManager3D
[t2-6-dm-verify] DM widget registry count=1
[t2-6-dm-verify] OK -- DM tracks node vtkMRMLBezierSurfaceNode1 via widget vtkLiverBezierWidget
```

Confirms: (i) the DM is registered in the 3D view's group, (ii)
adding a `vtkMRMLBezierSurfaceNode` grows the registry to 1, and
(iii) `dm.GetWidget(node)` returns the expected widget.

### Files added / modified

**Added**

- `LiverResections/MRMLDM/vtkMRMLLiverBezierSurfaceDisplayableManager3D.{h,cxx}`
- `LiverResections/MRMLDM/Testing/CMakeLists.txt`
- `LiverResections/MRMLDM/Testing/Cxx/CMakeLists.txt`
- `LiverResections/MRMLDM/Testing/Cxx/vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1.cxx`

**Modified**

- `LiverResections/CMakeLists.txt` — reorder `add_subdirectory` so
  `VTKWidgets` precedes `MRMLDM`; the DM links against the widget kit.
- `LiverResections/MRMLDM/CMakeLists.txt` — new DM source +
  VTKWidgets dependency + Testing subdir.
- `LiverResections/qSlicerLiverResectionsModule.cxx` — replace the
  `TODO(T2.6-DM)` marker with the real
  `vtkMRMLThreeDViewDisplayableManagerFactory::GetInstance()
  ->RegisterDisplayableManager(...)` call.
- `LiverResections/qSlicerLiverResectionsReader.cxx` — re-enable the
  `.lrp.json` filter entry.

## Test plan

- [x] Local C++ build green
  (`cmake --build /home/rafael/src/Slicer-Liver-t2-6-dm-build -j16`).
- [x] New ctkTest passes locally:
  `vtkMRMLLiverBezierSurfaceDisplayableManager3DTest1` (4 sub-tests:
  NodeAdded spawn, NodeRemoved teardown, scene swap rebuild,
  multiple nodes).
- [x] All other LiverResections C++ ctkTests still pass
  (`vtkMRMLBezierSurfaceNodeTest1`,
  `vtkMRMLBezierSurfaceDisplayNodeTest1`,
  `vtkMRMLBezierSurfaceStorageNodeTest1`,
  `vtkLiverBezierWidgetTest1`,
  `vtkLiverBezierFitterTest1`,
  `vtkLiverBezierFitterEdgeCasesTest`,
  `vtkSlicerLiverResectionsLogicTest1`).
- [x] Manual-launch probe confirms DM registration + widget spawn.
- [ ] CI green on `feature/t2-6-dm`.
- [ ] Reviewer confirms the 3D-only scope choice + the
  `TODO(T2.6-DM-2D)` follow-up boundary.

## Out of scope

- T2.6-LayerDM-Pipeline (Python install glue + soft-import →
  hard-require swap in `LiverBezierSurfacePipeline.py`).
- T2.6-DM-2D (slice-view DM; needs a new 2D representation).
- T2.7 (legacy `vtkMRMLLiverResection*` retirement + rename).
- T2.8 (Place button).
- T2.3 iterations 2+3 (right-drag-ring-group + right-click-context).
- Relocated OpenGL mappers (`TODO(T2-mapper-relocation)`).
- Target-mesh weakref work (`TODO(T2-target-mesh-weakref)`).
- Issue #365 (orphan-storage breaks `scene.Connect()`).

---

*Drafted with the assistance of Claude (Anthropic) — model
`claude-opus-4-7[1m]`.*
