### PR TITLE
BUG: Use tj-actions/changed-files for docs-only CI skip (follow-up to #375)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,53 +167,46 @@ jobs:
       # Filter is PR-scoped — push events (merge to preview, direct push,
       # workflow_dispatch) always run the full build to catch any drift.
       # ---------------------------------------------------------------------
-      # Inversion: we define ``non-docs`` — a filter that's true when ANY
-      # changed file is OUTSIDE the docs-only set.  Skip build-test when
-      # ``non-docs == false`` (every changed file is a doc-shaped file).
+      # We want: "every changed file is a doc-shaped file → skip build".
+      # dorny/paths-filter@v3 cannot express that natively: its
+      # ``predicate-quantifier`` supports only ``some`` (≥ 1 file matches
+      # any pattern) and ``every`` (≥ 1 file matches every pattern);
+      # neither is "every file matches some pattern".  Prior attempts
+      # using ``predicate-quantifier: every`` with positive patterns
+      # (PR #368, PR #371) and the negation-plus-``**`` inversion
+      # (PR #375) both failed for that reason.  PR #375's smoke test
+      # against a single-file pure-docs diff explicitly confirmed
+      # ``non-docs = true`` instead of false.
       #
-      # Why the inversion: dorny/paths-filter@v3's ``predicate-quantifier:
-      # every`` means *every pattern must match at least one file*, NOT
-      # *every file must match at least one pattern*.  Previous attempts
-      # (PR #368 separate-list form + PR #371 ``requirements-docs.txt``
-      # addition) had the semantics backwards: with ``every`` the filter
-      # would only return true when every listed doc-pattern got touched
-      # in the diff — impossible for a typical PR — so docs-only PRs
-      # never actually skipped the heavy build.  Surfaced cleanly by
-      # PR #374 (the first pure-docs PR: build-test ran 7m57s when it
-      # should have skipped).
-      #
-      # The corrected shape uses picomatch negation patterns followed by
-      # ``**`` fallback.  With default ``predicate-quantifier: some`` the
-      # filter is true if at least one changed file matches ``**`` AFTER
-      # the negations have excluded the doc paths — i.e., at least one
-      # non-docs file changed.  Order matters: negations must precede
-      # ``**``.
+      # tj-actions/changed-files DOES express it natively via
+      # ``files_ignore``: ``any_changed`` is true iff at least one
+      # changed file is outside the ignored set.  Pure-docs PRs (every
+      # changed file matches the ignore list) yield ``any_changed=false``
+      # → skip the heavy build steps.
       - name: Detect non-docs change
         id: changes
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
+        uses: tj-actions/changed-files@v45
         with:
-          filters: |
-            non-docs:
-              - '!Docs/**'
-              - '!*.md'
-              - '!.github/pull_request_template.md'
-              - '!.github/CODEOWNERS'
-              - '!CITATION.cff'
-              - '!License.txt'
-              - '!COPYRIGHT.txt'
-              - '!requirements-docs.txt'
-              - '!.readthedocs.yaml'
-              - '**'
+          files_ignore: |
+            Docs/**
+            *.md
+            .github/pull_request_template.md
+            .github/CODEOWNERS
+            CITATION.cff
+            License.txt
+            COPYRIGHT.txt
+            requirements-docs.txt
+            .readthedocs.yaml
 
       - name: Report skip (docs-only PR)
-        if: github.event_name == 'pull_request' && steps.changes.outputs.non-docs == 'false'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.any_changed == 'false'
         run: |
-          echo "::notice::Skipping Slicer build/test — every changed file is a doc-shaped file."
-          echo "non-docs filter is false; build-test job reports success."
+          echo "::notice::Skipping Slicer build/test — every changed file is in the docs-ignore set."
+          echo "any_changed is false; build-test job reports success without running heavy steps."
 
       - name: Verify Slicer build tree
-        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
         run: |
           set -euo pipefail
           test -f "${Slicer_DIR}/SlicerConfig.cmake" \
@@ -232,7 +225,7 @@ jobs:
       # the clone + build.
       # -----------------------------------------------------------------
       - name: Cache SlicerLayerDM source + build tree
-        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
         id: cache-layerdm
         uses: actions/cache@v4
         with:
@@ -250,7 +243,7 @@ jobs:
 
       - name: Clone SlicerLayerDM (pinned)
         if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true') &&
+          (github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true') &&
           steps.cache-layerdm.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
@@ -263,7 +256,7 @@ jobs:
 
       - name: Configure SlicerLayerDM
         if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true') &&
+          (github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true') &&
           steps.cache-layerdm.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
@@ -274,12 +267,12 @@ jobs:
 
       - name: Build SlicerLayerDM
         if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true') &&
+          (github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true') &&
           steps.cache-layerdm.outputs.cache-hit != 'true'
         run: cmake --build "${LAYERDM_BUILD}" --config Release -j "$(nproc)"
 
       - name: Configure
-        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
         run: |
           set -euo pipefail
           mkdir -p build
@@ -295,11 +288,11 @@ jobs:
             -DLayerDisplayableManager_DIR="${LAYERDM_BUILD}"
 
       - name: Build
-        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
         run: cmake --build build --config Release -j "$(nproc)"
 
       - name: Test (CTest)
-        if: github.event_name != 'pull_request' || steps.changes.outputs.non-docs == 'true'
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
         run: |
           set -euo pipefail
           cd build


### PR DESCRIPTION
## Summary

**Follow-up to #375 (merged 2026-05-18) — that fix did not work; smoke-tested + refuted.**

PR #375's negation-plus-`**` inversion in `dorny/paths-filter@v3` did not correctly skip the heavy `build-test` job on pure-docs PRs.  Empirical CI evidence (smoke-test PR #376, now closed, single-file diff `Docs/SMOKE.md` against #375's branch):

```
[added] Docs/SMOKE.md
Detected 1 changed files
Filter non-docs = true
Matching files:
Docs/SMOKE.md [added]
```

The `Report skip (docs-only PR)` step was skipped (its `if:` is `non-docs == 'false'`) and the heavy steps (`Verify Slicer build tree`, `Configure`, `Build`, `Test (CTest)`) all ran.

## Why the dorny shape can't work

`dorny/paths-filter@v3` ORs across patterns within a filter — a file matches the filter if ANY pattern matches it.  `picomatch('!*.md')('Docs/SMOKE.md')` is `true` because:

- `*.md` does not span `/`, so it matches only root-level `.md` files.
- `Docs/SMOKE.md` is NOT a root-level `.md` file, so it does NOT match `*.md`.
- A picomatch negation `!*.md` matches every file that does NOT match `*.md`.
- → `Docs/SMOKE.md` matches `!*.md` → the file matches the `non-docs` filter → filter returns `true` on a single-file pure-docs PR.

More fundamentally, dorny's `predicate-quantifier` supports only:

- `some` (default): filter true if at least one changed file matches any pattern.
- `every`: filter true if at least one file matches every pattern (i.e., "every pattern is touched").

Neither is "every file matches at least one pattern" — and that's the predicate the docs-only gate actually needs.

## Fix

Replace dorny with **`tj-actions/changed-files@v45`** which expresses the predicate natively via `files_ignore` + `any_changed`:

```yaml
- name: Detect non-docs change
  id: changes
  if: github.event_name == 'pull_request'
  uses: tj-actions/changed-files@v45
  with:
    files_ignore: |
      Docs/**
      *.md
      .github/pull_request_template.md
      .github/CODEOWNERS
      CITATION.cff
      License.txt
      COPYRIGHT.txt
      requirements-docs.txt
      .readthedocs.yaml
```

- `any_changed == 'true'`  ⇔  at least one changed file is OUTSIDE the ignore set → run heavy steps.
- `any_changed == 'false'` ⇔  every changed file is in the ignore set → skip heavy steps.

Step-level `if:` conditions flipped from `steps.changes.outputs.non-docs` to `steps.changes.outputs.any_changed` throughout the `build-test` job.  Ignore list is the same path set as #375.

## Self-skip caveat (unchanged)

This PR's own diff touches `ci.yml` (non-docs), so its own `build-test` cannot skip — that's correct and expected.  Future pure-docs PRs benefit, validated by their own organic CI runs.

## Smoke-test plan (after merge)

The next pure-docs PR that lands (e.g., the next ADR amendment or doc edit) will organically validate this fix.  Look for:

- `Detect non-docs change` step output: `any_changed: false`.
- `Report skip (docs-only PR)` step: runs and emits the notice.
- `Verify Slicer build tree`, `Configure`, `Build`, `Test (CTest)`: all show as `skipped`.
- Job total runtime: < 60 s (vs ~8 min today).

No standalone smoke-test PR — the fix surfaces organically on the next legitimate docs-only PR.

## Test plan

- [x] No source-code changes; only CI workflow edit.
- [x] No copyright check applies (ci.yml not gated).
- [x] CI: `build-test` runs on this PR (expected — ci.yml is non-docs).
- [ ] Next pure-docs PR after merge shows `any_changed: false` + heavy steps `skipped`.

## References

- PR #375 — predecessor (negation+`**` shape).  Merged but ineffective.
- PR #376 — closed smoke-test that surfaced the bug.
- PR #371 — earlier attempt (predicate-quantifier `every`).
- PR #368 — original attempt (separate-list, default `some`).
- PR #374 — first pure-docs PR; the canary that exposed the regression.
- ADR-0017 — Sphinx scaffold; introduced the docs-only filter requirement.
- `tj-actions/changed-files` README — `files_ignore` + `any_changed` semantics.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code.  Opened for human review after the empirical smoke-test refuted the #375 approach.*