### PR TITLE
BUG: Invert docs-only filter so pure-docs PRs actually skip build-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,44 +167,53 @@ jobs:
       # Filter is PR-scoped — push events (merge to preview, direct push,
       # workflow_dispatch) always run the full build to catch any drift.
       # ---------------------------------------------------------------------
-      # dorny/paths-filter@v3 with predicate-quantifier: every matches when
-      # every changed file matches at least one of the listed patterns.
-      # Each pattern goes on its own list entry (canonical form); the
-      # earlier brace-consolidated single-pattern form silently matched
-      # files outside the alternation set (surfaced by PR #368's CI run
-      # against ci.yml + CMakeLists.txt changes), so we revert to the
-      # separated form per dorny/paths-filter docs.
-      - name: Detect docs-only change
+      # Inversion: we define ``non-docs`` — a filter that's true when ANY
+      # changed file is OUTSIDE the docs-only set.  Skip build-test when
+      # ``non-docs == false`` (every changed file is a doc-shaped file).
+      #
+      # Why the inversion: dorny/paths-filter@v3's ``predicate-quantifier:
+      # every`` means *every pattern must match at least one file*, NOT
+      # *every file must match at least one pattern*.  Previous attempts
+      # (PR #368 separate-list form + PR #371 ``requirements-docs.txt``
+      # addition) had the semantics backwards: with ``every`` the filter
+      # would only return true when every listed doc-pattern got touched
+      # in the diff — impossible for a typical PR — so docs-only PRs
+      # never actually skipped the heavy build.  Surfaced cleanly by
+      # PR #374 (the first pure-docs PR: build-test ran 7m57s when it
+      # should have skipped).
+      #
+      # The corrected shape uses picomatch negation patterns followed by
+      # ``**`` fallback.  With default ``predicate-quantifier: some`` the
+      # filter is true if at least one changed file matches ``**`` AFTER
+      # the negations have excluded the doc paths — i.e., at least one
+      # non-docs file changed.  Order matters: negations must precede
+      # ``**``.
+      - name: Detect non-docs change
         id: changes
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         with:
-          predicate-quantifier: every
           filters: |
-            docs-only:
-              - 'Docs/**'
-              - '*.md'
-              - '.github/pull_request_template.md'
-              - '.github/CODEOWNERS'
-              - 'CITATION.cff'
-              - 'License.txt'
-              - 'COPYRIGHT.txt'
-              # Docs-build-supporting root files — touching these
-              # affects only the Sphinx scaffold (ADR-0017), not the
-              # C++ build path.  Surfaced by PR #371 where bumping
-              # ``requirements-docs.txt`` triggered a full build-test
-              # despite being a docs-only change.
-              - 'requirements-docs.txt'
-              - '.readthedocs.yaml'
+            non-docs:
+              - '!Docs/**'
+              - '!*.md'
+              - '!.github/pull_request_template.md'
+              - '!.github/CODEOWNERS'
+              - '!CITATION.cff'
+              - '!License.txt'
+              - '!COPYRIGHT.txt'
+              - '!requirements-docs.txt'
+              - '!.readthedocs.yaml'
+              - '**'
 
       - name: Report skip (docs-only PR)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.docs-only == 'true'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.non-docs == 'false'
         run: |
-          echo "::notice::Skipping Slicer build/test — this PR only touches documentation, ADRs, or repo-meta files."
-          echo "Filtered paths matched every changed file; build-test job reports success."
+          echo "::notice::Skipping Slicer build/test — every changed file is a doc-shaped file."
+          echo "non-docs filter is false; build-test job reports success."
 
       - name: Verify Slicer build tree
-        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
         run: |
           set -euo pipefail
           test -f "${Slicer_DIR}/SlicerConfig.cmake" \
@@ -223,7 +232,7 @@ jobs:
       # the clone + build.
       # -----------------------------------------------------------------
       - name: Cache SlicerLayerDM source + build tree
-        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
         id: cache-layerdm
         uses: actions/cache@v4
         with:
@@ -241,7 +250,7 @@ jobs:
 
       - name: Clone SlicerLayerDM (pinned)
         if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true') &&
+          (github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true') &&
           steps.cache-layerdm.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
@@ -254,7 +263,7 @@ jobs:
 
       - name: Configure SlicerLayerDM
         if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true') &&
+          (github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true') &&
           steps.cache-layerdm.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
@@ -265,12 +274,12 @@ jobs:
 
       - name: Build SlicerLayerDM
         if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true') &&
+          (github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true') &&
           steps.cache-layerdm.outputs.cache-hit != 'true'
         run: cmake --build "${LAYERDM_BUILD}" --config Release -j "$(nproc)"
 
       - name: Configure
-        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
         run: |
           set -euo pipefail
           mkdir -p build
@@ -286,11 +295,11 @@ jobs:
             -DLayerDisplayableManager_DIR="${LAYERDM_BUILD}"
 
       - name: Build
-        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
         run: cmake --build build --config Release -j "$(nproc)"
 
       - name: Test (CTest)
-        if: github.event_name != 'pull_request' || steps.changes.outputs.docs-only != 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
         run: |
           set -euo pipefail
           cd build


### PR DESCRIPTION
## Summary

PR #374 (ADR-0020, pure-docs: 2 files under `Docs/**`) ran the full ~8 min `build-test (slicer-main, Linux)` job instead of skipping.  Root cause: previous filter shapes (PR #368 separate-list form + PR #371 `requirements-docs.txt` addition) had the dorny/paths-filter semantics backwards.

## Status — STILL BROKEN (smoke-test failed)

The negation+`**` shape in this PR's HEAD does NOT correctly skip build-test on a pure-docs PR.  Empirical CI evidence from a smoke run (single-file diff `Docs/SMOKE.md` against this branch):

```
[added] Docs/SMOKE.md
Detected 1 changed files
Filter non-docs = true
Matching files:
Docs/SMOKE.md [added]
```

The "Report skip (docs-only PR)" step was skipped and the heavy steps (`Verify Slicer build tree`, `Configure`, `Build`, `Test (CTest)`) all ran.  The fix does NOT work.

**Why** — dorny/paths-filter v3 applies OR across patterns within a filter (a file matches if ANY pattern matches it).  `picomatch('!*.md')` matches files that do NOT match `*.md`.  Since `*.md` (no slash) only matches root-level `.md` files, the negation `!*.md` DOES match `Docs/SMOKE.md`.  So that single pattern alone causes `non-docs = true`.  The `**` fallback was already redundant; the issue is that multiple negation patterns OR'd together always re-include the very docs files they were meant to exclude.

dorny v3 supports only two predicate-quantifiers (`some`, `every`); neither expresses "every changed file matches at least one pattern" which is what the docs-only gate actually needs.

## Proposed corrected approaches (need decision)

1. **Replace dorny with a shell-script step** that diffs base..head and `grep -vE` the doc-path regex; emit `non-docs=true|false` to `$GITHUB_OUTPUT`.  Explicit, no DSL surprises.
2. **Replace dorny with `tj-actions/changed-files`** + its `files_yaml` / `files_ignore` inputs which natively express "all changed files match a positive set".
3. **Composite extglob pattern**: `!(Docs/**|*.md|.readthedocs.yaml|requirements-docs.txt|CITATION.cff|License.txt|COPYRIGHT.txt|.github/pull_request_template.md|.github/CODEOWNERS)` as a single dorny pattern.  Picomatch supports extglob; whether dorny's wrapper preserves the semantics under OR aggregation needs its own smoke test before relying on it.

(Was: original PR body proposed inversion-with-negation-and-`**`; smoke-test refuted that.)

## Original root-cause analysis (still valid)

`dorny/paths-filter@v3`'s `predicate-quantifier: every` means **every pattern must match at least one file**, NOT **every file must match at least one pattern**.  PR #368's separate-list + PR #371's additions both failed for that reason; they only "worked" because every prior PR happened to touch at least one non-docs file (so the side-effect of the broken `docs-only` filter going false matched the desired "don't skip" outcome by accident).  PR #374 was the first pure-docs PR and surfaced the bug.

## What's true in this PR's diff

- The inversion to `non-docs` + step-level `if:` polarity flip is mechanically correct GIVEN a working filter.  Once one of the corrected approaches above lands, the step-level `if:` conditions don't need to move.
- The doc-path negation list (`Docs/**`, `*.md`, `.readthedocs.yaml`, etc.) is the correct path set.

## Self-skip caveat (unchanged)

This PR's own diff includes ci.yml (non-docs), so its own build-test cannot skip; that's not a regression and not what the smoke-test was checking.

## Test plan

- [x] No source-code changes; only CI workflow edit.
- [x] No copyright check applies (ci.yml not gated).
- [x] CI: build-test runs on this PR (expected — ci.yml is non-docs).
- [ ] **Smoke-test:** pure-docs PR (touching only `Docs/foo.md`) should produce `non-docs = false`.  **FAILED on this PR's HEAD** — empirical evidence above.  Re-test after the corrected approach lands.

## References

- PR #368 — first attempt (brace-consolidated → separate-list).
- PR #371 — second attempt (added `requirements-docs.txt` + `.readthedocs.yaml`).
- PR #374 — first pure-docs PR; surfaced the bug.
- dorny/paths-filter v3 README — predicate-quantifier semantics.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code.  Opened for human review; the smoke-test refutation was AI-conducted via a (now-closed) pure-docs PR #376 against this branch.*