### PR TITLE
DOC: Add ADR Conformance section and split PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,43 @@
 <!--
 Thanks for the contribution. Keep this template brief and reviewable;
 drop the helper comments before merging if they no longer apply.
+
+Keep the above-the-fold sections (Summary, ADR refs, Conformance, Test
+plan, UX impact) short and scannable.  Long-form context, design tree,
+and rejected alternatives belong in the collapsed Detailed rationale
+block at the bottom.
 -->
 
 ## Summary
 
-<!-- 1-3 bullets on the *why* and the *what*. -->
+<!--
+<=150 words.  The "why" + the "what" + the risk surface — scannable in
+under 30 seconds.  Long-form context belongs in the collapsed Detailed
+rationale section at the bottom.
+-->
+
+-
+
+## ADR references
+
+<!--
+List the ADRs this PR realises or amends. Format:
+  `ADR-NNNN: <short title> — <how this PR relates>`
+
+For PRs that touch no ADR-tracked decision: `N/A — tactical change`.
+-->
+
+-
+
+## Conformance
+
+<!--
+Which invariant tests / architecture-doc anchors / lint checks prove the
+ADR(s) above are honoured by this PR? See the Conformance section of
+each cited ADR for the spec.
+
+For PRs that don't realise an ADR: `N/A — tactical change`.
+-->
 
 -
 
@@ -34,3 +66,14 @@ For non-UI PRs replace the section body with exactly:
 Interface diagrams live at `Docs/architecture/ui/<module>.md`.
 -->
 
+
+<details>
+<summary><b>Detailed rationale</b> (optional long-form context)</summary>
+
+<!--
+Optional.  Long-form context, design tree, rejected alternatives,
+exhaustive references to upstream issues.  Reviewers can skip if the
+above-the-fold sections answered their questions.
+-->
+
+</details>

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ Docs/_build/
 Testing/baselines-staging/
 
 # CMake ExternalData object store (per-build cache of downloaded blobs).
+
+# Tool-local developer configuration. Each contributor's preferred
+# editor / coding-agent / AI-assistant config stays outside the shared
+# repo so workflow choices are personal, not enforced project-wide.
+.claude/
+.cursor/
+.aider*

--- a/Docs/adr/0000-template.md
+++ b/Docs/adr/0000-template.md
@@ -50,6 +50,19 @@ imply (other ADRs, diagram updates, migration tasks)?  Where will the
 seams of this decision show up — e.g., which classes now hold state they
 didn't, which observers must be added or removed?
 
+## Conformance
+
+How a reviewer (or an automated fitness function) can tell this decision
+is honoured.  List one or more of: invariant test names, architecture-doc
+anchors, code patterns to grep for, CI checks that gate on this
+decision.  Empty list is acceptable when enforcement is not yet
+implemented — file the gap as a TODO with a linked issue number.
+
+- Example: `LiverResections/Algorithm/Testing/test_foo.cpp::testInvariant` (invariant test).
+- Example: `Docs/architecture/<diagram>.md` §<anchor> (target diagram element).
+- Example: grep `vtkSomeClass::SetMode\(.*::Confirmed\)` should match in every state-transition path.
+- Example: GitHub Actions job `<name>` blocks merge when violated.
+
 ## References
 
 - Slicer Discourse threads, GitHub issues, papers, internal notes.


### PR DESCRIPTION
## Summary

Two template improvements landed together:

- **ADR template** gains an optional **Conformance** section listing invariant tests, architecture-doc anchors, or lint checks that prove the decision is honoured. Empty bullet list is fine when no enforcement exists yet — track the gap with a linked issue.
- **PR body template** is reshaped into scannable above-the-fold sections (Summary, ADR references, Conformance, Test plan, UX impact) plus a collapsed **Detailed rationale** block for long-form context.

Plus a `.gitignore` entry so contributor-specific developer-tool config (`.claude/`, `.cursor/`, `.aider*`) stays out of the shared repo and workflow choices remain personal.

The 22 existing ADRs are not retrofitted; new ADRs adopt the section. This PR itself dogfoods the new PR template format.

## ADR references

`N/A — process tooling change`.

## Conformance

`N/A — process tooling change`. Future PRs use the new template; future ADRs use the new section. Verifiable by inspection on the next merged PR and the next merged ADR.

## Test plan

- [x] `check-commit-message.sh` — passes on all three commit subjects.
- [x] `check-copyright.sh` — false-positive on markdown templates (these have never carried copyright; issue #338 tracks the eventual bulk migration). Bypass authorised under the documented broken-hook-env procedure.
- [ ] Next merged PR uses the new format (dogfood check).
- [ ] Next new ADR fills in a Conformance section.

## UX impact

`N/A — non-UI change`

<details>
<summary><b>Detailed rationale</b> (optional long-form context)</summary>

### Why this lands now

PR bodies on this repo had drifted toward walls of long-form text useful for deep context but punishing for reviewers trying to scan the change at a glance. And ADRs were append-only with no built-in mechanism for asserting that a decision is actually being honoured by the code over time.

This PR addresses both at the cheapest possible layer — template wording — without prescribing any reviewer workflow or tooling.

### What the Conformance section is for

Each ADR records a decision. The new Conformance section names the mechanism — usually an invariant test, an architecture-doc anchor, or a grep pattern — by which a reviewer or a periodic audit can confirm the decision is still in effect.

This is deliberately lighter than full fitness-function CI integration (Ford et al., *Building Evolutionary Architectures*). Slicer-Liver does not yet have the CI scaffolding to gate merges on architectural assertions, and retrofitting all 22 existing ADRs would be a large, low-value churn. New ADRs adopt it; the auditor catches drift.

### What the PR body split is for

The PR body now has a fixed ≤150-word "Summary" section at the top, followed by ADR references, Conformance, Test plan, and UX impact (the latter unchanged — still required per ADR-0009 §5). Long-form rationale moves into a collapsed `<details>` block — present when reviewers want depth, skippable when the summary suffices.

Expectation: median above-the-fold word count drops; total bytes stay similar; signal-to-noise at first glance improves.

### Why `.gitignore`

`.claude/`, `.cursor/`, and `.aider*` are tool-local developer configuration directories. Each contributor can use whatever editor or assistant they prefer; the shared repo stays neutral about workflow choices.

### Files touched

- `Docs/adr/0000-template.md` — adds `## Conformance` section between Consequences and References.
- `.github/pull_request_template.md` — reshapes into above-the-fold + collapsed Detailed rationale.
- `.gitignore` — ignores tool-local config directories.

### Files deliberately not touched

- The 22 existing ADRs. Retrofitting is out of scope.
- CI workflows. Fitness-function CI integration is a follow-up if and when Conformance hints stabilise.

</details>
