### PR TITLE
COMP: Make Codecov uploads carry real coverage data (closes #404)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,15 @@ jobs:
           # python3-pytest-cov in the base image).
           python3 -m venv /tmp/coverage-venv
           /tmp/coverage-venv/bin/pip install --upgrade pip
-          /tmp/coverage-venv/bin/pip install 'gcovr>=7' 'pytest-cov>=5' 'pytest>=8'
+          # ``numpy`` is required by ``Testing/Python/unit/test_bezier_characterization.py``
+          # (it imports ``numpy as np`` at module load).  Without it
+          # pytest's collection phase errors with
+          # ``ModuleNotFoundError: No module named 'numpy'`` and the
+          # full session is interrupted before pytest-cov can emit the
+          # Cobertura XML — symptom: ``coverage-py.xml`` never appears
+          # at the workspace root and Codecov's upload arrives without
+          # any Python coverage data.
+          /tmp/coverage-venv/bin/pip install 'gcovr>=7' 'pytest-cov>=5' 'pytest>=8' 'numpy>=1.24'
           echo "/tmp/coverage-venv/bin" >> "$GITHUB_PATH"
 
       - name: Verify Slicer build tree
@@ -451,13 +459,18 @@ jobs:
           # outside the resolved root and gcovr filtered everything out
           # with ``All coverage data is filtered out``, falling through
           # to the empty-skeleton heredoc below.
+          # ``--exclude '.*/build-coverage/.*'`` removed: gcovr applies
+          # filters to the gcov *data file* paths it discovers, not just
+          # source-file paths.  Every .gcda lives under build-coverage/
+          # by design; the exclude was matching them all and pruning the
+          # real coverage data out before source-path resolution.
+          # Symptom: ``(WARNING) All coverage data is filtered out``.
           gcovr \
             --root "$GITHUB_WORKSPACE" \
             --xml --output coverage-cxx.xml \
             --exclude '.*Testing.*' \
             --exclude '.*CMakeFiles.*' \
             --exclude '/usr/.*' \
-            --exclude '.*/build-coverage/.*' \
             --print-summary \
             build-coverage || {
               echo "::warning::gcovr produced no usable data — coverage upload will be partial."
@@ -495,7 +508,16 @@ jobs:
           [ -d LiverResections/Testing/Python ] && test_roots+=(LiverResections/Testing/Python)
           if [ ${#test_roots[@]} -gt 0 ] && \
              find "${test_roots[@]}" \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit | grep -q .; then
+            # ``--continue-on-collection-errors``: one bad module
+            # (e.g. a missing optional dep) shouldn't abort the
+            # entire session and prevent pytest-cov from writing the
+            # XML for the modules that DO collect.  Belt-and-braces
+            # alongside the numpy install above — there will always
+            # be a future test module that imports something opt-
+            # ional, and we want partial Python coverage rather than
+            # none in that case.
             python3 -m pytest "${test_roots[@]}" \
+              --continue-on-collection-errors \
               --cov=LiverResections/LiverResectionsLib \
               --cov-report=xml:coverage-py.xml \
               --cov-report=term \


### PR DESCRIPTION
## Summary

Three targeted `ci.yml` fixes addressing the diagnosis in #404. Each one points at a single root cause surfaced by PR #403's coverage run logs:

1. **Python pytest:** add `numpy` to the coverage venv's pip install. Collection failed on `test_bezier_characterization.py:96` (`import numpy as np`) with `ModuleNotFoundError`, aborting the session before pytest-cov could write `coverage-py.xml`.
2. **Python pytest:** add `--continue-on-collection-errors` belt-and-braces so a single bad module doesn't blank the signal for the other ~106 collectable tests.
3. **C++ gcovr:** drop `--exclude '.*/build-coverage/.*'`. gcovr applies filters to the gcov *data file* paths it discovers, not just resolved source-file paths. Every `.gcda` lives under `build-coverage/` by design; the exclude was pruning every real coverage data file before source resolution could happen.

Closes #404 (per the acceptance criteria in the issue body).

## ADR references

- ADR-0021 §"Rollout plan" — this PR is the v2 integration pass the ADR anticipated; the `coverage (slicer-main, Linux)` job stays non-blocking.

## Conformance

- After merge, the `coverage (slicer-main, Linux)` job's `coverage-cxx.xml` and `coverage-py.xml` should each contain at least one real `<class>` / `<package>` element rather than the empty Cobertura skeleton.
- Codecov dashboard PR pages should render non-zero percentages on at least one of `lines:` / `functions:` / `branches:` for both `cxx` and `py` flags.

## Test plan

- [x] Single file changed (`.github/workflows/ci.yml`, +24/-2).
- [x] All three changes carry inline comments explaining the diagnosis they address.
- [ ] **Validation deferred to the next post-merge coverage run** — the only way to verify `numpy` install + the gcovr exclude removal + the pytest flag work end-to-end is to observe a coverage job on `preview` after this lands. If gcovr still emits `(WARNING) All coverage data is filtered out`, the next step is to add `--verbose` temporarily and inspect what filter token is matching.

## UX impact

`N/A — CI-only change`

<details>
<summary><b>Detailed rationale</b> (optional long-form context)</summary>

### Why three fixes, not one

PR #401's earlier path-discovery fix moved the workflow from "broken paths" to "discoverable paths" but the Codecov uploads still arrived empty. The diagnosis in #404 traced this to two structurally different root causes (one Python, one C++) plus a belt-and-braces concern (pytest's hard-fail-on-collection-error default). Each fix is independently meaningful and lands together because they share a file.

### Why drop the build-coverage exclude

The exclude was inherited from the v1 cut of `ci.yml` (ADR-0021's first pass) with the intent of "skip CMake-generated wrapper sources (`moc_*.cxx`, `qrc_*.cxx`, `*PythonWrapping.cxx`) that get emitted under `build-coverage/`". The intent was right; the regex shape was wrong — `.*/build-coverage/.*` matches every gcov data file path because every `.gcda` is under `build-coverage/`. The other three excludes (`Testing`, `CMakeFiles`, `/usr/`) target source-path components and apply correctly to resolved source paths.

If wrapper-source filtering proves necessary later, the right shape is something like `--exclude '.*moc_.*\.cxx$'` and `--exclude '.*PythonWrapping\.cxx$'` — patterns that match the wrapper file *names*, not the build directory.

### Why `numpy>=1.24`

That's the version pin Slicer-core uses in its `requirements.txt` for the bundled Python. Matching the upstream version reduces the chance of a numpy-version skew between the coverage venv and the Slicer Python that the actual tests run under (in a Slicer launcher).

</details>
