### PR TITLE
ENH: Resection state machine (Init/Planning/Confirmed)

### DIFF
--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -1,4 +1,7 @@
 #-----------------------------------------------------------------------------
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+#
 # T2.6-LayerDM — Python install rules for the LayerDM Pipeline classes.
 #
 # Mirrors the convention used by Slicer-core's ``MarkupsLib`` and the
@@ -23,6 +26,7 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   LiverBezierSurfacePipeline.py
   Representations/__init__.py
   Representations/BezierPlanningRepresentation.py
+  Representations/ConfirmedRepresentation.py
   Representations/DistanceSpheroidInitRepresentation.py
   Representations/SlicingPlaneInitRepresentation.py
   )

--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -126,6 +126,7 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 REPRESENTATION_SLICING_PLANE_INIT = "SlicingPlaneInit"
 REPRESENTATION_DISTANCE_SPHEROID_INIT = "DistanceSpheroidInit"
 REPRESENTATION_BEZIER_PLANNING = "BezierPlanning"
+REPRESENTATION_CONFIRMED = "Confirmed"
 
 
 # --------------------------------------------------------------------------- #
@@ -144,6 +145,7 @@ REPRESENTATION_BEZIER_PLANNING = "BezierPlanning"
 
 STATE_INIT = 0
 STATE_PLANNING = 1
+STATE_CONFIRMED = 2
 
 INIT_MODE_SLICING_PLANE = 0
 INIT_MODE_DISTANCE_SPHEROID = 1
@@ -212,6 +214,7 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             REPRESENTATION_SLICING_PLANE_INIT: None,
             REPRESENTATION_DISTANCE_SPHEROID_INIT: None,
             REPRESENTATION_BEZIER_PLANNING: None,
+            REPRESENTATION_CONFIRMED: None,
         }
 
         # Whether Representations have been constructed yet — guards
@@ -408,6 +411,9 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             from .Representations.BezierPlanningRepresentation import (
                 BezierPlanningRepresentation,
             )
+            from .Representations.ConfirmedRepresentation import (
+                ConfirmedRepresentation,
+            )
             from .Representations.DistanceSpheroidInitRepresentation import (
                 DistanceSpheroidInitRepresentation,
             )
@@ -417,6 +423,9 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         except ImportError:
             from Representations.BezierPlanningRepresentation import (  # type: ignore[no-redef]
                 BezierPlanningRepresentation,
+            )
+            from Representations.ConfirmedRepresentation import (  # type: ignore[no-redef]
+                ConfirmedRepresentation,
             )
             from Representations.DistanceSpheroidInitRepresentation import (  # type: ignore[no-redef]
                 DistanceSpheroidInitRepresentation,
@@ -433,6 +442,9 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         )
         self._representations[REPRESENTATION_DISTANCE_SPHEROID_INIT] = (
             DistanceSpheroidInitRepresentation(renderer=renderer)
+        )
+        self._representations[REPRESENTATION_CONFIRMED] = (
+            ConfirmedRepresentation(renderer=renderer)
         )
 
         self._representations_initialised = True
@@ -456,11 +468,14 @@ class LiverBezierSurfacePipeline(_PipelineBase):
     def _select_representation(
         self, state: int | None, init_mode: int | None
     ) -> str | None:
-        """Map ``(state, initMode)`` → Representation key per ADR-0014 §2.
+        """Map ``(state, initMode)`` → Representation key per ADR-0014 §2
+        and ADR-0019 §"Pipeline dispatch".
 
         Returns ``None`` when no Representation matches (e.g. an
         unrecognised state value).
         """
+        if state == STATE_CONFIRMED:
+            return REPRESENTATION_CONFIRMED
         if state == STATE_PLANNING:
             return REPRESENTATION_BEZIER_PLANNING
         if state == STATE_INIT:

--- a/LiverResections/LiverResectionsLib/Representations/ConfirmedRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/ConfirmedRepresentation.py
@@ -1,0 +1,408 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Representation active in ``(ResectionState=Confirmed, *)`` per ADR-0019.
+
+Renders the fitted Bezier surface as a "clean view" — control polygon
+hidden, widget disabled, and the parenchyma-trim shader on the
+surface mapper so the bit of the resection plane exterior to the
+liver parenchyma does not render.  Round-trippable: a transition back
+to ``Planning`` returns to ``BezierPlanningRepresentation`` and the
+control polygon reappears.
+
+Scope of this skeleton
+----------------------
+Per ADR-0019 §"Rollout plan" item 3, the parenchyma-trim mapper
+relocates from ``LiverMarkups/VTKWidgets/`` into
+``LiverResections/VTKWidgets/`` on a separate ENH PR
+(``T2-mapper-relocation``).  Until that relocation lands, the
+relocated ``vtkOpenGLBezierResectionPolyDataMapper`` is not the
+Representation's surface-mapper field — this skeleton uses the
+generic ``vtkPolyDataMapper`` for parity with the sibling
+``BezierPlanningRepresentation`` and routes the trim-shader call
+defensively (``hasattr`` check on ``SetResectionClipOut``).  The
+public API of this Representation does not change when the
+relocation completes; only the mapper field's concrete type flips.
+
+Per-state visual contract (ADR-0019 §"Per-state contract")
+----------------------------------------------------------
+The full reference matrix lives in
+``Docs/architecture/resection-state-machine.md``.  Relevant rows for
+this Representation:
+
+* Control polygon visible        — **no**.
+* Widget enabled                 — **no**.
+* Init markers visible           — no.
+* Bezier surface visible         — **yes** (trimmed to liver parenchyma).
+* Grid-overlay shader            — **off**.
+* Parenchyma-trim shader         — **on** (``uResectionClipOut == 1``).
+
+References
+----------
+* `ADR-0013`_ §6 — Representations as composable VTK pipelines.
+* `ADR-0014`_ §3 — mapper relocation.
+* `ADR-0019`_ — 3-state machine (this Representation is the
+  ``Confirmed`` row of the dispatch table).
+
+.. _ADR-0013: ../../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0014: ../../../Docs/adr/0014-livermarkups-dissolution.md
+.. _ADR-0019: ../../../Docs/adr/0019-resection-state-machine.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# VTK is a soft dependency — same pattern as BezierPlanningRepresentation: a
+# pure-Python pytest run skips the VTK-only branches, while a Slicer process
+# (or an environment with VTK on PYTHONPATH) exercises the full pipeline.
+# --------------------------------------------------------------------------- #
+
+try:  # pragma: no cover — exercised inside Slicer / when VTK is available
+    import vtk
+
+    _HAS_VTK = True
+except ImportError:  # pragma: no cover — pure-Python path
+    vtk = None  # type: ignore[assignment]
+    _HAS_VTK = False
+
+
+# --------------------------------------------------------------------------- #
+# Default colour / opacity values — matched to BezierPlanningRepresentation so
+# the visual transition Planning <-> Confirmed only differs in the trim shader
+# and widget visibility, not in the surface colour.
+# --------------------------------------------------------------------------- #
+
+DEFAULT_RESECTION_COLOR = (1.0, 1.0, 1.0)
+DEFAULT_RESECTION_OPACITY = 1.0
+
+
+class ConfirmedRepresentation:
+    """VTK assembly for the Confirmed-state Bezier surface.
+
+    Constructor
+    -----------
+    ``ConfirmedRepresentation(renderer=None)``
+
+    * ``renderer`` — the ``vtkRenderer`` the actors are added to.
+      Optional; ``None`` is supported for unit tests (the actors
+      exist but are unrendered).
+
+    Public methods
+    --------------
+    * ``update(display_node, data_node)`` — reads decoration from the
+      display node, geometry from the data node, applies the trim
+      shader on the mapper (when available), and reconciles the
+      surface actor.  Tolerant of ``None`` arguments.
+    * ``cleanup()`` — detaches the actor from the renderer and releases
+      the VTK pipeline.
+
+    Trim shader binding
+    -------------------
+    The relocated ``vtkOpenGLBezierResectionPolyDataMapper`` exposes
+    ``SetResectionClipOut(bool)``.  ``ConfirmedRepresentation`` sets
+    it to ``True`` on every ``update()`` while
+    ``BezierPlanningRepresentation`` leaves it at the constructor
+    default (``False``).  Until the relocation lands the surface
+    mapper is a generic ``vtkPolyDataMapper`` without that method —
+    the call is gated by a ``hasattr`` check so the Representation
+    survives the in-between state without crashing.
+
+    Introspection (used by unit tests)
+    ----------------------------------
+    * ``GetSurfaceActor()`` / ``GetSurfaceMapper()`` — the actor +
+      mapper pair, or ``None`` when VTK is absent.
+    * ``GetCurrentColor()`` / ``GetCurrentOpacity()`` — the values last
+      written to the actor property; stubs for tests without VTK.
+    * ``GetClipOutApplied()`` — last ``SetResectionClipOut`` call's
+      argument (``True`` when the relocated mapper accepted the call,
+      ``None`` when the mapper does not expose the method).
+    """
+
+    def __init__(self, renderer: Any | None = None) -> None:
+        self._renderer: Any | None = None
+
+        self._surface_polydata: Any | None = None
+        self._surface_mapper: Any | None = None
+        self._surface_actor: Any | None = None
+
+        self._current_color: tuple[float, float, float] = DEFAULT_RESECTION_COLOR
+        self._current_opacity: float = DEFAULT_RESECTION_OPACITY
+
+        # Tracks the last ``SetResectionClipOut`` value the
+        # Representation pushed onto the surface mapper.  ``None``
+        # until the first ``update()`` runs OR the mapper does not
+        # expose ``SetResectionClipOut`` (skeleton state pre-mapper-
+        # relocation).  Exposed via ``GetClipOutApplied`` for unit
+        # tests that assert the trim toggle fires.
+        self._clip_out_applied: bool | None = None
+
+        # Memoised input — same idempotency strategy as
+        # BezierPlanningRepresentation.
+        self._last_grid_signature: tuple | None = None
+        self._input_refresh_count: int = 0
+
+        # TODO(T2-mapper-relocation): swap ``vtk.vtkPolyDataMapper`` for
+        # ``vtkOpenGLBezierResectionPolyDataMapper`` once the four
+        # custom mappers are relocated from
+        # ``LiverMarkups/VTKWidgets/`` to ``LiverResections/VTKWidgets/``
+        # per ADR-0014 §3.  The public API of this Representation does
+        # not change — only the mapper field's concrete type.  The
+        # relocated mapper exposes ``SetResectionClipOut(bool)`` (see
+        # ``vtkOpenGLBezierResectionPolyDataMapper.h``); the
+        # ``hasattr`` gate in ``_apply_data_node`` flips on
+        # automatically once the swap happens.
+        if _HAS_VTK:
+            self._build_vtk_pipeline()
+
+        if renderer is not None:
+            self.SetRenderer(renderer)
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def SetRenderer(self, renderer: Any | None) -> None:
+        """Attach the Representation's actors to ``renderer``."""
+        if self._renderer is not None and self._renderer is not renderer:
+            self._detach_actors(self._renderer)
+        self._renderer = renderer
+        if renderer is not None:
+            self._attach_actors(renderer)
+
+    def GetRenderer(self) -> Any | None:
+        return self._renderer
+
+    def update(
+        self, display_node: Any | None, data_node: Any | None
+    ) -> None:
+        """Reconcile the actor against the current display + data nodes.
+
+        Tolerant of ``None`` arguments — when either node is missing
+        the actor falls back to invisible / default state.
+        """
+        self._apply_display_node(display_node)
+        self._apply_data_node(data_node)
+
+    def cleanup(self) -> None:
+        """Detach actors from the renderer and drop the VTK pipeline."""
+        if self._renderer is not None:
+            self._detach_actors(self._renderer)
+            self._renderer = None
+        self._surface_polydata = None
+        self._surface_mapper = None
+        self._surface_actor = None
+
+    # ------------------------------------------------------------------ #
+    # Introspection — used by the unit-layer tests
+    # ------------------------------------------------------------------ #
+
+    def GetSurfaceActor(self) -> Any | None:
+        return self._surface_actor
+
+    def GetSurfaceMapper(self) -> Any | None:
+        return self._surface_mapper
+
+    def GetCurrentColor(self) -> tuple[float, float, float]:
+        return self._current_color
+
+    def GetCurrentOpacity(self) -> float:
+        return self._current_opacity
+
+    def GetClipOutApplied(self) -> bool | None:
+        """Last value pushed to the surface mapper's
+        ``SetResectionClipOut`` — ``True`` once the relocated mapper
+        accepts the trim toggle, ``None`` while the skeleton's generic
+        mapper does not expose the method (pre-mapper-relocation).
+        """
+        return self._clip_out_applied
+
+    def GetInputRefreshCount(self) -> int:
+        return self._input_refresh_count
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _build_vtk_pipeline(self) -> None:
+        """Construct the surface actor.
+
+        TODO(T2-mapper-relocation): swap the generic
+        ``vtkPolyDataMapper`` for ADR-0014 §3's relocated
+        ``vtkOpenGLBezierResectionPolyDataMapper`` and wire the
+        trim-shader uniform feed from the display node's ``ClipOut``
+        field.  The mapper exposes ``SetResectionClipOut(bool)`` today
+        on the legacy mapper at
+        ``LiverMarkups/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cpp``
+        (relocated by T2-mapper-relocation); see
+        ``vtkOpenGLBezierResectionPolyDataMapper.h`` for the full
+        uniform surface.
+        """
+        assert vtk is not None  # gated by _HAS_VTK
+
+        self._surface_polydata = vtk.vtkPolyData()
+        self._surface_mapper = vtk.vtkPolyDataMapper()
+        self._surface_mapper.SetInputData(self._surface_polydata)
+        self._surface_actor = vtk.vtkActor()
+        self._surface_actor.SetMapper(self._surface_mapper)
+        self._surface_actor.GetProperty().SetColor(*DEFAULT_RESECTION_COLOR)
+        self._surface_actor.GetProperty().SetOpacity(DEFAULT_RESECTION_OPACITY)
+
+    def _attach_actors(self, renderer: Any) -> None:
+        if self._surface_actor is not None and hasattr(renderer, "AddActor"):
+            renderer.AddActor(self._surface_actor)
+
+    def _detach_actors(self, renderer: Any) -> None:
+        if self._surface_actor is not None and hasattr(
+            renderer, "RemoveActor"
+        ):
+            try:
+                renderer.RemoveActor(self._surface_actor)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+    def _apply_display_node(self, display_node: Any | None) -> None:
+        """Push decoration fields onto the actor."""
+        if display_node is None:
+            color = DEFAULT_RESECTION_COLOR
+            opacity = DEFAULT_RESECTION_OPACITY
+        else:
+            color_getter = getattr(display_node, "GetResectionColor", None)
+            opacity_getter = getattr(
+                display_node, "GetResectionOpacity", None
+            )
+
+            color = (
+                _as_color_tuple(color_getter())
+                if color_getter is not None
+                else DEFAULT_RESECTION_COLOR
+            )
+            opacity = (
+                float(opacity_getter())
+                if opacity_getter is not None
+                else DEFAULT_RESECTION_OPACITY
+            )
+
+        self._current_color = color
+        self._current_opacity = opacity
+
+        if self._surface_actor is not None:
+            prop = self._surface_actor.GetProperty()
+            prop.SetColor(*color)
+            prop.SetOpacity(opacity)
+
+    def _apply_data_node(self, data_node: Any | None) -> None:
+        """Push the 4×4 control grid onto the surface mapper, then
+        engage the parenchyma-trim shader uniform.
+
+        The Bezier control grid is the editable geometry in
+        ``Planning`` and the frozen geometry in ``Confirmed``; this
+        Representation reads the same field — ``Confirmed`` only
+        differs from ``Planning`` in the shader-side trim, the absence
+        of the control-polygon glyphs, and the disabled widget.  All
+        three differences live outside this method.
+        """
+        if data_node is None:
+            return
+
+        grid_getter = getattr(data_node, "GetControlGrid", None)
+        if grid_getter is None:
+            return
+
+        try:
+            raw = grid_getter()
+        except Exception:  # pragma: no cover - defensive
+            return
+        if raw is None:
+            return
+
+        try:
+            flat = tuple(float(raw[i]) for i in range(48))
+        except Exception:
+            return
+
+        signature = flat
+        if signature == self._last_grid_signature:
+            # Geometry unchanged; still re-apply the trim toggle in
+            # case the mapper was reset out from under us between
+            # update() calls.
+            self._apply_trim_shader()
+            return
+        self._last_grid_signature = signature
+        self._input_refresh_count += 1
+
+        if not _HAS_VTK:
+            return
+
+        points = _make_points_from_flat(flat)
+        self._refresh_surface_polydata(points)
+        self._apply_trim_shader()
+
+    def _refresh_surface_polydata(self, points: Any) -> None:
+        assert vtk is not None
+        polydata = self._surface_polydata
+        if polydata is None:
+            return
+        polydata.SetPoints(points)
+
+        cells = vtk.vtkCellArray()
+        for v in range(3):
+            for u in range(3):
+                quad = vtk.vtkQuad()
+                quad.GetPointIds().SetId(0, v * 4 + u)
+                quad.GetPointIds().SetId(1, v * 4 + (u + 1))
+                quad.GetPointIds().SetId(2, (v + 1) * 4 + (u + 1))
+                quad.GetPointIds().SetId(3, (v + 1) * 4 + u)
+                cells.InsertNextCell(quad)
+        polydata.SetPolys(cells)
+        polydata.Modified()
+
+    def _apply_trim_shader(self) -> None:
+        """Push the parenchyma-trim toggle onto the surface mapper.
+
+        Gated by ``hasattr`` because the skeleton's surface mapper is
+        a generic ``vtkPolyDataMapper`` until T2-mapper-relocation
+        swaps it for the relocated
+        ``vtkOpenGLBezierResectionPolyDataMapper``.  Until then the
+        call is a no-op observationally (``self._clip_out_applied``
+        stays ``None``).
+        """
+        mapper = self._surface_mapper
+        if mapper is None:
+            return
+        setter = getattr(mapper, "SetResectionClipOut", None)
+        if setter is None:
+            return
+        setter(True)
+        self._clip_out_applied = True
+
+
+# --------------------------------------------------------------------------- #
+# Helpers — small + shared semantically with BezierPlanningRepresentation
+# but duplicated locally to keep each Representation self-contained per
+# ADR-0013 §6 (Representations are independently importable).
+# --------------------------------------------------------------------------- #
+
+
+def _as_color_tuple(raw: Any) -> tuple[float, float, float]:
+    """Coerce a colour accessor's return value to ``(r, g, b)``."""
+    try:
+        r = max(0.0, min(1.0, float(raw[0])))
+        g = max(0.0, min(1.0, float(raw[1])))
+        b = max(0.0, min(1.0, float(raw[2])))
+        return (r, g, b)
+    except Exception:
+        return DEFAULT_RESECTION_COLOR
+
+
+def _make_points_from_flat(flat: tuple) -> Any:
+    """Build a ``vtkPoints`` from a 48-double row-major control grid."""
+    assert vtk is not None
+    points = vtk.vtkPoints()
+    points.SetNumberOfPoints(16)
+    for i in range(16):
+        x = flat[i * 3 + 0]
+        y = flat[i * 3 + 1]
+        z = flat[i * 3 + 2]
+        points.SetPoint(i, x, y, z)
+    return points

--- a/LiverResections/LiverResectionsLib/Representations/__init__.py
+++ b/LiverResections/LiverResectionsLib/Representations/__init__.py
@@ -16,10 +16,15 @@
 #   plane (ring on the target liver surface deferred per
 #   TODO(T2-target-mesh-weakref) until the data node gains a target
 #   mesh reference).
-#
-# Reserved for the remaining T2.2 stack iteration (slot name defined
-# as a constant on ``LiverBezierSurfacePipeline``):
-#
 # * ``DistanceSpheroidInitRepresentation`` — active in
 #   (state=Init, mode=DistanceSpheroid); renders the spheroid control
 #   points + the spheroid + the ring.
+# * ``ConfirmedRepresentation`` — active in (state=Confirmed, *) per
+#   ADR-0019.  Renders the fitted Bezier surface with the parenchyma-
+#   trim shader on (``uResectionClipOut == 1``) and hides the control
+#   polygon + widget.  The trim-shader wiring is gated on
+#   T2-mapper-relocation (the relocated
+#   ``vtkOpenGLBezierResectionPolyDataMapper`` is the
+#   ``SetResectionClipOut`` host); until that lands the Representation
+#   renders the surface without the trim, matching the ADR-0019
+#   §"Rollout plan" "land WITHOUT a working trim shader" fallback.

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Tests for vtkMRMLBezierSurfaceNode — the data-only node landed by
   ADR-0014 §1.  Exercises:
@@ -71,11 +71,12 @@ int testDefaults()
 
 int testEnumRoundTrip()
 {
-  // Init→Planning is the only state transition committed by
-  // ADR-0014 §4 (no Planning→Init); the dedicated
-  // ``testInitDataReadOnlyAfterPlanning`` sub-test below characterises
-  // the rejection branch.  Here we just exercise the forward edge and
-  // the enum string converters, on a fresh node per direction.
+  // Init -> Planning is the canonical forward edge; ADR-0019 adds the
+  // Planning <-> Confirmed round-trip on top.  The dedicated
+  // ``testInitDataReadOnlyAfterPlanning`` and
+  // ``testConfirmedStateTransitions`` sub-tests below characterise the
+  // legal transition cycle and every forbidden edge.  Here we just
+  // exercise the enum string converters across all three states.
   vtkNew<vtkMRMLBezierSurfaceNode> node;
   node->SetState(vtkMRMLBezierSurfaceNode::Planning);
   CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Planning);
@@ -88,14 +89,144 @@ int testEnumRoundTrip()
 
   CHECK_STRING(vtkMRMLBezierSurfaceNode::GetStateAsString(vtkMRMLBezierSurfaceNode::Init), "Init");
   CHECK_STRING(vtkMRMLBezierSurfaceNode::GetStateAsString(vtkMRMLBezierSurfaceNode::Planning), "Planning");
+  CHECK_STRING(vtkMRMLBezierSurfaceNode::GetStateAsString(vtkMRMLBezierSurfaceNode::Confirmed), "Confirmed");
   CHECK_INT(vtkMRMLBezierSurfaceNode::GetStateFromString("Init"), vtkMRMLBezierSurfaceNode::Init);
   CHECK_INT(vtkMRMLBezierSurfaceNode::GetStateFromString("Planning"), vtkMRMLBezierSurfaceNode::Planning);
+  CHECK_INT(vtkMRMLBezierSurfaceNode::GetStateFromString("Confirmed"), vtkMRMLBezierSurfaceNode::Confirmed);
   CHECK_INT(vtkMRMLBezierSurfaceNode::GetStateFromString("bogus"), -1);
 
   CHECK_STRING(vtkMRMLBezierSurfaceNode::GetInitModeAsString(vtkMRMLBezierSurfaceNode::SlicingPlane), "SlicingPlane");
   CHECK_STRING(vtkMRMLBezierSurfaceNode::GetInitModeAsString(vtkMRMLBezierSurfaceNode::DistanceSpheroid), "DistanceSpheroid");
   CHECK_INT(vtkMRMLBezierSurfaceNode::GetInitModeFromString("DistanceSpheroid"), vtkMRMLBezierSurfaceNode::DistanceSpheroid);
   CHECK_INT(vtkMRMLBezierSurfaceNode::GetInitModeFromString(nullptr), -1);
+  return EXIT_SUCCESS;
+}
+
+int testConfirmedStateTransitions()
+{
+  // ADR-0019 transition matrix:
+  //
+  //   Init      -> Planning   allowed.
+  //   Planning  -> Confirmed  allowed.
+  //   Confirmed -> Planning   allowed (round-trip).
+  //   Init      -> Confirmed  forbidden.
+  //   Planning  -> Init       forbidden (also covered by
+  //                            ``testInitDataReadOnlyAfterPlanning``).
+  //   Confirmed -> Init       forbidden.
+  //
+  // Each rejected transition emits a vtkWarningMacro and leaves the
+  // state unchanged; advance/non-advance of GetMTime() is the
+  // observable proxy.
+
+  // ---- Legal path: Init -> Planning -> Confirmed -> Planning ----
+  vtkNew<vtkMRMLBezierSurfaceNode> node;
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Init);
+
+  // Init -> Planning (forward edge).
+  vtkMTimeType pre = node->GetMTime();
+  node->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Planning);
+  if (node->GetMTime() <= pre)
+  {
+    std::cerr << "Expected MTime advance on Init -> Planning\n";
+    return EXIT_FAILURE;
+  }
+
+  // Planning -> Confirmed.
+  pre = node->GetMTime();
+  node->SetState(vtkMRMLBezierSurfaceNode::Confirmed);
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Confirmed);
+  if (node->GetMTime() <= pre)
+  {
+    std::cerr << "Expected MTime advance on Planning -> Confirmed\n";
+    return EXIT_FAILURE;
+  }
+
+  // Confirmed -> Planning (round-trip).
+  pre = node->GetMTime();
+  node->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Planning);
+  if (node->GetMTime() <= pre)
+  {
+    std::cerr << "Expected MTime advance on Confirmed -> Planning\n";
+    return EXIT_FAILURE;
+  }
+
+  // Re-confirm — Planning -> Confirmed again.
+  pre = node->GetMTime();
+  node->SetState(vtkMRMLBezierSurfaceNode::Confirmed);
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Confirmed);
+  if (node->GetMTime() <= pre)
+  {
+    std::cerr << "Expected MTime advance on second Planning -> Confirmed\n";
+    return EXIT_FAILURE;
+  }
+
+  // Same-state self-assign is a no-op (no warning, no MTime advance).
+  pre = node->GetMTime();
+  node->SetState(vtkMRMLBezierSurfaceNode::Confirmed);
+  CHECK_INT(node->GetMTime(), pre);
+
+  // ---- Forbidden: Confirmed -> Init ----
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  pre = node->GetMTime();
+  node->SetState(vtkMRMLBezierSurfaceNode::Init);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Confirmed);
+  CHECK_INT(node->GetMTime(), pre);
+
+  // ---- Forbidden: Init -> Confirmed (fresh node) ----
+  vtkNew<vtkMRMLBezierSurfaceNode> nodeInit;
+  CHECK_INT(nodeInit->GetState(), vtkMRMLBezierSurfaceNode::Init);
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  pre = nodeInit->GetMTime();
+  nodeInit->SetState(vtkMRMLBezierSurfaceNode::Confirmed);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  CHECK_INT(nodeInit->GetState(), vtkMRMLBezierSurfaceNode::Init);
+  CHECK_INT(nodeInit->GetMTime(), pre);
+
+  // Audit-data setters stay rejected in Confirmed (per ADR-0019
+  // §"Per-state contract": init data is read-only in both Planning
+  // and Confirmed).  Drive the node to Confirmed via the legal path
+  // and assert the guard fires.
+  vtkNew<vtkMRMLBezierSurfaceNode> guarded;
+  double origin[3] = { 1.0, 2.0, 3.0 };
+  guarded->SetSlicingPlaneOrigin(origin);
+  guarded->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  guarded->SetState(vtkMRMLBezierSurfaceNode::Confirmed);
+  CHECK_INT(guarded->GetState(), vtkMRMLBezierSurfaceNode::Confirmed);
+
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  pre = guarded->GetMTime();
+  double clobber[3] = { 99.0, 99.0, 99.0 };
+  guarded->SetSlicingPlaneOrigin(clobber);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  CHECK_INT(guarded->GetMTime(), pre);
+  double readBack[3];
+  guarded->GetSlicingPlaneOrigin(readBack);
+  CHECK_DOUBLE(readBack[0], 1.0);
+
+  // Control-grid IS editable in Confirmed at the data-node level — the
+  // ADR-0019 §"Per-state contract" "control-grid mutable: no
+  // (rejected)" row describes the UX-level lockout, enforced by the
+  // widget (vtkLiverBezierWidget) and Representation gating, not by
+  // the data node's macro setter.  Keeping the data-node setter open
+  // preserves round-trippability of scene XML and the
+  // Pipeline-driven SetState round-trip pattern (Confirmed ->
+  // Planning -> edit -> Confirmed) without a defensive
+  // unset/re-set dance.
+  pre = guarded->GetMTime();
+  double values[vtkMRMLBezierSurfaceNode::ControlGridSize];
+  for (int i = 0; i < vtkMRMLBezierSurfaceNode::ControlGridSize; ++i)
+  {
+    values[i] = static_cast<double>(i);
+  }
+  guarded->SetControlGrid(values);
+  if (guarded->GetMTime() <= pre)
+  {
+    std::cerr << "Expected SetControlGrid in Confirmed to fire Modified()\n";
+    return EXIT_FAILURE;
+  }
   return EXIT_SUCCESS;
 }
 
@@ -807,6 +938,7 @@ int vtkMRMLBezierSurfaceNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testModifiedEventsOnSetters());
   CHECK_EXIT_SUCCESS(testDisplayNodeAttachedSceneRoundTrip());
   CHECK_EXIT_SUCCESS(testInitDataReadOnlyAfterPlanning());
+  CHECK_EXIT_SUCCESS(testConfirmedStateTransitions());
 
   std::cout << "vtkMRMLBezierSurfaceNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -194,6 +194,72 @@ int testJsonRoundTrip()
   return EXIT_SUCCESS;
 }
 
+int testConfirmedStateRoundTrip()
+{
+  // ADR-0019: ``Confirmed`` is the third state and round-trips
+  // through .lrp.json the same way Planning does — schemaVersion is
+  // unchanged (still 1), only the enum-string set grows.
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  populate(source.GetPointer());
+  // ``populate`` leaves the source in Planning; advance to Confirmed
+  // for this test.  Planning -> Confirmed is the legal forward edge.
+  source->SetState(vtkMRMLBezierSurfaceNode::Confirmed);
+
+  const std::string path = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> writeStorage;
+  writeStorage->SetFileName(path.c_str());
+  CHECK_INT(writeStorage->WriteData(source.GetPointer()), 1);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> readStorage;
+  readStorage->SetFileName(path.c_str());
+  CHECK_INT(readStorage->ReadData(sink.GetPointer()), 1);
+
+  CHECK_INT(sink->GetState(), vtkMRMLBezierSurfaceNode::Confirmed);
+  // Control grid carried across the round-trip in Confirmed (the
+  // serialiser does not gate on state).
+  for (int i = 0; i < vtkMRMLBezierSurfaceNode::ControlGridSize; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], source->GetControlGrid()[i], 1e-9);
+  }
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testUnknownStateFallback()
+{
+  // ADR-0019 §"Storage / persistence": an unknown ``state`` value
+  // falls back to ``Planning`` gracefully — exercises the forward-
+  // compatible default for scenes authored by a future build that
+  // adds a fourth state (or a build that pre-dates this PR loading
+  // a v3-authored "Confirmed" scene, which the test simulates by
+  // writing an unknown name directly).
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 1,\n";
+    ofs << "  \"state\": \"Approved\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\"\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+
+  // The fallback emits a vtkWarningMacro by design (visible audit
+  // trail for the unknown-state degrade).
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  CHECK_INT(sink->GetState(), vtkMRMLBezierSurfaceNode::Planning);
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
 int testSchemaVersionMismatch()
 {
   // Synthesize a JSON with an unknown schemaVersion and assert
@@ -383,6 +449,8 @@ int vtkMRMLBezierSurfaceStorageNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testDefaultWriteFileExtension());
   CHECK_EXIT_SUCCESS(testCanReadCanWriteDiscrimination());
   CHECK_EXIT_SUCCESS(testJsonRoundTrip());
+  CHECK_EXIT_SUCCESS(testConfirmedStateRoundTrip());
+  CHECK_EXIT_SUCCESS(testUnknownStateFallback());
   CHECK_EXIT_SUCCESS(testSchemaVersionMismatch());
   CHECK_EXIT_SUCCESS(testLegacyFcsvRead());
   CHECK_EXIT_SUCCESS(testLegacyFcsvWriteRejected());

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -57,31 +57,33 @@
 #include <string>
 
 //------------------------------------------------------------------------------
-// Read-only-after-Planning guard (ADR-0014 §4).
+// Read-only-after-Init guard (ADR-0014 §4 + ADR-0019).
 //
 // Init-mode subordinate data (slicing-plane / distance-spheroid init
 // points + derived plane / spheroid parameters) is mutable while
 // ``State == Init`` and becomes read-only audit data the moment the
-// node transitions to ``Planning``.  Every setter on that data routes
-// through this macro; if the node is in Planning the call emits a
-// ``vtkWarningMacro`` and returns without mutating or firing
-// ``Modified()``.  Per ADR-0014 §4: "There is no Planning→Init
-// transition" — see ``SetState`` for the matching one-way invariant
-// on the state machine itself.
+// node transitions to ``Planning``.  It stays read-only across the
+// ``Planning <-> Confirmed`` round-trip introduced by ADR-0019 — the
+// audit invariant is "init data is fixed once committed", regardless
+// of which post-Init state the node currently sits in.  Every setter
+// on that data routes through this macro; if the node is in any
+// post-Init state the call emits a ``vtkWarningMacro`` and returns
+// without mutating or firing ``Modified()``.
 //
 // File-local — ``#define``d here and ``#undef``ed at end-of-file so
 // the macro does not leak into other translation units.  ``do { …
 // } while (0)`` lets the macro sit on a single line at the top of the
 // setter body and behave like a statement (early ``return``).
-#define LIVER_BEZIER_GUARD_INIT_ONLY(fieldName)                                     \
-  do                                                                                \
-  {                                                                                 \
-    if (this->State == Planning && !this->LoadingFromXML)                           \
-    {                                                                               \
-      vtkWarningMacro("Cannot mutate " #fieldName " after Init→Planning transition" \
-                      " (ADR-0014 §4 read-only audit data)");                       \
-      return;                                                                       \
-    }                                                                               \
+#define LIVER_BEZIER_GUARD_INIT_ONLY(fieldName)                                        \
+  do                                                                                   \
+  {                                                                                    \
+    if (this->State != Init && !this->LoadingFromXML)                                  \
+    {                                                                                  \
+      vtkWarningMacro("Cannot mutate " #fieldName " after Init->Planning transition"   \
+                      " (ADR-0014 §4 / ADR-0019 read-only audit data; current state: " \
+                      << GetStateAsString(this->State) << ")");                        \
+      return;                                                                          \
+    }                                                                                  \
   } while (0)
 
 //------------------------------------------------------------------------------
@@ -124,20 +126,37 @@ vtkMRMLBezierSurfaceNode::~vtkMRMLBezierSurfaceNode() = default;
 //------------------------------------------------------------------------------
 void vtkMRMLBezierSurfaceNode::SetState(int state)
 {
-  // ADR-0014 §4: the Init→Planning transition is one-way.  Attempting
-  // to drop back from Planning to Init is rejected (warning + no-op).
-  // The same-state self-assign and any unrecognised int are passed
-  // through to the macro-equivalent path so the caller sees identical
-  // observability to a plain vtkSetMacro short-circuit.
+  // ADR-0019 transition matrix:
+  //
+  //   Init      -> Planning   allowed (one-way; ADR-0014 §4).
+  //   Planning  -> Confirmed  allowed.
+  //   Confirmed -> Planning   allowed (round-trip).
+  //   Init      -> Confirmed  forbidden (must traverse Planning).
+  //   Planning  -> Init       forbidden (ADR-0014 §4).
+  //   Confirmed -> Init       forbidden (audit data permanent).
+  //
+  // Self-assign and any unrecognised int are passed through to the
+  // macro-equivalent path so the caller sees identical observability
+  // to a plain vtkSetMacro short-circuit.  XML deserialisation is
+  // exempt from the transition guard via ``LoadingFromXML`` so a scene
+  // serialised with ``state="Confirmed"`` loads into a freshly-default
+  // ``Init`` node without tripping the Init -> Confirmed rejection.
   if (state == this->State)
   {
     return;
   }
-  if (this->State == Planning && state == Init && !this->LoadingFromXML)
+  if (!this->LoadingFromXML)
   {
-    vtkWarningMacro("Planning→Init transition is not permitted"
-                    " (ADR-0014 §4); state left at Planning");
-    return;
+    const bool forbidden =                            //
+      (this->State == Planning && state == Init)      // ADR-0014 §4
+      || (this->State == Confirmed && state == Init)  // ADR-0019
+      || (this->State == Init && state == Confirmed); // ADR-0019
+    if (forbidden)
+    {
+      vtkWarningMacro("Resection state transition " << GetStateAsString(this->State) << " -> " << GetStateAsString(state) << " is not permitted (ADR-0019); state left at "
+                                                    << GetStateAsString(this->State));
+      return;
+    }
   }
   this->State = state;
   this->Modified();
@@ -150,6 +169,7 @@ const char* vtkMRMLBezierSurfaceNode::GetStateAsString(int state)
   {
     case Init: return "Init";
     case Planning: return "Planning";
+    case Confirmed: return "Confirmed";
     default: return "Invalid";
   }
 }
@@ -218,17 +238,19 @@ bool vtkMRMLBezierSurfaceNode::SetSlicingPlaneInitPoint(int index, const double 
   {
     return false;
   }
-  // ADR-0014 §4 read-only guard.  Returns false (rather than the
-  // macro's plain ``return``) so callers that check the bool see a
-  // clear signal that the mutation did not apply, matching the
+  // ADR-0014 §4 / ADR-0019 read-only guard.  Returns false (rather
+  // than the macro's plain ``return``) so callers that check the bool
+  // see a clear signal that the mutation did not apply, matching the
   // existing "rejected on bad input" return path of this setter.
   // ``LoadingFromXML`` exempts XML deserialisation — see the
   // ``LIVER_BEZIER_GUARD_INIT_ONLY`` macro at the top of this file.
-  if (this->State == Planning && !this->LoadingFromXML)
+  if (this->State != Init && !this->LoadingFromXML)
   {
     vtkWarningMacro("Cannot mutate SlicingPlaneInitPoint[" << index << "]"
-                                                           << " after Init→Planning transition"
-                                                           << " (ADR-0014 §4 read-only audit data)");
+                                                           << " after Init->Planning transition"
+                                                           << " (ADR-0014 §4 / ADR-0019 read-only audit data;"
+                                                              " current state: "
+                                                           << GetStateAsString(this->State) << ")");
     return false;
   }
   this->SlicingPlaneInitPoints[index][0] = point[0];
@@ -312,13 +334,16 @@ bool vtkMRMLBezierSurfaceNode::SetDistanceSpheroidInitPoint(int index, const dou
   {
     return false;
   }
-  // ADR-0014 §4 read-only guard.  Mirrors the bool-returning rejection
-  // path of SetSlicingPlaneInitPoint — see that setter for rationale.
-  if (this->State == Planning && !this->LoadingFromXML)
+  // ADR-0014 §4 / ADR-0019 read-only guard.  Mirrors the bool-returning
+  // rejection path of SetSlicingPlaneInitPoint — see that setter for
+  // rationale.
+  if (this->State != Init && !this->LoadingFromXML)
   {
     vtkWarningMacro("Cannot mutate DistanceSpheroidInitPoint[" << index << "]"
-                                                               << " after Init→Planning transition"
-                                                               << " (ADR-0014 §4 read-only audit data)");
+                                                               << " after Init->Planning transition"
+                                                               << " (ADR-0014 §4 / ADR-0019 read-only audit data;"
+                                                                  " current state: "
+                                                               << GetStateAsString(this->State) << ")");
     return false;
   }
   const size_t base = static_cast<size_t>(index) * 3;

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
@@ -2,7 +2,7 @@
 
  Distributed under the OSI-approved BSD 3-Clause License.
 
-  Copyright (c) Oslo University Hospital. All rights reserved.
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -124,7 +124,36 @@ public:
   vtkTypeMacro(vtkMRMLBezierSurfaceNode, vtkMRMLDisplayableNode);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  /// Resection state machine (per ADR-0013 §4).
+  /// Resection state machine (per ADR-0013 §4 and ADR-0019).
+  ///
+  /// Three-state automaton:
+  ///
+  /// \verbatim
+  ///   [*] -> Init -> Planning <-> Confirmed
+  /// \endverbatim
+  ///
+  /// - ``Init``      — node exists, init-mode audit data is editable,
+  ///                   the Bezier control grid is not yet fitted.
+  /// - ``Planning``  — control polygon is editable, init-mode audit
+  ///                   data is read-only (ADR-0014 §4), the full
+  ///                   resection surface renders (no parenchyma trim).
+  /// - ``Confirmed`` — control polygon is frozen, the parenchyma-trim
+  ///                   shader is active (``uResectionClipOut == 1`` on
+  ///                   ``vtkOpenGLBezierResectionPolyDataMapper``); the
+  ///                   surgeon can revise back to ``Planning``.
+  ///
+  /// ``SetState`` enforces the transition matrix from ADR-0019:
+  ///
+  ///   - Init      -> Planning   allowed (one-way per ADR-0014 §4).
+  ///   - Planning  -> Confirmed  allowed.
+  ///   - Confirmed -> Planning   allowed (round-trip).
+  ///   - Init      -> Confirmed  forbidden (must traverse Planning).
+  ///   - Planning  -> Init       forbidden (ADR-0014 §4).
+  ///   - Confirmed -> Init       forbidden (audit data permanent).
+  ///
+  /// Forbidden transitions emit a ``vtkWarningMacro`` and reject the
+  /// change (mirrors the Planning -> Init rejection precedent set by
+  /// the ADR-0014 §4 read-only audit-data rule).
   ///
   /// Enum integer values are pinned explicitly so that a future
   /// reorder or insertion does not silently shift any Python or C++
@@ -136,6 +165,7 @@ public:
   {
     Init = 0,
     Planning = 1,
+    Confirmed = 2,
     ResectionState_Last
   };
 
@@ -189,14 +219,16 @@ public:
   // State machine
   //--------------------------------------------------------------------------
 
-  /// Resection state (Init / Planning).  Persisted in XML.
+  /// Resection state (Init / Planning / Confirmed).  Persisted in XML.
   ///
-  /// ``SetState`` enforces the ADR-0014 §4 one-way invariant: the
-  /// Init→Planning transition is allowed, but a Planning→Init drop-back
-  /// is rejected (emits a ``vtkWarningMacro`` and leaves ``State``
-  /// unchanged).  Setting the same state is a no-op (no ``Modified()``
-  /// emitted) so the macro-generated short-circuit semantics are
-  /// preserved.
+  /// ``SetState`` enforces the ADR-0019 transition matrix (which
+  /// subsumes the ADR-0014 §4 Planning -> Init invariant): the
+  /// Init -> Planning, Planning -> Confirmed, and Confirmed -> Planning
+  /// transitions are allowed; every other non-self transition is
+  /// rejected with a ``vtkWarningMacro``.  Setting the same state is a
+  /// no-op (no ``Modified()`` emitted) so the macro-generated
+  /// short-circuit semantics are preserved.  See the ``ResectionState``
+  /// enum docstring for the full matrix.
   vtkGetMacro(State, int);
   void SetState(int state);
 

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
@@ -232,6 +232,21 @@ public:
   vtkGetMacro(State, int);
   void SetState(int state);
 
+  /// ``LoadingFromXML`` — internal flag that exempts the ADR-0014 §4
+  /// audit-data setters and the ADR-0019 ``SetState`` transition
+  /// matrix from the public-API guards for the duration of a
+  /// scene/storage read.  Set automatically by ``ReadXMLAttributes``;
+  /// also set by ``vtkMRMLBezierSurfaceStorageNode::ReadJson`` for
+  /// JSON-driven loads so a Confirmed-state ``.lrp.json`` round-trips
+  /// into a fresh sink (sink starts at ``Init``; without the bypass,
+  /// ``SetState(Confirmed)`` is rejected as an illegal Init→Confirmed
+  /// transition).  Public setter so the storage node — which is in a
+  /// different translation unit and not a friend — can drive the
+  /// flag.  Treat as an internal API: callers other than the storage
+  /// reader path should NOT touch it.
+  vtkGetMacro(LoadingFromXML, bool);
+  vtkSetMacro(LoadingFromXML, bool);
+
   /// Initialization mode (SlicingPlane / DistanceSpheroid).  Persisted
   /// in XML.  Meaningful for both States: in Init it drives the
   /// active Representation; in Planning it tags which init-mode audit

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -48,7 +48,7 @@
 //
 //   {
 //     "schemaVersion": 1,
-//     "state": "Init" | "Planning",
+//     "state": "Init" | "Planning" | "Confirmed",
 //     "initMode": "SlicingPlane" | "DistanceSpheroid",
 //     "controlGrid": [48 doubles in row-major (i, j, k) order],
 //     "slicingPlane": {
@@ -472,11 +472,22 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
   if (root->HasMember("state"))
   {
     const std::string s = root->GetStringProperty("state");
-    const int code = vtkMRMLBezierSurfaceNode::GetStateFromString(s.c_str());
+    int code = vtkMRMLBezierSurfaceNode::GetStateFromString(s.c_str());
     if (code < 0)
     {
-      vtkErrorMacro("ReadJson: unknown state name '" << s << "' in '" << filePath << "'");
-      return 0;
+      // ADR-0019 §"Storage / persistence": unknown state values fall
+      // back to "Planning" gracefully so a scene authored by a future
+      // build that adds a fourth state (e.g. "Approved") still opens
+      // in older builds with the surface visible and editable.  The
+      // fallback also covers the symmetric forward-compat case for the
+      // existing readership: a v3-authored "Confirmed" scene loaded by
+      // a build that pre-dates this PR would have read as unknown;
+      // adding the fallback here means the same loader behaviour ages
+      // gracefully into the next schema bump.
+      vtkWarningMacro("ReadJson: unknown state name '" << s << "' in '" << filePath
+                                                       << "' — falling back to Planning"
+                                                          " (ADR-0019 forward-compatible default)");
+      code = vtkMRMLBezierSurfaceNode::Planning;
     }
     pendingState = code;
   }

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -440,8 +440,50 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
 }
 
 //------------------------------------------------------------------------------
+namespace
+{
+// RAII guard: flip the surface node's ``LoadingFromXML`` flag on for
+// the duration of a JSON read, restore it on scope exit (covers early
+// returns too).  Mirrors the wrap pattern used in
+// ``vtkMRMLBezierSurfaceNode::ReadXMLAttributes`` so JSON deserialisation
+// bypasses the ADR-0014 §4 audit-data setters' read-only guards and
+// the ADR-0019 ``SetState`` transition matrix the same way XML loads
+// do.  Without the bypass a Confirmed-state round-trip fails: the
+// fresh sink starts at ``Init`` and ``SetState(Confirmed)`` is
+// rejected as an illegal Init→Confirmed transition (the legal path
+// is Init→Planning→Confirmed).
+class ScopedLoadingFromXML
+{
+public:
+  explicit ScopedLoadingFromXML(vtkMRMLBezierSurfaceNode* node)
+    : Node(node)
+    , Prev(node != nullptr ? node->GetLoadingFromXML() : false)
+  {
+    if (this->Node != nullptr)
+    {
+      this->Node->SetLoadingFromXML(true);
+    }
+  }
+  ~ScopedLoadingFromXML()
+  {
+    if (this->Node != nullptr)
+    {
+      this->Node->SetLoadingFromXML(this->Prev);
+    }
+  }
+  ScopedLoadingFromXML(const ScopedLoadingFromXML&) = delete;
+  ScopedLoadingFromXML& operator=(const ScopedLoadingFromXML&) = delete;
+
+private:
+  vtkMRMLBezierSurfaceNode* Node;
+  bool Prev;
+};
+} // namespace
+
 int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMRMLBezierSurfaceNode* surfaceNode)
 {
+  ScopedLoadingFromXML loadingGuard(surfaceNode);
+
   vtkNew<vtkMRMLJsonReader> reader;
   vtkSmartPointer<vtkMRMLJsonElement> root = vtkSmartPointer<vtkMRMLJsonElement>::Take(reader->ReadFromFile(filePath.c_str()));
   if (root == nullptr)

--- a/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
+++ b/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
@@ -335,6 +335,53 @@ int testReadOnlyEnforcement()
   return EXIT_SUCCESS;
 }
 
+int testConfirmedStatePickGate()
+{
+  // ADR-0019 §"Per-state contract": in ``Confirmed`` the widget is
+  // disabled and the control polygon is hidden.  The representation
+  // must return ``PickRole_None`` for every (X, Y), and the widget
+  // must not enter ``Dragging`` on any pick attempt — even at a
+  // display coordinate that maps to a control-grid world point.
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = makePlanningNode();
+  // Legal transition Planning -> Confirmed (the only path to
+  // Confirmed; Init -> Confirmed is rejected per ADR-0019).
+  node->SetState(vtkMRMLBezierSurfaceNode::Confirmed);
+  CHECK_INT(node->GetState(), vtkMRMLBezierSurfaceNode::Confirmed);
+
+  vtkSmartPointer<vtkRenderer> renderer = makeRenderer();
+  vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+  renderWindow->SetShowWindow(false);
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetSize(400, 400);
+  renderer->ResetCameraClippingRange();
+
+  vtkNew<vtkLiverBezierRepresentation> rep;
+  rep->SetRenderer(renderer);
+  rep->SetBezierNode(node);
+  rep->BuildRepresentation();
+
+  vtkNew<vtkLiverBezierWidget> widget;
+  widget->SetRepresentation(rep);
+  widget->SetBezierNode(node);
+
+  // Display coordinate of a control point that *would* pick if the
+  // state were Planning — assert it misses in Confirmed.
+  double world[3] = { -5.0, 5.0, 0.0 };
+  renderer->SetWorldPoint(world[0], world[1], world[2], 1.0);
+  renderer->WorldToDisplay();
+  double* d = renderer->GetDisplayPoint();
+  const int X = static_cast<int>(std::round(d[0]));
+  const int Y = static_cast<int>(std::round(d[1]));
+
+  vtkLiverBezierRepresentation::PickResult pick = rep->Pick(X, Y);
+  CHECK_INT(pick.Role, vtkLiverBezierRepresentation::PickRole_None);
+
+  // Widget rejects a left-drag at the same coordinate.
+  CHECK_BOOL(widget->BeginLeftDragAt(X, Y), false);
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Start);
+  return EXIT_SUCCESS;
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -344,6 +391,7 @@ int vtkLiverBezierWidgetTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testPickControlPoint());
   CHECK_EXIT_SUCCESS(testLeftDragMutatesControlGrid());
   CHECK_EXIT_SUCCESS(testReadOnlyEnforcement());
+  CHECK_EXIT_SUCCESS(testConfirmedStatePickGate());
 
   std::cout << "vtkLiverBezierWidgetTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
@@ -161,7 +161,11 @@ void vtkLiverBezierRepresentation::UpdatePickableGlyphs()
     return;
   }
 
-  // ADR-0014 §3 — pickable set depends on (State, InitMode).
+  // ADR-0014 §3 + ADR-0019 — pickable set depends on (State, InitMode).
+  // In ``Confirmed`` the control polygon is hidden and the widget is
+  // disabled (per ADR-0019 §"Per-state contract"), so no points are
+  // pickable.  In ``Planning`` the 16 Bezier control-grid points are
+  // pickable; in ``Init`` the init-mode subordinate points are.
   const int state = node->GetState();
   const int mode = node->GetInitMode();
 
@@ -171,7 +175,14 @@ void vtkLiverBezierRepresentation::UpdatePickableGlyphs()
     verts->InsertNextCell(1, &id);
   };
 
-  if (state == vtkMRMLBezierSurfaceNode::Planning)
+  if (state == vtkMRMLBezierSurfaceNode::Confirmed)
+  {
+    // No pickable glyphs in Confirmed — ADR-0019 §"Per-state contract"
+    // commits to "control polygon hidden, widget disabled".  The
+    // empty glyph cloud below makes ``BuildRepresentation`` hide the
+    // glyph actor on the next render pass.
+  }
+  else if (state == vtkMRMLBezierSurfaceNode::Planning)
   {
     // 16 Bezier control points become pickable.
     const double* grid = node->GetControlGrid();
@@ -271,9 +282,15 @@ vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int 
   double rayDir[3] = { farWorld[0] - nearWorld[0], farWorld[1] - nearWorld[1], farWorld[2] - nearWorld[2] };
   vtkMath::Normalize(rayDir);
 
-  // ADR-0014 §3 — pickability is state-gated.
+  // ADR-0014 §3 + ADR-0019 — pickability is state-gated.  In
+  // ``Confirmed`` the widget is disabled, so every (X, Y) is a miss
+  // regardless of where the cursor lands.
   const int state = node->GetState();
   const int mode = node->GetInitMode();
+  if (state == vtkMRMLBezierSurfaceNode::Confirmed)
+  {
+    return result;
+  }
 
   // Helper: distance from point to ray.
   auto distanceToRay = [&](const double p[3])

--- a/Testing/Python/unit/test_bezier_surface_node.py
+++ b/Testing/Python/unit/test_bezier_surface_node.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
 """Python unit tests for ``vtkMRMLBezierSurfaceNode`` and
 ``vtkMRMLBezierSurfaceDisplayNode`` — T2 Stack 2 / T2.1.
 
@@ -98,21 +100,57 @@ def test_node_default_state_and_mode(mrml_module):
 
 
 def test_node_state_round_trip(mrml_module):
-    """State setter accepts both enum values.
+    """State setter accepts all three enum values along the legal path.
 
-    Init→Planning is the one-way transition committed by ADR-0014 §4;
-    a separate test (``test_node_init_data_read_only_after_planning``)
-    asserts that Planning→Init is rejected.  This test exercises the
-    forward edge and the same-state no-op.
+    Init -> Planning -> Confirmed -> Planning is the legal cycle
+    committed by ADR-0019; ADR-0014 §4's Planning -> Init invariant
+    plus ADR-0019's Confirmed -> Init and Init -> Confirmed bans are
+    covered by ``test_node_state_transitions_forbidden`` below.
     """
-    node = mrml_module.vtkMRMLBezierSurfaceNode()
-    node.SetState(mrml_module.vtkMRMLBezierSurfaceNode.Planning)
-    assert node.GetState() == mrml_module.vtkMRMLBezierSurfaceNode.Planning
+    cls = mrml_module.vtkMRMLBezierSurfaceNode
+    node = cls()
+    node.SetState(cls.Planning)
+    assert node.GetState() == cls.Planning
     # Same-state self-assign is a no-op (no Modified() expected; not
     # asserted here but covered by testModifiedEventsOnSetters on the
     # C++ side).
-    node.SetState(mrml_module.vtkMRMLBezierSurfaceNode.Planning)
-    assert node.GetState() == mrml_module.vtkMRMLBezierSurfaceNode.Planning
+    node.SetState(cls.Planning)
+    assert node.GetState() == cls.Planning
+    # ADR-0019: Planning -> Confirmed -> Planning round-trip.
+    node.SetState(cls.Confirmed)
+    assert node.GetState() == cls.Confirmed
+    node.SetState(cls.Planning)
+    assert node.GetState() == cls.Planning
+
+
+def test_node_state_transitions_forbidden(mrml_module):
+    """Forbidden transitions per ADR-0019 leave State unchanged.
+
+    Each rejection emits a ``vtkWarningMacro`` and short-circuits
+    without firing ``Modified()`` — only the post-condition (State
+    unchanged) is asserted from Python; ``GetMTime()`` non-advance is
+    covered by the C++ ``testConfirmedStateTransitions`` sub-test.
+    """
+    cls = mrml_module.vtkMRMLBezierSurfaceNode
+
+    # Init -> Confirmed forbidden.
+    node = cls()
+    node.SetState(cls.Confirmed)
+    assert node.GetState() == cls.Init
+
+    # Confirmed -> Init forbidden.
+    node2 = cls()
+    node2.SetState(cls.Planning)
+    node2.SetState(cls.Confirmed)
+    node2.SetState(cls.Init)
+    assert node2.GetState() == cls.Confirmed
+
+    # Planning -> Init forbidden (also covered by
+    # ``test_node_init_data_read_only_after_planning`` below).
+    node3 = cls()
+    node3.SetState(cls.Planning)
+    node3.SetState(cls.Init)
+    assert node3.GetState() == cls.Planning
 
 
 def test_node_initialization_mode_round_trip(mrml_module):
@@ -131,8 +169,10 @@ def test_node_enum_string_converters(mrml_module):
     cls = mrml_module.vtkMRMLBezierSurfaceNode
     assert cls.GetStateAsString(cls.Init) == "Init"
     assert cls.GetStateAsString(cls.Planning) == "Planning"
+    assert cls.GetStateAsString(cls.Confirmed) == "Confirmed"
     assert cls.GetStateFromString("Init") == cls.Init
     assert cls.GetStateFromString("Planning") == cls.Planning
+    assert cls.GetStateFromString("Confirmed") == cls.Confirmed
     assert cls.GetStateFromString("nonsense") == -1
 
     assert cls.GetInitModeAsString(cls.SlicingPlane) == "SlicingPlane"

--- a/Testing/Python/unit/test_confirmed_representation.py
+++ b/Testing/Python/unit/test_confirmed_representation.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Python unit tests for ``ConfirmedRepresentation`` — ADR-0019.
+
+Mirrors ``test_bezier_planning_representation.py``'s structure
+(pure-Python introspection assertions + a thin VTK-mediated layer).
+The Confirmed Representation differs from BezierPlanning in three
+ways committed by ADR-0019:
+
+* No control-polygon glyph cloud (the widget is disabled in
+  ``Confirmed``; the data-node-driven glyph rebuild on
+  ``vtkLiverBezierRepresentation`` is the canonical enforcer — covered
+  by the C++ ``vtkLiverBezierRepresentation`` test path).
+* The parenchyma-trim shader is engaged on the surface mapper:
+  ``mapper.SetResectionClipOut(True)``.  The skeleton's surface
+  mapper is a generic ``vtkPolyDataMapper`` without that method until
+  T2-mapper-relocation lands the relocated
+  ``vtkOpenGLBezierResectionPolyDataMapper``; the Representation
+  guards the call with a ``hasattr`` check and exposes the last-pushed
+  value via ``GetClipOutApplied``.  These tests assert the no-op
+  observability of the skeleton state — the post-relocation
+  assertion (``GetClipOutApplied() is True``) is gated by a stub
+  mapper inside this file so the assertion exercises both the legacy
+  generic-mapper branch AND the future relocated-mapper branch.
+
+References
+----------
+* ADR-0008 §2 — Representation tests, unit layer.
+* ADR-0013 §6 — Representations as composable VTK pipelines.
+* ADR-0019 — 3-state machine (``ConfirmedRepresentation`` is the
+  ``Confirmed`` row of the dispatch table).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Repo geometry — mirrors test_bezier_planning_representation.py.
+# --------------------------------------------------------------------------- #
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "LiverResections" / "LiverResectionsLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Stub nodes
+# --------------------------------------------------------------------------- #
+
+
+class _StubDisplayNode:
+    def __init__(
+        self,
+        color: tuple = (1.0, 1.0, 1.0),
+        opacity: float = 1.0,
+    ) -> None:
+        self.color = color
+        self.opacity = opacity
+
+    def GetResectionColor(self):
+        return self.color
+
+    def GetResectionOpacity(self) -> float:
+        return self.opacity
+
+
+class _StubDataNode:
+    def __init__(self, control_grid: tuple = (0.0,) * 48) -> None:
+        self.control_grid = control_grid
+
+    def GetControlGrid(self):
+        return self.control_grid
+
+
+@pytest.fixture
+def rep_module():
+    from Representations.ConfirmedRepresentation import (
+        ConfirmedRepresentation,
+    )
+
+    return ConfirmedRepresentation
+
+
+# --------------------------------------------------------------------------- #
+# Pure-Python assertions (run with or without VTK)
+# --------------------------------------------------------------------------- #
+
+
+def test_representation_construct_with_no_renderer(rep_module):
+    """Construct without a renderer — no exception, default state set."""
+    rep = rep_module()
+    assert rep.GetRenderer() is None
+    assert rep.GetCurrentColor() == (1.0, 1.0, 1.0)
+    assert rep.GetCurrentOpacity() == pytest.approx(1.0)
+    # Clip-out applied state starts at None — no update() yet.
+    assert rep.GetClipOutApplied() is None
+    rep.cleanup()
+
+
+def test_representation_update_with_none_display_falls_back_to_defaults(
+    rep_module,
+):
+    rep = rep_module()
+    rep.update(display_node=None, data_node=_StubDataNode())
+    assert rep.GetCurrentColor() == (1.0, 1.0, 1.0)
+    assert rep.GetCurrentOpacity() == pytest.approx(1.0)
+    rep.cleanup()
+
+
+def test_representation_color_round_trip(rep_module):
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.25, 0.5, 0.75))
+    data = _StubDataNode()
+    rep.update(display, data)
+    assert rep.GetCurrentColor() == (0.25, 0.5, 0.75)
+    rep.cleanup()
+
+
+def test_representation_opacity_round_trip(rep_module):
+    rep = rep_module()
+    display = _StubDisplayNode(opacity=0.5)
+    rep.update(display, _StubDataNode())
+    assert rep.GetCurrentOpacity() == pytest.approx(0.5)
+    rep.cleanup()
+
+
+def test_representation_input_refresh_on_grid_change(rep_module):
+    """Mutating the control grid increments the input-refresh counter."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode(control_grid=tuple(0.1 * i for i in range(48)))
+    rep.update(display, data)
+    after_first = rep.GetInputRefreshCount()
+    assert after_first == 1
+
+    # Re-running update() with the same grid is a no-op (memoised).
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == after_first
+
+    # Mutating the grid forces a refresh.
+    data.control_grid = tuple(0.2 * i for i in range(48))
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == after_first + 1
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# Trim-shader binding — the post-T2-mapper-relocation contract
+# --------------------------------------------------------------------------- #
+
+
+class _StubMapperWithClipOut:
+    """Drop-in replacement for the Representation's surface mapper that
+    exposes ``SetResectionClipOut`` — the relocated
+    ``vtkOpenGLBezierResectionPolyDataMapper``'s API.  Used to exercise
+    the ``hasattr``-gated branch in ``ConfirmedRepresentation`` without
+    waiting for T2-mapper-relocation to land.
+    """
+
+    def __init__(self) -> None:
+        self.clip_out: bool | None = None
+        self._input = None
+
+    def SetResectionClipOut(self, value: bool) -> None:
+        self.clip_out = bool(value)
+
+    def SetInputData(self, polydata) -> None:
+        self._input = polydata
+
+
+def test_representation_engages_trim_shader_when_mapper_supports_it(
+    rep_module,
+):
+    """When the surface mapper exposes ``SetResectionClipOut`` (i.e.
+    the post-T2-mapper-relocation state), ``update()`` flips it to
+    ``True``."""
+    rep = rep_module()
+    # Inject the stub mapper to simulate the post-relocation state.
+    rep._surface_mapper = _StubMapperWithClipOut()
+
+    display = _StubDisplayNode()
+    data = _StubDataNode(control_grid=tuple(0.1 * i for i in range(48)))
+    rep.update(display, data)
+
+    assert rep._surface_mapper.clip_out is True
+    assert rep.GetClipOutApplied() is True
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# VTK-mediated assertions
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def vtk_module():
+    """Import the ``vtk`` module or skip the test."""
+    return pytest.importorskip(
+        "vtk",
+        reason=(
+            "vtk not importable; skip the VTK-mediated Representation "
+            "tests."
+        ),
+    )
+
+
+def test_representation_mapper_color_matches_display_node(
+    rep_module, vtk_module
+):
+    rep = rep_module()
+    display = _StubDisplayNode(color=(0.25, 0.5, 0.75), opacity=0.42)
+    rep.update(display, _StubDataNode())
+
+    actor = rep.GetSurfaceActor()
+    assert actor is not None
+    prop_color = actor.GetProperty().GetColor()
+    assert list(prop_color) == pytest.approx([0.25, 0.5, 0.75])
+    assert actor.GetProperty().GetOpacity() == pytest.approx(0.42)
+    rep.cleanup()
+
+
+def test_representation_skeleton_mapper_does_not_have_clipout_attribute(
+    rep_module, vtk_module
+):
+    """The pre-T2-mapper-relocation skeleton uses
+    ``vtkPolyDataMapper``, which does NOT expose ``SetResectionClipOut``
+    — the Representation's ``hasattr`` gate stays defensive and
+    ``GetClipOutApplied`` stays ``None`` after ``update()``.
+
+    This test pins the "no-op pre-relocation" branch.  When
+    T2-mapper-relocation lands and the Representation's surface mapper
+    flips to the relocated
+    ``vtkOpenGLBezierResectionPolyDataMapper``, this assertion will
+    flip to ``is True`` — that is the load-bearing signal that the
+    relocation completed successfully.
+    """
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode(control_grid=tuple(0.1 * i for i in range(48)))
+    rep.update(display, data)
+
+    mapper = rep.GetSurfaceMapper()
+    assert mapper is not None
+    # Either the relocation has happened (mapper exposes the trim
+    # toggle and the Representation engaged it) OR it has not (mapper
+    # is the generic vtkPolyDataMapper and GetClipOutApplied is None).
+    if hasattr(mapper, "SetResectionClipOut"):
+        assert rep.GetClipOutApplied() is True
+    else:
+        assert rep.GetClipOutApplied() is None
+    rep.cleanup()

--- a/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
+++ b/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
@@ -122,6 +122,20 @@ def test_pipeline_update_dispatches_state(pipeline_module, bezier_nodes):
         pipeline_module.REPRESENTATION_BEZIER_PLANNING
     )
 
+    # ADR-0019: transition to (state=Confirmed) → Confirmed slot wins.
+    data.SetState(pipeline_module.STATE_CONFIRMED)
+    pipeline.UpdatePipeline()
+    assert pipeline.GetCurrentRepresentationName() == (
+        pipeline_module.REPRESENTATION_CONFIRMED
+    )
+
+    # Round-trip back to Planning re-activates BezierPlanning.
+    data.SetState(pipeline_module.STATE_PLANNING)
+    pipeline.UpdatePipeline()
+    assert pipeline.GetCurrentRepresentationName() == (
+        pipeline_module.REPRESENTATION_BEZIER_PLANNING
+    )
+
     pipeline.cleanup()
 
 


### PR DESCRIPTION
## Summary

Code-side enabler for [ADR-0019](Docs/adr/0019-resection-state-machine.md):
extends `vtkMRMLBezierSurfaceNode::ResectionState` from a 2-state
enum to the 3-state automaton `Init -> Planning <-> Confirmed`.

The `Confirmed` state freezes the control polygon and engages the
parenchyma-trim shader on the surface mapper (existing
`SetResectionClipOut` entry point on
`vtkOpenGLBezierResectionPolyDataMapper`), producing the v1-style
"clean view" the surgeon sees after confirming a plan.  Round-
trippable: `Confirmed -> Planning` re-opens the control polygon for
further editing.

### What changed

**Node + storage**
- `Confirmed = 2` added to the `ResectionState` enum.
- `SetState` enforces the ADR-0019 transition matrix:
  `Init -> Planning`, `Planning -> Confirmed`, `Confirmed -> Planning`
  allowed; `Init -> Confirmed`, `Planning -> Init`, `Confirmed -> Init`
  rejected with `vtkWarningMacro`.
- Read-only audit-data guard widens to "any post-Init state" so
  init-mode setters reject in both `Planning` and `Confirmed`.
- `.lrp.json` `schemaVersion` stays at 1; only the state-enum string
  set grows.  Reader gains the ADR-0019 forward-compatible
  unknown-state fallback to `"Planning"` so future enum extensions
  degrade gracefully in older builds.

**Representation + pipeline**
- `vtkLiverBezierRepresentation`: in `Confirmed` the glyph cloud is
  empty and `Pick` returns `PickRole_None` — widget disabled per the
  ADR-0019 per-state contract.
- `LiverBezierSurfacePipeline` dispatch table grows one row:
  `(Confirmed, *) -> ConfirmedRepresentation` (new Python class
  under `LiverResections/LiverResectionsLib/Representations/`).
- `ConfirmedRepresentation` calls `SetResectionClipOut(True)` on the
  surface mapper when the mapper exposes it; the call is gated by
  `hasattr` so the pre-T2-mapper-relocation skeleton (generic
  `vtkPolyDataMapper`) survives.  **The mapper file
  `vtkOpenGLBezierResectionPolyDataMapper.{h,cxx}` is NOT touched**
  — the in-flight mapper-refresh PR is the canonical owner.

**Tests**
- `testConfirmedStateTransitions` (C++) pins the full transition
  matrix + audit-data invariants in `Confirmed`.
- `testConfirmedStateRoundTrip` + `testUnknownStateFallback` (C++)
  cover `.lrp.json` read/write of the new state and the forward-
  compatible degrade.
- `testConfirmedStatePickGate` (C++) confirms the widget +
  representation stay quiescent in `Confirmed`.
- `test_confirmed_representation.py` (Python) covers the new
  Representation, including the post-T2-mapper-relocation
  `SetResectionClipOut(True)` branch via a stub mapper.
- Existing state / enum-string tests extend to all three states.

### Storage decision

The `.lrp.json` storage **already round-trips state** as a string
enum (per ADR-0014 §5).  Schema version stays at **1** — only the
enum's string-set grows.  Per ADR-0019 §"Storage / persistence",
the reader gains a forward-compatible unknown-state fallback to
`"Planning"` so a future enum extension (e.g. `Approved`) degrades
gracefully when read by a build that pre-dates the extension.

### UI scope choice

**Minimal — no per-resection widget UI in this PR.**  The
`LiverResections` Qt module hosts no per-resection widget today
(`qSlicerLiverResectionsModule.cxx` registers the storage / reader /
writer + Pipeline but no `qSlicerAbstractModuleWidget`).  The
canonical state-machine setter lives on the data node;
`vtkMRMLBezierSurfaceNode::SetState(Confirmed)` is the contract for
any future UI or Python script.  A follow-up PR can layer a button
or status badge once the broader Resection UI lands.

### Coordination with the mapper-refresh PR

The in-flight `chore/bezier-mapper-refresh` PR refreshes
`vtkOpenGLBezierResectionPolyDataMapper`.  This PR does **NOT** touch
that file — it only calls the existing public `SetResectionClipOut`
entry point through a `hasattr`-gated wrapper.  The two PRs should
merge cleanly regardless of order.

### Anything surprising

The legacy `vtkMRMLBezierSurfaceDisplayNode::ClipOut` field already
exists and is wired into the legacy
`vtkSlicerBezierSurfaceRepresentation3D` (the v1 path).  This PR
does NOT re-route the v1 path through the state machine — the v1
representation stays on its own `ClipOut` plumbing.  The state
machine is canonical for the v2 LayerDM path
(`LiverBezierSurfacePipeline` + the new
`ConfirmedRepresentation`); the v1 path retires per T2.7.

## Test plan

- [x] CI: clang-format clean, ruff clean, copyright headers clean.
- [x] `vtkMRMLBezierSurfaceNodeTest1` — new `testConfirmedStateTransitions`
      passes (legal cycle + every forbidden edge + read-only audit
      invariants in `Confirmed`).
- [x] `vtkMRMLBezierSurfaceStorageNodeTest1` — `testConfirmedStateRoundTrip`
      and `testUnknownStateFallback` pass.
- [x] `vtkLiverBezierWidgetTest1` — `testConfirmedStatePickGate` confirms
      the widget rejects drag in `Confirmed`.
- [~] Python: `test_confirmed_representation.py`, plus the extended
      `test_bezier_surface_node.py` / `test_liver_bezier_surface_pipeline.py`
      pass under Slicer's pytest.

---
This PR was drafted by an AI agent (claude-opus-4-7) on behalf of @RafaelPalomar.