### PR TITLE
DOC: Add per-stage UI architecture docs

### DIFF
--- a/Docs/architecture/ui-stage-1-case-setup.md
+++ b/Docs/architecture/ui-stage-1-case-setup.md
@@ -57,7 +57,7 @@ Load → Tag Volume Roles → (optional) Register → Layout → Hand off to Sta
 
 ### Role tagging
 
-- **Vocabulary**: `Native`, `Arterial`, `Portal venous`, `Delayed/venous`, `Other`. Stored as a scene attribute on each volume node (key TBD at implementation; suggested `LiverLiver.RoleTag`).
+- **Vocabulary**: `Native`, `Arterial`, `Portal venous`, `Delayed/venous`, `Other`. Stored as a scene attribute on each volume node (key TBD at implementation; suggested `LiverVolume.RoleTag` — parallel to the existing `LiverSegments.SegmentationId` / `LiverSegments.VascTerrId` attribute convention).
 - **Auto-tag from DICOM**: when `SeriesDescription`, `ContrastBolusAgent`, or `AcquisitionTime` headers permit inference, the manifest pre-populates the role with the heuristic guess + an asterisk badge marking it as auto-tagged. Surgeon-correctable via the dropdown.
 - **NIfTI / NRRD / MetaImage**: no header hints; role starts empty; surgeon tags manually.
 - **Re-loading a saved scene**: existing role tags persist on the volume nodes; manifest reflects them.

--- a/Docs/architecture/ui-stage-1-case-setup.md
+++ b/Docs/architecture/ui-stage-1-case-setup.md
@@ -1,24 +1,27 @@
 # UI architecture — Stage 1: Case Setup
 
-Reference companion to [ADR-0023 §Stage 1][adr-0023]. Captures the
-panel structure, control affordances, role-tagging UX, and cross-
-stage hand-off for Slicer-Liver's first workflow stage.
+Reference companion to [ADR-0023 §Stage 1][adr-0023] + the forthcoming [ADR-0029 — Stage 1 case-setup functional contract][adr-0029]. Captures the panel structure, control affordances, role-tagging UX, registration-detection signal, and cross-stage hand-off for Slicer-Liver's first workflow stage.
 
 [adr-0023]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0023-unified-gui-stage-workflow.md
+[adr-0029]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0029-stage1-case-setup-contract.md
 
 ## What this stage does
 
-Load patient data (DICOM, NIfTI, NRRD, MetaImage, MHA — anything Slicer reads); tag each loaded volume with a clinical role (Native / Arterial / Portal venous / Delayed / Other); optionally register multi-phase acquisitions; arrange the canonical Slicer layout. Hands off to downstream stages a manifest of role-tagged volumes.
+Load patient data (DICOM, NIfTI, NRRD, MetaImage, MHA — anything Slicer reads); tag each loaded volume with a clinical role (Native / Arterial / Portal venous / Delayed / Other); arrange the canonical Slicer layout. Hands off to downstream stages a manifest of role-tagged volumes.
+
+The **dominant case is single-volume** (one Portal-venous-phase CT, common to most research datasets and many clinical acquisitions). The manifest + multi-phase affordances are progressive disclosure that only matter when ≥2 volumes are loaded.
+
+**Registration is explicitly out of v2.0 scope** (per ADR-0029). Slicer-Liver does not ship in-extension registration UI in v2.0; when volumes are not co-registered the panel surfaces a hint pointing at Slicer's stock registration tools and lets the surgeon pick whatever fits their data.
 
 Module home: handled directly by the `Liver` shell (section under the shell sidebar, not a separate scripted module).
 
 ## Sub-flow
 
 ```
-Load → Tag Volume Roles → (optional) Register → Layout → Hand off to Stage 2
+Load → Tag Volume Roles → Layout → Hand off to Stage 2
 ```
 
-## Panel layout
+## Panel layout — single-volume default (dominant case)
 
 ```
 ┌─ 1. Case Setup ────────────────────────────────────────────────┐
@@ -28,6 +31,31 @@ Load → Tag Volume Roles → (optional) Register → Layout → Hand off to Sta
 │ │ [Load Volume…]  (delegates to "Add Data" for NIfTI/etc.) │  │
 │ └──────────────────────────────────────────────────────────┘  │
 │                                                                │
+│ ┌─ Volume ─────────────────────────────────────────────────┐  │
+│ │  patient_PV.nrrd     Role: [▼ Portal venous*]            │  │
+│ │  * = auto-tagged from DICOM header (surgeon-correctable) │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                │
+│ ┌─ Layout ─────────────────────────────────────────────────┐  │
+│ │  ◉ Conventional (3D + 3 ortho)                           │  │
+│ │  [Apply layout]                                          │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                │
+│ [Continue to Anatomy Definition ▶]                             │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Panel layout — multi-volume case (progressive disclosure)
+
+When ≥2 volumes are loaded, the single-volume row expands into a manifest table; the registration-status banner appears; the multi-phase comparison layout option unlocks.
+
+```
+┌─ 1. Case Setup ────────────────────────────────────────────────┐
+│                                                                │
+│ ┌─ Load ───────────────────────────────────────────────────┐  │
+│ │ [Load DICOM…]   [Load Volume…]                           │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                │
 │ ┌─ Volume manifest ────────────────────────────────────────┐  │
 │ │  Name              Role                  Source          │  │
 │ │ ─────────────────────────────────────────────────────    │  │
@@ -35,12 +63,10 @@ Load → Tag Volume Roles → (optional) Register → Layout → Hand off to Sta
 │ │  patient_ART.dcm   [▼ Arterial]          DICOM           │  │
 │ │  patient_NAT.dcm   [▼ Native]            DICOM           │  │
 │ │                                                          │  │
+│ │  Registration:  ✓ appears co-registered                  │  │
+│ │   (or)          ⚠ may not be co-registered — see hint    │  │
+│ │                                                          │  │
 │ │  * = auto-tagged from DICOM header (surgeon-correctable) │  │
-│ └──────────────────────────────────────────────────────────┘  │
-│                                                                │
-│ ┌─ Registration (advanced) ────────────────────────────────┐  │
-│ │  Status: ✓ Volumes appear pre-registered                 │  │
-│ │  [Recommend registration]   (BRAINSFit / Elastix)        │  │
 │ └──────────────────────────────────────────────────────────┘  │
 │                                                                │
 │ ┌─ Layout ─────────────────────────────────────────────────┐  │
@@ -62,33 +88,44 @@ Load → Tag Volume Roles → (optional) Register → Layout → Hand off to Sta
 - **NIfTI / NRRD / MetaImage**: no header hints; role starts empty; surgeon tags manually.
 - **Re-loading a saved scene**: existing role tags persist on the volume nodes; manifest reflects them.
 
-### Stage 2 unlock criterion
+### Single-volume default
 
-Stage 2 (Anatomy Definition) becomes "available" in the sidebar when **at least one volume has a role appropriate for segmentation** — typically `Portal venous`, falling back to `Native` with a warning per ADR-0023 §"Anatomy Definition". The check is soft (warns rather than blocks) so research-data with single-phase NIfTI is supported.
+- Scene has 0 volumes → manifest empty, only `[Load …]` buttons visible. Stage 2 stays gated until at least one volume + role tag.
+- Scene has 1 volume → "Volume" section (not "manifest table") shows the single volume row. No registration status, no 2-up layout option.
+- Scene has ≥ 2 volumes → manifest table replaces the single-volume row. Registration-status banner appears. The 2-up layout option becomes selectable.
 
 ### Registration
 
-- Optional. Multi-volume scenes get a hint banner: "Volumes may not be co-registered — consider [Recommend registration]."
-- Delegates to stock Slicer registration modules (BRAINSFit / Elastix). Slicer-Liver does not re-skin the registration UI; it provides the entry point.
+**Out of v2.0 scope** per [ADR-0029][adr-0029]. Slicer-Liver does not ship registration UI; surgeon uses Slicer's stock registration tools (Slicer's Registration module category — BRAINSFit, or installed extensions like `SlicerElastix`, `SlicerANTs`) outside the Slicer-Liver shell when needed.
+
+The registration-status banner is detection-only:
+
+- **`✓ appears co-registered`** when all loaded volumes share the same voxel grid (origin, spacing, direction matrix, dimensions) OR share the same DICOM `FrameOfReferenceUID`. Both are *strong* signals — voxel-grid match means the data is on the same sampling grid; matching `FrameOfReferenceUID` is the DICOM contract for co-registration.
+- **`⚠ may not be co-registered — see hint`** when the above doesn't hold. The hint expands to a short message naming Slicer's stock registration module category as the path forward. No `[Run registration]` button — Slicer-Liver does not invoke a specific tool.
+- The detection is **soft** — surgeon's eyeball is the final judge; the hint never blocks Stage 2.
 
 ### Layout
 
-- Canonical Slicer layout (Conventional or FourUp) is the default.
-- The "2-up multi-phase comparison" layout is a Slicer-Liver-registered custom layout (CMakeLists / module-load time) showing two 3D-or-slice views side-by-side, intended for surgeons comparing Portal-venous vs Arterial phases.
+- Canonical Slicer layout (Conventional / FourUp) is the default.
+- The "2-up multi-phase comparison" layout is a Slicer-Liver-registered custom layout (CMakeLists / module-load time) showing two 3D-or-slice views side-by-side, intended for surgeons comparing Portal-venous vs Arterial phases. Only available when ≥2 volumes are loaded.
+
+### Stage 2 unlock criterion
+
+Stage 2 (Anatomy Definition) becomes "available" in the sidebar when **at least one volume has a role appropriate for segmentation** — typically `Portal venous`, falling back to `Native` with a warning per ADR-0023 §"Anatomy Definition". The check is soft (warns rather than blocks) so research data with single-phase NIfTI is supported.
 
 ### Defaults (per the 2026-05-21 Stage 1 walkthrough)
 
 1. **Mandatory vs optional role-tagging** — warn-and-proceed, not block.
 2. **Auto-tagging aggressiveness** — auto-tag with visible diff (asterisk badge); surgeon-correctable.
-3. **Manifest** — explicit (the table above is always visible).
-4. **Registration** — recommend, don't require.
+3. **Manifest** — progressive disclosure (single-volume row by default; table when ≥2 volumes).
+4. **Registration** — detection-only hint banner; no in-extension UI. See ADR-0029.
 5. **Single-phase research data** — first-class support (no AI-tool gating downstream).
 
 ## Cross-stage interactions
 
 | Direction | Surface |
 |-----------|---------|
-| Stage 1 → Stage 2 | The role-tagged volume manifest is read by Stage 2's per-structure cards (each card's "Source" dropdown defaults to whichever volume has the `Portal venous` role). |
+| Stage 1 → Stage 2 | The role-tagged volume manifest is read by Stage 2's per-structure cards (each card's "Source" dropdown defaults to whichever volume has the `Portal venous` role; in single-volume scenes the dropdown is auto-set with no alternatives). |
 | Stage 1 → Stage 3 (Auto path) | The same `Portal venous`-tagged image is the source for the TotalSegmentator Couinaud inference. |
 | Stage 1 → Stage 4 | The role-tagged image identifies the canonical CT volume the Bezier-surface mapper renders against. |
 | Sidebar | Stage 1 state indicator turns ✓ when at least one volume is loaded + role-tagged. |
@@ -96,5 +133,6 @@ Stage 2 (Anatomy Definition) becomes "available" in the sidebar when **at least 
 ## See also
 
 - [ADR-0023 §Stage 1][adr-0023]
+- [ADR-0029 — Stage 1 case-setup functional contract][adr-0029] (forthcoming) — codifies registration-detection algorithm + no-bundled-registration stance + single-volume-default.
 - [GUI stage flow](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md) — Stage 1 in the cross-stage data flow diagram.
 - [Stage 2 — Anatomy Definition](ui-stage-2-anatomy-definition.md) — downstream consumer of the role-tagged manifest.

--- a/Docs/architecture/ui-stage-1-case-setup.md
+++ b/Docs/architecture/ui-stage-1-case-setup.md
@@ -1,0 +1,100 @@
+# UI architecture — Stage 1: Case Setup
+
+Reference companion to [ADR-0023 §Stage 1][adr-0023]. Captures the
+panel structure, control affordances, role-tagging UX, and cross-
+stage hand-off for Slicer-Liver's first workflow stage.
+
+[adr-0023]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0023-unified-gui-stage-workflow.md
+
+## What this stage does
+
+Load patient data (DICOM, NIfTI, NRRD, MetaImage, MHA — anything Slicer reads); tag each loaded volume with a clinical role (Native / Arterial / Portal venous / Delayed / Other); optionally register multi-phase acquisitions; arrange the canonical Slicer layout. Hands off to downstream stages a manifest of role-tagged volumes.
+
+Module home: handled directly by the `Liver` shell (section under the shell sidebar, not a separate scripted module).
+
+## Sub-flow
+
+```
+Load → Tag Volume Roles → (optional) Register → Layout → Hand off to Stage 2
+```
+
+## Panel layout
+
+```
+┌─ 1. Case Setup ────────────────────────────────────────────────┐
+│                                                                │
+│ ┌─ Load ───────────────────────────────────────────────────┐  │
+│ │ [Load DICOM…]   (delegates to Slicer's DICOM browser)    │  │
+│ │ [Load Volume…]  (delegates to "Add Data" for NIfTI/etc.) │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                │
+│ ┌─ Volume manifest ────────────────────────────────────────┐  │
+│ │  Name              Role                  Source          │  │
+│ │ ─────────────────────────────────────────────────────    │  │
+│ │  patient_PV.nrrd   [▼ Portal venous*]    NIfTI           │  │
+│ │  patient_ART.dcm   [▼ Arterial]          DICOM           │  │
+│ │  patient_NAT.dcm   [▼ Native]            DICOM           │  │
+│ │                                                          │  │
+│ │  * = auto-tagged from DICOM header (surgeon-correctable) │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                │
+│ ┌─ Registration (advanced) ────────────────────────────────┐  │
+│ │  Status: ✓ Volumes appear pre-registered                 │  │
+│ │  [Recommend registration]   (BRAINSFit / Elastix)        │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                │
+│ ┌─ Layout ─────────────────────────────────────────────────┐  │
+│ │  ◉ Conventional (3D + 3 ortho)                           │  │
+│ │  ○ 2-up multi-phase comparison                           │  │
+│ │  [Apply layout]                                          │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                │
+│ [Continue to Anatomy Definition ▶]                             │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## Behaviour notes
+
+### Role tagging
+
+- **Vocabulary**: `Native`, `Arterial`, `Portal venous`, `Delayed/venous`, `Other`. Stored as a scene attribute on each volume node (key TBD at implementation; suggested `LiverLiver.RoleTag`).
+- **Auto-tag from DICOM**: when `SeriesDescription`, `ContrastBolusAgent`, or `AcquisitionTime` headers permit inference, the manifest pre-populates the role with the heuristic guess + an asterisk badge marking it as auto-tagged. Surgeon-correctable via the dropdown.
+- **NIfTI / NRRD / MetaImage**: no header hints; role starts empty; surgeon tags manually.
+- **Re-loading a saved scene**: existing role tags persist on the volume nodes; manifest reflects them.
+
+### Stage 2 unlock criterion
+
+Stage 2 (Anatomy Definition) becomes "available" in the sidebar when **at least one volume has a role appropriate for segmentation** — typically `Portal venous`, falling back to `Native` with a warning per ADR-0023 §"Anatomy Definition". The check is soft (warns rather than blocks) so research-data with single-phase NIfTI is supported.
+
+### Registration
+
+- Optional. Multi-volume scenes get a hint banner: "Volumes may not be co-registered — consider [Recommend registration]."
+- Delegates to stock Slicer registration modules (BRAINSFit / Elastix). Slicer-Liver does not re-skin the registration UI; it provides the entry point.
+
+### Layout
+
+- Canonical Slicer layout (Conventional or FourUp) is the default.
+- The "2-up multi-phase comparison" layout is a Slicer-Liver-registered custom layout (CMakeLists / module-load time) showing two 3D-or-slice views side-by-side, intended for surgeons comparing Portal-venous vs Arterial phases.
+
+### Defaults (per the 2026-05-21 Stage 1 walkthrough)
+
+1. **Mandatory vs optional role-tagging** — warn-and-proceed, not block.
+2. **Auto-tagging aggressiveness** — auto-tag with visible diff (asterisk badge); surgeon-correctable.
+3. **Manifest** — explicit (the table above is always visible).
+4. **Registration** — recommend, don't require.
+5. **Single-phase research data** — first-class support (no AI-tool gating downstream).
+
+## Cross-stage interactions
+
+| Direction | Surface |
+|-----------|---------|
+| Stage 1 → Stage 2 | The role-tagged volume manifest is read by Stage 2's per-structure cards (each card's "Source" dropdown defaults to whichever volume has the `Portal venous` role). |
+| Stage 1 → Stage 3 (Auto path) | The same `Portal venous`-tagged image is the source for the TotalSegmentator Couinaud inference. |
+| Stage 1 → Stage 4 | The role-tagged image identifies the canonical CT volume the Bezier-surface mapper renders against. |
+| Sidebar | Stage 1 state indicator turns ✓ when at least one volume is loaded + role-tagged. |
+
+## See also
+
+- [ADR-0023 §Stage 1][adr-0023]
+- [GUI stage flow](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md) — Stage 1 in the cross-stage data flow diagram.
+- [Stage 2 — Anatomy Definition](ui-stage-2-anatomy-definition.md) — downstream consumer of the role-tagged manifest.

--- a/Docs/architecture/ui-stage-2-anatomy-definition.md
+++ b/Docs/architecture/ui-stage-2-anatomy-definition.md
@@ -1,0 +1,118 @@
+# UI architecture — Stage 2: Anatomy Definition
+
+Reference companion to [ADR-0023 §Stage 2][adr-0023] + [ADR-0024
+(orchestration)][adr-0024] + [ADR-0026 (Segment Editor effects)][adr-0026].
+Captures the per-structure card layout, tool invocation surface, the
+scratch + Accept review UX, and the lazy-AI-install integration.
+
+[adr-0023]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0023-unified-gui-stage-workflow.md
+[adr-0024]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0024-segmentation-orchestration.md
+[adr-0026]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0026-segment-editor-effects.md
+[adr-0011]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0011-sct-terminology-dispatch.md
+
+## What this stage does
+
+Segment four anatomical structures (Liver / Portal vein / Hepatic vein / Tumors) using per-structure micro-workflows that orchestrate TotalSegmentator + Kumar-Oram (Segment Editor effect) + Segment Editor for manual fixes. Each structure publishes one segment in the canonical `vtkMRMLSegmentationNode` per [ADR-0011][adr-0011]. Interactive tumor refinement (e.g. MONAILabel-DeepGrow) is deferred to v2.1+ per [ADR-0024][adr-0024] Alternative H — MONAILabel's client/server architecture violates the lazy-pip-install envelope.
+
+Module home: `LiverSegmentation/` (new in v2.0; see ADR-0024).
+
+## Panel layout
+
+```
+┌─ 2. Anatomy Definition ────────────────────────────────────────────┐
+│                                                                    │
+│ ┌─ Checklist ──────────────────────────────────────────────────┐  │
+│ │  Liver          ✓   Accepted                                 │  │
+│ │  Portal vein    ⋯   Scratch pending review                   │  │
+│ │  Hepatic vein   ○   Not started                              │  │
+│ │  Tumors (2)     ✓   2 accepted                               │  │
+│ └──────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│ ┌─ Liver ──────────────────────────────────────────────────────┐  │
+│ │  Source: [▼ Portal venous (patient_PV.nrrd)]                 │  │
+│ │  Tools:  [Run TotalSegmentator]                              │  │
+│ │  Scratch: ✓ accepted as canonical                            │  │
+│ │  [Edit in Segment Editor]   [Reset to Scratch]               │  │
+│ └──────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│ ┌─ Portal vein ────────────────────────────────────────────────┐  │
+│ │  Source: [▼ Portal venous (patient_PV.nrrd)]                 │  │
+│ │  Tools:  [Run TotalSegmentator (liver_vessels)]              │  │
+│ │  Scratch: ⋯ pending — [Accept] [Reject]                      │  │
+│ │  Refinement: [Refine with Kumar-Oram] (opens Segment Editor) │  │
+│ │  [Edit in Segment Editor]                                    │  │
+│ └──────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│ ┌─ Tumors ─────────────────────────────────────────────────────┐  │
+│ │  Source: [▼ Portal venous (patient_PV.nrrd)]                 │  │
+│ │  Tumor list:                                                 │  │
+│ │   ▰ Tumor 1   ✓ accepted   [edit][×]                         │  │
+│ │   ▰ Tumor 2   ✓ accepted   [edit][×]                         │  │
+│ │   [+ Add tumor]                                              │  │
+│ │  Tools:  [Run TotalSegmentator (tumor channel)]              │  │
+│ │  [Edit in Segment Editor]                                    │  │
+│ └──────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│ [Continue to Vascular Territories ▶]                               │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+(The Hepatic vein card mirrors Portal vein structurally; collapsed
+in the sketch for brevity.)
+
+## Behaviour notes
+
+### Per-structure cards
+
+Each card encapsulates one structure's micro-workflow:
+
+| Structure | Tool chain | Notes |
+|-----------|-----------|-------|
+| Liver | TotalSegmentator → Segment Editor → Accept | Single-step AI; manual cleanup if needed. |
+| Portal vein | TotalSegmentator (`liver_vessels`) → Accept → Kumar-Oram (effect) → Segment Editor | AI mask is the seed for Kumar-Oram refinement. |
+| Hepatic vein | TotalSegmentator (`liver_vessels`) → Accept → Kumar-Oram (effect) → Segment Editor | Same chain as Portal vein, dispatched by SCT target. |
+| Tumors | TotalSegmentator (tumor channel) → Segment Editor → Accept | Multi-focal via per-tumor sub-list. Interactive AI tumor refinement is deferred to v2.1+ per ADR-0024 Alt H. |
+
+### Scratch + Accept lifecycle (per ADR-0024)
+
+- AI tool-run writes into an orchestrator-private *scratch* `vtkMRMLSegmentationNode`.
+- Card surfaces three actions while scratch is pending: **Accept** (copy into canonical, mark structure ✓ in checklist), **Reject** (discard scratch; card returns to "not started" state), **Re-run** (re-invoke the tool with different parameters or source).
+- After Accept, the canonical segment is in-place editable via **Edit in Segment Editor** (which opens Segment Editor with that segment selected).
+- For vessels, **Refine with Kumar-Oram** opens Segment Editor with the segment selected + the Kumar-Oram effect pre-activated (hybrid pattern per ADR-0026). Surgeon iteratively refines via the effect; on the effect's own Accept, the segment updates in place. No further orchestrator-side Accept needed (Segment Editor's effect Accept *is* the commit).
+
+### Lazy AI install (per ADR-0023 + ADR-0024)
+
+- TotalSegmentator is NOT an `EXTENSION_DEPENDS` entry.
+- First click of `[Run TotalSegmentator]` triggers `slicer.util.pip_install` with a confirmation dialog showing the download size + GPU recommendation.
+- The lazy-pip-install pattern is bounded to AI tools that consume as a Python package with no external runtime. MONAILabel-DeepGrow (server architecture) is out of v2.0 scope per ADR-0024 Alt H.
+- Subsequent calls skip the prompt.
+- Install failure: clear error message + manual-segmentation path remains available via Segment Editor.
+
+### Tumor enumeration
+
+- Multi-focal cases: tumor list inside the Tumors card. Each row is one tumor (numbered + untyped per ADR-0023 §"What is NOT in v2.0" + the 2026-05-14 terminology decision).
+- Per-tumor actions: `[edit]` opens Segment Editor on that tumor's segment; `[×]` deletes with confirmation. Deletion cascades renumber + flag downstream consumers (Stage 4 margin readouts).
+- `[+ Add tumor]` creates an empty tumor segment + invites the surgeon to run TotalSegmentator on the full volume (which will surface all tumors at once) or paint manually via Segment Editor for a single tumor.
+
+### Source dropdown per card
+
+Each card's `Source` dropdown defaults to the volume tagged `Portal venous` in Stage 1's manifest. Surgeon can override per-structure (some tumor types segment better on arterial — researcher use case). Dropdown shows volume name + role tag.
+
+## Cross-stage interactions
+
+| Direction | Surface |
+|-----------|---------|
+| Stage 1 → Stage 2 | Source dropdowns default to the volume's role tag from Stage 1's manifest. |
+| Stage 2 → Stage 3 (Manual path) | The Portal vein segment is the input to Stage 3 Manual's VMTK ExtractCenterline. |
+| Stage 2 → Stage 4 | The canonical Segmentation node is the input to Stage 4's distance-map computation (tumor / portal / hepatic). |
+| Stage 2 → Stage 5 | The canonical Segmentation provides the ROI (Liver segment) for Stage 5's volumetry framework. |
+| Sidebar | Stage 2 state indicator turns ✓ when all four structures have at least one Accepted segment. |
+
+## See also
+
+- [ADR-0023 §Stage 2][adr-0023] — workflow shape.
+- [ADR-0024][adr-0024] — orchestrator implementation.
+- [ADR-0026][adr-0026] — Segment Editor effects + Kumar-Oram placement.
+- [GUI stage flow](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md) — Stage 2 in the cross-stage data flow diagram.
+- [Stage 1 — Case Setup](ui-stage-1-case-setup.md) — upstream.
+- [Stage 3 — Vascular Territories](ui-stage-3-vascular-territories.md) — downstream (Manual path consumes Stage 2's vessel segments).

--- a/Docs/architecture/ui-stage-2-anatomy-definition.md
+++ b/Docs/architecture/ui-stage-2-anatomy-definition.md
@@ -43,6 +43,14 @@ Module home: `LiverSegmentation/` (new in v2.0; see ADR-0024).
 │ │  [Edit in Segment Editor]                                    │  │
 │ └──────────────────────────────────────────────────────────────┘  │
 │                                                                    │
+│ ┌─ Hepatic vein ───────────────────────────────────────────────┐  │
+│ │  Source: [▼ Portal venous (patient_PV.nrrd)]                 │  │
+│ │  Tools:  [Run TotalSegmentator (liver_vessels)]              │  │
+│ │  Scratch: ○ not started                                      │  │
+│ │  Refinement: [Refine with Kumar-Oram] (opens Segment Editor) │  │
+│ │  [Edit in Segment Editor]                                    │  │
+│ └──────────────────────────────────────────────────────────────┘  │
+│                                                                    │
 │ ┌─ Tumors ─────────────────────────────────────────────────────┐  │
 │ │  Source: [▼ Portal venous (patient_PV.nrrd)]                 │  │
 │ │  Tumor list:                                                 │  │
@@ -57,8 +65,7 @@ Module home: `LiverSegmentation/` (new in v2.0; see ADR-0024).
 └────────────────────────────────────────────────────────────────────┘
 ```
 
-(The Hepatic vein card mirrors Portal vein structurally; collapsed
-in the sketch for brevity.)
+(All four cards are shown above. The Hepatic vein card mirrors Portal vein structurally — same tool chain, same refinement affordance — but is dispatched on a different SCT target.)
 
 ## Behaviour notes
 

--- a/Docs/architecture/ui-stage-3-vascular-territories.md
+++ b/Docs/architecture/ui-stage-3-vascular-territories.md
@@ -1,0 +1,168 @@
+# UI architecture — Stage 3: Vascular Territories
+
+Reference companion to [ADR-0023 §Stage 3][adr-0023]. Captures the
+two-tab structure (Couinaud-automatic vs Custom-manual), the
+hierarchical centerlines+groupings table with master-detail
+endpoints sub-table, and the `qMRMLNodeComboBox`-driven node
+management for `vtkMRMLAbstractTerritoriesNode` subclass instances.
+
+[adr-0023]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0023-unified-gui-stage-workflow.md
+[territories]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/territories-class-hierarchy.md
+
+## What this stage does
+
+Produce a partition of the liver parenchyma into anatomical territories — typically Couinaud segments I–VIII, but the framework supports custom partitions. Two surgeon-facing paths share an abstract base class but coexist as different concrete subtypes (see [Territories class hierarchy][territories]):
+
+- **Couinaud (automatic)** tab — calls TotalSegmentator (or another backend if configured) on the source image; produces `vtkMRMLStdCouinaudTerritoriesNode`. Depends only on Stage 1.
+- **Custom segments** tab — surgeon defines centerlines (VMTK-extracted from fiducial endpoints) and groups them into segments; produces `vtkMRMLCustomTerritoriesNode`. Depends on Stage 2's vessel segmentation.
+
+Module home: `VascularTerritories/` (renamed from `LiverSegments/`).
+
+## Tab structure
+
+```
+┌─ 3. Vascular Territories ──────────────────────────────────────────────┐
+│ ┌─[ Couinaud (automatic) ]──[ Custom segments ]──────────────────────┐ │
+│ │ <tab-specific content>                                             │ │
+│ └────────────────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+Both tabs publish into the same scene as separate `vtkMRMLAbstractTerritoriesNode` instances; downstream consumers polymorphically work with either subtype.
+
+## Automatic Couinaud tab
+
+```
+┌─[ Couinaud (automatic) ]──[ Custom segments ]──────────────────────┐
+│                                                                    │
+│ ┌─ Source ─────────────────────────────────────────────────────┐  │
+│ │  Backend:    [▼ TotalSegmentator]                            │  │
+│ │  Source:     [▼ Portal venous (patient_PV.nrrd)]             │  │
+│ │  [Compute]                                                   │  │
+│ └──────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│ ┌─ Result ─────────────────────────────────────────────────────┐  │
+│ │  Status: ✓ Computed 2 min ago via TotalSegmentator           │  │
+│ │  ┌────────┬───────┬────┐                                     │  │
+│ │  │ Segment│ Color │ 👁 │                                     │  │
+│ │  ├────────┼───────┼────┤                                     │  │
+│ │  │ I      │ ■     │ 👁 │                                     │  │
+│ │  │ II     │ ■     │ 👁 │                                     │  │
+│ │  │ III    │ ■     │ 👁 │                                     │  │
+│ │  │ ⋯                                                          │  │
+│ │  └────────┴───────┴────┘                                     │  │
+│ └──────────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+- **`[Compute]`** triggers the backend on the Source image. First-use triggers `pip_install` per ADR-0023 lazy-install convention.
+- Result table is read-only — segments are auto-derived. Surgeon can toggle visibility per segment (`👁` column) for 3D-overlay inspection.
+- No `qMRMLNodeComboBox` in the tab; each compute replaces the previous Auto result (one auto-territory node per scene at a time, unless surgeon explicitly creates more in the Custom tab).
+
+## Custom segments tab
+
+```
+┌─[ Couinaud (automatic) ]──[ Custom segments ]──────────────────────────┐
+│  Classification: [▼ Manual Couinaud  ] [+][-][⋮]                       │
+│  Subdivision:    ◉ Couinaud I-VIII (with IVa/IVb)  ○ Custom            │
+│                                                                        │
+│  ┌─ Centerlines & groupings ────────────────────────────────────────┐ │
+│  │  Name              Color   Endpoints  Actions                    │ │
+│  │ ▼ Segment II        ■                  [⋯]                       │ │
+│  │     P2-main         ■        5         [↗][×]                    │ │
+│  │     P2-accessory ●  ■        3 ⚠       [↗][×]    ← selected      │ │
+│  │ ▶ Segment III (1)   ■                  [⋯]                       │ │
+│  │ ▶ Segment IV (empty)■                  [⋯]                       │ │
+│  │ ▶ Segment V (empty) ■                  [⋯]                       │ │
+│  │ ▶ Segment VI (empty)■                  [⋯]                       │ │
+│  │ ▶ Segment VII(empty)■                  [⋯]                       │ │
+│  │ ▶ Segment VIII(emp.)■                  [⋯]                       │ │
+│  │ ▶ Segment I  (empty)■                  [⋯]                       │ │
+│  │ ▼ (Unassigned)                                                   │ │
+│  │     loose1          ◌        2         [↗][×]                    │ │
+│  │ [+ Add centerline]   [+ Add segment]                             │ │
+│  └──────────────────────────────────────────────────────────────────┘ │
+│                                                                        │
+│  ┌─ Endpoints of: P2-accessory                  ⚠ stale ────────────┐ │
+│  │  qMRMLMarkupsControlPointTableWidget (Slicer-core, reused)       │ │
+│  │  #│ Name      │ R (mm)│ A (mm)│ S (mm) │ Vis │ Actions           │ │
+│  │  1│ P2-acc-1  │ -23.4 │  18.7 │   5.2  │ 👁  │ [⋯][×]            │ │
+│  │  2│ P2-acc-2  │ -19.1 │  14.3 │   7.8  │ 👁  │ [⋯][×]            │ │
+│  │  3│ P2-acc-3  │ -15.8 │  10.5 │  10.1  │ 👁  │ [⋯][×]            │ │
+│  │  [+ Add endpoint]   [Re-run ExtractCenterline]                   │ │
+│  └──────────────────────────────────────────────────────────────────┘ │
+│                                                                        │
+│  [Compute partition]                                                   │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### Top combobox
+
+- `qMRMLNodeComboBox` filtered on `vtkMRMLCustomTerritoriesNode` (the Custom subclass).
+- `[+]` creates a new empty manual classification — surgeon names it (defaults to "Manual Couinaud" or "Custom partition").
+- `[-]` deletes the current classification.
+- `[⋮]` exposes rename / advanced node-property edits.
+
+### Hierarchical table (master)
+
+Two-level tree: group → centerline. CRUD operations per ADR-0023's grilling-pass settlement:
+
+| Operation | Affordance |
+|-----------|-----------|
+| Add centerline | `[+ Add centerline]` → enters curve-markup placement mode → after Enter, prompt for group assignment → centerline appears in tree. |
+| Group centerlines | Drag a centerline across groups, OR `[↗]` opens a dropdown of groups to reassign. |
+| Delete centerline | `[×]` on the centerline row → confirmation → MRML node removed. |
+| Delete grouping | `[⋯ → Delete grouping]` on the group row → confirmation → group removed; centerlines fall back to `(Unassigned)` (not deleted). |
+| Reorder groups | Drag-to-reorder (Custom subdivision only; Couinaud subdivision has fixed I–VIII anatomical order). |
+
+The `(Unassigned)` pseudo-group at the bottom holds centerlines that exist but are not yet part of any segment. Visible-but-dotted/grey in 3D. Doesn't contribute to the partition until assigned.
+
+### Endpoints sub-table (detail)
+
+Reuses Slicer-core's `qMRMLMarkupsControlPointTableWidget`. Shows the control points of the **currently-selected centerline**. Selecting a group row (rather than a centerline) shows a hint "Select a centerline to view its endpoints."
+
+| Operation | Affordance |
+|-----------|-----------|
+| Add endpoint | `[+ Add endpoint]` → enters fiducial placement mode → new endpoint appends to the centerline's fiducial node. Centerline marked `⚠ stale`. |
+| Move endpoint | Edit R / A / S cells directly, OR drag the fiducial in 3D. Centerline marked `⚠ stale`. |
+| Delete endpoint | `[×]` per row. Centerline marked `⚠ stale`. |
+| Re-extract | `[Re-run ExtractCenterline]` → invokes VMTK on the current endpoint set → updates the centerline polyline node → clears stale flag. |
+| Reorder | Drag rows (affects centerline direction if relevant). |
+
+### Stale-state handling
+
+VMTK extraction is non-trivial (seconds). Edits mark the centerline `⚠ stale` rather than auto-re-running. Re-extraction triggers on explicit `[Re-run ExtractCenterline]` or implicitly on `[Compute partition]` (any stale centerlines re-extract first). `[Save]`-equivalent (just scene save, no bespoke button) blocks if anything stale; surgeon clicks Re-run first.
+
+## Behaviour notes
+
+### Subdivision modes (Custom tab)
+
+- **Couinaud I-VIII (with IVa/IVb)** — pre-populated groups Segment I through VIII (10 groups including IVa/IVb split per the verified SCT codes); fixed anatomical order; group rename disabled.
+- **Couinaud I-VIII (IV whole)** — 8 groups; IVa/IVb merged into IV.
+- **Custom** — surgeon-defined groups; `[+ Add segment]` creates a new empty group with editable name; drag-to-reorder enabled.
+
+### Computation
+
+`[Compute partition]` invokes the volumetry framework's Fast Marching algorithm (per the 2026-05-15 framework decision) with seeds sampled along the assigned centerlines (no barriers). Output: a partition `vtkImageData` + per-segment colors stored on the `vtkMRMLCustomTerritoriesNode`. Warns on `(Unassigned)` non-empty: "N centerlines unassigned — won't contribute. Compute anyway?".
+
+### Centerline data model
+
+Surgeon-facing primitive: endpoints (`vtkMRMLMarkupsFiducialNode`, N≥2 points). VMTK's `ExtractCenterlineLogic.extractCenterline(...)` returns the actual centerline polyline as a `vtkMRMLModelNode` per the existing implementation (NOT a `vtkMRMLMarkupsCurveNode` — that would be a geometric curve through clicks, not a vessel-following centerline). See [ADR-0023 §"Class abstraction for territories"][adr-0023] for the full data-model rationale.
+
+## Cross-stage interactions
+
+| Direction | Surface |
+|-----------|---------|
+| Stage 1 → Stage 3 (Auto tab) | Source image for backend inference. |
+| Stage 2 → Stage 3 (Custom tab) | Portal vein segment is the input to VMTK ExtractCenterline. |
+| Stage 3 → Stage 4 | Stage 4's classification-overlay combobox shows both subtypes; surgeon picks which to render. |
+| Stage 3 → Stage 5 | Stage 5's per-segment table joins the classification's segments against the resection partition. |
+| Sidebar | Stage 3 state indicator turns ✓ when at least one classification exists (either subtype). |
+
+## See also
+
+- [ADR-0023 §Stage 3][adr-0023]
+- [Territories class hierarchy][territories]
+- [GUI stage flow](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md)
+- [Stage 2 — Anatomy Definition](ui-stage-2-anatomy-definition.md) — upstream (Manual path).
+- [Stage 4 — Resection Planning](ui-stage-4-resection-planning.md) — downstream (classification overlay).

--- a/Docs/architecture/ui-stage-4-resection-planning.md
+++ b/Docs/architecture/ui-stage-4-resection-planning.md
@@ -1,0 +1,178 @@
+# UI architecture — Stage 4: Resection Planning
+
+Reference companion to [ADR-0023 §Stage 4][adr-0023]. Captures the
+resection-table inline-column layout, the per-row state machine
+controls, the distance-map status section, the classification
+overlay binding, and the resectogram-view invocation.
+
+[adr-0023]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0023-unified-gui-stage-workflow.md
+[adr-0019]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0019-resection-state-machine.md
+
+## What this stage does
+
+Define one or more resection surfaces via Bezier control polygons. Each resection cycles through a state machine (Init → Planning → Confirmed per [ADR-0019][adr-0019]). Multi-resection workflows (two-stage hepatectomy, RFA + resection) are first-class.
+
+Module home: `LiverResections/`.
+
+## Panel layout
+
+```
+┌─ 4. Resection Planning ────────────────────────────────────────────────┐
+│                                                                        │
+│ ┌─ Resections ─────────────────────────────────────────────────────┐  │
+│ │ ☰│●│👁│■│ Name        │ State    │ Init     │ Safety│ Risk     │⋯│  │
+│ │ ─┼─┼──┼─┼─────────────┼──────────┼──────────┼───────┼──────────┼─│  │
+│ │ ☰│●│👁│■│Right hep.   │ ✓ Conf.  │ S.Plane  │ 10 mm │avg spc.  │⋯│  │
+│ │ ☰│○│👁│■│Tumor wedge  │ Planning │ Spheroid │  8 mm │Custom 2 m│🔒│  │
+│ │ ☰│○│⊘│■│Wedge 3      │ Init 1/N │ Spheroid │ 10 mm │avg spc.  │⋯│  │
+│ │ [+ Add resection]                                                │  │
+│ └──────────────────────────────────────────────────────────────────┘  │
+│                                                                        │
+│ ┌─ Active resection: Tumor wedge ──────────────────────────────────┐  │
+│ │  [Init] ─▶ [Planning] ─▶ [Confirmed]                             │  │
+│ │              ↑ current                                           │  │
+│ │  Bezier:     4×4 grid  [⋯ Change grid]                           │  │
+│ │  Editing:    drag control points in 3D                           │  │
+│ │  [◀ Unlock to Init]   [Commit Planning → Confirmed ▶]            │  │
+│ │  [Open resectogram view ▶]                                       │  │
+│ └──────────────────────────────────────────────────────────────────┘  │
+│                                                                        │
+│ ┌─ Distance maps ──────────────────────────────────────────────────┐  │
+│ │  Status: ✓ Computed 2 min ago                                    │  │
+│ │  ✓ Tumor   ✓ Portal   ✓ Hepatic                                  │  │
+│ │  [Recompute distance maps]                                       │  │
+│ └──────────────────────────────────────────────────────────────────┘  │
+│                                                                        │
+│ ┌─ Classification overlay ─────────────────────────────────────────┐  │
+│ │  Classification: [▼ Couinaud (auto, TotalSegmentator)         ]  │  │
+│ │  ☑ Show segments in 3D view  ☐ Show in slice views               │  │
+│ │  Opacity: ─────────●─── 30%                                      │  │
+│ └──────────────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+## Resections table
+
+### Inline columns
+
+| Column | Affordance |
+|--------|-----------|
+| `☰` | Drag handle for re-ordering (the order is semantically load-bearing — surgical order + locator-overlap precedence on the resectogram). |
+| `●` | Active radio (only one resection editable at a time). |
+| `👁/⊘` | Visibility toggle. Non-active confirmed resections render semi-transparent; non-active editing-state resections hide. |
+| `■` | Color swatch — click opens color picker; stored on `vtkMRMLBezierSurfaceDisplayNode`. |
+| Name | Inline-editable. Click to rename. |
+| State | Badge (`Init <n>/<N>` / `Planning` / `✓ Conf.`). |
+| Init mode | `S.Plane` / `Spheroid` — locked at creation, requires Reset-to-Init to switch. |
+| Safety | Numeric mm input (free value, default 10 mm). |
+| Risk | Dropdown preset (`avg spacing` / `largest spacing` / `Custom N mm`). |
+| `⋯` | Menu: Rename, Delete (confirmation required for Confirmed), Duplicate, Unlock-from-Confirmed. |
+| `🔒` | Per-row Confirm button (shown when Planning state is ready to commit; replaces the `⋯` menu for that row). |
+
+### Re-order semantic
+
+Drag-to-reorder updates the resection list. The list order has weight:
+
+- **Surgical order** — typically reflects the planned operative sequence (two-stage hepatectomy: Stage 1 resection first row, Stage 2 resection second).
+- **`.lrp.json` schema v3** — persisted as a list (ordered).
+- **Locator precedence on resectogram overlap** — when multiple resection surfaces project onto the resectogram view (Stage 4 detail panel), top of table wins.
+
+## Active resection detail panel
+
+### State breadcrumb
+
+`[Init] ─▶ [Planning] ─▶ [Confirmed]` with an indicator under the current state. Visualised as a non-interactive breadcrumb — surgeon advances via the bottom-row transition buttons (or the per-row `🔒` in the resection table). Stepping back uses `[◀ Unlock to ...]`.
+
+### State-specific contents
+
+**Init state:**
+
+```
+Init mode:    ◉ Slicing Plane   ○ Distance Spheroid
+Init points:  2 / 2 placed
+              [Reset init points]
+              [Commit init → Planning ▶]
+```
+
+**Planning state:**
+
+```
+Bezier:       4 × 4 grid  (per ADR-0018 — 3×3 also possible via [⋯ → Change grid])
+Editing:      drag control points in 3D view (vtkLiverBezierWidget)
+              [◀ Unlock to Init]   [Commit Planning → Confirmed ▶]
+[Open resectogram view ▶]
+```
+
+**Confirmed state:**
+
+```
+Confirmed at: 2026-05-21 14:32 by current session
+For volumes + verification → continue to Stage 5.
+              [◀ Unlock to re-plan]
+[Open resectogram view ▶]
+```
+
+No numeric readouts in any state. Volume / margin / vessel-cut numbers live in Stage 5 per the 2026-05-21 compute-on-stable-state pushback.
+
+### Resectogram view button
+
+`[Open resectogram view ▶]` is visible per active resection across Planning and Confirmed states. Clicking it switches Slicer to a Slicer-Liver-registered custom layout (Hyperprobe-style separate view per the 2026-05-15 resectogram decision) showing the unrolled resection surface for the active resection. Closing the resectogram returns to Conventional layout.
+
+## Distance maps section
+
+```
+Status: ✓ Computed 2 min ago | ⚠ Not computed — margin visualization disabled
+[Recompute distance maps]
+```
+
+- Auto-triggers on Stage 4 entry per the 2026-05-14 decision (background infrastructure).
+- `[Recompute]` is the manual-recompute affordance (also per 2026-05-14).
+- When distance maps don't exist (fresh entry without computation, or after data invalidation), UI elements depending on them disable:
+  - Tumor-margin visualization on the resection-surface shader.
+  - Safety/Risk band coloring on the surface.
+  - (Stage 5's verification consumers are unaffected here.)
+- Status banner explains the disable state ("⚠ Not computed — margin visualization disabled").
+
+## Classification overlay section
+
+```
+Classification: [▼ Couinaud (auto, TotalSegmentator)] [None]
+☑ Show segments in 3D view  ☐ Show in slice views
+Opacity: ─────────●─── 30%
+```
+
+- `qMRMLNodeComboBox` filtered on `vtkMRMLAbstractTerritoriesNode` (both subtypes from Stage 3 surface here).
+- `addEnabled=false` / `removeEnabled=false` — Stage 4 doesn't create or delete classifications (that's Stage 3's responsibility). Independent binding per ADR-0023 — Stage 4's selection doesn't sync to Stages 3 or 5.
+- `noneEnabled=true` — selecting "None" disables the overlay cleanly.
+- Opacity slider applies to the segment overlay; resection surfaces render fully opaque on top.
+
+## Multi-resection visualization
+
+- All Confirmed resections render in 3D simultaneously (per the 2026-05-21 settlement).
+- Non-active Confirmed resections are semi-transparent.
+- Active resection's Bezier widget is the only interactive surface — other surfaces render but don't pick.
+- Per-row `👁/⊘` lets surgeon explicitly hide any resection.
+
+## Add-resection workflow
+
+`[+ Add resection]` immediately enters Init mode with auto-name (`Resection 1`, `Resection 2`, ...). Defaults: Slicing Plane init, Safety 10 mm, Risk = image-spacing-average. Surgeon renames via the table row's name cell. Friction-free start; per the 2026-05-21 settlement.
+
+## Cross-stage interactions
+
+| Direction | Surface |
+|-----------|---------|
+| Stage 1 → Stage 4 | Provides the CT volume the Bezier-surface mapper renders against. |
+| Stage 2 → Stage 4 | Canonical Segmentation node provides liver / tumor / portal / hepatic structures for the distance-map computation. |
+| Stage 3 → Stage 4 | Classification overlay combobox surfaces both `Std` and `Custom` Territories subtypes. Independent binding. |
+| Stage 4 → Stage 5 | Confirmed resections become barriers for Stage 5's volumetry partition. |
+| Stage 4 → Stage 6 | Confirmed resections + their per-row name / margins / state persist into `.lrp.json` schema v3. |
+| Sidebar | Stage 4 state indicator turns ✓ when at least one resection reaches Confirmed state. |
+
+## See also
+
+- [ADR-0023 §Stage 4][adr-0023]
+- [ADR-0019 — Resection state machine][adr-0019]
+- [Resection state machine diagram](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/resection-state-machine.md)
+- [GUI stage flow](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md)
+- [Stage 3 — Vascular Territories](ui-stage-3-vascular-territories.md) — supplies the classification overlay.
+- [Stage 5 — Volumetry](ui-stage-5-volumetry.md) — consumes Confirmed resections as barriers.

--- a/Docs/architecture/ui-stage-4-resection-planning.md
+++ b/Docs/architecture/ui-stage-4-resection-planning.md
@@ -29,8 +29,7 @@ Module home: `LiverResections/`.
 │ └──────────────────────────────────────────────────────────────────┘  │
 │                                                                        │
 │ ┌─ Active resection: Tumor wedge ──────────────────────────────────┐  │
-│ │  [Init] ─▶ [Planning] ─▶ [Confirmed]                             │  │
-│ │              ↑ current                                           │  │
+│ │   Init  ─▶  [Planning]  ─▶  Confirmed                            │  │
 │ │  Bezier:     4×4 grid  [⋯ Change grid]                           │  │
 │ │  Editing:    drag control points in 3D                           │  │
 │ │  [◀ Unlock to Init]   [Commit Planning → Confirmed ▶]            │  │
@@ -81,11 +80,13 @@ Drag-to-reorder updates the resection list. The list order has weight:
 
 ### State breadcrumb
 
-`[Init] ─▶ [Planning] ─▶ [Confirmed]` with an indicator under the current state. Visualised as a non-interactive breadcrumb — surgeon advances via the bottom-row transition buttons (or the per-row `🔒` in the resection table). Stepping back uses `[◀ Unlock to ...]`.
+`Init ─▶ [Planning] ─▶ Confirmed` — the **bracketed** state is the current state; non-current states render as plain labels. In the actual Qt UI the indicator is a **colour code** on the current state's label (e.g. accent foreground + bracket glyph) — the ASCII mockup uses brackets `[...]` to convey the same idea without colour. No separate "↑ current" annotation line; the bracket/colour *is* the indicator.
+
+Visualised as a non-interactive breadcrumb — surgeon advances via the bottom-row transition buttons (or the per-row `🔒` in the resection table). Stepping back uses `[◀ Unlock to ...]`.
 
 ### State-specific contents
 
-**Init state:**
+**Init state** (breadcrumb: `[Init] ─▶ Planning ─▶ Confirmed`):
 
 ```
 Init mode:    ◉ Slicing Plane   ○ Distance Spheroid
@@ -94,7 +95,7 @@ Init points:  2 / 2 placed
               [Commit init → Planning ▶]
 ```
 
-**Planning state:**
+**Planning state** (breadcrumb: `Init ─▶ [Planning] ─▶ Confirmed`):
 
 ```
 Bezier:       4 × 4 grid  (per ADR-0018 — 3×3 also possible via [⋯ → Change grid])
@@ -103,7 +104,7 @@ Editing:      drag control points in 3D view (vtkLiverBezierWidget)
 [Open resectogram view ▶]
 ```
 
-**Confirmed state:**
+**Confirmed state** (breadcrumb: `Init ─▶ Planning ─▶ [Confirmed]`):
 
 ```
 Confirmed at: 2026-05-21 14:32 by current session

--- a/Docs/architecture/ui-stage-5-volumetry.md
+++ b/Docs/architecture/ui-stage-5-volumetry.md
@@ -1,0 +1,152 @@
+# UI architecture — Stage 5: Volumetry
+
+Reference companion to [ADR-0023 §Stage 5][adr-0023]. Captures the
+flexible seed-and-category builder, the categories master + seeds
+control-points detail, the barriers checkbox list, and the
+explicit-compute output table.
+
+[adr-0023]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0023-unified-gui-stage-workflow.md
+
+## What this stage does
+
+Compute per-category volumes by partitioning the liver parenchyma via the seed-and-category framework (2026-05-15 decision). Categories are surgeon-defined; seeds are fiducial points; barriers are Confirmed resection surfaces from Stage 4. Pure analytical workbench — **no verification card** in v2.0 (research-tool-grade per ADR-0023).
+
+Module home: `LiverVolumetry/`.
+
+## Panel layout
+
+```
+┌─ 5. Volumetry ─────────────────────────────────────────────────────┐
+│                                                                    │
+│  Partition: [▼ Resected vs Remnant] [+][-][⋮]                      │
+│                                                                    │
+│  ┌─ Categories ───────────────────────────────────────────────┐   │
+│  │  Name              Color   Seeds   Actions                 │   │
+│  │  Resected      ●   ■         2     [⋯]                     │   │
+│  │  Remnant           ■         1     [⋯]                     │   │
+│  │  [+ Add category]                                          │   │
+│  └────────────────────────────────────────────────────────────┘   │
+│                                                                    │
+│  ┌─ Seeds of: Resected ───────────────────────────────────────┐   │
+│  │  qMRMLMarkupsControlPointTableWidget (Slicer-core, reused) │   │
+│  │  # │ Name      │ R (mm)│ A (mm)│ S (mm) │ Vis │ Actions    │   │
+│  │  1 │ Reseed-1  │ ⋯     │ ⋯     │ ⋯      │ 👁  │ [⋯][×]     │   │
+│  │  2 │ Reseed-2  │ ⋯     │ ⋯     │ ⋯      │ 👁  │ [⋯][×]     │   │
+│  │  [+ Add seed]                                              │   │
+│  └────────────────────────────────────────────────────────────┘   │
+│                                                                    │
+│  ┌─ Barriers ─────────────────────────────────────────────────┐   │
+│  │  Resections as barriers:                                   │   │
+│  │   ☑ Right hemihepatectomy                                  │   │
+│  │   ☑ Tumor 2 wedge                                          │   │
+│  │   ☐ Wedge 3 (not Confirmed — disabled)                     │   │
+│  └────────────────────────────────────────────────────────────┘   │
+│                                                                    │
+│  ┌─ Compute ──────────────────────────────────────────────────┐   │
+│  │  ROI: [▼ Liver (resolved via SCT)]                         │   │
+│  │  [Compute partition]    Last: 30 s ago                     │   │
+│  │                                                            │   │
+│  │  Volumes:                                                  │   │
+│  │   Resected    330 mL   (22 %)                              │   │
+│  │   Remnant    1210 mL   (78 %)                              │   │
+│  │                                                            │   │
+│  │  Output partition: [auto-named Segmentation ▼ visible]     │   │
+│  └────────────────────────────────────────────────────────────┘   │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## Top combobox — partitions
+
+- `qMRMLNodeComboBox` filtered on `vtkMRMLLiverVolumetryNode`.
+- Multiple partitions per scene are supported (e.g., "Resected vs Remnant" + "Custom regional analysis 1" + "Right-anterior watershed").
+- `[+]` creates a new empty partition. Default name on first creation: "Resected vs Remnant" (the dominant use case). Per the 2026-05-21 settlement: **empty by default** — no auto-populated categories or seeds.
+- `[-]` deletes the current partition (confirmation; deletes the output Segmentation node alongside).
+- `[⋮]` exposes rename / advanced properties.
+
+## Categories master table
+
+Flat table — categories don't have sub-entities at the row level (their seeds appear in the detail panel below when selected).
+
+| Column | Affordance |
+|--------|-----------|
+| Name | Inline-editable. Surgeon-defined ("Resected", "Remnant", "Segment II watershed", "Custom region A"). |
+| Color | Click opens color picker; stored on the category's metadata in the volumetry node. |
+| Seeds | Count of fiducial points in the category's `vtkMRMLMarkupsFiducialNode`. |
+| Actions | `[⋯]` menu: Rename, Change color, Delete. Multi-select for batch delete. |
+
+### Active category radio
+
+The `●` selector in the leftmost column (not shown in the column list above but visually present) marks the active category. The Seeds sub-table below shows the active category's seeds. Switching the active radio swaps the sub-table contents.
+
+## Seeds detail sub-table
+
+Reuses Slicer-core's `qMRMLMarkupsControlPointTableWidget`, wired to the active category's fiducial node. Same affordances as the Stage 3 endpoints sub-table — add, move, delete, jump-to-3D, multi-select.
+
+Per the 2026-05-21 settlement: **seeds are surgeon-placed**. No auto-placement for the Resected/Remnant case (surgeon picks one point on each side of the resection surface manually). This adds friction in the dominant case but keeps the framework primitive simple and predictable.
+
+## Barriers section
+
+```
+Resections as barriers:
+ ☑ Right hemihepatectomy
+ ☑ Tumor 2 wedge
+ ☐ Wedge 3 (not Confirmed — disabled)
+```
+
+- Lists every resection from Stage 4. Confirmed resections are check-eligible; non-Confirmed are disabled with hint text.
+- Per the 2026-05-21 settlement: **all Confirmed resections auto-tick as barriers on Stage 5 entry**. Surgeon unticks any that should not act as a barrier (rare).
+- Barriers feed the framework's Fast Marching speed map (1 inside ROI, 0 on rasterised barrier voxels per the 2026-05-15 framework decision).
+
+## Compute section
+
+### ROI selector
+
+`[▼ Liver (resolved via SCT)]` — typically auto-resolved from the canonical Segmentation node's Liver segment (SCT 10200004). Surgeon can override for research workflows.
+
+### Compute trigger
+
+`[Compute partition]` — explicit button. Lazy evaluation (no auto-compute on input change) because Fast Marching is non-trivial and surgeon's input-fiddling shouldn't trigger spurious recomputes.
+
+### Volumes table
+
+Per-category volumes appear after compute:
+
+```
+Resected    330 mL   (22 %)
+Remnant    1210 mL   (78 %)
+```
+
+Percentages are of total liver ROI volume. Sortable column header.
+
+### Output Segmentation node
+
+A `vtkMRMLSegmentationNode` named after the partition (e.g., "Resected vs Remnant — partition"), with one segment per category, color-matched to the category's color. Stock Slicer rendering in 3D + slice views per ADR-0012's deferral of LayerDM display-side migration to v2.1. Surgeon can toggle visibility globally (`▼ visible`).
+
+## What's not in Stage 5
+
+- **No verification card** (the 2026-05-21 settlement dropped it from v2.0).
+- **No per-resection volume breakdown** beyond what the partition naturally produces. Per-resection-specific volumes (if needed) come from running multiple partitions with different category configurations.
+- **No per-segment intersection with classification** (that's verification-flavoured analytics).
+- **No resectogram** — the resectogram view lives in Stage 4 per ADR-0023.
+- **No "Continue to Export" button on top** — sidebar navigation handles stage transitions.
+
+## Persistence
+
+Per the 2026-05-21 settlement: multiple partitions persist in `.lrp.json` schema v3 as a list (per partition: name, category names + colors, seed positions, output Segmentation node reference). Per-stage last-selection field stores which partition the surgeon was last viewing. Reload restores both.
+
+## Cross-stage interactions
+
+| Direction | Surface |
+|-----------|---------|
+| Stage 2 → Stage 5 | Canonical Segmentation provides the ROI (Liver segment). |
+| Stage 3 → Stage 5 | Classification combobox (if added — currently not in v2.0 Stage 5 panel; downstream consumers may add it). Per-segment intersection analytics deferred. |
+| Stage 4 → Stage 5 | Confirmed resections appear in the Barriers checkbox list (auto-ticked). |
+| Stage 5 → Stage 6 | Volumetry partitions persist into `.lrp.json` schema v3 as part of the plan sidecar. |
+| Sidebar | Stage 5 state indicator turns ✓ when at least one partition has been computed. |
+
+## See also
+
+- [ADR-0023 §Stage 5][adr-0023]
+- [GUI stage flow](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md)
+- [Stage 4 — Resection Planning](ui-stage-4-resection-planning.md) — supplies Confirmed resections as barriers.
+- 2026-05-15 volumetry-framework PKS subnote — algorithm details (Fast Marching with binary speed map, ITK `FastMarchingImageFilter`, barrier rasterisation via `vtkPolyDataToImageStencil`).

--- a/Docs/architecture/ui-stage-6-export.md
+++ b/Docs/architecture/ui-stage-6-export.md
@@ -1,0 +1,101 @@
+# UI architecture — Stage 6: Export
+
+Reference companion to [ADR-0023 §Stage 6][adr-0023]. Captures the
+minimal export panel that lives as a section under the Liver shell
+(not a separate scripted module).
+
+[adr-0023]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0023-unified-gui-stage-workflow.md
+
+## What this stage does
+
+Persist the plan and capture screenshots. Three buttons, each a thin wrapper around an existing Slicer mechanism. No bespoke export logic beyond the `.lrp.json` schema v3 storage node.
+
+Module home: section under the `Liver` shell (per the 2026-05-21 settlement — light enough not to warrant a separate scripted module).
+
+## Panel layout
+
+```
+┌─ 6. Export ────────────────────────────────────────────────────────┐
+│                                                                    │
+│  ┌─ Resection plan ─────────────────────────────────────────────┐ │
+│  │  Saves all Confirmed resections, their state, init points,   │ │
+│  │  classification + volumetry references.                      │ │
+│  │                                                              │ │
+│  │  Format: .lrp.json (schema v3)                               │ │
+│  │  Default path: <scene_dir>/<scene_name>.lrp.json             │ │
+│  │  [Export plan…]                                              │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+│                                                                    │
+│  ┌─ Full scene ─────────────────────────────────────────────────┐ │
+│  │  Includes volumes, segmentations, classification, volumetry, │ │
+│  │  resections — everything in the scene.                       │ │
+│  │                                                              │ │
+│  │  Use Slicer's standard File ▸ Save Data, or:                 │ │
+│  │  [Save scene…]    (delegates to stock Slicer)                │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+│                                                                    │
+│  ┌─ Screenshot ─────────────────────────────────────────────────┐ │
+│  │  Capture current 3D + slice views.                           │ │
+│  │  [Capture views…]   (delegates to Slicer's ScreenCapture)    │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## Behaviour notes
+
+### Export plan
+
+- Invokes `vtkMRMLBezierSurfaceStorageNode::WriteData(...)` (the existing storage node from PR #361, upgraded to schema v3 per ADR-0023 §"Persistence" + tracking issue #411).
+- Default save path: `<scene_directory>/<scene_name>.lrp.json` — surgeon overrides via the file dialog.
+- No auto-save per the 2026-05-21 settlement. Explicit-only.
+- Sidecar-only (scene-local node IDs) per the v2.0 stance; cross-machine plan transfer is a deferred v2.1 concern (tracked under issue #415).
+
+### Save scene
+
+- One-click shortcut to Slicer's `File ▸ Save Data` dialog. The shortcut exists for surgeon convenience — Slicer's stock menu also works.
+- Saves the full scene (`.mrml` + supporting files for volumes, segmentations, etc.) — independent of the `.lrp.json` export.
+
+### Screenshot
+
+- Invokes Slicer's stock `ScreenCapture` module. The shortcut exists so surgeon doesn't have to navigate to a different module.
+
+## What's NOT in Stage 6 (v2.0)
+
+Per ADR-0023 §"What is NOT in v2.0":
+
+- **PDF report generation** — needs a template + formatting decisions + verification content (which v2.0 doesn't have). Deferred.
+- **3D model export (STL / OBJ)** — surgeon uses Slicer's stock Model export for now. AR / intraop integration is its own concern.
+- **Plan diff / comparison** between two `.lrp.json` files — research feature; deferred.
+- **Auto-save on Confirmed transition** — adds complexity (paths, conflicts) without clear demand; deferred.
+- **Cross-machine plan transfer** — `.lrp.json` is sidecar-only in v2.0 (stable-ID resolution is v2.1+).
+
+## Cross-stage interactions
+
+| Direction | Surface |
+|-----------|---------|
+| Stage 1 → Stage 6 | Scene contains the role-tagged volumes; "Save scene" persists them. |
+| Stage 2 → Stage 6 | Canonical Segmentation node persists in the scene save. Not in `.lrp.json` (too large; lives in `.mrml` + sidecar files). |
+| Stage 3 → Stage 6 | Classification node references persist in `.lrp.json` schema v3. The classification's own data (labelmap, centerlines, etc.) lives in the scene. |
+| Stage 4 → Stage 6 | Confirmed resections — Bezier control polygons, state, init points, margins, name, ordering — all persist in `.lrp.json` schema v3 (the primary content). |
+| Stage 5 → Stage 6 | Volumetry partition references persist in `.lrp.json`. Partition output Segmentations live in the scene. |
+| Sidebar | Stage 6 state indicator turns ✓ when either `[Export plan]` or `[Save scene]` has been invoked in the current session. |
+
+## Persistence schema (v3) — what `.lrp.json` captures
+
+| Content | Source | Stored as |
+|---------|--------|-----------|
+| Per-resection name + Safety + Risk margins + state + init points + Bezier control polygon | Stage 4 | Inline (the schema's primary content). |
+| Resection list ordering | Stage 4 | List position (ordered). |
+| Classification node reference + subtype discriminator | Stage 3 | Scene-local node ID + `subtype` field. |
+| Volumetry partition references | Stage 5 | List of scene-local node IDs. |
+| Per-stage last-selection | Stages 3, 4, 5 | Field on the schema's `metadata`. |
+
+`.lrp.json` v2 → v3 fallback loader required for backward compatibility (per issue #411).
+
+## See also
+
+- [ADR-0023 §Stage 6][adr-0023]
+- [GUI stage flow](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md)
+- [Stage 4 — Resection Planning](ui-stage-4-resection-planning.md) — primary content source for `.lrp.json`.
+- Issue [#411](https://github.com/ALive-research/Slicer-Liver/issues/411) — schema v3 implementation.
+- Issue [#415](https://github.com/ALive-research/Slicer-Liver/issues/415) — v2.1 cross-machine plan transfer (deferred).

--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -128,7 +128,24 @@ exclude_patterns = [
     "_build",
     "Thumbs.db",
     ".DS_Store",
-    "architecture/**",
+    # Architecture docs are admitted individually via the index
+    # toctree as they get touched up to compile under -W (per
+    # ADR-0017's rollout plan).  Pre-existing docs that still ship
+    # raw `{mermaid}` fences and cross-repo-root links are listed
+    # by name so newly-authored, convention-compliant docs (e.g.
+    # the `ui-stage-*` set from the 2026-05-21 design push) can
+    # join the toctree without dragging the pre-existing files in.
+    "architecture/README.md",
+    "architecture/control-grid-grouping.md",
+    "architecture/current-mrml-node-hierarchy.md",
+    "architecture/gui-stage-flow.md",
+    "architecture/rendering-pipeline.md",
+    "architecture/resection-state-machine.md",
+    "architecture/slicer-host-accessibility-survey.md",
+    "architecture/surface-representation-taxonomy.md",
+    "architecture/target-mrml-node-hierarchy.md",
+    "architecture/territories-class-hierarchy.md",
+    "architecture/ui/**",
     "dependencies/**",
     # ADRs are admitted *individually* via the index toctree so the
     # scaffold compiles without dragging in unmigrated cross-refs.

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -45,3 +45,15 @@ adr/0023-unified-gui-stage-workflow.md
 adr/0024-segmentation-orchestration.md
 adr/0026-segment-editor-effects.md
 ```
+
+```{toctree}
+:maxdepth: 1
+:caption: UI architecture (per-stage)
+
+architecture/ui-stage-1-case-setup.md
+architecture/ui-stage-2-anatomy-definition.md
+architecture/ui-stage-3-vascular-territories.md
+architecture/ui-stage-4-resection-planning.md
+architecture/ui-stage-5-volumetry.md
+architecture/ui-stage-6-export.md
+```


### PR DESCRIPTION
## Summary

Captures the surgeon-facing UI mockups + behaviour notes for each of the six v2.0 workflow stages defined in ADR-0023. Fills the gap where ADR text + chat history were the only home for the per-stage panel layouts.

Six new docs under `Docs/architecture/`:

| Doc | Covers |
|-----|--------|
| `ui-stage-1-case-setup.md` | DICOM/NIfTI load + role tagging + manifest + optional registration + layout |
| `ui-stage-2-anatomy-definition.md` | per-structure cards; scratch + Accept; Kumar-Oram refinement via Segment Editor effect; tumor enumeration |
| `ui-stage-3-vascular-territories.md` | two-tab structure (Couinaud Auto / Custom segments); hierarchical centerlines+groupings table; master-detail endpoints sub-table |
| `ui-stage-4-resection-planning.md` | resection table inline columns; active-resection state breadcrumb; distance-map status; classification overlay; resectogram-view button |
| `ui-stage-5-volumetry.md` | flexible seed-and-category builder; categories master + seeds detail; barriers checkbox list; explicit compute |
| `ui-stage-6-export.md` | three-button minimal section under the Liver shell; `.lrp.json` schema v3 + scene save + screenshot delegations |

Plus a new toctree section `"UI architecture (per-stage)"` in `Docs/index.md` so Sphinx/RTD builds them.

## Why ASCII not Mermaid

Considered modern Mermaid `block-beta` (Mermaid 11+) for the UI layouts. block-beta can show zone-level layouts but cannot represent columns *inside* a block — which is most of what stages 3, 4, and 5 need (resection table with 8+ inline columns; hierarchical centerlines tree with endpoints sub-table; categories+seeds master-detail). ASCII handles tables natively and renders identically on GitHub + Sphinx.

## Alignment with in-flight ADR PRs

- ADR-0023 (merged PR #406) + amendment PR #421 (drops MONAILabel from lazy-install).
- ADR-0024 (Draft PR #419) — including Alt H drop of MONAILabel-DeepGrow from v2.0.
- ADR-0026 (Draft PR #420) — Segment Editor effects with Kumar-Oram first instance.
- Stage 2 doc (in this PR) aligns with Alt H (drops MONAILabel-DeepGrow path; mentions Segment Editor manual refinement for tumors; flags v2.1+ deferred decision).
- Stage 3 doc references the territories class hierarchy via absolute URL.
- Stage 4 doc references the resection state machine via absolute URL.
- Stage 5 doc says no verification card per ADR-0023 §"What is NOT in v2.0" + Q5 (research-tool-grade positioning).
- Stage 6 doc references schema v3 + sidecar-only stance.

## Per-stage internal links

The 6 stage docs cross-reference each other via relative-path sibling links (e.g., `[Stage 2 — Anatomy Definition](ui-stage-2-anatomy-definition.md)`). Since they're all in the same new toctree section, MyST resolves these as xrefs.

References to non-stage architecture docs (gui-stage-flow.md, resection-state-machine.md, territories-class-hierarchy.md) use absolute GitHub URLs since those docs are not yet in any toctree.

## Authorship

These docs were drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code, drawing on the 2026-05-21 stage-by-stage design walkthrough + grilling pass + the resolved scope changes (Kumar-Oram → effect; MONAILabel → v2.1+). Opened as Draft for human review.

## Test plan

- [ ] Maintainer reads each per-stage doc and confirms the mockup + behaviour notes match the 2026-05-21 design conversation.
- [ ] CI green (sphinx-build builds the new toctree section; docs-lint validates Markdown).
- [ ] `/slicer-review` may be requested before flip to Ready.