### PR TITLE
BUG: Reader must CreateDefaultDisplayNodes after .lrp.json ReadData

### DIFF
--- a/LiverResections/qSlicerLiverResectionsReader.cxx
+++ b/LiverResections/qSlicerLiverResectionsReader.cxx
@@ -201,6 +201,17 @@ bool qSlicerLiverResectionsReader::load(const IOProperties& properties)
       return false;
     }
 
+    // ADR-0013 §8 — the display-side decoration (margin / grid /
+    // colour) lives on a separate display node.  Neither
+    // ``vtkMRMLBezierSurfaceStorageNode::ReadDataInternal`` nor the
+    // base ``vtkMRMLStorageNode::ReadData`` create a display node.
+    // Without this call the loaded surface lands with no display
+    // node attached; the eventual LayerDM Pipeline (registered when
+    // the SlicerLayerDM library is reachable in the build, per
+    // ADR-0013 §5's three-call registration contract) needs a
+    // display node to drive the actor pipeline from.
+    surfaceNode->CreateDefaultDisplayNodes();
+
     this->setLoadedNodes(QStringList() << QString(surfaceNode->GetID()));
     return true;
   }


### PR DESCRIPTION
## Summary

Salvaged from the closed PR #366 (T2.6-DM, mis-shaped as a custom per-module displayable manager and closed without merge per the architectural rule in ADR-0002 + ADR-0013).  The reader fix here is the one piece of that PR that was correct on its own merit and lands as a tiny standalone BUG fix.

## What

After `qSlicerLiverResectionsReader::load()` succeeds on a `.lrp.json` import:

```cpp
const int readResult = storageNode->ReadData(surfaceNode);
// ... error handling ...

// NEW: ADR-0013 §8 — display-side decoration lives on a separate
// display node; storage::ReadData does not create one.
surfaceNode->CreateDefaultDisplayNodes();
```

`vtkMRMLBezierSurfaceStorageNode::ReadDataInternal` does not create a display node — neither does the base `vtkMRMLStorageNode::ReadData`.  So the resulting `vtkMRMLBezierSurfaceNode` lands in the scene with no `vtkMRMLBezierSurfaceDisplayNode` attached unless the caller creates one explicitly.  Per ADR-0013 §8 the display-side decoration (margin / grid / colour fields) lives on the display node, and the eventual LayerDM Pipeline drives the actor pipeline from it.

## Scope-out

The `.lrp.json` filter in `qSlicerLiverResectionsReader::extensions()` **stays withheld** in this PR (per PR #364's original gating).  The full T2.6 rendering chain is still not wired end-to-end — that lands as a combined T2.6-LayerDM deliverable gated on the SlicerLayerDM library becoming reachable in the Slicer-main build (`vtkMRMLLayerDMPipelineFactory.h` is currently missing from `${Slicer_DIR}/include`).  When the LayerDM library lands, the `.lrp.json` filter rejoins `extensions()` in that PR.

## Test plan

- [x] Local build clean (no compile churn — single function call added).
- [x] Local lint (`Utilities/Hooks/check-copyright.sh`, `clang-format --Werror --dry-run`).
- [ ] CI: standard lint + build-test + check-commit-message.

## References

- ADR-0002 — migrate-to-SlicerLayerDM (commits Slicer-Liver to the upstream library's generic DM, NOT per-module DMs).
- ADR-0013 §5 — three registration calls for a LayerDM-aware module.
- ADR-0013 §8 — display-node split (the contract this PR honours).
- PR #364 — T2.6 storage I/O (Option B+, withheld `.lrp.json` from `extensions()`).
- PR #366 — closed without merge; mis-shaped T2.6-DM as a custom per-module DM.  This PR salvages the one correct piece.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code.  Opened for human review.*