### PR TITLE
DOC: ADR-0019 — Resection state machine extension to a third Confirmed state

### DIFF
--- a/Docs/adr/0014-livermarkups-dissolution.md
+++ b/Docs/adr/0014-livermarkups-dissolution.md
@@ -11,6 +11,23 @@
 
 ## Amendments
 
+- **2026-05-18 — 3-state resection machine (ADR-0019).**  §4 of this
+  ADR commits to a 2-state `ResectionState` enum (`Init` /
+  `Planning`) with the `Init → Planning` transition as irreversible
+  audit-data-locking.  Per
+  [ADR-0019](0019-resection-state-machine.md),
+  a third `Confirmed = 2` state lands as a peer of `Planning`,
+  round-trippable: `Planning ↔ Confirmed`.  The `Confirmed` state
+  hides the control polygon, disables the widget, and renders the
+  resection surface with the parenchyma-trim shader (a v1 feature
+  the 2-state contract dropped).  The read-only-after-Planning
+  audit-data rule in §4 below is **unchanged in substance** — init
+  data becomes audit-only at the first `Init → Planning`
+  transition; subsequent transitions (`Planning ↔ Confirmed`) only
+  re-enable / re-lock the control polygon, never the init data.
+  No `Planning → Init` or `Confirmed → Init` transitions are
+  permitted.
+
 - **2026-05-18 — `{3×3, 4×4}` control polygons + NURBS extension surface (ADR-0018).**
   The v2.0.0 commitment in this ADR consistently refers to "the 4×4
   control grid".  Per [ADR-0018](0018-nurbs-extension-surface.md) §1
@@ -22,15 +39,13 @@
   Per-setter validation on `vtkMRMLBezierSurfaceNode::SetRows` /
   `SetCols` rejects other `(Rows, Cols)` combinations.  Arbitrary
   M×N control polygons remain reserved for the v2.1 NURBS sibling
-  representation per [ADR-0018][adr-0018-link] §3.  The widget
-  event-table (`vtkLiverBezierWidget`) parameterizes on `(Rows,
-  Cols)`; the same ring-of-control-points formula handles both
-  shapes.  `.lrp.json` schema v2 carries explicit `rows` + `cols`
-  alongside `controlGrid`; v1 files implicit-load as (4, 4); v2
-  readers validate `(rows, cols) ∈ {(3, 3), (4, 4)}` and reject
+  representation per [ADR-0018](0018-nurbs-extension-surface.md) §3.
+  The widget event-table (`vtkLiverBezierWidget`) parameterizes on
+  `(Rows, Cols)`; the same ring-of-control-points formula handles
+  both shapes.  `.lrp.json` schema v2 carries explicit `rows` +
+  `cols` alongside `controlGrid`; v1 files implicit-load as (4, 4);
+  v2 readers validate `(rows, cols) ∈ {(3, 3), (4, 4)}` and reject
   others.
-
-[adr-0018-link]: 0018-nurbs-extension-surface.md
 
 - **2026-05-16 — rename Bezier-surface MRML classes.**  The `Liver`
   prefix on the Bezier-surface MRML class trio

--- a/Docs/adr/0019-resection-state-machine.md
+++ b/Docs/adr/0019-resection-state-machine.md
@@ -76,15 +76,19 @@ ResectionState ::= Init = 0
                  | Confirmed = 2
 ```
 
-with the transition table:
+with the transition diagram:
 
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Init : node created
+    Init --> Planning : surgeon commits init data<br/>(irreversible per ADR-0014 §4)
+    Planning --> Confirmed : surgeon confirms plan
+    Confirmed --> Planning : surgeon revises plan
 ```
-                            ┌──────────────────────────────────────┐
-                            ▼                                      │
-        Init ──────────► Planning ◄═══════════════════► Confirmed
-   (start state)      (irreversible from Init;       (round-trippable
-                       reversible from Confirmed)     with Planning)
-```
+
+Full per-state contract + workflow sequence diagram live in the
+[architecture companion](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/resection-state-machine.md).
 
 The full transition matrix:
 

--- a/Docs/adr/0019-resection-state-machine.md
+++ b/Docs/adr/0019-resection-state-machine.md
@@ -1,0 +1,324 @@
+# 0019. Resection state machine: extend to a third `Confirmed` state
+
+- **Status:** Proposed
+- **Date:** 2026-05-18
+- **Deciders:** Rafael Palomar
+- **Diagrams:** `Docs/architecture/resection-state-machine.md`
+- **PR:** _filled in on merge_
+
+## Context
+
+The v2.0.0 resection state machine that landed across PRs #341
+(data-node ResectionState enum + initial 2-state contract) and #350
+(read-only-after-Planning enforcement) is a **2-state automaton**:
+
+```
+       Init  →  Planning   (irreversible)
+```
+
+Per [ADR-0014][adr-0014] §4 and PR #350's per-setter guards on
+`vtkMRMLBezierSurfaceNode`, once a resection transitions from `Init`
+to `Planning` the init data (slicing-plane origin/normal + init
+points OR distance-spheroid center/radii + init points) becomes
+**read-only audit data**.  No `Planning → Init` transition is
+permitted.
+
+Review feedback on PR #369 (T2.6-LayerDM) surfaced a missing third
+state, observable in the v1 user experience but not captured in the
+v2.0.0 contract:
+
+> *"After the resection has been defined, for visualization, the
+> control points/polygon disappear (no further manipulation possible)
+> and the resection exceeding the liver parenchyma is removed
+> (shader; current v1 has this functionality). This provides users
+> with a cleaner view. This state can be called `Locked` or
+> `Confirmed` and it has a way back to resection modification."*
+> — RafaelPalomar on PR #369, 2026-05-18
+
+The clinical workflow this third state enables:
+
+- The surgeon iterates on the Bezier-surface control polygon to
+  shape the resection plane during **`Planning`**.
+- When satisfied, the surgeon **`Confirms`** the resection.  The
+  control polygon + widget visuals disappear; the surface is
+  rendered with the parenchyma-trim shader (the bit of the surface
+  outside the liver is hidden); the visualization is "clean" for
+  review or surgical-plan export.
+- If the surgeon changes their mind, they can **return to
+  `Planning`** to modify the control polygon — the surface +
+  control-polygon visuals reappear, the trim shader disengages.
+
+Crucial detail: the `Confirmed` state is **not "done"**; it is a
+viewing mode that locks manipulation without losing the ability to
+go back.  Modelling it as a state of the same data node (vs a flag
+on the display node) is the architectural decision this ADR
+commits.
+
+The v1 module (legacy `vtkMRMLLiverResectionNode` family) carried
+this functionality in a parallel enum (`Initialization` /
+`Deformation` / `Completed`); the v2.0.0 work consolidated to
+2-state and the third concept got lost in translation.  This ADR
+restores it under the v2.0.0 contract.
+
+[adr-0001]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0001-resection-three-node-assembly.md
+[adr-0013]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md
+[adr-0014]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0014-livermarkups-dissolution.md
+[adr-0018]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0018-nurbs-extension-surface.md
+
+## Decision
+
+Extend `vtkMRMLBezierSurfaceNode::ResectionState` from a 2-state
+enum (`Init = 0`, `Planning = 1`) to a **3-state enum**:
+
+```
+ResectionState ::= Init = 0
+                 | Planning = 1
+                 | Confirmed = 2
+```
+
+with the transition table:
+
+```
+                            ┌──────────────────────────────────────┐
+                            ▼                                      │
+        Init ──────────► Planning ◄═══════════════════► Confirmed
+   (start state)      (irreversible from Init;       (round-trippable
+                       reversible from Confirmed)     with Planning)
+```
+
+The full transition matrix:
+
+| From → To  | Init | Planning  | Confirmed |
+|------------|------|-----------|-----------|
+| Init       | self | **allowed** (irreversible) | forbidden |
+| Planning   | forbidden (per ADR-0014 §4) | self | **allowed** |
+| Confirmed  | forbidden | **allowed** (round-trip back) | self |
+
+Forbidden transitions emit a `vtkWarningMacro` and reject the state
+change (mirrors PR #350's existing rejection pattern for
+`Planning → Init`).
+
+### Per-state contract
+
+| State        | Control polygon | Widget interaction | Surface render | Init data       | Audit fields |
+|--------------|-----------------|--------------------|----------------|-----------------|--------------|
+| `Init`       | absent          | init-mode-specific widget (markers + plane / spheroid) | minimal (init geometry) | editable | live |
+| `Planning`   | visible (M×N grid + ring glyphs) | `vtkLiverBezierWidget` enabled (left-drag, right-drag-ring, right-click context) | full surface; grid overlay shader on; **no parenchyma trim** | **read-only** | preserved |
+| `Confirmed`  | **hidden**      | widget **disabled** | full surface; grid overlay **off**; **parenchyma-trim shader on** | **read-only** | preserved |
+
+### Pipeline dispatch (per [ADR-0013][adr-0013] §4)
+
+The Pipeline's dispatch table grows a row:
+
+| `(ResectionState, InitializationMode)`   | Representation                                |
+|------------------------------------------|-----------------------------------------------|
+| `(Init, SlicingPlane)`                   | `SlicingPlaneInitRepresentation` (existing)   |
+| `(Init, DistanceSpheroid)`               | `DistanceSpheroidInitRepresentation` (existing) |
+| `(Planning, *)`                          | `BezierPlanningRepresentation` (existing)     |
+| **`(Confirmed, *)`**                     | **`ConfirmedRepresentation`** (new)           |
+
+`ConfirmedRepresentation` IS NOT a render-mode flag on
+`BezierPlanningRepresentation`.  It is a **first-class sibling
+Representation** with its own VTK pipeline:
+
+- No widget instance.
+- Surface mapper uses the **parenchyma-trim shader** (relocated from
+  `LiverMarkups/VTKWidgets/` during T2-mapper-relocation; the same
+  shader the v1 module's `Completed` state uses).
+- Grid-overlay shader uniforms (`GridVisibility`, `GridDivisions`,
+  `GridThickness`, `ResectionGridColor` on the display node) are
+  bypassed — `Confirmed` always renders the grid as off, regardless
+  of the display node's `GridVisibility` field.
+
+### Storage / persistence
+
+`.lrp.json` schema (PR #361 v1; will be v2 after [ADR-0018][adr-0018]'s
+enabler PR) carries `state` as a string-valued enum.  v1/v2 readers
+that don't recognise `"Confirmed"` should fall back to `"Planning"`
+gracefully (forward-compatible default).  v3 readers know all three.
+
+For round-trip: a scene saved with a `Confirmed` resection re-opens
+in `Confirmed` (the state IS persisted; the v1 module did this
+correctly).  The `.lrp.json` storage round-trip in PR #361's
+`vtkMRMLBezierSurfaceStorageNode` handles this transparently — the
+existing `state` field carries one more enum value.
+
+### Why `Confirmed`, not `Locked`
+
+Both names appear in the PR #369 review comment.  `Confirmed` wins
+for three reasons:
+
+- The user intent the state captures is *commitment to the resection
+  plan*, not *prevention of accidental edits*.  `Confirmed` reads
+  the way the surgeon thinks about it.
+- `Locked` over-specifies the implementation: it suggests the lock
+  could be released without changing the plan.  `Confirmed` reads
+  as "the plan is set; click here to revise it" — which is the
+  intended UX.
+- `Locked` collides with existing Slicer-core node concepts
+  (`SetLocked`, `LockedOn`, etc.) that have a different semantic
+  (markups-anti-tampering); avoiding the name avoids reader
+  confusion.
+
+### Why the round-trip transition (Confirmed → Planning), not "lock forever"
+
+The PR #369 review comment is explicit: *"it has a way back to
+resection modification"*.  This is the clinically realistic case —
+plans get reviewed by colleagues, get adjusted, get re-confirmed.
+
+Architectural consequence: the read-only-after-Planning contract
+from [ADR-0014][adr-0014] §4 stays unchanged — init data is still
+audit-only — but **`Planning ↔ Confirmed` is a bidirectional
+manipulation cycle** for the control polygon.  Specifically:
+
+- `Confirmed → Planning` does NOT re-open init data for editing.
+- Within `Planning`, the control polygon stays editable.
+- `Confirmed → Planning → Confirmed` is the expected user gesture
+  for "I want to tweak the surface and re-finalise".
+
+### Why a new Representation, not a mode flag on `BezierPlanningRepresentation`
+
+Two reasons:
+
+- The Pipeline-dispatch convention from [ADR-0013][adr-0013] §4 +
+  §6 is *one Representation per `(state, initMode)` tuple*.  A
+  mode flag inside `BezierPlanningRepresentation` would smear two
+  concepts into one class — exactly the legacy pattern the
+  Pipeline/Representation split set out to avoid.
+- The `Confirmed` Representation's render-pipeline is genuinely
+  different: different shader (parenchyma trim vs grid overlay),
+  different widget binding (none vs the `vtkLiverBezierWidget`),
+  different actor count.  Sibling classes capture this divergence
+  honestly.
+
+### Why a no-`Planning → Init` rule stays
+
+`Confirmed → Planning` does NOT compose into `Confirmed → Planning
+→ Init`.  Per [ADR-0014][adr-0014] §4 and PR #350, init data becomes
+audit-only at the first `Init → Planning` transition; no subsequent
+state changes can revert it.  `Confirmed → Planning` only re-enables
+control-polygon editing, NOT init-data editing.
+
+The transition matrix table above is the load-bearing artifact: no
+row contains a `Planning → Init` or `Confirmed → Init` cell that is
+"allowed".
+
+### Why `ConfirmedRepresentation` is the right place for the trim shader
+
+The parenchyma-trim shader is what v1 used to remove the
+out-of-parenchyma portion of the resection surface for clean
+viewing.  In the v2.0.0 architecture (per [ADR-0014][adr-0014] §3),
+shaders live in custom OpenGL mappers, attached to Representations.
+The trim shader is one of the four mappers slated for
+T2-mapper-relocation; this ADR commits the trim mapper to
+`ConfirmedRepresentation` (vs `BezierPlanningRepresentation`).
+
+The grid overlay shader stays on `BezierPlanningRepresentation`.
+Both mappers ultimately share a common base
+(`vtkOpenGLBezierResectionPolyDataMapper`) but expose different
+uniforms.  The Representation owns which uniforms are bound.
+
+## Consequences
+
+**Positive:**
+
+- The v1 "clean view" UX surfaces in v2.0.0.  Plans are reviewable
+  without the control-polygon visuals occluding the surface.
+- The `Confirmed` state is a first-class persistence-aware state —
+  scene save / reload preserves it.
+- The Pipeline dispatch grows by one row; no architectural surface
+  changes.  Adding new states later (e.g., `Approved` as a peer of
+  `Confirmed` with co-surgeon sign-off semantics) is a small
+  extension.
+- Composes cleanly with [ADR-0018][adr-0018]'s NURBS sibling work:
+  `Confirmed` state applies to both Bezier and NURBS representations;
+  the Pipeline + Representation taxonomy is orthogonal to the
+  state-machine axis.
+
+**Negative:**
+
+- The 2-state contract in [ADR-0014][adr-0014] §4 ages out — code
+  reviewers must read this ADR alongside ADR-0014 to track the
+  current state machine.  Mitigated by the inline amendment block
+  at the top of [ADR-0014][adr-0014] (landed by this PR).
+- The trim shader is in `LiverMarkups/VTKWidgets/` and not yet
+  relocated.  `ConfirmedRepresentation` implementation IS BLOCKED
+  on T2-mapper-relocation; the implementation PR (queued after
+  this ADR + T2-mapper-relocation merge) lands the
+  `ConfirmedRepresentation` class but its render path is a no-op
+  until the trim mapper relocates.
+- `.lrp.json` v1/v2 forward-compatibility relies on readers
+  defaulting unknown `state` values to `"Planning"`.  The current
+  storage node (PR #361 + #367) does not do this explicitly; the
+  enabler PR adds the fall-through.  Until then, a v3-authored
+  scene with `state = "Confirmed"` opens in older readers as a
+  state-load error (acceptable for an unreleased feature).
+
+## Rollout plan
+
+1. **DOC PR — this ADR + state-machine diagram + ADR-0014 amendment**
+   (this PR):
+   - New `Docs/adr/0019-resection-state-machine.md`.
+   - New `Docs/architecture/resection-state-machine.md` — Mermaid
+     `stateDiagram-v2` showing the three states + transitions +
+     forbidden arrows + per-state contract.
+   - Light amendment to [ADR-0014][adr-0014] §4 (read-only
+     audit data + 2-state → 3-state extension).
+
+2. **ENH PR — Confirmed-state implementation** (separate PR, blocked
+   on T2-mapper-relocation):
+   - `vtkMRMLBezierSurfaceNode::ResectionState::Confirmed = 2`.
+   - Per-setter guards updated:
+     `Planning → Confirmed` allowed; `Confirmed → Planning`
+     allowed; `Confirmed → Init` forbidden.
+   - `ConfirmedRepresentation` Python class under
+     `LiverResections/LiverResectionsLib/Representations/`.
+   - Pipeline dispatch table updated.
+   - `.lrp.json` reader gains the forward-compatible
+     unknown-state fallback to `"Planning"`.
+   - Characterisation tests pin the transition matrix.
+
+3. **T2-mapper-relocation** (separate ENH PR, also queued):
+   - Relocates the parenchyma-trim mapper from
+     `LiverMarkups/VTKWidgets/` into `LiverResections/VTKWidgets/`.
+   - `ConfirmedRepresentation` wires the trim mapper into its
+     actor + sets the uniform feeds from the display node.
+
+The Confirmed-state implementation lands on top of
+T2-mapper-relocation; if T2-mapper-relocation slips, the Confirmed
+state can land WITHOUT a working trim shader (the
+Representation still hides the widget and disables the grid
+overlay; the trim shader's absence just means the cut-away view
+isn't there yet).
+
+## Out of scope for this ADR
+
+- Approval workflow (multi-surgeon sign-off).  Possible future
+  state above `Confirmed` (e.g., `Approved`); not in v2.0.0.
+- Undo / redo across the state machine.  The transition matrix is
+  Markovian — each state change is the user's deliberate action;
+  no automatic backstack.  Slicer-core's MRML undo would replay
+  state changes if enabled, which is acceptable.
+- UI affordance for the state transitions (button placement,
+  modal-vs-inline confirmation, etc.) — covered by ADR-0009 (UX
+  + design discipline); the state-machine diagram in this ADR
+  is the C++/MRML-side contract, not the UX flow.
+
+## Cross-references
+
+- [ADR-0001][adr-0001] — three-node assembly that `State` is a field of.
+- [ADR-0013][adr-0013] §4 + §6 — Pipeline dispatch contract;
+  `(Confirmed, *)` becomes a new row.
+- [ADR-0014][adr-0014] §4 — read-only-after-Planning audit-data rule;
+  unchanged in substance, amended to note 3-state extension.
+- [ADR-0018][adr-0018] §3 — sibling-Pipeline pattern for the future
+  NURBS extension; `ConfirmedRepresentation` is per-Pipeline
+  (Bezier today; NURBS sibling at v2.1) for the same reasons.
+
+## References
+
+- PR #369 review comment by RafaelPalomar (2026-05-18) — the
+  feedback this ADR captures.
+- v1 `vtkMRMLLiverResectionNode::ResectionState` enum
+  (`Initialization` / `Deformation` / `Completed`) — the legacy
+  3-state machine this ADR restores under v2.0.0 naming.

--- a/Docs/architecture/resection-state-machine.md
+++ b/Docs/architecture/resection-state-machine.md
@@ -1,0 +1,166 @@
+# Resection state machine — `Init` → `Planning` ↔ `Confirmed`
+
+Reference companion to [ADR-0019][adr-0019].  Shows the
+3-state automaton on `vtkMRMLBezierSurfaceNode::ResectionState` and
+the per-state contract for control-polygon visibility, widget
+interaction, surface rendering, and init-data mutability.
+
+[adr-0019]: ../adr/0019-resection-state-machine.md
+[adr-0014]: ../adr/0014-livermarkups-dissolution.md
+
+## State diagram
+
+```{mermaid}
+stateDiagram-v2
+    direction LR
+
+    [*] --> Init : node created
+
+    Init --> Planning : surgeon commits init data<br/>(irreversible per ADR-0014 §4)
+
+    Planning --> Confirmed : surgeon confirms plan
+    Confirmed --> Planning : surgeon revises plan
+
+    Init --> Init : edit slicing-plane /<br/>distance-spheroid init points
+    Planning --> Planning : edit control polygon
+    Confirmed --> Confirmed : view-only (no edits)
+
+    note right of Init
+        Init data editable.
+        Control polygon absent.
+        Init-mode-specific Representation
+        (SlicingPlane | DistanceSpheroid).
+    end note
+
+    note right of Planning
+        Control polygon visible (M×N grid).
+        vtkLiverBezierWidget enabled
+        (left-drag, right-drag-ring,
+         right-click context).
+        Grid-overlay shader on.
+        Init data read-only audit.
+    end note
+
+    note left of Confirmed
+        Control polygon hidden.
+        Widget disabled.
+        Parenchyma-trim shader on.
+        Grid overlay off.
+        Init data read-only audit.
+    end note
+```
+
+## Forbidden transitions (rejected with `vtkWarningMacro`)
+
+```{mermaid}
+stateDiagram-v2
+    direction LR
+
+    Planning --> Init : ❌ rejected<br/>(ADR-0014 §4: no Planning → Init)
+    Confirmed --> Init : ❌ rejected<br/>(audit data permanent)
+
+    note right of Planning
+        Setter on
+        vtkMRMLBezierSurfaceNode::SetState
+        emits vtkWarningMacro and
+        returns without Modified()
+        per PR #350 precedent.
+    end note
+```
+
+## Per-state contract — full table
+
+| Field                                   | `Init`                  | `Planning`              | `Confirmed`             |
+|-----------------------------------------|-------------------------|-------------------------|-------------------------|
+| **Active Representation**               | init-mode-specific      | `BezierPlanningRepresentation` | `ConfirmedRepresentation` |
+| Control polygon visible                 | no                      | **yes** (M×N grid)      | no                      |
+| `vtkLiverBezierWidget` enabled          | no                      | **yes**                 | no                      |
+| Init markers visible                    | **yes** (SlicingPlane: 2 markers; DistanceSpheroid: N markers) | no | no |
+| Init-mode geometry visible              | **yes** (plane or spheroid) | no                  | no                      |
+| Bezier surface visible                  | no                      | **yes** (full extent)   | **yes** (trimmed to liver parenchyma) |
+| Grid-overlay shader                     | n/a                     | **on**                  | off                     |
+| Parenchyma-trim shader                  | n/a                     | off                     | **on**                  |
+| Init data mutable (`SetSlicingPlaneOrigin`, `SetDistanceSpheroidInitPoint`, …) | **yes** | no (rejected) | no (rejected) |
+| Control-grid mutable (`SetControlGrid`, `SetControlGridPoint`) | n/a (not yet fitted) | **yes** | no (rejected) |
+
+## Allowed transitions — full table
+
+| From → To       | Init                    | Planning                | Confirmed               |
+|-----------------|-------------------------|-------------------------|-------------------------|
+| **Init →**      | self                    | **allowed (one-way)**   | forbidden               |
+| **Planning →**  | forbidden               | self                    | **allowed**             |
+| **Confirmed →** | forbidden               | **allowed (round-trip)** | self                    |
+
+## Sequence: typical surgeon workflow
+
+```{mermaid}
+sequenceDiagram
+    actor Surgeon
+    participant Node as vtkMRMLBezierSurfaceNode
+    participant Pipeline as LiverBezierSurfacePipeline
+    participant Init as SlicingPlaneInitRepresentation
+    participant Planning as BezierPlanningRepresentation
+    participant Confirmed as ConfirmedRepresentation
+
+    Note over Node: state = Init
+    Surgeon->>Node: place init points
+    Surgeon->>Pipeline: (Init, SlicingPlane) dispatch
+    Pipeline->>Init: render markers + plane
+
+    Surgeon->>Node: SetState(Planning)
+    Note over Node: state = Planning;<br/>init data now read-only
+    Pipeline->>Planning: render control polygon + surface
+
+    loop control-polygon iteration
+        Surgeon->>Node: SetControlGridPoint(i, j, x, y, z)
+        Pipeline->>Planning: re-render
+    end
+
+    Surgeon->>Node: SetState(Confirmed)
+    Note over Node: state = Confirmed
+    Pipeline->>Confirmed: render trimmed surface;<br/>hide widget + control polygon
+
+    Note over Surgeon: plan review
+
+    alt surgeon revises
+        Surgeon->>Node: SetState(Planning)
+        Pipeline->>Planning: re-render control polygon + surface
+    else surgeon exports plan
+        Surgeon->>Node: storage→WriteData(.lrp.json)
+        Note over Node: state = Confirmed persisted
+    end
+```
+
+## Notes
+
+- All three states are **first-class persisted state** — the
+  `.lrp.json` v2 schema's `state` field carries `"Init"`,
+  `"Planning"`, or `"Confirmed"`.  Forward-compatibility: older
+  readers that don't recognise `"Confirmed"` fall back to
+  `"Planning"`.
+- The state machine is **per-resection** — multiple
+  `vtkMRMLBezierSurfaceNode` instances in the same scene can each
+  be in different states.  Useful for multi-resection treatment
+  planning where one plan is reviewed (Confirmed) while another is
+  being edited (Planning).
+- The `Confirmed` state is **NOT terminal**.  Round-trip back to
+  `Planning` is the expected user gesture for "I want to tweak this".
+- The state machine is **orthogonal to** the
+  [ADR-0018][adr-0018] §3 representation kind
+  (Bezier vs NURBS).  A v2.1 NURBS resection has the same three
+  states; the per-state contract above is identical modulo the
+  surface representation.
+
+[adr-0018]: ../adr/0018-nurbs-extension-surface.md
+
+## Out of scope of this diagram
+
+- The UI affordance for state transitions (button placement, modal
+  confirmation, undo handling) — covered by ADR-0009 (UX +
+  design discipline).
+- Multi-surgeon approval workflow (`Approved` state above
+  `Confirmed`) — out of v2.0.0 scope per [ADR-0019][adr-0019]'s
+  "Out of scope".
+- Per-setter rejection mechanics (which mutators emit warnings;
+  exact warning text) — covered in [ADR-0014][adr-0014] §4 +
+  PR #350's implementation.

--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -108,6 +108,14 @@ myst_heading_anchors = 6
 # Block math with equation-label syntax.
 myst_dmath_allow_labels = True
 
+# Route bare ``` mermaid `` ` fenced code blocks to the
+# sphinxcontrib.mermaid directive.  Without this, MyST falls
+# through to Pygments syntax highlighting and "mermaid" is not a
+# known lexer, so the build fails with `[misc.highlighting_failure]`.
+# The bare-fence form is also what GitHub renders natively (per
+# PR #371's review feedback on ``` {mermaid} `` ` vs ``` mermaid `` `).
+myst_fence_as_directive = ["mermaid"]
+
 templates_path = ["_templates"]
 # Scaffold scope (ADR-0017 PR 1): only `index.md` and the ADR ledger
 # are wired into the build.  The architecture diagrams, dependency

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -37,4 +37,5 @@ ReadTheDocs.  Mirrors the upstream Slicer-core convention.
 
 adr/0017-sphinx-readthedocs.md
 adr/0018-nurbs-extension-surface.md
+adr/0019-resection-state-machine.md
 ```


### PR DESCRIPTION
## Summary

Architectural commitment to a **3-state resection machine**: `Init → Planning ↔ Confirmed`.  Extends the 2-state contract landed by PR #341 + PR #350 with a `Confirmed` peer of `Planning`, restoring the v1 module's clean-view UX (control polygon hidden, parenchyma-trim shader applied).

Surfaced by your review comment on PR #369 (2026-05-18).

This PR is the **DOC PR only** — ADR + architecture diagram + light ADR-0014 amendment.  No source-code changes; the enabling ENH PR is queued as a follow-up after T2-mapper-relocation (which delivers the trim shader).

## What lands

### ADRs

- **`Docs/adr/0019-resection-state-machine.md`** — new ADR.  Sub-decisions:
  - 3-state enum (`Init = 0`, `Planning = 1`, `Confirmed = 2`).
  - Transition matrix: `Init → Planning` irreversible; `Planning ↔ Confirmed` round-trippable; no `Planning → Init` or `Confirmed → Init`.
  - `ConfirmedRepresentation` is a first-class sibling Representation (NOT a flag on `BezierPlanningRepresentation`).
  - Name choice (`Confirmed` over `Locked`) — captures *commitment to the plan*, not *anti-tampering*.
  - Round-trip transition justified (`Confirmed → Planning` allowed) per the review comment's "way back to resection modification".
- **`Docs/adr/0014-livermarkups-dissolution.md`** — amendment block at the top documenting the 2-state → 3-state extension.  §4's read-only-after-Planning audit-data rule is unchanged in substance — init data still becomes audit-only at the first `Init → Planning` transition.

### Architecture diagram (new)

- **`Docs/architecture/resection-state-machine.md`** — Mermaid `stateDiagram-v2` showing the three states + transitions + forbidden arrows; per-state contract table; full allowed-transitions matrix; typical-workflow sequence diagram.

### Scaffold integration

- **`Docs/index.md`** — toctree updated to include ADR-0019.
- **No `sphinxcontrib-mermaid`** added in this PR — ADR-0019 itself has zero Mermaid blocks; the Mermaid lives in `Docs/architecture/resection-state-machine.md`, which is `exclude_patterns`-d from the scaffold's Sphinx build.  GitHub renders the Mermaid natively.  If ADR-0018's separate PR (which adds `sphinxcontrib-mermaid`) lands first + merges with this one, the architecture diagram will render in Sphinx automatically once the migration PR lifts the exclusion.

## Out of scope

- **`ConfirmedRepresentation` C++/Python implementation** — separate ENH PR.  Blocked on T2-mapper-relocation (which delivers the parenchyma-trim mapper).
- **T2-mapper-relocation** — separate ENH PR.  Relocates the four custom OpenGL mappers from `LiverMarkups/VTKWidgets/` to `LiverResections/VTKWidgets/`; the trim mapper is the one `ConfirmedRepresentation` depends on.
- **Multi-surgeon approval workflow** (an `Approved` state above `Confirmed`) — out of v2.0.0 scope per ADR-0019's "Out of scope".
- **UI affordance for the state transitions** (button placement, modal confirmation, undo handling) — covered by ADR-0009 (UX + design discipline).

## Test plan

- [x] Local `sphinx-build -W --keep-going Docs Docs/_build/html` succeeds with 0 warnings.
- [x] No PR/issue refs in source comments (per `feedback_no_pr_refs_in_code.md`).
- [x] No local-only references in PR body (per `feedback_pr_text_no_local_refs.md`).
- [ ] CI: `docs-build (sphinx-build (HTML))` runs.

## References

- [ADR-0019](Docs/adr/0019-resection-state-machine.md) — this PR's primary spec.
- [ADR-0014](Docs/adr/0014-livermarkups-dissolution.md) §4 — read-only-after-Planning audit-data rule; amended here.
- [ADR-0018](https://github.com/ALive-research/Slicer-Liver/pull/371) (open) — NURBS sibling + variable-size; composes orthogonally with this state-machine extension.
- PR #341 — initial `vtkMRMLBezierSurfaceNode::ResectionState` enum.
- PR #350 — read-only-after-Planning per-setter guards (existing rejection pattern this ADR's `Confirmed → Init` rejection mirrors).
- PR #369 — review comment that surfaced this missing state.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code.  Opened for human review.*