### PR TITLE
COMP: Honour ADR-0016 cutover discipline on push-to-preview Lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,8 +37,15 @@ jobs:
       # `extra_args: --all-files`, which checks every file in the repo —
       # surfaced by PR #341 (T2 Stack 2) where Lint failed on ~19 unrelated
       # files (`Paper/`, `LiverSegments/`, `LiverVolumetry/`, etc.).
-      # Restrict to PR-diff on pull_request events; push events to preview
-      # still run --all-files to catch any drift on the trunk.
+      #
+      # On pull_request: scope to PR-diff (base..head).
+      # On push to preview: scope to the merge's introduced files
+      # (before..sha).  Earlier intent of running --all-files on push
+      # "to catch trunk drift" was incompatible with ADR-0016: the
+      # grandfather-until-touched policy guarantees the trunk carries
+      # legacy un-reformatted files until the per-module bulk-reformat
+      # cascade lands, so --all-files was perpetually red on preview
+      # pushes regardless of any actual drift.
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
-          extra_args: ${{ github.event_name == 'pull_request' && format('--from-ref {0} --to-ref {1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || '--all-files' }}
+          extra_args: ${{ github.event_name == 'pull_request' && format('--from-ref {0} --to-ref {1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || format('--from-ref {0} --to-ref {1}', github.event.before, github.sha) }}


### PR DESCRIPTION
## Summary

The `Lint` workflow used `--all-files` on push events to preview, but ADR-0016 §"Cutover discipline" explicitly grandfathers legacy un-reformatted files until something touches them. The trunk consequently carries ~50+ legacy `.cxx`/`.h`/`.cpp` files across `LiverMarkups`, `LiverSegments`, `LiverVolumetry`, and `Paper` — so `--all-files` was perpetually red on preview pushes. Five consecutive preview pushes today tripped it.

Scope push events to the merge's introduced files (`before..sha`), matching the PR-diff scope (`base..head`) used on `pull_request` events. Real drift is still caught — any file the merge introduces or modifies gets the full hook suite — but the grandfather-until-touched policy now applies uniformly across both event types.

## ADR references

- ADR-0016 §"Cutover discipline" — the grandfather-until-touched policy this change re-aligns the workflow with.

## Conformance

- Push-to-preview Lint runs the same `pre-commit` hooks against the same files the originating PR's Lint already passed. Verifiable by re-running `gh run list --branch preview --workflow=lint.yml` after the next merge: expected `success` instead of `failure`.

## Test plan

- [x] `git diff --stat` confirms `.github/workflows/lint.yml` is the only touched file (+10/-3, comment + one expression branch).
- [ ] Next merge to preview triggers Lint and goes green (post-merge validation).

## UX impact

`N/A — non-UI change`

<details>
<summary><b>Detailed rationale</b> (optional long-form context)</summary>

### Why the previous behaviour was wrong

The earlier comment in `lint.yml:40-41` claimed `--all-files` on push catches "trunk drift". Under ADR-0016 §"Cutover discipline" that intent is illusory: the trunk is dirty *by design* until the per-module bulk-reformat cascade completes (ADR-0016 §"Cutover discipline", second paragraph — "Per-module bulk-reformat commits are expected to land as part of the LayerDM migration cascade"), so the workflow cannot distinguish real new drift from grandfathered legacy noise. The signal-to-noise ratio of the Lint check on preview pushes was effectively zero.

### Why diff-only on push is the right scope

GitHub Actions exposes `github.event.before` (the SHA before the push) and `github.sha` (the new HEAD) on `push` events. The diff between them is exactly the set of files the push introduces — for a squash-merge or merge-commit, that's the set of files the originating PR touched. So push-to-preview Lint now re-validates the same set the PR's Lint already validated, which is the only meaningful drift check the cutover policy permits.

### What this change does NOT do

It does not land the bulk-reformat cascade (issue #338 and ADR-0016's planned T2 Stack 7 / v2.1 LayerDM module reformats). That remains the long-term endgame. When the cascade completes and the trunk is fully reformatted, restoring `--all-files` on push is a one-line revert.

### Files touched

- `.github/workflows/lint.yml` — comment block (re-explains the policy alignment) + one expression branch (`'--all-files'` → `format('--from-ref {0} --to-ref {1}', github.event.before, github.sha)`).

</details>
