### PR TITLE
ENH: Visual-test harness self-tests + scenario matrix doc (closes #387, #388)

### DIFF
--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -32,6 +32,59 @@ if(NOT BUILD_TESTING)
 endif()
 
 # ---------------------------------------------------------------------------
+# Harness self-tests (always-on)
+# ---------------------------------------------------------------------------
+#
+# Pure-Python pytest covering the visual-regression harness's own
+# helpers (``_has_baseline``, ``_resolve_baseline_png``,
+# ``_save_bundle``) and the ``upload_baseline.sh`` bundle-completeness
+# pre-flight.  Tracked separately from the visual-regression CTest
+# entries below because these tests do not need:
+#
+#   * the Slicer launcher (they stub ``slicer`` / ``qt`` / ``vtk``
+#     into ``sys.modules`` before importing ``capture_baseline``);
+#   * captured baselines on the ALiveResearchTestingData release
+#     (each test materialises its own fixture under
+#     pytest's ``tmp_path``);
+#   * the ``SlicerLiver_ENABLE_VISUAL_TESTS`` opt-in gate (which
+#     defers the full visual-regression CTest entries until
+#     baselines + launcher-exit have been confirmed on CI).
+#
+# Skipped gracefully when ``pytest`` is not importable from the
+# configured Python — same pattern as the cross-module
+# ``pytest_scaffold`` entry under ``Testing/Python/CMakeLists.txt``.
+# See ADR-0008 §"observability" + issue #387.
+
+if(DEFINED Python3_EXECUTABLE)
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c "import pytest"
+    RESULT_VARIABLE _liver_resections_pytest_probe_rc
+    OUTPUT_QUIET
+    ERROR_QUIET
+  )
+  if(_liver_resections_pytest_probe_rc EQUAL 0)
+    add_test(
+      NAME LiverResections_harness_self_tests
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_harness"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_harness_self_tests PROPERTIES
+      LABELS "pytest;harness-self-tests;LiverResections"
+    )
+  else()
+    message(STATUS
+      "Slicer-Liver: pytest not importable from ${Python3_EXECUTABLE}; "
+      "skipping LiverResections harness self-tests registration.")
+  endif()
+else()
+  message(STATUS
+    "Slicer-Liver: Python3_EXECUTABLE not set; "
+    "skipping LiverResections harness self-tests registration.")
+endif()
+
+# ---------------------------------------------------------------------------
 # Opt-in gate for the visual-regression harness.
 #
 # Default OFF until two preconditions land: (a) the

--- a/LiverResections/Testing/Python/test_harness/__init__.py
+++ b/LiverResections/Testing/Python/test_harness/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.

--- a/LiverResections/Testing/Python/test_harness/test_bundle_completeness_preflight.py
+++ b/LiverResections/Testing/Python/test_harness/test_bundle_completeness_preflight.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Harness self-tests for ``upload_baseline.sh``'s bundle-completeness
+pre-flight.
+
+GAP-1 follow-up from PR #384's /slicer-review synthesis (issue #387).
+The pre-flight check defends the same partial-bundle invariant as
+``capture_baseline._save_bundle`` (see ``test_save_bundle.py``), but
+on the upload boundary: refuse to push a structurally invalid
+baseline (PNG without MRML, MRML without camera/viewport, etc.) to
+the testing-data release.  A complete bundle is the four sidecars
+documented in ``LiverResections/Testing/README.md`` §"Bundle contents":
+
+    .png  .mrml  .camera.json  .viewport.json
+
+The tests run the script as a subprocess against an isolated fake
+repo layout in ``tmp_path``.  ``DRY_RUN=1`` short-circuits the
+destructive stage step *after* the pre-flight passes, so the
+"all four present" success path can be characterised without
+polluting the real ``Data/Baseline/`` directory or the maintainer's
+``INCOMING/``.
+
+References
+----------
+* ADR-0008 §"observability" — pure-Python helpers carry self-tests.
+* ``LiverResections/Testing/Scripts/upload_baseline.sh``.
+* PR #384 /slicer-review synthesis comment, GAP-1 (this issue) +
+  GAP-4 (the upstream pre-flight finding).
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+_HERE = pathlib.Path(__file__).resolve()
+_REAL_SCRIPT = (
+    _HERE.parent.parent.parent  # LiverResections/Testing/
+    / "Scripts"
+    / "upload_baseline.sh"
+)
+
+
+# Skip the whole module on Windows — the shell script is bash-only,
+# and Slicer-Liver CI is Ubuntu-only at present.  Use ``sys.platform``
+# rather than ``shutil.which("bash")`` so the skip reason is precise.
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="upload_baseline.sh is bash-only; Slicer-Liver CI is Ubuntu-only.",
+)
+
+
+def _build_fake_repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Mirror the slice of the repo layout the script reaches for.
+
+    Returns the path to the script copy inside the fake repo.  The
+    script resolves ``REPO_ROOT`` from ``SCRIPT_DIR/../../..``, so
+    placing it at ``<tmp>/LiverResections/Testing/Scripts/`` gives
+    a ``REPO_ROOT`` of ``<tmp>`` — same shape as the real checkout.
+    """
+    scripts_dir = tmp_path / "LiverResections" / "Testing" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    script_copy = scripts_dir / "upload_baseline.sh"
+    shutil.copy2(_REAL_SCRIPT, script_copy)
+    script_copy.chmod(0o755)
+
+    (tmp_path / "Testing" / "baselines-staging").mkdir(parents=True)
+    (tmp_path / "LiverResections" / "Testing" / "Data" / "Baseline").mkdir(parents=True)
+    return script_copy
+
+
+def _stage_bundle(
+    tmp_path: pathlib.Path,
+    test_name: str,
+    *,
+    extensions: tuple[str, ...],
+) -> None:
+    """Write deterministic placeholder bytes into the staging dir for
+    the requested subset of bundle extensions.
+
+    The pre-flight only checks ``-f`` presence, so any non-empty
+    content works.  Use distinct contents per extension to surface
+    any accidental cross-wiring in the script.
+    """
+    staging = tmp_path / "Testing" / "baselines-staging"
+    for ext in extensions:
+        (staging / f"{test_name}.{ext}").write_text(
+            f"placeholder for {test_name}.{ext}\n"
+        )
+
+
+def _run_script(
+    script: pathlib.Path,
+    test_name: str,
+    incoming_dir: pathlib.Path,
+    *,
+    dry_run: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the script with a controlled environment.  ``DRY_RUN=1``
+    short-circuits the destructive stage step so success-path tests
+    don't pollute the fake repo or the real one."""
+    env = os.environ.copy()
+    env["ALIVE_TESTING_DATA_INCOMING"] = str(incoming_dir)
+    if dry_run:
+        env["DRY_RUN"] = "1"
+    return subprocess.run(
+        ["bash", str(script), test_name],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def test_preflight_accepts_complete_bundle(tmp_path: pathlib.Path) -> None:
+    """All four sidecars present → script exits 0 in dry-run mode.
+
+    The success path is characterised under ``DRY_RUN=1`` so the test
+    does not write into the real repo's ``Data/Baseline/`` directory
+    or shell out to ``gh``.
+    """
+    script = _build_fake_repo(tmp_path)
+    incoming = tmp_path / "INCOMING"
+    incoming.mkdir()
+    _stage_bundle(
+        tmp_path,
+        "BezierSurface4x4Planning",
+        extensions=("png", "mrml", "camera.json", "viewport.json"),
+    )
+
+    result = _run_script(
+        script,
+        "BezierSurface4x4Planning",
+        incoming,
+    )
+    assert result.returncode == 0, (
+        f"script exited {result.returncode} on complete bundle\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+    assert "dry-run" in result.stdout.lower()
+    # The dry-run path must NOT touch INCOMING or the stub dir.
+    assert list(incoming.iterdir()) == []
+    stub_dir = tmp_path / "LiverResections" / "Testing" / "Data" / "Baseline"
+    assert list(stub_dir.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "missing_ext",
+    ["png", "mrml", "camera.json", "viewport.json"],
+)
+def test_preflight_rejects_single_missing_sidecar(
+    tmp_path: pathlib.Path,
+    missing_ext: str,
+) -> None:
+    """Any one of the four sidecars missing → script exits non-zero
+    with a clear "incomplete bundle" message in stderr.
+
+    Parametrised over all four extensions so a future re-ordering of
+    the bundle list can't accidentally let one slip through the
+    check.
+    """
+    script = _build_fake_repo(tmp_path)
+    incoming = tmp_path / "INCOMING"
+    incoming.mkdir()
+    present = tuple(
+        ext for ext in ("png", "mrml", "camera.json", "viewport.json")
+        if ext != missing_ext
+    )
+    _stage_bundle(tmp_path, "BezierSurface4x4Planning", extensions=present)
+
+    result = _run_script(
+        script,
+        "BezierSurface4x4Planning",
+        incoming,
+    )
+    assert result.returncode != 0, (
+        f"script unexpectedly succeeded with {missing_ext} missing"
+    )
+    assert "incomplete bundle" in result.stderr.lower(), (
+        f"stderr did not flag incomplete bundle: {result.stderr!r}"
+    )
+    assert f"BezierSurface4x4Planning.{missing_ext}" in result.stderr
+
+
+def test_preflight_rejects_all_missing(tmp_path: pathlib.Path) -> None:
+    """Empty staging dir (no sidecars) → script exits non-zero with
+    every sidecar listed."""
+    script = _build_fake_repo(tmp_path)
+    incoming = tmp_path / "INCOMING"
+    incoming.mkdir()
+    # Deliberately do NOT call _stage_bundle — the staging dir exists
+    # (created by _build_fake_repo) but is empty.
+
+    result = _run_script(
+        script,
+        "BezierSurface4x4Planning",
+        incoming,
+    )
+    assert result.returncode != 0
+    stderr = result.stderr.lower()
+    assert "incomplete bundle" in stderr
+    for ext in ("png", "mrml", "camera.json", "viewport.json"):
+        assert f"beziersurface4x4planning.{ext}" in stderr, (
+            f"stderr did not list missing {ext}: {result.stderr!r}"
+        )
+
+
+def test_preflight_rejects_when_alive_incoming_unset(
+    tmp_path: pathlib.Path,
+) -> None:
+    """``ALIVE_TESTING_DATA_INCOMING`` unset → script refuses to run.
+
+    This guards the documented contract that the operator point the
+    script at an actual testing-data checkout before invoking it.
+    """
+    script = _build_fake_repo(tmp_path)
+    _stage_bundle(
+        tmp_path,
+        "BezierSurface4x4Planning",
+        extensions=("png", "mrml", "camera.json", "viewport.json"),
+    )
+
+    env = os.environ.copy()
+    env.pop("ALIVE_TESTING_DATA_INCOMING", None)
+    # Keep DRY_RUN off so we'd notice if the pre-flight order ever
+    # let an unset INCOMING through.
+    result = subprocess.run(
+        ["bash", str(script), "BezierSurface4x4Planning"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "ALIVE_TESTING_DATA_INCOMING" in result.stderr

--- a/LiverResections/Testing/Python/test_harness/test_has_baseline.py
+++ b/LiverResections/Testing/Python/test_harness/test_has_baseline.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Harness self-tests for ``replay_test._has_baseline``.
+
+GAP-1 follow-up from PR #384's /slicer-review synthesis (issue #387).
+
+``_has_baseline(baseline_dir, test_name)`` answers a single question:
+"is there enough on disk for the replay driver to attempt a real
+comparison?".  The contract is the 4-row truth table below: True iff
+both the resolved PNG (``<test>.png``) and the committed stub
+(``<test>.png.sha512``) are present.  The PNG presence proves
+ExternalData found a blob to resolve to; the stub's presence proves
+the test was registered with content (and survives a `git clean -dxf`).
+Either signal alone is ambiguous, so the helper requires both.
+
+These tests use pytest's ``tmp_path`` fixture to construct each of
+the four scenarios in isolation — no real ExternalData fetch, no
+captured baseline coupling.
+
+References
+----------
+* ADR-0008 §"observability" — pure-Python helpers carry self-tests.
+* PR #384 /slicer-review synthesis comment, GAP-1.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+
+# The replay module imports cleanly in plain Python (the slicer / vtk
+# imports are pushed inside the render / compare helpers, not at
+# module top-level).  Drop the harness directory on ``sys.path`` so
+# ``import replay_test`` resolves without coupling to a packaging step.
+_HERE = pathlib.Path(__file__).resolve()
+_HARNESS_DIR = _HERE.parent.parent  # LiverResections/Testing/Python/
+if str(_HARNESS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HARNESS_DIR))
+
+import replay_test  # noqa: E402 — path injection above must run first.
+
+
+TEST_NAME = "FakeScenario"
+
+
+def _make_files(
+    baseline_dir: pathlib.Path,
+    *,
+    png: bool,
+    stub: bool,
+) -> None:
+    """Materialise the requested subset of bundle artefacts in
+    ``baseline_dir``.
+
+    Contents are intentionally minimal — ``_has_baseline`` only checks
+    file existence, not bytes.
+    """
+    if png:
+        (baseline_dir / f"{TEST_NAME}.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    if stub:
+        # 64-byte SHA-512 hex digest placeholder; matches the
+        # ``.sha512`` stub format ExternalData rotates on capture.
+        (baseline_dir / f"{TEST_NAME}.png.sha512").write_text("0" * 128 + "\n")
+
+
+@pytest.mark.parametrize(
+    ("png_present", "stub_present", "expected"),
+    [
+        (True, True, True),    # canonical "captured baseline" state
+        (True, False, False),  # PNG without stub — broken capture path
+        (False, True, False),  # stub without resolved blob — fetch failed
+        (False, False, False), # nothing on disk — fresh scaffold
+    ],
+    ids=[
+        "png_and_stub_both_present",
+        "png_present_stub_missing",
+        "stub_present_png_missing",
+        "neither_png_nor_stub",
+    ],
+)
+def test_has_baseline_truth_table(
+    tmp_path: pathlib.Path,
+    png_present: bool,
+    stub_present: bool,
+    expected: bool,
+) -> None:
+    """Exercise the documented 4-row truth table.
+
+    ``_has_baseline`` returns True iff BOTH the resolved PNG and the
+    committed sha512 stub exist.  Any other combination must return
+    False so the replay driver hits its "skip with clear message"
+    branch instead of attempting a comparison against incomplete
+    state.
+    """
+    _make_files(tmp_path, png=png_present, stub=stub_present)
+    assert replay_test._has_baseline(tmp_path, TEST_NAME) is expected
+
+
+def test_has_baseline_isolated_per_test_name(tmp_path: pathlib.Path) -> None:
+    """A captured ``FooBaseline`` must not satisfy ``BarBaseline``.
+
+    The helper composes the path from ``test_name``; presence of an
+    unrelated scenario's artefacts in the same directory must not
+    leak across.
+    """
+    (tmp_path / "FooBaseline.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    (tmp_path / "FooBaseline.png.sha512").write_text("0" * 128 + "\n")
+    assert replay_test._has_baseline(tmp_path, "FooBaseline") is True
+    assert replay_test._has_baseline(tmp_path, "BarBaseline") is False

--- a/LiverResections/Testing/Python/test_harness/test_resolve_baseline_png.py
+++ b/LiverResections/Testing/Python/test_harness/test_resolve_baseline_png.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Harness self-tests for ``replay_test._resolve_baseline_png``.
+
+GAP-1 follow-up from PR #384's /slicer-review synthesis (issue #387).
+
+``_resolve_baseline_png`` is intentionally trivial — it composes
+``<baseline_dir> / "<test>.png"``.  The point of the test is to pin
+that contract: the resolved path must be a plain ``<test>.png`` under
+``baseline_dir``, no algorithm suffix, no nested subdirectory.  If a
+future refactor accidentally adds a ``baselines/`` subdir or appends a
+hash, the replay driver's ExternalData wiring breaks silently — this
+test trips first.
+
+References
+----------
+* ADR-0008 §"observability" — pure-Python helpers carry self-tests.
+* ``CMake/ExternalData`` URL template wiring in
+  ``LiverResections/Testing/Python/CMakeLists.txt``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+# Sibling-of-tests path injection — same shape as test_has_baseline.py.
+_HERE = pathlib.Path(__file__).resolve()
+_HARNESS_DIR = _HERE.parent.parent
+if str(_HARNESS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HARNESS_DIR))
+
+import replay_test  # noqa: E402
+
+
+def test_resolve_baseline_png_path_composition(tmp_path: pathlib.Path) -> None:
+    """The resolved path is ``<baseline_dir> / "<test>.png"``."""
+    resolved = replay_test._resolve_baseline_png(tmp_path, "BezierSurface4x4Planning")
+    assert resolved == tmp_path / "BezierSurface4x4Planning.png"
+
+
+def test_resolve_baseline_png_returns_path_object(tmp_path: pathlib.Path) -> None:
+    """The helper must return a ``pathlib.Path`` (string concatenation
+    would break the ``.exists()`` call in ``_has_baseline``)."""
+    resolved = replay_test._resolve_baseline_png(tmp_path, "AnyScenario")
+    assert isinstance(resolved, pathlib.Path)
+
+
+def test_resolve_baseline_png_no_filesystem_side_effects(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Path composition must NOT create the file — that's the capture
+    driver's job, not the resolver's.  Pin the read-only contract so a
+    future ``.touch()`` accident gets caught."""
+    replay_test._resolve_baseline_png(tmp_path, "NeverWritten")
+    assert list(tmp_path.iterdir()) == []

--- a/LiverResections/Testing/Python/test_harness/test_save_bundle.py
+++ b/LiverResections/Testing/Python/test_harness/test_save_bundle.py
@@ -1,0 +1,442 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Harness self-tests for ``capture_baseline._save_bundle``.
+
+GAP-1 follow-up from PR #384's /slicer-review synthesis (issue #387).
+
+``_save_bundle`` is the heart of the capture flow: on a single 's'
+keypress in the capture window it materialises the four-file bundle
+(``.png`` + ``.mrml`` + ``.camera.json`` + ``.viewport.json``) into
+the staging directory.  The contract documented in
+``LiverResections/Testing/README.md`` is:
+
+1. All four sidecars are written.
+2. The ``notes.md`` sidecar is NOT written automatically — it stays
+   an optional, on-demand human-rationale file (see the bundle table
+   in the README).
+3. If the screenshot step (the first action) fails, the helper raises
+   and leaves no half-written sidecars — the partial-bundle invariant
+   that ``upload_baseline.sh``'s pre-flight check also defends.
+
+``capture_baseline`` does top-level ``import qt`` / ``import slicer``
+/ ``import vtk``.  None of those are importable in a plain pytest
+environment (or even in a Slicer Python that is not running inside a
+QApplication), so this module **stubs all three into**
+``sys.modules`` **before** importing ``capture_baseline``.  The stubs
+record the calls the helper makes against them, which is exactly the
+surface this test characterises.
+
+References
+----------
+* ADR-0008 §"observability" — pure-Python helpers carry self-tests.
+* ``LiverResections/Testing/README.md`` §"Bundle contents" — the
+  four-file contract.
+* ``LiverResections/Testing/Scripts/upload_baseline.sh`` — the
+  upload-side pre-flight that also defends the partial-bundle
+  invariant.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import types
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# Stub modules
+# --------------------------------------------------------------------------- #
+#
+# ``capture_baseline`` does ``import qt`` / ``import slicer`` /
+# ``import vtk`` at module top level.  Inject minimal stub modules
+# into ``sys.modules`` *before* the import so the module loads in
+# plain CPython.  The stubs only need to expose the symbols that
+# ``_save_bundle`` (and the helpers it calls — ``_serialise_camera``,
+# ``_serialise_viewport``) reaches for.
+
+
+class _StubVTKWindowToImageFilter:
+    """Records the ``SetInput`` argument + supports the small fluent
+    surface ``_save_bundle`` calls."""
+
+    def __init__(self) -> None:
+        self._input = None
+        self.updated = False
+
+    def SetInput(self, render_window) -> None:  # noqa: N802 (VTK API)
+        self._input = render_window
+
+    def SetInputBufferTypeToRGB(self) -> None:  # noqa: N802
+        pass
+
+    def ReadFrontBufferOff(self) -> None:  # noqa: N802
+        pass
+
+    def SetShouldRerender(self, _flag: int) -> None:  # noqa: N802
+        pass
+
+    def Update(self) -> None:  # noqa: N802
+        self.updated = True
+
+    def GetOutput(self):  # noqa: N802
+        return object()  # opaque sentinel — writer doesn't introspect it
+
+
+class _StubVTKPNGWriter:
+    """PNG writer stub.
+
+    Default behaviour writes a deterministic 8-byte PNG-signature blob
+    to the configured filename.  ``fail_on_write=True`` raises from
+    ``Write()`` — exercises the partial-bundle invariant.
+    """
+
+    fail_on_write = False
+
+    def __init__(self) -> None:
+        self._filename: pathlib.Path | None = None
+
+    def SetFileName(self, path: str) -> None:  # noqa: N802
+        self._filename = pathlib.Path(path)
+
+    def SetInputData(self, _data) -> None:  # noqa: N802
+        pass
+
+    def Write(self) -> None:  # noqa: N802
+        if type(self).fail_on_write:
+            raise RuntimeError("simulated screenshot-write failure")
+        assert self._filename is not None
+        # PNG magic header — minimal valid-looking bytes.
+        self._filename.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+
+def _make_vtk_stub() -> types.ModuleType:
+    vtk = types.ModuleType("vtk")
+    vtk.vtkWindowToImageFilter = _StubVTKWindowToImageFilter
+    vtk.vtkPNGWriter = _StubVTKPNGWriter
+    return vtk
+
+
+class _StubCamera:
+    """Stub ``vtkCamera`` — fixed numbers so the JSON contents are
+    asserted exactly."""
+
+    def GetPosition(self):  # noqa: N802
+        return (1.0, 2.0, 3.0)
+
+    def GetFocalPoint(self):  # noqa: N802
+        return (0.0, 0.0, 0.0)
+
+    def GetViewUp(self):  # noqa: N802
+        return (0.0, 1.0, 0.0)
+
+    def GetParallelScale(self):  # noqa: N802
+        return 1.5
+
+    def GetViewAngle(self):  # noqa: N802
+        return 30.0
+
+    def GetClippingRange(self):  # noqa: N802
+        return (0.1, 1000.0)
+
+
+class _StubCameraNode:
+    def GetCamera(self):  # noqa: N802
+        return _StubCamera()
+
+
+class _StubCamerasLogic:
+    def GetViewActiveCameraNode(self, _view_node):  # noqa: N802
+        return _StubCameraNode()
+
+
+class _StubCamerasModule:
+    def logic(self):
+        return _StubCamerasLogic()
+
+
+class _StubModules:
+    cameras = _StubCamerasModule()
+
+
+class _StubUtil:
+    """``slicer.util.saveScene`` stub — writes a placeholder MRML
+    blob so the resulting file exists for the assertions."""
+
+    @staticmethod
+    def saveScene(path: str) -> bool:  # noqa: N802 (Slicer API)
+        pathlib.Path(path).write_text(
+            '<?xml version="1.0"?>\n<MRML version="1.0"></MRML>\n'
+        )
+        return True
+
+
+def _make_slicer_stub() -> types.ModuleType:
+    slicer = types.ModuleType("slicer")
+    slicer.modules = _StubModules()
+    slicer.util = _StubUtil()
+    return slicer
+
+
+class _StubQEvent:
+    KeyPress = 6  # match Qt's enum value; unused by _save_bundle
+
+
+class _StubQt:
+    KeyPress = _StubQEvent.KeyPress
+    Key_S = 83
+    Key_Q = 81
+
+
+class _StubQObject:
+    """Minimal ``QObject`` substitute — capture_baseline subclasses it
+    in ``_KeyFilter``; the subclass body is not exercised by these
+    tests, so any object that supports an empty ``__init__`` works."""
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+
+def _make_qt_stub() -> types.ModuleType:
+    qt = types.ModuleType("qt")
+    qt.QEvent = _StubQEvent
+    qt.Qt = _StubQt
+    qt.QObject = _StubQObject
+    # ``QApplication`` is reached for in ``_KeyFilter.eventFilter`` only,
+    # not in ``_save_bundle``; provide a marker so any accidental call
+    # surfaces as an attribute error rather than a silent no-op.
+    qt.QApplication = types.SimpleNamespace()
+    return qt
+
+
+@pytest.fixture
+def capture_module(monkeypatch):
+    """Import ``capture_baseline`` under stubbed Qt / Slicer / VTK
+    modules and return the imported module object.
+
+    Each test gets a fresh import so the per-test ``fail_on_write``
+    toggle on ``_StubVTKPNGWriter`` cannot leak into a sibling test.
+    """
+    # Ensure default behaviour at fixture entry — paranoid clean-slate
+    # in case a prior test crashed before the fixture's teardown.
+    _StubVTKPNGWriter.fail_on_write = False
+
+    monkeypatch.setitem(sys.modules, "qt", _make_qt_stub())
+    monkeypatch.setitem(sys.modules, "slicer", _make_slicer_stub())
+    monkeypatch.setitem(sys.modules, "vtk", _make_vtk_stub())
+
+    here = pathlib.Path(__file__).resolve()
+    harness_dir = here.parent.parent  # LiverResections/Testing/Python/
+    monkeypatch.syspath_prepend(str(harness_dir))
+
+    # Force re-import so the stubs above are picked up fresh.
+    monkeypatch.delitem(sys.modules, "capture_baseline", raising=False)
+    import capture_baseline  # noqa: E402
+
+    yield capture_baseline
+
+    # Defensive: reset the toggle for the next fixture entry.
+    _StubVTKPNGWriter.fail_on_write = False
+
+
+# --------------------------------------------------------------------------- #
+# Stub view-node + view-widget surfaces
+# --------------------------------------------------------------------------- #
+
+
+class _StubRenderWindow:
+    def GetMultiSamples(self) -> int:  # noqa: N802
+        return 0
+
+
+class _StubThreeDView:
+    def __init__(self) -> None:
+        self.force_render_calls = 0
+
+    def forceRender(self) -> None:  # noqa: N802 (Slicer API)
+        self.force_render_calls += 1
+
+    def renderWindow(self):  # noqa: N802
+        return _StubRenderWindow()
+
+
+class _StubSize:
+    def __init__(self, w: int, h: int) -> None:
+        self._w = w
+        self._h = h
+
+    def width(self) -> int:
+        return self._w
+
+    def height(self) -> int:
+        return self._h
+
+
+class _StubViewWidget:
+    def __init__(self) -> None:
+        self._three_d_view = _StubThreeDView()
+        self.size = _StubSize(800, 600)
+
+    def threeDView(self):  # noqa: N802
+        return self._three_d_view
+
+
+class _StubViewNode:
+    def GetBackgroundColor(self):  # noqa: N802
+        return (0.0, 0.0, 0.0)
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def test_save_bundle_writes_all_four_sidecars(
+    capture_module,
+    tmp_path: pathlib.Path,
+) -> None:
+    """The four-file bundle contract: ``.png`` + ``.mrml`` +
+    ``.camera.json`` + ``.viewport.json`` all written into the
+    staging dir."""
+    capture_module._save_bundle(
+        "FakeScenario",
+        tmp_path,
+        _StubViewNode(),
+        _StubViewWidget(),
+    )
+
+    expected = {
+        "FakeScenario.png",
+        "FakeScenario.mrml",
+        "FakeScenario.camera.json",
+        "FakeScenario.viewport.json",
+    }
+    actual = {p.name for p in tmp_path.iterdir()}
+    assert expected == actual, f"missing/extra files: {expected ^ actual}"
+
+
+def test_save_bundle_camera_json_shape(
+    capture_module,
+    tmp_path: pathlib.Path,
+) -> None:
+    """The ``.camera.json`` sidecar carries the six documented keys
+    (``LiverResections/Testing/README.md`` §"Bundle contents")."""
+    capture_module._save_bundle(
+        "FakeScenario",
+        tmp_path,
+        _StubViewNode(),
+        _StubViewWidget(),
+    )
+    payload = json.loads((tmp_path / "FakeScenario.camera.json").read_text())
+    assert set(payload.keys()) == {
+        "position",
+        "focal_point",
+        "view_up",
+        "parallel_scale",
+        "view_angle",
+        "clipping_range",
+    }
+    # Spot-check one value to pin the serialiser → JSON path.
+    assert payload["position"] == [1.0, 2.0, 3.0]
+
+
+def test_save_bundle_viewport_json_shape(
+    capture_module,
+    tmp_path: pathlib.Path,
+) -> None:
+    """The ``.viewport.json`` sidecar carries size + background +
+    anti-aliasing."""
+    capture_module._save_bundle(
+        "FakeScenario",
+        tmp_path,
+        _StubViewNode(),
+        _StubViewWidget(),
+    )
+    payload = json.loads((tmp_path / "FakeScenario.viewport.json").read_text())
+    assert payload == {
+        "size": [800, 600],
+        "background": [0.0, 0.0, 0.0],
+        "anti_aliasing_frames": 0,
+    }
+
+
+def test_save_bundle_does_not_write_notes_md(
+    capture_module,
+    tmp_path: pathlib.Path,
+) -> None:
+    """The optional ``notes.md`` sidecar must NOT be auto-emitted.
+
+    Per the README, ``notes.md`` is a human-rationale file added by
+    the maintainer on demand.  The auto-capture path must not invent
+    one — silent placeholder content would defeat its purpose.
+    """
+    capture_module._save_bundle(
+        "FakeScenario",
+        tmp_path,
+        _StubViewNode(),
+        _StubViewWidget(),
+    )
+    assert not (tmp_path / "FakeScenario.notes.md").exists()
+    # Same check generalised: no .md file appears at all.
+    assert not any(p.suffix == ".md" for p in tmp_path.iterdir())
+
+
+def test_save_bundle_creates_staging_dir(
+    capture_module,
+    tmp_path: pathlib.Path,
+) -> None:
+    """``mkdir(parents=True, exist_ok=True)`` runs first — the
+    caller can pass a not-yet-extant directory."""
+    nested = tmp_path / "nested" / "staging"
+    assert not nested.exists()
+
+    capture_module._save_bundle(
+        "FakeScenario",
+        nested,
+        _StubViewNode(),
+        _StubViewWidget(),
+    )
+    assert nested.is_dir()
+    assert (nested / "FakeScenario.png").exists()
+
+
+def test_save_bundle_screenshot_failure_leaves_no_sidecars(
+    capture_module,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Partial-bundle invariant.
+
+    The screenshot is the FIRST artefact written.  If it raises
+    (simulated by toggling ``fail_on_write`` on the PNG-writer stub),
+    the helper must propagate the exception and must NOT have written
+    any of the JSON or MRML sidecars — those rely on the screenshot
+    having landed.  This is the capture-side mirror of the
+    ``upload_baseline.sh`` pre-flight check (which rejects partial
+    bundles at the upload boundary).
+    """
+    _StubVTKPNGWriter.fail_on_write = True
+    try:
+        with pytest.raises(RuntimeError, match="simulated screenshot-write failure"):
+            capture_module._save_bundle(
+                "FakeScenario",
+                tmp_path,
+                _StubViewNode(),
+                _StubViewWidget(),
+            )
+    finally:
+        _StubVTKPNGWriter.fail_on_write = False
+
+    # No sidecar files were written.  The staging dir may still exist
+    # (``mkdir(exist_ok=True)`` ran before the failing write) — that's
+    # fine; the contract is about *bundle artefacts*, not the dir.
+    leftovers = [p.name for p in tmp_path.iterdir()]
+    forbidden_sidecars = {
+        "FakeScenario.mrml",
+        "FakeScenario.camera.json",
+        "FakeScenario.viewport.json",
+    }
+    assert not (forbidden_sidecars & set(leftovers)), (
+        f"partial bundle leaked sidecars on screenshot failure: {leftovers}"
+    )

--- a/LiverResections/Testing/README.md
+++ b/LiverResections/Testing/README.md
@@ -166,6 +166,53 @@ git commit -m "ENH: Capture BezierSurface4x4Planning visual-regression baseline"
 The CTest entry registers automatically once the scenario is listed in
 the CMake; no per-scenario CMake boilerplate.
 
+## v2.0.0 target baseline matrix
+
+The visual-regression harness scaffold landed with two scenarios
+(`BezierSurface4x4Planning`, `BezierSurface4x4Confirmed`).  The
+v2.0.0 release target is to grow this matrix to cover the
+behaviour-relevant variants surfaced by [ADR-0019](../../Docs/adr/0019-resection-state-machine.md)
+(state machine) and [ADR-0020](../../Docs/adr/0020-gpu-tessellation.md)
+(GPU tessellation rewrite gate).  Each scenario
+is a separate `Python/scenarios/<Name>.py` module plus a captured
+`.sha512` stub bundle — the harness scales by adding entries, not by
+restructuring the test driver.
+
+| Scenario                                          | Design driver                            | Status                                       |
+|---------------------------------------------------|------------------------------------------|----------------------------------------------|
+| `BezierSurface4x4Planning`                        | scaffold (this README §"Initial scope")  | scaffolded; awaiting first capture           |
+| `BezierSurface4x4Confirmed`                       | state machine per ADR-0019               | scaffolded; awaiting first capture           |
+| `BezierSurface3x3Planning`                        | variable-size enabler (ADR-0019 §"Open") | pending capture                              |
+| `BezierSurface3x3Confirmed`                       | variable-size enabler (ADR-0019 §"Open") | pending capture                              |
+| `BezierSurface4x4Planning_GridDivisions_10`       | ADR-0020 §"Rollout plan"                 | grid-divisions shader variant; pending       |
+| `BezierSurface4x4Planning_GridDivisions_40`       | ADR-0020 §"Rollout plan"                 | grid-divisions shader variant; pending       |
+| `BezierSurface4x4Planning_NarrowMargins`          | ADR-0020 §"Rollout plan"                 | margin variant; pending                      |
+| `BezierSurface4x4Planning_WideMargins`            | ADR-0020 §"Rollout plan"                 | margin variant; pending                      |
+| `BezierSurface4x4Planning_InterpolatedMargins`    | ADR-0020 §"Rollout plan"                 | interpolated-margins shader path; pending    |
+
+v2.1 scenarios (NURBS variants) are gated on the upcoming NURBS
+surface ADR (in draft, see [ADR-0018](../../Docs/adr/0018-nurbs-extension-surface.md))
+and the v2.1 mapper work per ADR-0020 §"Rollout plan"; those will
+be planned in a separate matrix section once that work begins.
+Listing them here now would imply a commitment ahead of the ADR's
+design freeze.
+
+Adding a scenario is the same 3-step recipe documented in
+§"Adding a new scenario":
+
+1. Author `LiverResections/Testing/Python/scenarios/<NewScenario>.py`
+   exposing `setup_scene`, `setup_camera`, `setup_viewport`, and
+   `describe`.  See `BezierSurface4x4Planning.py` for the canonical
+   shape.
+2. Append `<NewScenario>` to the `_visual_test_scenarios` list in
+   `Python/CMakeLists.txt`.
+3. Run the capture flow per §"Capture (developer / maintainer)";
+   commit the rotated `.sha512` stubs.
+
+The harness's CTest registration picks up new entries automatically
+once steps 1-2 are in place; step 3 populates the bundle on the
+`ALive-research/ALiveResearchTestingData` `SHA512` release.
+
 ## Bumping baselines after a Slicer/VTK/image upgrade
 
 When a Slicer / VTK / VTK-image upgrade causes legitimate visual drift

--- a/LiverResections/Testing/Scripts/upload_baseline.sh
+++ b/LiverResections/Testing/Scripts/upload_baseline.sh
@@ -150,6 +150,17 @@ EOF
   exit 1
 fi
 
+# DRY_RUN=1 short-circuits the destructive operations (hashing, stub
+# writes, INCOMING copies) AFTER the pre-flight passes.  Used by the
+# harness self-tests under
+# ``LiverResections/Testing/Python/test_harness/`` to characterise
+# the bundle-completeness gate without polluting the repo's
+# ``Data/Baseline/`` directory or the maintainer's INCOMING/.
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "dry-run: bundle complete for ${TEST_NAME}; would stage to ${ALIVE_TESTING_DATA_INCOMING}/"
+  exit 0
+fi
+
 mkdir -p "${STUB_DIR}"
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Closes two low-priority follow-up issues from PR #384's `/slicer-review` synthesis (https://github.com/ALive-research/Slicer-Liver/pull/384#issuecomment-4477825147):

- **Closes #387 (GAP-1)** — pytest self-tests for the visual-regression harness's pure-Python helpers (`_has_baseline`, `_resolve_baseline_png`, `_save_bundle`, plus `upload_baseline.sh`'s bundle-completeness pre-flight via a new `DRY_RUN=1` env gate).  Per ADR-0008 §"observability".
- **Closes #388 (GAP-6)** — new `## v2.0.0 target baseline matrix` section in `LiverResections/Testing/README.md` listing the nine baselines that should land before declaring v2.0.0 visual-regression coverage adequate, plus the mechanical 3-step recipe for adding a scenario.

## What lands

- `LiverResections/Testing/Python/test_harness/` — new directory:
  - `test_has_baseline.py` — 4-row truth-table coverage.
  - `test_resolve_baseline_png.py` — path-composition assertion.
  - `test_save_bundle.py` — bundle-write + partial-failure atomicity.
  - `test_bundle_completeness_preflight.py` — `upload_baseline.sh` rejection paths via subprocess + `DRY_RUN=1`.
- `LiverResections/Testing/Python/CMakeLists.txt` — new `pytest_harness_tests` CTest entry, gated on `Python3_EXECUTABLE` + pytest importability (mirrors the existing `pytest_scaffold` entry's skip-on-missing-pytest behaviour).
- `LiverResections/Testing/README.md` — new scenario-matrix section.
- `LiverResections/Testing/Scripts/upload_baseline.sh` — adds the `DRY_RUN=1` env gate so the test exercises the pre-flight without hitting `gh release upload`.

## Out of scope

No harness behaviour changes; pure-additive tests + doc.  The actual baseline capture for the matrix's nine scenarios is per-scenario maintainer work via the existing capture flow.

## Test plan

- [x] Python files are AST-parseable (validated locally).
- [x] No conflict markers, no Claude attributions in commit messages.
- [ ] CI: `Lint`, `docs-lint`, `check-commit-message`, `build-test (slicer-main, Linux)`, `coverage (slicer-main, Linux)`, `Paper Draft` all green.

## References

- PR #384 — visual-test harness scaffold; this PR is its declared follow-up.
- Issue #387 — closed by the test_harness/ additions.
- Issue #388 — closed by the README scenario-matrix section.
- ADR-0003 — testability invariant.
- ADR-0008 §"observability" — pure-Python helpers carry self-tests.

---

*AI-assisted authorship: this PR was drafted with help from Anthropic's Claude (Opus 4.7, \`claude-opus-4-7\`) via Claude Code.  Opened for human review.*