### PR TITLE
COMP: Wire Codecov + gcovr + pytest-cov coverage matrix (ADR-0021)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,76 @@
+# Codecov configuration for Slicer-Liver.
+#
+# Decision context: Docs/adr/0021-coverage-measurement.md.
+#
+# Signal philosophy for the first cut:
+#   - Diff coverage on the PR comment is the primary review surface;
+#     the comment shows reviewer + contributor which new/modified lines
+#     are uncovered, which is the load-bearing signal.
+#   - Both project (whole-tree %) and patch (diff %) checks run
+#     informationally — they appear in the GitHub UI but never block
+#     merge.  Premature gating discourages contributions and ADR-0003's
+#     characterisation-test-before-refactor convention is the actual
+#     enforcement mechanism.
+#   - Comment posts once and updates in place (`behavior: once`) and
+#     only when coverage actually changes (`require_changes: true`) so
+#     unchanged-coverage rebases don't spam the thread.
+#
+# Tighten any of these settings as the maintainer learns what's noisy.
+
+codecov:
+  require_ci_to_pass: true
+  # Wait briefly for both flags (cxx + py) before posting.  Without this,
+  # Codecov can post a comment after only one upload arrives, then
+  # update it on the second arrival — which counts as a thread bump on
+  # some notification settings.
+  notify:
+    wait_for_ci: true
+    after_n_builds: 1
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+        target: auto
+        if_not_found: success
+
+comment:
+  behavior: once
+  require_changes: true
+  layout: "diff,flags,files"
+
+flags:
+  cxx:
+    paths:
+      - LiverResections/
+      - LiverResectionsLib/
+      - LiverMarkups/
+      - LiverSegments/
+      - LiverVolumetry/
+      - Modeling/
+  py:
+    paths:
+      - LiverResections/Testing/Python/
+      - LiverResectionsLib/Testing/Python/
+      - LiverSegments/
+      - LiverVolumetry/
+
+# Exclude generated, test-only, and third-party code from both
+# coverage % and PR comment annotations.  These paths are uninteresting
+# for the "did this PR test what it changed?" signal.
+ignore:
+  - "**/Testing/**"
+  - "**/CMakeFiles/**"
+  - "build/**"
+  - "Docs/**"
+  - "Utilities/**"
+  - "**/moc_*.cpp"
+  - "**/qrc_*.cpp"
+  - "**/ui_*.h"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,9 +379,16 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
         run: |
           set -euo pipefail
-          python3 -m pip install --user --upgrade pip
-          python3 -m pip install --user 'gcovr>=7' 'pytest-cov>=5' 'pytest>=8'
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # Ubuntu 24.04's system Python is PEP 668 "externally managed",
+          # so ``pip install --user`` refuses without an explicit override.
+          # Use a dedicated venv inside the job — isolates from the image's
+          # Python without needing ``--break-system-packages`` (which the
+          # ALive-Docker follow-up could replace with apt-packaged gcovr +
+          # python3-pytest-cov in the base image).
+          python3 -m venv /tmp/coverage-venv
+          /tmp/coverage-venv/bin/pip install --upgrade pip
+          /tmp/coverage-venv/bin/pip install 'gcovr>=7' 'pytest-cov>=5' 'pytest>=8'
+          echo "/tmp/coverage-venv/bin" >> "$GITHUB_PATH"
 
       - name: Verify Slicer build tree
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # CI for Slicer-Liver — see Docs/adr/0005-github-actions-ci.md
 #
-# Two jobs run in parallel on every PR and on every push to `preview`:
+# Three jobs run in parallel on every PR and on every push to `preview`:
 #   - docs-lint   : fast (~30 s); validates Mermaid fences and internal
 #                   Markdown links across Docs/.  No Slicer dependency.
 #   - build-test  : slow (~10–30 min); builds the extension against the
@@ -8,6 +8,14 @@
 #                   slicer-build-ubuntu2404 image (Slicer main pre-built)
 #                   and runs CTest.  Image recipe and auto-build live in
 #                   the ALive-Docker repository.
+#   - coverage    : slow (~10–30 min); same image as build-test but
+#                   instruments the C++ build with GCC --coverage, runs
+#                   CTest + pytest under coverage.py, and uploads the
+#                   resulting Cobertura XML files to Codecov.  Per
+#                   Docs/adr/0021-coverage-measurement.md the job is
+#                   intentionally NON-BLOCKING in its first cut — not on
+#                   branch protection's required list; the PR-comment
+#                   diff coverage is the signal.
 
 name: CI
 
@@ -201,6 +209,7 @@ jobs:
             COPYRIGHT.txt
             requirements-docs.txt
             .readthedocs.yaml
+            .codecov.yml
 
       - name: Report skip (docs-only PR)
         if: github.event_name == 'pull_request' && steps.changes.outputs.any_changed == 'false'
@@ -290,3 +299,197 @@ jobs:
           cd build
           ctest -V --no-tests=error \
                 --tests-regex '^LiverBezierVisualTest_.*$'
+
+  # ---------------------------------------------------------------------------
+  # Job 3 — coverage instrumentation.
+  #
+  # Per Docs/adr/0021-coverage-measurement.md, builds the extension with
+  # GCC's --coverage flags (a Debug rebuild — separate from build-test's
+  # Release build, so the two jobs run in parallel without artefact
+  # collisions), runs CTest, generates a Cobertura coverage-cxx.xml
+  # via `gcovr`, generates a Cobertura coverage-py.xml from pytest's
+  # --cov plugin, and uploads both to Codecov via
+  # codecov/codecov-action@v5.
+  #
+  # The job is intentionally NON-BLOCKING in its first cut: do NOT add
+  # `coverage (slicer-main, Linux)` to branch-protection's required
+  # checks.  The signal is the PR comment (line-by-line diff coverage),
+  # not the job's pass/fail status.  ADR-0021 §"Why no absolute
+  # threshold" — informational only.
+  #
+  # The first run after this PR merges will likely fail or report
+  # partial data until the maintainer authorises the Codecov GitHub
+  # app on ALive-research/Slicer-Liver (one-time admin step, ~2 min,
+  # OAuth via codecov.io).  That's expected; the workflow itself is
+  # otherwise complete.
+  # ---------------------------------------------------------------------------
+  coverage:
+    name: coverage (slicer-main, Linux)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
+    defaults:
+      run:
+        shell: bash
+
+    container:
+      image: ghcr.io/alive-research/slicer-build-ubuntu2404:latest
+      options: --user root
+
+    env:
+      Slicer_DIR: /usr/src/Slicer-build/Slicer-build
+      QT_QPA_PLATFORM: offscreen
+      LayerDisplayableManager_DIR: /usr/src/SlicerLayerDM-build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Mirror build-test's docs-only skip: pure-docs PRs do not need
+      # the coverage job either.  Identical ignore list with the
+      # exception that .codecov.yml is NOT ignored here — changing the
+      # Codecov config should re-run the coverage job to verify the
+      # config still produces a valid upload.
+      - name: Detect non-docs change
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@v45
+        with:
+          files_ignore: |
+            Docs/**
+            *.md
+            .github/pull_request_template.md
+            .github/CODEOWNERS
+            CITATION.cff
+            License.txt
+            COPYRIGHT.txt
+            requirements-docs.txt
+            .readthedocs.yaml
+
+      - name: Report skip (docs-only PR)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.any_changed == 'false'
+        run: |
+          echo "::notice::Skipping coverage build — every changed file is in the docs-ignore set."
+
+      # gcovr + pytest-cov are not yet baked into the
+      # slicer-build-ubuntu2404 image.  Bootstrap via pip --user; an
+      # ALive-Docker follow-up issue tracks adding them to the base
+      # image so the bootstrap step disappears.
+      - name: Install coverage tools
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user --upgrade pip
+          python3 -m pip install --user 'gcovr>=7' 'pytest-cov>=5' 'pytest>=8'
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Slicer build tree
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          test -f "${Slicer_DIR}/SlicerConfig.cmake" \
+            || { echo "::error::SlicerConfig.cmake missing at ${Slicer_DIR} — image layout has drifted"; exit 1; }
+          test -f "${LayerDisplayableManager_DIR}/LayerDisplayableManagerConfig.cmake" \
+            || { echo "::error::LayerDisplayableManagerConfig.cmake missing at ${LayerDisplayableManager_DIR} — image layout has drifted"; exit 1; }
+
+      - name: Configure (Debug + --coverage)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p build-coverage
+          # -O0 prevents inlining that would confuse gcov line attribution.
+          # --coverage is short for -fprofile-arcs -ftest-coverage and
+          # implies -lgcov at link time.
+          cmake -S . -B build-coverage \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCMAKE_C_FLAGS="-O0 --coverage" \
+            -DCMAKE_CXX_FLAGS="-O0 --coverage" \
+            -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
+            -DCMAKE_SHARED_LINKER_FLAGS="--coverage" \
+            -DSlicer_DIR="${Slicer_DIR}" \
+            -DLayerDisplayableManager_DIR="${LayerDisplayableManager_DIR}"
+
+      - name: Build (instrumented)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        run: cmake --build build-coverage --config Debug -j "$(nproc)"
+
+      - name: Test (CTest, instrumented)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          cd build-coverage
+          # Same VMTK exclusion as build-test; coverage % drift between
+          # the two jobs is acceptable as long as the same set of tests
+          # actually runs in both.  fail_ci_if_error is false on the
+          # upload step so a single failed instrumented test does not
+          # block the rest of the PR.
+          ctest -V --no-tests=error \
+                --exclude-regex '^py_LiverSegmentsTest$' || true
+
+      - name: Generate coverage-cxx.xml (gcovr)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          # Cobertura output (Codecov auto-detects).  Excludes Testing
+          # subtrees + system headers; the path filter list mirrors
+          # `ignore:` in .codecov.yml so the two views agree.
+          gcovr \
+            --root . \
+            --xml --output coverage-cxx.xml \
+            --exclude '.*Testing.*' \
+            --exclude '.*CMakeFiles.*' \
+            --exclude '/usr/.*' \
+            --exclude '.*/build-coverage/.*' \
+            --print-summary \
+            build-coverage || {
+              echo "::warning::gcovr produced no usable data — coverage upload will be partial."
+              # Emit an empty Cobertura skeleton so the Codecov upload
+              # step still has a file path to attach (it tolerates
+              # empty coverage but errors on missing files).
+              cat > coverage-cxx.xml <<'XML'
+          <?xml version="1.0" ?>
+          <coverage version="0"><sources/><packages/></coverage>
+          XML
+            }
+
+      - name: Run pytest with coverage
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          # Per ADR-0021 §"Out of scope", Slicer-launcher Python
+          # coverage (wrapped MRML bindings) is opt-in per test and may
+          # not be reachable from a plain pytest invocation in the
+          # image.  Run what we can: collect any importable pytest
+          # roots under LiverResectionsLib/ and emit a Cobertura XML.
+          # If nothing collects, write an empty skeleton so the upload
+          # step has a file.
+          if find LiverResectionsLib -name 'test_*.py' -o -name '*_test.py' | grep -q .; then
+            python3 -m pytest LiverResectionsLib \
+              --cov=LiverResectionsLib \
+              --cov-report=xml:coverage-py.xml \
+              --cov-report=term \
+              || true
+          else
+            echo "::notice::No pytest tests discovered under LiverResectionsLib/ — emitting empty coverage-py.xml."
+            cat > coverage-py.xml <<'XML'
+          <?xml version="1.0" ?>
+          <coverage version="0"><sources/><packages/></coverage>
+          XML
+          fi
+
+      - name: Upload coverage to Codecov
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage-cxx.xml,./coverage-py.xml
+          flags: cxx,py
+          # Non-blocking: per ADR-0021 the job's pass/fail is not a
+          # branch-protection signal.  An upload failure (Codecov
+          # outage, OAuth not yet configured by the maintainer, etc.)
+          # surfaces as a workflow warning but does not fail the PR.
+          fail_ci_if_error: false
+          # No token needed for public repos with the Codecov GitHub
+          # app installed.  If/when the maintainer wants tokenless
+          # uploads disabled, set CODECOV_TOKEN in repo secrets and
+          # add `token: ${{ secrets.CODECOV_TOKEN }}` here.


### PR DESCRIPTION
## Summary

Implements the decision in [ADR-0021](https://github.com/ALive-research/Slicer-Liver/pull/385)
(sibling DOC PR): wires the Codecov + gcovr + pytest-cov coverage stack into CI.

- **`.codecov.yml`** — project + patch checks both `informational: true`
  (no hard absolute-% gate per ADR-0021).  Comment posts once and only
  on coverage changes (`behavior: once`, `require_changes: true`) so
  rebases on unchanged coverage do not spam the thread.  Flag/path
  mapping splits `cxx` vs `py` uploads.  `ignore:` excludes `Testing/`,
  generated Qt/VTK artefacts (`moc_*`, `qrc_*`, `ui_*`), `Docs/`,
  `Utilities/`, `build/`.

- **`.github/workflows/ci.yml`** — adds a new `coverage` job parallel
  to `docs-lint` + `build-test`.  Uses the same
  `ghcr.io/alive-research/slicer-build-ubuntu2404:latest` image; does a
  separate Debug rebuild under `build-coverage/` with `-O0 --coverage`
  so the two builds do not collide.  Runs CTest with the same VMTK
  exclusion as `build-test`, then `gcovr --xml` for the C++ side and
  `pytest --cov --cov-report=xml` for the Python side, then
  `codecov/codecov-action@v5` uploads both XMLs with `cxx,py` flags.

  The job is intentionally **non-blocking** in its first cut — do NOT
  add `coverage (slicer-main, Linux)` to branch protection's required
  checks.  The signal is the PR comment, not the job's pass/fail.

  Also adds `.codecov.yml` to `build-test`'s docs-only ignore list so
  pure Codecov-config tweaks do not retrigger the Release build, and
  reuses the (slightly different) ignore list for the coverage job's
  own docs-only skip.

## Why now

[ADR-0021](https://github.com/ALive-research/Slicer-Liver/pull/385)
records the rationale (diff-coverage on PRs as the load-bearing
signal, no absolute %, Codecov over Coveralls, free-for-OSS terms).
Per its rollout plan, this PR is the implementation half; the ADR is
the decision half.

## Known caveats (expected, not blockers)

- `gcovr` + `pytest-cov` are not yet in the
  `slicer-build-ubuntu2404` image.  Bootstrapped via
  `pip install --user` for now; a follow-up on the ALive-Docker side
  bakes them into the base image (referenced in the commit body).
- **The first CI run after merge will likely fail or report partial
  data** until the maintainer authorises the Codecov GitHub app on
  `ALive-research/Slicer-Liver`.  That is the one-time admin step
  called out in ADR-0021's rollout plan §3 (~2 min via codecov.io
  OAuth).  Until then, `fail_ci_if_error: false` keeps the upload
  step from failing the job.
- Slicer-launcher Python coverage (wrapped MRML bindings) is opt-in
  per test and may not be reachable from plain pytest in the image.
  ADR-0021 §"Out of scope" notes this; the pytest step falls back to
  an empty Cobertura skeleton when no `test_*.py` is collected, so
  the Codecov upload step still has a file to attach.

## Files

- `.codecov.yml` (new)
- `.github/workflows/ci.yml` (modified — adds the `coverage` job;
  adds `.codecov.yml` to the build-test docs-ignore list)

## Test plan

- [x] `pre-commit` (SKIP=prettier) passes on the staged files
      including `check-github-workflows`.
- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` parses both
      YAML files.
- [x] Every `run: |` snippet passes `bash -n` syntax check.
- [x] Commit-message regex `^(ENH|PERF|BUG|STYLE|DOC|COMP): [A-Z]` matches.
- [x] CI: docs-lint passes.
- [x] CI: build-test passes (unchanged from preview's coverage of the
      existing C++ + Python surface).
- [x] CI: new `coverage` job runs — expected to either upload
      successfully (if Codecov app is already authorised) or warn on
      the upload step (if not yet authorised; that is the maintainer's
      one-time follow-up).

---

*AI-assisted authorship: drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code.*