### PR TITLE
DIAG: gcovr -v to root-cause empty coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,27 @@ jobs:
           # by design; the exclude was matching them all and pruning the
           # real coverage data out before source-path resolution.
           # Symptom: ``(WARNING) All coverage data is filtered out``.
+          #
+          # DIAGNOSTIC RUN: ``-v`` (verbose) + the gcovr per-file
+          # filter trace via ``--print-summary`` is intentional here.
+          # The first cut of the gcovr step still emits "All coverage
+          # data is filtered out. lines: 0.0% (0 out of 0)" on every
+          # run since at least PR #405 landed; this run captures
+          # gcovr's own reasoning so the next-step fix is targeted at
+          # the actual rule that's pruning data rather than guesswork.
+          # Revert to a quiet invocation in the follow-up PR.
+          #
+          # We also ``ls`` the build-coverage tree first so the run
+          # log records whether ``.gcda`` files actually exist before
+          # gcovr runs (rules out "instrumentation never produced
+          # data" vs "data exists but is filtered").
+          echo "--- build-coverage .gcda inventory ---"
+          find build-coverage -name '*.gcda' 2>/dev/null | head -30 || true
+          echo "--- .gcda count: $(find build-coverage -name '*.gcda' 2>/dev/null | wc -l) ---"
+          echo "--- .gcno count: $(find build-coverage -name '*.gcno' 2>/dev/null | wc -l) ---"
+          echo "--- gcovr -v invocation ---"
           gcovr \
+            -v \
             --root "$GITHUB_WORKSPACE" \
             --xml --output coverage-cxx.xml \
             --exclude '.*Testing.*' \


### PR DESCRIPTION
## Why

Coverage CI has been emitting `(WARNING) All coverage data is filtered out. lines: 0.0% (0 out of 0)` on every run since at least PR #405 — visible on the latest `preview` run [26278430193](https://github.com/ALive-research/Slicer-Liver/actions/runs/26278430193) and on every open PR (e.g. PR #425). The PR-comment "no change" signal that PR authors are seeing on Codecov is correct: zero data is being uploaded.

## What this PR does

**Diagnostic-only.** Adds two lines before the existing `gcovr` invocation and `-v` to the invocation itself:

- `find build-coverage -name '*.gcda'` printed to the run log so we can tell apart "instrumentation never wrote .gcda files" (compiler / link-flag issue) vs. "data files exist but gcovr filters them out" (filter issue).
- `gcovr -v` so gcovr's own per-file decision log lands in the run log instead of just the summary line.

The remaining workflow shape is unchanged.

## What this PR does NOT do

No fix. Once one CI run completes and we know which case we're in, a follow-up PR ships the actual fix (most likely a one-line removal of `--exclude '.*CMakeFiles.*'`, by analogy with the prior removal of `--exclude '.*/build-coverage/.*'` already noted in this step's comment block — both are data-file-path excludes masquerading as source-path filters).

## Test plan

- [ ] CI run completes — coverage step runs (it is non-blocking per ADR-0021).
- [ ] Run log shows the `.gcda` inventory.
- [ ] Run log shows gcovr `-v` per-file decisions.
- [ ] Read both, write a 1-line root-cause comment on this PR, then close this PR un-merged and open the follow-up fix PR.

## References

- `Docs/adr/0021-coverage-measurement.md` — coverage is non-blocking by design in v2.0.0's first cut.
- Memory: `feedback_codecov_integration_first_cut.md` flags "gcovr filter shape" as one of the three known empty-upload modes.

---

*AI-assisted authorship: drafted by Claude Opus 4.7 (`claude-opus-4-7`) via Claude Code under the maintainer's brief.*