### PR TITLE
ENH: Add vtkMRMLNurbsSurfaceNode + .lrp.json schema v3 (NURBS-1)

### DIFF
--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -51,6 +51,14 @@
 #include "vtkMRMLBezierSurfaceDisplayNode.h"
 #include "vtkMRMLBezierSurfaceStorageNode.h"
 
+// v2.1 NURBS sibling data node + dedicated storage class
+// (ADR-0022 §"Decision 1 — Data node" + §"Decision 2 — Schema v3").
+// The NURBS data node is registered here for the same reason as the
+// Bezier family — scene save/load needs the class registered so MRML
+// can instantiate it on load.
+#include "vtkMRMLNurbsSurfaceNode.h"
+#include "vtkMRMLNurbsSurfaceStorageNode.h"
+
 #include <vtkCommand.h>
 #include <vtkMRMLMarkupsSlicingContourNode.h>
 #include <vtkMRMLMarkupsSlicingContourDisplayNode.h>
@@ -123,6 +131,13 @@ void vtkSlicerLiverResectionsLogic::RegisterNodes()
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceDisplayNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceStorageNode>::New());
+
+  // v2.1 NURBS sibling (ADR-0022 §"Decision 1 — Data node",
+  // §"Decision 2 — Schema v3").  Display-node + Pipeline come with
+  // NURBS-3; for NURBS-1 the data + storage classes alone are
+  // enough to round-trip scenes that carry NURBS resections.
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLNurbsSurfaceNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLNurbsSurfaceStorageNode>::New());
 }
 
 //---------------------------------------------------------------------------

--- a/LiverResections/MRML/CMakeLists.txt
+++ b/LiverResections/MRML/CMakeLists.txt
@@ -17,6 +17,10 @@ set(${KIT}_SRCS
   vtkMRMLBezierSurfaceDisplayNode.cxx
   vtkMRMLBezierSurfaceStorageNode.h
   vtkMRMLBezierSurfaceStorageNode.cxx
+  vtkMRMLNurbsSurfaceNode.h
+  vtkMRMLNurbsSurfaceNode.cxx
+  vtkMRMLNurbsSurfaceStorageNode.h
+  vtkMRMLNurbsSurfaceStorageNode.cxx
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -12,6 +12,7 @@ set(KIT_TEST_SRCS
   vtkMRMLBezierSurfaceNodeTest1.cxx
   vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
   vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+  vtkMRMLNurbsSurfaceNodeTest1.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -44,3 +45,4 @@ slicerMacroConfigureModuleCxxTestDriver(
 SIMPLE_TEST(vtkMRMLBezierSurfaceNodeTest1)
 SIMPLE_TEST(vtkMRMLBezierSurfaceDisplayNodeTest1)
 SIMPLE_TEST(vtkMRMLBezierSurfaceStorageNodeTest1)
+SIMPLE_TEST(vtkMRMLNurbsSurfaceNodeTest1)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -1185,6 +1185,245 @@ int testWriterAlwaysEmitsV3Bezier()
   return EXIT_SUCCESS;
 }
 
+int testJsonReadInvalidSurfaceType()
+{
+  // ADR-0022 §"Decision 2 — Schema v3": ``surfaceType`` is closed at
+  // {"Bezier", "NURBS"}.  An unrecognised value (e.g. "Catmull"
+  // emitted by a future / third-party tool) must be rejected at the
+  // read boundary so the data node never sees a malformed file.
+  // ``ReadDataInternal`` dispatches on the reference-node type — both
+  // dispatch arms (Bezier path + NURBS path) check the discriminator
+  // and reject the foreign value.
+
+  // Sub-case (a): NURBS reference + "Catmull" surfaceType → reject
+  // (ReadJsonNurbs rejects any non-"NURBS" value).
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 3,\n";
+      ofs << "  \"surfaceType\": \"Catmull\",\n";
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 4,\n";
+      ofs << "  \"cols\": 4,\n";
+      ofs << "  \"degreeU\": 3,\n";
+      ofs << "  \"degreeV\": 3,\n";
+      ofs << "  \"knotsU\": [0,0,0,0,1,1,1,1],\n";
+      ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+      ofs << "  \"weights\": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],\n";
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 48; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << static_cast<double>(i);
+      }
+      ofs << "]\n";
+      ofs << "}\n";
+    }
+
+    vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+    vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  // Sub-case (b): Bezier reference + "Catmull" surfaceType → reject
+  // (ReadJsonBezier rejects any non-"Bezier" value).
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 3,\n";
+      ofs << "  \"surfaceType\": \"Catmull\",\n";
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 4,\n";
+      ofs << "  \"cols\": 4,\n";
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 48; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << static_cast<double>(i);
+      }
+      ofs << "]\n";
+      ofs << "}\n";
+    }
+
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  // Sub-case (c): missing surfaceType on a v3 file.  Characterises
+  // current behaviour — the Bezier path tolerates the absent
+  // discriminator and falls through to Bezier-shaped parsing (this
+  // matches the legacy v2 path where there was no discriminator at
+  // all).  The NURBS path requires the discriminator and rejects.
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 3,\n";
+      // No "surfaceType" field.
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 4,\n";
+      ofs << "  \"cols\": 4,\n";
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 48; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << static_cast<double>(i);
+      }
+      ofs << "]\n";
+      ofs << "}\n";
+    }
+
+    // Bezier reference — accepted (falls back to Bezier parsing).
+    {
+      vtkNew<vtkMRMLBezierSurfaceNode> sink;
+      vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+      storage->SetFileName(path.c_str());
+      CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+      CHECK_INT(static_cast<int>(sink->GetRows()), 4);
+      CHECK_INT(static_cast<int>(sink->GetCols()), 4);
+    }
+    // NURBS reference — rejected (v3 NURBS files require the
+    // discriminator).
+    {
+      vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+      vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+      storage->SetFileName(path.c_str());
+      TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+      CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+      TESTING_OUTPUT_ASSERT_ERRORS_END();
+    }
+    vtksys::SystemTools::RemoveFile(path);
+  }
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV3NurbsControlGridLengthMismatch()
+{
+  // ADR-0022 §"Validation rules per surface type — NURBS":
+  // ``len(controlGrid) == 3 * rows * cols``.  Send a NURBS file with
+  // a correctly-sized {rows, cols, degrees, knots, weights} block
+  // but a controlGrid of wrong length — must be rejected at the
+  // read boundary.  Pairs ``testJsonReadV3NurbsInvalidKnotsLength``
+  // (knot length mismatch) + ``testJsonReadV3NurbsInvalidWeights``
+  // (weights length / positivity) to cover the third length-mismatch
+  // axis the NURBS payload exposes.
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 3,\n";
+    ofs << "  \"surfaceType\": \"NURBS\",\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 4,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"degreeU\": 3,\n";
+    ofs << "  \"degreeV\": 3,\n";
+    ofs << "  \"knotsU\": [0,0,0,0,1,1,1,1],\n";
+    ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+    ofs << "  \"weights\": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],\n";
+    // controlGrid of length 27 (a 3×3 grid) instead of the expected
+    // 48 (a 4×4 grid).
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 27; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << static_cast<double>(i);
+    }
+    ofs << "]\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+  vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV3NurbsInvalidKnotsContent()
+{
+  // ADR-0022 §"Validation rules per surface type — NURBS": knot
+  // vectors must be clamped + monotonic + within ``[0, 1]``.  Pair
+  // ``testJsonReadV3NurbsInvalidKnotsLength`` (length) by covering
+  // the content invariants — synthesise a length-correct but
+  // non-monotonic knotsU and confirm rejection at the read boundary.
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 3,\n";
+    ofs << "  \"surfaceType\": \"NURBS\",\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 4,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"degreeU\": 3,\n";
+    ofs << "  \"degreeV\": 3,\n";
+    // Length-correct (8) but non-monotonic: a 0.7 followed by 0.3
+    // in the middle of the (admittedly degenerate, no-interior)
+    // knot region.  Also clamping-violating — degree=3 expects 4
+    // equal repeats on each end.
+    ofs << "  \"knotsU\": [0,0,0,0.7,0.3,1,1,1],\n";
+    ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+    ofs << "  \"weights\": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << static_cast<double>(i);
+    }
+    ofs << "]\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+  vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
 int testNurbsStorageCanReadDiscrimination()
 {
   // The NURBS subclass inherits the base's CanRead/CanWrite
@@ -1241,6 +1480,9 @@ int vtkMRMLBezierSurfaceStorageNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testJsonReadV3NurbsInvalidKnotsLength());
   CHECK_EXIT_SUCCESS(testJsonReadV3NurbsInvalidWeights());
   CHECK_EXIT_SUCCESS(testJsonReadV3NurbsInvalidShape());
+  CHECK_EXIT_SUCCESS(testJsonReadInvalidSurfaceType());
+  CHECK_EXIT_SUCCESS(testJsonReadV3NurbsControlGridLengthMismatch());
+  CHECK_EXIT_SUCCESS(testJsonReadV3NurbsInvalidKnotsContent());
   CHECK_EXIT_SUCCESS(testWriterAlwaysEmitsV3Bezier());
   CHECK_EXIT_SUCCESS(testNurbsStorageCanReadDiscrimination());
 

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -21,6 +21,8 @@
 // This module MRML includes
 #include "vtkMRMLBezierSurfaceNode.h"
 #include "vtkMRMLBezierSurfaceStorageNode.h"
+#include "vtkMRMLNurbsSurfaceNode.h"
+#include "vtkMRMLNurbsSurfaceStorageNode.h"
 
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
@@ -426,15 +428,22 @@ int testJsonRoundTrip3x3()
     CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], grid33[i], 1e-9);
   }
 
-  // Spot-check the on-disk JSON carries the explicit shape — a
-  // schema-v2 file MUST emit rows + cols + schemaVersion = 2.
+  // Spot-check the on-disk JSON carries the explicit shape +
+  // discriminator — per ADR-0022 §"Decision 2 — Schema v3" the
+  // writer always emits ``schemaVersion: 3`` + ``surfaceType:
+  // "Bezier"`` + explicit ``rows`` / ``cols``.
   std::ifstream f(path);
   std::stringstream ss;
   ss << f.rdbuf();
   const std::string contents = ss.str();
-  if (contents.find("\"schemaVersion\":2") == std::string::npos && contents.find("\"schemaVersion\": 2") == std::string::npos)
+  if (contents.find("\"schemaVersion\":3") == std::string::npos && contents.find("\"schemaVersion\": 3") == std::string::npos)
   {
-    std::cerr << "Expected schemaVersion: 2 in output JSON\n" << contents << "\n";
+    std::cerr << "Expected schemaVersion: 3 in output JSON\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"surfaceType\":\"Bezier\"") == std::string::npos && contents.find("\"surfaceType\": \"Bezier\"") == std::string::npos)
+  {
+    std::cerr << "Expected surfaceType: \"Bezier\" in output JSON\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   if (contents.find("\"rows\":3") == std::string::npos && contents.find("\"rows\": 3") == std::string::npos)
@@ -687,6 +696,516 @@ int testLegacyFcsvFixture()
   return EXIT_SUCCESS;
 }
 
+//==============================================================================
+// v2.1 NURBS sibling tests (ADR-0022 §"Decision 2 — Schema v3" /
+// §"Reader compat matrix" / §"Validation rules per surface type").
+//==============================================================================
+
+/// Populate a NURBS surface node with deterministic, distinctive
+/// values touching every IVar the storage path round-trips.  The
+/// shape is rectangular + degrees asymmetric so the test catches any
+/// (rows ↔ cols) or (degreeU ↔ degreeV) swap in the read/write path.
+void populateNurbs(vtkMRMLNurbsSurfaceNode* node)
+{
+  // Drop degrees to (2, 3) so the (5, 4) shape is legal — need
+  // rows >= degreeU + 1 (5 >= 3) AND cols >= degreeV + 1 (4 >= 4).
+  node->SetDegreeU(2);
+  // DegreeV stays at default 3.
+  node->SetRows(5);
+  // SetCols(4) would be the default; do not assert here (this
+  // helper is ``void`` — callers check the round-trip post-condition
+  // via the public sink getters).
+
+  // Control grid — 3 * 5 * 4 = 60 doubles.
+  double grid[60];
+  for (int i = 0; i < 60; ++i)
+  {
+    grid[i] = static_cast<double>(i) * 0.125 + 0.0625;
+  }
+  node->SetControlGrid(grid);
+
+  // Weights — 5 * 4 = 20 doubles, all positive.
+  double weights[20];
+  for (int i = 0; i < 20; ++i)
+  {
+    weights[i] = 0.5 + static_cast<double>(i) * 0.05;
+  }
+  node->SetWeights(weights, 20);
+
+  // Hand-rolled knot vectors — overwrite the clamped-uniform
+  // defaults with a slightly different valid clamped vector to
+  // catch any "writer ignores knot edits + emits defaults" bug.
+  // KnotsU: length 5 + 2 + 1 = 8.  Clamped at both ends with
+  // three interior knots.
+  double knotsU[8] = { 0.0, 0.0, 0.0, 0.25, 0.6, 1.0, 1.0, 1.0 };
+  node->SetKnotsU(knotsU, 8);
+  // KnotsV: length 4 + 3 + 1 = 8.  Clamped at both ends with no
+  // interior knots (the degree-3, rows=degree+1 degenerate case).
+  double knotsV[8] = { 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0 };
+  node->SetKnotsV(knotsV, 8);
+
+  node->SetInitMode(vtkMRMLNurbsSurfaceNode::DistanceSpheroid);
+  node->SetState(vtkMRMLNurbsSurfaceNode::Planning);
+}
+
+int testJsonRoundTripNurbs()
+{
+  vtkNew<vtkMRMLNurbsSurfaceNode> source;
+  populateNurbs(source.GetPointer());
+
+  const std::string path = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLNurbsSurfaceStorageNode> writeStorage;
+  writeStorage->SetFileName(path.c_str());
+  CHECK_INT(writeStorage->WriteData(source.GetPointer()), 1);
+
+  vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+  vtkNew<vtkMRMLNurbsSurfaceStorageNode> readStorage;
+  readStorage->SetFileName(path.c_str());
+  CHECK_INT(readStorage->ReadData(sink.GetPointer()), 1);
+
+  // Shape + degrees round-trip.
+  CHECK_INT(static_cast<int>(sink->GetRows()), 5);
+  CHECK_INT(static_cast<int>(sink->GetCols()), 4);
+  CHECK_INT(static_cast<int>(sink->GetDegreeU()), 2);
+  CHECK_INT(static_cast<int>(sink->GetDegreeV()), 3);
+  CHECK_INT(sink->GetState(), vtkMRMLNurbsSurfaceNode::Planning);
+  CHECK_INT(sink->GetInitMode(), vtkMRMLNurbsSurfaceNode::DistanceSpheroid);
+
+  // Control grid round-trip (3 * 5 * 4 = 60 doubles).
+  for (int i = 0; i < 60; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], source->GetControlGrid()[i], 1e-9);
+  }
+
+  // Knots + weights round-trip.
+  for (unsigned int i = 0; i < sink->GetKnotsULength(); ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetKnotsU()[i], source->GetKnotsU()[i], 1e-9);
+  }
+  for (unsigned int i = 0; i < sink->GetKnotsVLength(); ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetKnotsV()[i], source->GetKnotsV()[i], 1e-9);
+  }
+  for (unsigned int i = 0; i < sink->GetWeightsLength(); ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetWeights()[i], source->GetWeights()[i], 1e-9);
+  }
+
+  // Spot-check the on-disk JSON for the v3 markers.
+  std::ifstream f(path);
+  std::stringstream ss;
+  ss << f.rdbuf();
+  const std::string contents = ss.str();
+  if (contents.find("\"schemaVersion\":3") == std::string::npos && contents.find("\"schemaVersion\": 3") == std::string::npos)
+  {
+    std::cerr << "Expected schemaVersion: 3 in NURBS output JSON\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"surfaceType\":\"NURBS\"") == std::string::npos && contents.find("\"surfaceType\": \"NURBS\"") == std::string::npos)
+  {
+    std::cerr << "Expected surfaceType: \"NURBS\" in output JSON\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"degreeU\":2") == std::string::npos && contents.find("\"degreeU\": 2") == std::string::npos)
+  {
+    std::cerr << "Expected degreeU: 2 in output JSON\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"weights\"") == std::string::npos)
+  {
+    std::cerr << "Expected weights field in output JSON\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV3BezierExplicit()
+{
+  // ADR-0022 §"Reader compat matrix": v3 + surfaceType "Bezier"
+  // loads via the Bezier path the same as v2 with the discriminator
+  // made explicit.  Synthesize a minimal v3 Bezier file and
+  // validate.
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 3,\n";
+    ofs << "  \"surfaceType\": \"Bezier\",\n";
+    ofs << "  \"state\": \"Planning\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 4,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << (static_cast<double>(i) * 0.25);
+    }
+    ofs << "]\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+
+  CHECK_INT(static_cast<int>(sink->GetRows()), 4);
+  CHECK_INT(static_cast<int>(sink->GetCols()), 4);
+  CHECK_INT(sink->GetState(), vtkMRMLBezierSurfaceNode::Planning);
+  for (int i = 0; i < 48; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], static_cast<double>(i) * 0.25, 1e-9);
+  }
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV3NurbsInvalidDegree()
+{
+  // ADR-0022 §"Validation rules per surface type — NURBS": degree
+  // out of {2, 3} is rejected with vtkErrorMacro.  Cover both
+  // edges: degreeU=1 and degreeU=4.
+  auto write = [](const std::string& p, int degreeU)
+  {
+    std::ofstream ofs(p);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 3,\n";
+    ofs << "  \"surfaceType\": \"NURBS\",\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 4,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"degreeU\": " << degreeU << ",\n";
+    ofs << "  \"degreeV\": 3,\n";
+    ofs << "  \"knotsU\": [0,0,0,0,1,1,1,1],\n";
+    ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+    ofs << "  \"weights\": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << static_cast<double>(i);
+    }
+    ofs << "]\n";
+    ofs << "}\n";
+  };
+
+  for (int badDegree : { 1, 4 })
+  {
+    const std::string path = makeTempPath("lrp.json");
+    write(path, badDegree);
+
+    vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+    vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV3NurbsInvalidKnotsLength()
+{
+  // ADR-0022 §"Validation rules per surface type — NURBS":
+  // ``len(knotsU) == rows + degreeU + 1`` (8 for the 4×4 / deg 3
+  // case).  Send a too-short knotsU and confirm rejection.
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 3,\n";
+    ofs << "  \"surfaceType\": \"NURBS\",\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 4,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"degreeU\": 3,\n";
+    ofs << "  \"degreeV\": 3,\n";
+    ofs << "  \"knotsU\": [0,0,0,1,1,1],\n"; // length 6, not 8
+    ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+    ofs << "  \"weights\": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << static_cast<double>(i);
+    }
+    ofs << "]\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+  vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV3NurbsInvalidWeights()
+{
+  // ADR-0022 §"Validation rules per surface type — NURBS":
+  // - weight must be strictly positive
+  // - len(weights) == rows * cols
+  // Cover both: a zero / negative entry + a wrong-length array.
+
+  // Sub-case (a): one zero weight.
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 3,\n";
+      ofs << "  \"surfaceType\": \"NURBS\",\n";
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 4,\n";
+      ofs << "  \"cols\": 4,\n";
+      ofs << "  \"degreeU\": 3,\n";
+      ofs << "  \"degreeV\": 3,\n";
+      ofs << "  \"knotsU\": [0,0,0,0,1,1,1,1],\n";
+      ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+      // Index 7 is zero — a singular weight in NURBS.
+      ofs << "  \"weights\": [1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1],\n";
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 48; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << static_cast<double>(i);
+      }
+      ofs << "]\n";
+      ofs << "}\n";
+    }
+
+    vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+    vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  // Sub-case (b): negative weight.
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 3,\n";
+      ofs << "  \"surfaceType\": \"NURBS\",\n";
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 4,\n";
+      ofs << "  \"cols\": 4,\n";
+      ofs << "  \"degreeU\": 3,\n";
+      ofs << "  \"degreeV\": 3,\n";
+      ofs << "  \"knotsU\": [0,0,0,0,1,1,1,1],\n";
+      ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+      ofs << "  \"weights\": [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,-0.5],\n";
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 48; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << static_cast<double>(i);
+      }
+      ofs << "]\n";
+      ofs << "}\n";
+    }
+
+    vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+    vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  // Sub-case (c): wrong length (8 instead of 16).
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 3,\n";
+      ofs << "  \"surfaceType\": \"NURBS\",\n";
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 4,\n";
+      ofs << "  \"cols\": 4,\n";
+      ofs << "  \"degreeU\": 3,\n";
+      ofs << "  \"degreeV\": 3,\n";
+      ofs << "  \"knotsU\": [0,0,0,0,1,1,1,1],\n";
+      ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+      ofs << "  \"weights\": [1,1,1,1,1,1,1,1],\n"; // length 8, not 16
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 48; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << static_cast<double>(i);
+      }
+      ofs << "]\n";
+      ofs << "}\n";
+    }
+
+    vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+    vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+  return EXIT_SUCCESS;
+}
+
+int testJsonReadV3NurbsInvalidShape()
+{
+  // ADR-0022 §"Validation rules per surface type — NURBS":
+  // rows < degreeU + 1 (or cols < degreeV + 1) leaves the basis
+  // empty — rejected.
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 3,\n";
+    ofs << "  \"surfaceType\": \"NURBS\",\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 3,\n"; // < degreeU + 1 = 4 → invalid
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"degreeU\": 3,\n";
+    ofs << "  \"degreeV\": 3,\n";
+    ofs << "  \"knotsU\": [0,0,0,0,1,1,1],\n";
+    ofs << "  \"knotsV\": [0,0,0,0,1,1,1,1],\n";
+    ofs << "  \"weights\": [1,1,1,1,1,1,1,1,1,1,1,1],\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 36; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << static_cast<double>(i);
+    }
+    ofs << "]\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+  vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testWriterAlwaysEmitsV3Bezier()
+{
+  // ADR-0022 §"Decision 2 — Schema v3": writer always emits v3 +
+  // ``surfaceType`` even for the (legacy) 4×4 Bezier case.  Round-
+  // trip a default-populated Bezier surface and assert the v3
+  // markers are present on disk.
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  source->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  double grid[48];
+  for (int i = 0; i < 48; ++i)
+  {
+    grid[i] = static_cast<double>(i);
+  }
+  source->SetControlGrid(grid);
+
+  const std::string path = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(path.c_str());
+  CHECK_INT(storage->WriteData(source.GetPointer()), 1);
+
+  std::ifstream f(path);
+  std::stringstream ss;
+  ss << f.rdbuf();
+  const std::string contents = ss.str();
+  if (contents.find("\"schemaVersion\":3") == std::string::npos && contents.find("\"schemaVersion\": 3") == std::string::npos)
+  {
+    std::cerr << "Expected schemaVersion: 3 in writer output\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"surfaceType\":\"Bezier\"") == std::string::npos && contents.find("\"surfaceType\": \"Bezier\"") == std::string::npos)
+  {
+    std::cerr << "Expected surfaceType: \"Bezier\" in writer output\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  // NURBS-only fields are absent.
+  if (contents.find("degreeU") != std::string::npos)
+  {
+    std::cerr << "Bezier writer output should NOT contain 'degreeU'\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"weights\"") != std::string::npos)
+  {
+    std::cerr << "Bezier writer output should NOT contain 'weights'\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+int testNurbsStorageCanReadDiscrimination()
+{
+  // The NURBS subclass inherits the base's CanRead/CanWrite
+  // predicates — both should accept either surface-type reference
+  // node (the storage class is unified per ADR-0022; the subclass
+  // just changes the node tag name + factory method).
+  vtkNew<vtkMRMLNurbsSurfaceStorageNode> storage;
+  vtkNew<vtkMRMLNurbsSurfaceNode> nurbs;
+  vtkNew<vtkMRMLBezierSurfaceNode> bezier;
+
+  CHECK_BOOL(storage->CanReadInReferenceNode(nurbs.GetPointer()), true);
+  CHECK_BOOL(storage->CanWriteFromReferenceNode(nurbs.GetPointer()), true);
+  // The base storage class accepts Bezier too — the subclass does
+  // not narrow the predicate.  Document this here so future drift
+  // is intentional.
+  CHECK_BOOL(storage->CanReadInReferenceNode(bezier.GetPointer()), true);
+  CHECK_BOOL(storage->CanWriteFromReferenceNode(bezier.GetPointer()), true);
+  CHECK_STRING(storage->GetNodeTagName(), "NurbsSurfaceStorage");
+  return EXIT_SUCCESS;
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -714,6 +1233,16 @@ int vtkMRMLBezierSurfaceStorageNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testJsonReadV2InvalidShape());
   CHECK_EXIT_SUCCESS(testJsonReadV2OutOfRange());
   CHECK_EXIT_SUCCESS(testJsonReadV2ControlGridLengthMismatch());
+
+  // v2.1 NURBS sibling — schema v3 (ADR-0022 §"Decision 2").
+  CHECK_EXIT_SUCCESS(testJsonRoundTripNurbs());
+  CHECK_EXIT_SUCCESS(testJsonReadV3BezierExplicit());
+  CHECK_EXIT_SUCCESS(testJsonReadV3NurbsInvalidDegree());
+  CHECK_EXIT_SUCCESS(testJsonReadV3NurbsInvalidKnotsLength());
+  CHECK_EXIT_SUCCESS(testJsonReadV3NurbsInvalidWeights());
+  CHECK_EXIT_SUCCESS(testJsonReadV3NurbsInvalidShape());
+  CHECK_EXIT_SUCCESS(testWriterAlwaysEmitsV3Bezier());
+  CHECK_EXIT_SUCCESS(testNurbsStorageCanReadDiscrimination());
 
   std::cout << "vtkMRMLBezierSurfaceStorageNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLNurbsSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLNurbsSurfaceNodeTest1.cxx
@@ -1,0 +1,627 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Tests for vtkMRMLNurbsSurfaceNode — the v2.1 NURBS sibling data
+  node landed by ADR-0022 §"Decision 1 — Data node" (NURBS-1
+  deliverable).  Exercises:
+
+   - defaults (constructor values: Rows=Cols=4, DegreeU=DegreeV=3,
+     KnotsU/V clamped-uniform, Weights all 1.0, ControlGrid zero)
+   - shape + degree validation (cross-IVar invariants)
+   - knot length invariants on shape / degree changes
+   - weights positivity validation
+   - state machine transitions (same matrix as Bezier per ADR-0019)
+   - CopyContent (in-type + cross-type rejection)
+   - XML round-trip via ReadXMLAttributes / WriteXML
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLNurbsSurfaceNode.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkSmartPointer.h>
+
+// STD includes
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace
+{
+
+int testDefaults()
+{
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+
+  CHECK_INT(static_cast<int>(node->GetRows()), vtkMRMLNurbsSurfaceNode::DefaultGridSize);
+  CHECK_INT(static_cast<int>(node->GetCols()), vtkMRMLNurbsSurfaceNode::DefaultGridSize);
+  CHECK_INT(static_cast<int>(node->GetDegreeU()), vtkMRMLNurbsSurfaceNode::DefaultDegree);
+  CHECK_INT(static_cast<int>(node->GetDegreeV()), vtkMRMLNurbsSurfaceNode::DefaultDegree);
+  CHECK_INT(node->GetState(), vtkMRMLNurbsSurfaceNode::Init);
+  CHECK_INT(node->GetInitMode(), vtkMRMLNurbsSurfaceNode::SlicingPlane);
+  CHECK_STRING(node->GetNodeTagName(), "NurbsSurface");
+
+  // Control grid is zero-filled at construction.  Length is
+  // 3 * Rows * Cols == 3 * 4 * 4 == 48 for the defaults.
+  CHECK_INT(static_cast<int>(node->GetControlGridLength()), 48);
+  const double* grid = node->GetControlGrid();
+  for (unsigned int i = 0; i < node->GetControlGridLength(); ++i)
+  {
+    CHECK_DOUBLE(grid[i], 0.0);
+  }
+
+  // Weights default to all-1.0 (non-rational B-spline degenerate
+  // case per ADR-0022 §"Weights default").  Length is Rows * Cols.
+  CHECK_INT(static_cast<int>(node->GetWeightsLength()), 16);
+  const double* weights = node->GetWeights();
+  for (unsigned int i = 0; i < node->GetWeightsLength(); ++i)
+  {
+    CHECK_DOUBLE(weights[i], 1.0);
+  }
+
+  // Default knots are clamped-uniform with length Rows + DegreeU + 1
+  // = 4 + 3 + 1 = 8.  For a degree-3, 4-row vector the de Boor
+  // convention emits [0, 0, 0, 0, 1, 1, 1, 1] — no interior knots
+  // because rows == degree + 1 (Bezier-equivalent degenerate case).
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 8);
+  CHECK_INT(static_cast<int>(node->GetKnotsVLength()), 8);
+  const double* knotsU = node->GetKnotsU();
+  for (int i = 0; i < 4; ++i)
+  {
+    CHECK_DOUBLE(knotsU[i], 0.0);
+  }
+  for (int i = 4; i < 8; ++i)
+  {
+    CHECK_DOUBLE(knotsU[i], 1.0);
+  }
+  return EXIT_SUCCESS;
+}
+
+int testClampedUniformKnotsWithInteriorNonEmpty()
+{
+  // Drive the node to a shape with interior knots present
+  // (Rows > DegreeU + 1).  For (Rows=5, DegreeU=2) the knot vector
+  // is length 8: [0, 0, 0, 1/3, 2/3, 1, 1, 1] — three zeros, two
+  // interior knots, three ones.
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+  node->SetDegree(2); // lower degree first so SetSize(5) does not
+                      // need to bump degrees down internally; both
+                      // axes valid because 5 >= 2+1.
+  node->SetSize(5);
+
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 8);
+  const double* knotsU = node->GetKnotsU();
+  CHECK_DOUBLE(knotsU[0], 0.0);
+  CHECK_DOUBLE(knotsU[1], 0.0);
+  CHECK_DOUBLE(knotsU[2], 0.0);
+  CHECK_DOUBLE_TOLERANCE(knotsU[3], 1.0 / 3.0, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(knotsU[4], 2.0 / 3.0, 1e-9);
+  CHECK_DOUBLE(knotsU[5], 1.0);
+  CHECK_DOUBLE(knotsU[6], 1.0);
+  CHECK_DOUBLE(knotsU[7], 1.0);
+  return EXIT_SUCCESS;
+}
+
+int testShapeValidation()
+{
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+
+  // Default is (4, 4) at degree 3.  ``SetSize(4)`` is a no-op.
+  const vtkMTimeType preNoop = node->GetMTime();
+  node->SetSize(4);
+  CHECK_INT(static_cast<int>(node->GetMTime()), static_cast<int>(preNoop));
+
+  // SetSize(5) is legal — 5 >= DegreeU + 1 = 4.
+  node->SetSize(5);
+  CHECK_INT(static_cast<int>(node->GetRows()), 5);
+  CHECK_INT(static_cast<int>(node->GetCols()), 5);
+  CHECK_INT(static_cast<int>(node->GetControlGridLength()), 75);
+
+  // SetSize(3) with the current default degree 3 is rejected — 3 <
+  // DegreeU + 1 = 4.  Need to drop degree first.
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetSize(3);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(static_cast<int>(node->GetRows()), 5); // unchanged
+
+  // After lowering degree to 2, SetSize(3) becomes legal.
+  node->SetDegree(2);
+  node->SetSize(3);
+  CHECK_INT(static_cast<int>(node->GetRows()), 3);
+  CHECK_INT(static_cast<int>(node->GetCols()), 3);
+
+  // SetRows(2) — even at degree 2 — is rejected; need Rows >= 3.
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetRows(2);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(static_cast<int>(node->GetRows()), 3);
+
+  // Asymmetric shape via SetRows / SetCols.  Going from (3, 3)
+  // degree (2, 2) to (5, 3) is legal.
+  node->SetRows(5);
+  CHECK_INT(static_cast<int>(node->GetRows()), 5);
+  CHECK_INT(static_cast<int>(node->GetCols()), 3);
+  CHECK_INT(static_cast<int>(node->GetControlGridLength()), 45);
+  return EXIT_SUCCESS;
+}
+
+int testDegreeValidation()
+{
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+
+  // Defaults: shape (4, 4), degrees (3, 3).
+  // Accept degree 2.
+  node->SetDegree(2);
+  CHECK_INT(static_cast<int>(node->GetDegreeU()), 2);
+  CHECK_INT(static_cast<int>(node->GetDegreeV()), 2);
+
+  // Accept degree 3.
+  node->SetDegree(3);
+  CHECK_INT(static_cast<int>(node->GetDegreeU()), 3);
+
+  // Reject degree 1 (below MinDegree).
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetDegree(1);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(static_cast<int>(node->GetDegreeU()), 3);
+
+  // Reject degree 4 (above MaxDegree).
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetDegree(4);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(static_cast<int>(node->GetDegreeU()), 3);
+
+  // Cross-IVar: cannot raise DegreeU above Rows - 1.  Drop Rows to
+  // 3 (need to lower degree first), then attempt to raise degreeU
+  // back to 3 — rejected.
+  node->SetDegree(2);
+  node->SetSize(3);
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetDegreeU(3);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(static_cast<int>(node->GetDegreeU()), 2);
+
+  // Constants exposed.
+  CHECK_INT(vtkMRMLNurbsSurfaceNode::MinDegree, 2);
+  CHECK_INT(vtkMRMLNurbsSurfaceNode::MaxDegree, 3);
+  CHECK_INT(vtkMRMLNurbsSurfaceNode::DefaultDegree, 3);
+  CHECK_INT(vtkMRMLNurbsSurfaceNode::DefaultGridSize, 4);
+  return EXIT_SUCCESS;
+}
+
+int testKnotLengthInvariant()
+{
+  // After every shape / degree change the knot vectors must
+  // satisfy len(KnotsU) == Rows + DegreeU + 1 and
+  // len(KnotsV) == Cols + DegreeV + 1.
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+
+  // (4, 4, 3, 3) → KnotsU/V length 8 each.
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 8);
+  CHECK_INT(static_cast<int>(node->GetKnotsVLength()), 8);
+
+  // Lower degree, expand shape.
+  node->SetDegree(2);
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 7); // 4 + 2 + 1
+  node->SetSize(10);
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 13); // 10 + 2 + 1
+
+  // Asymmetric: Cols changes only.
+  node->SetCols(6);
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 13);
+  CHECK_INT(static_cast<int>(node->GetKnotsVLength()), 9); // 6 + 2 + 1
+  return EXIT_SUCCESS;
+}
+
+int testWeightsPositivity()
+{
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+
+  // Default shape 4×4 → 16 weights, all 1.0.
+  CHECK_INT(static_cast<int>(node->GetWeightsLength()), 16);
+  const double* w = node->GetWeights();
+  for (unsigned int i = 0; i < 16; ++i)
+  {
+    CHECK_DOUBLE(w[i], 1.0);
+  }
+
+  // Accept a fresh valid weights vector.
+  double valid[16];
+  for (int i = 0; i < 16; ++i)
+  {
+    valid[i] = 0.5 + static_cast<double>(i) * 0.1;
+  }
+  CHECK_BOOL(node->SetWeights(valid, 16), true);
+  for (int i = 0; i < 16; ++i)
+  {
+    CHECK_DOUBLE(node->GetWeights()[i], valid[i]);
+  }
+
+  // Reject zero weight.
+  double withZero[16];
+  std::copy_n(valid, 16, withZero);
+  withZero[7] = 0.0;
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetWeights(withZero, 16), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  // Old values still in place.
+  CHECK_DOUBLE(node->GetWeights()[7], valid[7]);
+
+  // Reject negative weight.
+  double withNeg[16];
+  std::copy_n(valid, 16, withNeg);
+  withNeg[3] = -0.1;
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetWeights(withNeg, 16), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_DOUBLE(node->GetWeights()[3], valid[3]);
+
+  // Reject wrong length.
+  double tooShort[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetWeights(tooShort, 8), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  // Reject null pointer.
+  CHECK_BOOL(node->SetWeights(nullptr, 16), false);
+  return EXIT_SUCCESS;
+}
+
+int testStateTransitions()
+{
+  // ADR-0019 transition matrix — duplicated from
+  // ``vtkMRMLBezierSurfaceNode`` per ADR-0022 §"Sharing with the
+  // Bezier node — deliberate non-sharing".  Mirrors the
+  // testConfirmedStateTransitions test on the Bezier node.
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+  CHECK_INT(node->GetState(), vtkMRMLNurbsSurfaceNode::Init);
+
+  // Init -> Planning (legal forward edge).
+  vtkMTimeType pre = node->GetMTime();
+  node->SetState(vtkMRMLNurbsSurfaceNode::Planning);
+  CHECK_INT(node->GetState(), vtkMRMLNurbsSurfaceNode::Planning);
+  if (node->GetMTime() <= pre)
+  {
+    std::cerr << "Expected MTime advance on Init -> Planning\n";
+    return EXIT_FAILURE;
+  }
+
+  // Planning -> Confirmed (legal).
+  node->SetState(vtkMRMLNurbsSurfaceNode::Confirmed);
+  CHECK_INT(node->GetState(), vtkMRMLNurbsSurfaceNode::Confirmed);
+
+  // Confirmed -> Planning (legal round-trip).
+  node->SetState(vtkMRMLNurbsSurfaceNode::Planning);
+  CHECK_INT(node->GetState(), vtkMRMLNurbsSurfaceNode::Planning);
+
+  // Forbidden: Planning -> Init.
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  pre = node->GetMTime();
+  node->SetState(vtkMRMLNurbsSurfaceNode::Init);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  CHECK_INT(node->GetState(), vtkMRMLNurbsSurfaceNode::Planning);
+  CHECK_INT(node->GetMTime(), pre);
+
+  // Forbidden: Confirmed -> Init (drive to Confirmed via the legal
+  // path first).
+  node->SetState(vtkMRMLNurbsSurfaceNode::Confirmed);
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  pre = node->GetMTime();
+  node->SetState(vtkMRMLNurbsSurfaceNode::Init);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  CHECK_INT(node->GetState(), vtkMRMLNurbsSurfaceNode::Confirmed);
+  CHECK_INT(node->GetMTime(), pre);
+
+  // Forbidden: Init -> Confirmed (fresh node).
+  vtkNew<vtkMRMLNurbsSurfaceNode> fresh;
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  pre = fresh->GetMTime();
+  fresh->SetState(vtkMRMLNurbsSurfaceNode::Confirmed);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  CHECK_INT(fresh->GetState(), vtkMRMLNurbsSurfaceNode::Init);
+  CHECK_INT(fresh->GetMTime(), pre);
+
+  // Enum-string converters.
+  CHECK_STRING(vtkMRMLNurbsSurfaceNode::GetStateAsString(vtkMRMLNurbsSurfaceNode::Init), "Init");
+  CHECK_STRING(vtkMRMLNurbsSurfaceNode::GetStateAsString(vtkMRMLNurbsSurfaceNode::Planning), "Planning");
+  CHECK_STRING(vtkMRMLNurbsSurfaceNode::GetStateAsString(vtkMRMLNurbsSurfaceNode::Confirmed), "Confirmed");
+  CHECK_INT(vtkMRMLNurbsSurfaceNode::GetStateFromString("Confirmed"), vtkMRMLNurbsSurfaceNode::Confirmed);
+  CHECK_INT(vtkMRMLNurbsSurfaceNode::GetStateFromString("bogus"), -1);
+  CHECK_INT(vtkMRMLNurbsSurfaceNode::GetStateFromString(nullptr), -1);
+  CHECK_INT(vtkMRMLNurbsSurfaceNode::GetInitModeFromString("DistanceSpheroid"), vtkMRMLNurbsSurfaceNode::DistanceSpheroid);
+  return EXIT_SUCCESS;
+}
+
+int testCopyContent()
+{
+  // Same-type CopyContent must propagate every IVar.
+  vtkNew<vtkMRMLNurbsSurfaceNode> source;
+  source->SetDegree(2);
+  source->SetSize(5);
+  source->SetState(vtkMRMLNurbsSurfaceNode::Planning);
+  source->SetInitMode(vtkMRMLNurbsSurfaceNode::DistanceSpheroid);
+
+  double grid[75];
+  for (int i = 0; i < 75; ++i)
+  {
+    grid[i] = static_cast<double>(i) * 0.1;
+  }
+  source->SetControlGrid(grid);
+
+  double weights[25];
+  for (int i = 0; i < 25; ++i)
+  {
+    weights[i] = 0.5 + static_cast<double>(i) * 0.02;
+  }
+  source->SetWeights(weights, 25);
+
+  vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+  sink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
+
+  CHECK_INT(static_cast<int>(sink->GetRows()), 5);
+  CHECK_INT(static_cast<int>(sink->GetCols()), 5);
+  CHECK_INT(static_cast<int>(sink->GetDegreeU()), 2);
+  CHECK_INT(static_cast<int>(sink->GetDegreeV()), 2);
+  CHECK_INT(sink->GetState(), vtkMRMLNurbsSurfaceNode::Planning);
+  CHECK_INT(sink->GetInitMode(), vtkMRMLNurbsSurfaceNode::DistanceSpheroid);
+  for (int i = 0; i < 75; ++i)
+  {
+    CHECK_DOUBLE(sink->GetControlGrid()[i], grid[i]);
+  }
+  for (int i = 0; i < 25; ++i)
+  {
+    CHECK_DOUBLE(sink->GetWeights()[i], weights[i]);
+  }
+  // Knots also round-trip.
+  for (unsigned int i = 0; i < sink->GetKnotsULength(); ++i)
+  {
+    CHECK_DOUBLE(sink->GetKnotsU()[i], source->GetKnotsU()[i]);
+  }
+  return EXIT_SUCCESS;
+}
+
+int testCopyContentRejectsCrossType()
+{
+  // Cross-type sources are rejected with vtkErrorMacro per
+  // ADR-0022 §"Sharing with the Bezier node — deliberate
+  // non-sharing".  Bezier → NURBS copy is not meaningful without a
+  // fitter (Bezier carries no knots / weights / degrees) and
+  // returning early protects against silent zero-fill of those
+  // IVars on the sink.
+  vtkNew<vtkMRMLBezierSurfaceNode> bezier;
+  bezier->SetSize(3);
+
+  vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+  // Capture the sink's pre-copy state to assert the rejected copy
+  // did not partially mutate it.
+  const unsigned int preRows = sink->GetRows();
+  const unsigned int preDegreeU = sink->GetDegreeU();
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  sink->CopyContent(bezier.GetPointer(), /*deepCopy=*/true);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  // Sink IVars unchanged.
+  CHECK_INT(static_cast<int>(sink->GetRows()), static_cast<int>(preRows));
+  CHECK_INT(static_cast<int>(sink->GetDegreeU()), static_cast<int>(preDegreeU));
+
+  // Symmetric direction: NURBS -> Bezier sink is also rejected by
+  // the Bezier ``CopyContent`` for the same reason.
+  vtkNew<vtkMRMLNurbsSurfaceNode> nurbs;
+  vtkNew<vtkMRMLBezierSurfaceNode> bezierSink;
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  bezierSink->CopyContent(nurbs.GetPointer(), /*deepCopy=*/true);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  return EXIT_SUCCESS;
+}
+
+int testXMLRoundTrip()
+{
+  vtkNew<vtkMRMLNurbsSurfaceNode> source;
+  vtkNew<vtkMRMLScene> scene;
+  source->SetScene(scene.GetPointer());
+
+  source->SetDegree(2);
+  source->SetSize(5);
+  source->SetState(vtkMRMLNurbsSurfaceNode::Planning);
+  source->SetInitMode(vtkMRMLNurbsSurfaceNode::DistanceSpheroid);
+
+  double grid[75];
+  for (int i = 0; i < 75; ++i)
+  {
+    grid[i] = std::sin(static_cast<double>(i) * 0.1);
+  }
+  source->SetControlGrid(grid);
+
+  double weights[25];
+  for (int i = 0; i < 25; ++i)
+  {
+    weights[i] = 0.5 + static_cast<double>(i) * 0.05;
+  }
+  source->SetWeights(weights, 25);
+
+  std::ostringstream out;
+  source->WriteXML(out, 0);
+  const std::string xml = out.str();
+
+  // Sanity check: the XML stream should carry rows + cols +
+  // degreeU + degreeV + knots / weights / controlGrid.
+  if (xml.find("rows=\"5\"") == std::string::npos)
+  {
+    std::cerr << "Expected rows=\"5\" in NURBS XML:\n" << xml << "\n";
+    return EXIT_FAILURE;
+  }
+  if (xml.find("degreeU=\"2\"") == std::string::npos)
+  {
+    std::cerr << "Expected degreeU=\"2\" in NURBS XML:\n" << xml << "\n";
+    return EXIT_FAILURE;
+  }
+  if (xml.find("weights=") == std::string::npos)
+  {
+    std::cerr << "Expected weights attribute in NURBS XML:\n" << xml << "\n";
+    return EXIT_FAILURE;
+  }
+
+  // Walk the attribute list back into name/value pairs (same
+  // naïve parser as the Bezier node tests; libxml2 is not linked
+  // into this test driver).
+  std::vector<std::string> storage;
+  std::size_t pos = 0;
+  while (pos < xml.size())
+  {
+    while (pos < xml.size() && std::isspace(xml[pos]))
+    {
+      ++pos;
+    }
+    if (pos >= xml.size())
+    {
+      break;
+    }
+    const std::size_t eq = xml.find('=', pos);
+    if (eq == std::string::npos)
+    {
+      break;
+    }
+    std::string name = xml.substr(pos, eq - pos);
+    if (eq + 1 >= xml.size() || xml[eq + 1] != '"')
+    {
+      break;
+    }
+    const std::size_t valStart = eq + 2;
+    const std::size_t valEnd = xml.find('"', valStart);
+    if (valEnd == std::string::npos)
+    {
+      break;
+    }
+    std::string value = xml.substr(valStart, valEnd - valStart);
+    storage.push_back(name);
+    storage.push_back(value);
+    pos = valEnd + 1;
+  }
+  std::vector<const char*> atts;
+  for (const auto& s : storage)
+  {
+    atts.push_back(s.c_str());
+  }
+  atts.push_back(nullptr);
+
+  vtkNew<vtkMRMLNurbsSurfaceNode> sink;
+  sink->SetScene(scene.GetPointer());
+  sink->ReadXMLAttributes(atts.data());
+
+  CHECK_INT(sink->GetState(), source->GetState());
+  CHECK_INT(sink->GetInitMode(), source->GetInitMode());
+  CHECK_INT(static_cast<int>(sink->GetRows()), 5);
+  CHECK_INT(static_cast<int>(sink->GetCols()), 5);
+  CHECK_INT(static_cast<int>(sink->GetDegreeU()), 2);
+  CHECK_INT(static_cast<int>(sink->GetDegreeV()), 2);
+  for (int i = 0; i < 75; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], grid[i], 1e-5);
+  }
+  for (int i = 0; i < 25; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetWeights()[i], weights[i], 1e-5);
+  }
+  for (unsigned int i = 0; i < sink->GetKnotsULength(); ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sink->GetKnotsU()[i], source->GetKnotsU()[i], 1e-5);
+  }
+  return EXIT_SUCCESS;
+}
+
+int testResetKnotsHelper()
+{
+  // Direct exercise of the ResetKnotsToClampedUniform helper.
+  // After a SetWeights mutation that does not touch shape, the
+  // knot vectors should be unchanged from the clamped-uniform
+  // default; calling ResetKnotsToClampedUniform after manually
+  // editing the IVar vector restores defaults.  This test pins
+  // the helper contract for callers that bypass shape setters.
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+  node->SetDegree(2);
+  node->SetSize(5);
+
+  const std::vector<double>& knotsU = node->GetKnotsUVector();
+  CHECK_INT(static_cast<int>(knotsU.size()), 8);
+
+  // Save current values, then call reset — values should match.
+  std::vector<double> snapshot = knotsU;
+  node->ResetKnotsToClampedUniform();
+  for (size_t i = 0; i < snapshot.size(); ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(node->GetKnotsU()[i], snapshot[i], 1e-9);
+  }
+  return EXIT_SUCCESS;
+}
+
+int testSetKnotsLengthMismatch()
+{
+  // SetKnotsU / SetKnotsV reject length-mismatch payloads with
+  // vtkErrorMacro and return false.  ``data-node setter'' validation
+  // is independent of the storage-layer JSON validation per
+  // ADR-0022 §"Validation rules per surface type"; both layers
+  // enforce the invariant.
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 8);
+
+  double tooShort[7] = { 0, 0, 0, 0.5, 1, 1, 1 };
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetKnotsU(tooShort, 7), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  double tooLong[9] = { 0, 0, 0, 0, 0.5, 1, 1, 1, 1 };
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetKnotsU(tooLong, 9), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  double justRight[8] = { 0, 0, 0, 0, 1, 1, 1, 1 };
+  CHECK_BOOL(node->SetKnotsU(justRight, 8), true);
+
+  // Symmetric for KnotsV.
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetKnotsV(tooShort, 7), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_BOOL(node->SetKnotsV(justRight, 8), true);
+
+  // Null pointer rejected (no error message — same convention as
+  // SetControlGrid which returns false silently on null).
+  CHECK_BOOL(node->SetKnotsU(nullptr, 8), false);
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLNurbsSurfaceNodeTest1(int, char*[])
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLNurbsSurfaceNode> exerciseNode;
+  exerciseNode->SetScene(scene.GetPointer());
+  EXERCISE_ALL_BASIC_MRML_METHODS(exerciseNode.GetPointer());
+
+  CHECK_EXIT_SUCCESS(testDefaults());
+  CHECK_EXIT_SUCCESS(testClampedUniformKnotsWithInteriorNonEmpty());
+  CHECK_EXIT_SUCCESS(testShapeValidation());
+  CHECK_EXIT_SUCCESS(testDegreeValidation());
+  CHECK_EXIT_SUCCESS(testKnotLengthInvariant());
+  CHECK_EXIT_SUCCESS(testWeightsPositivity());
+  CHECK_EXIT_SUCCESS(testStateTransitions());
+  CHECK_EXIT_SUCCESS(testCopyContent());
+  CHECK_EXIT_SUCCESS(testCopyContentRejectsCrossType());
+  CHECK_EXIT_SUCCESS(testXMLRoundTrip());
+  CHECK_EXIT_SUCCESS(testResetKnotsHelper());
+  CHECK_EXIT_SUCCESS(testSetKnotsLengthMismatch());
+
+  std::cout << "vtkMRMLNurbsSurfaceNodeTest1 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLNurbsSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLNurbsSurfaceNodeTest1.cxx
@@ -26,6 +26,8 @@
 #include "vtkMRMLScene.h"
 
 // VTK includes
+#include <vtkCallbackCommand.h>
+#include <vtkCommand.h>
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
@@ -599,6 +601,155 @@ int testSetKnotsLengthMismatch()
   return EXIT_SUCCESS;
 }
 
+/// Minimal observer used by ``testModifiedFiresOnceOnSetSize`` —
+/// counts ``vtkCommand::ModifiedEvent`` invocations so the test can
+/// pin the ADR-0018 §1 single-fire invariant for the NURBS composite
+/// setters (``SetRows`` / ``SetCols`` / ``SetSize`` / ``SetDegreeU``
+/// / ``SetDegreeV`` / ``SetDegree``).  Mirrors the
+/// ``ModifiedCounter`` helper in the Bezier sibling test driver.
+class ModifiedCounter
+{
+public:
+  static void Callback(vtkObject*, unsigned long, void* clientData, void*) { static_cast<ModifiedCounter*>(clientData)->Count++; }
+  int Count = 0;
+  void Reset() { this->Count = 0; }
+};
+
+int testModifiedFiresOnceOnSetSize()
+{
+  // ADR-0018 §1 single-fire invariant: every accepted composite
+  // shape / degree change fires ``Modified()`` exactly once + every
+  // rejection fires zero times.  Each NURBS composite setter calls
+  // ``ResetKnotsToClampedUniform`` internally (which itself emits
+  // ``Modified()``) so without the ``MRMLNodeModifyBlocker`` wrap
+  // the setter doubles the event count downstream — a regression
+  // the MTime-advance tests would NOT catch because MTime still
+  // advances on the (single-fire) coalesced emission.
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+
+  ModifiedCounter counter;
+  vtkNew<vtkCallbackCommand> cb;
+  cb->SetCallback(&ModifiedCounter::Callback);
+  cb->SetClientData(&counter);
+  const unsigned long tag = node->AddObserver(vtkCommand::ModifiedEvent, cb.GetPointer());
+
+  // Default is (4, 4, 3, 3).  SetSize(5) is a real shape change →
+  // exactly one Modified.
+  counter.Reset();
+  node->SetSize(5);
+  CHECK_INT(counter.Count, 1);
+
+  // No-op self-assign on accepted-value path → zero Modified.
+  counter.Reset();
+  node->SetSize(5);
+  CHECK_INT(counter.Count, 0);
+
+  // Rejection path: SetSize(3) with the current default DegreeU=3
+  // (need 3 >= 4) is rejected with vtkErrorMacro + zero Modified.
+  counter.Reset();
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetSize(3);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(counter.Count, 0);
+  CHECK_INT(static_cast<int>(node->GetRows()), 5); // unchanged
+
+  // SetDegree(2) is accepted (admitted range, both axes 5 >= 3) →
+  // exactly one Modified.
+  counter.Reset();
+  node->SetDegree(2);
+  CHECK_INT(counter.Count, 1);
+
+  // SetDegree(4) is rejected (above MaxDegree) → zero Modified.
+  counter.Reset();
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  node->SetDegree(4);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_INT(counter.Count, 0);
+
+  // SetRows(6) is accepted (6 >= DegreeU + 1 = 3) → one Modified.
+  counter.Reset();
+  node->SetRows(6);
+  CHECK_INT(counter.Count, 1);
+
+  // SetCols(7) is accepted → one Modified.
+  counter.Reset();
+  node->SetCols(7);
+  CHECK_INT(counter.Count, 1);
+
+  // SetDegreeU(3) is accepted (DegreeU + 1 = 4 <= Rows = 6) → one
+  // Modified.
+  counter.Reset();
+  node->SetDegreeU(3);
+  CHECK_INT(counter.Count, 1);
+
+  // SetDegreeV(3) is accepted (DegreeV + 1 = 4 <= Cols = 7) → one
+  // Modified.
+  counter.Reset();
+  node->SetDegreeV(3);
+  CHECK_INT(counter.Count, 1);
+
+  // SetDegreeU(3) self-assign → zero Modified.
+  counter.Reset();
+  node->SetDegreeU(3);
+  CHECK_INT(counter.Count, 0);
+
+  node->RemoveObserver(tag);
+  return EXIT_SUCCESS;
+}
+
+int testSetKnotsRejectsNonMonotonic()
+{
+  // ADR-0022 §"Validation rules per surface type — NURBS":
+  // ``SetKnotsU`` / ``SetKnotsV`` reject knot vectors that violate
+  // the on-disk invariant (non-decreasing, clamped, in [0, 1]) with
+  // ``vtkErrorMacro``.  Pairs the storage-layer validation in
+  // ``vtkMRMLBezierSurfaceStorageNode::ReadJsonNurbs`` for the case
+  // where a caller drives the data node directly (bypassing the
+  // storage path).
+  vtkNew<vtkMRMLNurbsSurfaceNode> node;
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 8);
+
+  // Reject non-monotonic — a decrease in the interior.  Synthesise
+  // an 8-double knot vector that is clamped at both ends but with a
+  // decreasing pair mid-sequence.  ``SetSize(5)`` first to widen the
+  // interior region so we have somewhere to violate monotonicity.
+  node->SetDegree(2);
+  node->SetSize(5);
+  CHECK_INT(static_cast<int>(node->GetKnotsULength()), 8); // 5 + 2 + 1
+  // Default clamped-uniform is [0, 0, 0, 1/3, 2/3, 1, 1, 1].
+  // Replace the interior knot pair with a decreasing pair.
+  double nonMono[8] = { 0.0, 0.0, 0.0, 0.7, 0.4, 1.0, 1.0, 1.0 };
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetKnotsU(nonMono, 8), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  // Reject out-of-range — knots[0] < 0 or knots[end] > 1.
+  double outOfRange[8] = { -0.1, -0.1, -0.1, 0.3, 0.7, 1.0, 1.0, 1.0 };
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetKnotsU(outOfRange, 8), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  // Reject unclamped start — first ``degree + 1`` entries should
+  // all be equal (here degree = 2 → 3 equal repeats expected).
+  double unclamped[8] = { 0.0, 0.1, 0.2, 0.3, 0.7, 1.0, 1.0, 1.0 };
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetKnotsU(unclamped, 8), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  // A well-formed clamped-monotonic vector is still accepted —
+  // pins the contract did not become over-restrictive.
+  double valid[8] = { 0.0, 0.0, 0.0, 0.25, 0.75, 1.0, 1.0, 1.0 };
+  CHECK_BOOL(node->SetKnotsU(valid, 8), true);
+
+  // Symmetric for KnotsV.  At (Rows=5, Cols=5, DegreeV=2) the
+  // KnotsV length is also 8.
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(node->SetKnotsV(nonMono, 8), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  CHECK_BOOL(node->SetKnotsV(valid, 8), true);
+  return EXIT_SUCCESS;
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -621,6 +772,8 @@ int vtkMRMLNurbsSurfaceNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testXMLRoundTrip());
   CHECK_EXIT_SUCCESS(testResetKnotsHelper());
   CHECK_EXIT_SUCCESS(testSetKnotsLengthMismatch());
+  CHECK_EXIT_SUCCESS(testSetKnotsRejectsNonMonotonic());
+  CHECK_EXIT_SUCCESS(testModifiedFiresOnceOnSetSize());
 
   std::cout << "vtkMRMLNurbsSurfaceNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -38,22 +38,35 @@
 ==============================================================================*/
 
 //==============================================================================
-// .lrp.json — JSON schema v2 (ADR-0018 §1)
+// .lrp.json — JSON schema v3 (ADR-0022 §"Decision 2 — Schema v3")
 //==============================================================================
 //
 // One ``.lrp.json`` document per liver resection plan (surgeon-to-
 // surgeon plan sharing per ADR-0014 §5).  Current writer
-// ``schemaVersion`` is ``2`` — bump in lock-step with any documented
+// ``schemaVersion`` is ``3`` — bump in lock-step with any documented
 // extension; the reader accepts ``MinReadableSchemaVersion``
-// (currently ``1``) through ``SchemaVersion`` (currently ``2``).
+// (currently ``1``) through ``SchemaVersion`` (currently ``3``).
+//
+// v3 adds the ``surfaceType`` top-level discriminator and the
+// NURBS-specific fields (``degreeU``, ``degreeV``, ``knotsU``,
+// ``knotsV``, ``weights``).  Bezier files keep the v2 shape; the
+// NURBS path is additive.
 //
 //   {
-//     "schemaVersion": 2,
+//     "schemaVersion": 3,
+//     "surfaceType": "Bezier" | "NURBS",  // v3 only; absent → Bezier
 //     "state": "Init" | "Planning" | "Confirmed",
 //     "initMode": "SlicingPlane" | "DistanceSpheroid",
-//     "rows": int,             // v2 only — see migration below
-//     "cols": int,             // v2 only — see migration below
+//     "rows": int,
+//     "cols": int,
 //     "controlGrid": [3 * rows * cols doubles in row-major (i,j,k) order],
+//     // ---- NURBS-only block (only when surfaceType == "NURBS") ----
+//     "degreeU": int,                       // 2..3 per ADR-0022
+//     "degreeV": int,                       // 2..3 per ADR-0022
+//     "knotsU": [rows + degreeU + 1 doubles, non-decreasing, clamped],
+//     "knotsV": [cols + degreeV + 1 doubles, non-decreasing, clamped],
+//     "weights": [rows * cols doubles, all strictly positive],
+//     // ---- Bezier-only init-mode block (Bezier surfaces only) ----
 //     "slicingPlane": {
 //       "origin": [3 doubles, RAS],
 //       "normal": [3 doubles, RAS],
@@ -68,16 +81,29 @@
 //     "metadata": {}
 //   }
 //
-// v1 → v2 migration:
-//   - v1 files have no ``rows`` / ``cols`` and a 48-double
-//     ``controlGrid``.  The reader infers ``rows = cols = 4`` and
-//     validates the array length.
-//   - v2 files carry explicit ``rows`` and ``cols``.  The reader
-//     enforces ``(rows, cols) ∈ {(3, 3), (4, 4)}`` per ADR-0018 §1
-//     and validates the ``controlGrid`` length is
-//     ``3 * rows * cols``.
-//   - The writer always emits v2.  A v1 file round-tripped through
-//     load + save becomes v2 on disk.
+// v1 → v2 → v3 reader-compat matrix (ADR-0022 §"Reader compat
+// matrix"):
+//   - v1 (no ``rows``/``cols``/``surfaceType``) → implicit 4×4 Bezier.
+//   - v2 (``rows``+``cols``, no ``surfaceType``) → explicit Bezier
+//     with declared shape.
+//   - v3 + ``surfaceType == "Bezier"`` → Bezier path with the
+//     discriminator made explicit.
+//   - v3 + ``surfaceType == "NURBS"`` → full NURBS path; degrees +
+//     knots + weights consumed and validated.
+//
+// Validation per surface type (ADR-0022 §"Validation rules per
+// surface type"):
+//   - Bezier: ``(rows, cols) ∈ {(3, 3), (4, 4)}`` per ADR-0018 §1;
+//     ``len(controlGrid) == 3 * rows * cols``.
+//   - NURBS: ``2 ≤ degreeU, degreeV ≤ 3``; ``rows ≥ degreeU + 1``,
+//     ``cols ≥ degreeV + 1``; ``len(knotsU) == rows + degreeU + 1``,
+//     ``len(knotsV) == cols + degreeV + 1``; ``len(weights) ==
+//     rows * cols``, every weight > 0; ``len(controlGrid) == 3 *
+//     rows * cols``.
+//
+// The writer always emits v3 + the most-specific ``surfaceType`` +
+// the minimum redundant fields.  A v1 or v2 file round-tripped
+// through load + save becomes v3 on disk.
 //
 // The ``initPointsFlat`` fields use a flat layout because the
 // in-tree ``vtkMRMLJsonWriter`` lacks a key-less nested-array entry
@@ -156,6 +182,7 @@
 // This module MRML includes
 #include "vtkMRMLBezierSurfaceStorageNode.h"
 #include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLNurbsSurfaceNode.h"
 
 // MRML includes
 #include <vtkMRMLJsonElement.h>
@@ -200,13 +227,16 @@ void vtkMRMLBezierSurfaceStorageNode::PrintSelf(ostream& os, vtkIndent indent)
 //------------------------------------------------------------------------------
 bool vtkMRMLBezierSurfaceStorageNode::CanReadInReferenceNode(vtkMRMLNode* refNode)
 {
-  return refNode != nullptr && refNode->IsA("vtkMRMLBezierSurfaceNode");
+  // Per ADR-0022 §"Decision 2 — Schema v3" the storage node serves
+  // both Bezier and NURBS data nodes — the on-disk ``surfaceType``
+  // discriminator picks the read path inside ``ReadDataInternal``.
+  return refNode != nullptr && (refNode->IsA("vtkMRMLBezierSurfaceNode") || refNode->IsA("vtkMRMLNurbsSurfaceNode"));
 }
 
 //------------------------------------------------------------------------------
 bool vtkMRMLBezierSurfaceStorageNode::CanWriteFromReferenceNode(vtkMRMLNode* refNode)
 {
-  return refNode != nullptr && refNode->IsA("vtkMRMLBezierSurfaceNode");
+  return refNode != nullptr && (refNode->IsA("vtkMRMLBezierSurfaceNode") || refNode->IsA("vtkMRMLNurbsSurfaceNode"));
 }
 
 //------------------------------------------------------------------------------
@@ -263,10 +293,11 @@ int vtkMRMLBezierSurfaceStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
     vtkErrorMacro("ReadDataInternal: null reference node");
     return 0;
   }
-  auto* surfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(refNode);
-  if (surfaceNode == nullptr)
+  auto* bezierNode = vtkMRMLBezierSurfaceNode::SafeDownCast(refNode);
+  auto* nurbsNode = vtkMRMLNurbsSurfaceNode::SafeDownCast(refNode);
+  if (bezierNode == nullptr && nurbsNode == nullptr)
   {
-    vtkErrorMacro("ReadDataInternal: reference node is not a vtkMRMLBezierSurfaceNode (got '" << refNode->GetClassName() << "')");
+    vtkErrorMacro("ReadDataInternal: reference node is neither vtkMRMLBezierSurfaceNode nor vtkMRMLNurbsSurfaceNode (got '" << refNode->GetClassName() << "')");
     return 0;
   }
 
@@ -279,16 +310,25 @@ int vtkMRMLBezierSurfaceStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
 
   // Dispatch on the file extension.  Both ``.lrp.json`` and
   // ``.lrp.fcsv`` are accepted on read (legacy load-only migration
-  // per ADR-0014 §5).  ``.json`` alone is *not* accepted — the
-  // ``.lrp`` prefix discriminates Liver resection plans from any
-  // other JSON file someone might point the storage node at.
+  // per ADR-0014 §5).  Legacy ``.lrp.fcsv`` carries Bezier control
+  // points only; it predates the NURBS sibling so a NURBS reference
+  // node + ``.lrp.fcsv`` is a configuration error.
   if (endsWithLower(fullName, ".lrp.json"))
   {
-    return this->ReadJson(fullName, surfaceNode);
+    if (nurbsNode != nullptr)
+    {
+      return this->ReadJsonNurbs(fullName, nurbsNode);
+    }
+    return this->ReadJsonBezier(fullName, bezierNode);
   }
   if (endsWithLower(fullName, ".lrp.fcsv"))
   {
-    return this->ReadLegacyFcsv(fullName, surfaceNode);
+    if (nurbsNode != nullptr)
+    {
+      vtkErrorMacro("ReadDataInternal: legacy .lrp.fcsv is Bezier-only; cannot load into a vtkMRMLNurbsSurfaceNode ('" << fullName << "')");
+      return 0;
+    }
+    return this->ReadLegacyFcsv(fullName, bezierNode);
   }
   vtkErrorMacro("ReadDataInternal: unsupported file extension for '" << fullName << "' (expected .lrp.json or .lrp.fcsv)");
   return 0;
@@ -302,10 +342,11 @@ int vtkMRMLBezierSurfaceStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
     vtkErrorMacro("WriteDataInternal: null reference node");
     return 0;
   }
-  auto* surfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(refNode);
-  if (surfaceNode == nullptr)
+  auto* bezierNode = vtkMRMLBezierSurfaceNode::SafeDownCast(refNode);
+  auto* nurbsNode = vtkMRMLNurbsSurfaceNode::SafeDownCast(refNode);
+  if (bezierNode == nullptr && nurbsNode == nullptr)
   {
-    vtkErrorMacro("WriteDataInternal: reference node is not a vtkMRMLBezierSurfaceNode (got '" << refNode->GetClassName() << "')");
+    vtkErrorMacro("WriteDataInternal: reference node is neither vtkMRMLBezierSurfaceNode nor vtkMRMLNurbsSurfaceNode (got '" << refNode->GetClassName() << "')");
     return 0;
   }
 
@@ -336,11 +377,15 @@ int vtkMRMLBezierSurfaceStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
     vtkErrorMacro("WriteDataInternal: unsupported file extension for '" << fullName << "' (expected .lrp.json)");
     return 0;
   }
-  return this->WriteJson(fullName, surfaceNode);
+  if (nurbsNode != nullptr)
+  {
+    return this->WriteJsonNurbs(fullName, nurbsNode);
+  }
+  return this->WriteJsonBezier(fullName, bezierNode);
 }
 
 //------------------------------------------------------------------------------
-int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkMRMLBezierSurfaceNode* surfaceNode)
+int vtkMRMLBezierSurfaceStorageNode::WriteJsonBezier(const std::string& filePath, vtkMRMLBezierSurfaceNode* surfaceNode)
 {
   vtkNew<vtkMRMLJsonWriter> writer;
   // ``WriteToFileBegin`` writes the opening ``{`` and an optional
@@ -351,17 +396,21 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
   // file and is governed by the ``SchemaVersion`` integer).
   if (!writer->WriteToFileBegin(filePath.c_str(), nullptr))
   {
-    vtkErrorMacro("WriteJson: failed to open '" << filePath << "' for writing");
+    vtkErrorMacro("WriteJsonBezier: failed to open '" << filePath << "' for writing");
     return 0;
   }
 
   writer->WriteIntProperty("schemaVersion", SchemaVersion);
+  // schemaVersion 3 adds an explicit ``surfaceType`` discriminator
+  // per ADR-0022 §"Decision 2 — Schema v3".  Bezier writes never
+  // include the NURBS-only fields (``degreeU`` / ``degreeV`` /
+  // ``knotsU`` / ``knotsV`` / ``weights``) — those are meaningless
+  // for the Bernstein basis.
+  writer->WriteStringProperty("surfaceType", "Bezier");
   writer->WriteStringProperty("state", vtkMRMLBezierSurfaceNode::GetStateAsString(surfaceNode->GetState()));
   writer->WriteStringProperty("initMode", vtkMRMLBezierSurfaceNode::GetInitModeAsString(surfaceNode->GetInitMode()));
 
-  // rows + cols — schema v2 explicit shape (ADR-0018 §1).  v1
-  // implicit-4×4 files load via the migration branch in ReadJson;
-  // the writer always emits v2.
+  // rows + cols — explicit Bezier shape (ADR-0018 §1).
   writer->WriteIntProperty("rows", static_cast<int>(surfaceNode->GetRows()));
   writer->WriteIntProperty("cols", static_cast<int>(surfaceNode->GetCols()));
 
@@ -501,7 +550,7 @@ private:
 };
 } // namespace
 
-int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMRMLBezierSurfaceNode* surfaceNode)
+int vtkMRMLBezierSurfaceStorageNode::ReadJsonBezier(const std::string& filePath, vtkMRMLBezierSurfaceNode* surfaceNode)
 {
   ScopedLoadingFromXML loadingGuard(surfaceNode);
 
@@ -509,20 +558,33 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
   vtkSmartPointer<vtkMRMLJsonElement> root = vtkSmartPointer<vtkMRMLJsonElement>::Take(reader->ReadFromFile(filePath.c_str()));
   if (root == nullptr)
   {
-    vtkErrorMacro("ReadJson: failed to parse '" << filePath << "'");
+    vtkErrorMacro("ReadJsonBezier: failed to parse '" << filePath << "'");
     return 0;
   }
   if (!root->HasMember("schemaVersion"))
   {
-    vtkErrorMacro("ReadJson: missing required 'schemaVersion' field in '" << filePath << "'");
+    vtkErrorMacro("ReadJsonBezier: missing required 'schemaVersion' field in '" << filePath << "'");
     return 0;
   }
   const int schemaVersion = root->GetIntProperty("schemaVersion");
   if (schemaVersion < MinReadableSchemaVersion || schemaVersion > SchemaVersion)
   {
-    vtkErrorMacro("ReadJson: unsupported schemaVersion " << schemaVersion << " in '" << filePath << "' (this build understands schemaVersion " << MinReadableSchemaVersion
-                                                         << " through " << SchemaVersion << ")");
+    vtkErrorMacro("ReadJsonBezier: unsupported schemaVersion " << schemaVersion << " in '" << filePath << "' (this build understands schemaVersion " << MinReadableSchemaVersion
+                                                               << " through " << SchemaVersion << ")");
     return 0;
+  }
+  // v3 carries an explicit ``surfaceType`` discriminator.  If the
+  // file declares NURBS but the reference node is a Bezier node, the
+  // caller pointed the wrong storage path at the file — error out
+  // rather than silently misinterpreting the data.
+  if (schemaVersion >= 3 && root->HasMember("surfaceType"))
+  {
+    const std::string declared = root->GetStringProperty("surfaceType");
+    if (declared != "Bezier")
+    {
+      vtkErrorMacro("ReadJsonBezier: file declares surfaceType='" << declared << "' but reference node is a vtkMRMLBezierSurfaceNode in '" << filePath << "'");
+      return 0;
+    }
   }
 
   // Control-polygon shape (ADR-0018 §1).  v2 files carry explicit
@@ -535,7 +597,7 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
   {
     if (!root->HasMember("rows") || !root->HasMember("cols"))
     {
-      vtkErrorMacro("ReadJson: schemaVersion " << schemaVersion << " requires 'rows' and 'cols' fields in '" << filePath << "'");
+      vtkErrorMacro("ReadJsonBezier: schemaVersion " << schemaVersion << " requires 'rows' and 'cols' fields in '" << filePath << "'");
       return 0;
     }
     rows = static_cast<unsigned int>(root->GetIntProperty("rows"));
@@ -543,7 +605,7 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
   }
   if (rows != cols || static_cast<int>(rows) < vtkMRMLBezierSurfaceNode::MinGridSize || static_cast<int>(rows) > vtkMRMLBezierSurfaceNode::MaxGridSize)
   {
-    vtkErrorMacro("ReadJson: invalid (rows=" << rows << ", cols=" << cols << ") in '" << filePath << "' — ADR-0018 §1 admits {(3, 3), (4, 4)} only");
+    vtkErrorMacro("ReadJsonBezier: invalid (rows=" << rows << ", cols=" << cols << ") in '" << filePath << "' — ADR-0018 §1 admits {(3, 3), (4, 4)} only");
     return 0;
   }
   // SetSize zero-fills the control buffer to match the new shape;
@@ -573,9 +635,9 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
       // a build that pre-dates this PR would have read as unknown;
       // adding the fallback here means the same loader behaviour ages
       // gracefully into the next schema bump.
-      vtkWarningMacro("ReadJson: unknown state name '" << s << "' in '" << filePath
-                                                       << "' — falling back to Planning"
-                                                          " (ADR-0019 forward-compatible default)");
+      vtkWarningMacro("ReadJsonBezier: unknown state name '" << s << "' in '" << filePath
+                                                             << "' — falling back to Planning"
+                                                                " (ADR-0019 forward-compatible default)");
       code = vtkMRMLBezierSurfaceNode::Planning;
     }
     pendingState = code;
@@ -586,7 +648,7 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
     const int code = vtkMRMLBezierSurfaceNode::GetInitModeFromString(s.c_str());
     if (code < 0)
     {
-      vtkErrorMacro("ReadJson: unknown initMode name '" << s << "' in '" << filePath << "'");
+      vtkErrorMacro("ReadJsonBezier: unknown initMode name '" << s << "' in '" << filePath << "'");
       return 0;
     }
     surfaceNode->SetInitMode(code);
@@ -601,7 +663,7 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
     double grid[vtkMRMLBezierSurfaceNode::MaxControlGridSize];
     if (!root->GetVectorProperty("controlGrid", grid, static_cast<int>(expected)))
     {
-      vtkErrorMacro("ReadJson: 'controlGrid' must be an array of " << expected << " doubles (3 * rows * cols) in '" << filePath << "'");
+      vtkErrorMacro("ReadJsonBezier: 'controlGrid' must be an array of " << expected << " doubles (3 * rows * cols) in '" << filePath << "'");
       return 0;
     }
     surfaceNode->SetControlGrid(grid);
@@ -684,6 +746,320 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
   if (pendingState >= 0)
   {
     surfaceNode->SetState(pendingState);
+  }
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+// NURBS read / write paths (ADR-0022 §"Decision 2 — Schema v3").
+//
+// The implementation deliberately mirrors the Bezier paths above
+// rather than factoring into a templatized helper.  The two surface
+// types share the schema-version + state + initMode + shape blocks
+// but diverge on (a) the validation rules (degree range, knot
+// lengths, weights positivity for NURBS; ``{(3,3), (4,4)}`` for
+// Bezier) and (b) the per-surface-type field roster (no init-mode
+// audit data on NURBS in v2.1 per ADR-0022; the slicingPlane /
+// distanceSpheroid sub-objects belong to the Bezier path).  A future
+// refactor — paired with the ``vtkMRMLParametricSurfaceNode``
+// abstract base flagged in ADR-0022 §"Sharing with the Bezier node
+// — deliberate non-sharing" — can collapse the common prefix.
+//------------------------------------------------------------------------------
+
+namespace
+{
+/// RAII guard mirroring the Bezier ``ScopedLoadingFromXML`` above but
+/// for ``vtkMRMLNurbsSurfaceNode``.  Flips ``LoadingFromXML`` on for
+/// the duration of a JSON read so the ADR-0019 transition-matrix
+/// guard does not reject a Confirmed-state file loaded into a fresh
+/// (Init) sink.
+class ScopedNurbsLoadingFromXML
+{
+public:
+  explicit ScopedNurbsLoadingFromXML(vtkMRMLNurbsSurfaceNode* node)
+    : Node(node)
+    , Prev(node != nullptr ? node->GetLoadingFromXML() : false)
+  {
+    if (this->Node != nullptr)
+    {
+      this->Node->SetLoadingFromXML(true);
+    }
+  }
+  ~ScopedNurbsLoadingFromXML()
+  {
+    if (this->Node != nullptr)
+    {
+      this->Node->SetLoadingFromXML(this->Prev);
+    }
+  }
+  ScopedNurbsLoadingFromXML(const ScopedNurbsLoadingFromXML&) = delete;
+  ScopedNurbsLoadingFromXML& operator=(const ScopedNurbsLoadingFromXML&) = delete;
+
+private:
+  vtkMRMLNurbsSurfaceNode* Node;
+  bool Prev;
+};
+} // namespace
+
+int vtkMRMLBezierSurfaceStorageNode::WriteJsonNurbs(const std::string& filePath, vtkMRMLNurbsSurfaceNode* surfaceNode)
+{
+  vtkNew<vtkMRMLJsonWriter> writer;
+  if (!writer->WriteToFileBegin(filePath.c_str(), nullptr))
+  {
+    vtkErrorMacro("WriteJsonNurbs: failed to open '" << filePath << "' for writing");
+    return 0;
+  }
+
+  writer->WriteIntProperty("schemaVersion", SchemaVersion);
+  writer->WriteStringProperty("surfaceType", "NURBS");
+  writer->WriteStringProperty("state", vtkMRMLNurbsSurfaceNode::GetStateAsString(surfaceNode->GetState()));
+  writer->WriteStringProperty("initMode", vtkMRMLNurbsSurfaceNode::GetInitModeAsString(surfaceNode->GetInitMode()));
+
+  writer->WriteIntProperty("rows", static_cast<int>(surfaceNode->GetRows()));
+  writer->WriteIntProperty("cols", static_cast<int>(surfaceNode->GetCols()));
+  writer->WriteIntProperty("degreeU", static_cast<int>(surfaceNode->GetDegreeU()));
+  writer->WriteIntProperty("degreeV", static_cast<int>(surfaceNode->GetDegreeV()));
+
+  // controlGrid + NURBS-specific vector fields.  ``const_cast`` to
+  // match the writer signature (input-only; rapidjson backend does
+  // not mutate the buffer).
+  writer->WriteVectorProperty("controlGrid", const_cast<double*>(surfaceNode->GetControlGrid()), static_cast<int>(surfaceNode->GetControlGridLength()));
+  writer->WriteVectorProperty("knotsU", const_cast<double*>(surfaceNode->GetKnotsU()), static_cast<int>(surfaceNode->GetKnotsULength()));
+  writer->WriteVectorProperty("knotsV", const_cast<double*>(surfaceNode->GetKnotsV()), static_cast<int>(surfaceNode->GetKnotsVLength()));
+  writer->WriteVectorProperty("weights", const_cast<double*>(surfaceNode->GetWeights()), static_cast<int>(surfaceNode->GetWeightsLength()));
+
+  // metadata — reserved per ADR-0014 §5; emit empty for shape parity
+  // with the Bezier path so JSON-Schema validators see the same set
+  // of top-level keys across surface types.
+  writer->WriteObjectPropertyStart("metadata");
+  writer->WriteObjectPropertyEnd();
+
+  if (!writer->WriteToFileEnd())
+  {
+    vtkErrorMacro("WriteJsonNurbs: failed to close '" << filePath << "' after write");
+    return 0;
+  }
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLBezierSurfaceStorageNode::ReadJsonNurbs(const std::string& filePath, vtkMRMLNurbsSurfaceNode* surfaceNode)
+{
+  ScopedNurbsLoadingFromXML loadingGuard(surfaceNode);
+
+  vtkNew<vtkMRMLJsonReader> reader;
+  vtkSmartPointer<vtkMRMLJsonElement> root = vtkSmartPointer<vtkMRMLJsonElement>::Take(reader->ReadFromFile(filePath.c_str()));
+  if (root == nullptr)
+  {
+    vtkErrorMacro("ReadJsonNurbs: failed to parse '" << filePath << "'");
+    return 0;
+  }
+  if (!root->HasMember("schemaVersion"))
+  {
+    vtkErrorMacro("ReadJsonNurbs: missing required 'schemaVersion' field in '" << filePath << "'");
+    return 0;
+  }
+  const int schemaVersion = root->GetIntProperty("schemaVersion");
+  // NURBS files require schemaVersion >= 3 — the ``surfaceType``
+  // discriminator only exists in v3.  v1 / v2 files are implicit
+  // Bezier; routing them through this path is a configuration
+  // error.
+  if (schemaVersion < 3 || schemaVersion > SchemaVersion)
+  {
+    vtkErrorMacro("ReadJsonNurbs: schemaVersion " << schemaVersion << " is not a NURBS-capable schema (need 3..<=" << SchemaVersion << ") in '" << filePath << "'");
+    return 0;
+  }
+  if (!root->HasMember("surfaceType"))
+  {
+    vtkErrorMacro("ReadJsonNurbs: v3 file missing 'surfaceType' discriminator in '" << filePath << "'");
+    return 0;
+  }
+  const std::string declared = root->GetStringProperty("surfaceType");
+  if (declared != "NURBS")
+  {
+    vtkErrorMacro("ReadJsonNurbs: file declares surfaceType='" << declared << "' but reference node is a vtkMRMLNurbsSurfaceNode in '" << filePath << "'");
+    return 0;
+  }
+
+  // Shape + degrees — full ADR-0022 §"Validation rules per surface
+  // type — NURBS" check.
+  if (!root->HasMember("rows") || !root->HasMember("cols") || !root->HasMember("degreeU") || !root->HasMember("degreeV"))
+  {
+    vtkErrorMacro("ReadJsonNurbs: missing one of {rows, cols, degreeU, degreeV} in '" << filePath << "'");
+    return 0;
+  }
+  const int rowsI = root->GetIntProperty("rows");
+  const int colsI = root->GetIntProperty("cols");
+  const int degreeUI = root->GetIntProperty("degreeU");
+  const int degreeVI = root->GetIntProperty("degreeV");
+  if (degreeUI < vtkMRMLNurbsSurfaceNode::MinDegree || degreeUI > vtkMRMLNurbsSurfaceNode::MaxDegree     //
+      || degreeVI < vtkMRMLNurbsSurfaceNode::MinDegree || degreeVI > vtkMRMLNurbsSurfaceNode::MaxDegree) //
+  {
+    vtkErrorMacro("ReadJsonNurbs: invalid degrees (degreeU=" << degreeUI << ", degreeV=" << degreeVI << ") in '" << filePath << "' — ADR-0022 §IVar roster admits {2, 3} only");
+    return 0;
+  }
+  if (rowsI < degreeUI + 1 || colsI < degreeVI + 1)
+  {
+    vtkErrorMacro("ReadJsonNurbs: invalid (rows=" << rowsI << ", cols=" << colsI << ") for degrees (" << degreeUI << ", " << degreeVI << ") in '" << filePath
+                                                  << "' — ADR-0022 §IVar roster requires rows >= degreeU + 1 and cols >= degreeV + 1");
+    return 0;
+  }
+  const unsigned int rows = static_cast<unsigned int>(rowsI);
+  const unsigned int cols = static_cast<unsigned int>(colsI);
+  const unsigned int degreeU = static_cast<unsigned int>(degreeUI);
+  const unsigned int degreeV = static_cast<unsigned int>(degreeVI);
+
+  // Required NURBS-specific arrays.
+  if (!root->HasMember("knotsU") || !root->HasMember("knotsV") || !root->HasMember("weights") || !root->HasMember("controlGrid"))
+  {
+    vtkErrorMacro("ReadJsonNurbs: missing one of {knotsU, knotsV, weights, controlGrid} in '" << filePath << "'");
+    return 0;
+  }
+
+  const unsigned int expectedKnotsU = rows + degreeU + 1u;
+  const unsigned int expectedKnotsV = cols + degreeV + 1u;
+  const unsigned int expectedWeights = rows * cols;
+  const unsigned int expectedControlGrid = 3u * rows * cols;
+
+  std::vector<double> knotsU(expectedKnotsU, 0.0);
+  std::vector<double> knotsV(expectedKnotsV, 0.0);
+  std::vector<double> weights(expectedWeights, 0.0);
+  std::vector<double> controlGrid(expectedControlGrid, 0.0);
+
+  if (!root->GetVectorProperty("knotsU", knotsU.data(), static_cast<int>(expectedKnotsU)))
+  {
+    vtkErrorMacro("ReadJsonNurbs: 'knotsU' must be an array of " << expectedKnotsU << " doubles (rows + degreeU + 1) in '" << filePath << "'");
+    return 0;
+  }
+  if (!root->GetVectorProperty("knotsV", knotsV.data(), static_cast<int>(expectedKnotsV)))
+  {
+    vtkErrorMacro("ReadJsonNurbs: 'knotsV' must be an array of " << expectedKnotsV << " doubles (cols + degreeV + 1) in '" << filePath << "'");
+    return 0;
+  }
+  if (!root->GetVectorProperty("weights", weights.data(), static_cast<int>(expectedWeights)))
+  {
+    vtkErrorMacro("ReadJsonNurbs: 'weights' must be an array of " << expectedWeights << " doubles (rows * cols) in '" << filePath << "'");
+    return 0;
+  }
+  if (!root->GetVectorProperty("controlGrid", controlGrid.data(), static_cast<int>(expectedControlGrid)))
+  {
+    vtkErrorMacro("ReadJsonNurbs: 'controlGrid' must be an array of " << expectedControlGrid << " doubles (3 * rows * cols) in '" << filePath << "'");
+    return 0;
+  }
+  // Weights must be strictly positive (ADR-0022 §"Validation rules
+  // per surface type").  Non-positive weights produce singular
+  // rational denominators; reject loudly.
+  for (std::size_t i = 0; i < weights.size(); ++i)
+  {
+    if (!(weights[i] > 0.0))
+    {
+      vtkErrorMacro("ReadJsonNurbs: weight[" << i << "]=" << weights[i] << " is not strictly positive in '" << filePath << "'");
+      return 0;
+    }
+  }
+
+  // All payloads validated — apply.  Drive the data node through
+  // its public setters where possible so any field-level invariant
+  // change does not need to be re-implemented here.  The
+  // ``SetDegree`` / ``SetSize`` setters regenerate dependent buffers
+  // to defaults, so the order matters: shape + degree first, then
+  // overwrite knots / weights / controlGrid from the file.
+  //
+  // To avoid the cross-IVar-invariant rejections in the public
+  // setters during the intermediate state (e.g. setting Rows before
+  // Cols when both differ), we set the IVars directly on the data
+  // node via its file-load-aware code path.  The data node's
+  // ``LoadingFromXML`` is already true via ``ScopedNurbsLoadingFrom-
+  // XML``; we route the shape change through ``SetSize`` for the
+  // square case + manual fall-through for the rectangular case.
+  //
+  // Simpler implementation: zero the IVars to a sentinel default
+  // first (4,4,3,3 — guaranteed valid), then individually grow the
+  // axes that need growing.  This avoids the cross-IVar invariant
+  // tripping at any intermediate.
+  surfaceNode->SetSize(vtkMRMLNurbsSurfaceNode::DefaultGridSize);
+  surfaceNode->SetDegree(vtkMRMLNurbsSurfaceNode::DefaultDegree);
+  // Grow Rows / Cols / degrees in an order that always keeps the
+  // cross-IVar invariant satisfied:
+  //   - Drop degrees first (DegreeU + 1 <= current Rows always
+  //     holds at default 4 + degree 2 or 3).
+  //   - Set Rows + Cols to target.
+  //   - Then raise degrees to target if needed.
+  if (degreeU < surfaceNode->GetDegreeU())
+  {
+    surfaceNode->SetDegreeU(degreeU);
+  }
+  if (degreeV < surfaceNode->GetDegreeV())
+  {
+    surfaceNode->SetDegreeV(degreeV);
+  }
+  if (rows != surfaceNode->GetRows())
+  {
+    surfaceNode->SetRows(rows);
+  }
+  if (cols != surfaceNode->GetCols())
+  {
+    surfaceNode->SetCols(cols);
+  }
+  if (degreeU > surfaceNode->GetDegreeU())
+  {
+    surfaceNode->SetDegreeU(degreeU);
+  }
+  if (degreeV > surfaceNode->GetDegreeV())
+  {
+    surfaceNode->SetDegreeV(degreeV);
+  }
+
+  // Overwrite the (now resized) IVars with the file payload.  The
+  // public setters re-validate lengths + positivity; redundant with
+  // the explicit checks above but defensive against future drift.
+  if (!surfaceNode->SetKnotsU(knotsU.data(), knotsU.size()))
+  {
+    vtkErrorMacro("ReadJsonNurbs: rejected knotsU payload (post-validation drift?) in '" << filePath << "'");
+    return 0;
+  }
+  if (!surfaceNode->SetKnotsV(knotsV.data(), knotsV.size()))
+  {
+    vtkErrorMacro("ReadJsonNurbs: rejected knotsV payload (post-validation drift?) in '" << filePath << "'");
+    return 0;
+  }
+  if (!surfaceNode->SetWeights(weights.data(), weights.size()))
+  {
+    vtkErrorMacro("ReadJsonNurbs: rejected weights payload (post-validation drift?) in '" << filePath << "'");
+    return 0;
+  }
+  if (!surfaceNode->SetControlGrid(controlGrid.data()))
+  {
+    vtkErrorMacro("ReadJsonNurbs: rejected controlGrid payload in '" << filePath << "'");
+    return 0;
+  }
+
+  // State + InitMode last — same Init-then-Planning-then-Confirmed
+  // load order as the Bezier path.
+  if (root->HasMember("state"))
+  {
+    const std::string s = root->GetStringProperty("state");
+    int code = vtkMRMLNurbsSurfaceNode::GetStateFromString(s.c_str());
+    if (code < 0)
+    {
+      // Same forward-compatible fallback as the Bezier path.
+      vtkWarningMacro("ReadJsonNurbs: unknown state name '" << s << "' in '" << filePath
+                                                            << "' — falling back to Planning"
+                                                               " (ADR-0019 forward-compatible default)");
+      code = vtkMRMLNurbsSurfaceNode::Planning;
+    }
+    surfaceNode->SetState(code);
+  }
+  if (root->HasMember("initMode"))
+  {
+    const std::string s = root->GetStringProperty("initMode");
+    const int code = vtkMRMLNurbsSurfaceNode::GetInitModeFromString(s.c_str());
+    if (code < 0)
+    {
+      vtkErrorMacro("ReadJsonNurbs: unknown initMode name '" << s << "' in '" << filePath << "'");
+      return 0;
+    }
+    surfaceNode->SetInitMode(code);
   }
   return 1;
 }

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -946,6 +946,24 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJsonNurbs(const std::string& filePath, 
     vtkErrorMacro("ReadJsonNurbs: 'controlGrid' must be an array of " << expectedControlGrid << " doubles (3 * rows * cols) in '" << filePath << "'");
     return 0;
   }
+  // Knot-vector invariants (ADR-0022 §"Validation rules per surface
+  // type — NURBS"): non-decreasing, clamped at both ends to
+  // ``degree + 1`` equal repeats, in ``[0, 1]``.  Reject malformed
+  // knot vectors at the read boundary so a broken file does not
+  // reach the data node.
+  {
+    std::string knotError;
+    if (!vtkMRMLNurbsSurfaceNode::ValidateKnotsClampedMonotonic(knotsU, degreeU, knotError))
+    {
+      vtkErrorMacro("ReadJsonNurbs: invalid 'knotsU' in '" << filePath << "' — " << knotError);
+      return 0;
+    }
+    if (!vtkMRMLNurbsSurfaceNode::ValidateKnotsClampedMonotonic(knotsV, degreeV, knotError))
+    {
+      vtkErrorMacro("ReadJsonNurbs: invalid 'knotsV' in '" << filePath << "' — " << knotError);
+      return 0;
+    }
+  }
   // Weights must be strictly positive (ADR-0022 §"Validation rules
   // per surface type").  Non-positive weights produce singular
   // rational denominators; reject loudly.

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
@@ -75,33 +75,56 @@
  * ADR-0007's D-class compatibility-break category, the
  * ``.lrp.fcsv`` deprecation is part of the v2.0.0 MAJOR bump.
  *
- * \par JSON schema (v2 — ADR-0018 §1)
+ * \par JSON schema (v3 — ADR-0022 §"Decision 2 — Schema v3")
  *
  * See the in-source documentation at the top of
  * ``vtkMRMLBezierSurfaceStorageNode.cxx`` for the canonical
  * schema description.  Briefly:
  *
- *   - ``schemaVersion``: int, currently 2 (writer); reader accepts
- *     v1 + v2.
- *   - ``state``: "Init" | "Planning"
+ *   - ``schemaVersion``: int, currently 3 (writer); reader accepts
+ *     v1 + v2 + v3.
+ *   - ``surfaceType``: ``"Bezier"`` or ``"NURBS"`` (v3 only; absent
+ *     in v1 / v2 → implicit ``"Bezier"``).
+ *   - ``state``: "Init" | "Planning" | "Confirmed"
  *   - ``initMode``: "SlicingPlane" | "DistanceSpheroid"
- *   - ``rows`` / ``cols``: control-polygon shape (v2 only; in v1
- *     these are implicit 4×4).  Per ADR-0018 §1, square only and
- *     in ``{(3, 3), (4, 4)}``.
+ *   - ``rows`` / ``cols``: control-polygon shape (v2+; v1 implicit
+ *     4×4).  For Bezier per ADR-0018 §1 square + in
+ *     ``{(3, 3), (4, 4)}``; for NURBS per ADR-0022 §"IVar roster"
+ *     ``rows >= degreeU + 1`` and ``cols >= degreeV + 1``.
  *   - ``controlGrid``: array of ``3 * rows * cols`` doubles
- *     (row-major; 27 for 3×3, 48 for 4×4).
- *   - ``slicingPlane``: {origin, normal, initPoints}
+ *     (row-major).
+ *   - ``slicingPlane``: {origin, normal, initPoints} (Bezier only).
  *   - ``distanceSpheroid``: {center, radius{x,y,z}, initPoints}
- *   - ``metadata``: object (empty in v1; reserved for v2's
- *     timestamps + surgeon ID per ADR-0014 §5)
+ *     (Bezier only).
+ *   - NURBS-only: ``degreeU``, ``degreeV`` (int), ``knotsU``,
+ *     ``knotsV`` (double arrays), ``weights`` (double array,
+ *     all positive).
+ *   - ``metadata``: object.
  *
- * \par v1 → v2 migration
+ * \par v1 → v2 → v3 migration
  *
- * The reader infers ``rows = cols = 4`` for v1 files (no ``rows`` /
- * ``cols`` fields) and validates the ``controlGrid`` array length
- * is 48.  The writer always emits v2 with explicit ``rows`` +
- * ``cols``.  Round-trip of a v1 file produces a v2 file on the
- * next save.
+ * - v1 (no ``rows`` / ``cols`` / ``surfaceType``) — implicit 4×4
+ *   Bezier per ADR-0018 §1.
+ * - v2 (``rows`` + ``cols`` present, no ``surfaceType``) — explicit
+ *   Bezier shape.
+ * - v3 (``surfaceType`` present) — dispatch on ``Bezier`` vs
+ *   ``NURBS``.  Bezier writes include none of the NURBS-only fields;
+ *   NURBS writes include all of them.
+ *
+ * The writer always emits v3 with the most-specific ``surfaceType``
+ * and the minimum redundant fields.  Round-trip of a v1 / v2 file
+ * produces a v3 file on the next save.
+ *
+ * \par Sharing the storage class between Bezier and NURBS
+ *
+ * Per ADR-0022 §"Decision 2 — Schema v3" + the NURBS-1 design note,
+ * a single storage class handles both surface types — dispatched on
+ * ``surfaceType`` at read time and on the concrete reference-node
+ * class at write time.  ``vtkMRMLNurbsSurfaceStorageNode`` is a
+ * thin subclass that exists so each data-node family has a
+ * dedicated default-storage class (matching Slicer-core's
+ * ``CreateDefaultStorageNode`` lookup convention) while sharing the
+ * read / write implementation here.
  *
  * \par See also
  *
@@ -124,14 +147,15 @@ public:
   /// Current JSON schema version emitted by ``WriteDataInternal``.
   /// Bump this integer in lock-step with any documented schema
   /// extension; ``ReadDataInternal`` MUST grow an explicit branch
-  /// for every old version it intends to keep loading.  Per ADR-0018
-  /// §1 the reader accepts both v1 (implicit 4×4 control polygon)
-  /// and v2 (explicit ``rows`` / ``cols``).
-  static constexpr int SchemaVersion = 2;
+  /// for every old version it intends to keep loading.  Per
+  /// ADR-0022 §"Decision 2 — Schema v3" the reader accepts v1
+  /// (implicit 4×4 Bezier), v2 (explicit Bezier shape), and v3
+  /// (explicit ``surfaceType`` discriminator).
+  static constexpr int SchemaVersion = 3;
 
   /// Lowest schema version the reader admits.  v1 files (no
-  /// ``rows`` / ``cols``) load with an inferred 4×4 control polygon
-  /// per the ADR-0018 §1 migration path.
+  /// ``rows`` / ``cols`` / ``surfaceType``) load as 4×4 Bezier per
+  /// the ADR-0018 §1 migration path.
   static constexpr int MinReadableSchemaVersion = 1;
 
   vtkMRMLNode* CreateNodeInstance() override;
@@ -141,10 +165,16 @@ public:
   /// node family (vtkMRMLBezierSurfaceNode / DisplayNode).
   const char* GetNodeTagName() override { return "BezierSurfaceStorage"; }
 
-  /// Returns true iff ``refNode`` is a ``vtkMRMLBezierSurfaceNode``.
+  /// Returns true iff ``refNode`` is a ``vtkMRMLBezierSurfaceNode``
+  /// or a ``vtkMRMLNurbsSurfaceNode`` (per ADR-0022 §"Decision 2 —
+  /// Schema v3" the storage class serves both surface types; the
+  /// schema-v3 ``surfaceType`` discriminator picks the right read
+  /// path).
   bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
 
-  /// Returns true iff ``refNode`` is a ``vtkMRMLBezierSurfaceNode``.
+  /// Returns true iff ``refNode`` is a ``vtkMRMLBezierSurfaceNode``
+  /// or a ``vtkMRMLNurbsSurfaceNode``.  Same dispatch as
+  /// ``CanReadInReferenceNode``.
   bool CanWriteFromReferenceNode(vtkMRMLNode* refNode) override;
 
   /// Return the default extension emitted by ``WriteDataInternal``
@@ -179,21 +209,38 @@ private:
   vtkMRMLBezierSurfaceStorageNode(const vtkMRMLBezierSurfaceStorageNode&) = delete;
   void operator=(const vtkMRMLBezierSurfaceStorageNode&) = delete;
 
-  /// Read the new-format ``.lrp.json`` from ``filePath`` into
-  /// ``surfaceNode``.  Returns 1 on success, 0 on failure (with
-  /// errors routed through the storage node's user-messages
-  /// collection).
-  int ReadJson(const std::string& filePath, class vtkMRMLBezierSurfaceNode* surfaceNode);
+  /// Read a Bezier-typed ``.lrp.json`` from ``filePath`` into
+  /// ``surfaceNode``.  Returns 1 on success, 0 on failure.  Used
+  /// for v1 / v2 files (implicit Bezier) and for v3 files with
+  /// ``surfaceType: "Bezier"``.
+  int ReadJsonBezier(const std::string& filePath, class vtkMRMLBezierSurfaceNode* surfaceNode);
+
+  /// Read a NURBS-typed ``.lrp.json`` from ``filePath`` into
+  /// ``surfaceNode``.  Returns 1 on success, 0 on failure.  Used
+  /// for v3 files with ``surfaceType: "NURBS"``.  Per ADR-0022
+  /// §"Validation rules per surface type", validates degree range,
+  /// knot lengths, weights positivity, controlGrid length; any
+  /// violation aborts with ``vtkErrorMacro``.
+  int ReadJsonNurbs(const std::string& filePath, class vtkMRMLNurbsSurfaceNode* surfaceNode);
 
   /// Read the legacy ``.lrp.fcsv`` from ``filePath`` into
   /// ``surfaceNode``.  Returns 1 on success, 0 on failure.  See
   /// the implementation for the legacy-field → new-field mapping
-  /// table.
+  /// table.  Legacy CSV is Bezier-only — NURBS predates no legacy
+  /// format and the path returns 0 for NURBS sinks.
   int ReadLegacyFcsv(const std::string& filePath, class vtkMRMLBezierSurfaceNode* surfaceNode);
 
-  /// Write the new-format ``.lrp.json`` for ``surfaceNode`` to
-  /// ``filePath``.  Returns 1 on success, 0 on failure.
-  int WriteJson(const std::string& filePath, class vtkMRMLBezierSurfaceNode* surfaceNode);
+  /// Write the Bezier-typed ``.lrp.json`` for ``surfaceNode`` to
+  /// ``filePath``.  Returns 1 on success, 0 on failure.  Always
+  /// emits ``schemaVersion: 3`` + ``surfaceType: "Bezier"``.
+  int WriteJsonBezier(const std::string& filePath, class vtkMRMLBezierSurfaceNode* surfaceNode);
+
+  /// Write the NURBS-typed ``.lrp.json`` for ``surfaceNode`` to
+  /// ``filePath``.  Returns 1 on success, 0 on failure.  Always
+  /// emits ``schemaVersion: 3`` + ``surfaceType: "NURBS"`` plus the
+  /// NURBS-specific fields (``degreeU``, ``degreeV``, ``knotsU``,
+  /// ``knotsV``, ``weights``).
+  int WriteJsonNurbs(const std::string& filePath, class vtkMRMLNurbsSurfaceNode* surfaceNode);
 };
 
 #endif //__vtkmrmlbeziersurfacestoragenode_h_

--- a/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.cxx
@@ -341,7 +341,14 @@ bool vtkMRMLNurbsSurfaceNode::SetKnotsU(const double* values, std::size_t length
     vtkErrorMacro("SetKnotsU: length mismatch — expected " << this->GetKnotsULength() << " doubles (Rows + DegreeU + 1) but got " << length);
     return false;
   }
-  this->KnotsU.assign(values, values + length);
+  std::vector<double> candidate(values, values + length);
+  std::string error;
+  if (!ValidateKnotsClampedMonotonic(candidate, this->DegreeU, error))
+  {
+    vtkErrorMacro("SetKnotsU: " << error);
+    return false;
+  }
+  this->KnotsU = std::move(candidate);
   this->Modified();
   return true;
 }
@@ -358,8 +365,86 @@ bool vtkMRMLNurbsSurfaceNode::SetKnotsV(const double* values, std::size_t length
     vtkErrorMacro("SetKnotsV: length mismatch — expected " << this->GetKnotsVLength() << " doubles (Cols + DegreeV + 1) but got " << length);
     return false;
   }
-  this->KnotsV.assign(values, values + length);
+  std::vector<double> candidate(values, values + length);
+  std::string error;
+  if (!ValidateKnotsClampedMonotonic(candidate, this->DegreeV, error))
+  {
+    vtkErrorMacro("SetKnotsV: " << error);
+    return false;
+  }
+  this->KnotsV = std::move(candidate);
   this->Modified();
+  return true;
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLNurbsSurfaceNode::ValidateKnotsClampedMonotonic(const std::vector<double>& knots, unsigned int degree, std::string& error)
+{
+  // ADR-0022 §"Validation rules per surface type — NURBS" pins the
+  // on-disk knot invariant: non-decreasing, clamped at both ends
+  // (``degree + 1`` equal repeats), in ``[0, 1]``.  v2.1 admits
+  // clamped-uniform only; OPEN-UNIFORM + other parameterisations are
+  // deferred (numerical-stability + clinical-demand reasons noted in
+  // the ADR's "Default degree" §).  Length is assumed to have been
+  // size-checked by the caller — only monotonicity + clamping +
+  // range are verified here.
+  const std::size_t n = knots.size();
+  const std::size_t needed = static_cast<std::size_t>(degree) + 1u;
+  if (n < 2u * needed)
+  {
+    std::ostringstream oss;
+    oss << "knot vector of length " << n << " is too short for degree " << degree << " (need at least " << (2u * needed) << " entries for the clamping repeats)";
+    error = oss.str();
+    return false;
+  }
+  // Range — first / last entries must lie in [0, 1].  Combined with
+  // the clamping + monotonicity checks below this also pins the
+  // whole vector to [0, 1].
+  if (!(knots.front() >= 0.0) || !(knots.back() <= 1.0))
+  {
+    std::ostringstream oss;
+    oss << "knot vector out of range — front=" << knots.front() << ", back=" << knots.back() << " (expected within [0, 1] per ADR-0022 §IVar roster)";
+    error = oss.str();
+    return false;
+  }
+  // Clamping — the first (degree + 1) entries must all equal
+  // knots.front(); the last (degree + 1) entries must all equal
+  // knots.back().
+  const double startValue = knots.front();
+  for (std::size_t i = 0; i < needed; ++i)
+  {
+    if (knots[i] != startValue)
+    {
+      std::ostringstream oss;
+      oss << "knot vector is not clamped at the start — knots[" << i << "]=" << knots[i] << " differs from knots[0]=" << startValue << " (need " << needed
+          << " equal repeats for degree " << degree << ")";
+      error = oss.str();
+      return false;
+    }
+  }
+  const double endValue = knots.back();
+  for (std::size_t i = n - needed; i < n; ++i)
+  {
+    if (knots[i] != endValue)
+    {
+      std::ostringstream oss;
+      oss << "knot vector is not clamped at the end — knots[" << i << "]=" << knots[i] << " differs from knots[" << (n - 1) << "]=" << endValue << " (need " << needed
+          << " equal repeats for degree " << degree << ")";
+      error = oss.str();
+      return false;
+    }
+  }
+  // Monotonicity — non-decreasing along the full sequence.
+  for (std::size_t i = 1; i < n; ++i)
+  {
+    if (knots[i] < knots[i - 1])
+    {
+      std::ostringstream oss;
+      oss << "knot vector is not non-decreasing — knots[" << i << "]=" << knots[i] << " < knots[" << (i - 1) << "]=" << knots[i - 1];
+      error = oss.str();
+      return false;
+    }
+  }
   return true;
 }
 

--- a/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.cxx
@@ -1,0 +1,734 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the v2.1 NURBS rollout (NURBS-1 deliverable, see
+  ADR-0022 §"Decision 1 — Data node").
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLNurbsSurfaceNode.h"
+
+// MRML includes
+#include <vtkMRMLNodePropertyMacros.h>
+#include <vtkMRMLScene.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkSmartPointer.h>
+
+// STD includes
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
+#include <string>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLNurbsSurfaceNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLNurbsSurfaceNode::vtkMRMLNurbsSurfaceNode()
+  : State(ResectionState::Init)
+  , InitMode(InitializationMode::SlicingPlane)
+  , Rows(DefaultGridSize)
+  , Cols(DefaultGridSize)
+  , DegreeU(DefaultDegree)
+  , DegreeV(DefaultDegree)
+  , LoadingFromXML(false)
+{
+  // Zero-fill the control grid + all-1.0 weights (non-rational
+  // B-spline degenerate case, the safest default per ADR-0022
+  // §"Weights default").  Knots default to clamped-uniform via the
+  // helper so the (Rows + DegreeU + 1, Cols + DegreeV + 1) lengths
+  // stay in sync with the shape / degree IVars.
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+  this->Weights.assign(static_cast<size_t>(this->Rows) * this->Cols, 1.0);
+  this->ResetKnotsToClampedUniform();
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLNurbsSurfaceNode::~vtkMRMLNurbsSurfaceNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::SetState(int state)
+{
+  // ADR-0019 transition matrix — same as ``vtkMRMLBezierSurfaceNode``
+  // (the matrix is surface-type-agnostic).
+  //
+  // TODO(ADR-0022 §"Common abstract base"): collapse this duplicate
+  // into a shared free-standing helper alongside the state enum once
+  // the v2.2 / v3.0 abstract-base refactor lands.
+  if (state == this->State)
+  {
+    return;
+  }
+  if (!this->LoadingFromXML)
+  {
+    const bool forbidden =                            //
+      (this->State == Planning && state == Init)      //
+      || (this->State == Confirmed && state == Init)  //
+      || (this->State == Init && state == Confirmed); //
+    if (forbidden)
+    {
+      vtkWarningMacro("Resection state transition " << GetStateAsString(this->State) << " -> " << GetStateAsString(state) << " is not permitted (ADR-0019); state left at "
+                                                    << GetStateAsString(this->State));
+      return;
+    }
+  }
+  this->State = state;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+const char* vtkMRMLNurbsSurfaceNode::GetStateAsString(int state)
+{
+  switch (state)
+  {
+    case Init: return "Init";
+    case Planning: return "Planning";
+    case Confirmed: return "Confirmed";
+    default: return "Invalid";
+  }
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLNurbsSurfaceNode::GetStateFromString(const char* name)
+{
+  if (name == nullptr)
+  {
+    return -1;
+  }
+  for (int i = 0; i < ResectionState_Last; ++i)
+  {
+    if (std::strcmp(name, GetStateAsString(i)) == 0)
+    {
+      return i;
+    }
+  }
+  return -1;
+}
+
+//------------------------------------------------------------------------------
+const char* vtkMRMLNurbsSurfaceNode::GetInitModeAsString(int mode)
+{
+  switch (mode)
+  {
+    case SlicingPlane: return "SlicingPlane";
+    case DistanceSpheroid: return "DistanceSpheroid";
+    default: return "Invalid";
+  }
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLNurbsSurfaceNode::GetInitModeFromString(const char* name)
+{
+  if (name == nullptr)
+  {
+    return -1;
+  }
+  for (int i = 0; i < InitializationMode_Last; ++i)
+  {
+    if (std::strcmp(name, GetInitModeAsString(i)) == 0)
+    {
+      return i;
+    }
+  }
+  return -1;
+}
+
+//------------------------------------------------------------------------------
+// Shape + degree setters (ADR-0022 §"IVar roster").  Each accepts a
+// new value only if (a) it is in the admitted range and (b) the
+// cross-IVar invariant ``Rows >= DegreeU + 1`` (etc.) holds with the
+// new value.  On acceptance, the dependent buffers (knots / weights /
+// control grid) are regenerated to defaults — a shape or degree
+// change discards the in-flight surface (same convention as
+// ``vtkMRMLBezierSurfaceNode::SetSize``).
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::SetRows(unsigned int rows)
+{
+  if (rows < this->DegreeU + 1u)
+  {
+    vtkErrorMacro("SetRows: invalid Rows " << rows << "; must satisfy Rows >= DegreeU + 1 (current DegreeU=" << this->DegreeU << ") per ADR-0022 §IVar roster — leaving Rows at "
+                                           << this->Rows);
+    return;
+  }
+  if (rows == this->Rows)
+  {
+    return;
+  }
+  this->Rows = rows;
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+  this->Weights.assign(static_cast<size_t>(this->Rows) * this->Cols, 1.0);
+  this->ResetKnotsToClampedUniform();
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::SetCols(unsigned int cols)
+{
+  if (cols < this->DegreeV + 1u)
+  {
+    vtkErrorMacro("SetCols: invalid Cols " << cols << "; must satisfy Cols >= DegreeV + 1 (current DegreeV=" << this->DegreeV << ") per ADR-0022 §IVar roster — leaving Cols at "
+                                           << this->Cols);
+    return;
+  }
+  if (cols == this->Cols)
+  {
+    return;
+  }
+  this->Cols = cols;
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+  this->Weights.assign(static_cast<size_t>(this->Rows) * this->Cols, 1.0);
+  this->ResetKnotsToClampedUniform();
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::SetSize(unsigned int n)
+{
+  if (n < this->DegreeU + 1u || n < this->DegreeV + 1u)
+  {
+    vtkErrorMacro("SetSize: invalid size " << n << "; must satisfy n >= DegreeU+1 (" << (this->DegreeU + 1u) << ") and n >= DegreeV+1 (" << (this->DegreeV + 1u)
+                                           << ") per ADR-0022 §IVar roster — leaving shape at (" << this->Rows << ", " << this->Cols << ")");
+    return;
+  }
+  if (this->Rows == n && this->Cols == n)
+  {
+    return;
+  }
+  this->Rows = n;
+  this->Cols = n;
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+  this->Weights.assign(static_cast<size_t>(this->Rows) * this->Cols, 1.0);
+  this->ResetKnotsToClampedUniform();
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::SetDegreeU(unsigned int degree)
+{
+  if (static_cast<int>(degree) < MinDegree || static_cast<int>(degree) > MaxDegree)
+  {
+    vtkErrorMacro("SetDegreeU: invalid degree " << degree << "; ADR-0022 §IVar roster admits {" << MinDegree << ", " << MaxDegree << "} only — leaving DegreeU at "
+                                                << this->DegreeU);
+    return;
+  }
+  if (degree + 1u > this->Rows)
+  {
+    vtkErrorMacro("SetDegreeU: cannot raise DegreeU to " << degree << " when Rows=" << this->Rows << " (need Rows >= DegreeU + 1) per ADR-0022 §IVar roster — leaving DegreeU at "
+                                                         << this->DegreeU);
+    return;
+  }
+  if (degree == this->DegreeU)
+  {
+    return;
+  }
+  this->DegreeU = degree;
+  this->ResetKnotsToClampedUniform();
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::SetDegreeV(unsigned int degree)
+{
+  if (static_cast<int>(degree) < MinDegree || static_cast<int>(degree) > MaxDegree)
+  {
+    vtkErrorMacro("SetDegreeV: invalid degree " << degree << "; ADR-0022 §IVar roster admits {" << MinDegree << ", " << MaxDegree << "} only — leaving DegreeV at "
+                                                << this->DegreeV);
+    return;
+  }
+  if (degree + 1u > this->Cols)
+  {
+    vtkErrorMacro("SetDegreeV: cannot raise DegreeV to " << degree << " when Cols=" << this->Cols << " (need Cols >= DegreeV + 1) per ADR-0022 §IVar roster — leaving DegreeV at "
+                                                         << this->DegreeV);
+    return;
+  }
+  if (degree == this->DegreeV)
+  {
+    return;
+  }
+  this->DegreeV = degree;
+  this->ResetKnotsToClampedUniform();
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::SetDegree(unsigned int d)
+{
+  if (static_cast<int>(d) < MinDegree || static_cast<int>(d) > MaxDegree)
+  {
+    vtkErrorMacro("SetDegree: invalid degree " << d << "; ADR-0022 §IVar roster admits {" << MinDegree << ", " << MaxDegree << "} only — leaving degrees at (" << this->DegreeU
+                                               << ", " << this->DegreeV << ")");
+    return;
+  }
+  if (d + 1u > this->Rows || d + 1u > this->Cols)
+  {
+    vtkErrorMacro("SetDegree: cannot raise degree to " << d << " with shape (" << this->Rows << ", " << this->Cols << ") — need both axes >= degree + 1 per ADR-0022 §IVar roster"
+                                                       << " — leaving degrees at (" << this->DegreeU << ", " << this->DegreeV << ")");
+    return;
+  }
+  if (d == this->DegreeU && d == this->DegreeV)
+  {
+    return;
+  }
+  this->DegreeU = d;
+  this->DegreeV = d;
+  this->ResetKnotsToClampedUniform();
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLNurbsSurfaceNode::SetControlGrid(const double* values)
+{
+  if (values == nullptr)
+  {
+    return false;
+  }
+  const size_t length = this->ControlGrid.size();
+  std::copy_n(values, length, this->ControlGrid.begin());
+  this->Modified();
+  return true;
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLNurbsSurfaceNode::SetKnotsU(const double* values, std::size_t length)
+{
+  if (values == nullptr)
+  {
+    return false;
+  }
+  if (length != this->GetKnotsULength())
+  {
+    vtkErrorMacro("SetKnotsU: length mismatch — expected " << this->GetKnotsULength() << " doubles (Rows + DegreeU + 1) but got " << length);
+    return false;
+  }
+  this->KnotsU.assign(values, values + length);
+  this->Modified();
+  return true;
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLNurbsSurfaceNode::SetKnotsV(const double* values, std::size_t length)
+{
+  if (values == nullptr)
+  {
+    return false;
+  }
+  if (length != this->GetKnotsVLength())
+  {
+    vtkErrorMacro("SetKnotsV: length mismatch — expected " << this->GetKnotsVLength() << " doubles (Cols + DegreeV + 1) but got " << length);
+    return false;
+  }
+  this->KnotsV.assign(values, values + length);
+  this->Modified();
+  return true;
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLNurbsSurfaceNode::SetWeights(const double* values, std::size_t length)
+{
+  if (values == nullptr)
+  {
+    return false;
+  }
+  if (length != this->GetWeightsLength())
+  {
+    vtkErrorMacro("SetWeights: length mismatch — expected " << this->GetWeightsLength() << " doubles (Rows * Cols) but got " << length);
+    return false;
+  }
+  // Every weight must be strictly positive — non-positive weights
+  // produce singularities in the NURBS basis (division by zero on
+  // the rational denominator).  ADR-0022 §"Validation rules per
+  // surface type" pins this invariant explicitly.
+  for (std::size_t i = 0; i < length; ++i)
+  {
+    if (!(values[i] > 0.0))
+    {
+      vtkErrorMacro("SetWeights: weight at index " << i << " is " << values[i] << "; weights must be strictly positive per ADR-0022 §IVar roster");
+      return false;
+    }
+  }
+  this->Weights.assign(values, values + length);
+  this->Modified();
+  return true;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::ResetKnotsToClampedUniform()
+{
+  // Clamped-uniform knot vector per de Boor convention:
+  //   [0, 0, ..., 0,  k_1, k_2, ..., k_{m-1},  1, 1, ..., 1]
+  //   |---degree+1--| |--rows-degree-1 interior--| |---degree+1---|
+  //
+  // ``rows - degree - 1`` interior knots uniformly spaced in
+  // ``(0, 1)`` — k_i = i / (rows - degree).  When ``rows == degree+1``
+  // the interior region is empty and the knot vector is just
+  // ``degree + 1`` zeros followed by ``degree + 1`` ones (the
+  // degree-n Bezier degenerate case of NURBS).
+  auto buildKnots = [](unsigned int n, unsigned int degree, std::vector<double>& out)
+  {
+    const unsigned int knotCount = n + degree + 1u;
+    out.assign(knotCount, 0.0);
+    // First (degree + 1) entries stay 0.0 (assign initialises them);
+    // last (degree + 1) entries to 1.0.
+    for (unsigned int i = knotCount - degree - 1u; i < knotCount; ++i)
+    {
+      out[i] = 1.0;
+    }
+    // Interior knots, uniformly spaced.  ``denom`` is the step
+    // count: from k_0 = 0 to k_{n-degree} = 1 in (n - degree) steps
+    // → interior values at i / (n - degree) for i = 1 .. n-degree-1.
+    if (n > degree + 1u)
+    {
+      const unsigned int interiorStart = degree + 1u;
+      const unsigned int interiorCount = n - degree - 1u;
+      const double denom = static_cast<double>(n - degree);
+      for (unsigned int i = 0; i < interiorCount; ++i)
+      {
+        out[interiorStart + i] = static_cast<double>(i + 1) / denom;
+      }
+    }
+  };
+  buildKnots(this->Rows, this->DegreeU, this->KnotsU);
+  buildKnots(this->Cols, this->DegreeV, this->KnotsV);
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+namespace
+{
+/// Helper: serialise N doubles to a space-separated string.
+std::string writeDoubles(const double* values, std::size_t n)
+{
+  std::stringstream ss;
+  for (std::size_t i = 0; i < n; ++i)
+  {
+    if (i > 0)
+    {
+      ss << " ";
+    }
+    ss << values[i];
+  }
+  return ss.str();
+}
+
+/// Helper: parse N doubles from a space-separated string.
+void readDoubles(const char* text, std::vector<double>& out)
+{
+  out.clear();
+  if (text == nullptr)
+  {
+    return;
+  }
+  std::stringstream ss(text);
+  double v;
+  while (ss >> v)
+  {
+    out.push_back(v);
+  }
+}
+} // namespace
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent);
+
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLEnumMacro(state, State);
+  vtkMRMLWriteXMLEnumMacro(initMode, InitMode);
+  vtkMRMLWriteXMLIntMacro(rows, Rows);
+  vtkMRMLWriteXMLIntMacro(cols, Cols);
+  vtkMRMLWriteXMLIntMacro(degreeU, DegreeU);
+  vtkMRMLWriteXMLIntMacro(degreeV, DegreeV);
+  vtkMRMLWriteXMLEndMacro();
+
+  // Free-form vector payloads emitted as XML-attribute-encoded
+  // strings, mirroring the convention used by
+  // ``vtkMRMLBezierSurfaceNode::WriteXML``.
+  of << " controlGrid=\"" << this->XMLAttributeEncodeString(writeDoubles(this->ControlGrid.data(), this->ControlGrid.size())) << "\"";
+  of << " knotsU=\"" << this->XMLAttributeEncodeString(writeDoubles(this->KnotsU.data(), this->KnotsU.size())) << "\"";
+  of << " knotsV=\"" << this->XMLAttributeEncodeString(writeDoubles(this->KnotsV.data(), this->KnotsV.size())) << "\"";
+  of << " weights=\"" << this->XMLAttributeEncodeString(writeDoubles(this->Weights.data(), this->Weights.size())) << "\"";
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+
+  // Bypass the ADR-0019 transition guard for the duration of the
+  // attribute parse so a scene serialised with ``state="Confirmed"``
+  // loads into a freshly-Init sink without rejection.  Same pattern
+  // as ``vtkMRMLBezierSurfaceNode::ReadXMLAttributes``.
+  const bool wasLoadingFromXML = this->LoadingFromXML;
+  this->LoadingFromXML = true;
+
+  Superclass::ReadXMLAttributes(atts);
+
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLEnumMacro(state, State);
+  vtkMRMLReadXMLEnumMacro(initMode, InitMode);
+  vtkMRMLReadXMLEndMacro();
+
+  // Shape + degree are read manually (not via the
+  // ``vtkMRMLReadXMLIntMacro``) for the same reason ``vtkMRMLBezier-
+  // SurfaceNode`` reads ``rows`` / ``cols`` manually — XML
+  // deserialisation is an internal-load context, exempt from the
+  // public-API setter validation that would otherwise reject
+  // intermediate cross-IVar states (e.g. setting Rows before Cols
+  // when both change).
+  unsigned int parsedRows = this->Rows;
+  unsigned int parsedCols = this->Cols;
+  unsigned int parsedDegU = this->DegreeU;
+  unsigned int parsedDegV = this->DegreeV;
+  for (const char** att = atts; att && *att; att += 2)
+  {
+    const char* name = att[0];
+    const char* value = att[1];
+    if (value == nullptr)
+    {
+      break;
+    }
+    if (std::strcmp(name, "rows") == 0)
+    {
+      parsedRows = static_cast<unsigned int>(std::atoi(value));
+    }
+    else if (std::strcmp(name, "cols") == 0)
+    {
+      parsedCols = static_cast<unsigned int>(std::atoi(value));
+    }
+    else if (std::strcmp(name, "degreeU") == 0)
+    {
+      parsedDegU = static_cast<unsigned int>(std::atoi(value));
+    }
+    else if (std::strcmp(name, "degreeV") == 0)
+    {
+      parsedDegV = static_cast<unsigned int>(std::atoi(value));
+    }
+  }
+  // Lightweight validity check: clamp to defaults if the parsed
+  // shape would leave the basis empty.  The storage-node JSON path
+  // performs the load-bearing validation; this is the defensive XML
+  // fallback for malformed scenes.
+  if (static_cast<int>(parsedDegU) < MinDegree || static_cast<int>(parsedDegU) > MaxDegree)
+  {
+    vtkWarningMacro("ReadXMLAttributes: invalid degreeU=" << parsedDegU << "; falling back to " << DefaultDegree);
+    parsedDegU = DefaultDegree;
+  }
+  if (static_cast<int>(parsedDegV) < MinDegree || static_cast<int>(parsedDegV) > MaxDegree)
+  {
+    vtkWarningMacro("ReadXMLAttributes: invalid degreeV=" << parsedDegV << "; falling back to " << DefaultDegree);
+    parsedDegV = DefaultDegree;
+  }
+  if (parsedRows < parsedDegU + 1u || parsedCols < parsedDegV + 1u)
+  {
+    vtkWarningMacro("ReadXMLAttributes: invalid shape (rows=" << parsedRows << ", cols=" << parsedCols << ") for degrees (" << parsedDegU << ", " << parsedDegV
+                                                              << "); falling back to defaults");
+    parsedRows = DefaultGridSize;
+    parsedCols = DefaultGridSize;
+    parsedDegU = DefaultDegree;
+    parsedDegV = DefaultDegree;
+  }
+  this->Rows = parsedRows;
+  this->Cols = parsedCols;
+  this->DegreeU = parsedDegU;
+  this->DegreeV = parsedDegV;
+  // Resize the IVar buffers in lock-step with the parsed shape.
+  // Knots get re-built to clamped-uniform first; the explicit
+  // ``knotsU`` / ``knotsV`` payloads below overwrite that default if
+  // the attribute is present in the stream.
+  this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
+  this->Weights.assign(static_cast<size_t>(this->Rows) * this->Cols, 1.0);
+  this->ResetKnotsToClampedUniform();
+
+  // Free-form payloads — replay the attribute stream so attribute
+  // order in the XML does not matter.
+  for (const char** att = atts; att && *att; att += 2)
+  {
+    const char* name = att[0];
+    const char* value = att[1];
+    if (value == nullptr)
+    {
+      break;
+    }
+    if (std::strcmp(name, "controlGrid") == 0)
+    {
+      std::vector<double> values;
+      const std::string decoded = this->XMLAttributeDecodeString(value);
+      readDoubles(decoded.c_str(), values);
+      const std::size_t expected = this->ControlGrid.size();
+      if (values.size() >= expected)
+      {
+        std::copy_n(values.begin(), expected, this->ControlGrid.begin());
+      }
+      else
+      {
+        vtkWarningMacro("Truncated controlGrid attribute; expected " << expected << " doubles (3 * Rows * Cols), got " << values.size() << " — leaving at default");
+      }
+    }
+    else if (std::strcmp(name, "knotsU") == 0)
+    {
+      std::vector<double> values;
+      const std::string decoded = this->XMLAttributeDecodeString(value);
+      readDoubles(decoded.c_str(), values);
+      if (values.size() == this->GetKnotsULength())
+      {
+        this->KnotsU = values;
+      }
+      else
+      {
+        vtkWarningMacro("knotsU length " << values.size() << " != expected " << this->GetKnotsULength() << " (Rows + DegreeU + 1) — leaving at clamped-uniform default");
+      }
+    }
+    else if (std::strcmp(name, "knotsV") == 0)
+    {
+      std::vector<double> values;
+      const std::string decoded = this->XMLAttributeDecodeString(value);
+      readDoubles(decoded.c_str(), values);
+      if (values.size() == this->GetKnotsVLength())
+      {
+        this->KnotsV = values;
+      }
+      else
+      {
+        vtkWarningMacro("knotsV length " << values.size() << " != expected " << this->GetKnotsVLength() << " (Cols + DegreeV + 1) — leaving at clamped-uniform default");
+      }
+    }
+    else if (std::strcmp(name, "weights") == 0)
+    {
+      std::vector<double> values;
+      const std::string decoded = this->XMLAttributeDecodeString(value);
+      readDoubles(decoded.c_str(), values);
+      if (values.size() == this->GetWeightsLength())
+      {
+        // Defensive positivity check — match the public setter's
+        // validation contract.  An invalid payload leaves the
+        // default all-1.0 weights in place.
+        bool allPositive = true;
+        for (double w : values)
+        {
+          if (!(w > 0.0))
+          {
+            allPositive = false;
+            break;
+          }
+        }
+        if (allPositive)
+        {
+          this->Weights = values;
+        }
+        else
+        {
+          vtkWarningMacro("weights attribute contains non-positive value(s); leaving at default all-1.0");
+        }
+      }
+      else
+      {
+        vtkWarningMacro("weights length " << values.size() << " != expected " << this->GetWeightsLength() << " (Rows * Cols) — leaving at default all-1.0");
+      }
+    }
+  }
+
+  this->LoadingFromXML = wasLoadingFromXML;
+  this->EndModify(disabledModify);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLNurbsSurfaceNode* other = vtkMRMLNurbsSurfaceNode::SafeDownCast(anode);
+  if (other == nullptr)
+  {
+    // Cross-type sources are rejected — a Bezier source carries no
+    // knots / weights / degrees, and a meaningful conversion (Bezier
+    // → NURBS or NURBS → Bezier) needs a degree-elevation /
+    // approximation pass, not a field-by-field copy.  ADR-0022
+    // §"Sharing with the Bezier node — deliberate non-sharing" pins
+    // sibling-not-subclass; matching cross-type Copy is rejected by
+    // ``vtkMRMLBezierSurfaceNode::CopyContent`` symmetrically.
+    vtkErrorMacro("CopyContent: source node is not a vtkMRMLNurbsSurfaceNode (got '" << (anode != nullptr ? anode->GetClassName() : "null") << "')");
+    return;
+  }
+
+  this->State = other->State;
+  this->InitMode = other->InitMode;
+  this->Rows = other->Rows;
+  this->Cols = other->Cols;
+  this->DegreeU = other->DegreeU;
+  this->DegreeV = other->DegreeV;
+  this->KnotsU = other->KnotsU;
+  this->KnotsV = other->KnotsV;
+  this->Weights = other->Weights;
+  this->ControlGrid = other->ControlGrid;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintEnumMacro(State);
+  vtkMRMLPrintEnumMacro(InitMode);
+  vtkMRMLPrintIntMacro(Rows);
+  vtkMRMLPrintIntMacro(Cols);
+  vtkMRMLPrintIntMacro(DegreeU);
+  vtkMRMLPrintIntMacro(DegreeV);
+  vtkMRMLPrintEndMacro();
+
+  auto dumpVector = [&os, &indent](const char* label, const std::vector<double>& v)
+  {
+    os << indent << label << " (" << v.size() << " doubles): ";
+    for (size_t i = 0; i < v.size(); ++i)
+    {
+      if (i > 0)
+      {
+        os << " ";
+      }
+      os << v[i];
+    }
+    os << "\n";
+  };
+  dumpVector("KnotsU", this->KnotsU);
+  dumpVector("KnotsV", this->KnotsV);
+  dumpVector("Weights", this->Weights);
+  dumpVector("ControlGrid", this->ControlGrid);
+}

--- a/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.cxx
@@ -190,11 +190,16 @@ void vtkMRMLNurbsSurfaceNode::SetRows(unsigned int rows)
   {
     return;
   }
+  // ``MRMLNodeModifyBlocker`` suppresses the intermediate
+  // ``Modified()`` emitted by ``ResetKnotsToClampedUniform`` so the
+  // composite shape change fires ``Modified()`` exactly once on
+  // scope exit (ADR-0018 §1 single-fire invariant — same pattern
+  // ``CopyContent`` uses below).
+  MRMLNodeModifyBlocker blocker(this);
   this->Rows = rows;
   this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
   this->Weights.assign(static_cast<size_t>(this->Rows) * this->Cols, 1.0);
   this->ResetKnotsToClampedUniform();
-  this->Modified();
 }
 
 //------------------------------------------------------------------------------
@@ -210,11 +215,11 @@ void vtkMRMLNurbsSurfaceNode::SetCols(unsigned int cols)
   {
     return;
   }
+  MRMLNodeModifyBlocker blocker(this);
   this->Cols = cols;
   this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
   this->Weights.assign(static_cast<size_t>(this->Rows) * this->Cols, 1.0);
   this->ResetKnotsToClampedUniform();
-  this->Modified();
 }
 
 //------------------------------------------------------------------------------
@@ -230,12 +235,12 @@ void vtkMRMLNurbsSurfaceNode::SetSize(unsigned int n)
   {
     return;
   }
+  MRMLNodeModifyBlocker blocker(this);
   this->Rows = n;
   this->Cols = n;
   this->ControlGrid.assign(static_cast<size_t>(3u) * this->Rows * this->Cols, 0.0);
   this->Weights.assign(static_cast<size_t>(this->Rows) * this->Cols, 1.0);
   this->ResetKnotsToClampedUniform();
-  this->Modified();
 }
 
 //------------------------------------------------------------------------------
@@ -257,9 +262,9 @@ void vtkMRMLNurbsSurfaceNode::SetDegreeU(unsigned int degree)
   {
     return;
   }
+  MRMLNodeModifyBlocker blocker(this);
   this->DegreeU = degree;
   this->ResetKnotsToClampedUniform();
-  this->Modified();
 }
 
 //------------------------------------------------------------------------------
@@ -281,9 +286,9 @@ void vtkMRMLNurbsSurfaceNode::SetDegreeV(unsigned int degree)
   {
     return;
   }
+  MRMLNodeModifyBlocker blocker(this);
   this->DegreeV = degree;
   this->ResetKnotsToClampedUniform();
-  this->Modified();
 }
 
 //------------------------------------------------------------------------------
@@ -305,10 +310,10 @@ void vtkMRMLNurbsSurfaceNode::SetDegree(unsigned int d)
   {
     return;
   }
+  MRMLNodeModifyBlocker blocker(this);
   this->DegreeU = d;
   this->DegreeV = d;
   this->ResetKnotsToClampedUniform();
-  this->Modified();
 }
 
 //------------------------------------------------------------------------------

--- a/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.h
@@ -293,10 +293,13 @@ public:
   /// Set ``KnotsU`` from a flat array.  ``values`` must point at at
   /// least ``length`` doubles, and ``length`` must equal
   /// ``GetKnotsULength()`` for the current shape.  Returns true on
-  /// success; false on null pointer or length mismatch.  Does NOT
-  /// validate non-decreasing / clamped-at-ends — those are storage-
-  /// layer JSON validations (per ADR-0022 §"Validation rules per
-  /// surface type") which the data-node setter does not re-litigate.
+  /// success; false on null pointer, length mismatch, or invariant
+  /// violation.  The setter validates the on-disk invariant
+  /// (non-decreasing, clamped at both ends to ``degree + 1`` equal
+  /// repeats, in ``[0, 1]``) via ``ValidateKnotsClampedMonotonic`` —
+  /// callers passing arbitrary numeric arrays get an explicit rejection
+  /// rather than a silently-accepted malformed surface (ADR-0022
+  /// §"Validation rules per surface type — NURBS").
   bool SetKnotsU(const double* values, std::size_t length);
 
   /// Read ``KnotsU`` as a flat array; length is ``GetKnotsULength()``.
@@ -319,6 +322,26 @@ public:
   /// Read ``Weights`` as a flat array; length is ``GetWeightsLength()``.
   const double* GetWeights() const { return this->Weights.data(); }
   const std::vector<double>& GetWeightsVector() const { return this->Weights; }
+
+  /// Validate that ``knots`` describes a clamped, non-decreasing
+  /// vector with values in ``[0, 1]`` — the on-disk invariant for a
+  /// clamped-uniform NURBS knot vector per ADR-0022 §"Validation
+  /// rules per surface type — NURBS".
+  ///
+  /// Length is **not** validated here — the caller is expected to
+  /// size-check (``knots.size() == axisCount + degree + 1``) before
+  /// invoking the helper.  Validation performed:
+  ///   - clamping: the first ``degree + 1`` entries are equal AND the
+  ///     last ``degree + 1`` entries are equal.
+  ///   - monotonicity: ``knots[i] <= knots[i+1]`` for every ``i``.
+  ///   - range: ``knots.front() >= 0.0`` AND ``knots.back() <= 1.0``.
+  ///
+  /// On rejection, ``error`` carries a diagnostic; on success it is
+  /// left untouched.  Returns ``true`` iff the vector satisfies every
+  /// invariant.  v2.1 admits only clamped-uniform parameterisation
+  /// (range pinned to ``[0, 1]``); OPEN-UNIFORM and other
+  /// parameterisations are deferred to a future ADR.
+  static bool ValidateKnotsClampedMonotonic(const std::vector<double>& knots, unsigned int degree, std::string& error);
 
   /// Regenerate ``KnotsU`` and ``KnotsV`` to clamped-uniform vectors
   /// from the current ``Rows``, ``Cols``, ``DegreeU``, ``DegreeV``.

--- a/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.h
@@ -94,6 +94,37 @@
  * are duplicated from ``vtkMRMLBezierSurfaceNode`` for v2.1 per
  * ADR-0022 §"Sharing with the Bezier node — deliberate non-sharing".
  *
+ * \par Shape-change side effects
+ *
+ * The shape-change setters — ``SetRows``, ``SetCols``, ``SetSize``,
+ * ``SetDegreeU``, ``SetDegreeV``, ``SetDegree`` — regenerate the
+ * dependent buffers from defaults on every accepted call:
+ *
+ *   - ``Weights`` is re-filled with ``1.0`` (the non-rational
+ *     B-spline degenerate case — pre-resize weight edits do **not**
+ *     survive a shape change).
+ *   - ``ControlGrid`` is re-zeroed to the new ``3 * Rows * Cols``
+ *     length (matching ``vtkMRMLBezierSurfaceNode``'s
+ *     analogous behaviour — a shape change discards the in-flight
+ *     surface, on the assumption that a new shape implies a new
+ *     surface, not a fitted resample).
+ *   - ``KnotsU`` / ``KnotsV`` are regenerated to clamped-uniform
+ *     vectors of the new length (``Rows + DegreeU + 1`` resp.
+ *     ``Cols + DegreeV + 1``) via ``ResetKnotsToClampedUniform``.
+ *
+ * Each accepted setter coalesces these dependent mutations into
+ * exactly one ``Modified()`` event via ``MRMLNodeModifyBlocker`` so
+ * downstream observers see a single shape-change notification per
+ * setter call (ADR-0018 §1 single-fire invariant — same convention
+ * as ``vtkMRMLBezierSurfaceNode::SetSize``).  Rejected setter calls
+ * fire ``Modified()`` zero times.
+ *
+ * The NURBS-specific ``Weights`` regeneration is the meaningful
+ * delta from the Bezier sibling (which regenerates only the
+ * ``ControlGrid``).  Consumers that have populated ``Weights`` and
+ * then change the shape need to re-issue ``SetWeights`` on the new
+ * shape.
+ *
  * \par TODO — common abstract base
  *
  * ADR-0022 §"Sharing with the Bezier node — deliberate non-sharing"

--- a/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLNurbsSurfaceNode.h
@@ -1,0 +1,377 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the v2.1 NURBS rollout (NURBS-1 deliverable, see
+  ADR-0022 §"Decision 1 — Data node").
+
+==============================================================================*/
+
+#ifndef __vtkmrmlnurbssurfacenode_h_
+#define __vtkmrmlnurbssurfacenode_h_
+
+#include "vtkSlicerLiverResectionsModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLDisplayableNode.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkSetGet.h>
+
+// STD includes
+#include <vector>
+
+/**
+ * \class vtkMRMLNurbsSurfaceNode
+ *
+ * \brief Data-only MRML node carrying the geometry of a NURBS-surface
+ *        resection plan — sibling of ``vtkMRMLBezierSurfaceNode``.
+ *
+ * Lands as the NURBS-1 deliverable of ADR-0022 §"Rollout plan".
+ * Per ADR-0022 §"Decision 1 — Data node", the NURBS node is a
+ * **sibling** of the Bezier node (NOT a subclass of a shared abstract
+ * ``vtkMRMLParametricSurfaceNode``).  Field-level duplication between
+ * the two trios (``Rows``, ``Cols``, ``ControlGrid``, ``State``,
+ * ``InitMode``) is the deliberate cost; the payoff is exact-class
+ * dispatch in the LayerDM Pipeline factory per ADR-0013 §5 call 3.
+ *
+ * \par IVars (ADR-0022 §"Decision 1 — Data node")
+ *
+ * - ``Rows``, ``Cols`` (``unsigned int``) — control-polygon shape.
+ *   Constraints: ``Rows >= DegreeU + 1``, ``Cols >= DegreeV + 1``.
+ *   Default ``DefaultGridSize`` (4 — the minimum valid degree-3 grid).
+ * - ``DegreeU``, ``DegreeV`` (``unsigned int``) — basis degrees.
+ *   Allowed values for v2.1: ``{2, 3}``.  Defaults to 3 (cubic NURBS,
+ *   the surgical-planning canonical per ADR-0022 §"Default degree").
+ * - ``KnotsU`` (``std::vector<double>``, length ``Rows + DegreeU + 1``)
+ *   — knot vector along U.  Default: **clamped-uniform** per the de
+ *   Boor convention — ``DegreeU + 1`` zeros at the start, uniformly
+ *   spaced interior knots in ``(0, 1)``, ``DegreeU + 1`` ones at the
+ *   end.  Surface domain is ``[0, 1] x [0, 1]``; corners are
+ *   interpolated.
+ * - ``KnotsV`` — symmetric to ``KnotsU`` along V.
+ * - ``Weights`` (``std::vector<double>``, length ``Rows * Cols``) —
+ *   rational weights.  Default all ``1.0`` (non-rational ↔ B-spline).
+ *   Constraint: strictly positive.
+ * - ``ControlGrid`` (``std::vector<double>``, length
+ *   ``3 * Rows * Cols``) — control polygon, same row-major
+ *   ``(row, col) -> flat[row * Cols + col] * 3 + {0, 1, 2}`` layout
+ *   as ``vtkMRMLBezierSurfaceNode::ControlGrid``.
+ *
+ * State machine (``Init`` / ``Planning`` / ``Confirmed``) and
+ * ``InitializationMode`` (``SlicingPlane`` / ``DistanceSpheroid``)
+ * are duplicated from ``vtkMRMLBezierSurfaceNode`` for v2.1 per
+ * ADR-0022 §"Sharing with the Bezier node — deliberate non-sharing".
+ *
+ * \par TODO — common abstract base
+ *
+ * ADR-0022 §"Sharing with the Bezier node — deliberate non-sharing"
+ * notes that a future ``vtkMRMLParametricSurfaceNode`` abstract base
+ * may collapse the duplicated state-enum + transition-matrix +
+ * shared-field declarations.  v2.1 keeps the duplication intentional
+ * for sibling exact-class dispatch; v2.2 / v3.0 may revisit.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLNurbsSurfaceNode : public vtkMRMLDisplayableNode
+{
+public:
+  static vtkMRMLNurbsSurfaceNode* New();
+  vtkTypeMacro(vtkMRMLNurbsSurfaceNode, vtkMRMLDisplayableNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Resection state machine — duplicated from
+  /// ``vtkMRMLBezierSurfaceNode::ResectionState`` per ADR-0022
+  /// §"Sharing with the Bezier node — deliberate non-sharing".
+  /// Same transition matrix as Bezier per ADR-0019 (the matrix is
+  /// surface-type-agnostic).
+  ///
+  /// TODO(ADR-0022 §"Common abstract base"): collapse the state enum
+  /// + the SetState transition matrix into a free-standing
+  /// ``vtkMRMLParametricSurfaceState`` helper once the v2.2 / v3.0
+  /// abstract-base refactor lands.  Out of scope for NURBS-1.
+  enum ResectionState
+  {
+    Init = 0,
+    Planning = 1,
+    Confirmed = 2,
+    ResectionState_Last
+  };
+
+  /// Init-mode dispatch — duplicated from
+  /// ``vtkMRMLBezierSurfaceNode::InitializationMode``.  Same TODO
+  /// applies as for ``ResectionState`` above.
+  enum InitializationMode
+  {
+    SlicingPlane = 0,
+    DistanceSpheroid = 1,
+    InitializationMode_Last
+  };
+
+  /// Default NURBS control-grid side length (``DegreeU + 1`` for the
+  /// default cubic degree — i.e. the minimum valid grid size).
+  /// Typed ``int`` (matching ``vtkMRMLBezierSurfaceNode::DefaultGridSize``)
+  /// for sign-clean iteration idioms at call sites.
+  static constexpr int DefaultGridSize = 4;
+
+  /// Default NURBS basis degree.  Per ADR-0022 §"Default degree" —
+  /// cubic NURBS is the surgical-planning canonical (matches
+  /// degree-3 Bezier; matches CAD-industry default).
+  static constexpr int DefaultDegree = 3;
+
+  /// Minimum / maximum NURBS basis degree admitted in v2.1 per
+  /// ADR-0022 §"IVar roster".  Higher-than-degree-3 NURBS deferred
+  /// to a future ADR (numerical stability + thin clinical demand).
+  static constexpr int MinDegree = 2;
+  static constexpr int MaxDegree = 3;
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Get node XML tag name (like Volume, Model).  No ``Liver`` prefix
+  /// per the convention established by ``vtkMRMLBezierSurfaceNode``
+  /// (BezierSurface / NurbsSurface — type names without a module
+  /// prefix).
+  const char* GetNodeTagName() override { return "NurbsSurface"; }
+
+  /// Read node attributes from XML.
+  void ReadXMLAttributes(const char** atts) override;
+
+  /// Write this node's information to a MRML file in XML format.
+  void WriteXML(ostream& of, int indent) override;
+
+  /// Copy node content.  Rejects cross-type sources (Bezier source →
+  /// NURBS sink) with a ``vtkErrorMacro`` — the two surface types
+  /// carry different IVar rosters (degrees, knots, weights are
+  /// NURBS-only) and a meaningful cross-type copy needs a fitter, not
+  /// a simple field-by-field copy.  Same rejection contract as
+  /// ``vtkMRMLBezierSurfaceNode::CopyContent``.
+  void CopyContent(vtkMRMLNode* anode, bool deepCopy = true) override;
+
+  //--------------------------------------------------------------------------
+  // State machine — same matrix as ``vtkMRMLBezierSurfaceNode`` per
+  // ADR-0019 (the matrix is surface-type-agnostic).
+  //--------------------------------------------------------------------------
+
+  /// Resection state (Init / Planning / Confirmed).  Persisted in XML.
+  /// Transition matrix per ADR-0019: Init→Planning, Planning↔Confirmed
+  /// allowed; every other non-self transition rejected with a
+  /// ``vtkWarningMacro``.  Self-assign is a no-op.
+  vtkGetMacro(State, int);
+  void SetState(int state);
+
+  /// Internal flag — set during XML / JSON load so the read path can
+  /// bypass the ADR-0019 transition guards and load a serialised
+  /// Confirmed-state file into a freshly-Init sink.  Public setter so
+  /// the storage node (different translation unit, not a friend) can
+  /// drive the flag.  Treat as an internal API.
+  vtkGetMacro(LoadingFromXML, bool);
+  vtkSetMacro(LoadingFromXML, bool);
+
+  /// Initialization mode (SlicingPlane / DistanceSpheroid).  Mutable
+  /// in any state per ADR-0014 §1.
+  vtkGetMacro(InitMode, int);
+  vtkSetMacro(InitMode, int);
+
+  /// Enum string converters — required by the XML enum macros + the
+  /// storage node's JSON dispatch.
+  static const char* GetStateAsString(int state);
+  static int GetStateFromString(const char* name);
+  static const char* GetInitModeAsString(int mode);
+  static int GetInitModeFromString(const char* name);
+
+  //--------------------------------------------------------------------------
+  // NURBS shape — Rows × Cols control grid plus DegreeU × DegreeV
+  // basis, KnotsU + KnotsV vectors, and Weights.
+  //
+  // Validation enforces:
+  //   - 2 ≤ DegreeU, DegreeV ≤ 3 (ADR-0022 §"IVar roster")
+  //   - Rows ≥ DegreeU + 1 and Cols ≥ DegreeV + 1 (non-empty basis)
+  //   - len(KnotsU) == Rows + DegreeU + 1; symmetric for KnotsV
+  //   - len(Weights) == Rows * Cols
+  //   - every weight strictly positive
+  //
+  // Cross-IVar setters route through these validators; a setter that
+  // would leave the node in an inconsistent state (e.g. Rows < the
+  // current DegreeU + 1) is rejected with ``vtkErrorMacro`` and no
+  // ``Modified()`` emission.
+  //--------------------------------------------------------------------------
+
+  /// Number of control-grid rows (M).  Default ``DefaultGridSize``.
+  /// Must satisfy ``Rows >= DegreeU + 1``; rejected with
+  /// ``vtkErrorMacro`` otherwise.  On accepted change, knots /
+  /// weights / control grid are regenerated to clamped-uniform /
+  /// all-1.0 / zeros respectively (analogous to
+  /// ``vtkMRMLBezierSurfaceNode::SetRows`` — a shape change discards
+  /// the in-flight grid).
+  vtkGetMacro(Rows, unsigned int);
+  void SetRows(unsigned int rows);
+
+  /// Number of control-grid columns (N).  Default ``DefaultGridSize``.
+  /// Must satisfy ``Cols >= DegreeV + 1``; same regeneration on
+  /// accepted change as ``SetRows``.
+  vtkGetMacro(Cols, unsigned int);
+  void SetCols(unsigned int cols);
+
+  /// Square-grid convenience setter — set both ``Rows`` and ``Cols``
+  /// to ``n`` atomically.  Validated against
+  /// ``n >= DegreeU + 1 && n >= DegreeV + 1``.  Regenerates knots +
+  /// weights + control grid to defaults.
+  void SetSize(unsigned int n);
+
+  /// Basis degree along U.  Default ``DefaultDegree`` (3).  Allowed
+  /// values for v2.1: ``{MinDegree, MaxDegree}`` = ``{2, 3}``.  Must
+  /// also satisfy ``DegreeU + 1 <= Rows`` (non-empty basis); rejected
+  /// with ``vtkErrorMacro`` otherwise.  On accepted change, ``KnotsU``
+  /// is regenerated to clamped-uniform.
+  vtkGetMacro(DegreeU, unsigned int);
+  void SetDegreeU(unsigned int degree);
+
+  /// Basis degree along V.  Same validation + regeneration as
+  /// ``SetDegreeU``.
+  vtkGetMacro(DegreeV, unsigned int);
+  void SetDegreeV(unsigned int degree);
+
+  /// Square-degree convenience setter — set both ``DegreeU`` and
+  /// ``DegreeV`` to ``d`` atomically.  Validated against
+  /// ``{MinDegree, MaxDegree}`` + ``d + 1 <= Rows && d + 1 <= Cols``.
+  void SetDegree(unsigned int d);
+
+  /// Per-node control-grid byte count, ``3 * Rows * Cols``.
+  unsigned int GetControlGridLength() const { return 3u * this->Rows * this->Cols; }
+
+  /// Expected length of ``KnotsU`` given current ``Rows`` + ``DegreeU``
+  /// (de Boor convention: ``Rows + DegreeU + 1``).
+  unsigned int GetKnotsULength() const { return this->Rows + this->DegreeU + 1u; }
+
+  /// Expected length of ``KnotsV`` given current ``Cols`` + ``DegreeV``.
+  unsigned int GetKnotsVLength() const { return this->Cols + this->DegreeV + 1u; }
+
+  /// Expected length of ``Weights`` given current shape (``Rows * Cols``).
+  unsigned int GetWeightsLength() const { return this->Rows * this->Cols; }
+
+  /// Set the control grid from a flat array.  ``values`` must point at
+  /// at least ``GetControlGridLength()`` doubles.  Returns true on
+  /// success; false on null pointer.
+  bool SetControlGrid(const double* values);
+
+  /// Read the control grid as a flat row-major array.  Pointer is
+  /// valid until the next shape mutation.
+  const double* GetControlGrid() const { return this->ControlGrid.data(); }
+
+  /// Set ``KnotsU`` from a flat array.  ``values`` must point at at
+  /// least ``length`` doubles, and ``length`` must equal
+  /// ``GetKnotsULength()`` for the current shape.  Returns true on
+  /// success; false on null pointer or length mismatch.  Does NOT
+  /// validate non-decreasing / clamped-at-ends — those are storage-
+  /// layer JSON validations (per ADR-0022 §"Validation rules per
+  /// surface type") which the data-node setter does not re-litigate.
+  bool SetKnotsU(const double* values, std::size_t length);
+
+  /// Read ``KnotsU`` as a flat array; length is ``GetKnotsULength()``.
+  const double* GetKnotsU() const { return this->KnotsU.data(); }
+  const std::vector<double>& GetKnotsUVector() const { return this->KnotsU; }
+
+  /// Same as ``SetKnotsU`` for ``KnotsV``.
+  bool SetKnotsV(const double* values, std::size_t length);
+  const double* GetKnotsV() const { return this->KnotsV.data(); }
+  const std::vector<double>& GetKnotsVVector() const { return this->KnotsV; }
+
+  /// Set ``Weights`` from a flat array.  ``length`` must equal
+  /// ``GetWeightsLength()`` for the current shape.  Every weight must
+  /// be strictly positive; a zero or negative weight rejects the call
+  /// with ``vtkErrorMacro`` and no state change.  Returns true on
+  /// success; false on null pointer, length mismatch, or invalid
+  /// value.
+  bool SetWeights(const double* values, std::size_t length);
+
+  /// Read ``Weights`` as a flat array; length is ``GetWeightsLength()``.
+  const double* GetWeights() const { return this->Weights.data(); }
+  const std::vector<double>& GetWeightsVector() const { return this->Weights; }
+
+  /// Regenerate ``KnotsU`` and ``KnotsV`` to clamped-uniform vectors
+  /// from the current ``Rows``, ``Cols``, ``DegreeU``, ``DegreeV``.
+  /// De Boor convention: ``DegreeU + 1`` zeros at the start,
+  /// ``Rows - DegreeU - 1`` uniformly-spaced interior knots in
+  /// ``(0, 1)``, ``DegreeU + 1`` ones at the end (same for V).  Used
+  /// by the constructor + by every shape / degree setter to keep
+  /// knots consistent on automatic regeneration; also exposed as a
+  /// public helper for callers that have edited ``Rows`` / ``Cols``
+  /// / degrees directly via the storage layer and want a reset.
+  /// Emits ``Modified()``.
+  void ResetKnotsToClampedUniform();
+
+protected:
+  vtkMRMLNurbsSurfaceNode();
+  ~vtkMRMLNurbsSurfaceNode() override;
+
+private:
+  vtkMRMLNurbsSurfaceNode(const vtkMRMLNurbsSurfaceNode&) = delete;
+  void operator=(const vtkMRMLNurbsSurfaceNode&) = delete;
+
+  /// State / mode enums stored as int (so the standard XML int / enum
+  /// macros work).  ``InitMode`` rather than ``InitializationMode``
+  /// avoids shadowing the enum of that name inside class scope (same
+  /// rationale as ``vtkMRMLBezierSurfaceNode``).
+  int State;
+  int InitMode;
+
+  /// Control-polygon shape.
+  unsigned int Rows;
+  unsigned int Cols;
+
+  /// Basis degrees.
+  unsigned int DegreeU;
+  unsigned int DegreeV;
+
+  /// Knot vectors (clamped-uniform at construction).
+  std::vector<double> KnotsU;
+  std::vector<double> KnotsV;
+
+  /// Rational weights (all 1.0 at construction → non-rational
+  /// B-spline degenerate case).
+  std::vector<double> Weights;
+
+  /// Control grid, row-major (row, col) → flat[row * Cols + col] * 3
+  /// + {0, 1, 2}.  Same layout as ``vtkMRMLBezierSurfaceNode::ControlGrid``.
+  std::vector<double> ControlGrid;
+
+  /// Internal flag — set true during XML / JSON load to bypass the
+  /// ADR-0019 transition-matrix guard so a Confirmed-state serialised
+  /// file loads into a fresh ``Init`` sink.  Public setter exposed
+  /// for the storage node; treat as internal API.
+  bool LoadingFromXML;
+};
+
+#endif //__vtkmrmlnurbssurfacenode_h_

--- a/LiverResections/MRML/vtkMRMLNurbsSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLNurbsSurfaceStorageNode.cxx
@@ -1,0 +1,58 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the v2.1 NURBS rollout (NURBS-1 deliverable, see
+  ADR-0022 §"Decision 2 — Schema v3").
+
+==============================================================================*/
+
+#include "vtkMRMLNurbsSurfaceStorageNode.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLNurbsSurfaceStorageNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLNurbsSurfaceStorageNode::vtkMRMLNurbsSurfaceStorageNode() = default;
+
+//------------------------------------------------------------------------------
+vtkMRMLNurbsSurfaceStorageNode::~vtkMRMLNurbsSurfaceStorageNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLNurbsSurfaceStorageNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os, indent);
+}

--- a/LiverResections/MRML/vtkMRMLNurbsSurfaceStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLNurbsSurfaceStorageNode.h
@@ -1,0 +1,88 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension
+  as part of the v2.1 NURBS rollout (NURBS-1 deliverable, see
+  ADR-0022 §"Decision 2 — Schema v3").
+
+==============================================================================*/
+
+#ifndef __vtkmrmlnurbssurfacestoragenode_h_
+#define __vtkmrmlnurbssurfacestoragenode_h_
+
+#include "vtkSlicerLiverResectionsModuleMRMLExport.h"
+
+// This module MRML includes
+#include "vtkMRMLBezierSurfaceStorageNode.h"
+
+/**
+ * \class vtkMRMLNurbsSurfaceStorageNode
+ *
+ * \brief Thin subclass of ``vtkMRMLBezierSurfaceStorageNode`` that
+ *        exists so each surface data-node family has a dedicated
+ *        default-storage class (matching Slicer-core's
+ *        ``CreateDefaultStorageNode`` convention) while sharing the
+ *        underlying schema-v3 ``.lrp.json`` read / write
+ *        implementation.
+ *
+ * Per ADR-0022 §"Decision 2 — Schema v3" the on-disk schema is
+ * unified: a single ``.lrp.json`` shape carries both Bezier and
+ * NURBS surfaces, dispatched on the top-level ``surfaceType``
+ * discriminator.  This subclass overrides only the node-tag-name
+ * + ``CreateNodeInstance`` plumbing; the read / write paths,
+ * validation, and JSON layout all live on the Bezier base class.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLNurbsSurfaceStorageNode : public vtkMRMLBezierSurfaceStorageNode
+{
+public:
+  static vtkMRMLNurbsSurfaceStorageNode* New();
+  vtkTypeMacro(vtkMRMLNurbsSurfaceStorageNode, vtkMRMLBezierSurfaceStorageNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Get node XML tag name.  ``NurbsSurfaceStorage`` matches the
+  /// ``BezierSurfaceStorage`` precedent on the base class — no
+  /// ``Liver`` prefix, mirroring the data-node naming convention.
+  const char* GetNodeTagName() override { return "NurbsSurfaceStorage"; }
+
+protected:
+  vtkMRMLNurbsSurfaceStorageNode();
+  ~vtkMRMLNurbsSurfaceStorageNode() override;
+
+private:
+  vtkMRMLNurbsSurfaceStorageNode(const vtkMRMLNurbsSurfaceStorageNode&) = delete;
+  void operator=(const vtkMRMLNurbsSurfaceStorageNode&) = delete;
+};
+
+#endif //__vtkmrmlnurbssurfacestoragenode_h_

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -238,6 +238,15 @@ void qSlicerLiverResectionsModule::setup()
                                                     QStringList() << "vtkMRMLBezierSurfaceNode",
                                                     /*supportUseCompression=*/true,
                                                     this));
+    // v2.1 NURBS sibling writer (ADR-0022 §"Decision 2 — Schema v3").
+    // Shares the schema-v3 ``.lrp.json`` on-disk format with the
+    // Bezier writer; the storage node dispatches on the data-node
+    // class to pick the surface-type-specific payload.
+    coreIOManager->registerIO(new qSlicerNodeWriter("NurbsSurface",
+                                                    QString("NurbsSurfaceFile"),
+                                                    QStringList() << "vtkMRMLNurbsSurfaceNode",
+                                                    /*supportUseCompression=*/true,
+                                                    this));
   }
 }
 


### PR DESCRIPTION
## Summary

First of the five NURBS deliverables for v2.1 per **ADR-0022 (in flight as PR #389)** §"Rollout plan".  Lands the data model + storage path; no rendering, no Pipeline wiring, no Representation, no UI.  Independent of NURBS-2 / NURBS-3 / NURBS-4 / NURBS-5.

### What's in

- **`vtkMRMLNurbsSurfaceNode`** — sibling of `vtkMRMLBezierSurfaceNode` per ADR-0022 §"Decision 1 — Data node".  IVars: `Rows`, `Cols`, `DegreeU`, `DegreeV`, `KnotsU`, `KnotsV`, `Weights`, `ControlGrid` + the shared `State` (`Init` / `Planning` / `Confirmed`) and `InitializationMode` enums.  Cross-IVar invariants enforced on every shape / degree setter (`Rows >= DegreeU + 1`, etc.); knot vectors regenerated to **clamped-uniform** on accepted shape / degree changes per the de-Boor convention; weights validated strictly positive.  State machine duplicates `vtkMRMLBezierSurfaceNode`'s ADR-0019 transition matrix verbatim — a `TODO(ADR-0022 §"Common abstract base")` flags the future refactor where the duplicate collapses.
- **`.lrp.json` schema v3** — adds the top-level `surfaceType` discriminator and the NURBS-only fields (`degreeU`, `degreeV`, `knotsU`, `knotsV`, `weights`) per ADR-0022 §"Decision 2 — Schema v3".  Reader compat matrix:
  - v1 (no `rows` / `cols` / `surfaceType`) → 4×4 Bezier (legacy path unchanged).
  - v2 (`rows` + `cols`, no `surfaceType`) → explicit Bezier shape (legacy path unchanged).
  - v3 + `surfaceType: "Bezier"` → Bezier path with the discriminator made explicit.
  - v3 + `surfaceType: "NURBS"` → full NURBS path; degree + knots + weights consumed and validated per ADR-0022 §"Validation rules per surface type" (degree range, knot lengths, weights positivity, control-grid length).
  Writer always emits v3 + the most-specific `surfaceType` + the minimum-redundant field roster.
- **`vtkMRMLBezierSurfaceStorageNode` extended** to serve both surface types via `CanReadInReferenceNode` / `CanWriteFromReferenceNode` predicates that accept either node class; read / write dispatched on the reference-node class at runtime.
- **`vtkMRMLNurbsSurfaceStorageNode`** — thin subclass providing the NURBS-specific node-tag-name + factory method.  Default-storage-node lookup resolves to the right class per surface family; the read / write implementation lives on the shared base.
- **C++ round-trip tests** — 12 new sub-tests on the NURBS data node (defaults, clamped-uniform knots, shape / degree validation, weights positivity, state matrix, in-type + cross-type Copy, XML round-trip, knot helpers, length-mismatch rejection) + 7 new sub-tests on the storage node (NURBS round-trip, v3-Bezier-explicit read, v3-NURBS-invalid-degree, v3-NURBS-invalid-knots-length, v3-NURBS-invalid-weights, v3-NURBS-invalid-shape, writer-always-emits-v3-Bezier, NURBS storage discriminator).

### Design notes

- **Option A on the storage class** (single class serving both surface types, dispatched on the data-node class + the `surfaceType` discriminator).  Rationale: keeps the schema-v3 JSON read / write code in one place; avoids duplicating the v1 / v2 migration scaffolding across two storage classes.  The thin `vtkMRMLNurbsSurfaceStorageNode` subclass exists for the `CreateDefaultStorageNode` lookup convention only; per-class behavior diverges only on the node tag name.
- **Cross-type `Copy()` rejected.**  Bezier-source → NURBS-sink (and the symmetric NURBS → Bezier path) emit `vtkErrorMacro` and leave the sink unchanged.  Rationale: the two types carry different IVar rosters (Bezier has no knots / weights / degrees) and a meaningful conversion needs a fitter / degree-elevation pass — not a field-by-field copy that would silently zero-fill the missing NURBS IVars on the sink.  Pinned by `testCopyContentRejectsCrossType` (both directions).
- **State machine duplicated** rather than shared with Bezier per the brief's directive — narrow scope for NURBS-1.  `TODO(ADR-0022 §"Common abstract base")` comments mark the future refactor target.
- **No widget / Pipeline / Representation impact.**  `vtkLiverBezierRepresentation` and friends were not touched; NURBS-3 wires the new node into the LayerDM Pipeline path.

## Out of scope (deferred to later NURBS-N PRs)

- NURBS CPU evaluator (`vtkLiverNurbsSurfaceSource`) — NURBS-2.
- Pipeline + Representation registration — NURBS-3.
- GPU tess mapper (paired with ADR-0020) — NURBS-5.
- NURBS fitter — NURBS-4.
- Module-widget pickers + degree / size UI — NURBS-6 (optional).
- Common `vtkMRMLParametricSurfaceNode` abstract base refactor — flagged with TODO comments; revisits at v2.2 / v3.0.

## Test plan

- [ ] CI green on Ubuntu 24.04 (build + ctest + diff coverage).
- [ ] `vtkMRMLNurbsSurfaceNodeTest1` passes (12 sub-tests covering defaults, validation, state machine, Copy semantics, XML round-trip).
- [ ] `vtkMRMLBezierSurfaceStorageNodeTest1` passes — both the existing Bezier coverage (15 sub-tests, including the schema-v2 fixtures the reader still accepts) and the new NURBS / v3 coverage (7 sub-tests).
- [ ] All pre-existing module tests still pass — the storage class extension is additive on the read path; v1 / v2 fixtures round-trip unchanged.

*AI-assisted authorship: drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code.  Opened for human review.*