### PR TITLE
DOC: Smoke test — pure-docs PR should skip build-test (validates #375)

### DIFF
--- a/Docs/SMOKE.md
+++ b/Docs/SMOKE.md
@@ -1,0 +1,18 @@
+# Smoke test — docs-only CI filter
+
+This file exists only to validate that the `non-docs` filter in
+`.github/workflows/ci.yml` correctly skips the heavy `build-test`
+job for pure-docs PRs (touching only `Docs/**`).
+
+Per the `non-docs` filter introduced in the docs-only-filter
+negation fix:
+
+- A PR that touches **only** files matching `!Docs/**` (or the
+  other allowed negations: `!*.md`, `!.readthedocs.yaml`,
+  `!requirements-docs.txt`, etc.) should produce
+  `steps.changes.outputs.non-docs == 'false'`.
+- `build-test` is gated by `if: steps.changes.outputs.non-docs ==
+  'true'` and therefore should not run.
+
+This page can be safely deleted once the smoke test has confirmed
+the behaviour.


### PR DESCRIPTION
## Summary

**Smoke test for PR #375** (docs-only filter negation fix).

This PR is the **first pure-docs PR** that targets the corrected
`non-docs` filter shape introduced in #375.  It adds a single file,
`Docs/SMOKE.md`, and nothing else.  Expected CI behaviour:

- `Detect non-docs change` step runs, with output `non-docs == 'false'`.
- `build-test (slicer-main, Linux)` job is **skipped** (its
  step-level `if:` is gated on `non-docs == 'true'`).
- `docs-lint` runs and passes.
- All other lint jobs run and pass.

If `build-test` still runs on this PR, the negation filter is wrong
and #375 needs another iteration.

## Why base = `fix/docs-only-filter-negation` (not `preview`)

Branching off #375 lets us exercise the corrected filter **before**
#375 merges to `preview`, so the merge of #375 itself doesn't gate
the validation.  Once #375 merges this PR can either rebase onto
`preview` (still pure-docs, still expected to skip) or be closed
(the gating is already proven by the CI runs here).

## Out of scope

- The smoke file itself has no documentation value.  It exists only
  to be a one-file diff.  Once the gating is confirmed (or once a
  routine future docs change has organically validated the filter),
  the file can be deleted.

## Test plan

- [ ] CI's `Detect non-docs change` step shows `non-docs: false`.
- [ ] `build-test (slicer-main, Linux)` does not run on this PR.
- [ ] `docs-lint (Mermaid + Markdown links)` runs and passes.

## References

- PR #375 — the filter fix this PR smoke-tests.
- ADR-0017 — Sphinx scaffold; originally introduced the
  (broken-then-corrected) `docs-only` filter.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code.  Opened for human review.*