### PR TITLE
BUG: Fix latent ref leak + UB in legacy Bezier mapper + drop dead posMarker code

### DIFF
--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -56,7 +56,6 @@
 #include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
 #include <vtkShaderProgram.h>
-#include <vtkTextureObject.h>
 #include <vtkTransform.h>
 
 //------------------------------------------------------------------------------
@@ -65,7 +64,6 @@ class vtkOpenGLBezierResectionPolyDataMapper::vtkInternal
 public:
   vtkInternal(vtkOpenGLBezierResectionPolyDataMapper* parent)
     : Parent(parent)
-    , DistanceMapTextureObject(nullptr)
     , RasToIjkMatrixT(nullptr)
     , IjkToTextureMatrixT(nullptr)
     , ResectionMargin(0.0f)
@@ -77,13 +75,14 @@ public:
     , ResectionOpacity(1.0f)
     , InterpolatedMargins(false)
     , ResectionClipOut(false)
+    , GridDivisions(20)
+    , GridThicknessFactor(9.5f)
   {
     this->RasToIjkMatrixT = vtkSmartPointer<vtkMatrix4x4>::New();
     this->IjkToTextureMatrixT = vtkSmartPointer<vtkMatrix4x4>::New();
   }
 
   vtkWeakPointer<vtkOpenGLBezierResectionPolyDataMapper> Parent;
-  vtkSmartPointer<vtkTextureObject> DistanceMapTextureObject;
   vtkSmartPointer<vtkMatrix4x4> RasToIjkMatrixT;
   vtkSmartPointer<vtkMatrix4x4> IjkToTextureMatrixT;
   float ResectionMargin;
@@ -161,7 +160,6 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(std::map<vtkSha
                                "//VTK::PositionVC::Dec\n"
                                "#define M_PI 3.1415926535897932384626433832795\n"
                                "uniform sampler3D distanceTexture;\n"
-                               "uniform sampler2D posMarker;\n"
                                "//vec4 fragPositionMC = vertexWCVSOutput;\n");
 
   vtkShaderProgram::Substitute(FSSource,
@@ -186,7 +184,6 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(std::map<vtkSha
     FSSource,
     "//VTK::Color::Impl",
     "//VTK::Color::Impl\n"
-    "vec4 marker = texture(posMarker, uvCoordsOutput);\n"
     "vec4 dist = texture(distanceTexture, fragPositionMC.xyz);\n"
     "float lowMargin = uResectionMargin - uUncertaintyMargin;\n"
     "float highMargin = uResectionMargin + uUncertaintyMargin;\n"
@@ -289,11 +286,6 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetMapperShaderParameters(vtkOpenGL
     cellBO.Program->SetUniformi("distanceTexture", 0);
   }
 
-  if (cellBO.Program->IsUniformUsed("posMarker"))
-  {
-    cellBO.Program->SetUniformi("posMarker", 15);
-  }
-
   if (cellBO.Program->IsUniformUsed("uRasToIjk"))
   {
     cellBO.Program->SetUniformMatrix("uRasToIjk", this->Impl->RasToIjkMatrixT);
@@ -360,29 +352,6 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetMapperShaderParameters(vtkOpenGL
   }
 
   Superclass::SetMapperShaderParameters(cellBO, ren, actor);
-}
-
-//------------------------------------------------------------------------------
-vtkTextureObject* vtkOpenGLBezierResectionPolyDataMapper::GetDistanceMapTextureObject() const
-{
-  return this->Impl->DistanceMapTextureObject;
-}
-
-//------------------------------------------------------------------------------
-void vtkOpenGLBezierResectionPolyDataMapper::SetDistanceMapTextureObject(vtkTextureObject* object)
-{
-  if (this->Impl->DistanceMapTextureObject == object)
-  {
-    return;
-  }
-
-  this->Impl->DistanceMapTextureObject = object;
-  if (object)
-  {
-    object->Register(this);
-  }
-
-  this->Modified();
 }
 
 //------------------------------------------------------------------------------

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
@@ -50,21 +50,12 @@
 #include <memory>
 
 //-------------------------------------------------------------------------------
-class vtkTextureObject;
-
-//-------------------------------------------------------------------------------
 class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkOpenGLBezierResectionPolyDataMapper : public vtkOpenGLPolyDataMapper
 {
 public:
   static vtkOpenGLBezierResectionPolyDataMapper* New();
   vtkTypeMacro(vtkOpenGLBezierResectionPolyDataMapper, vtkOpenGLPolyDataMapper);
   void PrintSelf(ostream& os, vtkIndent indent) override;
-
-  /// Get distance map
-  vtkTextureObject* GetDistanceMapTextureObject() const;
-
-  /// Set distance map
-  void SetDistanceMapTextureObject(vtkTextureObject* node);
 
   /// Set RAS - IKJ matrix
   void SetRasToIjkMatrix(const vtkMatrix4x4*);


### PR DESCRIPTION
## Summary

Follow-up B to PR #379 (T2-mapper-relocation, merged 2026-05-18).  Four
surgical fixes to `vtkOpenGLBezierResectionPolyDataMapper`, informed
by a follow-up review of the relocated mapper.

- Closes a latent ref leak in `SetDistanceMapTextureObject` and an
  uninitialised-read UB in the `vtkInternal` ctor.
- Drops two pieces of dead code: the orphaned `posMarker` sampler
  (orphaned by 2023-03-06 commit `b6dbd4a`) and the unused public
  `Set/GetDistanceMapTextureObject` API.
- Scope deliberately narrow — the class is slated for replacement
  by the v2.1 GPU-tessellation rewrite per
  [ADR-0020](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0020-gpu-tessellation.md)
  §"Rollout plan", so this PR is correctness + dead-code only, no
  modernisation.

## Per-change detail

### 1. Ref leak in `SetDistanceMapTextureObject`

The setter did a `vtkSmartPointer` assignment AND an explicit
`object->Register(this)`.  The smart pointer already holds the
reference; the manual `Register` added a second one with no matching
`UnRegister`.  Each setter call leaked one refcount on the texture
object.

Fix: drop the `Register(this)` call; let the `vtkSmartPointer`
member own the lifetime.

### 2. UB in `vtkInternal` ctor

`GridDivisions` (`unsigned int`) and `GridThicknessFactor` (`float`)
were not initialised by the ctor's member-initialiser list.  Reading
them before the consumer's first push to `SetGridDivisions` /
`SetGridThicknessFactor` was undefined behaviour; the shader could
sample garbage on the first frame.

Fix: initialise to `GridDivisions = 20`, `GridThicknessFactor = 9.5f`.
The `9.5f` choice is intentional — close to the shader's
`10.0 - thickness` discriminator, so the grid is faint-but-present
rather than blown out.  In practice
`vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay`
overwrites both before the first frame is drawn, so the bug was
unobservable in production — but the UB is now closed.

### 3. Drop dead `posMarker` sampler

Commit `b6dbd4a` (2023-03-06, *"ENH: Generating orientation marker
style directly from shader"*) replaced the texture-based orientation
marker with the procedural corner stripes that still ship today.
Three stranded references survived:

- `"uniform sampler2D posMarker;"` in the vertex-shader Dec.
- `"vec4 marker = texture(posMarker, uvCoordsOutput);"` in the
  fragment-shader Impl, into a `marker` var that's never read.
- `IsUniformUsed("posMarker")` + `SetUniformi("posMarker", 15)`
  binding in `SetMapperShaderParameters`.

No code anywhere writes to texture unit 15.  All three are removed.
The procedural corner colour markers in the fragment shader's
`corner stripe` block stay untouched — those are the current
orientation-marker implementation (separate review tracked in issue
#380).

### 4. Drop dead `Set/GetDistanceMapTextureObject` public API

Repo-wide grep confirms zero callers of either setter or getter.
The distance map is wired through
`vtkMultiTextureObjectHelper::CreateSeq3DFromRaw(..., texSeq=0)` in
`vtkSlicerBezierSurfaceRepresentation3D::CreateAndTransferDistanceMapTexture`,
bypassing this mapper's named setter entirely.  (The only sibling
matches in grep are the unrelated `vtkOpenGLResection2DPolyDataMapper`
class which has its own implementation.)

Removed:

- The `Set/GetDistanceMapTextureObject` declarations from the header.
- The setter/getter definitions from the `.cxx`.
- The `DistanceMapTextureObject` member from `vtkInternal`.
- The now-unused `vtkTextureObject` forward declaration + include.

## Test plan

- [ ] CI green (`build-test` job).
- [ ] Visual smoke (manual): mapper still renders; corner colour
      markers still visible; distance-map trim (clip-out) still works;
      grid overlay still works with the new default-init values.
- [ ] Pre-existing `vtkMRMLBezierSurfaceDisplayNode` / Bezier surface
      tests still pass (no MRML-layer changes here).

## References

- Parent PR #379 (T2-mapper-relocation, merged 2026-05-18) — relocated
  this mapper from `LiverMarkups/` to `LiverResections/` without
  behavioural change.
- Issue #380 — corner-marker review tracker (out of scope for this PR).
- [ADR-0020](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0020-gpu-tessellation.md)
  §"Rollout plan" — the v2.1 GPU-tessellation rewrite that replaces
  this mapper entirely.

---

*This pull request was drafted by Claude (Anthropic) — model
`claude-opus-4-7` — on behalf of the maintainer.*