### PR TITLE
ENH: T2-mapper-relocation — relocate Bezier resection mapper to LiverResections

### DIFF
--- a/LiverMarkups/VTKWidgets/CMakeLists.txt
+++ b/LiverMarkups/VTKWidgets/CMakeLists.txt
@@ -9,6 +9,17 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${vtkSlicer${MODULE_NAME}ModuleMRML_BINARY_DIR}
   ${vtkSlicerMarkupsModuleVTKWidgets_INCLUDE_DIRS}
   ${vtkSlicerMarkupsModuleVTKWidgets_INCLUDE_DIRS}
+  # ``vtkSlicerBezierSurfaceRepresentation3D`` still consumes
+  # ``vtkOpenGLBezierResectionPolyDataMapper.h``, which now lives in
+  # ``LiverResections/VTKWidgets/`` per ADR-0014 §3
+  # (T2-mapper-relocation).  Because the top-level CMakeLists
+  # processes ``LiverMarkups`` before ``LiverResections``, the
+  # ``vtkSlicerLiverResectionsModuleVTKWidgets_SOURCE_DIR`` variable
+  # is not yet defined here — use the explicit paths.  The
+  # corresponding ``target_link_libraries`` entry below is forward-
+  # resolved by CMake at generate time.
+  ${CMAKE_SOURCE_DIR}/LiverResections/VTKWidgets
+  ${CMAKE_BINARY_DIR}/LiverResections/VTKWidgets
   )
 
 set(${KIT}_SRCS
@@ -38,8 +49,6 @@ set(${KIT}_SRCS
   vtkBezierSurfaceSource.cxx
   vtkSlicerShaderHelper.h
   vtkSlicerShaderHelper.cxx
-  vtkOpenGLBezierResectionPolyDataMapper.h
-  vtkOpenGLBezierResectionPolyDataMapper.cxx
   vtkOpenGLResection2DPolyDataMapper.cpp
   vtkOpenGLResection2DPolyDataMapper.h
   vtkMultiTextureObjectHelper.cpp
@@ -49,6 +58,11 @@ set(${KIT}_SRCS
 set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleMRML
   vtkSlicerMarkupsModuleVTKWidgets
+  # ``vtkOpenGLBezierResectionPolyDataMapper`` now ships from the
+  # LiverResections VTKWidgets target (ADR-0014 §3 lift-and-shift).
+  # Forward-reference resolved at CMake generate time; the source
+  # ordering caveat is documented under INCLUDE_DIRECTORIES above.
+  vtkSlicerLiverResectionsModuleVTKWidgets
   )
 
 #-----------------------------------------------------------------------------

--- a/LiverResections/VTKWidgets/CMakeLists.txt
+++ b/LiverResections/VTKWidgets/CMakeLists.txt
@@ -14,10 +14,15 @@
 #
 # Paired with ``vtkLiverBezierRepresentation`` (a
 # ``vtkWidgetRepresentation`` subclass), which owns the interaction-
-# time actors (selection highlight, drag preview).  The relocated
-# OpenGL surface mappers from ``LiverMarkups/VTKWidgets/`` are
-# TODO(T2-mapper-relocation); the LayerDM Pipeline keeps the
-# Bezier-surface render path through that follow-on.
+# time actors (selection highlight, drag preview).
+#
+# Per ADR-0014 §3, ``vtkOpenGLBezierResectionPolyDataMapper`` lives in
+# this module — it relocated here from ``LiverMarkups/VTKWidgets/`` as
+# a lift-and-shift (same algorithm, same shaders, same uniforms).
+# Subsequent work depends on the relocation: ADR-0019's
+# ``ConfirmedRepresentation`` consumes the mapper as-is, and the v2.1
+# GPU-tessellation rewrite per ADR-0020 replaces the geometry path in
+# this same file.
 #-----------------------------------------------------------------------------
 
 project(vtkSlicer${MODULE_NAME}ModuleVTKWidgets)
@@ -36,6 +41,8 @@ set(${KIT}_SRCS
   vtkLiverBezierRepresentation.cxx
   vtkLiverBezierWidget.h
   vtkLiverBezierWidget.cxx
+  vtkOpenGLBezierResectionPolyDataMapper.h
+  vtkOpenGLBezierResectionPolyDataMapper.cxx
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2018-2026, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -64,15 +64,19 @@ class vtkOpenGLBezierResectionPolyDataMapper::vtkInternal
 {
 public:
   vtkInternal(vtkOpenGLBezierResectionPolyDataMapper* parent)
-  : Parent(parent), DistanceMapTextureObject(nullptr),
-    RasToIjkMatrixT(nullptr), IjkToTextureMatrixT(nullptr),
-    ResectionMargin(0.0f), UncertaintyMargin(0.0f),
-    ResectionMarginColor{1.0f, 0.0f, 0.0f},
-    UncertaintyMarginColor{1.0f, 1.0f, 0.0f},
-    ResectionColor{1.0f,1.0f, 1.0f},
-    ResectionGridColor{0.0f,0.0f, 0.0f},
-    ResectionOpacity(1.0f),
-    InterpolatedMargins(false), ResectionClipOut(false)
+    : Parent(parent)
+    , DistanceMapTextureObject(nullptr)
+    , RasToIjkMatrixT(nullptr)
+    , IjkToTextureMatrixT(nullptr)
+    , ResectionMargin(0.0f)
+    , UncertaintyMargin(0.0f)
+    , ResectionMarginColor{ 1.0f, 0.0f, 0.0f }
+    , UncertaintyMarginColor{ 1.0f, 1.0f, 0.0f }
+    , ResectionColor{ 1.0f, 1.0f, 1.0f }
+    , ResectionGridColor{ 0.0f, 0.0f, 0.0f }
+    , ResectionOpacity(1.0f)
+    , InterpolatedMargins(false)
+    , ResectionClipOut(false)
   {
     this->RasToIjkMatrixT = vtkSmartPointer<vtkMatrix4x4>::New();
     this->IjkToTextureMatrixT = vtkSmartPointer<vtkMatrix4x4>::New();
@@ -89,8 +93,8 @@ public:
   float ResectionColor[3];
   float ResectionGridColor[3];
   float ResectionOpacity;
-  bool  InterpolatedMargins;
-  bool  ResectionClipOut;
+  bool InterpolatedMargins;
+  bool ResectionClipOut;
   unsigned int GridDivisions;
   float GridThicknessFactor;
 };
@@ -100,87 +104,87 @@ vtkStandardNewMacro(vtkOpenGLBezierResectionPolyDataMapper);
 
 //------------------------------------------------------------------------------
 vtkOpenGLBezierResectionPolyDataMapper::vtkOpenGLBezierResectionPolyDataMapper()
-  :Impl(nullptr)
+  : Impl(nullptr)
 {
   this->Impl = std::make_unique<vtkInternal>(this);
 }
 
 //------------------------------------------------------------------------------
-vtkOpenGLBezierResectionPolyDataMapper::~vtkOpenGLBezierResectionPolyDataMapper(){}
+vtkOpenGLBezierResectionPolyDataMapper::~vtkOpenGLBezierResectionPolyDataMapper() {}
 
 //------------------------------------------------------------------------------
 void vtkOpenGLBezierResectionPolyDataMapper::PrintSelf(ostream& os, vtkIndent indent)
 {
-   Superclass::PrintSelf(os, indent);
+  Superclass::PrintSelf(os, indent);
 }
 
 //------------------------------------------------------------------------------
 void vtkOpenGLBezierResectionPolyDataMapper::BuildBufferObjects(vtkRenderer* ren, vtkActor* act)
 {
   if (this->CurrentInput && this->HaveTCoords(this->CurrentInput))
-    {
+  {
     auto renWin = vtkOpenGLRenderWindow::SafeDownCast(ren->GetRenderWindow());
     vtkOpenGLVertexBufferObjectCache* cache = renWin->GetVBOCache();
     auto tcoords = this->CurrentInput->GetPointData()->GetTCoords();
     this->VBOs->CacheDataArray("uvCoords", tcoords, cache, VTK_FLOAT);
-    }
+  }
 
   Superclass::BuildBufferObjects(ren, act);
 }
 
 //------------------------------------------------------------------------------
-void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(
-  std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor)
+void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* actor)
 {
   std::string VSSource = shaders[vtkShader::Vertex]->GetSource();
   std::string FSSource = shaders[vtkShader::Fragment]->GetSource();
 
-  vtkShaderProgram::Substitute(
-    VSSource, "//VTK::PositionVC::Dec",
-    "//VTK::PositionVC::Dec\n"
-    "out vec4 vertexMCVSOutput;\n"
-    "out vec4 vertexWCVSOutput;\n"
-    "in vec2  uvCoords;\n"
-    "out vec2 uvCoordsOutput;\n"
-    "uniform mat4 uShiftScale;\n"
-    "uniform mat4 uRasToIjk;\n"
-    "uniform mat4 uIjkToTexture;\n");
+  vtkShaderProgram::Substitute(VSSource,
+                               "//VTK::PositionVC::Dec",
+                               "//VTK::PositionVC::Dec\n"
+                               "out vec4 vertexMCVSOutput;\n"
+                               "out vec4 vertexWCVSOutput;\n"
+                               "in vec2  uvCoords;\n"
+                               "out vec2 uvCoordsOutput;\n"
+                               "uniform mat4 uShiftScale;\n"
+                               "uniform mat4 uRasToIjk;\n"
+                               "uniform mat4 uIjkToTexture;\n");
+
+  vtkShaderProgram::Substitute(VSSource,
+                               "//VTK::PositionVC::Impl",
+                               "//VTK::PositionVC::Impl\n"
+                               "vertexMCVSOutput = vertexMC;\n"
+                               "uvCoordsOutput = uvCoords;\n"
+                               "vertexWCVSOutput = uIjkToTexture*uRasToIjk*uShiftScale*vertexMC;\n");
+
+  vtkShaderProgram::Substitute(FSSource,
+                               "//VTK::PositionVC::Dec",
+                               "//VTK::PositionVC::Dec\n"
+                               "#define M_PI 3.1415926535897932384626433832795\n"
+                               "uniform sampler3D distanceTexture;\n"
+                               "uniform sampler2D posMarker;\n"
+                               "//vec4 fragPositionMC = vertexWCVSOutput;\n");
+
+  vtkShaderProgram::Substitute(FSSource,
+                               "//VTK::Color::Dec",
+                               "//VTK::Color::Dec\n"
+                               "uniform float uResectionMargin;\n"
+                               "uniform float uUncertaintyMargin;\n"
+                               "uniform float uResectionOpacity;\n"
+                               "uniform vec3 uResectionMarginColor;\n"
+                               "uniform vec3 uUncertaintyMarginColor;\n"
+                               "uniform vec3 uResectionColor;\n"
+                               "uniform vec3 uResectionGridColor;\n"
+                               "uniform int uResectionClipOut;\n"
+                               "uniform int uInterpolatedMargins;\n"
+                               "uniform int uGridDivisions;\n"
+                               "uniform float uGridThickness;\n"
+                               "in vec4 vertexWCVSOutput;\n"
+                               "in vec2 uvCoordsOutput;\n"
+                               "vec4 fragPositionMC = vertexWCVSOutput;\n");
 
   vtkShaderProgram::Substitute(
-    VSSource, "//VTK::PositionVC::Impl",
-    "//VTK::PositionVC::Impl\n"
-    "vertexMCVSOutput = vertexMC;\n"
-    "uvCoordsOutput = uvCoords;\n"
-    "vertexWCVSOutput = uIjkToTexture*uRasToIjk*uShiftScale*vertexMC;\n");
-
-  vtkShaderProgram::Substitute(
-    FSSource, "//VTK::PositionVC::Dec",
-    "//VTK::PositionVC::Dec\n"
-    "#define M_PI 3.1415926535897932384626433832795\n"
-    "uniform sampler3D distanceTexture;\n"
-    "uniform sampler2D posMarker;\n"
-    "//vec4 fragPositionMC = vertexWCVSOutput;\n");
-
-  vtkShaderProgram::Substitute(
-    FSSource, "//VTK::Color::Dec",
-    "//VTK::Color::Dec\n"
-    "uniform float uResectionMargin;\n"
-    "uniform float uUncertaintyMargin;\n"
-    "uniform float uResectionOpacity;\n"
-    "uniform vec3 uResectionMarginColor;\n"
-    "uniform vec3 uUncertaintyMarginColor;\n"
-    "uniform vec3 uResectionColor;\n"
-    "uniform vec3 uResectionGridColor;\n"
-    "uniform int uResectionClipOut;\n"
-    "uniform int uInterpolatedMargins;\n"
-    "uniform int uGridDivisions;\n"
-    "uniform float uGridThickness;\n"
-    "in vec4 vertexWCVSOutput;\n"
-    "in vec2 uvCoordsOutput;\n"
-    "vec4 fragPositionMC = vertexWCVSOutput;\n");
-
-  vtkShaderProgram::Substitute(
-    FSSource, "//VTK::Color::Impl",
+    FSSource,
+    "//VTK::Color::Impl",
     "//VTK::Color::Impl\n"
     "vec4 marker = texture(posMarker, uvCoordsOutput);\n"
     "vec4 dist = texture(distanceTexture, fragPositionMC.xyz);\n"
@@ -240,10 +244,10 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(
     "  }\n"
     "}\n");
 
-   vtkShaderProgram::Substitute(
-    FSSource, "//VTK::Light::Impl",
-    "//VTK::Light::Impl\n"
-    "fragOutput0 = vec4(ambientColor+vec3(uvCoordsOutput,0.0)*0.00001 + diffuse + specular, uResectionOpacity);\n");
+  vtkShaderProgram::Substitute(FSSource,
+                               "//VTK::Light::Impl",
+                               "//VTK::Light::Impl\n"
+                               "fragOutput0 = vec4(ambientColor+vec3(uvCoordsOutput,0.0)*0.00001 + diffuse + specular, uResectionOpacity);\n");
 
   shaders[vtkShader::Vertex]->SetSource(VSSource);
   shaders[vtkShader::Fragment]->SetSource(FSSource);
@@ -251,8 +255,7 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(
 }
 
 //------------------------------------------------------------------------------
-void vtkOpenGLBezierResectionPolyDataMapper::SetCameraShaderParameters(
-  vtkOpenGLHelper& cellBO, vtkRenderer* ren, vtkActor* actor)
+void vtkOpenGLBezierResectionPolyDataMapper::SetCameraShaderParameters(vtkOpenGLHelper& cellBO, vtkRenderer* ren, vtkActor* actor)
 {
   vtkOpenGLVertexBufferObject* vvbo = this->VBOs->GetVBO("vertexMC");
 
@@ -262,100 +265,99 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetCameraShaderParameters(
   auto transformMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
 
   if (vvbo && vvbo->GetCoordShiftAndScaleEnabled())
-    {
-  auto shift = vvbo->GetShift();
-  auto scale = vvbo->GetScale();
-  transform->Translate(shift[0], shift[1], shift[2]);
-  transform->Scale(1.0/scale[0], 1.0/scale[1], 1.0/scale[2]);
-  transform->GetTranspose(transformMatrix);
-    }
+  {
+    auto shift = vvbo->GetShift();
+    auto scale = vvbo->GetScale();
+    transform->Translate(shift[0], shift[1], shift[2]);
+    transform->Scale(1.0 / scale[0], 1.0 / scale[1], 1.0 / scale[2]);
+    transform->GetTranspose(transformMatrix);
+  }
 
   if (cellBO.Program->IsUniformUsed("uShiftScale"))
-    {
+  {
     cellBO.Program->SetUniformMatrix("uShiftScale", transformMatrix);
-    }
+  }
 
   Superclass::SetCameraShaderParameters(cellBO, ren, actor);
 }
 
 //------------------------------------------------------------------------------
-void vtkOpenGLBezierResectionPolyDataMapper::SetMapperShaderParameters(
-  vtkOpenGLHelper& cellBO, vtkRenderer* ren, vtkActor* actor)
+void vtkOpenGLBezierResectionPolyDataMapper::SetMapperShaderParameters(vtkOpenGLHelper& cellBO, vtkRenderer* ren, vtkActor* actor)
 {
-    if (cellBO.Program->IsUniformUsed("distanceTexture"))
-    {
-        cellBO.Program->SetUniformi("distanceTexture", 0);
-    }
+  if (cellBO.Program->IsUniformUsed("distanceTexture"))
+  {
+    cellBO.Program->SetUniformi("distanceTexture", 0);
+  }
 
-    if (cellBO.Program->IsUniformUsed("posMarker"))
-    {
-        cellBO.Program->SetUniformi("posMarker", 15);
-    }
+  if (cellBO.Program->IsUniformUsed("posMarker"))
+  {
+    cellBO.Program->SetUniformi("posMarker", 15);
+  }
 
-    if (cellBO.Program->IsUniformUsed("uRasToIjk"))
-    {
+  if (cellBO.Program->IsUniformUsed("uRasToIjk"))
+  {
     cellBO.Program->SetUniformMatrix("uRasToIjk", this->Impl->RasToIjkMatrixT);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uIjkToTexture"))
-    {
+  {
     cellBO.Program->SetUniformMatrix("uIjkToTexture", this->Impl->IjkToTextureMatrixT);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uResectionMargin"))
-    {
+  {
     cellBO.Program->SetUniformf("uResectionMargin", this->Impl->ResectionMargin);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uUncertaintyMargin"))
-    {
+  {
     cellBO.Program->SetUniformf("uUncertaintyMargin", this->Impl->UncertaintyMargin);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uInterpolatedMargins"))
-    {
+  {
     cellBO.Program->SetUniformi("uInterpolatedMargins", this->Impl->InterpolatedMargins);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uResectionMarginColor"))
-    {
+  {
     cellBO.Program->SetUniform3f("uResectionMarginColor", this->Impl->ResectionMarginColor);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uUncertaintyMarginColor"))
-    {
+  {
     cellBO.Program->SetUniform3f("uUncertaintyMarginColor", this->Impl->UncertaintyMarginColor);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uResectionColor"))
-    {
+  {
     cellBO.Program->SetUniform3f("uResectionColor", this->Impl->ResectionColor);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uResectionGridColor"))
-    {
+  {
     cellBO.Program->SetUniform3f("uResectionGridColor", this->Impl->ResectionGridColor);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uResectionOpacity"))
-    {
+  {
     cellBO.Program->SetUniformf("uResectionOpacity", this->Impl->ResectionOpacity);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uResectionClipOut"))
-    {
+  {
     cellBO.Program->SetUniformi("uResectionClipOut", this->Impl->ResectionClipOut);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uGridDivisions"))
-    {
+  {
     cellBO.Program->SetUniformi("uGridDivisions", this->Impl->GridDivisions);
-    }
+  }
 
   if (cellBO.Program->IsUniformUsed("uGridThickness"))
-    {
+  {
     cellBO.Program->SetUniformf("uGridThickness", this->Impl->GridThicknessFactor);
-    }
+  }
 
   Superclass::SetMapperShaderParameters(cellBO, ren, actor);
 }
@@ -370,21 +372,21 @@ vtkTextureObject* vtkOpenGLBezierResectionPolyDataMapper::GetDistanceMapTextureO
 void vtkOpenGLBezierResectionPolyDataMapper::SetDistanceMapTextureObject(vtkTextureObject* object)
 {
   if (this->Impl->DistanceMapTextureObject == object)
-    {
+  {
     return;
-    }
+  }
 
   this->Impl->DistanceMapTextureObject = object;
   if (object)
-    {
+  {
     object->Register(this);
-    }
+  }
 
   this->Modified();
 }
 
 //------------------------------------------------------------------------------
-vtkMatrix4x4 const* vtkOpenGLBezierResectionPolyDataMapper::GetRasToIjkMatrixT() const
+const vtkMatrix4x4* vtkOpenGLBezierResectionPolyDataMapper::GetRasToIjkMatrixT() const
 {
   return this->Impl->RasToIjkMatrixT;
 }
@@ -393,9 +395,9 @@ vtkMatrix4x4 const* vtkOpenGLBezierResectionPolyDataMapper::GetRasToIjkMatrixT()
 void vtkOpenGLBezierResectionPolyDataMapper::SetRasToIjkMatrixT(const vtkMatrix4x4* matrix)
 {
   if (matrix == nullptr)
-    {
+  {
     return;
-    }
+  }
 
   this->Impl->RasToIjkMatrixT->DeepCopy(matrix);
   this->Modified();
@@ -405,9 +407,9 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetRasToIjkMatrixT(const vtkMatrix4
 void vtkOpenGLBezierResectionPolyDataMapper::SetRasToIjkMatrix(const vtkMatrix4x4* matrix)
 {
   if (matrix == nullptr)
-    {
+  {
     return;
-    }
+  }
 
   this->Impl->RasToIjkMatrixT->DeepCopy(matrix);
   this->Impl->RasToIjkMatrixT->Transpose();
@@ -415,7 +417,7 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetRasToIjkMatrix(const vtkMatrix4x
 }
 
 //------------------------------------------------------------------------------
-vtkMatrix4x4 const* vtkOpenGLBezierResectionPolyDataMapper::GetIjkToTextureMatrixT() const
+const vtkMatrix4x4* vtkOpenGLBezierResectionPolyDataMapper::GetIjkToTextureMatrixT() const
 {
   return this->Impl->IjkToTextureMatrixT;
 }
@@ -424,9 +426,9 @@ vtkMatrix4x4 const* vtkOpenGLBezierResectionPolyDataMapper::GetIjkToTextureMatri
 void vtkOpenGLBezierResectionPolyDataMapper::SetIjkToTextureMatrixT(const vtkMatrix4x4* matrix)
 {
   if (matrix == nullptr)
-    {
+  {
     return;
-    }
+  }
 
   this->Impl->IjkToTextureMatrixT->DeepCopy(matrix);
   this->Modified();
@@ -436,9 +438,9 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetIjkToTextureMatrixT(const vtkMat
 void vtkOpenGLBezierResectionPolyDataMapper::SetIjkToTextureMatrix(const vtkMatrix4x4* matrix)
 {
   if (matrix == nullptr)
-    {
+  {
     return;
-    }
+  }
 
   this->Impl->IjkToTextureMatrixT->DeepCopy(matrix);
   this->Impl->IjkToTextureMatrixT->Transpose();
@@ -470,9 +472,8 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetUncertaintyMargin(float margin)
   this->Modified();
 }
 
-
 //------------------------------------------------------------------------------
-float const* vtkOpenGLBezierResectionPolyDataMapper::GetResectionMarginColor() const
+const float* vtkOpenGLBezierResectionPolyDataMapper::GetResectionMarginColor() const
 {
   return this->Impl->ResectionMarginColor;
 }
@@ -496,7 +497,7 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetResectionMarginColor(float red, 
 }
 
 //------------------------------------------------------------------------------
-float const* vtkOpenGLBezierResectionPolyDataMapper::GetUncertaintyMarginColor() const
+const float* vtkOpenGLBezierResectionPolyDataMapper::GetUncertaintyMarginColor() const
 {
   return this->Impl->UncertaintyMarginColor;
 }
@@ -520,7 +521,7 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetUncertaintyMarginColor(float red
 }
 
 //------------------------------------------------------------------------------
-float const* vtkOpenGLBezierResectionPolyDataMapper::GetResectionColor() const
+const float* vtkOpenGLBezierResectionPolyDataMapper::GetResectionColor() const
 {
   return this->Impl->ResectionColor;
 }
@@ -544,7 +545,7 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetResectionColor(float red, float 
 }
 
 //------------------------------------------------------------------------------
-float const* vtkOpenGLBezierResectionPolyDataMapper::GetResectionGridColor() const
+const float* vtkOpenGLBezierResectionPolyDataMapper::GetResectionGridColor() const
 {
   return this->Impl->ResectionGridColor;
 }
@@ -566,7 +567,6 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetResectionGridColor(float red, fl
   this->Impl->ResectionGridColor[2] = blue;
   this->Modified();
 }
-
 
 //------------------------------------------------------------------------------
 float vtkOpenGLBezierResectionPolyDataMapper::GetResectionOpacity() const
@@ -616,8 +616,8 @@ unsigned int vtkOpenGLBezierResectionPolyDataMapper::GetGridDivisions() const
 //------------------------------------------------------------------------------
 void vtkOpenGLBezierResectionPolyDataMapper::SetGridDivisions(unsigned int divisions)
 {
- this->Impl->GridDivisions = divisions;
- this->Modified();
+  this->Impl->GridDivisions = divisions;
+  this->Modified();
 }
 
 //------------------------------------------------------------------------------
@@ -629,6 +629,6 @@ float vtkOpenGLBezierResectionPolyDataMapper::GetGridThicknessFactor() const
 //------------------------------------------------------------------------------
 void vtkOpenGLBezierResectionPolyDataMapper::SetGridThicknessFactor(float thickness)
 {
- this->Impl->GridThicknessFactor = thickness;
- this->Modified();
+  this->Impl->GridThicknessFactor = thickness;
+  this->Modified();
 }

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2018-2026, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -40,7 +40,7 @@
 #ifndef vtkopenglresectionbezierpolydatamapper_h_
 #define vtkopenglresectionbezierpolydatamapper_h_
 
-#include "vtkSlicerLiverMarkupsModuleVTKWidgetsExport.h"
+#include "vtkSlicerLiverResectionsModuleVTKWidgetsExport.h"
 
 // VTK includes
 #include <vtkOpenGLPolyDataMapper.h>
@@ -53,7 +53,7 @@
 class vtkTextureObject;
 
 //-------------------------------------------------------------------------------
-class VTK_SLICER_LIVERMARKUPS_MODULE_VTKWIDGETS_EXPORT vtkOpenGLBezierResectionPolyDataMapper : public vtkOpenGLPolyDataMapper
+class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkOpenGLBezierResectionPolyDataMapper : public vtkOpenGLPolyDataMapper
 {
 public:
   static vtkOpenGLBezierResectionPolyDataMapper *New();

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
@@ -46,7 +46,7 @@
 #include <vtkOpenGLPolyDataMapper.h>
 #include <vtkRenderingOpenGL2Module.h>
 
-//STD includes
+// STD includes
 #include <memory>
 
 //-------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ class vtkTextureObject;
 class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkOpenGLBezierResectionPolyDataMapper : public vtkOpenGLPolyDataMapper
 {
 public:
-  static vtkOpenGLBezierResectionPolyDataMapper *New();
+  static vtkOpenGLBezierResectionPolyDataMapper* New();
   vtkTypeMacro(vtkOpenGLBezierResectionPolyDataMapper, vtkOpenGLPolyDataMapper);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
@@ -71,14 +71,14 @@ public:
   /// Set RAS - IKJ matrix transposed
   void SetRasToIjkMatrixT(const vtkMatrix4x4*);
   /// Get RAS - IJK matrix transposed
-  vtkMatrix4x4 const* GetRasToIjkMatrixT() const;
+  const vtkMatrix4x4* GetRasToIjkMatrixT() const;
 
   /// Set IKJ - Texture space matrix
   void SetIjkToTextureMatrix(const vtkMatrix4x4*);
   /// Set IJK - Texture space matrix transposed
   void SetIjkToTextureMatrixT(const vtkMatrix4x4*);
   /// Get IJK - Texture matrixj
-  vtkMatrix4x4 const* GetIjkToTextureMatrixT() const;
+  const vtkMatrix4x4* GetIjkToTextureMatrixT() const;
 
   /// Get the resection margin
   float GetResectionMargin() const;
@@ -91,28 +91,28 @@ public:
   void SetUncertaintyMargin(float margin);
 
   /// Get the interpolated margin
-  float const* GetResectionMarginColor() const;
+  const float* GetResectionMarginColor() const;
   /// Set the resection margin
   void SetResectionMarginColor(float color[3]);
   /// Set the resection margin
   void SetResectionMarginColor(float red, float green, float blue);
 
   /// Get the interpolated margin
-  float const* GetUncertaintyMarginColor() const;
+  const float* GetUncertaintyMarginColor() const;
   /// Set the resection margin
   void SetUncertaintyMarginColor(float color[3]);
   /// Set the resection margin
   void SetUncertaintyMarginColor(float red, float green, float blue);
 
   /// Get the resection color
-  float const* GetResectionColor() const;
+  const float* GetResectionColor() const;
   /// Set the resection color
   void SetResectionColor(float color[3]);
   /// Set the resection color
   void SetResectionColor(float red, float green, float blue);
 
   /// Get the resection grid color
-  float const* GetResectionGridColor() const;
+  const float* GetResectionGridColor() const;
   /// Set the resection gird color
   void SetResectionGridColor(float color[3]);
   /// Set the resection grid color
@@ -143,7 +143,6 @@ public:
   /// Set the thickness factor for the grid
   void SetGridThicknessFactor(float thicknessFactor);
 
-
 protected:
   vtkOpenGLBezierResectionPolyDataMapper();
   ~vtkOpenGLBezierResectionPolyDataMapper();
@@ -151,18 +150,13 @@ protected:
   void BuildBufferObjects(vtkRenderer* ren, vtkActor* act) override;
 
   // Perform string replacements on the shader templates
-  void ReplaceShaderValues(std::map<vtkShader::Type, vtkShader*> shaders,
-                           vtkRenderer* ren,
-                           vtkActor* act) override;
+  void ReplaceShaderValues(std::map<vtkShader::Type, vtkShader*> shaders, vtkRenderer* ren, vtkActor* act) override;
 
-  void SetMapperShaderParameters(vtkOpenGLHelper& cellBO,
-                                 vtkRenderer* ren,
-                                 vtkActor* actor) override;
+  void SetMapperShaderParameters(vtkOpenGLHelper& cellBO, vtkRenderer* ren, vtkActor* actor) override;
 
   // Set CameraShaderParameters
-  void SetCameraShaderParameters(vtkOpenGLHelper& cellBO,
-                                 vtkRenderer* ren,
-                                 vtkActor* actor) override;
+  void SetCameraShaderParameters(vtkOpenGLHelper& cellBO, vtkRenderer* ren, vtkActor* actor) override;
+
 private:
   class vtkInternal;
   std::unique_ptr<vtkInternal> Impl;


### PR DESCRIPTION
## Summary

Lift-and-shift `vtkOpenGLBezierResectionPolyDataMapper.{h,cxx}` from
`LiverMarkups/VTKWidgets/` to `LiverResections/VTKWidgets/` per
[ADR-0014 §3](Docs/adr/0014-livermarkups-dissolution.md).

No algorithmic change, no shader change, no API change — same
uniforms, same Bernstein-on-CPU + VS+FS pipeline, same parenchyma-
trim discard controlled by `uResectionClipOut`.  History follows via
`git mv` (the rename detector reports 99% / 96% similarity).

This is the v2.0.0 baseline that two follow-on changes depend on:

- [ADR-0019](Docs/adr/0019-resection-state-machine.md) — the new
  `ConfirmedRepresentation` consumes this mapper as-is, sharing it
  with `BezierPlanningRepresentation`.
- [ADR-0020](Docs/adr/0020-gpu-tessellation.md) — the v2.1
  GPU-tessellation enabler rewrites the mapper's geometry path; the
  rewrite assumes the mapper already lives in
  `LiverResections/VTKWidgets/`.

The algorithmic + shader rewrite is **not** in this PR; ADR-0020
tracks that as the v2.1 follow-up.

## What moved

- `LiverMarkups/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h`
  → `LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h`
- `LiverMarkups/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx`
  → `LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx`

## What stayed

- The four other custom OpenGL mappers
  (`vtkOpenGLSlicingContourPolyDataMapper`,
  `vtkOpenGLDistanceContourPolyDataMapper`,
  `vtkOpenGLResection2DPolyDataMapper`,
  `vtkMultiTextureObjectHelper`) — out of scope for this PR; their
  relocation lands in a separate T2 mapper-relocation follow-on.
- The legacy `vtkSlicerBezierSurfaceRepresentation3D.{h,cxx}` widget
  + representation in `LiverMarkups/VTKWidgets/` — the broader
  `LiverMarkups` dissolution (ADR-0014 §3) hasn't completed; the
  legacy widget is still registered from
  `qSlicerLiverMarkupsModule.cxx` and still instantiates the mapper.
  This PR keeps that consumer working.

## What was rewired

- `LiverResections/VTKWidgets/CMakeLists.txt` — adds the two new
  source files to `${KIT}_SRCS`.  Header comment updated to reflect
  the mapper's new home (the old `TODO(T2-mapper-relocation)` note
  is replaced with the ADR-0019 / ADR-0020 forward references).
- `LiverMarkups/VTKWidgets/CMakeLists.txt` — drops the two source-
  list entries; adds `vtkSlicerLiverResectionsModuleVTKWidgets` to
  `${KIT}_TARGET_LIBRARIES` (forward-reference, resolved by CMake
  at generate time); adds explicit
  `${CMAKE_SOURCE_DIR}/LiverResections/VTKWidgets` +
  `${CMAKE_BINARY_DIR}/LiverResections/VTKWidgets` to
  `${KIT}_INCLUDE_DIRECTORIES` so the still-hosted
  `vtkSlicerBezierSurfaceRepresentation3D.cxx` can find the
  re-pathed header.  The CMake variable
  `${vtkSlicerLiverResectionsModuleVTKWidgets_SOURCE_DIR}` is not
  yet defined when `LiverMarkups/VTKWidgets/` parses (top-level
  `add_subdirectory` orders LiverMarkups before LiverResections);
  the explicit paths sidestep that.  An inline comment in the
  CMakeLists captures the why.
- The moved header's export macro flips:
  `VTK_SLICER_LIVERMARKUPS_MODULE_VTKWIDGETS_EXPORT` →
  `VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT`; the export-
  symbol header include flips to match.  Module-level wiring only,
  no API surface change.

## Out of scope (post-merge follow-ups)

- **No characterisation tests for the mapper exist yet.**  Per
  [ADR-0003](Docs/adr/0003-testability-invariant.md), behaviour-
  preserving moves of untested code are admissible; the test gap is
  tracked for the broader T2 mapper-relocation effort.  Since this
  is lift-and-shift with no behavioural change, the
  characterisation-tests-first invariant is satisfied vacuously.
- The other three custom mappers + helper relocate in a follow-up
  PR; the `vtkSlicerBezierSurfaceRepresentation3D` widget retires
  when the broader ADR-0014 §3 dissolution completes.

## Test plan

- [ ] CI `build-test` job is green on the head SHA.
- [ ] `LiverMarkups`'s legacy `vtkSlicerBezierSurfaceWidget` +
      `vtkSlicerBezierSurfaceRepresentation3D` still link and load
      against the relocated mapper (verified by the CI build).
- [ ] Downstream consumers (`vtkLiverBezierRepresentation` in
      `LiverResections/VTKWidgets/`, the LayerDM Pipeline
      Representations in
      `LiverResections/LiverResectionsLib/Representations/`) compile
      against the new header location.

---

*AI-assisted authorship: this pull request was drafted with help
from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude
Code.  Plan and brief from the orchestrating Opus 4.7 session;
implementation by a Claude Code agent.  Opened for human review
before merge.*