### PR TITLE
DOC: ADR-0018 — NURBS as sibling representation; variable-size control polygon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,13 @@ jobs:
               - 'CITATION.cff'
               - 'License.txt'
               - 'COPYRIGHT.txt'
+              # Docs-build-supporting root files — touching these
+              # affects only the Sphinx scaffold (ADR-0017), not the
+              # C++ build path.  Surfaced by PR #371 where bumping
+              # ``requirements-docs.txt`` triggered a full build-test
+              # despite being a docs-only change.
+              - 'requirements-docs.txt'
+              - '.readthedocs.yaml'
 
       - name: Report skip (docs-only PR)
         if: github.event_name == 'pull_request' && steps.changes.outputs.docs-only == 'true'

--- a/Docs/adr/0014-livermarkups-dissolution.md
+++ b/Docs/adr/0014-livermarkups-dissolution.md
@@ -11,24 +11,26 @@
 
 ## Amendments
 
-- **2026-05-18 — variable-size control polygon (ADR-0018).**  The
-  v2.0.0 commitment in this ADR consistently refers to "the 4×4
+- **2026-05-18 — `{3×3, 4×4}` control polygons + NURBS extension surface (ADR-0018).**
+  The v2.0.0 commitment in this ADR consistently refers to "the 4×4
   control grid".  Per [ADR-0018](0018-nurbs-extension-surface.md) §1
-  the architectural commitment is **variable-size M×N control
-  polygon, defaulting to 4×4**.  Everywhere the text below says
-  "4×4 control grid" or "16 control points" or "ring role: corners
-  (4), edges (8), interior (4)", read it as the **default case** of
-  the general M×N formulation:
-  - corners — always exactly 4
-  - edges — `2(M-2) + 2(N-2)`
-  - interior — `(M-2)(M-2)`
-  - total — `M × N`
-  The widget event-table (`vtkLiverBezierWidget`) generalizes
-  mechanically; the per-ring manipulation events are independent of
-  M, N.  `.lrp.json` schema v2 carries explicit `rows` + `cols`
-  alongside `controlGrid`; v1 files implicit-load as (4, 4).  Full
-  rationale + the v2.1 NURBS-as-sibling extension surface in
-  [ADR-0018](0018-nurbs-extension-surface.md).
+  the architectural commitment **admits two Bezier shapes**: 3×3 and
+  4×4 (square only).  Both shapes preserve the corners / edges /
+  interior ring philosophy:
+  - 3×3: corners(4) + edges(4) + interior(1) = 9
+  - 4×4: corners(4) + edges(8) + interior(4) = 16
+  Per-setter validation on `vtkMRMLBezierSurfaceNode::SetRows` /
+  `SetCols` rejects other `(Rows, Cols)` combinations.  Arbitrary
+  M×N control polygons remain reserved for the v2.1 NURBS sibling
+  representation per [ADR-0018][adr-0018-link] §3.  The widget
+  event-table (`vtkLiverBezierWidget`) parameterizes on `(Rows,
+  Cols)`; the same ring-of-control-points formula handles both
+  shapes.  `.lrp.json` schema v2 carries explicit `rows` + `cols`
+  alongside `controlGrid`; v1 files implicit-load as (4, 4); v2
+  readers validate `(rows, cols) ∈ {(3, 3), (4, 4)}` and reject
+  others.
+
+[adr-0018-link]: 0018-nurbs-extension-surface.md
 
 - **2026-05-16 — rename Bezier-surface MRML classes.**  The `Liver`
   prefix on the Bezier-surface MRML class trio

--- a/Docs/adr/0014-livermarkups-dissolution.md
+++ b/Docs/adr/0014-livermarkups-dissolution.md
@@ -11,6 +11,25 @@
 
 ## Amendments
 
+- **2026-05-18 — variable-size control polygon (ADR-0018).**  The
+  v2.0.0 commitment in this ADR consistently refers to "the 4×4
+  control grid".  Per [ADR-0018](0018-nurbs-extension-surface.md) §1
+  the architectural commitment is **variable-size M×N control
+  polygon, defaulting to 4×4**.  Everywhere the text below says
+  "4×4 control grid" or "16 control points" or "ring role: corners
+  (4), edges (8), interior (4)", read it as the **default case** of
+  the general M×N formulation:
+  - corners — always exactly 4
+  - edges — `2(M-2) + 2(N-2)`
+  - interior — `(M-2)(M-2)`
+  - total — `M × N`
+  The widget event-table (`vtkLiverBezierWidget`) generalizes
+  mechanically; the per-ring manipulation events are independent of
+  M, N.  `.lrp.json` schema v2 carries explicit `rows` + `cols`
+  alongside `controlGrid`; v1 files implicit-load as (4, 4).  Full
+  rationale + the v2.1 NURBS-as-sibling extension surface in
+  [ADR-0018](0018-nurbs-extension-surface.md).
+
 - **2026-05-16 — rename Bezier-surface MRML classes.**  The `Liver`
   prefix on the Bezier-surface MRML class trio
   (`vtkMRMLLiverBezierSurface{,Display,Storage}Node`) carries no

--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -10,15 +10,42 @@
 
 - **2026-05-18 — variable-degree Bernstein + future NURBS fitter (ADR-0018).**
   Per [ADR-0018](0018-nurbs-extension-surface.md) §1 the
-  `vtkLiverBezierFitter` generalises to degree-`(Rows-1)` ×
-  degree-`(Cols-1)` Bernstein basis to support variable-size control
-  polygons.  The Eigen normal-equation pseudo-inverse path is
-  unchanged; only the basis-matrix shape parameterizes.  ADR-0018 §1
-  also commits a v2.1 sibling `vtkLiverNurbsFitter` (least-squares on
-  B-spline basis with rational weights + knot vectors); the
-  Eigen-via-ITK-bundle linkage this ADR commits to covers both
-  fitters.  Read every "4×4" / "16-point" reference below as the
-  default case of the general M×N + variable-degree formulation.
+  `vtkLiverBezierFitter` parameterizes to degree-`(Rows-1)` Bernstein
+  basis to support the v2.0.0 `{3×3, 4×4}` Bezier shapes.  The Eigen
+  normal-equation pseudo-inverse path is unchanged; only the
+  basis-matrix shape parameterizes (degree-2 for 3×3; degree-3 for
+  4×4).  Eigen alone covers v2.0.0; no new external dependency.
+
+  ADR-0018 §3 commits a v2.1 sibling `vtkLiverNurbsFitter` for the
+  NURBS extension.  **NURBS evaluation does require additional
+  numerics** (de Boor's recursive algorithm, knot-vector validation,
+  rational weight division) that Eigen does not ship.  Three library
+  options for the v2.1 NURBS fitter, deferred to the v2.1
+  NURBS-specific ADR:
+
+  - **Custom B-spline code atop Eigen.**  Smallest dependency
+    surface; Eigen handles the linear-algebra core (least squares,
+    weight estimation).  The de Boor recursion is ~150 lines of C++.
+    Risk: home-rolled numerics need careful characterisation testing
+    (per [ADR-0003](0003-testability-invariant.md)).
+  - **[OpenNURBS](https://github.com/mcneel/opennurbs)** (BSD-3, McNeel & Associates).  Industry-standard
+    NURBS toolkit used by Rhino, FreeCAD, gmsh.  Pros: battle-tested
+    numerics, complete B-spline + NURBS API, IGES / STEP I/O if
+    surgeon-to-CAD interchange ever lands.  Cons: ~50 KLOC, slow
+    build, brings in its own geometry kernel types that don't
+    interop directly with `vtkPolyData`.
+  - **[CGAL](https://www.cgal.org/)** (GPL / commercial dual-license; LGPL for some packages).
+    Has a `Polynomial`/`Algebraic_kernel` surface, but NURBS-surface
+    coverage is incomplete + licensing makes downstream distribution
+    in a Slicer extension complicated (Slicer is BSD-3; CGAL's
+    GPL packages would force GPL contamination per the GPL viral
+    clause, which is incompatible with Slicer-Liver's BSD-3
+    license).
+
+  **Decision deferred** to the v2.1 NURBS ADR; the v2.0.0 Bezier
+  parameterization in this ADR's main body needs no new library.
+  Read every "4×4" / "16-point" reference below as the 4×4 case of
+  the parameterized {3×3, 4×4} formulation.
 
 ## Context
 

--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -6,6 +6,20 @@
 - **Diagrams:** N/A
 - **PR:** _filled in on merge_
 
+## Amendments
+
+- **2026-05-18 — variable-degree Bernstein + future NURBS fitter (ADR-0018).**
+  Per [ADR-0018](0018-nurbs-extension-surface.md) §1 the
+  `vtkLiverBezierFitter` generalises to degree-`(Rows-1)` ×
+  degree-`(Cols-1)` Bernstein basis to support variable-size control
+  polygons.  The Eigen normal-equation pseudo-inverse path is
+  unchanged; only the basis-matrix shape parameterizes.  ADR-0018 §1
+  also commits a v2.1 sibling `vtkLiverNurbsFitter` (least-squares on
+  B-spline basis with rational weights + knot vectors); the
+  Eigen-via-ITK-bundle linkage this ADR commits to covers both
+  fitters.  Read every "4×4" / "16-point" reference below as the
+  default case of the general M×N + variable-degree formulation.
+
 ## Context
 
 [ADR-0004](0004-python-cpp-boundary.md) commits Slicer-Liver to a sharp

--- a/Docs/adr/0018-nurbs-extension-surface.md
+++ b/Docs/adr/0018-nurbs-extension-surface.md
@@ -70,40 +70,59 @@ representation under a single agreed data-node + Pipeline taxonomy.
 
 The decision splits into four sub-commitments:
 
-### 1. Variable-size control polygon in v2.0.0
+### 1. Two control-polygon sizes in v2.0.0: `{3×3, 4×4}` square-only
 
 The `vtkMRMLBezierSurfaceNode` data type carries explicit `Rows` and
-`Cols` integer fields (defaulting to `4` and `4` for backward
-compatibility with PR #361's `.lrp.json` v1 schema).  The
-`ControlGrid` storage becomes a variable-length array of `3 * Rows *
-Cols` doubles.  All downstream code that previously assumed `4 * 4 *
-3 = 48` is parameterized:
+`Cols` integer fields (defaulting to `4` and `4`).  For the v2.0.0
+release the **valid Bezier sizes are restricted to two square
+shapes**:
 
-- **`vtkLiverBezierWidget`** ring-group taxonomy generalizes per the
-  formula:
-  - corners — always exactly 4 (the four corners of any rectangular
-    grid)
-  - edges — `2 * (Rows - 2) + 2 * (Cols - 2)` boundary points minus
-    the corners
-  - interior — `(Rows - 2) * (Cols - 2)`
-  - total — `Rows * Cols`
+| Shape   | Corners | Edges | Interior | Total |
+|---------|---------|-------|----------|-------|
+| **3×3** | 4       | 4     | 1        | 9     |
+| **4×4** | 4       | 8     | 4        | 16    |
+
+Both shapes have a natural "corners-edges-interior" three-ring
+structure, which matches the project's existing ring-of-control-points
+manipulation philosophy ([ADR-0014][adr-0014] §3 widget event
+table).  Non-square shapes (3×4, 4×3) break ring symmetry and are
+NOT admitted in v2.0.0.  Larger sizes (5×5, 5×7, etc.) are also
+not admitted — they are NURBS-territory and arrive with the v2.1
+NURBS sibling (see §3 below).
+
+Setter on `vtkMRMLBezierSurfaceNode::SetRows` / `SetCols` validates
+`(Rows, Cols) ∈ {(3, 3), (4, 4)}` and emits a `vtkErrorMacro` +
+returns without `Modified()` on any other value (mirrors PR #350's
+existing rejection pattern for forbidden state transitions).
+
+The `ControlGrid` storage becomes a variable-length array of `3 *
+Rows * Cols` doubles — either `27` (3×3 case) or `48` (4×4 case).
+Downstream code that previously assumed `48` parameterizes on
+`3 * Rows * Cols`:
+
+- **`vtkLiverBezierWidget`** ring-group taxonomy parameterizes on
+  the (Rows, Cols) shape:
+  - 3×3: corners(4) + edges(4) + interior(1) = 9
+  - 4×4: corners(4) + edges(8) + interior(4) = 16
   The right-drag-ring-group event (`TODO(T2.3 right-drag-ring-group)`)
   manipulates whichever ring set is currently selected; the
-  manipulation math is the same for any M×N.
-- **`vtkLiverBezierFitter`** generalizes to degree-`(Rows-1)` ×
-  degree-`(Cols-1)` Bernstein basis.  The Eigen normal-equation
-  pseudo-inverse path is unchanged; only the basis-matrix shape
-  parameterizes.
+  manipulation math is the same shape per shape.
+- **`vtkLiverBezierFitter`** parameterizes to degree-`(Rows-1)`
+  Bernstein basis (degree-2 for 3×3; degree-3 for 4×4).  The Eigen
+  normal-equation pseudo-inverse path is unchanged; only the
+  basis-matrix shape parameterizes.
 - **`.lrp.json` schema** bumps to v2.  v2 carries explicit `rows` +
   `cols` fields alongside `controlGrid: [3 * rows * cols doubles]`.
   v1 files (with implicit 4×4) load via the existing storage node's
   migration path; default `rows = 4, cols = 4` if the fields are
-  absent.
+  absent.  Schema v2 validates `(rows, cols) ∈ {(3, 3), (4, 4)}` on
+  load + rejects with `vtkErrorMacro` on any other shape.
 
 The 4×4 case stays the **default** because the d'Albenzio study
 identifies it as the most common surgeon-facing shape; the
-architectural change is admitting other sizes, not changing the
-default.
+architectural change is admitting the **smaller** 3×3 shape as a
+valid alternative, NOT opening to arbitrary M×N.  Arbitrary M×N is
+the NURBS v2.1 territory.
 
 ### 2. Single data node, parameterized — NOT a parent class
 
@@ -141,9 +160,9 @@ Concretely:
 Sibling Pipelines, not a polymorphic dispatch on a third axis.
 
 - **v2.0.0**: `LiverBezierSurfacePipeline` is the only Pipeline.  It
-  handles 4×4 and 5×7 and any M×N Bezier surface; the geometry
-  generation is parameterized but the surface math (Bernstein basis,
-  no weights, no knots) is fixed.
+  handles both `{3×3, 4×4}` Bezier shapes; the geometry generation
+  is parameterized but the surface math (Bernstein basis, no weights,
+  no knots) is fixed.
 - **v2.1**: `LiverNurbsSurfacePipeline` lands as a peer Pipeline
   registered with `vtkMRMLLayerDMPipelineFactory` against
   `vtkMRMLNurbsSurfaceDisplayNode`.  Per [ADR-0013][adr-0013] §5 call 3,
@@ -185,6 +204,33 @@ substance; the schema bumps to v2 with explicit `rows` + `cols`
 fields.  v1 files load via the migration path the storage node
 already implements (legacy `Curved` mode handling from PR #361
 extends naturally to legacy-implicit-4×4 handling).
+
+## Why `{3×3, 4×4}` square-only, not arbitrary M×N in v2.0.0
+
+The d'Albenzio study's variable-control-polygon claim covers the
+**NURBS-representation space**, where the control polygon is
+genuinely arbitrary.  For v2.0.0 Bezier surfaces, two arguments
+favour restricting to two square shapes:
+
+- **Ring-philosophy fit.**  The widget's right-drag-ring-group
+  event ([ADR-0014][adr-0014] §3) groups control points by corners /
+  edges / interior.  Both 3×3 and 4×4 have all three ring sets
+  non-empty; non-square shapes (3×4, 4×3, 5×4, …) lose the corner
+  symmetry and the edge-ring is unevenly split between
+  row-direction and column-direction edges.  The UX gets messy.
+- **Clinical signal.**  d'Albenzio's surgeon-interview data does
+  not show evidence that surgeons need M×N > 4×4 for *Bezier*
+  surfaces; the demand for arbitrary M×N is paired with the demand
+  for the NURBS basis (local-control, knot insertion, conic-section
+  reproducibility).  Bezier's degree-`(N-1)` Bernstein basis at large
+  N becomes numerically unstable + has zero local control, which is
+  the wrong shape for clinical-grade surface fitting at scale.
+
+Two-shape restriction in v2.0.0 + NURBS opens the M×N space in v2.1
+is the right phasing.  The architectural surface in `vtkMRMLBezierSurfaceNode`
+(`Rows`/`Cols` IVars, parameterized widget + fitter) is unchanged
+by the restriction — the runtime validation is the only added
+constraint, and it's a single switch statement.
 
 ## Why Option A, not full NURBS in v2.0.0
 
@@ -259,7 +305,8 @@ third axis would make the slot table 3-dimensional.  Rejected because:
   right (some anatomies need 5×5 or 5×7 control polygons; the 4×4
   specialisation was a v1 limitation, not a deliberate UX decision).
 - Schema v2 (`.lrp.json`) carries forward — surgeon plans authored
-  with arbitrary M×N round-trip cleanly.
+  with either `{3×3, 4×4}` shape round-trip cleanly; v2.1 schema v3
+  will admit larger M×N for the NURBS sibling.
 - The ring-group taxonomy generalizes mechanically; T2.3's
   `right-drag-ring-group` event flow inherits the formula.
 - d'Albenzio et al. citation lands as a committed architectural
@@ -295,7 +342,7 @@ third axis would make the slot table 3-dimensional.  Rejected because:
      Bezier ↔ NURBS class taxonomy + mathematical-model contrast.
    - New `Docs/architecture/control-grid-grouping.md` — ring-group
      formula for M×N + example layouts.
-   - Light amendment to [ADR-0014][adr-0014] §3 (4×4 → M×N).
+   - Light amendment to [ADR-0014][adr-0014] §3 (4×4 → {3×3, 4×4}).
    - Light amendment to [ADR-0015][adr-0015] (extension surface for variable-degree
      Bernstein + future NURBS fitter).
    - `sphinxcontrib-mermaid` added to `requirements-docs.txt` +

--- a/Docs/adr/0018-nurbs-extension-surface.md
+++ b/Docs/adr/0018-nurbs-extension-surface.md
@@ -1,0 +1,368 @@
+# 0018. NURBS as a sibling representation; variable-size control polygon
+
+- **Status:** Proposed
+- **Date:** 2026-05-18
+- **Deciders:** Rafael Palomar
+- **Diagrams:**
+  - `Docs/architecture/target-mrml-node-hierarchy.md`
+  - `Docs/architecture/surface-representation-taxonomy.md`
+  - `Docs/architecture/control-grid-grouping.md`
+  - `Docs/architecture/rendering-pipeline.md`
+- **PR:** _filled in on merge_
+
+## Context
+
+The v2.0.0 Bezier-surface family was designed around a **fixed 4×4
+control grid** (16 control points, degree-3 Bernstein basis):
+
+- `vtkMRMLBezierSurfaceNode` exposes a `ControlGridSize = 48` constant
+  (`3 * 4 * 4` doubles) and a `GridSize = 4` constant.
+- `vtkLiverBezierWidget`'s ring-group taxonomy is named in
+  [ADR-0014][adr-0014] §3 as "corners 4 + edges 8 + interior 4" —
+  hard-coded counts.
+- `vtkLiverBezierFitter` (per [ADR-0015][adr-0015]) instantiates a
+  degree-3 Bernstein basis.
+- `.lrp.json` v1 schema (per [ADR-0014][adr-0014] §5) encodes
+  `controlGrid` as 48 doubles row-major.
+
+d'Albenzio et al's SPIE Medical Imaging 2024 usability study
+(*Surgeon-driven design of resection planning interfaces*) positions
+NURBS — Non-Uniform Rational B-Splines — as a **valid alternative
+representation** to Bezier for surgeon-defined resection surfaces.
+The study's clinical motivation: certain anatomies (sharp curvature
+transitions, asymmetric resection volumes) are awkward to express
+with a degree-3 4×4 Bezier patch but natural with a NURBS surface
+of arbitrary control-polygon size and arbitrary local degree.
+
+Crucially: **NURBS requires a control polygon, which can be any
+M×N**.  The 4×4 hard-code in the current v2.0.0 data structures is a
+specialisation of the more general M×N case — it bakes a representation
+choice into types that the architecture is going to want to widen.
+
+The earlier v2.0.0 design discussion (captured in the project's PKS
+log under "NURBS future variant") deferred NURBS proper to v2.1 as
+"a sibling Representation alongside `BezierPlanningRepresentation`
+and a `vtkLiverNurbsFitter` sibling to `vtkLiverBezierFitter`, both
+without breaking architectural shape".  That commitment stands; this
+ADR makes it explicit + adds the **variable-size-control-polygon
+prerequisite** as v2.0.0-in-scope work.
+
+<!--
+  Cross-references below use full GitHub URLs because the scaffold
+  build (per ADR-0017) explicitly excludes the older ADRs from the
+  Sphinx tree via conf.py's exclude_patterns.  Cannot use MyST
+  cross-refs ([](file.md)) here until the migration PR lifts those
+  exclusions.  Same pattern as ADR-0017.
+-->
+
+[adr-0001]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0001-resection-three-node-assembly.md
+[adr-0013]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md
+[adr-0014]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0014-livermarkups-dissolution.md
+[adr-0015]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0015-cpp-algorithm-library.md
+[adr-0016]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0016-code-style-and-lint.md
+
+## Decision
+
+Adopt **Option A**: commit to variable-size control polygons as a
+v2.0.0 architectural extension; defer full NURBS (rational B-spline
+basis with explicit knots and weights) to v2.1 as a sibling
+representation under a single agreed data-node + Pipeline taxonomy.
+
+The decision splits into four sub-commitments:
+
+### 1. Variable-size control polygon in v2.0.0
+
+The `vtkMRMLBezierSurfaceNode` data type carries explicit `Rows` and
+`Cols` integer fields (defaulting to `4` and `4` for backward
+compatibility with PR #361's `.lrp.json` v1 schema).  The
+`ControlGrid` storage becomes a variable-length array of `3 * Rows *
+Cols` doubles.  All downstream code that previously assumed `4 * 4 *
+3 = 48` is parameterized:
+
+- **`vtkLiverBezierWidget`** ring-group taxonomy generalizes per the
+  formula:
+  - corners — always exactly 4 (the four corners of any rectangular
+    grid)
+  - edges — `2 * (Rows - 2) + 2 * (Cols - 2)` boundary points minus
+    the corners
+  - interior — `(Rows - 2) * (Cols - 2)`
+  - total — `Rows * Cols`
+  The right-drag-ring-group event (`TODO(T2.3 right-drag-ring-group)`)
+  manipulates whichever ring set is currently selected; the
+  manipulation math is the same for any M×N.
+- **`vtkLiverBezierFitter`** generalizes to degree-`(Rows-1)` ×
+  degree-`(Cols-1)` Bernstein basis.  The Eigen normal-equation
+  pseudo-inverse path is unchanged; only the basis-matrix shape
+  parameterizes.
+- **`.lrp.json` schema** bumps to v2.  v2 carries explicit `rows` +
+  `cols` fields alongside `controlGrid: [3 * rows * cols doubles]`.
+  v1 files (with implicit 4×4) load via the existing storage node's
+  migration path; default `rows = 4, cols = 4` if the fields are
+  absent.
+
+The 4×4 case stays the **default** because the d'Albenzio study
+identifies it as the most common surgeon-facing shape; the
+architectural change is admitting other sizes, not changing the
+default.
+
+### 2. Single data node, parameterized — NOT a parent class
+
+Reject the alternative of introducing a parent `vtkMRMLParametricSurfaceNode`
+with `vtkMRMLBezierSurfaceNode` / `vtkMRMLNurbsSurfaceNode` subclasses.
+Two reasons:
+
+- The Bezier ↔ NURBS distinction is mathematically real but
+  Pipeline-level orthogonal: every Pipeline cares about
+  `(controlGrid, rows, cols, state, initMode)` regardless of whether
+  the underlying interpolation is Bernstein or B-spline.  A parent
+  class fragments the type surface without buying clarity.
+- Slicer's MRML convention for "alternative-shape" extensions is a
+  sibling node, not a subclass: `vtkMRMLModelNode` is the canonical
+  example — no abstract `vtkMRMLGeometryNode` parent above it.
+  Subclassing introduces dispatch surfaces (slot lookups by class
+  pointer) that complicate the Pipeline registration in [ADR-0013][adr-0013] §5
+  call 3.
+
+Concretely:
+
+- **v2.0.0**: `vtkMRMLBezierSurfaceNode` with `Rows`/`Cols` IVars.
+  No `vtkMRMLNurbsSurfaceNode` yet.
+- **v2.1**: `vtkMRMLNurbsSurfaceNode` lands as a peer of
+  `vtkMRMLBezierSurfaceNode`, NOT a subclass.  It carries
+  NURBS-specific fields the Bezier node does not: `DegreeU`, `DegreeV`,
+  `KnotsU` (variable-length), `KnotsV` (variable-length), `Weights`
+  (`Rows * Cols` rational coefficients).  Shared shape — `Rows`,
+  `Cols`, `ControlGrid`, `ResectionState`, `InitializationMode` —
+  duplicates at the field level; this is acceptable cost for clean
+  per-type dispatch.
+
+### 3. Single Pipeline per representation — NOT a polymorphic parent
+
+Sibling Pipelines, not a polymorphic dispatch on a third axis.
+
+- **v2.0.0**: `LiverBezierSurfacePipeline` is the only Pipeline.  It
+  handles 4×4 and 5×7 and any M×N Bezier surface; the geometry
+  generation is parameterized but the surface math (Bernstein basis,
+  no weights, no knots) is fixed.
+- **v2.1**: `LiverNurbsSurfacePipeline` lands as a peer Pipeline
+  registered with `vtkMRMLLayerDMPipelineFactory` against
+  `vtkMRMLNurbsSurfaceDisplayNode`.  Per [ADR-0013][adr-0013] §5 call 3,
+  each Pipeline-creator dispatches on display-node class — so
+  `vtkMRMLBezierSurfaceDisplayNode` → BezierPipeline,
+  `vtkMRMLNurbsSurfaceDisplayNode` → NurbsPipeline, no class-level
+  ambiguity.
+
+Representations follow the same sibling pattern:
+`BezierPlanningRepresentation` (v2.0.0) /
+`NurbsPlanningRepresentation` (v2.1).  Initialization-mode
+Representations (`SlicingPlaneInitRepresentation`,
+`DistanceSpheroidInitRepresentation`) are agnostic — the init
+points + plane + spheroid are the surgeon's input, independent of
+whether the eventual fitted surface is Bezier or NURBS.  These
+Representations stay shared; only the post-Init "Planning" surface
+Representation differentiates.
+
+### 4. New ADR; light amendments to ADR-0014 §3 and ADR-0015
+
+Two existing ADRs need light amendments:
+
+- **[ADR-0014][adr-0014] §3** — the "4×4 control grid" + "corners 4 + edges 8
+  + interior 4" phrasings become "M×N control grid, defaulting to
+  4×4" + "corners 4 + edges `2(M-2) + 2(N-2)` + interior `(M-2)(N-2)`".
+  The Bezier-specificity language stays — ADR-0014 is the Bezier
+  dissolution ADR; NURBS is documented here, in ADR-0018.
+- **[ADR-0015][adr-0015]** — extension surface added: the algorithm library
+  admits a future `vtkLiverNurbsFitter` sibling.  ADR-0015's
+  Eigen-via-ITK-bundle linkage covers both Bezier (degree-`(N-1)`
+  Bernstein) and NURBS (B-spline + weights) math.
+
+[ADR-0014][adr-0014] §4's read-only-after-Planning contract from PR #350
+is unchanged: still applies to init data only, regardless of
+control-polygon size or eventual NURBS extension.
+
+[ADR-0014][adr-0014] §5's `.lrp.json` schema commitment is unchanged in
+substance; the schema bumps to v2 with explicit `rows` + `cols`
+fields.  v1 files load via the migration path the storage node
+already implements (legacy `Curved` mode handling from PR #361
+extends naturally to legacy-implicit-4×4 handling).
+
+## Why Option A, not full NURBS in v2.0.0
+
+The d'Albenzio study identifies the *valid-representation-space*
+extension as the architectural commitment, not "ship NURBS now".  The
+v2.0.0 work-in-flight (T2 LiverResections refactor) is already
+substantial; admitting variable-size Bezier closes the
+type-architecture door on the 4×4 specialisation **without** taking
+on the NURBS-evaluation math (de Boor's algorithm, knot-vector
+normalisation, rational-vs-polynomial division-by-weight) that a real
+NURBS fitter needs.
+
+Risk if v2.0.0 ships only fixed 4×4: every v2.1 NURBS PR has to
+re-litigate every field that bakes 4×4 in.  Risk avoided by Option A.
+
+Risk if v2.0.0 ships full NURBS: NURBS evaluation has known
+numerical traps (weight degeneracies, knot-vector validation,
+periodic-vs-clamped basis) that need their own characterisation-test
+suite per [ADR-0003][adr-0003].  That suite is non-trivial; conflating it with
+the existing T2 stack work overloads the v2.0.0 release.
+
+[adr-0003]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0003-testability-invariant.md
+
+Option A is the **minimum architectural commitment** that honours
+d'Albenzio's mathematical-extensibility claim without scope creep.
+
+## Why a single data type per representation kind, not a parent class
+
+Subclasses are tempting (`vtkMRMLBezierSurfaceNode <:
+vtkMRMLParametricSurfaceNode :> vtkMRMLNurbsSurfaceNode`) for sharing
+the `Rows`/`Cols`/`ControlGrid`/state-machine fields.  Rejected
+because:
+
+- Slicer-core's MRML hierarchy avoids the "geometry-parent" pattern.
+  `vtkMRMLModelNode` is a peer of `vtkMRMLMarkupsNode`, not a
+  subclass of a common geometry parent.  Sibling consistency
+  outweighs DRY-on-fields.
+- The Pipeline-factory registration in [ADR-0013][adr-0013] §5 call 3 dispatches
+  on **display-node class** (`vtkMRMLBezierSurfaceDisplayNode` vs
+  `vtkMRMLNurbsSurfaceDisplayNode`).  A parent class introduces an
+  isinstance / SafeDownCast cascade in the creator lambda; sibling
+  classes give exact-class dispatch.
+- Storage-node duality (`vtkMRMLBezierSurfaceStorageNode` vs
+  `vtkMRMLNurbsSurfaceStorageNode`) extends the sibling pattern
+  cleanly; a parent would force a polymorphic storage that has to
+  branch on subtype anyway.
+
+## Why sibling Pipelines, not a polymorphic third axis
+
+The current Pipeline dispatch is `(ResectionState, InitializationMode)
+→ Representation`.  Adding `RepresentationKind` (Bezier/NURBS) as a
+third axis would make the slot table 3-dimensional.  Rejected because:
+
+- The Init-mode Representations are agnostic to Bezier-vs-NURBS (init
+  data is surgeon input; surface fitting is downstream).  Sharing
+  them across two Pipelines is cleaner than maintaining a
+  three-axis table where 2/3 of the slots are duplicates.
+- The post-Init "Planning" Representation IS Bezier-vs-NURBS-specific
+  (different surface generation, different shader uniforms,
+  different fitter call).  Sibling Pipelines make this divergence
+  explicit at the registration level.
+- LayerDM's `vtkMRMLLayerDMPipelineFactory` registration model is
+  "one creator per display-node type"; sibling Pipelines map 1:1.
+
+## Consequences
+
+**Positive:**
+
+- v2.0.0 architectural surface admits the NURBS extension without
+  retrofit.
+- Variable-size Bezier is a legitimate clinical feature in its own
+  right (some anatomies need 5×5 or 5×7 control polygons; the 4×4
+  specialisation was a v1 limitation, not a deliberate UX decision).
+- Schema v2 (`.lrp.json`) carries forward — surgeon plans authored
+  with arbitrary M×N round-trip cleanly.
+- The ring-group taxonomy generalizes mechanically; T2.3's
+  `right-drag-ring-group` event flow inherits the formula.
+- d'Albenzio et al. citation lands as a committed architectural
+  reference, anchored in ADR-0018 (so it survives future drift).
+
+**Negative:**
+
+- The enabling PR (variable-size code parameterization) touches
+  every site that hard-codes `4`, `16`, or `48`.  Substantial but
+  mechanical work; characterisation tests from [ADR-0003][adr-0003] catch
+  regressions on the 4×4 default.
+- Schema v2 introduces a migration path (v1 → v2 implicit 4×4) that
+  needs explicit test coverage (parallel to PR #361's legacy
+  `.lrp.fcsv` migration).
+- The eventual v2.1 NURBS work has a clearer landing zone but ALSO
+  more upfront design: deciding the knot-vector representation
+  (clamped vs periodic; uniform vs non-uniform), weight encoding
+  (per-control-point vs implicit-1.0), and the
+  fitter's least-squares formulation (linear in weights vs
+  non-linear).  Deferred to a v2.1 ADR.
+
+## Rollout plan
+
+1. **DOC PR — this ADR + 4 architecture diagrams + ADR amendments**
+   (this PR):
+   - New `Docs/adr/0018-nurbs-extension-surface.md`.
+   - New `Docs/architecture/target-mrml-node-hierarchy.md` —
+     post-T2 + variable-size + NURBS sibling extension surface.
+   - New `Docs/architecture/rendering-pipeline.md` — sequence flow
+     from `vtkMRMLLayerDisplayableManager` dispatch through Pipeline,
+     Representation, custom mapper, shader uniforms.
+   - New `Docs/architecture/surface-representation-taxonomy.md` —
+     Bezier ↔ NURBS class taxonomy + mathematical-model contrast.
+   - New `Docs/architecture/control-grid-grouping.md` — ring-group
+     formula for M×N + example layouts.
+   - Light amendment to [ADR-0014][adr-0014] §3 (4×4 → M×N).
+   - Light amendment to [ADR-0015][adr-0015] (extension surface for variable-degree
+     Bernstein + future NURBS fitter).
+   - `sphinxcontrib-mermaid` added to `requirements-docs.txt` +
+     `Docs/conf.py` extensions so the new diagrams render in the
+     Sphinx build (the ADR ledger entry compiles, the architecture
+     diagrams stay excluded per [ADR-0017][adr-0017]'s scaffold-scope
+     `exclude_patterns`).
+
+[adr-0017]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0017-sphinx-readthedocs.md
+
+2. **ENH PR — variable-size code parameterization (Option A enabler)**:
+   - `vtkMRMLBezierSurfaceNode`: drop `GridSize = 4`,
+     `ControlGridSize = 48` constants; add `Rows`/`Cols` IVars
+     (default 4, 4).  Migration in `ReadXMLAttributes`: if `rows` /
+     `cols` attributes absent, default to (4, 4).
+   - `vtkMRMLBezierSurfaceStorageNode`: schema v2 with explicit
+     `rows` + `cols`.  Read path branches on schemaVersion (1 implies
+     4×4; 2 reads explicit values).  Write path always emits v2.
+   - `vtkLiverBezierWidget` + `vtkLiverBezierRepresentation`:
+     ring-group generalization (corners always 4, edges + interior
+     compute from `Rows`/`Cols`).
+   - `vtkLiverBezierFitter`: degree-`(Rows-1)` × degree-`(Cols-1)`
+     Bernstein basis.  Existing tests pin 4×4 behaviour; new tests
+     pin 5×4 + 5×5 + non-square cases.
+   - Characterisation tests from [ADR-0003][adr-0003] verify the 4×4 path is
+     bit-identical to the pre-parameterization output.
+
+3. **v2.1 — full NURBS** (separate ADR, not this one):
+   - `vtkMRMLNurbsSurfaceNode` + display + storage sibling trio.
+   - `LiverNurbsSurfacePipeline` registered with
+     `vtkMRMLLayerDMPipelineFactory` for `vtkMRMLNurbsSurfaceDisplayNode`.
+   - `NurbsPlanningRepresentation` siblings `BezierPlanningRepresentation`.
+   - `vtkLiverNurbsFitter` siblings `vtkLiverBezierFitter`.
+   - `.lrp.json` schema v3 — adds NURBS-specific fields (knots,
+     weights, degree-per-axis) when `representationKind == "Nurbs"`.
+
+## Out of scope for this ADR
+
+- Full NURBS implementation.  Deferred to v2.1.
+- Periodic / closed B-spline surfaces.  d'Albenzio's study covers
+  clamped non-periodic only.
+- Trimmed NURBS (NURBS surface with one or more trimming curves).
+  Out of v2.0.0 + v2.1 scope; clinical motivation thin.
+- Subdivision surfaces (Catmull-Clark, Loop, etc.).  Not in
+  d'Albenzio's reference space.
+
+## Cross-references
+
+- [ADR-0001][adr-0001] — the three-node assembly (data + display + storage)
+  that this ADR's M×N generalisation extends.
+- [ADR-0013][adr-0013] §5 — Pipeline factory registration; the v2.1 NURBS
+  sibling Pipeline lands via call 3 with `vtkMRMLNurbsSurfaceDisplayNode`
+  as its display-node class.
+- [ADR-0014][adr-0014] §3 — Bezier dissolution + 4×4-to-M×N amendment landed
+  alongside this ADR.
+- [ADR-0015][adr-0015] — algorithm library + extension surface for variable-degree
+  Bernstein and the future NURBS fitter.
+- [ADR-0016][adr-0016] — code style + lint enforcement; the parameterization
+  PR inherits the discipline.
+- [ADR-0017][adr-0017] — Sphinx/RTD scaffold; this ADR's architecture
+  diagrams use Mermaid via `sphinxcontrib-mermaid`.
+
+## References
+
+- d'Albenzio, G. et al. *Surgeon-driven design of resection planning
+  interfaces*. SPIE Medical Imaging 2024.  (Cited as the architectural
+  authority for NURBS-as-sibling.)
+- [The NURBS Book](https://link.springer.com/book/10.1007/978-3-642-59223-2),
+  Piegl & Tiller, 2nd ed., Springer 1996/1997.  (Reference for the
+  v2.1 NURBS-evaluation math.)

--- a/Docs/architecture/control-grid-grouping.md
+++ b/Docs/architecture/control-grid-grouping.md
@@ -1,37 +1,46 @@
-# Control-grid grouping — M×N ring-group taxonomy
+# Control-grid grouping — `{3×3, 4×4}` ring-group taxonomy
 
 Reference companion to [ADR-0014][adr-0014] §3 +
-[ADR-0018][adr-0018] §1.  Generalises the
-`vtkLiverBezierWidget` right-drag ring-group taxonomy from the v1
-fixed-4×4 case to arbitrary M×N control polygons.
+[ADR-0018][adr-0018] §1.  The `vtkLiverBezierWidget`'s right-drag
+ring-group taxonomy operates on the two control-polygon shapes
+v2.0.0 admits: **3×3** and **4×4** (square only).
+
+Per [ADR-0018][adr-0018] §"Why `{3×3, 4×4}` square-only, not
+arbitrary M×N in v2.0.0", both shapes have a natural three-ring
+structure (corners, edges, interior) that matches the ring-of-
+control-points manipulation philosophy.  Non-square shapes and
+larger sizes are v2.1 NURBS territory.
 
 [adr-0014]: ../adr/0014-livermarkups-dissolution.md
 [adr-0018]: ../adr/0018-nurbs-extension-surface.md
 
-## Ring formula
+## Ring counts
 
-For an M-row × N-column control polygon:
-
-- **Corners** — always exactly `4`.
-- **Edges** — `2 * (M - 2) + 2 * (N - 2)` — boundary points minus corners.
-- **Interior** — `(M - 2) * (N - 2)` — non-boundary points.
-- **Total** — `M * N` — sanity check: `4 + 2(M-2) + 2(N-2) + (M-2)(N-2) = MN`.
-
-| (M, N)  | Corners | Edges | Interior | Total |
+| Shape   | Corners | Edges | Interior | Total |
 |---------|---------|-------|----------|-------|
-| (3, 3)  | 4       | 4     | 1        | 9     |
-| (4, 4)  | 4       | 8     | 4        | 16    |
-| (5, 4)  | 4       | 10    | 6        | 20    |
-| (5, 5)  | 4       | 12    | 9        | 25    |
-| (5, 7)  | 4       | 16    | 15       | 35    |
-| (M, N)  | 4       | 2(M-2)+2(N-2) | (M-2)(N-2) | MN |
+| **3×3** | 4       | 4     | 1        | 9     |
+| **4×4** | 4       | 8     | 4        | 16    |
 
-## Example layouts
+## Layouts
 
 Each cell is a control point; `C` = corner, `E` = edge, `I` =
 interior.
 
-### 4×4 (v1 default)
+### 3×3 — degree-2 Bezier (the smaller shape ADR-0018 adds)
+
+```
++---+---+---+
+| C | E | C |
++---+---+---+
+| E | I | E |
++---+---+---+
+| C | E | C |
++---+---+---+
+```
+
+Corners = 4, Edges = 4, Interior = 1.  Total = 9.
+
+### 4×4 — degree-3 Bezier (the v2.0.0 default)
 
 ```
 +---+---+---+---+
@@ -47,42 +56,6 @@ interior.
 
 Corners = 4, Edges = 8, Interior = 4.  Total = 16.
 
-### 5×5
-
-```
-+---+---+---+---+---+
-| C | E | E | E | C |
-+---+---+---+---+---+
-| E | I | I | I | E |
-+---+---+---+---+---+
-| E | I | I | I | E |
-+---+---+---+---+---+
-| E | I | I | I | E |
-+---+---+---+---+---+
-| C | E | E | E | C |
-+---+---+---+---+---+
-```
-
-Corners = 4, Edges = 12, Interior = 9.  Total = 25.
-
-### 5×7 (non-square)
-
-```
-+---+---+---+---+---+---+---+
-| C | E | E | E | E | E | C |
-+---+---+---+---+---+---+---+
-| E | I | I | I | I | I | E |
-+---+---+---+---+---+---+---+
-| E | I | I | I | I | I | E |
-+---+---+---+---+---+---+---+
-| E | I | I | I | I | I | E |
-+---+---+---+---+---+---+---+
-| C | E | E | E | E | E | C |
-+---+---+---+---+---+---+---+
-```
-
-Corners = 4, Edges = 16, Interior = 15.  Total = 35.
-
 ## Right-drag ring-group event flow
 
 The `vtkLiverBezierWidget` right-drag event (per
@@ -91,28 +64,30 @@ manipulates the picked control point's **ring set** as a group.
 Picking a corner translates / rotates all 4 corners; picking an edge
 point manipulates the edge ring; picking an interior point
 manipulates the interior ring.  The ring-set identification is
-purely positional — `(row, col)` in `[0, M-1] × [0, N-1]`:
+purely positional — `(row, col)` in `[0, Rows-1] × [0, Cols-1]`:
 
 ```
-ring_of(row, col):
-    if row in (0, M-1) and col in (0, N-1):
+ring_of(row, col, Rows, Cols):
+    if row in (0, Rows-1) and col in (0, Cols-1):
         return Corner
-    if row in (0, M-1) or col in (0, N-1):
+    if row in (0, Rows-1) or col in (0, Cols-1):
         return Edge
     return Interior
 ```
 
-This formula is independent of M, N — the right-drag-ring-group
-event flow inherits the formula mechanically, no per-size branching.
+This formula is shape-agnostic — the same code handles 3×3 and 4×4.
+The widget's runtime validates `(Rows, Cols) ∈ {(3, 3), (4, 4)}` at
+its `SetBezierNode()` entry; other shapes are rejected by the data
+node's `SetRows`/`SetCols` setters per [ADR-0018][adr-0018] §1.
 
 ## Implications for `vtkLiverBezierFitter`
 
 The fitter ([ADR-0015][adr-0015]) is independent of the ring taxonomy
 — it sees only the flat control-grid array.  Per [ADR-0018][adr-0018]
-§1, the fitter parameterizes its basis matrix on degree
-`(Rows-1) × (Cols-1)` Bernstein; ring grouping does not feed into the
-fit.  This is the right separation of concerns: the widget owns
-*manipulation*, the fitter owns *math*.
+§1, the fitter parameterizes its basis matrix on degree-`(Rows-1)`
+Bernstein (degree-2 for 3×3; degree-3 for 4×4).  Ring grouping does
+not feed into the fit.  This is the right separation of concerns:
+the widget owns *manipulation*, the fitter owns *math*.
 
 [adr-0015]: ../adr/0015-cpp-algorithm-library.md
 
@@ -120,16 +95,18 @@ fit.  This is the right separation of concerns: the widget owns
 
 The schema v2 (per [ADR-0018][adr-0018] §1 rollout) carries explicit
 `rows` + `cols` + `controlGrid: [3 * rows * cols doubles]` row-major.
-The widget reads these to derive ring membership at load time.  No
-ring metadata is serialised; it derives mechanically from `(rows,
-cols)`.
+Schema v2 readers validate `(rows, cols) ∈ {(3, 3), (4, 4)}` at load
++ reject otherwise with `vtkErrorMacro`.  Forward-compat: v3 readers
+(post NURBS landing) admit larger M×N for the NURBS node sibling but
+keep the {3×3, 4×4} restriction for Bezier nodes.
 
 ## Out of scope of this diagram
 
 - The widget's left-drag (per-point) event flow — handled by the
-  existing skeleton (PR #360) and parameterizes trivially for any
-  M×N.
+  existing skeleton (PR #360) and parameterizes trivially for both
+  shapes.
 - The widget's right-click context menu — separate
   `TODO(T2.3 right-click-context-menu)` deliverable.
 - NURBS-specific manipulation events (e.g., "edit weight at corner")
-  — deferred to v2.1's NURBS extension.
+  — deferred to v2.1's NURBS extension.  v2.1 may relax to arbitrary
+  M×N for NURBS surfaces; Bezier stays {3×3, 4×4}.

--- a/Docs/architecture/control-grid-grouping.md
+++ b/Docs/architecture/control-grid-grouping.md
@@ -1,0 +1,135 @@
+# Control-grid grouping — M×N ring-group taxonomy
+
+Reference companion to [ADR-0014][adr-0014] §3 +
+[ADR-0018][adr-0018] §1.  Generalises the
+`vtkLiverBezierWidget` right-drag ring-group taxonomy from the v1
+fixed-4×4 case to arbitrary M×N control polygons.
+
+[adr-0014]: ../adr/0014-livermarkups-dissolution.md
+[adr-0018]: ../adr/0018-nurbs-extension-surface.md
+
+## Ring formula
+
+For an M-row × N-column control polygon:
+
+- **Corners** — always exactly `4`.
+- **Edges** — `2 * (M - 2) + 2 * (N - 2)` — boundary points minus corners.
+- **Interior** — `(M - 2) * (N - 2)` — non-boundary points.
+- **Total** — `M * N` — sanity check: `4 + 2(M-2) + 2(N-2) + (M-2)(N-2) = MN`.
+
+| (M, N)  | Corners | Edges | Interior | Total |
+|---------|---------|-------|----------|-------|
+| (3, 3)  | 4       | 4     | 1        | 9     |
+| (4, 4)  | 4       | 8     | 4        | 16    |
+| (5, 4)  | 4       | 10    | 6        | 20    |
+| (5, 5)  | 4       | 12    | 9        | 25    |
+| (5, 7)  | 4       | 16    | 15       | 35    |
+| (M, N)  | 4       | 2(M-2)+2(N-2) | (M-2)(N-2) | MN |
+
+## Example layouts
+
+Each cell is a control point; `C` = corner, `E` = edge, `I` =
+interior.
+
+### 4×4 (v1 default)
+
+```
++---+---+---+---+
+| C | E | E | C |
++---+---+---+---+
+| E | I | I | E |
++---+---+---+---+
+| E | I | I | E |
++---+---+---+---+
+| C | E | E | C |
++---+---+---+---+
+```
+
+Corners = 4, Edges = 8, Interior = 4.  Total = 16.
+
+### 5×5
+
+```
++---+---+---+---+---+
+| C | E | E | E | C |
++---+---+---+---+---+
+| E | I | I | I | E |
++---+---+---+---+---+
+| E | I | I | I | E |
++---+---+---+---+---+
+| E | I | I | I | E |
++---+---+---+---+---+
+| C | E | E | E | C |
++---+---+---+---+---+
+```
+
+Corners = 4, Edges = 12, Interior = 9.  Total = 25.
+
+### 5×7 (non-square)
+
+```
++---+---+---+---+---+---+---+
+| C | E | E | E | E | E | C |
++---+---+---+---+---+---+---+
+| E | I | I | I | I | I | E |
++---+---+---+---+---+---+---+
+| E | I | I | I | I | I | E |
++---+---+---+---+---+---+---+
+| E | I | I | I | I | I | E |
++---+---+---+---+---+---+---+
+| C | E | E | E | E | E | C |
++---+---+---+---+---+---+---+
+```
+
+Corners = 4, Edges = 16, Interior = 15.  Total = 35.
+
+## Right-drag ring-group event flow
+
+The `vtkLiverBezierWidget` right-drag event (per
+[ADR-0014][adr-0014] §3, deferred under `TODO(T2.3 right-drag-ring-group)`)
+manipulates the picked control point's **ring set** as a group.
+Picking a corner translates / rotates all 4 corners; picking an edge
+point manipulates the edge ring; picking an interior point
+manipulates the interior ring.  The ring-set identification is
+purely positional — `(row, col)` in `[0, M-1] × [0, N-1]`:
+
+```
+ring_of(row, col):
+    if row in (0, M-1) and col in (0, N-1):
+        return Corner
+    if row in (0, M-1) or col in (0, N-1):
+        return Edge
+    return Interior
+```
+
+This formula is independent of M, N — the right-drag-ring-group
+event flow inherits the formula mechanically, no per-size branching.
+
+## Implications for `vtkLiverBezierFitter`
+
+The fitter ([ADR-0015][adr-0015]) is independent of the ring taxonomy
+— it sees only the flat control-grid array.  Per [ADR-0018][adr-0018]
+§1, the fitter parameterizes its basis matrix on degree
+`(Rows-1) × (Cols-1)` Bernstein; ring grouping does not feed into the
+fit.  This is the right separation of concerns: the widget owns
+*manipulation*, the fitter owns *math*.
+
+[adr-0015]: ../adr/0015-cpp-algorithm-library.md
+
+## Implications for `.lrp.json` schema v2
+
+The schema v2 (per [ADR-0018][adr-0018] §1 rollout) carries explicit
+`rows` + `cols` + `controlGrid: [3 * rows * cols doubles]` row-major.
+The widget reads these to derive ring membership at load time.  No
+ring metadata is serialised; it derives mechanically from `(rows,
+cols)`.
+
+## Out of scope of this diagram
+
+- The widget's left-drag (per-point) event flow — handled by the
+  existing skeleton (PR #360) and parameterizes trivially for any
+  M×N.
+- The widget's right-click context menu — separate
+  `TODO(T2.3 right-click-context-menu)` deliverable.
+- NURBS-specific manipulation events (e.g., "edit weight at corner")
+  — deferred to v2.1's NURBS extension.

--- a/Docs/architecture/rendering-pipeline.md
+++ b/Docs/architecture/rendering-pipeline.md
@@ -1,0 +1,91 @@
+# Rendering pipeline — LayerDM dispatch through to shader uniforms
+
+Reference companion to [ADR-0013][adr-0013] §5 + [ADR-0018][adr-0018].
+Shows the data flow from the moment a `vtkMRMLBezierSurfaceNode`
+lands in the scene to the point a custom OpenGL mapper writes
+framebuffer pixels.
+
+[adr-0013]: ../adr/0013-layerdm-pipeline-pattern.md
+[adr-0014]: ../adr/0014-livermarkups-dissolution.md
+[adr-0018]: ../adr/0018-nurbs-extension-surface.md
+
+## Sequence
+
+```{mermaid}
+sequenceDiagram
+    participant User
+    participant Scene as vtkMRMLScene
+    participant Logic as vtkSlicerLiverResectionsLogic
+    participant DM as vtkMRMLLayerDisplayableManager<br/>(upstream)
+    participant Factory as vtkMRMLLayerDMPipelineFactory<br/>(upstream)
+    participant Pipeline as LiverBezierSurfacePipeline
+    participant Rep as BezierPlanningRepresentation
+    participant Mapper as vtkOpenGLBezierResectionPolyDataMapper<br/>(post T2-mapper-relocation)
+    participant GPU as GLSL fragment shader
+
+    Note over User,Scene: User opens .lrp.json OR adds a resection via toolbar
+    User->>Scene: Add vtkMRMLBezierSurfaceNode
+    Scene->>Logic: NodeAddedEvent
+    Note over Logic,DM: Logic invoked via RegisterNodes() per ADR-0013 §5 call 1
+    Scene->>DM: NodeAddedEvent (data + display nodes)
+
+    Note over DM,Factory: ADR-0013 §5 call 2: DM observes scene<br/>and dispatches per display-node class
+    DM->>Factory: CreatePipeline(viewNode, displayNode)
+    Factory->>Factory: lookup creator for vtkMRMLBezierSurfaceDisplayNode
+    Note over Factory: ADR-0013 §5 call 3:<br/>creator registered via AddPipelineCreator
+    Factory->>Pipeline: instantiate
+
+    Pipeline->>Pipeline: SetDisplayNode(displayNode)
+    Pipeline->>Pipeline: GetDisplayableNode() → vtkMRMLBezierSurfaceNode
+    Pipeline->>Pipeline: observe (state, initMode) modifications
+
+    Note over Pipeline,Rep: Dispatch table per ADR-0013 §4:<br/>(ResectionState, InitializationMode) → Representation
+    Pipeline->>Rep: select by (Planning, *)
+    Rep->>Mapper: SetInputData(controlGridPolyData)
+    Rep->>Mapper: SetUniform(GridDivisions, GridThickness, ResectionGridColor)
+    Rep->>Mapper: SetUniform(ResectionMargin, UncertaintyMargin)
+
+    Note over Mapper,GPU: ADR-0014 §3 — grid is a *shader feature*,<br/>not separate geometry
+    Mapper->>GPU: render pass
+    GPU->>GPU: evaluate Bernstein basis on parametric (u,v)
+    GPU->>GPU: overlay grid: tan(uv * pi * gridDivisions) > thickness
+    GPU->>GPU: trim by parenchyma distance (Confirmed-state shader)
+    GPU-->>Mapper: framebuffer
+```
+
+## What lands when
+
+| Element                                          | Status                       |
+|--------------------------------------------------|------------------------------|
+| `vtkMRMLBezierSurfaceNode` + display + storage   | ✓ landed (PRs #341/#348/#350/#361) |
+| `vtkSlicerLiverResectionsLogic::RegisterNodes()` | ✓ landed (PR #364)            |
+| `vtkMRMLLayerDisplayableManager::RegisterInDefaultViews()` | ✓ landed (PR #369) |
+| `vtkMRMLLayerDMPipelineFactory::AddPipelineCreator(...)`   | ✓ landed (PR #369) |
+| `LiverBezierSurfacePipeline` (lifecycle, dispatch)         | ✓ landed (PR #354 + #369) |
+| `BezierPlanningRepresentation` (with generic mapper)       | ✓ landed (PR #354)  |
+| `SlicingPlaneInitRepresentation`                           | ✓ landed (PR #358)  |
+| `DistanceSpheroidInitRepresentation`                       | ✓ landed (PR #359)  |
+| Custom OpenGL mappers (`vtkOpenGLBezierResectionPolyDataMapper`, …) | ⏳ **T2-mapper-relocation** |
+| Display-node fields → mapper uniforms              | ⏳ T2-mapper-relocation |
+| Fragment-shader grid overlay                       | ⏳ T2-mapper-relocation |
+| Parenchyma-trim shader (Confirmed state)           | ⏳ T2-mapper-relocation + ADR-0019 |
+| Resectogram texture path                           | ⏳ T3 |
+
+## Notes
+
+- The upstream `vtkMRMLLayerDisplayableManager` is **generic** — it
+  hosts Pipelines without per-module specialisation.  Slicer-Liver
+  does NOT subclass it ([ADR-0002][adr-0002] migration commitment;
+  rule captured in the project's no-custom-DM memory).
+- Pipeline creators are registered as **scripted Python callbacks**
+  via `vtkMRMLLayerDMPipelineScriptedCreator` — see PR #369's
+  `registerPipelineCreator()` for the canonical invocation.
+- The dispatch axis is **display-node class** for the factory and
+  **(state, initMode) for the Pipeline's internal Representation
+  table**.  ADR-0018 §3 commits sibling Pipelines (not a third axis)
+  for the future Bezier vs NURBS divergence.
+- Today's Representations attach a **generic** `vtkPolyDataMapper`;
+  the custom OpenGL mappers under `LiverMarkups/VTKWidgets/` swap
+  in during **T2-mapper-relocation**.
+
+[adr-0002]: ../adr/0002-migrate-to-slicerlayerdm.md

--- a/Docs/architecture/rendering-pipeline.md
+++ b/Docs/architecture/rendering-pipeline.md
@@ -3,15 +3,141 @@
 Reference companion to [ADR-0013][adr-0013] §5 + [ADR-0018][adr-0018].
 Shows the data flow from the moment a `vtkMRMLBezierSurfaceNode`
 lands in the scene to the point a custom OpenGL mapper writes
-framebuffer pixels.
+framebuffer pixels.  Two views: a **class diagram** of the C++ /
+Python types involved + a **sequence diagram** of the runtime
+dispatch.
 
 [adr-0013]: ../adr/0013-layerdm-pipeline-pattern.md
 [adr-0014]: ../adr/0014-livermarkups-dissolution.md
 [adr-0018]: ../adr/0018-nurbs-extension-surface.md
 
+## Class structure
+
+```mermaid
+classDiagram
+    direction TB
+
+    class vtkMRMLScene {
+        <<Slicer-core>>
+    }
+    class vtkMRMLBezierSurfaceNode {
+        <<v2.0.0 data node>>
+    }
+    class vtkMRMLBezierSurfaceDisplayNode {
+        <<v2.0.0 display node>>
+        +GridVisibility / Divisions / Thickness
+        +ResectionGridColor
+        +ResectionMargin / UncertaintyMargin
+        +TerminologyEntry
+    }
+    class vtkMRMLLayerDisplayableManager {
+        <<upstream LayerDM>>
+        Observes scene
+        Per-view singleton
+    }
+    class vtkMRMLLayerDMPipelineFactory {
+        <<upstream LayerDM>>
+        AddPipelineCreator()
+        CreatePipeline(viewNode, displayNode)
+    }
+    class vtkMRMLLayerDMPipelineScriptedCreator {
+        <<upstream LayerDM>>
+        SetPythonCallback(tryCreate)
+    }
+
+    class LiverBezierSurfacePipeline {
+        <<v2.0.0 — Python>>
+        SetDisplayNode()
+        UpdatePipeline()
+        OnRendererAdded()
+        cleanup()
+        Dispatch: (state, initMode) → Representation
+    }
+
+    class BezierPlanningRepresentation {
+        <<v2.0.0 — Python>>
+        Active in (Planning, *)
+    }
+    class SlicingPlaneInitRepresentation {
+        <<v2.0.0 — Python>>
+        Active in (Init, SlicingPlane)
+    }
+    class DistanceSpheroidInitRepresentation {
+        <<v2.0.0 — Python>>
+        Active in (Init, DistanceSpheroid)
+    }
+    class ConfirmedRepresentation {
+        <<ADR-0019 Proposed>>
+        Active in (Confirmed, *)
+    }
+
+    class vtkOpenGLBezierResectionPolyDataMapper {
+        <<post T2-mapper-relocation>>
+        Bezier surface render
+        + grid-overlay shader (Planning)
+        + parenchyma-trim shader (Confirmed)
+        Both gated by uniform feeds
+    }
+    class vtkOpenGLDistanceContourPolyDataMapper {
+        <<post T2-mapper-relocation>>
+        Distance-map contour shader
+    }
+    class vtkOpenGLResectogramPolyDataMapper {
+        <<post T2-mapper-relocation;<br/>T3 wire-up>>
+        Resectogram texture path
+    }
+    class FragmentShader {
+        <<GLSL>>
+        Bernstein basis evaluation
+        Grid overlay: tan(uv*π*divs) > thickness
+        Margin / uncertainty colour stops
+        Parenchyma trim by distance
+    }
+
+    vtkMRMLScene "1" --> "*" vtkMRMLBezierSurfaceNode : contains
+    vtkMRMLBezierSurfaceNode "1" --> "1" vtkMRMLBezierSurfaceDisplayNode : SetAndObserveDisplayNodeID
+
+    vtkMRMLScene "1" --> "1" vtkMRMLLayerDisplayableManager : observed by (per view)
+    vtkMRMLLayerDisplayableManager ..> vtkMRMLLayerDMPipelineFactory : dispatches
+    vtkMRMLLayerDMPipelineFactory ..> vtkMRMLLayerDMPipelineScriptedCreator : per-creator
+    vtkMRMLLayerDMPipelineScriptedCreator ..> LiverBezierSurfacePipeline : Python lambda<br/>(tryCreate)
+
+    LiverBezierSurfacePipeline ..> BezierPlanningRepresentation : Planning
+    LiverBezierSurfacePipeline ..> SlicingPlaneInitRepresentation : Init / SlicingPlane
+    LiverBezierSurfacePipeline ..> DistanceSpheroidInitRepresentation : Init / DistanceSpheroid
+    LiverBezierSurfacePipeline ..> ConfirmedRepresentation : Confirmed<br/>(ADR-0019)
+
+    BezierPlanningRepresentation ..> vtkOpenGLBezierResectionPolyDataMapper : surface + grid uniforms
+    ConfirmedRepresentation ..> vtkOpenGLBezierResectionPolyDataMapper : trim uniforms on / grid off
+    BezierPlanningRepresentation ..> vtkOpenGLDistanceContourPolyDataMapper : distance contours
+
+    vtkOpenGLBezierResectionPolyDataMapper ..> FragmentShader : GLSL uniforms
+    vtkOpenGLDistanceContourPolyDataMapper ..> FragmentShader : GLSL uniforms
+    vtkOpenGLResectogramPolyDataMapper ..> FragmentShader : GLSL uniforms
+
+    vtkMRMLBezierSurfaceDisplayNode ..> vtkOpenGLBezierResectionPolyDataMapper : uniform feed
+```
+
+The class diagram shows:
+
+- **Scene → display node → Pipeline**: the scene owns data + display
+  nodes; `vtkMRMLLayerDisplayableManager` observes scene events and
+  uses the factory to instantiate one Pipeline per `(view,
+  display node)` pair.
+- **Pipeline → Representation**: one Pipeline owns four
+  Representations (v2.0.0 + ADR-0019); dispatch table on
+  `(ResectionState, InitializationMode)` picks one active at a time.
+- **Representation → custom OpenGL mapper**: each Representation
+  owns a (small) set of mappers; the mappers live under
+  `LiverResections/VTKWidgets/` post T2-mapper-relocation.
+- **Mapper → fragment shader**: each mapper feeds uniforms to a
+  GLSL fragment shader that does the actual pixel work.  The
+  display node's fields (`GridVisibility`, `GridDivisions`,
+  `ResectionMargin`, …) wire into the uniform binds.
+
 ## Sequence
 
-```{mermaid}
+```mermaid
 sequenceDiagram
     participant User
     participant Scene as vtkMRMLScene

--- a/Docs/architecture/surface-representation-taxonomy.md
+++ b/Docs/architecture/surface-representation-taxonomy.md
@@ -10,7 +10,7 @@ that lands in v2.0.0 (Bezier-only) and extends in v2.1 (NURBS).
 
 ## Class taxonomy
 
-```{mermaid}
+```mermaid
 classDiagram
     direction TB
 
@@ -22,8 +22,9 @@ classDiagram
         <<v2.0.0>>
         +RepresentationKind = Bezier
         +SurfaceMath = Bernstein basis
-        +Degree = (Rows-1) × (Cols-1)
-        +DefaultGrid = 4×4
+        +Degree = (Rows-1)<br/>(square-only)
+        +Shapes = {3×3, 4×4}
+        +Default = 4×4
     }
 
     class LiverNurbsSurfacePipeline {
@@ -41,7 +42,7 @@ classDiagram
     class BezierPlanningRepresentation {
         <<v2.0.0>>
         Generates Bezier surface polydata
-        from M×N control grid
+        from {3×3, 4×4} control grid
     }
     class NurbsPlanningRepresentation {
         <<v2.1 Proposed>>
@@ -65,7 +66,7 @@ classDiagram
     class vtkLiverBezierFitter {
         <<v2.0.0>>
         Eigen normal equations
-        Degree-(Rows-1) × (Cols-1) Bernstein basis
+        Degree-(Rows-1) Bernstein basis<br/>(degree-2 / degree-3)
     }
     class vtkLiverNurbsFitter {
         <<v2.1 Proposed>>
@@ -86,7 +87,7 @@ classDiagram
 | Degree              | Implicit from control polygon: `(Rows-1) × (Cols-1)` | Independent per axis: `DegreeU`, `DegreeV` |
 | Knots               | Implicit (uniform)                       | Explicit per axis (`KnotsU`, `KnotsV`); clamped       |
 | Weights             | Uniform (1.0 per control point; non-rational) | Per control point (`Weights[i, j]`); rational    |
-| Control polygon     | M × N (default 4×4)                      | M × N (no default; surgeon-chosen)                    |
+| Control polygon     | `{3×3, 4×4}` square-only (default 4×4)   | M × N (no default; surgeon-chosen)                    |
 | Local control       | Full surface depends on every control point | Locally bounded by `DegreeU+1 × DegreeV+1` span     |
 | Evaluation          | Direct Bernstein polynomial sum          | de Boor's algorithm (recursive) + weight division     |
 | Conic-section repro | Approximation                            | Exact (circles, ellipses, hyperbolas via weights)     |

--- a/Docs/architecture/surface-representation-taxonomy.md
+++ b/Docs/architecture/surface-representation-taxonomy.md
@@ -22,8 +22,8 @@ classDiagram
         <<v2.0.0>>
         +RepresentationKind = Bezier
         +SurfaceMath = Bernstein basis
-        +Degree = (Rows-1)<br/>(square-only)
-        +Shapes = {3×3, 4×4}
+        +Degree = (Rows-1)
+        +Shapes = 3×3 or 4×4 (square only)
         +Default = 4×4
     }
 
@@ -42,7 +42,7 @@ classDiagram
     class BezierPlanningRepresentation {
         <<v2.0.0>>
         Generates Bezier surface polydata
-        from {3×3, 4×4} control grid
+        from 3×3 or 4×4 control grid
     }
     class NurbsPlanningRepresentation {
         <<v2.1 Proposed>>

--- a/Docs/architecture/surface-representation-taxonomy.md
+++ b/Docs/architecture/surface-representation-taxonomy.md
@@ -1,0 +1,140 @@
+# Surface representation taxonomy — Bezier ↔ NURBS
+
+Reference companion to [ADR-0018][adr-0018].  Shows the
+sibling-Pipeline + sibling-Representation + sibling-Fitter taxonomy
+that lands in v2.0.0 (Bezier-only) and extends in v2.1 (NURBS).
+
+[adr-0018]: ../adr/0018-nurbs-extension-surface.md
+[adr-0013]: ../adr/0013-layerdm-pipeline-pattern.md
+[adr-0015]: ../adr/0015-cpp-algorithm-library.md
+
+## Class taxonomy
+
+```{mermaid}
+classDiagram
+    direction TB
+
+    class vtkMRMLLayerDMScriptedPipeline {
+        <<upstream LayerDM>>
+    }
+
+    class LiverBezierSurfacePipeline {
+        <<v2.0.0>>
+        +RepresentationKind = Bezier
+        +SurfaceMath = Bernstein basis
+        +Degree = (Rows-1) × (Cols-1)
+        +DefaultGrid = 4×4
+    }
+
+    class LiverNurbsSurfacePipeline {
+        <<v2.1 Proposed>>
+        +RepresentationKind = NURBS
+        +SurfaceMath = B-spline basis + weights
+        +DegreeU + DegreeV : independent
+        +KnotsU + KnotsV : variable
+        +RationalWeights : per control point
+    }
+
+    vtkMRMLLayerDMScriptedPipeline <|-- LiverBezierSurfacePipeline
+    vtkMRMLLayerDMScriptedPipeline <|-- LiverNurbsSurfacePipeline
+
+    class BezierPlanningRepresentation {
+        <<v2.0.0>>
+        Generates Bezier surface polydata
+        from M×N control grid
+    }
+    class NurbsPlanningRepresentation {
+        <<v2.1 Proposed>>
+        Generates NURBS surface polydata
+        via de Boor's algorithm
+    }
+    class SlicingPlaneInitRepresentation {
+        <<v2.0.0 — shared>>
+    }
+    class DistanceSpheroidInitRepresentation {
+        <<v2.0.0 — shared>>
+    }
+
+    LiverBezierSurfacePipeline ..> BezierPlanningRepresentation : Planning state
+    LiverBezierSurfacePipeline ..> SlicingPlaneInitRepresentation : Init / SlicingPlane
+    LiverBezierSurfacePipeline ..> DistanceSpheroidInitRepresentation : Init / DistanceSpheroid
+    LiverNurbsSurfacePipeline ..> NurbsPlanningRepresentation : Planning state
+    LiverNurbsSurfacePipeline ..> SlicingPlaneInitRepresentation : Init / SlicingPlane
+    LiverNurbsSurfacePipeline ..> DistanceSpheroidInitRepresentation : Init / DistanceSpheroid
+
+    class vtkLiverBezierFitter {
+        <<v2.0.0>>
+        Eigen normal equations
+        Degree-(Rows-1) × (Cols-1) Bernstein basis
+    }
+    class vtkLiverNurbsFitter {
+        <<v2.1 Proposed>>
+        Least squares on basis × weights
+        Knot insertion / refinement
+        Rational weight estimation
+    }
+
+    BezierPlanningRepresentation ..> vtkLiverBezierFitter : fits surface
+    NurbsPlanningRepresentation ..> vtkLiverNurbsFitter : fits surface
+```
+
+## Mathematical model contrast
+
+| Aspect              | Bezier (v2.0.0)                          | NURBS (v2.1 Proposed)                                 |
+|---------------------|------------------------------------------|-------------------------------------------------------|
+| Basis               | Bernstein polynomials                    | B-spline (with weights → rational B-spline)           |
+| Degree              | Implicit from control polygon: `(Rows-1) × (Cols-1)` | Independent per axis: `DegreeU`, `DegreeV` |
+| Knots               | Implicit (uniform)                       | Explicit per axis (`KnotsU`, `KnotsV`); clamped       |
+| Weights             | Uniform (1.0 per control point; non-rational) | Per control point (`Weights[i, j]`); rational    |
+| Control polygon     | M × N (default 4×4)                      | M × N (no default; surgeon-chosen)                    |
+| Local control       | Full surface depends on every control point | Locally bounded by `DegreeU+1 × DegreeV+1` span     |
+| Evaluation          | Direct Bernstein polynomial sum          | de Boor's algorithm (recursive) + weight division     |
+| Conic-section repro | Approximation                            | Exact (circles, ellipses, hyperbolas via weights)     |
+| Continuity at knots | C∞ (single Bezier patch)                 | C^(DegreeU-1) at internal knots                       |
+
+## What is shared, what is sibling
+
+**Shared across v2.0.0 + v2.1:**
+
+- The dispatch contract for `(ResectionState, InitializationMode)`
+  per [ADR-0013][adr-0013] §4.
+- The init-mode Representations (`SlicingPlaneInitRepresentation` +
+  `DistanceSpheroidInitRepresentation`) — the surgeon's input is
+  representation-agnostic; surface fitting only differs **after**
+  Init data is committed.
+- The widget — `vtkLiverBezierWidget` (per [ADR-0014][adr-0014] §3)
+  manipulates an M×N control polygon regardless of the underlying
+  Bezier-vs-NURBS math.  The ring-group taxonomy generalises (see
+  `control-grid-grouping.md`); the manipulation events fire the same
+  way for both representations.  v2.1 may add NURBS-specific events
+  (e.g., "edit weight at corner" for rational weights) but the core
+  positional manipulation is shared.
+
+[adr-0014]: ../adr/0014-livermarkups-dissolution.md
+
+**Sibling (separate for v2.0.0 vs v2.1):**
+
+- Data + display + storage MRML node trios.
+- Pipeline classes.
+- Planning-state Representations.
+- Surface fitters under `LiverResections/Algorithm/` (per
+  [ADR-0015][adr-0015]).
+- `.lrp.json` schema (v2 carries Bezier-only fields; v3 adds the
+  NURBS extension fields when `representationKind == "Nurbs"`).
+
+## Why sibling, not polymorphic
+
+See [ADR-0018][adr-0018] §"Why sibling Pipelines, not a polymorphic third
+axis" for the design-decision narrative.  Short form: the Pipeline
+factory dispatches on **display-node class**; sibling display-node
+types give exact-class dispatch with no SafeDownCast cascade.
+
+## Out of scope of this diagram
+
+- Trimmed NURBS, subdivision surfaces, T-splines.  Excluded by
+  [ADR-0018][adr-0018]'s "Out of scope" list.
+- The render-time data flow (Pipeline → Mapper → shader) — see
+  `rendering-pipeline.md`.
+- The widget control-grid grouping math — see
+  `control-grid-grouping.md`.
+- The data-node field roster — see `target-mrml-node-hierarchy.md`.

--- a/Docs/architecture/target-mrml-node-hierarchy.md
+++ b/Docs/architecture/target-mrml-node-hierarchy.md
@@ -1,0 +1,139 @@
+# Target MRML node hierarchy — post-T2 + ADR-0018 extension surface
+
+Reference companion to [ADR-0018][adr-0018].  Shows the post-T2
+parametric-surface family (`vtkMRMLBezierSurfaceNode` trio) with the
+v2.0.0 variable-size commitment + the v2.1 NURBS sibling extension
+surface.
+
+[adr-0018]: ../adr/0018-nurbs-extension-surface.md
+[adr-0014]: ../adr/0014-livermarkups-dissolution.md
+[adr-0015]: ../adr/0015-cpp-algorithm-library.md
+[adr-0001]: ../adr/0001-resection-three-node-assembly.md
+
+## Class hierarchy
+
+```{mermaid}
+classDiagram
+    direction LR
+
+    class vtkMRMLStorableNode {
+        <<Slicer-core>>
+    }
+    class vtkMRMLDisplayableNode {
+        <<Slicer-core>>
+    }
+    class vtkMRMLDisplayNode {
+        <<Slicer-core>>
+    }
+    class vtkMRMLStorageNode {
+        <<Slicer-core>>
+    }
+
+    vtkMRMLStorableNode <|-- vtkMRMLDisplayableNode
+
+    class vtkMRMLBezierSurfaceNode {
+        <<v2.0.0>>
+        +int Rows = 4
+        +int Cols = 4
+        +double[3*Rows*Cols] ControlGrid
+        +ResectionState State : Init | Planning
+        +InitializationMode InitMode : SlicingPlane | DistanceSpheroid
+        +double[3] SlicingPlaneOrigin
+        +double[3] SlicingPlaneNormal
+        +double[3] SlicingPlaneInitPoint0
+        +double[3] SlicingPlaneInitPoint1
+        +double[3] DistanceSpheroidCenter
+        +double DistanceSpheroidRadiusX
+        +double DistanceSpheroidRadiusY
+        +double DistanceSpheroidRadiusZ
+        +int NumberOfDistanceSpheroidInitPoints
+        +double[3*N] DistanceSpheroidInitPoints
+        +string TargetOrganModelNodeID
+    }
+
+    class vtkMRMLBezierSurfaceDisplayNode {
+        <<v2.0.0>>
+        +string TerminologyEntry
+        +int GridVisibility
+        +int GridDivisions
+        +double GridThickness
+        +double[3] ResectionGridColor
+        +double ResectionMargin
+        +double UncertaintyMargin
+    }
+
+    class vtkMRMLBezierSurfaceStorageNode {
+        <<v2.0.0>>
+        +.lrp.json schemaVersion = 2
+        +legacy .lrp.fcsv read-only migration
+    }
+
+    class vtkMRMLNurbsSurfaceNode {
+        <<v2.1 Proposed>>
+        +int Rows
+        +int Cols
+        +int DegreeU
+        +int DegreeV
+        +double[] KnotsU
+        +double[] KnotsV
+        +double[Rows*Cols] Weights
+        +double[3*Rows*Cols] ControlGrid
+        +ResectionState State
+        +InitializationMode InitMode
+    }
+
+    class vtkMRMLNurbsSurfaceDisplayNode {
+        <<v2.1 Proposed>>
+    }
+
+    class vtkMRMLNurbsSurfaceStorageNode {
+        <<v2.1 Proposed>>
+        +.lrp.json schemaVersion = 3
+    }
+
+    vtkMRMLDisplayableNode <|-- vtkMRMLBezierSurfaceNode
+    vtkMRMLDisplayableNode <|-- vtkMRMLNurbsSurfaceNode : sibling
+    vtkMRMLDisplayNode <|-- vtkMRMLBezierSurfaceDisplayNode
+    vtkMRMLDisplayNode <|-- vtkMRMLNurbsSurfaceDisplayNode
+    vtkMRMLStorageNode <|-- vtkMRMLBezierSurfaceStorageNode
+    vtkMRMLStorageNode <|-- vtkMRMLNurbsSurfaceStorageNode
+
+    vtkMRMLBezierSurfaceNode "1" --> "1" vtkMRMLBezierSurfaceDisplayNode : display ref
+    vtkMRMLBezierSurfaceNode "1" --> "1" vtkMRMLBezierSurfaceStorageNode : storage ref
+    vtkMRMLNurbsSurfaceNode "1" --> "1" vtkMRMLNurbsSurfaceDisplayNode : display ref
+    vtkMRMLNurbsSurfaceNode "1" --> "1" vtkMRMLNurbsSurfaceStorageNode : storage ref
+```
+
+## Notes
+
+- **Sibling, not subclass.** Per [ADR-0018][adr-0018] §"Why a single data
+  type per representation kind, not a parent class", the NURBS trio
+  parallels the Bezier trio without a shared parent.  Field-level
+  duplication (`Rows`, `Cols`, `ControlGrid`, `State`, `InitMode`) is
+  intentional — it preserves Slicer's "peer types, no geometry-parent"
+  convention (`vtkMRMLModelNode` and `vtkMRMLMarkupsNode` are
+  parallel; this trio is parallel for the same reasons).
+- **Default for the Bezier node is 4×4** ([ADR-0018][adr-0018] §1).  Variable
+  M×N is admitted; legacy `.lrp.fcsv` files (per
+  [ADR-0014][adr-0014] §5's migration path) implicitly load as 4×4.
+- **Legacy `vtkMRMLLiverResection*` nodes** (the pre-rename / pre-T2
+  family) are retired by **T2.7**.  They do not appear here.
+- **NURBS-specific fields** (`DegreeU`, `DegreeV`, `KnotsU`, `KnotsV`,
+  `Weights`) live ONLY on `vtkMRMLNurbsSurfaceNode`; the Bezier node
+  has no degree field (always polynomial degree `Rows-1` × `Cols-1`)
+  and no weights (uniform rational coefficients are implicit Bezier).
+- The data → display node reference is the
+  `SetAndObserveDisplayNodeID` standard Slicer relationship.  The
+  data → storage node reference is `SetAndObserveStorageNodeID` per
+  [ADR-0001][adr-0001].
+
+## Out of scope of this diagram
+
+- The LayerDM Pipeline + Representation taxonomy — see
+  `surface-representation-taxonomy.md`.
+- The render-time data flow (Pipeline → Mapper → shader) — see
+  `rendering-pipeline.md`.
+- The widget control-grid grouping math — see
+  `control-grid-grouping.md`.
+- Trimmed NURBS, subdivision surfaces — out of scope per
+  [ADR-0018][adr-0018]'s "Out of scope" section.

--- a/Docs/architecture/target-mrml-node-hierarchy.md
+++ b/Docs/architecture/target-mrml-node-hierarchy.md
@@ -12,7 +12,7 @@ surface.
 
 ## Class hierarchy
 
-```{mermaid}
+```mermaid
 classDiagram
     direction LR
 
@@ -113,8 +113,11 @@ classDiagram
   intentional — it preserves Slicer's "peer types, no geometry-parent"
   convention (`vtkMRMLModelNode` and `vtkMRMLMarkupsNode` are
   parallel; this trio is parallel for the same reasons).
-- **Default for the Bezier node is 4×4** ([ADR-0018][adr-0018] §1).  Variable
-  M×N is admitted; legacy `.lrp.fcsv` files (per
+- **Default for the Bezier node is 4×4** ([ADR-0018][adr-0018] §1).
+  v2.0.0 admits `(Rows, Cols) ∈ {(3, 3), (4, 4)}` only — square-only,
+  two shapes; per-setter validation rejects other values with
+  `vtkErrorMacro`.  Arbitrary M×N is NURBS-territory and lands with
+  `vtkMRMLNurbsSurfaceNode` in v2.1.  Legacy `.lrp.fcsv` files (per
   [ADR-0014][adr-0014] §5's migration path) implicitly load as 4×4.
 - **Legacy `vtkMRMLLiverResection*` nodes** (the pre-rename / pre-T2
   family) are retired by **T2.7**.  They do not appear here.

--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -69,6 +69,9 @@ extensions = [
     "sphinx-jsonschema",
     "sphinx_reredirects",
     "sphinx_design",
+    # Mermaid diagrams in the architecture chapter + state-machine
+    # diagrams in ADR-0019.  Added by ADR-0018's scaffold extension.
+    "sphinxcontrib.mermaid",
 ]
 
 # Mocks for autodoc — `LiverResectionsLib` imports from the Slicer

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -36,4 +36,5 @@ ReadTheDocs.  Mirrors the upstream Slicer-core convention.
 :caption: Scaffold
 
 adr/0017-sphinx-readthedocs.md
+adr/0018-nurbs-extension-surface.md
 ```

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -15,3 +15,8 @@ sphinx-notfound-page
 sphinx-design
 sphinx-reredirects
 sphinx_rtd_theme>=0.5.2
+# Mermaid diagrams.  Used by the architecture diagrams under
+# Docs/architecture/ — class diagrams (target MRML hierarchy,
+# surface taxonomy), sequence diagrams (rendering pipeline), and
+# state diagrams (ADR-0019).  Added by ADR-0018's scaffold extension.
+sphinxcontrib-mermaid


### PR DESCRIPTION
## Summary

Architectural commitment to **NURBS as a sibling representation to Bezier**, anchored in d'Albenzio et al's SPIE Medical Imaging 2024 usability study.  Variable-size M×N control polygon admitted in v2.0.0 as the prerequisite for the v2.1 NURBS extension surface; full NURBS (B-spline basis with knots + weights) deferred to v2.1 per **Option A** scope ([ADR-0018](Docs/adr/0018-nurbs-extension-surface.md) §"Why Option A, not full NURBS in v2.0.0").

This PR is the **DOC PR only** — ADR + architecture diagrams + light ADR amendments.  No source-code changes; the enabling ENH PR (variable-size code parameterization) is queued as a follow-up.

## What lands

### ADRs

- **`Docs/adr/0018-nurbs-extension-surface.md`** — new ADR, full design narrative.  Sub-decisions:
  - Single data type per representation kind (sibling nodes, NOT a parent class).
  - Sibling Pipelines (NOT a polymorphic third axis).
  - New ADR rather than amending ADR-0014 / ADR-0015 in place.
- **`Docs/adr/0014-livermarkups-dissolution.md`** — amendment block at the top documenting that "4×4 control grid" references throughout are the default of the general M×N formulation.  The ring-group taxonomy generalises mechanically.
- **`Docs/adr/0015-cpp-algorithm-library.md`** — amendment block documenting variable-degree Bernstein extension + v2.1 sibling `vtkLiverNurbsFitter`.

### Architecture diagrams (new)

- **`Docs/architecture/target-mrml-node-hierarchy.md`** — Mermaid class diagram of the post-T2 `vtkMRMLBezierSurface*` trio + the v2.1 `vtkMRMLNurbsSurface*` sibling extension surface.  Makes the field-level surface explicit (`Rows`, `Cols`, `ControlGrid`, etc. on the Bezier node; `DegreeU`, `DegreeV`, `KnotsU`, `KnotsV`, `Weights` on the NURBS sibling).
- **`Docs/architecture/rendering-pipeline.md`** — Mermaid sequence diagram from `vtkMRMLLayerDisplayableManager` dispatch through Pipeline → Representation → custom mapper → shader uniforms.  Makes the T2-mapper-relocation landing zone concrete (where does `vtkOpenGLBezierResectionPolyDataMapper` plug in, what feeds its uniforms).
- **`Docs/architecture/surface-representation-taxonomy.md`** — Mermaid class diagram of the Bezier ↔ NURBS sibling Pipeline + Representation + Fitter trios, plus a mathematical-model contrast table (Bernstein vs B-spline, weights, knots, continuity, conic-section reproducibility).
- **`Docs/architecture/control-grid-grouping.md`** — ring-group formula (corners always 4; edges `2(M-2)+2(N-2)`; interior `(M-2)(N-2)`) + ASCII layouts for 4×4 / 5×5 / 5×7.  Generalises the `vtkLiverBezierWidget` right-drag-ring-group event (`TODO(T2.3 right-drag-ring-group)`) for any M×N.

### Scaffold extension

- **`requirements-docs.txt`** + **`Docs/conf.py`** — add `sphinxcontrib-mermaid` so the new architecture diagrams' Mermaid blocks render in Sphinx.  Architecture diagrams stay excluded from the current build per ADR-0017's scaffold scope; this PR adds the renderer for when the migration PR lifts the exclusion.
- **`Docs/index.md`** — toctree updated to include ADR-0018.

## Out of scope

- **Code parameterization** (variable-size enabler) — separate ENH PR.  Will land after this DOC PR.
- **Full NURBS implementation** — v2.1 ADR + ENH; out of v2.0.0 scope per ADR-0018 §"Why Option A".
- **State machine extension** (Confirmed / Locked state from PR #369's review comment) — separate ADR-0019 DOC PR, queued after this one.
- **Migration of existing `Docs/**/*.md` into the Sphinx tree** — deferred per ADR-0017's rollout plan §2.

## Test plan

- [x] Local `sphinx-build -W --keep-going Docs Docs/_build/html` succeeds with 0 warnings.
- [x] No PR/issue refs in source comments (per `feedback_no_pr_refs_in_code.md`).
- [x] No local-only references in PR body (per `feedback_pr_text_no_local_refs.md`).
- [ ] CI: `docs-build (sphinx-build (HTML))` runs.

## References

- [ADR-0018](Docs/adr/0018-nurbs-extension-surface.md) — this PR's primary spec.
- [ADR-0014 §3](Docs/adr/0014-livermarkups-dissolution.md) — Bezier dissolution; amended here.
- [ADR-0015](Docs/adr/0015-cpp-algorithm-library.md) — algorithm library; amended here.
- [ADR-0017](Docs/adr/0017-sphinx-readthedocs.md) — Sphinx scaffold this PR extends with mermaid.
- d'Albenzio, G. et al. *Surgeon-driven design of resection planning interfaces*. SPIE Medical Imaging 2024.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code.  Opened for human review.*