### PR TITLE
COMP: Fix Codecov coverage discovery paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,8 +441,18 @@ jobs:
           # Cobertura output (Codecov auto-detects).  Excludes Testing
           # subtrees + system headers; the path filter list mirrors
           # `ignore:` in .codecov.yml so the two views agree.
+          #
+          # `--root` must be the absolute workspace path: gcov records
+          # absolute source paths in the .gcno/.gcda metadata
+          # (``/__w/Slicer-Liver/Slicer-Liver/...`` inside the GitHub
+          # Actions container), and gcovr's source-path filtering
+          # only matches when ``--root`` is an absolute prefix of those
+          # recorded paths.  Using ``--root .`` left every source file
+          # outside the resolved root and gcovr filtered everything out
+          # with ``All coverage data is filtered out``, falling through
+          # to the empty-skeleton heredoc below.
           gcovr \
-            --root . \
+            --root "$GITHUB_WORKSPACE" \
             --xml --output coverage-cxx.xml \
             --exclude '.*Testing.*' \
             --exclude '.*CMakeFiles.*' \
@@ -467,18 +477,31 @@ jobs:
           # Per ADR-0021 §"Out of scope", Slicer-launcher Python
           # coverage (wrapped MRML bindings) is opt-in per test and may
           # not be reachable from a plain pytest invocation in the
-          # image.  Run what we can: collect any importable pytest
-          # roots under LiverResectionsLib/ and emit a Cobertura XML.
-          # If nothing collects, write an empty skeleton so the upload
-          # step has a file.
-          if find LiverResectionsLib -name 'test_*.py' -o -name '*_test.py' | grep -q .; then
-            python3 -m pytest LiverResectionsLib \
-              --cov=LiverResectionsLib \
+          # image.  Run what we can: discover the two pytest roots
+          # (``Testing/Python/`` declared in pytest.ini as the project
+          # default, plus ``LiverResections/Testing/Python/`` for the
+          # module-local test_harness suite) and emit a Cobertura XML
+          # measuring the actual Python source module
+          # ``LiverResections/LiverResectionsLib``.
+          #
+          # The earlier discovery path (``LiverResectionsLib`` from the
+          # repo root) matched no directory: the module lives at
+          # ``LiverResections/LiverResectionsLib`` and the tests live
+          # under ``Testing/Python/`` and ``LiverResections/Testing/Python/``.
+          # ``find`` returned nothing, the ``else`` branch fired, and an
+          # empty coverage-py.xml shipped to Codecov.
+          test_roots=()
+          [ -d Testing/Python ] && test_roots+=(Testing/Python)
+          [ -d LiverResections/Testing/Python ] && test_roots+=(LiverResections/Testing/Python)
+          if [ ${#test_roots[@]} -gt 0 ] && \
+             find "${test_roots[@]}" \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit | grep -q .; then
+            python3 -m pytest "${test_roots[@]}" \
+              --cov=LiverResections/LiverResectionsLib \
               --cov-report=xml:coverage-py.xml \
               --cov-report=term \
               || true
           else
-            echo "::notice::No pytest tests discovered under LiverResectionsLib/ — emitting empty coverage-py.xml."
+            echo "::notice::No pytest tests discovered under Testing/Python or LiverResections/Testing/Python — emitting empty coverage-py.xml."
             cat > coverage-py.xml <<'XML'
           <?xml version="1.0" ?>
           <coverage version="0"><sources/><packages/></coverage>


### PR DESCRIPTION
## Summary

The `coverage (slicer-main, Linux)` job has been silently uploading empty Cobertura XML to Codecov since ADR-0021's coverage matrix landed. Two independent root causes in `.github/workflows/ci.yml`, both fixed here:

1. **pytest discovery path was wrong.** The workflow grepped under `LiverResectionsLib/` from the repo root, but that directory does not exist there — the Python module lives at `LiverResections/LiverResectionsLib/` and pytest roots are `Testing/Python/` (declared in `pytest.ini`) and `LiverResections/Testing/Python/`. `find` returned nothing, the `else` branch fired, and an empty skeleton shipped as `coverage-py.xml`.
2. **gcovr `--root .` filtered out everything.** gcov records absolute source paths in `.gcno`/`.gcda` (`/__w/Slicer-Liver/Slicer-Liver/...` inside the GHA container). gcovr's path filtering only matches when `--root` is an absolute prefix; `.` resolved to a relative root, gcovr emitted `All coverage data is filtered out`, and the OR-fallback heredoc wrote the empty skeleton over the partial output.

Pure CI integration fix. Single-file (`.github/workflows/ci.yml`), no behaviour change to anything under test.

## ADR references

- ADR-0021: Coverage measurement — restores the diff-coverage signal the ADR specifies; `Out of scope` clause still holds for Slicer-launcher Python coverage.

## Conformance

- After merge, the next CI run on `preview` should show a non-empty `coverage-cxx.xml` and `coverage-py.xml` arriving at Codecov, and the PR-comment diff-coverage surface specified by ADR-0021 §"Signal philosophy" should populate. The first run is the validation; a follow-up tweak is proposed in the Detailed rationale if either upload remains empty.
- Local check: `find Testing/Python LiverResections/Testing/Python \( -name 'test_*.py' -o -name '*_test.py' \)` now returns 16 test files (vs. 0 before).

## Test plan

- [ ] Merge to `preview`; observe the next CI run's `coverage (slicer-main, Linux)` job.
- [ ] Confirm the Codecov PR comment populates on a follow-up PR (the comment requires both flags `cxx` and `py` to land non-empty per `.codecov.yml` `after_n_builds: 1` + `wait_for_ci: true`).
- [ ] Spot-check the gcovr log line for a non-zero "lines covered" summary instead of `All coverage data is filtered out`.

## UX impact

N/A — non-UI change

<details>
<summary><b>Detailed rationale</b> (optional long-form context)</summary>

### Discovery path fix

`pytest.ini` declares `testpaths = Testing/Python` as the project default. A bare `pytest` invocation from the repo root would already pick that up. However, `LiverResections/Testing/Python/` (the test_harness suite for visual-regression bundling) is not in `pytest.ini`'s declared roots, so we pass both roots explicitly to `pytest`:

```bash
test_roots=()
[ -d Testing/Python ] && test_roots+=(Testing/Python)
[ -d LiverResections/Testing/Python ] && test_roots+=(LiverResections/Testing/Python)
```

`--cov` now points at `LiverResections/LiverResectionsLib` — the actual Python source module — rather than the non-existent `LiverResectionsLib`. The `.codecov.yml` `flags.py.paths` entry already includes `LiverResections/Testing/Python/`, so the flag tagging matches.

### gcovr `--root` fix

The behaviour was diagnosable from the CI log warning `(WARNING) All coverage data is filtered out. Please check your paths and filters.` followed by the empty-skeleton heredoc being emitted by the `||` fallback. gcovr's `--root` is used both as the base for `--filter`/`--exclude` regex resolution AND to relativise source paths in the Cobertura output; when `--root` is `.` (current working directory) it gets resolved relative to gcovr's invocation, but the source paths in the `.gcno` files are absolute, so the prefix never matched. Using `"$GITHUB_WORKSPACE"` gives an absolute prefix that does match.

### Why this didn't show as a CI failure

`fail_ci_if_error: false` on `codecov/codecov-action@v5` per ADR-0021's non-blocking-first-cut decision swallows upload errors. Combined with both the `gcovr || { ... heredoc ... }` OR-fallback and the `if find ... else heredoc fi` discovery fallback, the empty XMLs uploaded "successfully" and the workflow stayed green. The signal was the absence of the PR-comment diff coverage on subsequent PRs — a quieter failure mode than a hard CI error.

### Follow-up if the first post-merge run still shows empty XML

If the gcovr summary line still reports zero data after this lands, the next step is `--root /__w/Slicer-Liver/Slicer-Liver` (the hard-coded GitHub Actions workspace path inside the container) instead of `$GITHUB_WORKSPACE`. The two should be identical in a checkout-action@v4 setup, but the env var has been observed to drift in container-job contexts.

</details>