### PR TITLE
BUG: Strip SlicerLayerDM build layer from CI (image now bakes it in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,14 +135,17 @@ jobs:
       # `QT_QPA_PLATFORM=offscreen` is Qt's official headless mode —
       # it renders to an in-memory surface, suitable for CTest.
       QT_QPA_PLATFORM: offscreen
-      # SlicerLayerDM build layer — built as a prerequisite of every
-      # Slicer-Liver build because LayerDM is now an unconditional
-      # EXTENSION_DEPENDS entry (per ADR-0002 / ADR-0013 §5).
-      # Pinned to a specific upstream commit so CI is reproducible;
-      # bump deliberately and document the bump in the commit message.
-      LAYERDM_SHA: 1689cc55d2deef1f1edd96f6dfa301683e47a469
-      LAYERDM_SRC: /tmp/SlicerLayerDisplayableManager
-      LAYERDM_BUILD: /tmp/SlicerLayerDisplayableManager-build
+      # SlicerLayerDM is pre-built into the slicer-build-ubuntu2404
+      # image as an EXTENSION_DEPENDS provider for Slicer-Liver
+      # (per ADR-0002 / ADR-0013 §5).  The image's Dockerfile pins
+      # LAYERDM_REVISION and exports SlicerLayerDisplayableManager_DIR
+      # pointing at /usr/src/SlicerLayerDM-build.  Slicer-Liver's
+      # find_package call uses the upstream extension's project() name
+      # (LayerDisplayableManager, NOT SlicerLayerDisplayableManager —
+      # see CMakeLists.txt comment on the EXTENSION_DEPENDS entry), so
+      # we re-bind the same build tree to that variable here.  Bumping
+      # the pin happens in the ALive-Docker repo + image rebuild.
+      LayerDisplayableManager_DIR: /usr/src/SlicerLayerDM-build
 
     steps:
       - name: Checkout
@@ -211,81 +214,26 @@ jobs:
           set -euo pipefail
           test -f "${Slicer_DIR}/SlicerConfig.cmake" \
             || { echo "::error::SlicerConfig.cmake missing at ${Slicer_DIR} — image layout has drifted"; exit 1; }
+          test -f "${LayerDisplayableManager_DIR}/LayerDisplayableManagerConfig.cmake" \
+            || { echo "::error::LayerDisplayableManagerConfig.cmake missing at ${LayerDisplayableManager_DIR} — image layout has drifted"; exit 1; }
           echo "Slicer_DIR=${Slicer_DIR}"
-          echo "LAYERDM_SHA=${LAYERDM_SHA}"
-
-      # -----------------------------------------------------------------
-      # SlicerLayerDM build layer.  LayerDM is an EXTENSION_DEPENDS entry
-      # of Slicer-Liver per ADR-0013 §5; the Slicer-Liver configure needs
-      # LayerDisplayableManager_DIR pointing at a built copy of the
-      # upstream extension (the upstream's ``project()`` and the exported
-      # ``*Config.cmake`` file are both named ``LayerDisplayableManager``,
-      # not ``SlicerLayerDisplayableManager``).  Cached on
-      # (runner OS, pinned SHA) so subsequent runs on the same pin skip
-      # the clone + build.
-      # -----------------------------------------------------------------
-      - name: Cache SlicerLayerDM source + build tree
-        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
-        id: cache-layerdm
-        uses: actions/cache@v4
-        with:
-          # Cache both the source AND the build tree.  The exported
-          # ``LayerDisplayableManagerConfig.cmake`` references absolute
-          # paths under the source dir (``${LAYERDM_SRC}/LayerDM/...``)
-          # for its imported targets' ``INTERFACE_INCLUDE_DIRECTORIES``;
-          # caching only the build dir leaves those paths dangling on
-          # a cache HIT and the downstream Slicer-Liver configure
-          # fails with "non-existent path" errors.
-          path: |
-            ${{ env.LAYERDM_SRC }}
-            ${{ env.LAYERDM_BUILD }}
-          key: layerdm-${{ runner.os }}-${{ env.LAYERDM_SHA }}-src-build
-
-      - name: Clone SlicerLayerDM (pinned)
-        if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true') &&
-          steps.cache-layerdm.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          rm -rf "${LAYERDM_SRC}"
-          git clone https://github.com/KitwareMedical/SlicerLayerDisplayableManager.git \
-            "${LAYERDM_SRC}"
-          cd "${LAYERDM_SRC}"
-          git checkout "${LAYERDM_SHA}"
-          echo "LayerDM HEAD: $(git rev-parse HEAD)"
-
-      - name: Configure SlicerLayerDM
-        if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true') &&
-          steps.cache-layerdm.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          mkdir -p "${LAYERDM_BUILD}"
-          cmake -S "${LAYERDM_SRC}" -B "${LAYERDM_BUILD}" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DSlicer_DIR="${Slicer_DIR}"
-
-      - name: Build SlicerLayerDM
-        if: |
-          (github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true') &&
-          steps.cache-layerdm.outputs.cache-hit != 'true'
-        run: cmake --build "${LAYERDM_BUILD}" --config Release -j "$(nproc)"
+          echo "LayerDisplayableManager_DIR=${LayerDisplayableManager_DIR}"
 
       - name: Configure
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
         run: |
           set -euo pipefail
           mkdir -p build
-          # Upstream SlicerLayerDM is a flat-layout extension: project()
-          # produces LayerDisplayableManagerConfig.cmake at the build root
-          # (not in a *-build subdirectory).  LayerDisplayableManager_DIR
-          # (matching the upstream ``project()`` name) is therefore
-          # LAYERDM_BUILD itself.
+          # LayerDisplayableManager_DIR is set in the job-level env: block
+          # and points at the pre-built tree baked into the
+          # slicer-build-ubuntu2404 image.  find_package(LayerDisplayableManager)
+          # in CMakeLists.txt picks it up automatically; we still pass it
+          # explicitly here for trace clarity in the CI log.
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING:BOOL=ON \
             -DSlicer_DIR="${Slicer_DIR}" \
-            -DLayerDisplayableManager_DIR="${LAYERDM_BUILD}"
+            -DLayerDisplayableManager_DIR="${LayerDisplayableManager_DIR}"
 
       - name: Build
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'


### PR DESCRIPTION
## Summary

ALive-Docker [PR #9](https://github.com/ALive-research/ALive-Docker/pull/9) (merged 2026-05-17) updated `slicer-build-ubuntu2404` to pre-build SlicerLayerDisplayableManager as an `EXTENSION_DEPENDS` provider.  The image now ships:

- `/usr/src/SlicerLayerDM-build/` — pre-built LayerDM tree with `LayerDisplayableManagerConfig.cmake` at its root.
- `ENV SlicerLayerDisplayableManager_DIR=/usr/src/SlicerLayerDM-build` in the image.

That makes the transitional Cache + Clone + Configure + Build SlicerLayerDM steps in this repo's CI redundant.  This PR strips them.

## What changed in `.github/workflows/ci.yml`

- Removed 4 steps: `Cache SlicerLayerDM source + build tree`, `Clone SlicerLayerDM (pinned)`, `Configure SlicerLayerDM`, `Build SlicerLayerDM`.
- Removed 3 env vars: `LAYERDM_SHA`, `LAYERDM_SRC`, `LAYERDM_BUILD`.
- Added 1 env var: `LayerDisplayableManager_DIR: /usr/src/SlicerLayerDM-build`.  Re-binds the image's pre-built tree to the variable name `find_package(LayerDisplayableManager)` actually consumes, since the upstream extension's `project()` is `LayerDisplayableManager` not `SlicerLayerDisplayableManager` (the image's exported var name follows the *repo* name; CMake needs the *project* name — see the comment in this repo's `CMakeLists.txt` on the EXTENSION_DEPENDS entry).
- Extended `Verify Slicer build tree` to assert `LayerDisplayableManagerConfig.cmake` is present at the image-provided path, so an image-layout drift fails fast with a clear error instead of surfacing as a confusing find_package failure deep in the Configure step.
- Preserved unchanged: the `Detect non-docs change` step (tj-actions/changed-files wiring from #377) and the `if: any_changed == 'true'` gates on the remaining heavy steps.

## Net effect

- CI runs are faster (~2-3 min saved per non-cache-hit run, no Slicer-side LayerDM rebuild).
- LayerDM pin bumps now flow through the ALive-Docker repo + image rebuild — single source of truth, removes the prior risk of two pins drifting out of sync.
- Slicer-Liver CI no longer reaches out to GitHub to clone an unrelated repo on every cold run.

## Test plan

- [x] `pre-commit run --files .github/workflows/ci.yml` (with `SKIP=prettier` for Guix-host env) — passes.
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` — parses clean.
- [ ] This PR's own `build-test (slicer-main, Linux)` run on `preview` base completes green end-to-end — the self-test for the image-provided LayerDM path.

---

*AI-assisted authorship: drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code.  Opened for human review.*