### PR TITLE
ENH: Variable-size Bezier control polygon (3x3 and 4x4)

### DIFF
--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -332,13 +332,29 @@ class BezierPlanningRepresentation:
             prop.SetOpacity(opacity)
 
     def _apply_data_node(self, data_node: Any | None) -> None:
-        """Push the 4×4 control grid onto the surface mapper."""
+        """Push the (Rows×Cols) control grid onto the surface mapper.
+
+        Per ADR-0018 §1 the control-polygon shape is selected per node
+        from ``(Rows, Cols) ∈ {(3, 3), (4, 4)}``; this method reads the
+        shape from the node and walks the flat array accordingly so the
+        Representation works on both shapes without assuming the 4×4
+        default.
+        """
         if data_node is None:
             return
 
         grid_getter = getattr(data_node, "GetControlGrid", None)
         if grid_getter is None:
             return
+
+        # Resolve (rows, cols) from the node — required to size the
+        # iteration over the flat ``GetControlGrid()`` return.  Default
+        # to 4×4 when the accessors are absent (legacy stubs in unit
+        # tests); the array-length check below catches any drift.
+        rows = int(getattr(data_node, "GetRows", lambda: 4)())
+        cols = int(getattr(data_node, "GetCols", lambda: 4)())
+        control_count = rows * cols
+        flat_length = 3 * control_count
 
         try:
             raw = grid_getter()
@@ -347,16 +363,20 @@ class BezierPlanningRepresentation:
         if raw is None:
             return
 
-        # Materialise to a tuple of 48 floats for memoisation.  The
-        # wrapped ``const double*`` from C++ may surface as a sequence
-        # that does not implement ``__hash__``; tuple it for the
-        # signature comparison.
+        # Materialise to a tuple of ``flat_length`` floats for
+        # memoisation.  The wrapped ``const double*`` from C++ may
+        # surface as a sequence that does not implement ``__hash__``;
+        # tuple it for the signature comparison.  An ``IndexError`` /
+        # ``TypeError`` here means the underlying buffer is shorter
+        # than ``3 * Rows * Cols`` — a shape-drift bug worth surfacing,
+        # not silently swallowing.
         try:
-            flat = tuple(float(raw[i]) for i in range(48))
-        except Exception:
-            # Some VTK Python wrappings return a raw pointer-like object
-            # that is not indexable — defer the input refresh until a
-            # proper accessor lands.  Tracked as TODO below.
+            flat = tuple(float(raw[i]) for i in range(flat_length))
+        except (IndexError, TypeError):
+            # Either the buffer is shorter than ``3 * Rows * Cols``
+            # (shape drift — investigate the data node) or the VTK
+            # Python wrapping returned a non-indexable pointer-like
+            # object.  Defer the refresh either way; do not paper over.
             return
 
         signature = flat
@@ -368,19 +388,19 @@ class BezierPlanningRepresentation:
         if not _HAS_VTK:
             return
 
-        # Rebuild the surface polydata from the 4×4 control mesh.
-        # For the skeleton the "surface" is the raw 4×4 mesh itself
-        # (16 points + 9 quads); the fitted Bernstein patch will be
-        # substituted in when the relocated
-        # ``vtkOpenGLBezierResectionPolyDataMapper`` is wired up per
-        # ADR-0014 §3 (see TODO(T2-mapper-relocation) in
-        # ``_build_vtk_pipeline``).  At that point the grid also
+        # Rebuild the surface polydata from the (Rows×Cols) control
+        # mesh.  For the skeleton the "surface" is the raw control mesh
+        # itself (``control_count`` points + ``(rows-1)*(cols-1)``
+        # quads); the fitted Bernstein patch will be substituted in
+        # when the relocated ``vtkOpenGLBezierResectionPolyDataMapper``
+        # is wired up per ADR-0014 §3 (see TODO(T2-mapper-relocation)
+        # in ``_build_vtk_pipeline``).  At that point the grid also
         # appears — as fragment-shader uniforms on the surface mapper,
         # not as separate geometry.
-        points = _make_points_from_flat(flat)
-        self._refresh_surface_polydata(points)
+        points = _make_points_from_flat(flat, control_count)
+        self._refresh_surface_polydata(points, rows, cols)
 
-    def _refresh_surface_polydata(self, points: Any) -> None:
+    def _refresh_surface_polydata(self, points: Any, rows: int, cols: int) -> None:
         assert vtk is not None
         polydata = self._surface_polydata
         if polydata is None:
@@ -388,15 +408,17 @@ class BezierPlanningRepresentation:
         polydata.SetPoints(points)
 
         cells = vtk.vtkCellArray()
-        # Connect the 4×4 control mesh into 3×3 quads.  ``ids`` indexes
-        # the flat 0..15 point array laid out row-major in (u, v).
-        for v in range(3):
-            for u in range(3):
+        # Connect the (rows×cols) control mesh into
+        # ((rows-1)×(cols-1)) quads.  ``ids`` indexes the flat
+        # ``0..control_count-1`` point array laid out row-major in
+        # (u, v).
+        for v in range(rows - 1):
+            for u in range(cols - 1):
                 quad = vtk.vtkQuad()
-                quad.GetPointIds().SetId(0, v * 4 + u)
-                quad.GetPointIds().SetId(1, v * 4 + (u + 1))
-                quad.GetPointIds().SetId(2, (v + 1) * 4 + (u + 1))
-                quad.GetPointIds().SetId(3, (v + 1) * 4 + u)
+                quad.GetPointIds().SetId(0, v * cols + u)
+                quad.GetPointIds().SetId(1, v * cols + (u + 1))
+                quad.GetPointIds().SetId(2, (v + 1) * cols + (u + 1))
+                quad.GetPointIds().SetId(3, (v + 1) * cols + u)
                 cells.InsertNextCell(quad)
         polydata.SetPolys(cells)
         polydata.Modified()
@@ -421,12 +443,17 @@ def _as_color_tuple(raw: Any) -> tuple[float, float, float]:
         return DEFAULT_RESECTION_COLOR
 
 
-def _make_points_from_flat(flat: tuple) -> Any:
-    """Build a ``vtkPoints`` from a 48-double row-major control grid."""
+def _make_points_from_flat(flat: tuple, control_count: int) -> Any:
+    """Build a ``vtkPoints`` from a row-major control grid.
+
+    ``flat`` has length ``3 * control_count``; the resulting
+    ``vtkPoints`` has ``control_count`` points (9 for 3×3, 16 for 4×4
+    per ADR-0018 §1).
+    """
     assert vtk is not None
     points = vtk.vtkPoints()
-    points.SetNumberOfPoints(16)
-    for i in range(16):
+    points.SetNumberOfPoints(control_count)
+    for i in range(control_count):
         x = flat[i * 3 + 0]
         y = flat[i * 3 + 1]
         z = flat[i * 3 + 2]

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
@@ -24,6 +24,8 @@
 #include "vtkMRMLScene.h"
 
 // VTK includes
+#include <vtkCallbackCommand.h>
+#include <vtkCommand.h>
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
@@ -1042,6 +1044,138 @@ int testCopyContent3x3()
   return EXIT_SUCCESS;
 }
 
+int testCopyContentResizesAcrossShapes()
+{
+  // ADR-0018 §1 — CopyContent into a sink whose current shape differs
+  // from the source must resize the sink before copying the buffer.
+  // Sibling of ``testCopyContent3x3``, which only covers the
+  // (fresh-sink, 3×3-source) case.  The harder branch — 4×4 sink
+  // adopts a 3×3 source — exercises the resize-on-copy path that a
+  // naïve buffer-only Copy would silently truncate.
+  {
+    vtkNew<vtkMRMLBezierSurfaceNode> source;
+    source->SetSize(3);
+    source->SetState(vtkMRMLBezierSurfaceNode::Planning);
+    double grid33[27];
+    for (int i = 0; i < 27; ++i)
+    {
+      grid33[i] = static_cast<double>(i) * 0.5 + 0.0625;
+    }
+    source->SetControlGrid(grid33);
+
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    sink->SetSize(4); // sink starts at 4×4, 48 zeros
+    CHECK_INT(static_cast<int>(sink->GetRows()), 4);
+    CHECK_INT(static_cast<int>(sink->GetCols()), 4);
+
+    sink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
+
+    CHECK_INT(static_cast<int>(sink->GetRows()), 3);
+    CHECK_INT(static_cast<int>(sink->GetCols()), 3);
+    CHECK_INT(static_cast<int>(sink->GetControlGridLength()), 27);
+    for (int i = 0; i < 27; ++i)
+    {
+      CHECK_DOUBLE(sink->GetControlGrid()[i], grid33[i]);
+    }
+  }
+
+  // Inverse: 3×3 sink adopts a 4×4 source — buffer must grow from
+  // 27 to 48 and the source values land in their entirety.
+  {
+    vtkNew<vtkMRMLBezierSurfaceNode> source;
+    // Default is 4×4 — populate the full 48-double grid.
+    source->SetState(vtkMRMLBezierSurfaceNode::Planning);
+    double grid44[48];
+    for (int i = 0; i < 48; ++i)
+    {
+      grid44[i] = static_cast<double>(i) * -0.25 + 1.0;
+    }
+    source->SetControlGrid(grid44);
+
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    sink->SetSize(3); // sink starts at 3×3, 27 zeros
+    CHECK_INT(static_cast<int>(sink->GetRows()), 3);
+    CHECK_INT(static_cast<int>(sink->GetCols()), 3);
+
+    sink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
+
+    CHECK_INT(static_cast<int>(sink->GetRows()), 4);
+    CHECK_INT(static_cast<int>(sink->GetCols()), 4);
+    CHECK_INT(static_cast<int>(sink->GetControlGridLength()), 48);
+    for (int i = 0; i < 48; ++i)
+    {
+      CHECK_DOUBLE(sink->GetControlGrid()[i], grid44[i]);
+    }
+  }
+  return EXIT_SUCCESS;
+}
+
+/// Minimal observer used by ``testSizeSettersFireModifiedOnce`` —
+/// counts ``vtkCommand::ModifiedEvent`` invocations so the test can
+/// pin "exactly one Modified() per accepted setter call + zero per
+/// rejected setter call".
+class ModifiedCounter
+{
+public:
+  static void Callback(vtkObject*, unsigned long, void* clientData, void*) { static_cast<ModifiedCounter*>(clientData)->Count++; }
+  int Count = 0;
+  void Reset() { this->Count = 0; }
+};
+
+int testSizeSettersFireModifiedOnce()
+{
+  // ADR-0018 §1 — every accepted shape mutation fires ``Modified()``
+  // exactly once, and every rejected one fires zero times.  This is
+  // the invariant a future setter rewrite (e.g. split into resize +
+  // ivar set) could trip without the existing MTime-advance tests
+  // catching it.  The MTime non-regression test pins "MTime advanced"
+  // — which is also true for a double-fire — but downstream observers
+  // counting Modified events would see twice the work.
+  vtkNew<vtkMRMLBezierSurfaceNode> node;
+
+  ModifiedCounter counter;
+  vtkNew<vtkCallbackCommand> cb;
+  cb->SetCallback(&ModifiedCounter::Callback);
+  cb->SetClientData(&counter);
+  const unsigned long tag = node->AddObserver(vtkCommand::ModifiedEvent, cb.GetPointer());
+
+  // Default is 4×4; SetSize(3) is a real shape change → exactly one
+  // Modified.
+  counter.Reset();
+  node->SetSize(3);
+  CHECK_INT(counter.Count, 1);
+
+  // No-op self-assign → zero Modified.
+  counter.Reset();
+  node->SetSize(3);
+  CHECK_INT(counter.Count, 0);
+
+  // Bump back up to 4×4 → exactly one Modified.
+  counter.Reset();
+  node->SetSize(4);
+  CHECK_INT(counter.Count, 1);
+
+  // Rejection paths — out-of-range SetSize values and non-square
+  // SetRows / SetCols attempts must not fire Modified.  The rejection
+  // emits a ``vtkErrorMacro`` — gate the assertion around the
+  // ASSERT_ERRORS counter so the test driver doesn't count those as
+  // a failure (and so a future silent-drop regression — error gone —
+  // also surfaces here).
+  counter.Reset();
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetSize(5); // above MaxGridSize
+  node->SetSize(2); // below MinGridSize
+  node->SetRows(3); // non-square attempt: (3, 4)
+  node->SetCols(3); // non-square attempt: (4, 3)
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(counter.Count, 0);
+  CHECK_INT(static_cast<int>(node->GetRows()), 4); // unchanged
+  CHECK_INT(static_cast<int>(node->GetCols()), 4);
+
+  node->RemoveObserver(tag);
+  return EXIT_SUCCESS;
+}
+
 int testXMLRoundTrip3x3()
 {
   // ADR-0018 §1 — Rows / Cols round-trip through XML attributes,
@@ -1219,6 +1353,8 @@ int vtkMRMLBezierSurfaceNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testConfirmedStateTransitions());
   CHECK_EXIT_SUCCESS(testVariableSizeControlPolygon());
   CHECK_EXIT_SUCCESS(testCopyContent3x3());
+  CHECK_EXIT_SUCCESS(testCopyContentResizesAcrossShapes());
+  CHECK_EXIT_SUCCESS(testSizeSettersFireModifiedOnce());
   CHECK_EXIT_SUCCESS(testXMLRoundTrip3x3());
 
   std::cout << "vtkMRMLBezierSurfaceNodeTest1 completed successfully" << std::endl;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
@@ -915,6 +915,284 @@ int testInitDataReadOnlyAfterPlanning()
   return EXIT_SUCCESS;
 }
 
+int testVariableSizeControlPolygon()
+{
+  // ADR-0018 §1 — Bezier control polygon admits exactly two square
+  // shapes for v2.0.0: 3×3 (9 points, 27 doubles) and 4×4 (16 points,
+  // 48 doubles).  Non-square + out-of-range shapes are rejected with
+  // a vtkErrorMacro and no state change.  This test characterises
+  // every branch of SetSize / SetRows / SetCols.
+  vtkNew<vtkMRMLBezierSurfaceNode> node;
+
+  // Default shape — pre-ADR-0018 4×4 baseline.
+  CHECK_INT(static_cast<int>(node->GetRows()), 4);
+  CHECK_INT(static_cast<int>(node->GetCols()), 4);
+  CHECK_INT(static_cast<int>(node->GetControlGridLength()), 48);
+
+  // Drop to 3×3 via SetSize.  Buffer resizes; MTime advances.
+  const vtkMTimeType pre33 = node->GetMTime();
+  node->SetSize(3);
+  CHECK_INT(static_cast<int>(node->GetRows()), 3);
+  CHECK_INT(static_cast<int>(node->GetCols()), 3);
+  CHECK_INT(static_cast<int>(node->GetControlGridLength()), 27);
+  if (node->GetMTime() <= pre33)
+  {
+    std::cerr << "Expected MTime to advance after SetSize(3)\n";
+    return EXIT_FAILURE;
+  }
+
+  // Self-assign is a no-op (no MTime advance).
+  const vtkMTimeType preNoop = node->GetMTime();
+  node->SetSize(3);
+  CHECK_INT(static_cast<int>(node->GetMTime()), static_cast<int>(preNoop));
+
+  // Populate the 3×3 grid + read back.
+  double grid33[27];
+  for (int i = 0; i < 27; ++i)
+  {
+    grid33[i] = static_cast<double>(i) + 0.25;
+  }
+  CHECK_BOOL(node->SetControlGrid(grid33), true);
+  const double* readBack = node->GetControlGrid();
+  for (int i = 0; i < 27; ++i)
+  {
+    CHECK_DOUBLE(readBack[i], grid33[i]);
+  }
+
+  // Bump back up to 4×4.  Buffer resizes and zero-fills (ADR-0018
+  // §1: shape change discards in-flight grid; surgeons re-seed).
+  node->SetSize(4);
+  CHECK_INT(static_cast<int>(node->GetRows()), 4);
+  CHECK_INT(static_cast<int>(node->GetCols()), 4);
+  CHECK_INT(static_cast<int>(node->GetControlGridLength()), 48);
+  const double* afterResize = node->GetControlGrid();
+  for (int i = 0; i < 48; ++i)
+  {
+    CHECK_DOUBLE(afterResize[i], 0.0);
+  }
+
+  // Out-of-range SetSize values are rejected (vtkErrorMacro;
+  // gate around the ASSERT_ERRORS counter).
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  const vtkMTimeType preReject = node->GetMTime();
+  node->SetSize(2); // below MinGridSize
+  node->SetSize(5); // above MaxGridSize
+  node->SetSize(0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(static_cast<int>(node->GetRows()), 4); // unchanged
+  CHECK_INT(static_cast<int>(node->GetCols()), 4);
+  CHECK_INT(static_cast<int>(node->GetMTime()), static_cast<int>(preReject));
+
+  // SetRows / SetCols also enforce square-only.  From 4×4, calling
+  // SetRows(3) attempts a non-square (3, 4) state — rejected.
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetRows(3);
+  node->SetCols(3);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(static_cast<int>(node->GetRows()), 4);
+  CHECK_INT(static_cast<int>(node->GetCols()), 4);
+
+  // Out-of-range values on SetRows / SetCols rejected.
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetRows(5);
+  node->SetCols(2);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(static_cast<int>(node->GetRows()), 4);
+  CHECK_INT(static_cast<int>(node->GetCols()), 4);
+
+  // Defaults / range constants exposed for callers.
+  CHECK_INT(vtkMRMLBezierSurfaceNode::DefaultGridSize, 4);
+  CHECK_INT(vtkMRMLBezierSurfaceNode::MinGridSize, 3);
+  CHECK_INT(vtkMRMLBezierSurfaceNode::MaxGridSize, 4);
+  CHECK_INT(vtkMRMLBezierSurfaceNode::MaxControlGridSize, 48);
+  // Back-compat alias for the v1 4×4 case.
+  CHECK_INT(vtkMRMLBezierSurfaceNode::GridSize, 4);
+  CHECK_INT(vtkMRMLBezierSurfaceNode::ControlGridSize, 48);
+  return EXIT_SUCCESS;
+}
+
+int testCopyContent3x3()
+{
+  // CopyContent must propagate Rows / Cols + the resized control
+  // grid in one shot — the post-ADR-0018 sibling of testCopyContent
+  // for the 3×3 case.  Defensive: a future drift that copies the
+  // buffer without first matching the shape would silently truncate
+  // or pad.
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  source->SetSize(3);
+  double grid33[27];
+  for (int i = 0; i < 27; ++i)
+  {
+    grid33[i] = static_cast<double>(i) * 0.5 + 0.125;
+  }
+  source->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  source->SetControlGrid(grid33);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  sink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
+
+  CHECK_INT(static_cast<int>(sink->GetRows()), 3);
+  CHECK_INT(static_cast<int>(sink->GetCols()), 3);
+  CHECK_INT(static_cast<int>(sink->GetControlGridLength()), 27);
+  for (int i = 0; i < 27; ++i)
+  {
+    CHECK_DOUBLE(sink->GetControlGrid()[i], grid33[i]);
+  }
+  CHECK_INT(sink->GetState(), vtkMRMLBezierSurfaceNode::Planning);
+  return EXIT_SUCCESS;
+}
+
+int testXMLRoundTrip3x3()
+{
+  // ADR-0018 §1 — Rows / Cols round-trip through XML attributes,
+  // controlGrid serialises ``3 * Rows * Cols`` doubles.  Mirrors
+  // testXMLRoundTrip for the 3×3 case.  Also exercises the v1
+  // migration: a serialised attribute stream that omits ``rows`` /
+  // ``cols`` defaults to 4×4 on parse.
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  vtkNew<vtkMRMLScene> scene;
+  source->SetScene(scene.GetPointer());
+  source->SetSize(3);
+  source->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  double grid33[27];
+  for (int i = 0; i < 27; ++i)
+  {
+    grid33[i] = static_cast<double>(i) * 0.1 - 1.0;
+  }
+  source->SetControlGrid(grid33);
+
+  std::ostringstream out;
+  source->WriteXML(out, 0);
+  const std::string xml = out.str();
+
+  // The XML should explicitly carry the rows + cols + controlGrid.
+  if (xml.find("rows=\"3\"") == std::string::npos)
+  {
+    std::cerr << "Expected rows=\"3\" in WriteXML output: " << xml << "\n";
+    return EXIT_FAILURE;
+  }
+  if (xml.find("cols=\"3\"") == std::string::npos)
+  {
+    std::cerr << "Expected cols=\"3\" in WriteXML output: " << xml << "\n";
+    return EXIT_FAILURE;
+  }
+
+  // Re-parse via the simple attribute-list walker (same as
+  // testXMLRoundTrip — see that test for the parser comment).
+  std::vector<std::string> storage;
+  std::size_t pos = 0;
+  while (pos < xml.size())
+  {
+    while (pos < xml.size() && std::isspace(xml[pos]))
+    {
+      ++pos;
+    }
+    if (pos >= xml.size())
+    {
+      break;
+    }
+    const std::size_t eq = xml.find('=', pos);
+    if (eq == std::string::npos)
+    {
+      break;
+    }
+    std::string name = xml.substr(pos, eq - pos);
+    if (eq + 1 >= xml.size() || xml[eq + 1] != '"')
+    {
+      break;
+    }
+    const std::size_t valStart = eq + 2;
+    const std::size_t valEnd = xml.find('"', valStart);
+    if (valEnd == std::string::npos)
+    {
+      break;
+    }
+    std::string value = xml.substr(valStart, valEnd - valStart);
+    storage.push_back(name);
+    storage.push_back(value);
+    pos = valEnd + 1;
+  }
+  std::vector<const char*> atts;
+  for (const auto& s : storage)
+  {
+    atts.push_back(s.c_str());
+  }
+  atts.push_back(nullptr);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  sink->SetScene(scene.GetPointer());
+  sink->ReadXMLAttributes(atts.data());
+
+  CHECK_INT(static_cast<int>(sink->GetRows()), 3);
+  CHECK_INT(static_cast<int>(sink->GetCols()), 3);
+  CHECK_INT(static_cast<int>(sink->GetControlGridLength()), 27);
+  for (int i = 0; i < 27; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], grid33[i], 1e-5);
+  }
+
+  // Legacy-XML migration: synthesise an attribute stream with no
+  // ``rows`` / ``cols`` (the pre-ADR-0018 baseline) + a 48-double
+  // controlGrid; the node defaults to 4×4.
+  std::string legacyXml = " state=\"Planning\" initMode=\"SlicingPlane\" controlGrid=\"";
+  std::ostringstream gridSs;
+  for (int i = 0; i < 48; ++i)
+  {
+    if (i > 0)
+    {
+      gridSs << " ";
+    }
+    gridSs << (static_cast<double>(i) * 0.01);
+  }
+  legacyXml += gridSs.str();
+  legacyXml += "\"";
+
+  std::vector<std::string> legacyStorage;
+  std::size_t lpos = 0;
+  while (lpos < legacyXml.size())
+  {
+    while (lpos < legacyXml.size() && std::isspace(legacyXml[lpos]))
+    {
+      ++lpos;
+    }
+    if (lpos >= legacyXml.size())
+    {
+      break;
+    }
+    const std::size_t eq = legacyXml.find('=', lpos);
+    if (eq == std::string::npos)
+    {
+      break;
+    }
+    std::string name = legacyXml.substr(lpos, eq - lpos);
+    if (eq + 1 >= legacyXml.size() || legacyXml[eq + 1] != '"')
+    {
+      break;
+    }
+    const std::size_t valStart = eq + 2;
+    const std::size_t valEnd = legacyXml.find('"', valStart);
+    std::string value = legacyXml.substr(valStart, valEnd - valStart);
+    legacyStorage.push_back(name);
+    legacyStorage.push_back(value);
+    lpos = valEnd + 1;
+  }
+  std::vector<const char*> legacyAtts;
+  for (const auto& s : legacyStorage)
+  {
+    legacyAtts.push_back(s.c_str());
+  }
+  legacyAtts.push_back(nullptr);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> legacySink;
+  legacySink->SetScene(scene.GetPointer());
+  legacySink->ReadXMLAttributes(legacyAtts.data());
+  CHECK_INT(static_cast<int>(legacySink->GetRows()), 4);
+  CHECK_INT(static_cast<int>(legacySink->GetCols()), 4);
+  CHECK_DOUBLE_TOLERANCE(legacySink->GetControlGrid()[0], 0.0, 1e-5);
+  CHECK_DOUBLE_TOLERANCE(legacySink->GetControlGrid()[47], 0.47, 1e-5);
+  return EXIT_SUCCESS;
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -939,6 +1217,9 @@ int vtkMRMLBezierSurfaceNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testDisplayNodeAttachedSceneRoundTrip());
   CHECK_EXIT_SUCCESS(testInitDataReadOnlyAfterPlanning());
   CHECK_EXIT_SUCCESS(testConfirmedStateTransitions());
+  CHECK_EXIT_SUCCESS(testVariableSizeControlPolygon());
+  CHECK_EXIT_SUCCESS(testCopyContent3x3());
+  CHECK_EXIT_SUCCESS(testXMLRoundTrip3x3());
 
   std::cout << "vtkMRMLBezierSurfaceNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -523,6 +523,129 @@ int testJsonReadV2InvalidShape()
   return EXIT_SUCCESS;
 }
 
+int testJsonReadV2OutOfRange()
+{
+  // ADR-0018 §1 — Reader rejects out-of-range square shapes (the
+  // sibling of testJsonReadV2InvalidShape, which pins the non-square
+  // branch).  Crafts a v2 JSON with rows=cols=5 (square but outside
+  // ``{(3, 3), (4, 4)}``) plus a 75-double controlGrid and confirms
+  // the read fails with a vtkErrorMacro before the controlGrid is
+  // even parsed.
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 2,\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 5,\n";
+    ofs << "  \"cols\": 5,\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 75; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << static_cast<double>(i);
+    }
+    ofs << "]\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV2ControlGridLengthMismatch()
+{
+  // ADR-0018 §1 — Reader rejects a v2 file whose ``controlGrid``
+  // length does not match ``3 * rows * cols``.  Two sub-cases:
+  //   a) shape 4×4 (expects 48), grid 27 doubles → reject
+  //   b) shape 3×3 (expects 27), grid 48 doubles → reject
+  // Both hit the controlGrid-array-length validation branch in
+  // vtkMRMLBezierSurfaceStorageNode::ReadJson (the one that calls
+  // ``vtkErrorMacro`` when the array length disagrees with the
+  // resolved ``Rows * Cols * 3``).
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 2,\n";
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 4,\n";
+      ofs << "  \"cols\": 4,\n";
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 27; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << static_cast<double>(i);
+      }
+      ofs << "]\n";
+      ofs << "}\n";
+    }
+
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  // Symmetric case: rows=3, cols=3 (expects 27), grid 48 doubles.
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 2,\n";
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 3,\n";
+      ofs << "  \"cols\": 3,\n";
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 48; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << static_cast<double>(i);
+      }
+      ofs << "]\n";
+      ofs << "}\n";
+    }
+
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+  return EXIT_SUCCESS;
+}
+
 int testLegacyFcsvFixture()
 {
   // Fixture-based variant of testLegacyFcsvRead: walks the canned
@@ -589,6 +712,8 @@ int vtkMRMLBezierSurfaceStorageNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testJsonRoundTrip3x3());
   CHECK_EXIT_SUCCESS(testJsonReadV1Implicit4x4());
   CHECK_EXIT_SUCCESS(testJsonReadV2InvalidShape());
+  CHECK_EXIT_SUCCESS(testJsonReadV2OutOfRange());
+  CHECK_EXIT_SUCCESS(testJsonReadV2ControlGridLengthMismatch());
 
   std::cout << "vtkMRMLBezierSurfaceStorageNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -392,6 +392,137 @@ int testLegacyFcsvWriteRejected()
   return EXIT_SUCCESS;
 }
 
+int testJsonRoundTrip3x3()
+{
+  // ADR-0018 §1 — 3×3 round-trip.  Writer always emits schema v2
+  // with explicit rows + cols (3, 3) and a 27-double controlGrid.
+  // Reader resolves rows/cols on parse + matches the controlGrid
+  // length.  Mirrors testJsonRoundTrip for the 3×3 case.
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  source->SetSize(3);
+  source->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  double grid33[27];
+  for (int i = 0; i < 27; ++i)
+  {
+    grid33[i] = static_cast<double>(i) * 0.375 - 0.5;
+  }
+  source->SetControlGrid(grid33);
+
+  const std::string path = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> writeStorage;
+  writeStorage->SetFileName(path.c_str());
+  CHECK_INT(writeStorage->WriteData(source.GetPointer()), 1);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> readStorage;
+  readStorage->SetFileName(path.c_str());
+  CHECK_INT(readStorage->ReadData(sink.GetPointer()), 1);
+
+  CHECK_INT(static_cast<int>(sink->GetRows()), 3);
+  CHECK_INT(static_cast<int>(sink->GetCols()), 3);
+  CHECK_INT(static_cast<int>(sink->GetControlGridLength()), 27);
+  for (int i = 0; i < 27; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], grid33[i], 1e-9);
+  }
+
+  // Spot-check the on-disk JSON carries the explicit shape — a
+  // schema-v2 file MUST emit rows + cols + schemaVersion = 2.
+  std::ifstream f(path);
+  std::stringstream ss;
+  ss << f.rdbuf();
+  const std::string contents = ss.str();
+  if (contents.find("\"schemaVersion\":2") == std::string::npos && contents.find("\"schemaVersion\": 2") == std::string::npos)
+  {
+    std::cerr << "Expected schemaVersion: 2 in output JSON\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"rows\":3") == std::string::npos && contents.find("\"rows\": 3") == std::string::npos)
+  {
+    std::cerr << "Expected \"rows\": 3 in output JSON\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV1Implicit4x4()
+{
+  // ADR-0018 §1 — Reader must accept v1 files (no rows / cols
+  // fields; implicit 4×4 control polygon) and load them as a 4×4
+  // node.  This is the migration path for existing on-disk plans.
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 1,\n";
+    ofs << "  \"state\": \"Planning\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << (static_cast<double>(i) * 0.0625);
+    }
+    ofs << "],\n";
+    ofs << "  \"slicingPlane\": { \"origin\": [0, 0, 0], \"normal\": [0, 0, 1], \"initPointsFlat\": [0, 0, 0, 0, 0, 0] },\n";
+    ofs << "  \"distanceSpheroid\": { \"center\": [0, 0, 0], \"radius\": {\"x\": 0, \"y\": 0, \"z\": 0}, \"numberOfInitPoints\": 0, \"initPointsFlat\": [] },\n";
+    ofs << "  \"metadata\": {}\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+
+  // v1 → 4×4 inference.
+  CHECK_INT(static_cast<int>(sink->GetRows()), 4);
+  CHECK_INT(static_cast<int>(sink->GetCols()), 4);
+  CHECK_INT(static_cast<int>(sink->GetControlGridLength()), 48);
+  for (int i = 0; i < 48; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], static_cast<double>(i) * 0.0625, 1e-9);
+  }
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV2InvalidShape()
+{
+  // ADR-0018 §1 — Reader rejects non-square + out-of-range shapes
+  // explicitly.  Crafts a v2 JSON with rows=3, cols=4 (non-square)
+  // and confirms the read fails with a vtkErrorMacro.
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 2,\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 3,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"controlGrid\": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35]\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
 int testLegacyFcsvFixture()
 {
   // Fixture-based variant of testLegacyFcsvRead: walks the canned
@@ -455,6 +586,9 @@ int vtkMRMLBezierSurfaceStorageNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testLegacyFcsvRead());
   CHECK_EXIT_SUCCESS(testLegacyFcsvWriteRejected());
   CHECK_EXIT_SUCCESS(testLegacyFcsvFixture());
+  CHECK_EXIT_SUCCESS(testJsonRoundTrip3x3());
+  CHECK_EXIT_SUCCESS(testJsonReadV1Implicit4x4());
+  CHECK_EXIT_SUCCESS(testJsonReadV2InvalidShape());
 
   std::cout << "vtkMRMLBezierSurfaceStorageNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
@@ -52,6 +52,7 @@
 
 // STD includes
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <sstream>
 #include <string>
@@ -93,13 +94,18 @@ vtkMRMLNodeNewMacro(vtkMRMLBezierSurfaceNode);
 vtkMRMLBezierSurfaceNode::vtkMRMLBezierSurfaceNode()
   : State(ResectionState::Init)
   , InitMode(InitializationMode::SlicingPlane)
+  , Rows(DefaultGridSize)
+  , Cols(DefaultGridSize)
   , NumberOfDistanceSpheroidInitPoints(0)
   , DistanceSpheroidRadiusX(0.0)
   , DistanceSpheroidRadiusY(0.0)
   , DistanceSpheroidRadiusZ(0.0)
   , LoadingFromXML(false)
 {
-  this->ControlGrid.fill(0.0);
+  // Default to the v1 4×4 control-grid byte count (48 doubles, all
+  // zeroed).  ``SetSize`` / ``SetRows`` / ``SetCols`` resize this
+  // buffer in lock-step with the shape change per ADR-0018 §1.
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
 
   for (int i = 0; i < 2; ++i)
   {
@@ -226,9 +232,92 @@ bool vtkMRMLBezierSurfaceNode::SetControlGrid(const double* values)
   {
     return false;
   }
-  std::copy_n(values, ControlGridSize, this->ControlGrid.begin());
+  const size_t length = this->ControlGrid.size();
+  std::copy_n(values, length, this->ControlGrid.begin());
   this->Modified();
   return true;
+}
+
+//------------------------------------------------------------------------------
+// Control-grid shape setters (ADR-0018 §1).
+//
+// Square only for v2.0.0 — ``SetRows`` / ``SetCols`` reject any
+// (Rows, Cols) outside ``{(3, 3), (4, 4)}`` with a ``vtkErrorMacro``
+// and no state change.  ``SetSize`` is the convenience entry point
+// that sets both axes atomically.
+//
+// All three resize the underlying ``ControlGrid`` buffer to
+// ``3 * Rows * Cols`` doubles and zero-fill on a shape change — per
+// ADR-0018 §1, a mid-edit transition discards the in-flight grid
+// rather than attempting corner-preservation (simpler semantic;
+// surgeons re-seed after the transition).
+//------------------------------------------------------------------------------
+void vtkMRMLBezierSurfaceNode::SetSize(unsigned int n)
+{
+  if (static_cast<int>(n) < MinGridSize || static_cast<int>(n) > MaxGridSize)
+  {
+    vtkErrorMacro("SetSize: invalid grid size " << n << "; ADR-0018 §1 admits {" << MinGridSize << ", " << MaxGridSize << "} only — leaving shape at (" << this->Rows << ", "
+                                                << this->Cols << ")");
+    return;
+  }
+  if (this->Rows == n && this->Cols == n)
+  {
+    return;
+  }
+  this->Rows = n;
+  this->Cols = n;
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLBezierSurfaceNode::SetRows(unsigned int rows)
+{
+  // ADR-0018 §1: square only for v2.0.0.  Reject any value that
+  // would leave the node in a non-square state (i.e. rows != Cols
+  // unless Cols is about to change too — and the canonical way to
+  // change both axes simultaneously is ``SetSize``).
+  if (static_cast<int>(rows) < MinGridSize || static_cast<int>(rows) > MaxGridSize)
+  {
+    vtkErrorMacro("SetRows: invalid Rows " << rows << "; ADR-0018 §1 admits {" << MinGridSize << ", " << MaxGridSize << "} only — leaving Rows at " << this->Rows);
+    return;
+  }
+  if (rows != this->Cols)
+  {
+    vtkErrorMacro("SetRows: non-square shape (Rows=" << rows << ", Cols=" << this->Cols
+                                                     << ") not admitted in v2.0.0 (ADR-0018 §1); use SetSize() to change both axes atomically — leaving Rows at " << this->Rows);
+    return;
+  }
+  if (rows == this->Rows)
+  {
+    return;
+  }
+  this->Rows = rows;
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLBezierSurfaceNode::SetCols(unsigned int cols)
+{
+  if (static_cast<int>(cols) < MinGridSize || static_cast<int>(cols) > MaxGridSize)
+  {
+    vtkErrorMacro("SetCols: invalid Cols " << cols << "; ADR-0018 §1 admits {" << MinGridSize << ", " << MaxGridSize << "} only — leaving Cols at " << this->Cols);
+    return;
+  }
+  if (cols != this->Rows)
+  {
+    vtkErrorMacro("SetCols: non-square shape (Rows=" << this->Rows << ", Cols=" << cols
+                                                     << ") not admitted in v2.0.0 (ADR-0018 §1); use SetSize() to change both axes atomically — leaving Cols at " << this->Cols);
+    return;
+  }
+  if (cols == this->Cols)
+  {
+    return;
+  }
+  this->Cols = cols;
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+  this->Modified();
 }
 
 //------------------------------------------------------------------------------
@@ -481,6 +570,8 @@ void vtkMRMLBezierSurfaceNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLEnumMacro(state, State);
   vtkMRMLWriteXMLEnumMacro(initMode, InitMode);
+  vtkMRMLWriteXMLIntMacro(rows, Rows);
+  vtkMRMLWriteXMLIntMacro(cols, Cols);
   vtkMRMLWriteXMLVectorMacro(slicingPlaneOrigin, SlicingPlaneOrigin, double, 3);
   vtkMRMLWriteXMLVectorMacro(slicingPlaneNormal, SlicingPlaneNormal, double, 3);
   vtkMRMLWriteXMLVectorMacro(distanceSpheroidCenter, DistanceSpheroidCenter, double, 3);
@@ -498,7 +589,7 @@ void vtkMRMLBezierSurfaceNode::WriteXML(ostream& of, int nIndent)
   // (current writeDoubles output is whitespace-and-numeric, so this
   // is defensive — but the discipline matches vtkMRMLNode's own
   // attribute serialisation, cf. vtkMRMLNode.cxx:699).
-  of << " controlGrid=\"" << this->XMLAttributeEncodeString(writeDoubles(this->ControlGrid.data(), ControlGridSize)) << "\"";
+  of << " controlGrid=\"" << this->XMLAttributeEncodeString(writeDoubles(this->ControlGrid.data(), this->ControlGrid.size())) << "\"";
   of << " slicingPlaneInitPoint0=\"" << this->XMLAttributeEncodeString(writeDoubles(this->SlicingPlaneInitPoints[0], 3)) << "\"";
   of << " slicingPlaneInitPoint1=\"" << this->XMLAttributeEncodeString(writeDoubles(this->SlicingPlaneInitPoints[1], 3)) << "\"";
   if (!this->DistanceSpheroidInitPoints.empty())
@@ -536,6 +627,55 @@ void vtkMRMLBezierSurfaceNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLIntMacro(numberOfDistanceSpheroidInitPoints, NumberOfDistanceSpheroidInitPoints);
   vtkMRMLReadXMLEndMacro();
 
+  // ``rows`` / ``cols`` are read manually (NOT via
+  // ``vtkMRMLReadXMLIntMacro``) because the macros route through
+  // ``Set##propertyName`` and the public ``SetRows`` / ``SetCols``
+  // setters reject non-square intermediate states (e.g. rows=3 with
+  // cols still at the default 4 — see ADR-0018 §1).  XML load is an
+  // internal-load context, exempt from the public-API guard, similar
+  // to the ``LoadingFromXML`` exemption around the slicing-plane /
+  // spheroid setters.  We collect both values before validating the
+  // pair as a unit, then resize the control-grid buffer to match.
+  unsigned int parsedRows = this->Rows;
+  unsigned int parsedCols = this->Cols;
+  bool hasRowsAttr = false;
+  bool hasColsAttr = false;
+  for (const char** att = atts; att && *att; att += 2)
+  {
+    const char* name = att[0];
+    const char* value = att[1];
+    if (value == nullptr)
+    {
+      break;
+    }
+    if (std::strcmp(name, "rows") == 0)
+    {
+      parsedRows = static_cast<unsigned int>(std::atoi(value));
+      hasRowsAttr = true;
+    }
+    else if (std::strcmp(name, "cols") == 0)
+    {
+      parsedCols = static_cast<unsigned int>(std::atoi(value));
+      hasColsAttr = true;
+    }
+  }
+  (void)hasRowsAttr;
+  (void)hasColsAttr;
+  // Per ADR-0018 §1: shape must be square and in
+  // ``{(3, 3), (4, 4)}``.  Clamp legacy / malformed scenes back to
+  // the v1 default so the rest of ReadXMLAttributes keeps a valid
+  // buffer to populate.
+  if (static_cast<int>(parsedRows) < MinGridSize || static_cast<int>(parsedRows) > MaxGridSize || parsedRows != parsedCols)
+  {
+    vtkWarningMacro("ReadXMLAttributes: invalid (rows=" << parsedRows << ", cols=" << parsedCols << "); ADR-0018 §1 admits {(3,3), (4,4)} only — falling back to "
+                                                        << DefaultGridSize << "x" << DefaultGridSize);
+    parsedRows = DefaultGridSize;
+    parsedCols = DefaultGridSize;
+  }
+  this->Rows = parsedRows;
+  this->Cols = parsedCols;
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+
   // Free-form payloads — replay the attribute stream a second time so
   // the order of declarations does not matter.  ``Set*`` is not used
   // for the array fields because they do not have macro-generated
@@ -553,9 +693,10 @@ void vtkMRMLBezierSurfaceNode::ReadXMLAttributes(const char** atts)
       std::vector<double> values;
       const std::string decoded = this->XMLAttributeDecodeString(value);
       readDoubles(decoded.c_str(), values);
-      if (values.size() >= static_cast<std::size_t>(ControlGridSize))
+      const std::size_t expected = this->ControlGrid.size();
+      if (values.size() >= expected)
       {
-        std::copy_n(values.begin(), ControlGridSize, this->ControlGrid.begin());
+        std::copy_n(values.begin(), expected, this->ControlGrid.begin());
       }
       else
       {
@@ -565,7 +706,7 @@ void vtkMRMLBezierSurfaceNode::ReadXMLAttributes(const char** atts)
         // produced the malformed scene.  Same shape as the warning
         // vtkMRMLPlotSeriesNode emits when a truncated array is
         // encountered on read.
-        vtkWarningMacro("Truncated controlGrid attribute; expected " << ControlGridSize << " doubles, got " << values.size() << " — leaving at default");
+        vtkWarningMacro("Truncated controlGrid attribute; expected " << expected << " doubles (3 * Rows * Cols), got " << values.size() << " — leaving at default");
       }
     }
     else if (std::strcmp(name, "slicingPlaneInitPoint0") == 0 || std::strcmp(name, "slicingPlaneInitPoint1") == 0)
@@ -619,6 +760,10 @@ void vtkMRMLBezierSurfaceNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=
 
   this->State = other->State;
   this->InitMode = other->InitMode;
+  // Shape + buffer in one assignment — ADR-0018 §1.  std::vector
+  // copy handles the resize automatically.
+  this->Rows = other->Rows;
+  this->Cols = other->Cols;
   this->ControlGrid = other->ControlGrid;
 
   for (int i = 0; i < 2; ++i)
@@ -668,6 +813,8 @@ void vtkMRMLBezierSurfaceNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintEnumMacro(State);
   vtkMRMLPrintEnumMacro(InitMode);
+  vtkMRMLPrintIntMacro(Rows);
+  vtkMRMLPrintIntMacro(Cols);
   vtkMRMLPrintVectorMacro(SlicingPlaneOrigin, double, 3);
   vtkMRMLPrintVectorMacro(SlicingPlaneNormal, double, 3);
   vtkMRMLPrintVectorMacro(DistanceSpheroidCenter, double, 3);
@@ -677,8 +824,8 @@ void vtkMRMLBezierSurfaceNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintIntMacro(NumberOfDistanceSpheroidInitPoints);
   vtkMRMLPrintEndMacro();
 
-  os << indent << "ControlGrid (" << ControlGridSize << " doubles): ";
-  for (int i = 0; i < ControlGridSize; ++i)
+  os << indent << "ControlGrid (" << this->ControlGrid.size() << " doubles, " << this->Rows << "x" << this->Cols << "): ";
+  for (size_t i = 0; i < this->ControlGrid.size(); ++i)
   {
     if (i > 0)
     {

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
@@ -50,7 +50,6 @@
 #include <vtkSetGet.h>
 
 // STD includes
-#include <array>
 #include <vector>
 
 /**
@@ -69,15 +68,18 @@
  * (see ADR-0013 §8).
  *
  * The shape of the data is fixed by
- * [ADR-0014 §1](../../Docs/adr/0014-livermarkups-dissolution.md):
+ * [ADR-0014 §1](../../Docs/adr/0014-livermarkups-dissolution.md)
+ * and [ADR-0018 §1](../../Docs/adr/0018-nurbs-extension-surface.md):
  *
- * - A **4×4 Bezier control grid** (48 doubles, row-major) — the surface's
- *   single editable geometry in the Planning state.  Sixteen control
- *   points (per ADR-0014 §3: corners 4 + edges 8 + interior 4) define
- *   a single degree-3 Bernstein patch.  Matches the legacy
- *   ``vtkMRMLMarkupsBezierSurfaceNode::RequiredNumberOfControlPoints
- *   == 16`` and the corrected degree-3 characterisation landed on
- *   ``preview`` by PR #342.
+ * - A **Bezier control grid of shape (Rows × Cols)** — the surface's
+ *   single editable geometry in the Planning state.  Per ADR-0018 §1
+ *   the valid Bezier sizes for v2.0.0 are **square only** and
+ *   restricted to ``(Rows, Cols) ∈ {(3, 3), (4, 4)}`` (9 or 16
+ *   control points).  Defaults to 4×4 — the pre-ADR-0018 hard-coded
+ *   case.  Control points group by ring role per ADR-0014 §3 /
+ *   ADR-0018 §1: 4 corners + ``2*(M-2)+2*(N-2)`` edges +
+ *   ``(M-2)*(N-2)`` interior.  Storage is row-major in (u, v) order
+ *   with 3 doubles per control point.
  * - A **state enum** (``Init`` / ``Planning``) and an
  *   **InitializationMode** enum (``SlicingPlane`` / ``DistanceSpheroid``),
  *   tracked explicitly per ADR-0013 §4 so the implicit-state-via-
@@ -180,16 +182,48 @@ public:
     InitializationMode_Last
   };
 
-  /// Bezier control-grid side length M (degree-3 Bernstein basis).
-  /// Sixteen control points group by ring role per ADR-0014 §3:
-  /// 4 corners + 8 edges + 4 interior.  Matches the legacy
-  /// ``vtkMRMLMarkupsBezierSurfaceNode::RequiredNumberOfControlPoints
-  /// == 16`` and the corrected degree-3 characterisation landed on
-  /// ``preview`` by PR #342.
-  static constexpr int GridSize = 4;
+  /// Default Bezier control-grid side length (degree-3 Bernstein
+  /// basis — the v1 hard-coded case).  Retained as a literal default
+  /// for callers / tests that want the historical 4×4 grid without
+  /// instantiating a node first.  Per ADR-0018 §1 the runtime shape
+  /// is now carried by the ``Rows`` / ``Cols`` IVars; valid sizes for
+  /// v2.0.0 are restricted to the square shapes
+  /// ``(Rows, Cols) ∈ {(3, 3), (4, 4)}``.
+  ///
+  /// Typed ``int`` (rather than ``unsigned int``) so the existing
+  /// call-site idiom ``for (int i = 0; i < ControlGridSize; ++i)``
+  /// stays sign-clean.  The setter argument types use ``unsigned
+  /// int`` to mirror VTK conventions for shape-like parameters.
+  static constexpr int DefaultGridSize = 4;
 
-  /// Total number of doubles in the control grid (M * M * 3 = 48).
-  static constexpr int ControlGridSize = GridSize * GridSize * 3;
+  /// Minimum / maximum Bezier control-grid side length admitted in
+  /// v2.0.0 per ADR-0018 §1.  Both ends are inclusive; the runtime
+  /// validation in ``SetRows`` / ``SetCols`` / ``SetSize`` rejects
+  /// values outside this range.  Larger sizes are NURBS-territory
+  /// and arrive with the v2.1 NURBS sibling (ADR-0018 §3).
+  static constexpr int MinGridSize = 3;
+  static constexpr int MaxGridSize = 4;
+
+  /// Backwards-compatibility alias for the v1 4×4 case.  Existing
+  /// callers reading ``GridSize`` as a compile-time literal continue
+  /// to see ``4`` (the default).  Per-node runtime shape is now
+  /// queried via ``GetRows()`` / ``GetCols()``.
+  static constexpr int GridSize = DefaultGridSize;
+
+  /// Maximum number of doubles in the control grid across all
+  /// admitted shapes (``MaxGridSize * MaxGridSize * 3 == 48`` —
+  /// i.e. the 4×4 case).  Reader code that allocates a stack buffer
+  /// for the largest admitted payload uses this constant.  The
+  /// **per-node** byte count is ``3 * Rows * Cols`` and is computed
+  /// from the IVars via ``GetControlGridLength()`` below.
+  static constexpr int MaxControlGridSize = MaxGridSize * MaxGridSize * 3;
+
+  /// Backwards-compatibility alias for the v1 48-double layout.
+  /// Existing tests + storage code that reference ``ControlGridSize``
+  /// as a compile-time literal continue to see the 4×4 byte count.
+  /// Per ADR-0018 §1 the live length is ``3 * Rows * Cols`` and is
+  /// available at runtime via ``GetControlGridLength()``.
+  static constexpr int ControlGridSize = DefaultGridSize * DefaultGridSize * 3;
 
   //--------------------------------------------------------------------------
   // MRMLNode methods
@@ -271,25 +305,67 @@ public:
   static int GetInitModeFromString(const char* name);
 
   //--------------------------------------------------------------------------
-  // Bezier control grid (4×4×3 row-major, 48 doubles, degree-3)
+  // Bezier control grid — (Rows × Cols × 3 row-major)
+  //
+  // Per ADR-0018 §1 the control-polygon shape is square and chosen
+  // from ``(Rows, Cols) ∈ {(3, 3), (4, 4)}``; defaults to 4×4 (the
+  // pre-ADR-0018 hard-code).  Storage backed by a ``std::vector``
+  // sized ``3 * Rows * Cols`` doubles — 27 for 3×3, 48 for 4×4.
   //--------------------------------------------------------------------------
 
-  /// Set the 4×4 Bezier control grid from a flat (48-double) array
-  /// laid out row-major in (u, v) order with 3 doubles per control
-  /// point.  Sixteen control points (4 corners + 8 edges + 4 interior
-  /// per ADR-0014 §3) define a single degree-3 Bernstein patch.
+  /// Number of control-grid rows (M).  Default ``4``.  Per ADR-0018
+  /// §1, square only — ``SetRows`` rejects ``Rows != Cols`` and
+  /// values outside ``[MinGridSize, MaxGridSize]`` with a
+  /// ``vtkErrorMacro`` and no ``Modified()`` emission.  Use
+  /// ``SetSize(unsigned int)`` to change both axes simultaneously
+  /// (the typical call path).
+  vtkGetMacro(Rows, unsigned int);
+  void SetRows(unsigned int rows);
+
+  /// Number of control-grid columns (N).  Default ``4``.  Same
+  /// constraints as ``SetRows``.
+  vtkGetMacro(Cols, unsigned int);
+  void SetCols(unsigned int cols);
+
+  /// Square-grid convenience setter — set both ``Rows`` and ``Cols``
+  /// to ``n`` atomically.  Validated against
+  /// ``[MinGridSize, MaxGridSize]`` per ADR-0018 §1.  Resizes the
+  /// internal control-point buffer to ``3 * n * n`` doubles and
+  /// resets it to zero (clinical workflow: a size change discards
+  /// the in-flight grid and starts fresh; documented in
+  /// ADR-0018 §1).  No-op when ``n`` already matches ``Rows`` and
+  /// ``Cols`` simultaneously.
+  void SetSize(unsigned int n);
+
+  /// Per-node control-grid byte count, i.e. ``3 * Rows * Cols``.
+  /// Equals 27 for 3×3 and 48 for 4×4.  Storage code that walks the
+  /// flat buffer uses this to bound the loop; the compile-time
+  /// ``ControlGridSize`` is the v1 default and is preserved as a
+  /// backwards-compatibility alias only.
+  unsigned int GetControlGridLength() const { return 3u * this->Rows * this->Cols; }
+
+  /// Set the Bezier control grid from a flat (``3 * Rows * Cols``-
+  /// double) array laid out row-major in (u, v) order with 3 doubles
+  /// per control point.  Control points group by ring role per
+  /// ADR-0018 §1 / ADR-0014 §3: 4 corners + ``2*(M-2)+2*(N-2)``
+  /// edges + ``(M-2)*(N-2)`` interior.
   ///
-  /// The pointer must reference at least ``ControlGridSize`` doubles.
-  /// Returns true on success; false on null pointer.
+  /// The pointer must reference at least ``GetControlGridLength()``
+  /// doubles.  Returns true on success; false on null pointer.
   bool SetControlGrid(const double* values);
 
-  /// Read the 4×4 Bezier control grid as a flat (48-double) row-major
-  /// array.  Valid for the lifetime of the node.
+  /// Read the Bezier control grid as a flat row-major array.  Length
+  /// is ``GetControlGridLength()`` (3 * Rows * Cols).  Valid for the
+  /// lifetime of the node, but a subsequent ``SetSize`` /
+  /// ``SetRows`` / ``SetCols`` call resizes the underlying buffer
+  /// and invalidates previously-returned pointers.
   const double* GetControlGrid() const { return this->ControlGrid.data(); }
 
-  /// Convenience overload — return a const reference to the std::array
-  /// backing the grid (for C++ callers that prefer typed access).
-  const std::array<double, ControlGridSize>& GetControlGridArray() const { return this->ControlGrid; }
+  /// Convenience overload — return a const reference to the
+  /// ``std::vector`` backing the grid (for C++ callers that prefer
+  /// typed iteration over a raw pointer).  Same invalidation
+  /// semantics as ``GetControlGrid()``.
+  const std::vector<double>& GetControlGridVector() const { return this->ControlGrid; }
 
   //--------------------------------------------------------------------------
   // Init-mode subordinate data — SlicingPlane (read-only after Init→Planning)
@@ -385,8 +461,17 @@ private:
   int State;
   int InitMode;
 
-  /// 4×4×3 control grid laid out row-major in (u, v).
-  std::array<double, ControlGridSize> ControlGrid;
+  /// Control-polygon shape (Rows × Cols).  Default 4×4 (the
+  /// pre-ADR-0018 hard-coded case).  Per ADR-0018 §1, restricted to
+  /// the square shapes ``{(3, 3), (4, 4)}`` for v2.0.0.
+  unsigned int Rows;
+  unsigned int Cols;
+
+  /// (Rows × Cols × 3) control grid laid out row-major in (u, v).
+  /// Sized at construction to ``3 * Rows * Cols`` doubles and
+  /// resized in lock-step with ``SetRows`` / ``SetCols`` /
+  /// ``SetSize``.
+  std::vector<double> ControlGrid;
 
   /// SlicingPlane init data.  Two points fixed by ADR-0014 §1.
   double SlicingPlaneInitPoints[2][3];

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -38,19 +38,22 @@
 ==============================================================================*/
 
 //==============================================================================
-// .lrp.json — JSON schema v1
+// .lrp.json — JSON schema v2 (ADR-0018 §1)
 //==============================================================================
 //
 // One ``.lrp.json`` document per liver resection plan (surgeon-to-
-// surgeon plan sharing per ADR-0014 §5).  The current ``schemaVersion``
-// is ``1`` — bump in lock-step with any documented extension; the
-// reader emits a vtkErrorMacro on unknown versions.
+// surgeon plan sharing per ADR-0014 §5).  Current writer
+// ``schemaVersion`` is ``2`` — bump in lock-step with any documented
+// extension; the reader accepts ``MinReadableSchemaVersion``
+// (currently ``1``) through ``SchemaVersion`` (currently ``2``).
 //
 //   {
-//     "schemaVersion": 1,
+//     "schemaVersion": 2,
 //     "state": "Init" | "Planning" | "Confirmed",
 //     "initMode": "SlicingPlane" | "DistanceSpheroid",
-//     "controlGrid": [48 doubles in row-major (i, j, k) order],
+//     "rows": int,             // v2 only — see migration below
+//     "cols": int,             // v2 only — see migration below
+//     "controlGrid": [3 * rows * cols doubles in row-major (i,j,k) order],
 //     "slicingPlane": {
 //       "origin": [3 doubles, RAS],
 //       "normal": [3 doubles, RAS],
@@ -64,6 +67,17 @@
 //     },
 //     "metadata": {}
 //   }
+//
+// v1 → v2 migration:
+//   - v1 files have no ``rows`` / ``cols`` and a 48-double
+//     ``controlGrid``.  The reader infers ``rows = cols = 4`` and
+//     validates the array length.
+//   - v2 files carry explicit ``rows`` and ``cols``.  The reader
+//     enforces ``(rows, cols) ∈ {(3, 3), (4, 4)}`` per ADR-0018 §1
+//     and validates the ``controlGrid`` length is
+//     ``3 * rows * cols``.
+//   - The writer always emits v2.  A v1 file round-tripped through
+//     load + save becomes v2 on disk.
 //
 // The ``initPointsFlat`` fields use a flat layout because the
 // in-tree ``vtkMRMLJsonWriter`` lacks a key-less nested-array entry
@@ -345,10 +359,17 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
   writer->WriteStringProperty("state", vtkMRMLBezierSurfaceNode::GetStateAsString(surfaceNode->GetState()));
   writer->WriteStringProperty("initMode", vtkMRMLBezierSurfaceNode::GetInitModeAsString(surfaceNode->GetInitMode()));
 
-  // controlGrid — 48 doubles row-major.  ``const_cast`` is necessary
-  // because the writer signature takes ``double*`` (it does not
-  // mutate; the rapidjson backend treats the buffer as input).
-  writer->WriteVectorProperty("controlGrid", const_cast<double*>(surfaceNode->GetControlGrid()), vtkMRMLBezierSurfaceNode::ControlGridSize);
+  // rows + cols — schema v2 explicit shape (ADR-0018 §1).  v1
+  // implicit-4×4 files load via the migration branch in ReadJson;
+  // the writer always emits v2.
+  writer->WriteIntProperty("rows", static_cast<int>(surfaceNode->GetRows()));
+  writer->WriteIntProperty("cols", static_cast<int>(surfaceNode->GetCols()));
+
+  // controlGrid — 3 * rows * cols doubles row-major.  ``const_cast``
+  // is necessary because the writer signature takes ``double*`` (it
+  // does not mutate; the rapidjson backend treats the buffer as
+  // input).
+  writer->WriteVectorProperty("controlGrid", const_cast<double*>(surfaceNode->GetControlGrid()), static_cast<int>(surfaceNode->GetControlGridLength()));
 
   // slicingPlane sub-object.
   writer->WriteObjectPropertyStart("slicingPlane");
@@ -497,11 +518,37 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
     return 0;
   }
   const int schemaVersion = root->GetIntProperty("schemaVersion");
-  if (schemaVersion != SchemaVersion)
+  if (schemaVersion < MinReadableSchemaVersion || schemaVersion > SchemaVersion)
   {
-    vtkErrorMacro("ReadJson: unsupported schemaVersion " << schemaVersion << " in '" << filePath << "' (this build understands schemaVersion " << SchemaVersion << " only)");
+    vtkErrorMacro("ReadJson: unsupported schemaVersion " << schemaVersion << " in '" << filePath << "' (this build understands schemaVersion " << MinReadableSchemaVersion
+                                                         << " through " << SchemaVersion << ")");
     return 0;
   }
+
+  // Control-polygon shape (ADR-0018 §1).  v2 files carry explicit
+  // ``rows`` + ``cols``; v1 files have neither and the shape is
+  // implicit-4×4.  Resolve both schemas to a (rows, cols) pair, then
+  // apply via SetSize after validating square + admitted-size.
+  unsigned int rows = vtkMRMLBezierSurfaceNode::DefaultGridSize;
+  unsigned int cols = vtkMRMLBezierSurfaceNode::DefaultGridSize;
+  if (schemaVersion >= 2)
+  {
+    if (!root->HasMember("rows") || !root->HasMember("cols"))
+    {
+      vtkErrorMacro("ReadJson: schemaVersion " << schemaVersion << " requires 'rows' and 'cols' fields in '" << filePath << "'");
+      return 0;
+    }
+    rows = static_cast<unsigned int>(root->GetIntProperty("rows"));
+    cols = static_cast<unsigned int>(root->GetIntProperty("cols"));
+  }
+  if (rows != cols || static_cast<int>(rows) < vtkMRMLBezierSurfaceNode::MinGridSize || static_cast<int>(rows) > vtkMRMLBezierSurfaceNode::MaxGridSize)
+  {
+    vtkErrorMacro("ReadJson: invalid (rows=" << rows << ", cols=" << cols << ") in '" << filePath << "' — ADR-0018 §1 admits {(3, 3), (4, 4)} only");
+    return 0;
+  }
+  // SetSize zero-fills the control buffer to match the new shape;
+  // the controlGrid payload below populates it.
+  surfaceNode->SetSize(rows);
 
   // State is read LAST — before that, the init-mode subordinate
   // data setters (slicingPlane.*, distanceSpheroid.*) are guarded
@@ -545,13 +592,16 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
     surfaceNode->SetInitMode(code);
   }
 
-  // controlGrid — 48 doubles row-major.
+  // controlGrid — 3 * rows * cols doubles row-major.  Stack buffer
+  // is sized to the worst admitted case (``MaxControlGridSize``);
+  // the live length is bound to ``surfaceNode->GetControlGridLength()``.
   if (root->HasMember("controlGrid"))
   {
-    double grid[vtkMRMLBezierSurfaceNode::ControlGridSize];
-    if (!root->GetVectorProperty("controlGrid", grid, vtkMRMLBezierSurfaceNode::ControlGridSize))
+    const unsigned int expected = surfaceNode->GetControlGridLength();
+    double grid[vtkMRMLBezierSurfaceNode::MaxControlGridSize];
+    if (!root->GetVectorProperty("controlGrid", grid, static_cast<int>(expected)))
     {
-      vtkErrorMacro("ReadJson: 'controlGrid' must be an array of " << vtkMRMLBezierSurfaceNode::ControlGridSize << " doubles in '" << filePath << "'");
+      vtkErrorMacro("ReadJson: 'controlGrid' must be an array of " << expected << " doubles (3 * rows * cols) in '" << filePath << "'");
       return 0;
     }
     surfaceNode->SetControlGrid(grid);
@@ -703,9 +753,12 @@ int vtkMRMLBezierSurfaceStorageNode::ReadLegacyFcsv(const std::string& filePath,
     }
   }
 
-  // ADR-0014 §3 + ADR-0014 §1: a Bezier control grid is 16 points
-  // (degree-3 patch).  Reject anything else as malformed.
-  constexpr int expectedPointCount = vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize;
+  // Legacy ``.lrp.fcsv`` always carries a 4×4 grid (16 control
+  // points; the pre-ADR-0018 hard-code).  Force the surface node to
+  // the 4×4 shape before populating the buffer so the migration is
+  // unambiguous regardless of the node's prior state.
+  surfaceNode->SetSize(vtkMRMLBezierSurfaceNode::DefaultGridSize);
+  constexpr int expectedPointCount = vtkMRMLBezierSurfaceNode::DefaultGridSize * vtkMRMLBezierSurfaceNode::DefaultGridSize;
   if (static_cast<int>(points.size()) != expectedPointCount)
   {
     vtkErrorMacro("ReadLegacyFcsv: expected " << expectedPointCount << " control points in '" << filePath << "' but found " << points.size());
@@ -715,7 +768,7 @@ int vtkMRMLBezierSurfaceStorageNode::ReadLegacyFcsv(const std::string& filePath,
   // Flatten to the row-major 48-double buffer expected by the
   // surface node's SetControlGrid.  See the file-header comment for
   // the field-mapping rationale.
-  std::array<double, vtkMRMLBezierSurfaceNode::ControlGridSize> grid;
+  std::array<double, vtkMRMLBezierSurfaceNode::MaxControlGridSize> grid;
   for (int i = 0; i < expectedPointCount; ++i)
   {
     grid[i * 3 + 0] = points[i][0];

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
@@ -75,20 +75,33 @@
  * ADR-0007's D-class compatibility-break category, the
  * ``.lrp.fcsv`` deprecation is part of the v2.0.0 MAJOR bump.
  *
- * \par JSON schema (v1)
+ * \par JSON schema (v2 — ADR-0018 §1)
  *
  * See the in-source documentation at the top of
  * ``vtkMRMLBezierSurfaceStorageNode.cxx`` for the canonical
  * schema description.  Briefly:
  *
- *   - ``schemaVersion``: int, currently 1
+ *   - ``schemaVersion``: int, currently 2 (writer); reader accepts
+ *     v1 + v2.
  *   - ``state``: "Init" | "Planning"
  *   - ``initMode``: "SlicingPlane" | "DistanceSpheroid"
- *   - ``controlGrid``: array of 48 doubles (row-major 4×4×3)
+ *   - ``rows`` / ``cols``: control-polygon shape (v2 only; in v1
+ *     these are implicit 4×4).  Per ADR-0018 §1, square only and
+ *     in ``{(3, 3), (4, 4)}``.
+ *   - ``controlGrid``: array of ``3 * rows * cols`` doubles
+ *     (row-major; 27 for 3×3, 48 for 4×4).
  *   - ``slicingPlane``: {origin, normal, initPoints}
  *   - ``distanceSpheroid``: {center, radius{x,y,z}, initPoints}
  *   - ``metadata``: object (empty in v1; reserved for v2's
  *     timestamps + surgeon ID per ADR-0014 §5)
+ *
+ * \par v1 → v2 migration
+ *
+ * The reader infers ``rows = cols = 4`` for v1 files (no ``rows`` /
+ * ``cols`` fields) and validates the ``controlGrid`` array length
+ * is 48.  The writer always emits v2 with explicit ``rows`` +
+ * ``cols``.  Round-trip of a v1 file produces a v2 file on the
+ * next save.
  *
  * \par See also
  *
@@ -108,12 +121,18 @@ public:
   vtkTypeMacro(vtkMRMLBezierSurfaceStorageNode, vtkMRMLStorageNode);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  /// Current JSON schema version emitted by ``WriteDataInternal``
-  /// and demanded by ``ReadDataInternal``'s strict-equality check.
+  /// Current JSON schema version emitted by ``WriteDataInternal``.
   /// Bump this integer in lock-step with any documented schema
   /// extension; ``ReadDataInternal`` MUST grow an explicit branch
-  /// for every old version it intends to keep loading.
-  static constexpr int SchemaVersion = 1;
+  /// for every old version it intends to keep loading.  Per ADR-0018
+  /// §1 the reader accepts both v1 (implicit 4×4 control polygon)
+  /// and v2 (explicit ``rows`` / ``cols``).
+  static constexpr int SchemaVersion = 2;
+
+  /// Lowest schema version the reader admits.  v1 files (no
+  /// ``rows`` / ``cols``) load with an inferred 4×4 control polygon
+  /// per the ADR-0018 §1 migration path.
+  static constexpr int MinReadableSchemaVersion = 1;
 
   vtkMRMLNode* CreateNodeInstance() override;
 

--- a/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
+++ b/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
@@ -382,6 +382,61 @@ int testConfirmedStatePickGate()
   return EXIT_SUCCESS;
 }
 
+int testPickControlPoint3x3()
+{
+  // ADR-0018 §1 — the widget representation iterates Rows*Cols
+  // control points, not a hard-coded 16.  This test pins the 3×3
+  // (9-point) variant: pickable set must be exactly 9 points,
+  // picking a known position resolves to the right flat index.
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New();
+  node->SetSize(3);
+  node->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  double values[27] = { 0.0 };
+  constexpr double stride = 10.0;
+  for (int row = 0; row < 3; ++row)
+  {
+    for (int col = 0; col < 3; ++col)
+    {
+      const int i = row * 3 + col;
+      values[i * 3 + 0] = (col - 1.0) * stride;
+      values[i * 3 + 1] = (row - 1.0) * stride;
+      values[i * 3 + 2] = 0.0;
+    }
+  }
+  node->SetControlGrid(values);
+
+  vtkSmartPointer<vtkRenderer> renderer = makeRenderer();
+  vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+  renderWindow->SetShowWindow(false);
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetSize(400, 400);
+  renderer->ResetCameraClippingRange();
+
+  vtkNew<vtkLiverBezierRepresentation> rep;
+  rep->SetRenderer(renderer);
+  rep->SetBezierNode(node);
+  rep->BuildRepresentation();
+
+  // Project control point (row=1, col=2) → world (10, 0, 0) → flat
+  // index 1*3 + 2 = 5.
+  renderer->SetWorldPoint(10.0, 0.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  double* d = renderer->GetDisplayPoint();
+  vtkLiverBezierRepresentation::PickResult pick = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
+  CHECK_INT(pick.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
+  CHECK_INT(pick.Index, 5);
+
+  // Project a "would-be 4×4 corner" world coord (-15, -15, 0) that
+  // does NOT exist in the 3×3 grid (which has corners at ±10).
+  // Pick must miss.
+  renderer->SetWorldPoint(-15.0, -15.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  d = renderer->GetDisplayPoint();
+  vtkLiverBezierRepresentation::PickResult miss = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
+  CHECK_INT(miss.Role, vtkLiverBezierRepresentation::PickRole_None);
+  return EXIT_SUCCESS;
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -392,6 +447,7 @@ int vtkLiverBezierWidgetTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testLeftDragMutatesControlGrid());
   CHECK_EXIT_SUCCESS(testReadOnlyEnforcement());
   CHECK_EXIT_SUCCESS(testConfirmedStatePickGate());
+  CHECK_EXIT_SUCCESS(testPickControlPoint3x3());
 
   std::cout << "vtkLiverBezierWidgetTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
+++ b/LiverResections/VTKWidgets/Testing/Cxx/vtkLiverBezierWidgetTest1.cxx
@@ -382,12 +382,11 @@ int testConfirmedStatePickGate()
   return EXIT_SUCCESS;
 }
 
-int testPickControlPoint3x3()
+/// Construct a 3x3 (9-point) Bezier node in Planning state with a
+/// lattice control grid centred on (0, 0, 0).  Shared by the 3×3
+/// pick + drag-apply tests below.
+vtkSmartPointer<vtkMRMLBezierSurfaceNode> make3x3PlanningNode()
 {
-  // ADR-0018 §1 — the widget representation iterates Rows*Cols
-  // control points, not a hard-coded 16.  This test pins the 3×3
-  // (9-point) variant: pickable set must be exactly 9 points,
-  // picking a known position resolves to the right flat index.
   vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New();
   node->SetSize(3);
   node->SetState(vtkMRMLBezierSurfaceNode::Planning);
@@ -404,6 +403,22 @@ int testPickControlPoint3x3()
     }
   }
   node->SetControlGrid(values);
+  return node;
+}
+
+int testPickControlPoint3x3()
+{
+  // ADR-0018 §1 — the widget representation iterates Rows*Cols
+  // control points, not a hard-coded 16.  This test pins the 3×3
+  // (9-point) variant: pickable set must be exactly 9 points,
+  // picking a known position resolves to the right flat index.  The
+  // sub-assertions cover a CORNER glyph (index 0), an INTERIOR glyph
+  // (index 4 — the centre point of the 3×3), and an edge glyph
+  // (index 5) so the test exercises all three ring roles per
+  // ADR-0018 §1.  Also exercises the dynamic-shape-transition path
+  // (``SetSize(4)`` mid-test) — after the transition the previous
+  // ±10 corner coordinates are no longer in the grid.
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = make3x3PlanningNode();
 
   vtkSmartPointer<vtkRenderer> renderer = makeRenderer();
   vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
@@ -417,14 +432,32 @@ int testPickControlPoint3x3()
   rep->SetBezierNode(node);
   rep->BuildRepresentation();
 
-  // Project control point (row=1, col=2) → world (10, 0, 0) → flat
-  // index 1*3 + 2 = 5.
-  renderer->SetWorldPoint(10.0, 0.0, 0.0, 1.0);
+  // CORNER: control point (row=0, col=0) → world (-10, -10, 0) →
+  // flat index 0.
+  renderer->SetWorldPoint(-10.0, -10.0, 0.0, 1.0);
   renderer->WorldToDisplay();
   double* d = renderer->GetDisplayPoint();
-  vtkLiverBezierRepresentation::PickResult pick = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
-  CHECK_INT(pick.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
-  CHECK_INT(pick.Index, 5);
+  vtkLiverBezierRepresentation::PickResult cornerPick = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
+  CHECK_INT(cornerPick.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
+  CHECK_INT(cornerPick.Index, 0);
+
+  // INTERIOR: control point (row=1, col=1) → world (0, 0, 0) → flat
+  // index 4 (the lone interior of a 3×3 grid).
+  renderer->SetWorldPoint(0.0, 0.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  d = renderer->GetDisplayPoint();
+  vtkLiverBezierRepresentation::PickResult interiorPick = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
+  CHECK_INT(interiorPick.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
+  CHECK_INT(interiorPick.Index, 4);
+
+  // EDGE: control point (row=1, col=2) → world (10, 0, 0) → flat
+  // index 5.
+  renderer->SetWorldPoint(10.0, 0.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  d = renderer->GetDisplayPoint();
+  vtkLiverBezierRepresentation::PickResult edgePick = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
+  CHECK_INT(edgePick.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
+  CHECK_INT(edgePick.Index, 5);
 
   // Project a "would-be 4×4 corner" world coord (-15, -15, 0) that
   // does NOT exist in the 3×3 grid (which has corners at ±10).
@@ -434,6 +467,209 @@ int testPickControlPoint3x3()
   d = renderer->GetDisplayPoint();
   vtkLiverBezierRepresentation::PickResult miss = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
   CHECK_INT(miss.Role, vtkLiverBezierRepresentation::PickRole_None);
+
+  // Dynamic-shape transition: grow the node to 4×4.  Per ADR-0018 §1
+  // a size change discards the in-flight grid; rebuild the
+  // representation so the glyph cloud reflects the new shape.  The
+  // ±10 coordinates are no longer corners of the 4×4 grid — Pick
+  // there must miss now.
+  node->SetSize(4);
+  CHECK_INT(static_cast<int>(node->GetRows()), 4);
+  CHECK_INT(static_cast<int>(node->GetCols()), 4);
+  // After SetSize the grid is zeroed; nothing is on the camera's Z=0
+  // plane at the prior lattice positions any more.  Reinstate a 4×4
+  // lattice so the next Pick has something well-conditioned to hit
+  // (would-be index = row * 4 + col).
+  double values4[vtkMRMLBezierSurfaceNode::ControlGridSize] = { 0.0 };
+  constexpr double stride4 = 10.0;
+  for (int row = 0; row < 4; ++row)
+  {
+    for (int col = 0; col < 4; ++col)
+    {
+      const int i = row * 4 + col;
+      values4[i * 3 + 0] = (col - 1.5) * stride4;
+      values4[i * 3 + 1] = (row - 1.5) * stride4;
+      values4[i * 3 + 2] = 0.0;
+    }
+  }
+  CHECK_BOOL(node->SetControlGrid(values4), true);
+  rep->BuildRepresentation();
+
+  // Project (row=2, col=3) → world (15, 5, 0) → flat index 11.  This
+  // index is out of range for the prior 3×3 grid (9 points); the
+  // representation must accept it under the new 4×4 shape.
+  renderer->SetWorldPoint(15.0, 5.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  d = renderer->GetDisplayPoint();
+  vtkLiverBezierRepresentation::PickResult postResize = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
+  CHECK_INT(postResize.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
+  CHECK_INT(postResize.Index, 11);
+  return EXIT_SUCCESS;
+}
+
+int testApplyPickedPointWorld3x3()
+{
+  // ADR-0018 §1 — the drag-apply path on a 3×3 node must size its
+  // control-grid buffer + bounds check against the node's runtime
+  // shape, not the compile-time 4×4 default.  Pre-fix: the path
+  // assumed 48 doubles (4×4) and an [0, 16) bounds — on a 3×3 node
+  // (27 doubles, [0, 9) valid) that's a heap OOB read in the
+  // ``current``-array copy and a too-wide acceptance window.
+  //
+  // Observable via the widget's public ``BeginLeftDragAt`` +
+  // ``DragTo``: those route into ``ApplyPickedPointWorld`` and a
+  // successful drag must update exactly the picked 3-double triplet
+  // and leave the remaining 24 doubles untouched.
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = make3x3PlanningNode();
+
+  vtkSmartPointer<vtkRenderer> renderer = makeRenderer();
+  vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+  renderWindow->SetShowWindow(false);
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetSize(400, 400);
+  renderer->ResetCameraClippingRange();
+
+  vtkNew<vtkLiverBezierRepresentation> rep;
+  rep->SetRenderer(renderer);
+  rep->SetBezierNode(node);
+  rep->BuildRepresentation();
+
+  vtkNew<vtkLiverBezierWidget> widget;
+  widget->SetRepresentation(rep);
+  widget->SetBezierNode(node);
+
+  // Snapshot the pre-drag grid (27 doubles).
+  double before[27];
+  const double* grid = node->GetControlGrid();
+  for (int i = 0; i < 27; ++i)
+  {
+    before[i] = grid[i];
+  }
+
+  // Pick the interior glyph at world (0, 0, 0) → flat index 4 (the
+  // 3×3 centre, which would be index 4 under the new bounds check
+  // but lies WITHIN the bogus pre-fix bounds too — so the
+  // discriminator is the buffer-copy length, not the bounds check
+  // alone; see the "no write past 27 doubles" assertion below).
+  renderer->SetWorldPoint(0.0, 0.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  double* d = renderer->GetDisplayPoint();
+  const int startX = static_cast<int>(std::round(d[0]));
+  const int startY = static_cast<int>(std::round(d[1]));
+
+  CHECK_BOOL(widget->BeginLeftDragAt(startX, startY), true);
+  CHECK_INT(widget->GetPickedRole(), vtkLiverBezierRepresentation::PickRole_ControlPoint);
+  CHECK_INT(widget->GetPickedIndex(), 4);
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Dragging);
+
+  // Drag to world (3, -4, 0).
+  renderer->SetWorldPoint(3.0, -4.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  d = renderer->GetDisplayPoint();
+  const int endX = static_cast<int>(std::round(d[0]));
+  const int endY = static_cast<int>(std::round(d[1]));
+
+  double resolved[3] = { 0.0, 0.0, 0.0 };
+  CHECK_BOOL(widget->DragTo(endX, endY, resolved), true);
+  CHECK_DOUBLE_TOLERANCE(resolved[0], 3.0, 1e-3);
+  CHECK_DOUBLE_TOLERANCE(resolved[1], -4.0, 1e-3);
+  CHECK_DOUBLE_TOLERANCE(resolved[2], 0.0, 1e-3);
+
+  // The 3-double triplet for control point 4 (offsets 12..14) moved.
+  grid = node->GetControlGrid();
+  CHECK_DOUBLE_TOLERANCE(grid[12], 3.0, 1e-3);
+  CHECK_DOUBLE_TOLERANCE(grid[13], -4.0, 1e-3);
+  CHECK_DOUBLE_TOLERANCE(grid[14], 0.0, 1e-3);
+
+  // Every other double in the 27-double buffer must equal its
+  // pre-drag value — proves the buffer-copy walked only the 27-double
+  // range and did not write anything garbage past offset 26.
+  for (int i = 0; i < 27; ++i)
+  {
+    if (i == 12 || i == 13 || i == 14)
+    {
+      continue;
+    }
+    CHECK_DOUBLE_TOLERANCE(grid[i], before[i], 1e-9);
+  }
+
+  widget->EndLeftDrag();
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Start);
+  return EXIT_SUCCESS;
+}
+
+int testGlyphsHiddenInConfirmed()
+{
+  // ADR-0019 §"Per-state contract": in ``Confirmed`` state the
+  // control polygon is **hidden** and the widget is **disabled** —
+  // i.e. ``Pick()`` must return ``PickRole_None`` at every position
+  // that would otherwise hit a control-point glyph, and the glyph
+  // cloud emitted by ``UpdatePickableGlyphs`` is empty.
+  //
+  // ADR-0019 grows ``ResectionState`` from ``{Init, Planning}`` to
+  // ``{Init, Planning, Confirmed = 2}`` in its enabler PR; until that
+  // lands the integer literal ``2`` simulates the future value.
+  // ``SetState`` passes arbitrary ints through (see vtkMRMLBezierSurfaceNode.cxx
+  // ``SetState``), so this works on the current enum + flips clean
+  // when the third enum member arrives.
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> node = makePlanningNode();
+
+  vtkSmartPointer<vtkRenderer> renderer = makeRenderer();
+  vtkNew<vtkGenericOpenGLRenderWindow> renderWindow;
+  renderWindow->SetShowWindow(false);
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetSize(400, 400);
+  renderer->ResetCameraClippingRange();
+
+  vtkNew<vtkLiverBezierRepresentation> rep;
+  rep->SetRenderer(renderer);
+  rep->SetBezierNode(node);
+  rep->BuildRepresentation();
+
+  // Sanity-check: while in Planning the corner (row=0, col=0) at
+  // world (-15, -15, 0) DOES hit.
+  renderer->SetWorldPoint(-15.0, -15.0, 0.0, 1.0);
+  renderer->WorldToDisplay();
+  double* d = renderer->GetDisplayPoint();
+  const int X = static_cast<int>(std::round(d[0]));
+  const int Y = static_cast<int>(std::round(d[1]));
+  vtkLiverBezierRepresentation::PickResult planningHit = rep->Pick(X, Y);
+  CHECK_INT(planningHit.Role, vtkLiverBezierRepresentation::PickRole_ControlPoint);
+
+  // Transition to the future ``Confirmed = 2`` state and rebuild.
+  constexpr int kConfirmedState = 2;
+  node->SetState(kConfirmedState);
+  CHECK_INT(node->GetState(), kConfirmedState);
+  rep->BuildRepresentation();
+
+  // Same display coordinate now misses — the glyph cloud is empty in
+  // Confirmed per ADR-0019 §"Per-state contract".
+  vtkLiverBezierRepresentation::PickResult confirmedMiss = rep->Pick(X, Y);
+  CHECK_INT(confirmedMiss.Role, vtkLiverBezierRepresentation::PickRole_None);
+
+  // Sweep the four 4×4 corner positions; all must miss in Confirmed.
+  constexpr double cornersWorld[4][3] = {
+    { -15.0, -15.0, 0.0 },
+    { 15.0, -15.0, 0.0 },
+    { -15.0, 15.0, 0.0 },
+    { 15.0, 15.0, 0.0 },
+  };
+  for (int c = 0; c < 4; ++c)
+  {
+    renderer->SetWorldPoint(cornersWorld[c][0], cornersWorld[c][1], cornersWorld[c][2], 1.0);
+    renderer->WorldToDisplay();
+    d = renderer->GetDisplayPoint();
+    vtkLiverBezierRepresentation::PickResult corner = rep->Pick(static_cast<int>(std::round(d[0])), static_cast<int>(std::round(d[1])));
+    CHECK_INT(corner.Role, vtkLiverBezierRepresentation::PickRole_None);
+  }
+
+  // The widget must refuse to enter Dragging in Confirmed.
+  vtkNew<vtkLiverBezierWidget> widget;
+  widget->SetRepresentation(rep);
+  widget->SetBezierNode(node);
+  const bool started = widget->BeginLeftDragAt(X, Y);
+  CHECK_BOOL(started, false);
+  CHECK_INT(widget->GetWidgetState(), vtkLiverBezierWidget::Start);
   return EXIT_SUCCESS;
 }
 
@@ -448,6 +684,8 @@ int vtkLiverBezierWidgetTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testReadOnlyEnforcement());
   CHECK_EXIT_SUCCESS(testConfirmedStatePickGate());
   CHECK_EXIT_SUCCESS(testPickControlPoint3x3());
+  CHECK_EXIT_SUCCESS(testApplyPickedPointWorld3x3());
+  CHECK_EXIT_SUCCESS(testGlyphsHiddenInConfirmed());
 
   std::cout << "vtkLiverBezierWidgetTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
@@ -197,7 +197,7 @@ void vtkLiverBezierRepresentation::UpdatePickableGlyphs()
       pushPoint(grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2]);
     }
   }
-  else // Init
+  else if (state == vtkMRMLBezierSurfaceNode::Init)
   {
     if (mode == vtkMRMLBezierSurfaceNode::SlicingPlane)
     {
@@ -222,6 +222,18 @@ void vtkLiverBezierRepresentation::UpdatePickableGlyphs()
         }
       }
     }
+  }
+  else
+  {
+    // Per ADR-0019 §"Per-state contract", in any state other than
+    // ``Init`` / ``Planning`` (i.e. the future ``Confirmed = 2``
+    // value the enum will grow when ADR-0019's enabler PR lands) the
+    // control polygon is **hidden** and the widget is **disabled**.
+    // Leave the glyph cloud empty — the ``points->Reset()`` /
+    // ``verts->Reset()`` above already cleared it; nothing further to
+    // push.  ``BuildRepresentation`` turns the glyph actor invisible
+    // when ``GetNumberOfPoints() == 0``, matching the
+    // hidden-polygon + disabled-widget invariant.
   }
 
   this->GlyphPolyData->Modified();
@@ -328,7 +340,7 @@ vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int 
       }
     }
   }
-  else // Init — init-mode points become pickable.
+  else if (state == vtkMRMLBezierSurfaceNode::Init) // init-mode points become pickable.
   {
     if (mode == vtkMRMLBezierSurfaceNode::SlicingPlane)
     {
@@ -368,6 +380,9 @@ vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int 
       }
     }
   }
+  // else: future ``Confirmed`` state per ADR-0019 §"Per-state contract"
+  // — widget is disabled, nothing is pickable.  Fall through and
+  // return ``PickRole_None``.
 
   return result;
 }

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.cxx
@@ -184,9 +184,15 @@ void vtkLiverBezierRepresentation::UpdatePickableGlyphs()
   }
   else if (state == vtkMRMLBezierSurfaceNode::Planning)
   {
-    // 16 Bezier control points become pickable.
+    // Per ADR-0018 §1 the per-node Bezier control polygon is
+    // ``Rows × Cols`` points (9 for 3×3, 16 for 4×4); query the
+    // shape from the data node.  Tear-down of the previous glyph
+    // cloud is handled by the ``points->Reset()`` / ``verts->Reset()``
+    // above — the cloud size on the next BuildRepresentation()
+    // matches the data node's current shape.
     const double* grid = node->GetControlGrid();
-    for (int i = 0; i < vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize; ++i)
+    const unsigned int controlPointCount = node->GetRows() * node->GetCols();
+    for (unsigned int i = 0; i < controlPointCount; ++i)
     {
       pushPoint(grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2]);
     }
@@ -304,8 +310,13 @@ vtkLiverBezierRepresentation::PickResult vtkLiverBezierRepresentation::Pick(int 
   double bestDist = kPickRadiusWorld;
   if (state == vtkMRMLBezierSurfaceNode::Planning)
   {
+    // Per ADR-0018 §1 the pickable control-point set is
+    // ``Rows * Cols`` (9 for 3×3, 16 for 4×4).  The index returned
+    // in PickResult is grid-flat (i * Cols + j); callers that need
+    // (row, col) can recover it via the data node's Rows / Cols.
     const double* grid = node->GetControlGrid();
-    for (int i = 0; i < vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize; ++i)
+    const int controlPointCount = static_cast<int>(node->GetRows() * node->GetCols());
+    for (int i = 0; i < controlPointCount; ++i)
     {
       const double p[3] = { grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2] };
       const double d = distanceToRay(p);

--- a/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
+++ b/LiverResections/VTKWidgets/vtkLiverBezierRepresentation.h
@@ -66,17 +66,19 @@ class vtkSphereSource;
  * "representation" concepts coexist by accident of vocabulary.
  *
  * The representation observes a ``vtkMRMLBezierSurfaceNode`` for its
- * geometry source (the 4×4 control grid + init data per ADR-0014 §1)
- * and exposes a picker that resolves a display-space (X, Y) cursor to a
- * point index in the underlying data node.
+ * geometry source (the M×N control grid + init data per ADR-0014 §1
+ * and ADR-0018 §1; M = N ∈ {3, 4} for v2.0.0) and exposes a picker
+ * that resolves a display-space (X, Y) cursor to a point index in
+ * the underlying data node.
  *
- * Per ADR-0014 §3, the *pickable* set depends on the data node's
- * ``(State, InitMode)`` tuple:
+ * Per ADR-0014 §3 + ADR-0018 §1, the *pickable* set depends on the
+ * data node's ``(State, InitMode)`` tuple:
  *
  *   - ``(Init, SlicingPlane)``  — the two SlicingPlane init points.
  *   - ``(Init, DistanceSpheroid)`` — the DistanceSpheroid init points.
- *   - ``(Planning, *)``  — the 16 Bezier control-grid points
- *     (corners 4 + edges 8 + interior 4).
+ *   - ``(Planning, *)``  — the ``Rows * Cols`` Bezier control-grid
+ *     points (9 for 3×3, 16 for 4×4; ring-group taxonomy: corners 4 +
+ *     edges ``2*(M-2)+2*(N-2)`` + interior ``(M-2)*(N-2)``).
  *
  * Init-mode points are not pickable in Planning state; per ADR-0014 §4
  * they are read-only audit data and the widget must not enter a drag
@@ -96,15 +98,16 @@ public:
   enum PickRole
   {
     PickRole_None = 0,
-    PickRole_ControlPoint = 1,         ///< Bezier 4×4 grid (state=Planning).
+    PickRole_ControlPoint = 1,         ///< Bezier M×N grid (state=Planning); ADR-0018 §1.
     PickRole_SlicingPlaneInit = 2,     ///< Two SlicingPlane init points.
     PickRole_DistanceSpheroidInit = 3, ///< DistanceSpheroid init points.
   };
 
   /// Result of ``Pick(X, Y)`` — role + point index.  The index is
-  /// role-relative: control-grid is [0..15], slicing-plane init is
-  /// [0..1], distance-spheroid init is [0..N) where N is the data
-  /// node's ``NumberOfDistanceSpheroidInitPoints``.
+  /// role-relative: control-grid is [0..Rows*Cols-1] (per ADR-0018
+  /// §1; 9 or 16 for v2.0.0), slicing-plane init is [0..1],
+  /// distance-spheroid init is [0..N) where N is the data node's
+  /// ``NumberOfDistanceSpheroidInitPoints``.
   struct PickResult
   {
     int Role{ PickRole_None };
@@ -158,8 +161,13 @@ protected:
   ~vtkLiverBezierRepresentation() override;
 
   /// Rebuild the internal poly data carrying the currently-pickable
-  /// glyph cloud.  Cheap (≤ 16 sphere glyphs); called from
-  /// ``BuildRepresentation()``.  The control-grid OpenGL mapper from
+  /// glyph cloud.  Cheap (≤ ``MaxGridSize * MaxGridSize`` = 16
+  /// sphere glyphs for the 4×4 case; 9 for 3×3 per ADR-0018 §1);
+  /// called from ``BuildRepresentation()``.  Re-instantiates the
+  /// per-control-point glyph set on every shape change (the buffer
+  /// ``Reset`` above is idempotent across sizes; the glyph count on
+  /// the next frame matches the data node's current Rows × Cols).
+  /// The control-grid OpenGL mapper from
   /// ``LiverMarkups/VTKWidgets/`` is *not* hosted here — it relocates
   /// in TODO(T2-mapper-relocation) and the LayerDM Pipeline keeps the
   /// surface render path.  This representation only owns the

--- a/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
+++ b/LiverResections/VTKWidgets/vtkLiverBezierWidget.cxx
@@ -54,6 +54,8 @@
 #include <vtkWidgetEvent.h>
 #include <vtkWidgetEventTranslator.h>
 
+#include <vector>
+
 //------------------------------------------------------------------------------
 vtkStandardNewMacro(vtkLiverBezierWidget);
 
@@ -305,22 +307,29 @@ bool vtkLiverBezierWidget::ApplyPickedPointWorld(const double world[3])
   {
     case vtkLiverBezierRepresentation::PickRole_ControlPoint:
     {
-      if (this->PickedIndex < 0 || this->PickedIndex >= vtkMRMLBezierSurfaceNode::GridSize * vtkMRMLBezierSurfaceNode::GridSize)
+      // Per ADR-0018 §1 the control-polygon shape is selected per node
+      // (3x3 → 9 control points / 27 doubles; 4x4 → 16 / 48).  Query
+      // the node for both the control-point count and the flat-array
+      // length so the bounds check and the buffer walk match the
+      // node's current shape (not the compile-time 4x4 default).
+      const unsigned int controlCount = node->GetRows() * node->GetCols();
+      if (this->PickedIndex < 0 || static_cast<unsigned int>(this->PickedIndex) >= controlCount)
       {
         return false;
       }
-      // SetControlGrid takes the full 48-double array; copy current,
-      // patch the picked point, push back.
-      double values[vtkMRMLBezierSurfaceNode::ControlGridSize];
+      // SetControlGrid takes the full (3 * Rows * Cols)-double array;
+      // copy current, patch the picked point, push back.
+      const unsigned int flatLength = node->GetControlGridLength();
+      std::vector<double> values(flatLength);
       const double* current = node->GetControlGrid();
-      for (int i = 0; i < vtkMRMLBezierSurfaceNode::ControlGridSize; ++i)
+      for (unsigned int i = 0; i < flatLength; ++i)
       {
         values[i] = current[i];
       }
       values[this->PickedIndex * 3 + 0] = world[0];
       values[this->PickedIndex * 3 + 1] = world[1];
       values[this->PickedIndex * 3 + 2] = world[2];
-      return node->SetControlGrid(values);
+      return node->SetControlGrid(values.data());
     }
     case vtkLiverBezierRepresentation::PickRole_SlicingPlaneInit: return node->SetSlicingPlaneInitPoint(this->PickedIndex, world);
     case vtkLiverBezierRepresentation::PickRole_DistanceSpheroidInit: return node->SetDistanceSpheroidInitPoint(this->PickedIndex, world);


### PR DESCRIPTION
## Summary

Generalises `vtkMRMLBezierSurfaceNode` from a hard-coded 4×4 control grid to support both 3×3 and 4×4 shapes per [ADR-0018 §1](Docs/adr/0018-nurbs-extension-surface.md).  This is the architectural-surface widening that admits the smaller 3×3 shape without opening the door to arbitrary M×N (that lands with the NURBS sibling in v2.1).

- **Data node** carries `Rows` / `Cols` IVars + `GetControlGridLength()`.  `SetSize(n)`, `SetRows(rows)`, `SetCols(cols)` validate against `(Rows, Cols) ∈ {(3, 3), (4, 4)}` and resize the `std::vector` control buffer.  A shape change discards the in-flight grid (ADR-0018 §1 documented semantic).
- **Storage schema** bumped to v2 with explicit `rows` + `cols`.  Reader accepts v1 (no `rows`/`cols` → inferred 4×4) AND v2 (validated explicitly).  Writer always emits v2.  A v1 file round-tripped through load + save becomes v2 on disk.
- **`vtkLiverBezierRepresentation`** iterates `Rows * Cols` control points (9 for 3×3, 16 for 4×4) instead of the hard-coded 16.
- **XML** serialisation round-trips `rows` + `cols`; legacy attribute streams without those fields default to 4×4.
- **Tests** cover both shapes (in-memory, XML, `.lrp.json` round-trip) and the v1-implicit-4×4 read-compat path.
- Backwards-compat constants `GridSize == 4` and `ControlGridSize == 48` preserved as compile-time aliases of the v1 default; existing tests + Python callers see unchanged values.

## Out of scope

- NURBS support — deferred to v2.1 per ADR-0018 §3.
- Non-square M×N Bezier — v2.0.0 is square-only per ADR-0018 §1.
- Mapper changes — `vtkOpenGLBezierResectionPolyDataMapper` left untouched (control-polygon size is transparent to the GPU tessellator's vtkPolyData input).
- Cross-module locator changes — separate v2.1.0 thread.

## Test plan

- [x] `vtkMRMLBezierSurfaceNodeTest1` (existing 4×4 path + new 3×3 variable-size, copy-content, XML round-trip tests).
- [x] `vtkMRMLBezierSurfaceStorageNodeTest1` (existing JSON round-trip + new 3×3 round-trip, v1 implicit-4×4 read, v2 invalid-shape rejection).
- [x] `vtkLiverBezierWidgetTest1` (existing 4×4 widget + new 3×3 pick test).
- [x] All 16 `vtk*` C++ tests pass locally (`ctest -R 'vtk(MRML|Liver|Slicer)'`).
- [ ] CI green on the GitHub Actions `build-test` job.

---

Drafted with assistance from Claude (claude-opus-4-7).