### PR TITLE
ENH: .lrp.json schema v2 — capture v2.0 surgeon state (T5.2-e)

### DIFF
--- a/Docs/adr/0023-unified-gui-stage-workflow.md
+++ b/Docs/adr/0023-unified-gui-stage-workflow.md
@@ -110,9 +110,9 @@ The lazy-pip-install pattern is **only viable for AI tools that consume as a Pyt
 
 Slicer-Liver consumes TotalSegmentator's Python API directly — it does not require the upstream TotalSegmentator *Slicer extension wrapper* to be installed. Surgeon interacts via Slicer-Liver's UI, not via the upstream extension's widget.
 
-### Persistence — `.lrp.json` schema v3
+### Persistence — `.lrp.json` schema v2
 
-The existing `.lrp.json` storage (schema v2 from [PR #383](https://github.com/ALive-research/Slicer-Liver/pull/383)) bumps to v3 to capture v2.0's surgeon-facing state:
+The `.lrp.json` storage (introduced in [PR #361](https://github.com/ALive-research/Slicer-Liver/pull/361), extended for variable-size Bezier in [PR #383](https://github.com/ALive-research/Slicer-Liver/pull/383)) lands a unified schema v2 for the 2026 v2.0.0 release. v1 was preview-only and is not part of the released contract; the reader rejects it. v2 captures v2.0's surgeon-facing state:
 
 - Per-resection name + Safety + Risk margin values.
 - Resection list ordering (the surgical-order + locator-precedence semantic).
@@ -197,7 +197,7 @@ Force Stage 3 Auto and Manual to share the framework's `vtkMRMLLiverVolumetryNod
 - The Liver shell now owns a non-trivial navigation widget — implementation cost.
 - Per-stage state-indicator logic must compute correctness (e.g., "has Stage 2 produced a canonical Segmentation?"). Each module exposes a `isComplete()`-like query for the sidebar.
 - Two `vtkMRMLAbstractTerritoriesNode` subclasses + a base imply C++ MRML node hierarchy work (per [ADR-0004](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0004-python-cpp-boundary.md) — data nodes are C++).
-- `.lrp.json` schema v3 needs a migration loader from v2; load-time fallbacks for missing fields.
+- `.lrp.json` schema v2 carries the surgeon-facing state in a `resection` block + a scene-wide `scene` block; reader rejects v1 (preview-only, not part of the released contract).
 - Subject Hierarchy management code must be wired across every node-creating module — a per-module discipline gate.
 - The resectogram custom layout registration is a new mechanism in `LiverResections/`.
 
@@ -206,7 +206,7 @@ Force Stage 3 Auto and Manual to share the framework's `vtkMRMLLiverVolumetryNod
 - **Architecture diagrams** in `Docs/architecture/` — stage flow + dependency map, territories class hierarchy, MRML node landscape.
 - **ADR-0024 — Segmentation orchestration** for Stage 2's per-structure micro-workflows (TotalSegmentator + Kumar-Oram Segment Editor effect + Segment Editor manual orchestration). Interactive tumor refinement (e.g., MONAILabel-DeepGrow) is deferred to v2.1+ per ADR-0024 Alternative H.
 - **ADR-0025 — Locator architecture** for the resectogram hover→3D + click→reslice interactions, the 1:1 (u,v) mapping insight, and the v2.0/v2.1 scope split.
-- **Schema v3 migration** PR for `vtkMRMLBezierSurfaceStorageNode` (`.lrp.json`).
+- **Schema v2 unified surgeon-state** PR for `vtkMRMLBezierSurfaceStorageNode` (`.lrp.json`).
 - **Class refactor** PRs for `vtkMRMLAbstractTerritoriesNode` + subclasses + Stage 3 Auto and Manual tab rewiring.
 - **`LiverSegments/` → `VascularTerritories/` rename** + content refactor into the framework.
 - **`LiverSegmentation/` new module** + lazy-install machinery for TotalSegmentator.
@@ -225,7 +225,7 @@ Reviewable invariants that signal this decision is honoured:
 - `LiverResections/` registers a custom Slicer layout for the resectogram view.
 - The sidebar's per-stage state indicators are driven by a per-stage `isComplete()` query (or equivalent) defined by each stage's module.
 - No new module declares `TotalSegmentator` or `MONAILabel` as `EXTENSION_DEPENDS`. The first-use install path is implemented in `LiverSegmentation/Logic/` (and any other AI-consuming module).
-- `.lrp.json` schema header reads `"schemaVersion": 3` on writes; reader supports v2-to-v3 fallback loading.
+- `.lrp.json` schema header reads `"schemaVersion": 2` on writes; reader rejects v1 outright and tolerates absent surgeon-state blocks within v2 via documented defaults.
 - Subject Hierarchy folder names "Anatomy", "Vascular Territories", "Resections", "Volumetry" exist after typical workflow use. Grep for `SubjectHierarchyCreateFolder` (or upstream equivalent) in each module's logic.
 - The 2026-05-14 stitch and 2026-05-15 framework PKS notes carry "Superseded by ADR-0023" annotations on the relevant claims.
 

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -12,6 +12,7 @@ set(KIT_TEST_SRCS
   vtkMRMLBezierSurfaceNodeTest1.cxx
   vtkMRMLBezierSurfaceDisplayNodeTest1.cxx
   vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+  vtkMRMLBezierSurfaceStorageNodeTest2.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -44,3 +45,4 @@ slicerMacroConfigureModuleCxxTestDriver(
 SIMPLE_TEST(vtkMRMLBezierSurfaceNodeTest1)
 SIMPLE_TEST(vtkMRMLBezierSurfaceDisplayNodeTest1)
 SIMPLE_TEST(vtkMRMLBezierSurfaceStorageNodeTest1)
+SIMPLE_TEST(vtkMRMLBezierSurfaceStorageNodeTest2)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
@@ -4,18 +4,23 @@
 
   Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
-  Tests for vtkMRMLBezierSurfaceNode — the data-only node landed by
-  ADR-0014 §1.  Exercises:
-
-   - defaults (constructor values)
-   - State / InitializationMode enum round-trip
-   - Bezier control grid round-trip
-   - SlicingPlane init-mode subordinate data
-   - DistanceSpheroid init-mode subordinate data
-   - XML serialize/deserialize via an internal scene snapshot
-   - CopyContent / DeepCopy
-
 ==============================================================================*/
+
+/**
+ * \file vtkMRMLBezierSurfaceNodeTest1.cxx
+ *
+ * Tests for vtkMRMLBezierSurfaceNode — the data-only node landed by
+ * ADR-0014 §1.  Exercises:
+ *
+ *   - defaults (constructor values)
+ *   - State / InitializationMode enum round-trip
+ *   - Bezier control grid round-trip
+ *   - SlicingPlane init-mode subordinate data
+ *   - DistanceSpheroid init-mode subordinate data
+ *   - XML serialize/deserialize via an internal scene snapshot
+ *   - CopyContent / DeepCopy
+ *   - OrderIndex default sentinel + XML round-trip
+ */
 
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
@@ -398,6 +398,12 @@ int testXMLRoundTrip()
   source->SetDistanceSpheroidRadiusY(3.0);
   source->SetDistanceSpheroidRadiusZ(4.0);
 
+  // OrderIndex (ADR-0023 §"Persistence") — resection list ordering,
+  // surgical-order + locator-precedence semantic.  Non-default value
+  // pins the XML round-trip path; the ``-1`` sentinel for unordered
+  // is covered by ``testOrderIndexDefaultSentinel`` below.
+  source->SetOrderIndex(7);
+
   // Now transition to Planning and write the Bezier grid (the only
   // mutable geometry post-transition).  Init-mode data above is now
   // read-only audit data.
@@ -527,6 +533,70 @@ int testXMLRoundTrip()
   CHECK_DOUBLE_TOLERANCE(sink->GetDistanceSpheroidRadiusX(), source->GetDistanceSpheroidRadiusX(), 1e-5);
   CHECK_DOUBLE_TOLERANCE(sink->GetDistanceSpheroidRadiusY(), source->GetDistanceSpheroidRadiusY(), 1e-5);
   CHECK_DOUBLE_TOLERANCE(sink->GetDistanceSpheroidRadiusZ(), source->GetDistanceSpheroidRadiusZ(), 1e-5);
+
+  CHECK_INT(sink->GetOrderIndex(), source->GetOrderIndex());
+
+  return EXIT_SUCCESS;
+}
+
+// ADR-0023 §"Persistence" sentinel invariant — a freshly-constructed
+// ``vtkMRMLBezierSurfaceNode`` exposes ``OrderIndex == -1`` (unordered)
+// so the ``.lrp.json`` writer can rely on the sentinel for v2-file
+// fallback semantics, and the Stage 4 resection-table sort can treat
+// ``-1`` as "place at end of list" rather than "place at position -1".
+// The XML round-trip in ``testXMLRoundTrip`` pins the non-default
+// (=7) path; this sibling pins the default.
+int testOrderIndexDefaultSentinel()
+{
+  vtkNew<vtkMRMLBezierSurfaceNode> node;
+  CHECK_INT(node->GetOrderIndex(), -1);
+
+  // Also pin that the default round-trips through XML — a v3 sidecar
+  // for a resection that has never had its surgical-order set must
+  // observe the sentinel on reload, not lose it to a zero-init.
+  vtkNew<vtkMRMLScene> scene;
+  node->SetScene(scene.GetPointer());
+  std::ostringstream out;
+  node->WriteXML(out, 0);
+  const std::string xml = out.str();
+
+  std::vector<std::string> storage;
+  std::string::size_type cursor = 0;
+  while (cursor < xml.size())
+  {
+    const auto eq = xml.find('=', cursor);
+    if (eq == std::string::npos)
+    {
+      break;
+    }
+    const auto nameStart = xml.find_last_of(" \t\n\r", eq);
+    const auto valStart = xml.find('"', eq);
+    if (valStart == std::string::npos)
+    {
+      break;
+    }
+    const auto valEnd = xml.find('"', valStart + 1);
+    if (valEnd == std::string::npos)
+    {
+      break;
+    }
+    storage.push_back(xml.substr(nameStart + 1, eq - nameStart - 1));
+    storage.push_back(xml.substr(valStart + 1, valEnd - valStart - 1));
+    cursor = valEnd + 1;
+  }
+  std::vector<const char*> atts;
+  atts.reserve(storage.size() + 1);
+  for (auto& s : storage)
+  {
+    atts.push_back(s.c_str());
+  }
+  atts.push_back(nullptr);
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  sink->SetScene(scene.GetPointer());
+  sink->ReadXMLAttributes(atts.data());
+  CHECK_INT(sink->GetOrderIndex(), -1);
+
   return EXIT_SUCCESS;
 }
 
@@ -1546,6 +1616,7 @@ int vtkMRMLBezierSurfaceNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testSlicingPlaneInit());
   CHECK_EXIT_SUCCESS(testDistanceSpheroidInit());
   CHECK_EXIT_SUCCESS(testXMLRoundTrip());
+  CHECK_EXIT_SUCCESS(testOrderIndexDefaultSentinel());
   CHECK_EXIT_SUCCESS(testCopyContent());
   CHECK_EXIT_SUCCESS(testModifiedEventsOnSetters());
   CHECK_EXIT_SUCCESS(testDisplayNodeAttachedSceneRoundTrip());

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -4,19 +4,23 @@
 
   Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 
-  Tests for vtkMRMLBezierSurfaceStorageNode — the new ``.lrp.json``
-  storage node landed by task T2.5 per ADR-0014 §5.  Exercises:
-
-   - JSON round-trip (populate → write → read → assert equality)
-   - schemaVersion mismatch rejection
-   - CanReadInReferenceNode / CanWriteFromReferenceNode discrimination
-   - Legacy .lrp.fcsv migration read path
-   - Legacy .lrp.fcsv write rejection
-
-  ADR-0008 §2: C++ low-level tests live alongside the MRML library
-  and run under the ctkTest driver with no Slicer launch and no Qt.
-
 ==============================================================================*/
+
+/**
+ * \file vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+ *
+ * Tests for vtkMRMLBezierSurfaceStorageNode — the new ``.lrp.json``
+ * storage node landed by task T2.5 per ADR-0014 §5.  Exercises:
+ *
+ *   - JSON round-trip (populate → write → read → assert equality)
+ *   - schemaVersion mismatch rejection
+ *   - CanReadInReferenceNode / CanWriteFromReferenceNode discrimination
+ *   - Legacy .lrp.fcsv migration read path
+ *   - Legacy .lrp.fcsv write rejection
+ *
+ * ADR-0008 §2: C++ low-level tests live alongside the MRML library
+ * and run under the ctkTest driver with no Slicer launch and no Qt.
+ */
 
 // This module MRML includes
 #include "vtkMRMLBezierSurfaceNode.h"

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -232,16 +232,28 @@ int testUnknownStateFallback()
   // ADR-0019 §"Storage / persistence": an unknown ``state`` value
   // falls back to ``Planning`` gracefully — exercises the forward-
   // compatible default for scenes authored by a future build that
-  // adds a fourth state (or a build that pre-dates this PR loading
-  // a v3-authored "Confirmed" scene, which the test simulates by
-  // writing an unknown name directly).
+  // adds a fourth state.
   const std::string path = makeTempPath("lrp.json");
   {
     std::ofstream ofs(path);
     ofs << "{\n";
-    ofs << "  \"schemaVersion\": 1,\n";
+    ofs << "  \"schemaVersion\": 2,\n";
     ofs << "  \"state\": \"Approved\",\n";
-    ofs << "  \"initMode\": \"SlicingPlane\"\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 4,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << "0.0";
+    }
+    ofs << "],\n";
+    ofs << "  \"slicingPlane\": { \"origin\": [0, 0, 0], \"normal\": [0, 0, 1], \"initPointsFlat\": [0, 0, 0, 0, 0, 0] },\n";
+    ofs << "  \"distanceSpheroid\": { \"center\": [0, 0, 0], \"radius\": {\"x\": 0, \"y\": 0, \"z\": 0}, \"numberOfInitPoints\": 0, \"initPointsFlat\": [] }\n";
     ofs << "}\n";
   }
 
@@ -454,11 +466,13 @@ int testJsonRoundTrip3x3()
   return EXIT_SUCCESS;
 }
 
-int testJsonReadV1Implicit4x4()
+int testJsonReadV1Rejected()
 {
-  // ADR-0018 §1 — Reader must accept v1 files (no rows / cols
-  // fields; implicit 4×4 control polygon) and load them as a 4×4
-  // node.  This is the migration path for existing on-disk plans.
+  // ADR-0023 §"Persistence" — v1 was preview-only and not part of
+  // the v2.0.0 released contract.  ``MinReadableSchemaVersion`` is
+  // ``2`` and the reader rejects v1 files outright.  This test
+  // pins that rejection so a future writer regression (e.g. a
+  // partial-bump that lowers ``SchemaVersion`` back to 1) is caught.
   const std::string path = makeTempPath("lrp.json");
   {
     std::ofstream ofs(path);
@@ -475,26 +489,17 @@ int testJsonReadV1Implicit4x4()
       }
       ofs << (static_cast<double>(i) * 0.0625);
     }
-    ofs << "],\n";
-    ofs << "  \"slicingPlane\": { \"origin\": [0, 0, 0], \"normal\": [0, 0, 1], \"initPointsFlat\": [0, 0, 0, 0, 0, 0] },\n";
-    ofs << "  \"distanceSpheroid\": { \"center\": [0, 0, 0], \"radius\": {\"x\": 0, \"y\": 0, \"z\": 0}, \"numberOfInitPoints\": 0, \"initPointsFlat\": [] },\n";
-    ofs << "  \"metadata\": {}\n";
+    ofs << "]\n";
     ofs << "}\n";
   }
 
   vtkNew<vtkMRMLBezierSurfaceNode> sink;
   vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
   storage->SetFileName(path.c_str());
-  CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
 
-  // v1 → 4×4 inference.
-  CHECK_INT(static_cast<int>(sink->GetRows()), 4);
-  CHECK_INT(static_cast<int>(sink->GetCols()), 4);
-  CHECK_INT(static_cast<int>(sink->GetControlGridLength()), 48);
-  for (int i = 0; i < 48; ++i)
-  {
-    CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], static_cast<double>(i) * 0.0625, 1e-9);
-  }
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   vtksys::SystemTools::RemoveFile(path);
   return EXIT_SUCCESS;
@@ -717,7 +722,7 @@ int vtkMRMLBezierSurfaceStorageNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testLegacyFcsvWriteRejected());
   CHECK_EXIT_SUCCESS(testLegacyFcsvFixture());
   CHECK_EXIT_SUCCESS(testJsonRoundTrip3x3());
-  CHECK_EXIT_SUCCESS(testJsonReadV1Implicit4x4());
+  CHECK_EXIT_SUCCESS(testJsonReadV1Rejected());
   CHECK_EXIT_SUCCESS(testJsonReadV2InvalidShape());
   CHECK_EXIT_SUCCESS(testJsonReadV2OutOfRange());
   CHECK_EXIT_SUCCESS(testJsonReadV2ControlGridLengthMismatch());

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest1.cxx
@@ -394,7 +394,8 @@ int testLegacyFcsvWriteRejected()
 
 int testJsonRoundTrip3x3()
 {
-  // ADR-0018 §1 — 3×3 round-trip.  Writer always emits schema v2
+  // ADR-0018 §1 — 3×3 round-trip.  Writer always emits the current
+  // ``SchemaVersion`` (bumped to 3 per ADR-0023 §"Persistence")
   // with explicit rows + cols (3, 3) and a 27-double controlGrid.
   // Reader resolves rows/cols on parse + matches the controlGrid
   // length.  Mirrors testJsonRoundTrip for the 3×3 case.
@@ -426,15 +427,21 @@ int testJsonRoundTrip3x3()
     CHECK_DOUBLE_TOLERANCE(sink->GetControlGrid()[i], grid33[i], 1e-9);
   }
 
-  // Spot-check the on-disk JSON carries the explicit shape — a
-  // schema-v2 file MUST emit rows + cols + schemaVersion = 2.
+  // Spot-check the on-disk JSON carries the explicit shape — the
+  // writer MUST emit the current ``SchemaVersion`` literal alongside
+  // explicit rows + cols.  The literal value is queried from the
+  // class constant (rather than hard-coded) so this assertion ages
+  // forward with the next schema bump; the load-bearing invariant
+  // is "writer emits the current version", not the integer itself.
   std::ifstream f(path);
   std::stringstream ss;
   ss << f.rdbuf();
   const std::string contents = ss.str();
-  if (contents.find("\"schemaVersion\":2") == std::string::npos && contents.find("\"schemaVersion\": 2") == std::string::npos)
+  const std::string expectedCompact = std::string("\"schemaVersion\":") + std::to_string(vtkMRMLBezierSurfaceStorageNode::SchemaVersion);
+  const std::string expectedSpaced = std::string("\"schemaVersion\": ") + std::to_string(vtkMRMLBezierSurfaceStorageNode::SchemaVersion);
+  if (contents.find(expectedCompact) == std::string::npos && contents.find(expectedSpaced) == std::string::npos)
   {
-    std::cerr << "Expected schemaVersion: 2 in output JSON\n" << contents << "\n";
+    std::cerr << "Expected schemaVersion: " << vtkMRMLBezierSurfaceStorageNode::SchemaVersion << " in output JSON\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   if (contents.find("\"rows\":3") == std::string::npos && contents.find("\"rows\": 3") == std::string::npos)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
@@ -1,0 +1,661 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  Invariant test scaffolding for ``.lrp.json`` schema v3 — surfaces the
+  v2.0 surgeon-facing state per ADR-0023 §"Persistence".  Per ADR-0027,
+  these tests land BEFORE the implementation commit and pin the v3
+  design contract; they are expected to FAIL on the current v2 writer
+  + reader and to flip to passing once liver-implementer lands the v3
+  fields in vtkMRMLBezierSurfaceStorageNode.
+
+  Pinned invariants (ADR-0023 §"Persistence" + the schema-versioning
+  convention from the file-header comment in
+  vtkMRMLBezierSurfaceStorageNode.cxx):
+
+   - testV3RoundTripFullFields: name + Safety/Risk margins + orderIndex
+     + classification + volumetry partition references survive a
+     write → read → write cycle.
+   - testV2ToV3FallbackDefaults: v2 files load into v3-aware nodes with
+     documented defaults (name = MRML display name, margins = 0.0,
+     orderIndex = -1, classification absent, volumetry partitions
+     empty, stageSelection absent).
+   - testV3WriteEmitsSchemaVersion3: the on-disk schemaVersion is 3
+     and is not 2.
+   - testV3ClassificationSubtypeDiscriminator: scene.classification
+     .subtype matches the concrete vtkMRMLAbstractTerritoriesNode
+     subclass name (vtkMRMLStdCouinaudTerritoriesNode vs
+     vtkMRMLCustomTerritoriesNode), preserving the polymorphic-
+     interface discriminator from ADR-0023 §"Class abstraction for
+     territories".
+   - testV3ReaderAcceptsV3RangeAndRejectsV99: the reader's accepted
+     schemaVersion band grows from [1, 2] to [1, 3]; v99 stays
+     rejected (the schema-versioning invariant first pinned in
+     testSchemaVersionMismatch of Test1).
+
+  ADR-0008 §2: C++ low-level tests live alongside the MRML library
+  and run under the ctkTest driver with no Slicer launch and no Qt.
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLBezierSurfaceStorageNode.h"
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtksys/SystemTools.hxx>
+
+// STD includes
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+// Portable getpid — mirrors the helper in
+// vtkMRMLBezierSurfaceStorageNodeTest1.cxx so the temp-path generator
+// stays Windows-portable.
+#if defined(_WIN32)
+# include <process.h>
+# define LIVER_BEZIER_GETPID _getpid
+#else
+# include <unistd.h>
+# define LIVER_BEZIER_GETPID ::getpid
+#endif
+
+namespace
+{
+
+/// Generate a unique temp file path with the given extension under the
+/// CMake binary tree's Testing/Temporary directory (set via the
+/// LIVER_BEZIER_STORAGE_TEST_TEMP_DIR macro defined in CMakeLists.txt).
+std::string makeTempPath(const std::string& extension)
+{
+  static int counter = 0;
+  ++counter;
+  std::ostringstream ss;
+  ss << LIVER_BEZIER_STORAGE_TEST_TEMP_DIR << "/vtkMRMLBezierSurfaceStorageNodeTest2_" << static_cast<long long>(LIVER_BEZIER_GETPID()) << "_" << counter << "." << extension;
+  return ss.str();
+}
+
+/// Read the entire content of a file into a string for substring
+/// assertions.  The v3 invariant tests pin JSON shape at the byte
+/// level — accessor-based pinning is deferred until liver-implementer
+/// lands the v3 in-memory APIs on vtkMRMLBezierSurfaceNode.
+std::string slurp(const std::string& path)
+{
+  std::ifstream f(path);
+  std::stringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+/// Substring-or-tolerant-substring search.  rapidjson emits compact
+/// JSON (no whitespace around the ``:``); a future ADR may flip the
+/// writer to pretty-print.  Accept both shapes so the pin is not
+/// sensitive to that choice.
+bool contains(const std::string& haystack, const std::string& key, const std::string& value)
+{
+  // Compact:  "key":value
+  // Spaced:   "key": value
+  const std::string compact = std::string("\"") + key + "\":" + value;
+  const std::string spaced = std::string("\"") + key + "\": " + value;
+  return haystack.find(compact) != std::string::npos || haystack.find(spaced) != std::string::npos;
+}
+
+/// Populate a Bezier surface node with deterministic v2 fields.
+/// Mirrors the populate() helper in
+/// vtkMRMLBezierSurfaceStorageNodeTest1.cxx — kept self-contained
+/// because the two test translation units do not share helpers.
+void populateV2Fields(vtkMRMLBezierSurfaceNode* node)
+{
+  node->SetInitMode(vtkMRMLBezierSurfaceNode::SlicingPlane);
+  double origin[3] = { 1.0, 2.0, 3.0 };
+  node->SetSlicingPlaneOrigin(origin);
+  double normal[3] = { 0.0, 0.0, 1.0 };
+  node->SetSlicingPlaneNormal(normal);
+  double p0[3] = { 4.0, 5.0, 6.0 };
+  double p1[3] = { 7.0, 8.0, 9.0 };
+  node->SetSlicingPlaneInitPoint(0, p0);
+  node->SetSlicingPlaneInitPoint(1, p1);
+  node->SetState(vtkMRMLBezierSurfaceNode::Planning);
+  double grid[vtkMRMLBezierSurfaceNode::ControlGridSize];
+  for (int i = 0; i < vtkMRMLBezierSurfaceNode::ControlGridSize; ++i)
+  {
+    grid[i] = static_cast<double>(i) * 0.0625;
+  }
+  node->SetControlGrid(grid);
+}
+
+/// Populate a Bezier surface node with the v3 surgeon-facing state.
+/// The contract per ADR-0023 §"Persistence" is:
+///   - name      = node's MRML display name (here "Right hemihepatectomy")
+///   - safetyMargin_mm sourced from existing ResectionMargin field
+///   - riskMargin_mm   sourced from existing UncertaintyMargin field
+///   - orderIndex sourced from a new OrderIndex attribute on
+///     vtkMRMLBezierSurfaceNode (sentinel -1 for unordered).
+///
+/// Until liver-implementer lands the dedicated getters/setters on
+/// vtkMRMLBezierSurfaceNode, this helper communicates the intended
+/// values via MRML attributes — they are observable to the storage
+/// node via the in-tree GetAttribute() surface.  The implementer is
+/// free to migrate this populate path to typed accessors once those
+/// exist; the byte-level assertions on the emitted JSON do not
+/// change.
+void populateV3SurgeonState(vtkMRMLBezierSurfaceNode* node)
+{
+  node->SetName("Right hemihepatectomy");
+  // Attribute names match the JSON key vocabulary so the implementer's
+  // writer can route the value through either a typed accessor or a
+  // GetAttribute() lookup; the test does not commit to either path.
+  node->SetAttribute("safetyMargin_mm", "10.0");
+  node->SetAttribute("riskMargin_mm", "5.0");
+  node->SetAttribute("orderIndex", "0");
+}
+
+//------------------------------------------------------------------------------
+// Test 1 — v3 round-trip of the full surgeon-facing field roster.
+//
+// Pinned invariant (ADR-0023 §"Persistence"):
+//   A populated v3 file written then re-loaded then re-written carries
+//   forward name + safetyMargin_mm + riskMargin_mm + orderIndex +
+//   scene.classification + scene.volumetryPartitions with byte-fidelity
+//   on the strings and the documented 1e-12 tolerance on the doubles.
+//
+// This test must FAIL on the current v2 writer (which emits none of the
+// new fields).  liver-implementer flips it to PASS by extending
+// WriteJson + ReadJson in vtkMRMLBezierSurfaceStorageNode.
+//------------------------------------------------------------------------------
+int testV3RoundTripFullFields()
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  scene->AddNode(source.GetPointer());
+  populateV2Fields(source.GetPointer());
+  populateV3SurgeonState(source.GetPointer());
+
+  // First write — source → disk.
+  const std::string path1 = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> writeStorage;
+  writeStorage->SetFileName(path1.c_str());
+  CHECK_INT(writeStorage->WriteData(source.GetPointer()), 1);
+
+  // Read into a fresh sink — same scene so node IDs are stable.
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  scene->AddNode(sink.GetPointer());
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> readStorage;
+  readStorage->SetFileName(path1.c_str());
+  CHECK_INT(readStorage->ReadData(sink.GetPointer()), 1);
+
+  // Second write — sink → disk.  The byte-level assertions on this
+  // file pin the round-trip invariant: if the writer dropped a field
+  // on the first hop or the reader dropped it on the second, the
+  // re-write will not contain it.
+  const std::string path2 = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> rewriteStorage;
+  rewriteStorage->SetFileName(path2.c_str());
+  CHECK_INT(rewriteStorage->WriteData(sink.GetPointer()), 1);
+
+  const std::string contents = slurp(path2);
+
+  // resection block — name, safetyMargin_mm, riskMargin_mm, orderIndex.
+  // The string assertion is byte-fidelity per the test contract.
+  if (contents.find("\"name\":\"Right hemihepatectomy\"") == std::string::npos && contents.find("\"name\": \"Right hemihepatectomy\"") == std::string::npos)
+  {
+    std::cerr << "testV3RoundTripFullFields: expected \"name\": \"Right hemihepatectomy\" in re-written JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (!contains(contents, "safetyMargin_mm", "10.0") && !contains(contents, "safetyMargin_mm", "10"))
+  {
+    std::cerr << "testV3RoundTripFullFields: expected safetyMargin_mm = 10.0 in re-written JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (!contains(contents, "riskMargin_mm", "5.0") && !contains(contents, "riskMargin_mm", "5"))
+  {
+    std::cerr << "testV3RoundTripFullFields: expected riskMargin_mm = 5.0 in re-written JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (!contains(contents, "orderIndex", "0"))
+  {
+    std::cerr << "testV3RoundTripFullFields: expected orderIndex = 0 in re-written JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+
+  // scene block — classification + volumetryPartitions.  The exact
+  // node-ID strings are scene-dependent (vtkMRMLScene allocates them
+  // sequentially) so we pin the keys' presence; the per-subtype
+  // assertion lives in testV3ClassificationSubtypeDiscriminator.
+  if (contents.find("\"scene\"") == std::string::npos)
+  {
+    std::cerr << "testV3RoundTripFullFields: expected \"scene\" block in re-written JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"classification\"") == std::string::npos)
+  {
+    std::cerr << "testV3RoundTripFullFields: expected scene.classification in re-written JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (contents.find("\"volumetryPartitions\"") == std::string::npos)
+  {
+    std::cerr << "testV3RoundTripFullFields: expected scene.volumetryPartitions in re-written JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+
+  // resection block presence — sibling of the field-level checks above.
+  if (contents.find("\"resection\"") == std::string::npos)
+  {
+    std::cerr << "testV3RoundTripFullFields: expected \"resection\" block in re-written JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+
+  vtksys::SystemTools::RemoveFile(path1);
+  vtksys::SystemTools::RemoveFile(path2);
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Test 2 — v2-on-disk → v3-in-memory fallback defaults.
+//
+// Pinned invariant (ADR-0023 §"Persistence" + the v2→v3 migration
+// branch documented in the schema header of
+// vtkMRMLBezierSurfaceStorageNode.cxx):
+//   A v2 file (no resection/scene blocks) loads cleanly into a
+//   v3-aware reader.  The missing v3 fields take documented defaults:
+//
+//     name                          = the node's MRML display name
+//     resection.safetyMargin_mm     = 0.0
+//     resection.riskMargin_mm       = 0.0
+//     resection.orderIndex          = -1  (sentinel: unordered)
+//     scene.classification          = absent  (no reference set)
+//     scene.volumetryPartitions     = empty array
+//     scene.stageSelection          = absent
+//
+// The defaults are pinned via a re-write round-trip: after loading the
+// v2 file the test re-writes the (now v3-aware) node and asserts the
+// emitted JSON carries the documented defaults.  This bypasses the
+// need for new in-memory accessors on vtkMRMLBezierSurfaceNode and
+// keeps the test focused on the storage-node contract.
+//
+// This test must FAIL on the current writer (the re-written file is a
+// v2 file, not v3; the defaults block is absent).
+//------------------------------------------------------------------------------
+int testV2ToV3FallbackDefaults()
+{
+  // Synthesise a minimal valid v2 .lrp.json with no resection/scene
+  // blocks — i.e. exactly what the schema-v2 writer (current
+  // vtkMRMLBezierSurfaceStorageNode::SchemaVersion) emits.
+  const std::string v2Path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(v2Path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 2,\n";
+    ofs << "  \"state\": \"Planning\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 4,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << (static_cast<double>(i) * 0.0625);
+    }
+    ofs << "],\n";
+    ofs << "  \"slicingPlane\": { \"origin\": [0, 0, 0], \"normal\": [0, 0, 1], "
+           "\"initPointsFlat\": [0, 0, 0, 0, 0, 0] },\n";
+    ofs << "  \"distanceSpheroid\": { \"center\": [0, 0, 0], "
+           "\"radius\": {\"x\": 0, \"y\": 0, \"z\": 0}, "
+           "\"numberOfInitPoints\": 0, \"initPointsFlat\": [] },\n";
+    ofs << "  \"metadata\": {}\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  scene->AddNode(sink.GetPointer());
+  sink->SetName("LegacyPlanFromV2");
+
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(v2Path.c_str());
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+
+  // Re-write and inspect the emitted JSON for the v3 defaults.
+  const std::string rewritePath = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> rewriteStorage;
+  rewriteStorage->SetFileName(rewritePath.c_str());
+  CHECK_INT(rewriteStorage->WriteData(sink.GetPointer()), 1);
+
+  const std::string contents = slurp(rewritePath);
+
+  // Default name = MRML display name.
+  if (contents.find("\"name\":\"LegacyPlanFromV2\"") == std::string::npos && contents.find("\"name\": \"LegacyPlanFromV2\"") == std::string::npos)
+  {
+    std::cerr << "testV2ToV3FallbackDefaults: expected name default = MRML display name "
+                 "(\"LegacyPlanFromV2\") in re-written JSON; got:\n"
+              << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  // Default margins = 0.0.
+  if (!contains(contents, "safetyMargin_mm", "0.0") && !contains(contents, "safetyMargin_mm", "0"))
+  {
+    std::cerr << "testV2ToV3FallbackDefaults: expected safetyMargin_mm default = 0.0; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  if (!contains(contents, "riskMargin_mm", "0.0") && !contains(contents, "riskMargin_mm", "0"))
+  {
+    std::cerr << "testV2ToV3FallbackDefaults: expected riskMargin_mm default = 0.0; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  // Default orderIndex = -1 (sentinel: unordered).
+  if (!contains(contents, "orderIndex", "-1"))
+  {
+    std::cerr << "testV2ToV3FallbackDefaults: expected orderIndex default = -1 (sentinel); got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  // scene.classification absent (no nodeId emitted).  We tolerate a
+  // null-valued classification block as a valid v3 shape too — the
+  // Liver shell that writes the scene.stageSelection block lands in
+  // a follow-up; until then a v3 file with all-null stageSelection +
+  // absent classification is a valid v3 shape per ADR-0023
+  // §"Persistence".
+  const bool classificationAbsent = contents.find("\"classification\":null") != std::string::npos || contents.find("\"classification\": null") != std::string::npos
+                                    || contents.find("\"classification\"") == std::string::npos;
+  if (!classificationAbsent)
+  {
+    // If the block is present, it MUST NOT carry a populated nodeId
+    // (the sink was loaded from a v2 file with no classification).
+    if (contents.find("\"nodeId\":\"vtkMRML") != std::string::npos || contents.find("\"nodeId\": \"vtkMRML") != std::string::npos)
+    {
+      std::cerr << "testV2ToV3FallbackDefaults: expected absent / null classification "
+                   "block (no classification was set); got:\n"
+                << contents << "\n";
+      return EXIT_FAILURE;
+    }
+  }
+  // scene.volumetryPartitions = empty array.  Accept both "absent"
+  // and "[]" — the writer's choice between the two is below this
+  // test's pinning resolution.
+  if (contents.find("\"volumetryPartitions\":[]") == std::string::npos && contents.find("\"volumetryPartitions\": []") == std::string::npos
+      && contents.find("\"volumetryPartitions\"") != std::string::npos)
+  {
+    // Block present but not empty — the v2 source had no partitions.
+    std::cerr << "testV2ToV3FallbackDefaults: expected empty volumetryPartitions; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+
+  vtksys::SystemTools::RemoveFile(v2Path);
+  vtksys::SystemTools::RemoveFile(rewritePath);
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Test 3 — the writer emits schemaVersion = 3 (not 2).
+//
+// Pinned invariant (ADR-0023 §"Conformance" — "the schema header
+// reads schemaVersion: 3 on writes"):
+//   Every v3-aware write carries the literal "schemaVersion": 3 in
+//   the on-disk JSON.  The v2 marker "schemaVersion": 2 is absent.
+//
+// This test must FAIL on the current writer (which emits
+// "schemaVersion": 2 unconditionally).  liver-implementer flips it
+// to PASS by bumping
+// vtkMRMLBezierSurfaceStorageNode::SchemaVersion from 2 to 3.
+//------------------------------------------------------------------------------
+int testV3WriteEmitsSchemaVersion3()
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLBezierSurfaceNode> source;
+  scene->AddNode(source.GetPointer());
+  populateV2Fields(source.GetPointer());
+  populateV3SurgeonState(source.GetPointer());
+
+  const std::string path = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> writeStorage;
+  writeStorage->SetFileName(path.c_str());
+  CHECK_INT(writeStorage->WriteData(source.GetPointer()), 1);
+
+  const std::string contents = slurp(path);
+
+  // Positive — schemaVersion is 3.
+  if (contents.find("\"schemaVersion\":3") == std::string::npos && contents.find("\"schemaVersion\": 3") == std::string::npos)
+  {
+    std::cerr << "testV3WriteEmitsSchemaVersion3: expected \"schemaVersion\": 3 in JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+  // Negative — schemaVersion is NOT 2.  Pins the "writer always
+  // emits the current schema" half of the invariant.
+  if (contents.find("\"schemaVersion\":2") != std::string::npos || contents.find("\"schemaVersion\": 2") != std::string::npos)
+  {
+    std::cerr << "testV3WriteEmitsSchemaVersion3: unexpected \"schemaVersion\": 2 in JSON; got:\n" << contents << "\n";
+    return EXIT_FAILURE;
+  }
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Test 4 — scene.classification.subtype discriminates between
+// vtkMRMLAbstractTerritoriesNode subclasses.
+//
+// Pinned invariant (ADR-0023 §"Persistence" + §"Class abstraction
+// for territories"):
+//   The scene.classification.subtype string is the concrete VTK class
+//   name of the referent vtkMRMLAbstractTerritoriesNode subclass.
+//   Two sub-cases exercise the two extant subclasses landed by the
+//   territories class hierarchy: vtkMRMLStdCouinaudTerritoriesNode
+//   (Stage 3 Auto path) and vtkMRMLCustomTerritoriesNode (Stage 3
+//   Manual path).
+//
+// Until liver-implementer lands the resection→classification node-
+// reference role on vtkMRMLBezierSurfaceNode, the test communicates
+// the intended referent's class name via an MRML attribute
+// ("classificationSubtype").  The contract on the writer is to emit
+// scene.classification.subtype matching that class name regardless of
+// whether the implementer routes the value through a typed node
+// reference or through the attribute lookup.
+//
+// This test must FAIL on the current writer (no scene block).
+//------------------------------------------------------------------------------
+int testV3ClassificationSubtypeDiscriminator()
+{
+  // Sub-case A — standard Couinaud (Auto path).
+  {
+    vtkNew<vtkMRMLScene> scene;
+    vtkNew<vtkMRMLBezierSurfaceNode> source;
+    scene->AddNode(source.GetPointer());
+    populateV2Fields(source.GetPointer());
+    populateV3SurgeonState(source.GetPointer());
+    source->SetAttribute("classificationSubtype", "vtkMRMLStdCouinaudTerritoriesNode");
+
+    const std::string path = makeTempPath("lrp.json");
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> writeStorage;
+    writeStorage->SetFileName(path.c_str());
+    CHECK_INT(writeStorage->WriteData(source.GetPointer()), 1);
+
+    const std::string contents = slurp(path);
+    if (contents.find("\"subtype\":\"vtkMRMLStdCouinaudTerritoriesNode\"") == std::string::npos
+        && contents.find("\"subtype\": \"vtkMRMLStdCouinaudTerritoriesNode\"") == std::string::npos)
+    {
+      std::cerr << "testV3ClassificationSubtypeDiscriminator (Auto path): expected "
+                   "scene.classification.subtype = \"vtkMRMLStdCouinaudTerritoriesNode\"; got:\n"
+                << contents << "\n";
+      return EXIT_FAILURE;
+    }
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  // Sub-case B — custom Manual path.
+  {
+    vtkNew<vtkMRMLScene> scene;
+    vtkNew<vtkMRMLBezierSurfaceNode> source;
+    scene->AddNode(source.GetPointer());
+    populateV2Fields(source.GetPointer());
+    populateV3SurgeonState(source.GetPointer());
+    source->SetAttribute("classificationSubtype", "vtkMRMLCustomTerritoriesNode");
+
+    const std::string path = makeTempPath("lrp.json");
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> writeStorage;
+    writeStorage->SetFileName(path.c_str());
+    CHECK_INT(writeStorage->WriteData(source.GetPointer()), 1);
+
+    const std::string contents = slurp(path);
+    if (contents.find("\"subtype\":\"vtkMRMLCustomTerritoriesNode\"") == std::string::npos && contents.find("\"subtype\": \"vtkMRMLCustomTerritoriesNode\"") == std::string::npos)
+    {
+      std::cerr << "testV3ClassificationSubtypeDiscriminator (Custom path): expected "
+                   "scene.classification.subtype = \"vtkMRMLCustomTerritoriesNode\"; got:\n"
+                << contents << "\n";
+      return EXIT_FAILURE;
+    }
+    vtksys::SystemTools::RemoveFile(path);
+  }
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Test 5 — the schemaVersion-acceptance band is [1, 3]; v99 still
+// rejected.
+//
+// Pinned invariant (the schema-versioning convention in the file
+// header of vtkMRMLBezierSurfaceStorageNode.cxx — the
+// MinReadableSchemaVersion / SchemaVersion constants):
+//   The reader admits files with schemaVersion in
+//   [MinReadableSchemaVersion, SchemaVersion].  After v3 lands the
+//   upper bound is 3; v99 (or any other out-of-band value) is
+//   rejected with a vtkErrorMacro.
+//
+// This is the v3 extension of testSchemaVersionMismatch from Test1
+// (which exercises the v99 rejection against the [1, 2] band).  The
+// v99-rejection half of this test passes against the current writer
+// (99 is outside both [1, 2] and [1, 3]); the v3-acceptance half
+// fails until liver-implementer bumps the SchemaVersion constant.
+//------------------------------------------------------------------------------
+int testV3ReaderAcceptsV3RangeAndRejectsV99()
+{
+  // Half (a) — synthesise a v3 file with the minimal v3 shape and
+  // assert the reader accepts it.  Pre-implementation this assertion
+  // fails because the reader's upper bound is still 2.
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 3,\n";
+      ofs << "  \"state\": \"Planning\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\",\n";
+      ofs << "  \"rows\": 4,\n";
+      ofs << "  \"cols\": 4,\n";
+      ofs << "  \"controlGrid\": [";
+      for (int i = 0; i < 48; ++i)
+      {
+        if (i > 0)
+        {
+          ofs << ", ";
+        }
+        ofs << "0.0";
+      }
+      ofs << "],\n";
+      ofs << "  \"slicingPlane\": { \"origin\": [0, 0, 0], \"normal\": [0, 0, 1], "
+             "\"initPointsFlat\": [0, 0, 0, 0, 0, 0] },\n";
+      ofs << "  \"distanceSpheroid\": { \"center\": [0, 0, 0], "
+             "\"radius\": {\"x\": 0, \"y\": 0, \"z\": 0}, "
+             "\"numberOfInitPoints\": 0, \"initPointsFlat\": [] },\n";
+      ofs << "  \"resection\": { \"name\": \"\", \"safetyMargin_mm\": 0.0, "
+             "\"riskMargin_mm\": 0.0, \"orderIndex\": -1 },\n";
+      ofs << "  \"scene\": { \"volumetryPartitions\": [] },\n";
+      ofs << "  \"metadata\": {}\n";
+      ofs << "}\n";
+    }
+    vtkNew<vtkMRMLScene> scene;
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    scene->AddNode(sink.GetPointer());
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  // Half (b) — v99 stays rejected (regression-pin of the invariant
+  // first established by testSchemaVersionMismatch in Test1).  This
+  // passes today; the assertion is here so that the test guards the
+  // negative side of the [1, 3] band after the v3 bump too.
+  {
+    const std::string path = makeTempPath("lrp.json");
+    {
+      std::ofstream ofs(path);
+      ofs << "{\n";
+      ofs << "  \"schemaVersion\": 99,\n";
+      ofs << "  \"state\": \"Init\",\n";
+      ofs << "  \"initMode\": \"SlicingPlane\"\n";
+      ofs << "}\n";
+    }
+    vtkNew<vtkMRMLScene> scene;
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    scene->AddNode(sink.GetPointer());
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLBezierSurfaceStorageNodeTest2(int, char*[])
+{
+  // ADR-0027 §"Test target — v2.0 design, not v1 behaviour": these
+  // tests pin the v3 design contract from ADR-0023 §"Persistence".
+  // They are expected to FAIL until liver-implementer lands the v3
+  // writer + reader; they pass after that.
+  CHECK_EXIT_SUCCESS(testV3WriteEmitsSchemaVersion3());
+  CHECK_EXIT_SUCCESS(testV3RoundTripFullFields());
+  CHECK_EXIT_SUCCESS(testV2ToV3FallbackDefaults());
+  CHECK_EXIT_SUCCESS(testV3ClassificationSubtypeDiscriminator());
+  CHECK_EXIT_SUCCESS(testV3ReaderAcceptsV3RangeAndRejectsV99());
+
+  std::cout << "vtkMRMLBezierSurfaceStorageNodeTest2 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
@@ -31,41 +31,44 @@
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  Invariant test scaffolding for ``.lrp.json`` schema v2 — surfaces the
-  v2.0 surgeon-facing state per ADR-0023 §"Persistence".  Per ADR-0027,
-  these tests land BEFORE the implementation commit and pin the v2
-  design contract; they are expected to FAIL on the current v2 writer
-  + reader and to flip to passing once liver-implementer lands the v2
-  fields in vtkMRMLBezierSurfaceStorageNode.
-
-  Pinned invariants (ADR-0023 §"Persistence" + the schema-versioning
-  convention from the file-header comment in
-  vtkMRMLBezierSurfaceStorageNode.cxx):
-
-   - testV2RoundTripFullFields: name + Safety/Risk margins + orderIndex
-     + classification + volumetry partition references survive a
-     write → read → write cycle.
-   - testV2OptionalFieldsFallbackDefaults: v2 files load into v2-aware nodes with
-     documented defaults (name = MRML display name, margins = 0.0,
-     orderIndex = -1, classification absent, volumetry partitions
-     empty, stageSelection absent).
-   - testV2WriteEmitsSchemaVersion2: the on-disk schemaVersion is 2
-     and is not 3.
-   - testV2ClassificationSubtypeDiscriminator: scene.classification
-     .subtype matches the concrete vtkMRMLAbstractTerritoriesNode
-     subclass name (vtkMRMLStdCouinaudTerritoriesNode vs
-     vtkMRMLCustomTerritoriesNode), preserving the polymorphic-
-     interface discriminator from ADR-0023 §"Class abstraction for
-     territories".
-   - testV2ReaderRejectsV99: the reader's accepted
-     schemaVersion band is [2, 2]; v99 stays
-     rejected (the schema-versioning invariant first pinned in
-     testSchemaVersionMismatch of Test1).
-
-  ADR-0008 §2: C++ low-level tests live alongside the MRML library
-  and run under the ctkTest driver with no Slicer launch and no Qt.
-
 ==============================================================================*/
+
+/**
+ * \file vtkMRMLBezierSurfaceStorageNodeTest2.cxx
+ *
+ * Invariant test scaffolding for ``.lrp.json`` schema v2 — surfaces the
+ * v2.0 surgeon-facing state per ADR-0023 §"Persistence".  Per ADR-0027,
+ * these tests land BEFORE the implementation commit and pin the v2
+ * design contract; they are expected to FAIL on the current v2 writer
+ * + reader and to flip to passing once the v2 fields are wired in
+ * vtkMRMLBezierSurfaceStorageNode.
+ *
+ * Pinned invariants (ADR-0023 §"Persistence" + the schema-versioning
+ * convention from the file-header comment in
+ * vtkMRMLBezierSurfaceStorageNode.cxx):
+ *
+ *   - testV2RoundTripFullFields: name + Safety/Risk margins + orderIndex
+ *     + classification + volumetry partition references survive a
+ *     write → read → write cycle.
+ *   - testV2OptionalFieldsFallbackDefaults: v2 files load into v2-aware
+ *     nodes with documented defaults (name = MRML display name,
+ *     margins = 0.0, orderIndex = -1, classification absent, volumetry
+ *     partitions empty, stageSelection absent).
+ *   - testV2WriteEmitsSchemaVersion2: the on-disk schemaVersion is 2
+ *     and is not 3.
+ *   - testV2ClassificationSubtypeDiscriminator: scene.classification
+ *     .subtype matches the concrete vtkMRMLAbstractTerritoriesNode
+ *     subclass name (vtkMRMLStdCouinaudTerritoriesNode vs
+ *     vtkMRMLCustomTerritoriesNode), preserving the polymorphic-
+ *     interface discriminator from ADR-0023 §"Class abstraction for
+ *     territories".
+ *   - testV2ReaderRejectsV99: the reader's accepted schemaVersion band
+ *     is [2, 2]; v99 stays rejected (the schema-versioning invariant
+ *     first pinned in testSchemaVersionMismatch of Test1).
+ *
+ * ADR-0008 §2: C++ low-level tests live alongside the MRML library
+ * and run under the ctkTest driver with no Slicer launch and no Qt.
+ */
 
 // This module MRML includes
 #include "vtkMRMLBezierSurfaceNode.h"

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
@@ -31,34 +31,34 @@
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  Invariant test scaffolding for ``.lrp.json`` schema v3 — surfaces the
+  Invariant test scaffolding for ``.lrp.json`` schema v2 — surfaces the
   v2.0 surgeon-facing state per ADR-0023 §"Persistence".  Per ADR-0027,
-  these tests land BEFORE the implementation commit and pin the v3
+  these tests land BEFORE the implementation commit and pin the v2
   design contract; they are expected to FAIL on the current v2 writer
-  + reader and to flip to passing once liver-implementer lands the v3
+  + reader and to flip to passing once liver-implementer lands the v2
   fields in vtkMRMLBezierSurfaceStorageNode.
 
   Pinned invariants (ADR-0023 §"Persistence" + the schema-versioning
   convention from the file-header comment in
   vtkMRMLBezierSurfaceStorageNode.cxx):
 
-   - testV3RoundTripFullFields: name + Safety/Risk margins + orderIndex
+   - testV2RoundTripFullFields: name + Safety/Risk margins + orderIndex
      + classification + volumetry partition references survive a
      write → read → write cycle.
-   - testV2ToV3FallbackDefaults: v2 files load into v3-aware nodes with
+   - testV2OptionalFieldsFallbackDefaults: v2 files load into v2-aware nodes with
      documented defaults (name = MRML display name, margins = 0.0,
      orderIndex = -1, classification absent, volumetry partitions
      empty, stageSelection absent).
-   - testV3WriteEmitsSchemaVersion3: the on-disk schemaVersion is 3
-     and is not 2.
-   - testV3ClassificationSubtypeDiscriminator: scene.classification
+   - testV2WriteEmitsSchemaVersion2: the on-disk schemaVersion is 2
+     and is not 3.
+   - testV2ClassificationSubtypeDiscriminator: scene.classification
      .subtype matches the concrete vtkMRMLAbstractTerritoriesNode
      subclass name (vtkMRMLStdCouinaudTerritoriesNode vs
      vtkMRMLCustomTerritoriesNode), preserving the polymorphic-
      interface discriminator from ADR-0023 §"Class abstraction for
      territories".
-   - testV3ReaderAcceptsV3RangeAndRejectsV99: the reader's accepted
-     schemaVersion band grows from [1, 2] to [1, 3]; v99 stays
+   - testV2ReaderRejectsV99: the reader's accepted
+     schemaVersion band is [2, 2]; v99 stays
      rejected (the schema-versioning invariant first pinned in
      testSchemaVersionMismatch of Test1).
 
@@ -114,9 +114,9 @@ std::string makeTempPath(const std::string& extension)
 }
 
 /// Read the entire content of a file into a string for substring
-/// assertions.  The v3 invariant tests pin JSON shape at the byte
+/// assertions.  The v2 invariant tests pin JSON shape at the byte
 /// level — accessor-based pinning is deferred until liver-implementer
-/// lands the v3 in-memory APIs on vtkMRMLBezierSurfaceNode.
+/// lands the v2 in-memory APIs on vtkMRMLBezierSurfaceNode.
 std::string slurp(const std::string& path)
 {
   std::ifstream f(path);
@@ -162,7 +162,7 @@ void populateV2Fields(vtkMRMLBezierSurfaceNode* node)
   node->SetControlGrid(grid);
 }
 
-/// Populate a Bezier surface node with the v3 surgeon-facing state.
+/// Populate a Bezier surface node with the v2 surgeon-facing state.
 /// The contract per ADR-0023 §"Persistence" is:
 ///   - name      = node's MRML display name (here "Right hemihepatectomy")
 ///   - safetyMargin_mm sourced from existing ResectionMargin field
@@ -189,10 +189,10 @@ void populateV3SurgeonState(vtkMRMLBezierSurfaceNode* node)
 }
 
 //------------------------------------------------------------------------------
-// Test 1 — v3 round-trip of the full surgeon-facing field roster.
+// Test 1 — v2 round-trip of the full surgeon-facing field roster.
 //
 // Pinned invariant (ADR-0023 §"Persistence"):
-//   A populated v3 file written then re-loaded then re-written carries
+//   A populated v2 file written then re-loaded then re-written carries
 //   forward name + safetyMargin_mm + riskMargin_mm + orderIndex +
 //   scene.classification + scene.volumetryPartitions with byte-fidelity
 //   on the strings and the documented 1e-12 tolerance on the doubles.
@@ -201,7 +201,7 @@ void populateV3SurgeonState(vtkMRMLBezierSurfaceNode* node)
 // new fields).  liver-implementer flips it to PASS by extending
 // WriteJson + ReadJson in vtkMRMLBezierSurfaceStorageNode.
 //------------------------------------------------------------------------------
-int testV3RoundTripFullFields()
+int testV2RoundTripFullFields()
 {
   vtkNew<vtkMRMLScene> scene;
   vtkNew<vtkMRMLBezierSurfaceNode> source;
@@ -237,49 +237,49 @@ int testV3RoundTripFullFields()
   // The string assertion is byte-fidelity per the test contract.
   if (contents.find("\"name\":\"Right hemihepatectomy\"") == std::string::npos && contents.find("\"name\": \"Right hemihepatectomy\"") == std::string::npos)
   {
-    std::cerr << "testV3RoundTripFullFields: expected \"name\": \"Right hemihepatectomy\" in re-written JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2RoundTripFullFields: expected \"name\": \"Right hemihepatectomy\" in re-written JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   if (!contains(contents, "safetyMargin_mm", "10.0") && !contains(contents, "safetyMargin_mm", "10"))
   {
-    std::cerr << "testV3RoundTripFullFields: expected safetyMargin_mm = 10.0 in re-written JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2RoundTripFullFields: expected safetyMargin_mm = 10.0 in re-written JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   if (!contains(contents, "riskMargin_mm", "5.0") && !contains(contents, "riskMargin_mm", "5"))
   {
-    std::cerr << "testV3RoundTripFullFields: expected riskMargin_mm = 5.0 in re-written JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2RoundTripFullFields: expected riskMargin_mm = 5.0 in re-written JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   if (!contains(contents, "orderIndex", "0"))
   {
-    std::cerr << "testV3RoundTripFullFields: expected orderIndex = 0 in re-written JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2RoundTripFullFields: expected orderIndex = 0 in re-written JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
 
   // scene block — classification + volumetryPartitions.  The exact
   // node-ID strings are scene-dependent (vtkMRMLScene allocates them
   // sequentially) so we pin the keys' presence; the per-subtype
-  // assertion lives in testV3ClassificationSubtypeDiscriminator.
+  // assertion lives in testV2ClassificationSubtypeDiscriminator.
   if (contents.find("\"scene\"") == std::string::npos)
   {
-    std::cerr << "testV3RoundTripFullFields: expected \"scene\" block in re-written JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2RoundTripFullFields: expected \"scene\" block in re-written JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   if (contents.find("\"classification\"") == std::string::npos)
   {
-    std::cerr << "testV3RoundTripFullFields: expected scene.classification in re-written JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2RoundTripFullFields: expected scene.classification in re-written JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   if (contents.find("\"volumetryPartitions\"") == std::string::npos)
   {
-    std::cerr << "testV3RoundTripFullFields: expected scene.volumetryPartitions in re-written JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2RoundTripFullFields: expected scene.volumetryPartitions in re-written JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
 
   // resection block presence — sibling of the field-level checks above.
   if (contents.find("\"resection\"") == std::string::npos)
   {
-    std::cerr << "testV3RoundTripFullFields: expected \"resection\" block in re-written JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2RoundTripFullFields: expected \"resection\" block in re-written JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
 
@@ -289,13 +289,15 @@ int testV3RoundTripFullFields()
 }
 
 //------------------------------------------------------------------------------
-// Test 2 — v2-on-disk → v3-in-memory fallback defaults.
+// Test 2 — v2 optional-field fallback defaults.
 //
-// Pinned invariant (ADR-0023 §"Persistence" + the v2→v3 migration
-// branch documented in the schema header of
+// Pinned invariant (ADR-0023 §"Persistence" + the optional-field
+// tolerance branch documented in the schema header of
 // vtkMRMLBezierSurfaceStorageNode.cxx):
-//   A v2 file (no resection/scene blocks) loads cleanly into a
-//   v3-aware reader.  The missing v3 fields take documented defaults:
+//   A v2 file written before the surgeon-state fields were wired
+//   (preview-tracking deployments only — v2 has never been released)
+//   loads cleanly into the v2 reader.  The missing optional fields
+//   take documented defaults:
 //
 //     name                          = the node's MRML display name
 //     resection.safetyMargin_mm     = 0.0
@@ -305,16 +307,13 @@ int testV3RoundTripFullFields()
 //     scene.volumetryPartitions     = empty array
 //     scene.stageSelection          = absent
 //
-// The defaults are pinned via a re-write round-trip: after loading the
-// v2 file the test re-writes the (now v3-aware) node and asserts the
+// The defaults are pinned via a re-write round-trip: after loading
+// the minimal v2 file the test re-writes the node and asserts the
 // emitted JSON carries the documented defaults.  This bypasses the
 // need for new in-memory accessors on vtkMRMLBezierSurfaceNode and
 // keeps the test focused on the storage-node contract.
-//
-// This test must FAIL on the current writer (the re-written file is a
-// v2 file, not v3; the defaults block is absent).
 //------------------------------------------------------------------------------
-int testV2ToV3FallbackDefaults()
+int testV2OptionalFieldsFallbackDefaults()
 {
   // Synthesise a minimal valid v2 .lrp.json with no resection/scene
   // blocks — i.e. exactly what the schema-v2 writer (current
@@ -356,7 +355,7 @@ int testV2ToV3FallbackDefaults()
   storage->SetFileName(v2Path.c_str());
   CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
 
-  // Re-write and inspect the emitted JSON for the v3 defaults.
+  // Re-write and inspect the emitted JSON for the v2 defaults.
   const std::string rewritePath = makeTempPath("lrp.json");
   vtkNew<vtkMRMLBezierSurfaceStorageNode> rewriteStorage;
   rewriteStorage->SetFileName(rewritePath.c_str());
@@ -367,7 +366,7 @@ int testV2ToV3FallbackDefaults()
   // Default name = MRML display name.
   if (contents.find("\"name\":\"LegacyPlanFromV2\"") == std::string::npos && contents.find("\"name\": \"LegacyPlanFromV2\"") == std::string::npos)
   {
-    std::cerr << "testV2ToV3FallbackDefaults: expected name default = MRML display name "
+    std::cerr << "testV2OptionalFieldsFallbackDefaults: expected name default = MRML display name "
                  "(\"LegacyPlanFromV2\") in re-written JSON; got:\n"
               << contents << "\n";
     return EXIT_FAILURE;
@@ -375,25 +374,25 @@ int testV2ToV3FallbackDefaults()
   // Default margins = 0.0.
   if (!contains(contents, "safetyMargin_mm", "0.0") && !contains(contents, "safetyMargin_mm", "0"))
   {
-    std::cerr << "testV2ToV3FallbackDefaults: expected safetyMargin_mm default = 0.0; got:\n" << contents << "\n";
+    std::cerr << "testV2OptionalFieldsFallbackDefaults: expected safetyMargin_mm default = 0.0; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   if (!contains(contents, "riskMargin_mm", "0.0") && !contains(contents, "riskMargin_mm", "0"))
   {
-    std::cerr << "testV2ToV3FallbackDefaults: expected riskMargin_mm default = 0.0; got:\n" << contents << "\n";
+    std::cerr << "testV2OptionalFieldsFallbackDefaults: expected riskMargin_mm default = 0.0; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   // Default orderIndex = -1 (sentinel: unordered).
   if (!contains(contents, "orderIndex", "-1"))
   {
-    std::cerr << "testV2ToV3FallbackDefaults: expected orderIndex default = -1 (sentinel); got:\n" << contents << "\n";
+    std::cerr << "testV2OptionalFieldsFallbackDefaults: expected orderIndex default = -1 (sentinel); got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
   // scene.classification absent (no nodeId emitted).  We tolerate a
-  // null-valued classification block as a valid v3 shape too — the
+  // null-valued classification block as a valid v2 shape too — the
   // Liver shell that writes the scene.stageSelection block lands in
-  // a follow-up; until then a v3 file with all-null stageSelection +
-  // absent classification is a valid v3 shape per ADR-0023
+  // a follow-up; until then a v2 file with all-null stageSelection +
+  // absent classification is a valid v2 shape per ADR-0023
   // §"Persistence".
   const bool classificationAbsent = contents.find("\"classification\":null") != std::string::npos || contents.find("\"classification\": null") != std::string::npos
                                     || contents.find("\"classification\"") == std::string::npos;
@@ -403,7 +402,7 @@ int testV2ToV3FallbackDefaults()
     // (the sink was loaded from a v2 file with no classification).
     if (contents.find("\"nodeId\":\"vtkMRML") != std::string::npos || contents.find("\"nodeId\": \"vtkMRML") != std::string::npos)
     {
-      std::cerr << "testV2ToV3FallbackDefaults: expected absent / null classification "
+      std::cerr << "testV2OptionalFieldsFallbackDefaults: expected absent / null classification "
                    "block (no classification was set); got:\n"
                 << contents << "\n";
       return EXIT_FAILURE;
@@ -416,7 +415,7 @@ int testV2ToV3FallbackDefaults()
       && contents.find("\"volumetryPartitions\"") != std::string::npos)
   {
     // Block present but not empty — the v2 source had no partitions.
-    std::cerr << "testV2ToV3FallbackDefaults: expected empty volumetryPartitions; got:\n" << contents << "\n";
+    std::cerr << "testV2OptionalFieldsFallbackDefaults: expected empty volumetryPartitions; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
 
@@ -426,19 +425,15 @@ int testV2ToV3FallbackDefaults()
 }
 
 //------------------------------------------------------------------------------
-// Test 3 — the writer emits schemaVersion = 3 (not 2).
+// Test 3 — the writer emits schemaVersion = 2.
 //
 // Pinned invariant (ADR-0023 §"Conformance" — "the schema header
-// reads schemaVersion: 3 on writes"):
-//   Every v3-aware write carries the literal "schemaVersion": 3 in
-//   the on-disk JSON.  The v2 marker "schemaVersion": 2 is absent.
-//
-// This test must FAIL on the current writer (which emits
-// "schemaVersion": 2 unconditionally).  liver-implementer flips it
-// to PASS by bumping
-// vtkMRMLBezierSurfaceStorageNode::SchemaVersion from 2 to 3.
+// reads schemaVersion: 2 on writes"):
+//   Every v2-aware write carries the literal "schemaVersion": 2 in
+//   the on-disk JSON.  Guards against an accidental partial bump
+//   to a future version that doesn't match the reader-band update.
 //------------------------------------------------------------------------------
-int testV3WriteEmitsSchemaVersion3()
+int testV2WriteEmitsSchemaVersion2()
 {
   vtkNew<vtkMRMLScene> scene;
   vtkNew<vtkMRMLBezierSurfaceNode> source;
@@ -453,17 +448,19 @@ int testV3WriteEmitsSchemaVersion3()
 
   const std::string contents = slurp(path);
 
-  // Positive — schemaVersion is 3.
-  if (contents.find("\"schemaVersion\":3") == std::string::npos && contents.find("\"schemaVersion\": 3") == std::string::npos)
+  // Positive — schemaVersion is 2.
+  if (contents.find("\"schemaVersion\":2") == std::string::npos && contents.find("\"schemaVersion\": 2") == std::string::npos)
   {
-    std::cerr << "testV3WriteEmitsSchemaVersion3: expected \"schemaVersion\": 3 in JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2WriteEmitsSchemaVersion2: expected \"schemaVersion\": 2 in JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
-  // Negative — schemaVersion is NOT 2.  Pins the "writer always
-  // emits the current schema" half of the invariant.
-  if (contents.find("\"schemaVersion\":2") != std::string::npos || contents.find("\"schemaVersion\": 2") != std::string::npos)
+  // Negative — schemaVersion is NOT 3.  Pins the "writer always
+  // emits the current schema" half of the invariant: a future
+  // partial bump that changes the writer back to 3 without a
+  // matching reader-band update fails loudly here.
+  if (contents.find("\"schemaVersion\":3") != std::string::npos || contents.find("\"schemaVersion\": 3") != std::string::npos)
   {
-    std::cerr << "testV3WriteEmitsSchemaVersion3: unexpected \"schemaVersion\": 2 in JSON; got:\n" << contents << "\n";
+    std::cerr << "testV2WriteEmitsSchemaVersion2: unexpected \"schemaVersion\": 3 in JSON; got:\n" << contents << "\n";
     return EXIT_FAILURE;
   }
 
@@ -494,7 +491,7 @@ int testV3WriteEmitsSchemaVersion3()
 //
 // This test must FAIL on the current writer (no scene block).
 //------------------------------------------------------------------------------
-int testV3ClassificationSubtypeDiscriminator()
+int testV2ClassificationSubtypeDiscriminator()
 {
   // Sub-case A — standard Couinaud (Auto path).
   {
@@ -514,7 +511,7 @@ int testV3ClassificationSubtypeDiscriminator()
     if (contents.find("\"subtype\":\"vtkMRMLStdCouinaudTerritoriesNode\"") == std::string::npos
         && contents.find("\"subtype\": \"vtkMRMLStdCouinaudTerritoriesNode\"") == std::string::npos)
     {
-      std::cerr << "testV3ClassificationSubtypeDiscriminator (Auto path): expected "
+      std::cerr << "testV2ClassificationSubtypeDiscriminator (Auto path): expected "
                    "scene.classification.subtype = \"vtkMRMLStdCouinaudTerritoriesNode\"; got:\n"
                 << contents << "\n";
       return EXIT_FAILURE;
@@ -539,7 +536,7 @@ int testV3ClassificationSubtypeDiscriminator()
     const std::string contents = slurp(path);
     if (contents.find("\"subtype\":\"vtkMRMLCustomTerritoriesNode\"") == std::string::npos && contents.find("\"subtype\": \"vtkMRMLCustomTerritoriesNode\"") == std::string::npos)
     {
-      std::cerr << "testV3ClassificationSubtypeDiscriminator (Custom path): expected "
+      std::cerr << "testV2ClassificationSubtypeDiscriminator (Custom path): expected "
                    "scene.classification.subtype = \"vtkMRMLCustomTerritoriesNode\"; got:\n"
                 << contents << "\n";
       return EXIT_FAILURE;
@@ -550,72 +547,21 @@ int testV3ClassificationSubtypeDiscriminator()
 }
 
 //------------------------------------------------------------------------------
-// Test 5 — the schemaVersion-acceptance band is [1, 3]; v99 still
-// rejected.
+// Test 5 — schemaVersion 99 stays rejected after the v2.0 fold.
 //
 // Pinned invariant (the schema-versioning convention in the file
 // header of vtkMRMLBezierSurfaceStorageNode.cxx — the
 // MinReadableSchemaVersion / SchemaVersion constants):
 //   The reader admits files with schemaVersion in
-//   [MinReadableSchemaVersion, SchemaVersion].  After v3 lands the
-//   upper bound is 3; v99 (or any other out-of-band value) is
-//   rejected with a vtkErrorMacro.
-//
-// This is the v3 extension of testSchemaVersionMismatch from Test1
-// (which exercises the v99 rejection against the [1, 2] band).  The
-// v99-rejection half of this test passes against the current writer
-// (99 is outside both [1, 2] and [1, 3]); the v3-acceptance half
-// fails until liver-implementer bumps the SchemaVersion constant.
+//   [MinReadableSchemaVersion, SchemaVersion] — currently [2, 2].
+//   v99 (or any other out-of-band value) is rejected with a
+//   vtkErrorMacro.  Sibling of testSchemaVersionMismatch in Test1
+//   (which historically exercised the v99 rejection against the
+//   [1, 2] band).  The boundary-immediate neighbours (v1 and v3)
+//   are covered by testV2SchemaVersionBoundaryRejection.
 //------------------------------------------------------------------------------
-int testV3ReaderAcceptsV3RangeAndRejectsV99()
+int testV2ReaderRejectsV99()
 {
-  // Half (a) — synthesise a v3 file with the minimal v3 shape and
-  // assert the reader accepts it.  Pre-implementation this assertion
-  // fails because the reader's upper bound is still 2.
-  {
-    const std::string path = makeTempPath("lrp.json");
-    {
-      std::ofstream ofs(path);
-      ofs << "{\n";
-      ofs << "  \"schemaVersion\": 3,\n";
-      ofs << "  \"state\": \"Planning\",\n";
-      ofs << "  \"initMode\": \"SlicingPlane\",\n";
-      ofs << "  \"rows\": 4,\n";
-      ofs << "  \"cols\": 4,\n";
-      ofs << "  \"controlGrid\": [";
-      for (int i = 0; i < 48; ++i)
-      {
-        if (i > 0)
-        {
-          ofs << ", ";
-        }
-        ofs << "0.0";
-      }
-      ofs << "],\n";
-      ofs << "  \"slicingPlane\": { \"origin\": [0, 0, 0], \"normal\": [0, 0, 1], "
-             "\"initPointsFlat\": [0, 0, 0, 0, 0, 0] },\n";
-      ofs << "  \"distanceSpheroid\": { \"center\": [0, 0, 0], "
-             "\"radius\": {\"x\": 0, \"y\": 0, \"z\": 0}, "
-             "\"numberOfInitPoints\": 0, \"initPointsFlat\": [] },\n";
-      ofs << "  \"resection\": { \"name\": \"\", \"safetyMargin_mm\": 0.0, "
-             "\"riskMargin_mm\": 0.0, \"orderIndex\": -1 },\n";
-      ofs << "  \"scene\": { \"volumetryPartitions\": [] },\n";
-      ofs << "  \"metadata\": {}\n";
-      ofs << "}\n";
-    }
-    vtkNew<vtkMRMLScene> scene;
-    vtkNew<vtkMRMLBezierSurfaceNode> sink;
-    scene->AddNode(sink.GetPointer());
-    vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
-    storage->SetFileName(path.c_str());
-    CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
-    vtksys::SystemTools::RemoveFile(path);
-  }
-
-  // Half (b) — v99 stays rejected (regression-pin of the invariant
-  // first established by testSchemaVersionMismatch in Test1).  This
-  // passes today; the assertion is here so that the test guards the
-  // negative side of the [1, 3] band after the v3 bump too.
   {
     const std::string path = makeTempPath("lrp.json");
     {
@@ -644,21 +590,22 @@ int testV3ReaderAcceptsV3RangeAndRejectsV99()
 //------------------------------------------------------------------------------
 // Invariant 6 -- schemaVersion boundary rejection (low + high side).
 //
-// The reader's accepted band is [MinReadableSchemaVersion=1,
-// SchemaVersion=3].  testV3ReaderAcceptsV3RangeAndRejectsV99 covers
-// the far-out v99 case as a regression-pin of the v2 behaviour, but
-// does not exercise the immediate boundaries on either side.  This
-// test pins both:
+// The reader's accepted band is [MinReadableSchemaVersion=2,
+// SchemaVersion=2] — exactly v2.  testV2ReaderRejectsV99 covers
+// the far-out v99 case as a regression-pin of the v2.0 behaviour,
+// but does not exercise the immediate boundaries on either side.
+// This test pins both:
 //
-//   - schemaVersion = 0  is below MinReadableSchemaVersion -> rejected
-//   - schemaVersion = 4  is above SchemaVersion             -> rejected
+//   - schemaVersion = 1  is below MinReadableSchemaVersion -> rejected
+//   - schemaVersion = 3  is above SchemaVersion             -> rejected
 //
-// Without these, a future writer bumped from 3 -> 4 without a matching
-// reader-band update would silently emit unreadable files; and a
-// stray 0-valued schemaVersion (e.g. from a half-initialised v0 file)
-// would surface as a confusing parse failure deeper in the reader.
+// The v1 rejection is the post-fold behaviour: v1 was preview-only
+// and not part of the released contract (ADR-0023 §"Persistence";
+// see also the schema-header comment in the .cxx).  The v3
+// rejection is a defensive guard so a future writer bumped from
+// v2 -> v3 without a matching reader-band update fails loudly.
 //------------------------------------------------------------------------------
-int testV3SchemaVersionBoundaryRejection()
+int testV2SchemaVersionBoundaryRejection()
 {
   auto writeMinimal = [&](const std::string& path, int versionLiteral)
   {
@@ -670,10 +617,10 @@ int testV3SchemaVersionBoundaryRejection()
     ofs << "}\n";
   };
 
-  // Low-side boundary: 0 < MinReadableSchemaVersion=1.
+  // Low-side boundary: 1 < MinReadableSchemaVersion=2.
   {
     const std::string path = makeTempPath("lrp.json");
-    writeMinimal(path, 0);
+    writeMinimal(path, 1);
     vtkNew<vtkMRMLScene> scene;
     vtkNew<vtkMRMLBezierSurfaceNode> sink;
     scene->AddNode(sink.GetPointer());
@@ -687,11 +634,11 @@ int testV3SchemaVersionBoundaryRejection()
     vtksys::SystemTools::RemoveFile(path);
   }
 
-  // High-side boundary: 4 > SchemaVersion=3.  Defensive guard so a
-  // future v4 bump without a matching reader update fails loudly.
+  // High-side boundary: 3 > SchemaVersion=2.  Defensive guard so a
+  // future v3 bump without a matching reader update fails loudly.
   {
     const std::string path = makeTempPath("lrp.json");
-    writeMinimal(path, 4);
+    writeMinimal(path, 3);
     vtkNew<vtkMRMLScene> scene;
     vtkNew<vtkMRMLBezierSurfaceNode> sink;
     scene->AddNode(sink.GetPointer());
@@ -711,7 +658,7 @@ int testV3SchemaVersionBoundaryRejection()
 //------------------------------------------------------------------------------
 // Invariant 7 -- scene.stageSelection.currentStage round-trip.
 //
-// ADR-0023 §"Persistence" claims scene.stageSelection as part of v3.
+// ADR-0023 §"Persistence" claims scene.stageSelection as part of v2.
 // The Liver-shell writer for this block lands in a follow-up (T5.2-d);
 // however the storage *reader* already stashes the surgeon's last
 // currentStage into a node attribute on load.  Without this test the
@@ -719,18 +666,18 @@ int testV3SchemaVersionBoundaryRejection()
 // ``currentStage`` keys is dead-uncovered on Codecov, and a future
 // writer regression that drops the field would silently pass.
 //
-// Synthesise a minimal valid v3 .lrp.json with
+// Synthesise a minimal valid v2 .lrp.json with
 // scene.stageSelection.currentStage = 3, load it through the
 // storage-node reader, and assert the node carries the
 // ``currentStage`` attribute equal to "3".
 //------------------------------------------------------------------------------
-int testV3StageSelectionCurrentStageReader()
+int testV2StageSelectionCurrentStageReader()
 {
-  const std::string v3Path = makeTempPath("lrp.json");
+  const std::string v2Path = makeTempPath("lrp.json");
   {
-    std::ofstream ofs(v3Path);
+    std::ofstream ofs(v2Path);
     ofs << "{\n";
-    ofs << "  \"schemaVersion\": 3,\n";
+    ofs << "  \"schemaVersion\": 2,\n";
     ofs << "  \"state\": \"Planning\",\n";
     ofs << "  \"initMode\": \"SlicingPlane\",\n";
     ofs << "  \"rows\": 4,\n";
@@ -752,7 +699,7 @@ int testV3StageSelectionCurrentStageReader()
            "\"numberOfInitPoints\": 0, \"initPointsFlat\": [] },\n";
     ofs << "  \"resection\": { \"name\": \"PlanWithStageSelection\", "
            "\"safetyMargin_mm\": 0.0, \"riskMargin_mm\": 0.0, \"orderIndex\": -1 },\n";
-    // ``classification`` is omitted (matches what the v3 writer emits
+    // ``classification`` is omitted (matches what the v2 writer emits
     // when no ``vtkMRMLAbstractTerritoriesNode`` is present in the
     // scene -- the writer skips the key rather than emitting null,
     // and the reader's ``HasMember("classification")`` guard handles
@@ -772,7 +719,7 @@ int testV3StageSelectionCurrentStageReader()
   scene->AddNode(sink.GetPointer());
 
   vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
-  storage->SetFileName(v3Path.c_str());
+  storage->SetFileName(v2Path.c_str());
   CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
 
   // The reader stashes currentStage as a node attribute keyed by the
@@ -781,7 +728,7 @@ int testV3StageSelectionCurrentStageReader()
   CHECK_NOT_NULL(observed);
   CHECK_STRING(observed, "3");
 
-  vtksys::SystemTools::RemoveFile(v3Path);
+  vtksys::SystemTools::RemoveFile(v2Path);
   return EXIT_SUCCESS;
 }
 
@@ -791,16 +738,16 @@ int testV3StageSelectionCurrentStageReader()
 int vtkMRMLBezierSurfaceStorageNodeTest2(int, char*[])
 {
   // ADR-0027 §"Test target — v2.0 design, not v1 behaviour": these
-  // tests pin the v3 design contract from ADR-0023 §"Persistence".
-  // They are expected to FAIL until liver-implementer lands the v3
+  // tests pin the v2 design contract from ADR-0023 §"Persistence".
+  // They are expected to FAIL until liver-implementer lands the v2
   // writer + reader; they pass after that.
-  CHECK_EXIT_SUCCESS(testV3WriteEmitsSchemaVersion3());
-  CHECK_EXIT_SUCCESS(testV3RoundTripFullFields());
-  CHECK_EXIT_SUCCESS(testV2ToV3FallbackDefaults());
-  CHECK_EXIT_SUCCESS(testV3ClassificationSubtypeDiscriminator());
-  CHECK_EXIT_SUCCESS(testV3ReaderAcceptsV3RangeAndRejectsV99());
-  CHECK_EXIT_SUCCESS(testV3SchemaVersionBoundaryRejection());
-  CHECK_EXIT_SUCCESS(testV3StageSelectionCurrentStageReader());
+  CHECK_EXIT_SUCCESS(testV2WriteEmitsSchemaVersion2());
+  CHECK_EXIT_SUCCESS(testV2RoundTripFullFields());
+  CHECK_EXIT_SUCCESS(testV2OptionalFieldsFallbackDefaults());
+  CHECK_EXIT_SUCCESS(testV2ClassificationSubtypeDiscriminator());
+  CHECK_EXIT_SUCCESS(testV2ReaderRejectsV99());
+  CHECK_EXIT_SUCCESS(testV2SchemaVersionBoundaryRejection());
+  CHECK_EXIT_SUCCESS(testV2StageSelectionCurrentStageReader());
 
   std::cout << "vtkMRMLBezierSurfaceStorageNodeTest2 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
@@ -641,6 +641,83 @@ int testV3ReaderAcceptsV3RangeAndRejectsV99()
   return EXIT_SUCCESS;
 }
 
+//------------------------------------------------------------------------------
+// Invariant 6 -- scene.stageSelection.currentStage round-trip.
+//
+// ADR-0023 §"Persistence" claims scene.stageSelection as part of v3.
+// The Liver-shell writer for this block lands in a follow-up (T5.2-d);
+// however the storage *reader* already stashes the surgeon's last
+// currentStage into a node attribute on load.  Without this test the
+// reader branch in ReadJson around the ``stageSelection`` /
+// ``currentStage`` keys is dead-uncovered on Codecov, and a future
+// writer regression that drops the field would silently pass.
+//
+// Synthesise a minimal valid v3 .lrp.json with
+// scene.stageSelection.currentStage = 3, load it through the
+// storage-node reader, and assert the node carries the
+// ``currentStage`` attribute equal to "3".
+//------------------------------------------------------------------------------
+int testV3StageSelectionCurrentStageReader()
+{
+  const std::string v3Path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(v3Path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 3,\n";
+    ofs << "  \"state\": \"Planning\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\",\n";
+    ofs << "  \"rows\": 4,\n";
+    ofs << "  \"cols\": 4,\n";
+    ofs << "  \"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << (static_cast<double>(i) * 0.0625);
+    }
+    ofs << "],\n";
+    ofs << "  \"slicingPlane\": { \"origin\": [0, 0, 0], \"normal\": [0, 0, 1], "
+           "\"initPointsFlat\": [0, 0, 0, 0, 0, 0] },\n";
+    ofs << "  \"distanceSpheroid\": { \"center\": [0, 0, 0], "
+           "\"radius\": {\"x\": 0, \"y\": 0, \"z\": 0}, "
+           "\"numberOfInitPoints\": 0, \"initPointsFlat\": [] },\n";
+    ofs << "  \"resection\": { \"name\": \"PlanWithStageSelection\", "
+           "\"safetyMargin_mm\": 0.0, \"riskMargin_mm\": 0.0, \"orderIndex\": -1 },\n";
+    // ``classification`` is omitted (matches what the v3 writer emits
+    // when no ``vtkMRMLAbstractTerritoriesNode`` is present in the
+    // scene -- the writer skips the key rather than emitting null,
+    // and the reader's ``HasMember("classification")`` guard handles
+    // the absence cleanly).  ``volumetryPartitions`` stays empty and
+    // ``stageSelection.currentStage`` carries the value the reader
+    // must stash as a node attribute.
+    ofs << "  \"scene\": { \"volumetryPartitions\": [], "
+           "\"stageSelection\": { \"stage1\": null, \"stage2\": null, "
+           "\"stage3\": null, \"stage4\": null, \"stage5\": null, "
+           "\"currentStage\": 3 } },\n";
+    ofs << "  \"metadata\": {}\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLBezierSurfaceNode> sink;
+  scene->AddNode(sink.GetPointer());
+
+  vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+  storage->SetFileName(v3Path.c_str());
+  CHECK_INT(storage->ReadData(sink.GetPointer()), 1);
+
+  // The reader stashes currentStage as a node attribute keyed by the
+  // schema field name; the Liver shell consumes this on next launch.
+  const char* observed = sink->GetAttribute("currentStage");
+  CHECK_NOT_NULL(observed);
+  CHECK_STRING(observed, "3");
+
+  vtksys::SystemTools::RemoveFile(v3Path);
+  return EXIT_SUCCESS;
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -655,6 +732,7 @@ int vtkMRMLBezierSurfaceStorageNodeTest2(int, char*[])
   CHECK_EXIT_SUCCESS(testV2ToV3FallbackDefaults());
   CHECK_EXIT_SUCCESS(testV3ClassificationSubtypeDiscriminator());
   CHECK_EXIT_SUCCESS(testV3ReaderAcceptsV3RangeAndRejectsV99());
+  CHECK_EXIT_SUCCESS(testV3StageSelectionCurrentStageReader());
 
   std::cout << "vtkMRMLBezierSurfaceStorageNodeTest2 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
@@ -642,7 +642,74 @@ int testV3ReaderAcceptsV3RangeAndRejectsV99()
 }
 
 //------------------------------------------------------------------------------
-// Invariant 6 -- scene.stageSelection.currentStage round-trip.
+// Invariant 6 -- schemaVersion boundary rejection (low + high side).
+//
+// The reader's accepted band is [MinReadableSchemaVersion=1,
+// SchemaVersion=3].  testV3ReaderAcceptsV3RangeAndRejectsV99 covers
+// the far-out v99 case as a regression-pin of the v2 behaviour, but
+// does not exercise the immediate boundaries on either side.  This
+// test pins both:
+//
+//   - schemaVersion = 0  is below MinReadableSchemaVersion -> rejected
+//   - schemaVersion = 4  is above SchemaVersion             -> rejected
+//
+// Without these, a future writer bumped from 3 -> 4 without a matching
+// reader-band update would silently emit unreadable files; and a
+// stray 0-valued schemaVersion (e.g. from a half-initialised v0 file)
+// would surface as a confusing parse failure deeper in the reader.
+//------------------------------------------------------------------------------
+int testV3SchemaVersionBoundaryRejection()
+{
+  auto writeMinimal = [&](const std::string& path, int versionLiteral)
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": " << versionLiteral << ",\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"initMode\": \"SlicingPlane\"\n";
+    ofs << "}\n";
+  };
+
+  // Low-side boundary: 0 < MinReadableSchemaVersion=1.
+  {
+    const std::string path = makeTempPath("lrp.json");
+    writeMinimal(path, 0);
+    vtkNew<vtkMRMLScene> scene;
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    scene->AddNode(sink.GetPointer());
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  // High-side boundary: 4 > SchemaVersion=3.  Defensive guard so a
+  // future v4 bump without a matching reader update fails loudly.
+  {
+    const std::string path = makeTempPath("lrp.json");
+    writeMinimal(path, 4);
+    vtkNew<vtkMRMLScene> scene;
+    vtkNew<vtkMRMLBezierSurfaceNode> sink;
+    scene->AddNode(sink.GetPointer());
+    vtkNew<vtkMRMLBezierSurfaceStorageNode> storage;
+    storage->SetFileName(path.c_str());
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_INT(storage->ReadData(sink.GetPointer()), 0);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+    vtksys::SystemTools::RemoveFile(path);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Invariant 7 -- scene.stageSelection.currentStage round-trip.
 //
 // ADR-0023 §"Persistence" claims scene.stageSelection as part of v3.
 // The Liver-shell writer for this block lands in a follow-up (T5.2-d);
@@ -732,6 +799,7 @@ int vtkMRMLBezierSurfaceStorageNodeTest2(int, char*[])
   CHECK_EXIT_SUCCESS(testV2ToV3FallbackDefaults());
   CHECK_EXIT_SUCCESS(testV3ClassificationSubtypeDiscriminator());
   CHECK_EXIT_SUCCESS(testV3ReaderAcceptsV3RangeAndRejectsV99());
+  CHECK_EXIT_SUCCESS(testV3SchemaVersionBoundaryRejection());
   CHECK_EXIT_SUCCESS(testV3StageSelectionCurrentStageReader());
 
   std::cout << "vtkMRMLBezierSurfaceStorageNodeTest2 completed successfully" << std::endl;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceStorageNodeTest2.cxx
@@ -180,7 +180,7 @@ void populateV2Fields(vtkMRMLBezierSurfaceNode* node)
 /// free to migrate this populate path to typed accessors once those
 /// exist; the byte-level assertions on the emitted JSON do not
 /// change.
-void populateV3SurgeonState(vtkMRMLBezierSurfaceNode* node)
+void populateV2SurgeonState(vtkMRMLBezierSurfaceNode* node)
 {
   node->SetName("Right hemihepatectomy");
   // Attribute names match the JSON key vocabulary so the implementer's
@@ -210,7 +210,7 @@ int testV2RoundTripFullFields()
   vtkNew<vtkMRMLBezierSurfaceNode> source;
   scene->AddNode(source.GetPointer());
   populateV2Fields(source.GetPointer());
-  populateV3SurgeonState(source.GetPointer());
+  populateV2SurgeonState(source.GetPointer());
 
   // First write — source → disk.
   const std::string path1 = makeTempPath("lrp.json");
@@ -442,7 +442,7 @@ int testV2WriteEmitsSchemaVersion2()
   vtkNew<vtkMRMLBezierSurfaceNode> source;
   scene->AddNode(source.GetPointer());
   populateV2Fields(source.GetPointer());
-  populateV3SurgeonState(source.GetPointer());
+  populateV2SurgeonState(source.GetPointer());
 
   const std::string path = makeTempPath("lrp.json");
   vtkNew<vtkMRMLBezierSurfaceStorageNode> writeStorage;
@@ -502,7 +502,7 @@ int testV2ClassificationSubtypeDiscriminator()
     vtkNew<vtkMRMLBezierSurfaceNode> source;
     scene->AddNode(source.GetPointer());
     populateV2Fields(source.GetPointer());
-    populateV3SurgeonState(source.GetPointer());
+    populateV2SurgeonState(source.GetPointer());
     source->SetAttribute("classificationSubtype", "vtkMRMLStdCouinaudTerritoriesNode");
 
     const std::string path = makeTempPath("lrp.json");
@@ -528,7 +528,7 @@ int testV2ClassificationSubtypeDiscriminator()
     vtkNew<vtkMRMLBezierSurfaceNode> source;
     scene->AddNode(source.GetPointer());
     populateV2Fields(source.GetPointer());
-    populateV3SurgeonState(source.GetPointer());
+    populateV2SurgeonState(source.GetPointer());
     source->SetAttribute("classificationSubtype", "vtkMRMLCustomTerritoriesNode");
 
     const std::string path = makeTempPath("lrp.json");
@@ -591,7 +591,7 @@ int testV2ReaderRejectsV99()
 }
 
 //------------------------------------------------------------------------------
-// Invariant 6 -- schemaVersion boundary rejection (low + high side).
+// Test 6 — schemaVersion boundary rejection (low + high side).
 //
 // The reader's accepted band is [MinReadableSchemaVersion=2,
 // SchemaVersion=2] — exactly v2.  testV2ReaderRejectsV99 covers
@@ -659,7 +659,7 @@ int testV2SchemaVersionBoundaryRejection()
 }
 
 //------------------------------------------------------------------------------
-// Invariant 7 -- scene.stageSelection.currentStage round-trip.
+// Test 7 — scene.stageSelection.currentStage round-trip.
 //
 // ADR-0023 §"Persistence" claims scene.stageSelection as part of v2.
 // The Liver-shell writer for this block lands in a follow-up (T5.2-d);

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
@@ -94,6 +94,7 @@ vtkMRMLNodeNewMacro(vtkMRMLBezierSurfaceNode);
 vtkMRMLBezierSurfaceNode::vtkMRMLBezierSurfaceNode()
   : State(ResectionState::Init)
   , InitMode(InitializationMode::SlicingPlane)
+  , OrderIndex(-1)
   , Rows(DefaultGridSize)
   , Cols(DefaultGridSize)
   , NumberOfDistanceSpheroidInitPoints(0)
@@ -570,6 +571,7 @@ void vtkMRMLBezierSurfaceNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLEnumMacro(state, State);
   vtkMRMLWriteXMLEnumMacro(initMode, InitMode);
+  vtkMRMLWriteXMLIntMacro(orderIndex, OrderIndex);
   vtkMRMLWriteXMLIntMacro(rows, Rows);
   vtkMRMLWriteXMLIntMacro(cols, Cols);
   vtkMRMLWriteXMLVectorMacro(slicingPlaneOrigin, SlicingPlaneOrigin, double, 3);
@@ -618,6 +620,7 @@ void vtkMRMLBezierSurfaceNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLEnumMacro(state, State);
   vtkMRMLReadXMLEnumMacro(initMode, InitMode);
+  vtkMRMLReadXMLIntMacro(orderIndex, OrderIndex);
   vtkMRMLReadXMLVectorMacro(slicingPlaneOrigin, SlicingPlaneOrigin, double, 3);
   vtkMRMLReadXMLVectorMacro(slicingPlaneNormal, SlicingPlaneNormal, double, 3);
   vtkMRMLReadXMLVectorMacro(distanceSpheroidCenter, DistanceSpheroidCenter, double, 3);
@@ -760,6 +763,7 @@ void vtkMRMLBezierSurfaceNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=
 
   this->State = other->State;
   this->InitMode = other->InitMode;
+  this->OrderIndex = other->OrderIndex;
   // Shape + buffer in one assignment — ADR-0018 §1.  std::vector
   // copy handles the resize automatically.
   this->Rows = other->Rows;
@@ -813,6 +817,7 @@ void vtkMRMLBezierSurfaceNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintEnumMacro(State);
   vtkMRMLPrintEnumMacro(InitMode);
+  vtkMRMLPrintIntMacro(OrderIndex);
   vtkMRMLPrintIntMacro(Rows);
   vtkMRMLPrintIntMacro(Cols);
   vtkMRMLPrintVectorMacro(SlicingPlaneOrigin, double, 3);

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
@@ -305,6 +305,24 @@ public:
   static int GetInitModeFromString(const char* name);
 
   //--------------------------------------------------------------------------
+  // Surgeon-facing ordering metadata (ADR-0023 §"Persistence").
+  //
+  // ``OrderIndex`` is the zero-based position of this resection plan in
+  // the surgeon-defined operative sequence.  A sentinel value of
+  // ``-1`` means "unordered" (the default for a freshly-created node).
+  // The field round-trips through the v3 ``.lrp.json`` storage path
+  // (see ``vtkMRMLBezierSurfaceStorageNode.cxx`` schema-header block)
+  // and through XML scene serialisation.
+  //--------------------------------------------------------------------------
+
+  /// Operative-sequence position (zero-based).  Default ``-1`` =
+  /// unordered.  No transition guard — this is an editable surgeon-
+  /// facing field independent of the ``State`` machine; the planner
+  /// can reorder resections in any state.
+  vtkGetMacro(OrderIndex, int);
+  vtkSetMacro(OrderIndex, int);
+
+  //--------------------------------------------------------------------------
   // Bezier control grid — (Rows × Cols × 3 row-major)
   //
   // Per ADR-0018 §1 the control-polygon shape is square and chosen
@@ -460,6 +478,10 @@ private:
   /// SetInitializationMode accessor pair above).
   int State;
   int InitMode;
+
+  /// Surgeon-facing operative-sequence position.  Default ``-1`` =
+  /// unordered (see the accessor docstring above).
+  int OrderIndex;
 
   /// Control-polygon shape (Rows × Cols).  Default 4×4 (the
   /// pre-ADR-0018 hard-coded case).  Per ADR-0018 §1, restricted to

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
@@ -310,7 +310,7 @@ public:
   // ``OrderIndex`` is the zero-based position of this resection plan in
   // the surgeon-defined operative sequence.  A sentinel value of
   // ``-1`` means "unordered" (the default for a freshly-created node).
-  // The field round-trips through the v3 ``.lrp.json`` storage path
+  // The field round-trips through the v2 ``.lrp.json`` storage path
   // (see ``vtkMRMLBezierSurfaceStorageNode.cxx`` schema-header block)
   // and through XML scene serialisation.
   //--------------------------------------------------------------------------

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -38,21 +38,24 @@
 ==============================================================================*/
 
 //==============================================================================
-// .lrp.json — JSON schema v3 (ADR-0023 §"Persistence")
+// .lrp.json — JSON schema v2 (ADR-0023 §"Persistence")
 //==============================================================================
 //
 // One ``.lrp.json`` document per liver resection plan (surgeon-to-
 // surgeon plan sharing per ADR-0014 §5).  Current writer
-// ``schemaVersion`` is ``3`` — bump in lock-step with any documented
-// extension; the reader accepts ``MinReadableSchemaVersion``
-// (currently ``1``) through ``SchemaVersion`` (currently ``3``).
+// ``schemaVersion`` is ``2`` (the unified schema for the 2026 v2.0.0
+// release); the reader accepts only v2 — v1 was preview-only and
+// is not part of the released contract.  Bump ``SchemaVersion`` in
+// lock-step with any documented extension; widen
+// ``MinReadableSchemaVersion`` only when an older version is part
+// of the public release contract.
 //
 //   {
-//     "schemaVersion": 3,
+//     "schemaVersion": 2,
 //     "state": "Init" | "Planning" | "Confirmed",
 //     "initMode": "SlicingPlane" | "DistanceSpheroid",
-//     "rows": int,             // v2+ only — see migration below
-//     "cols": int,             // v2+ only — see migration below
+//     "rows": int,             // 3 or 4 per ADR-0018 §1
+//     "cols": int,             // same as rows (square admitted)
 //     "controlGrid": [3 * rows * cols doubles in row-major (i,j,k) order],
 //     "slicingPlane": {
 //       "origin": [3 doubles, RAS],
@@ -66,13 +69,13 @@
 //       "initPointsFlat": [3*N doubles — N RAS triplets concat]
 //     },
 //     "metadata": {},
-//     "resection": {                      // v3 only
+//     "resection": {
 //       "name": string,                   // surgeon-facing plan name
 //       "safetyMargin_mm": double,        // see margin mapping below
 //       "riskMargin_mm": double,          // see margin mapping below
 //       "orderIndex": int                 // -1 = unordered (sentinel)
 //     },
-//     "scene": {                          // v3 only
+//     "scene": {
 //       "classification": {
 //         "nodeId": string,
 //         "subtype": string               // concrete vtkMRMLAbstractTerritoriesNode subclass name
@@ -89,8 +92,8 @@
 //     }
 //   }
 //
-// v3 surgeon-facing margin mapping (ADR-0023 §"Persistence")
-// ----------------------------------------------------------
+// Surgeon-facing margin mapping (ADR-0023 §"Persistence")
+// -------------------------------------------------------
 // The on-disk ``resection.safetyMargin_mm`` and ``resection.riskMargin_mm``
 // fields use surgeon-facing labels, but their source values are the
 // existing ``vtkMRMLLiverResectionNode`` members:
@@ -98,12 +101,13 @@
 //   resection.safetyMargin_mm  <->  vtkMRMLLiverResectionNode::ResectionMargin
 //   resection.riskMargin_mm    <->  vtkMRMLLiverResectionNode::UncertaintyMargin
 //
-// The MRML class members keep their pre-v3 names; the renaming is
-// strictly storage-layer.  This avoids a cross-tree MRML attribute
-// rename that would ripple through the legacy display node, Logic,
-// and Python scripting.  T2.7 (legacy retirement) is the natural
-// place to collapse the two vocabularies; until then the JSON
-// surgeon-vocabulary and the MRML developer-vocabulary coexist.
+// The MRML class members keep their developer-facing names; the
+// renaming is strictly storage-layer.  This avoids a cross-tree
+// MRML attribute rename that would ripple through the legacy
+// display node, Logic, and Python scripting.  T2.7 (legacy
+// retirement) is the natural place to collapse the two vocabularies;
+// until then the JSON surgeon-vocabulary and the MRML
+// developer-vocabulary coexist.
 //
 // In v2.0 the ``vtkMRMLBezierSurfaceNode`` does not yet carry a
 // node reference to its sibling ``vtkMRMLLiverResectionNode`` —
@@ -114,8 +118,8 @@
 // gains a third lookup tier (typed accessor on the resection node)
 // ahead of the attribute-map fallback.
 //
-// v3 scene block — locating logic
-// -------------------------------
+// scene block — locating logic
+// ----------------------------
 //   - ``scene.classification``: queried via
 //     ``scene->GetNodesByClass("vtkMRMLAbstractTerritoriesNode")``.
 //     Multi-classification scenes are a v2.1+ concern; in v2.0 the
@@ -136,31 +140,24 @@
 //     stages unset); the reader accepts both the empty / absent
 //     form and the populated form via ``HasMember`` guards.
 //
-// v1 / v2 → v3 migration:
-//   - v1 files have no ``rows`` / ``cols`` and a 48-double
-//     ``controlGrid``.  The reader infers ``rows = cols = 4`` and
-//     validates the array length.
-//   - v2 files carry explicit ``rows`` and ``cols``.  The reader
-//     enforces ``(rows, cols) ∈ {(3, 3), (4, 4)}`` per ADR-0018 §1
-//     and validates the ``controlGrid`` length is
-//     ``3 * rows * cols``.
-//   - v3 files additionally carry ``resection`` and ``scene``
-//     blocks.  A v2 file loaded by the v3 reader gets documented
-//     defaults: name = node's MRML display name, both margins = 0.0,
-//     orderIndex = -1, classification absent, volumetry partitions
-//     empty, stageSelection absent.
-//   - The writer always emits v3.  A v1 / v2 file round-tripped
-//     through load + save becomes v3 on disk.
+// Optional-field tolerance (within v2):
+//   - ``resection`` and ``scene`` blocks are optional on read.  A
+//     v2 file written before the surgeon-state fields were wired
+//     (preview-tracking deployments only — v2 was not yet released)
+//     gets documented defaults on load: name = node's MRML display
+//     name, both margins = 0.0, orderIndex = -1, classification
+//     absent, volumetry partitions empty, stageSelection absent.
+//   - v1 is rejected at the schema-version gate — there are no
+//     released v1 files to migrate.
 //
 // The ``initPointsFlat`` fields use a flat layout because the
 // in-tree ``vtkMRMLJsonWriter`` lacks a key-less nested-array entry
 // point.  See the implementation of ``WriteJson`` below for the
-// rationale and a ``TODO(T2.5 lrp-json-v2-nested-init-points)``
-// marker.
+// rationale.
 //
-// The ``metadata`` object is intentionally empty in v1 and reserved
-// for v2's "richer metadata" allowance (timestamps, surgeon ID, …)
-// per ADR-0014 §5.
+// The ``metadata`` object is intentionally empty for v2.0 and
+// reserved for richer metadata (timestamps, surgeon ID, …) in a
+// future schema revision per ADR-0014 §5.
 //
 //==============================================================================
 // Legacy ``.lrp.fcsv`` migration (load-only)
@@ -433,9 +430,7 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
   writer->WriteStringProperty("state", vtkMRMLBezierSurfaceNode::GetStateAsString(surfaceNode->GetState()));
   writer->WriteStringProperty("initMode", vtkMRMLBezierSurfaceNode::GetInitModeAsString(surfaceNode->GetInitMode()));
 
-  // rows + cols — schema v2 explicit shape (ADR-0018 §1).  v1
-  // implicit-4×4 files load via the migration branch in ReadJson;
-  // the writer always emits v2.
+  // rows + cols — explicit control-polygon shape per ADR-0018 §1.
   writer->WriteIntProperty("rows", static_cast<int>(surfaceNode->GetRows()));
   writer->WriteIntProperty("cols", static_cast<int>(surfaceNode->GetCols()));
 
@@ -749,21 +744,15 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
   }
 
   // Control-polygon shape (ADR-0018 §1).  v2 files carry explicit
-  // ``rows`` + ``cols``; v1 files have neither and the shape is
-  // implicit-4×4.  Resolve both schemas to a (rows, cols) pair, then
-  // apply via SetSize after validating square + admitted-size.
-  unsigned int rows = vtkMRMLBezierSurfaceNode::DefaultGridSize;
-  unsigned int cols = vtkMRMLBezierSurfaceNode::DefaultGridSize;
-  if (schemaVersion >= 2)
+  // ``rows`` + ``cols``; both are required.  Apply via ``SetSize``
+  // after validating square + admitted-size.
+  if (!root->HasMember("rows") || !root->HasMember("cols"))
   {
-    if (!root->HasMember("rows") || !root->HasMember("cols"))
-    {
-      vtkErrorMacro("ReadJson: schemaVersion " << schemaVersion << " requires 'rows' and 'cols' fields in '" << filePath << "'");
-      return 0;
-    }
-    rows = static_cast<unsigned int>(root->GetIntProperty("rows"));
-    cols = static_cast<unsigned int>(root->GetIntProperty("cols"));
+    vtkErrorMacro("ReadJson: schemaVersion " << schemaVersion << " requires 'rows' and 'cols' fields in '" << filePath << "'");
+    return 0;
   }
+  const unsigned int rows = static_cast<unsigned int>(root->GetIntProperty("rows"));
+  const unsigned int cols = static_cast<unsigned int>(root->GetIntProperty("cols"));
   if (rows != cols || static_cast<int>(rows) < vtkMRMLBezierSurfaceNode::MinGridSize || static_cast<int>(rows) > vtkMRMLBezierSurfaceNode::MaxGridSize)
   {
     vtkErrorMacro("ReadJson: invalid (rows=" << rows << ", cols=" << cols << ") in '" << filePath << "' — ADR-0018 §1 admits {(3, 3), (4, 4)} only");
@@ -791,11 +780,11 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
       // back to "Planning" gracefully so a scene authored by a future
       // build that adds a fourth state (e.g. "Approved") still opens
       // in older builds with the surface visible and editable.  The
-      // fallback also covers the symmetric forward-compat case for the
-      // existing readership: a v3-authored "Confirmed" scene loaded by
-      // a build that pre-dates this PR would have read as unknown;
-      // adding the fallback here means the same loader behaviour ages
-      // gracefully into the next schema bump.
+      // fallback also covers the symmetric forward-compat case for
+      // the existing readership: a scene authored by a future build
+      // that adds a new state (e.g. "Approved") loaded by an older
+      // build reads as unknown; the fallback keeps the surface
+      // visible and editable rather than failing the load.
       vtkWarningMacro("ReadJson: unknown state name '" << s << "' in '" << filePath
                                                        << "' — falling back to Planning"
                                                           " (ADR-0019 forward-compatible default)");

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -38,21 +38,21 @@
 ==============================================================================*/
 
 //==============================================================================
-// .lrp.json — JSON schema v2 (ADR-0018 §1)
+// .lrp.json — JSON schema v3 (ADR-0023 §"Persistence")
 //==============================================================================
 //
 // One ``.lrp.json`` document per liver resection plan (surgeon-to-
 // surgeon plan sharing per ADR-0014 §5).  Current writer
-// ``schemaVersion`` is ``2`` — bump in lock-step with any documented
+// ``schemaVersion`` is ``3`` — bump in lock-step with any documented
 // extension; the reader accepts ``MinReadableSchemaVersion``
-// (currently ``1``) through ``SchemaVersion`` (currently ``2``).
+// (currently ``1``) through ``SchemaVersion`` (currently ``3``).
 //
 //   {
-//     "schemaVersion": 2,
+//     "schemaVersion": 3,
 //     "state": "Init" | "Planning" | "Confirmed",
 //     "initMode": "SlicingPlane" | "DistanceSpheroid",
-//     "rows": int,             // v2 only — see migration below
-//     "cols": int,             // v2 only — see migration below
+//     "rows": int,             // v2+ only — see migration below
+//     "cols": int,             // v2+ only — see migration below
 //     "controlGrid": [3 * rows * cols doubles in row-major (i,j,k) order],
 //     "slicingPlane": {
 //       "origin": [3 doubles, RAS],
@@ -65,10 +65,78 @@
 //       "numberOfInitPoints": int,
 //       "initPointsFlat": [3*N doubles — N RAS triplets concat]
 //     },
-//     "metadata": {}
+//     "metadata": {},
+//     "resection": {                      // v3 only
+//       "name": string,                   // surgeon-facing plan name
+//       "safetyMargin_mm": double,        // see margin mapping below
+//       "riskMargin_mm": double,          // see margin mapping below
+//       "orderIndex": int                 // -1 = unordered (sentinel)
+//     },
+//     "scene": {                          // v3 only
+//       "classification": {
+//         "nodeId": string,
+//         "subtype": string               // concrete vtkMRMLAbstractTerritoriesNode subclass name
+//       } | absent,
+//       "volumetryPartitions": [{ "nodeId": string }, …],
+//       "stageSelection": {               // ADR-0023 §"Stage transitions"
+//         "stage1": string | null,
+//         "stage2": string | null,
+//         "stage3": string | null,
+//         "stage4": string | null,
+//         "stage5": string | null,
+//         "currentStage": int | null
+//       } | absent
+//     }
 //   }
 //
-// v1 → v2 migration:
+// v3 surgeon-facing margin mapping (ADR-0023 §"Persistence")
+// ----------------------------------------------------------
+// The on-disk ``resection.safetyMargin_mm`` and ``resection.riskMargin_mm``
+// fields use surgeon-facing labels, but their source values are the
+// existing ``vtkMRMLLiverResectionNode`` members:
+//
+//   resection.safetyMargin_mm  <->  vtkMRMLLiverResectionNode::ResectionMargin
+//   resection.riskMargin_mm    <->  vtkMRMLLiverResectionNode::UncertaintyMargin
+//
+// The MRML class members keep their pre-v3 names; the renaming is
+// strictly storage-layer.  This avoids a cross-tree MRML attribute
+// rename that would ripple through the legacy display node, Logic,
+// and Python scripting.  T2.7 (legacy retirement) is the natural
+// place to collapse the two vocabularies; until then the JSON
+// surgeon-vocabulary and the MRML developer-vocabulary coexist.
+//
+// In v2.0 the ``vtkMRMLBezierSurfaceNode`` does not yet carry a
+// node reference to its sibling ``vtkMRMLLiverResectionNode`` —
+// the storage path therefore reads the margin values from the
+// surface node's attribute map (``GetAttribute("safetyMargin_mm")``
+// etc.) when present, and falls back to ``0.0`` otherwise.  Once
+// the resection-node reference lands in a follow-up, the writer
+// gains a third lookup tier (typed accessor on the resection node)
+// ahead of the attribute-map fallback.
+//
+// v3 scene block — locating logic
+// -------------------------------
+//   - ``scene.classification``: queried via
+//     ``scene->GetNodesByClass("vtkMRMLAbstractTerritoriesNode")``.
+//     Multi-classification scenes are a v2.1+ concern; in v2.0 the
+//     writer emits the block only when exactly one such node exists.
+//     A ``classificationSubtype`` attribute on the surface node
+//     short-circuits the scene query — the Liver shell sets this
+//     when wiring the surface node to its territories partner; the
+//     test path also uses it to communicate the intended subtype
+//     without instantiating a real territories node.
+//   - ``scene.volumetryPartitions``: queried via
+//     ``scene->GetNodesByClass("vtkMRMLLiverVolumetryPartitionNode")``.
+//     That class does not yet exist in v2.0 — the query returns 0
+//     and the writer emits an empty array.  The schema is
+//     forward-compatible: when the class lands in a future PR, the
+//     writer starts populating the array automatically.
+//   - ``scene.stageSelection``: written by the Liver shell (a
+//     follow-up to ADR-0023).  v2.0 emits an empty object (all
+//     stages unset); the reader accepts both the empty / absent
+//     form and the populated form via ``HasMember`` guards.
+//
+// v1 / v2 → v3 migration:
 //   - v1 files have no ``rows`` / ``cols`` and a 48-double
 //     ``controlGrid``.  The reader infers ``rows = cols = 4`` and
 //     validates the array length.
@@ -76,8 +144,13 @@
 //     enforces ``(rows, cols) ∈ {(3, 3), (4, 4)}`` per ADR-0018 §1
 //     and validates the ``controlGrid`` length is
 //     ``3 * rows * cols``.
-//   - The writer always emits v2.  A v1 file round-tripped through
-//     load + save becomes v2 on disk.
+//   - v3 files additionally carry ``resection`` and ``scene``
+//     blocks.  A v2 file loaded by the v3 reader gets documented
+//     defaults: name = node's MRML display name, both margins = 0.0,
+//     orderIndex = -1, classification absent, volumetry partitions
+//     empty, stageSelection absent.
+//   - The writer always emits v3.  A v1 / v2 file round-tripped
+//     through load + save becomes v3 on disk.
 //
 // The ``initPointsFlat`` fields use a flat layout because the
 // in-tree ``vtkMRMLJsonWriter`` lacks a key-less nested-array entry
@@ -160,6 +233,7 @@
 // MRML includes
 #include <vtkMRMLJsonElement.h>
 #include <vtkMRMLMessageCollection.h>
+#include <vtkMRMLScene.h>
 #include <vtkMRMLStorageNode.h>
 
 // VTK includes
@@ -452,6 +526,154 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
   writer->WriteObjectPropertyStart("metadata");
   writer->WriteObjectPropertyEnd();
 
+  // resection — v3 surgeon-facing block (ADR-0023 §"Persistence").
+  // The lookup tiers below favour the attribute map over the typed
+  // accessor so the future Liver shell wiring (which will copy
+  // values from the associated ``vtkMRMLLiverResectionNode``) and
+  // the C++ test driver share a single override path; the typed
+  // accessor on ``vtkMRMLBezierSurfaceNode`` is the canonical v2.0
+  // storage when no override is set.
+  auto readDoubleAttr = [&](const char* key) -> double {
+    const char* raw = surfaceNode->GetAttribute(key);
+    if (raw == nullptr)
+    {
+      return 0.0;
+    }
+    try
+    {
+      return std::stod(raw);
+    }
+    catch (const std::exception&)
+    {
+      return 0.0;
+    }
+  };
+
+  writer->WriteObjectPropertyStart("resection");
+  {
+    const char* nameAttr = surfaceNode->GetAttribute("name");
+    const char* mrmlName = surfaceNode->GetName();
+    std::string name;
+    if (nameAttr != nullptr)
+    {
+      name = nameAttr;
+    }
+    else if (mrmlName != nullptr)
+    {
+      name = mrmlName;
+    }
+    writer->WriteStringProperty("name", name);
+
+    writer->WriteDoubleProperty("safetyMargin_mm", readDoubleAttr("safetyMargin_mm"));
+    writer->WriteDoubleProperty("riskMargin_mm", readDoubleAttr("riskMargin_mm"));
+
+    int orderIndex = surfaceNode->GetOrderIndex();
+    const char* orderAttr = surfaceNode->GetAttribute("orderIndex");
+    if (orderAttr != nullptr)
+    {
+      try
+      {
+        orderIndex = std::stoi(orderAttr);
+      }
+      catch (const std::exception&)
+      {
+        // Malformed attribute — keep the typed-accessor value.
+      }
+    }
+    writer->WriteIntProperty("orderIndex", orderIndex);
+  }
+  writer->WriteObjectPropertyEnd();
+
+  // scene — v3 scene-wide context block (ADR-0023 §"Persistence").
+  // Three subordinate blocks:
+  //
+  //   - classification: nodeId + subtype of the active territories
+  //     node (a vtkMRMLAbstractTerritoriesNode subclass).  The
+  //     subtype is the concrete VTK class name so the reader can
+  //     re-instantiate the right subclass on restore.  Multi-
+  //     classification scenes are a v2.1+ concern.
+  //   - volumetryPartitions: list of {nodeId} for each
+  //     vtkMRMLLiverVolumetryPartitionNode in the scene.  That class
+  //     does not yet exist in v2.0; the array is empty until it
+  //     lands.
+  //   - stageSelection: per-stage node-ID + currentStage int written
+  //     by the Liver shell (ADR-0023 §"Stage transitions").  v2.0
+  //     emits the block as an empty object — the reader's HasMember
+  //     guards keep it forward-compatible with the shell's eventual
+  //     populated form.
+  vtkMRMLScene* scene = surfaceNode->GetScene();
+  writer->WriteObjectPropertyStart("scene");
+  {
+    // classification.  Attribute-override path first (covers the
+    // test driver + the shell's future wiring); scene-scan fall-back
+    // second.  Multi-classification scenes are explicitly NOT
+    // supported in v2.0 — if more than one territories node exists
+    // and no attribute override pins one, the block is emitted as
+    // an empty placeholder.
+    const char* subtypeAttr = surfaceNode->GetAttribute("classificationSubtype");
+    const char* nodeIdAttr = surfaceNode->GetAttribute("classificationNodeId");
+    std::string classificationSubtype;
+    std::string classificationNodeId;
+    if (subtypeAttr != nullptr && subtypeAttr[0] != '\0')
+    {
+      classificationSubtype = subtypeAttr;
+      if (nodeIdAttr != nullptr)
+      {
+        classificationNodeId = nodeIdAttr;
+      }
+    }
+    else if (scene != nullptr)
+    {
+      std::vector<vtkMRMLNode*> hits;
+      scene->GetNodesByClass("vtkMRMLAbstractTerritoriesNode", hits);
+      if (hits.size() == 1 && hits[0] != nullptr)
+      {
+        classificationSubtype = hits[0]->GetClassName();
+        if (hits[0]->GetID() != nullptr)
+        {
+          classificationNodeId = hits[0]->GetID();
+        }
+      }
+    }
+    writer->WriteObjectPropertyStart("classification");
+    if (!classificationSubtype.empty())
+    {
+      writer->WriteStringProperty("nodeId", classificationNodeId);
+      writer->WriteStringProperty("subtype", classificationSubtype);
+    }
+    writer->WriteObjectPropertyEnd();
+
+    // volumetryPartitions.  Forward-compatible scene scan: emit one
+    // ``{ "nodeId": <ID> }`` entry per
+    // ``vtkMRMLLiverVolumetryPartitionNode`` in the scene.  Class
+    // does not yet exist in v2.0 → array is empty.
+    writer->WriteArrayPropertyStart("volumetryPartitions");
+    if (scene != nullptr)
+    {
+      std::vector<vtkMRMLNode*> hits;
+      scene->GetNodesByClass("vtkMRMLLiverVolumetryPartitionNode", hits);
+      for (vtkMRMLNode* node : hits)
+      {
+        if (node == nullptr || node->GetID() == nullptr)
+        {
+          continue;
+        }
+        writer->WriteObjectStart();
+        writer->WriteStringProperty("nodeId", node->GetID());
+        writer->WriteObjectEnd();
+      }
+    }
+    writer->WriteArrayPropertyEnd();
+
+    // stageSelection.  Empty object in v2.0 — the Liver shell that
+    // restores the surgeon's stage position writes this block in a
+    // follow-up to ADR-0023.  Reader uses HasMember guards so the
+    // empty / absent form ages forward into the populated shape.
+    writer->WriteObjectPropertyStart("stageSelection");
+    writer->WriteObjectPropertyEnd();
+  }
+  writer->WriteObjectPropertyEnd();
+
   if (!writer->WriteToFileEnd())
   {
     vtkErrorMacro("WriteJson: failed to close '" << filePath << "' after write");
@@ -672,6 +894,115 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
           {
             double p[3] = { flat[static_cast<size_t>(i) * 3 + 0], flat[static_cast<size_t>(i) * 3 + 1], flat[static_cast<size_t>(i) * 3 + 2] };
             surfaceNode->SetDistanceSpheroidInitPoint(i, p);
+          }
+        }
+      }
+    }
+  }
+
+  // v3 resection block (ADR-0023 §"Persistence").  Defensive
+  // ``HasMember`` guard — a v1 / v2 file has no block and the v3
+  // fields take documented defaults (name = MRML display name,
+  // margins = 0.0, orderIndex = -1) which are already in place by
+  // virtue of the node's default-constructed state.  Surgeon-facing
+  // values are stashed both in typed members (OrderIndex) AND in the
+  // attribute map (margins, name override) so the round-trip writer
+  // picks them up symmetrically.  The attribute-map detour for
+  // margins covers the v2.0 gap that the surface node does not yet
+  // have a typed reference to its sibling ``vtkMRMLLiverResectionNode``;
+  // once that lands the reader applies the values via the typed
+  // accessor on the resection node and the attribute path retires.
+  if (root->HasMember("resection"))
+  {
+    vtkSmartPointer<vtkMRMLJsonElement> resection = vtkSmartPointer<vtkMRMLJsonElement>::Take(root->GetObjectProperty("resection"));
+    if (resection != nullptr)
+    {
+      if (resection->HasMember("name"))
+      {
+        const std::string name = resection->GetStringProperty("name");
+        if (!name.empty())
+        {
+          surfaceNode->SetName(name.c_str());
+        }
+      }
+      auto stashDoubleAttr = [&](const char* key) {
+        if (!resection->HasMember(key))
+        {
+          return;
+        }
+        double value = 0.0;
+        if (resection->GetDoubleProperty(key, value))
+        {
+          std::ostringstream oss;
+          oss << value;
+          surfaceNode->SetAttribute(key, oss.str().c_str());
+        }
+      };
+      stashDoubleAttr("safetyMargin_mm");
+      stashDoubleAttr("riskMargin_mm");
+      if (resection->HasMember("orderIndex"))
+      {
+        int orderIndex = -1;
+        if (resection->GetIntProperty("orderIndex", orderIndex))
+        {
+          surfaceNode->SetOrderIndex(orderIndex);
+        }
+      }
+    }
+  }
+
+  // v3 scene block (ADR-0023 §"Persistence").  Defensive parsing:
+  //   - classification: stash {nodeId, subtype} into attributes so
+  //     the next write re-emits them.  When the Liver shell wiring
+  //     lands, this path will set typed node references instead.
+  //   - volumetryPartitions: writer re-derives from the scene on
+  //     save, so the reader ignores the on-disk entries.
+  //   - stageSelection: stash currentStage (if present) so the
+  //     follow-up shell can restore the surgeon position; v2.0
+  //     does not yet consume the per-stage node IDs.
+  if (root->HasMember("scene"))
+  {
+    vtkSmartPointer<vtkMRMLJsonElement> sceneBlock = vtkSmartPointer<vtkMRMLJsonElement>::Take(root->GetObjectProperty("scene"));
+    if (sceneBlock != nullptr)
+    {
+      if (sceneBlock->HasMember("classification"))
+      {
+        vtkSmartPointer<vtkMRMLJsonElement> classification = vtkSmartPointer<vtkMRMLJsonElement>::Take(sceneBlock->GetObjectProperty("classification"));
+        if (classification != nullptr)
+        {
+          if (classification->HasMember("nodeId"))
+          {
+            const std::string nodeId = classification->GetStringProperty("nodeId");
+            if (!nodeId.empty())
+            {
+              surfaceNode->SetAttribute("classificationNodeId", nodeId.c_str());
+            }
+          }
+          if (classification->HasMember("subtype"))
+          {
+            const std::string subtype = classification->GetStringProperty("subtype");
+            if (!subtype.empty())
+            {
+              surfaceNode->SetAttribute("classificationSubtype", subtype.c_str());
+            }
+          }
+        }
+      }
+      // volumetryPartitions: not yet routed into anything in v2.0 —
+      // the writer re-derives the array from the scene on the next
+      // save, so the reader can ignore the on-disk entries.  Wiring
+      // into a typed list lands with ``vtkMRMLLiverVolumetryPartitionNode``.
+      if (sceneBlock->HasMember("stageSelection"))
+      {
+        vtkSmartPointer<vtkMRMLJsonElement> stageSelection = vtkSmartPointer<vtkMRMLJsonElement>::Take(sceneBlock->GetObjectProperty("stageSelection"));
+        if (stageSelection != nullptr && stageSelection->HasMember("currentStage"))
+        {
+          int currentStage = 0;
+          if (stageSelection->GetIntProperty("currentStage", currentStage))
+          {
+            std::ostringstream oss;
+            oss << currentStage;
+            surfaceNode->SetAttribute("currentStage", oss.str().c_str());
           }
         }
       }

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -81,7 +81,7 @@
 //         "subtype": string               // concrete vtkMRMLAbstractTerritoriesNode subclass name
 //       } | absent,
 //       "volumetryPartitions": [{ "nodeId": string }, …],
-//       "stageSelection": {               // ADR-0023 §"Stage transitions"
+//       "stageSelection": {               // ADR-0023 §"Persistence" — per-stage last-selection
 //         "stage1": string | null,
 //         "stage2": string | null,
 //         "stage3": string | null,
@@ -521,7 +521,7 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
   writer->WriteObjectPropertyStart("metadata");
   writer->WriteObjectPropertyEnd();
 
-  // resection — v3 surgeon-facing block (ADR-0023 §"Persistence").
+  // resection — v2 surgeon-facing block (ADR-0023 §"Persistence").
   // The lookup tiers below favour the attribute map over the typed
   // accessor so the future Liver shell wiring (which will copy
   // values from the associated ``vtkMRMLLiverResectionNode``) and
@@ -580,7 +580,7 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
   }
   writer->WriteObjectPropertyEnd();
 
-  // scene — v3 scene-wide context block (ADR-0023 §"Persistence").
+  // scene — v2 scene-wide context block (ADR-0023 §"Persistence").
   // Three subordinate blocks:
   //
   //   - classification: nodeId + subtype of the active territories
@@ -593,7 +593,8 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
   //     does not yet exist in v2.0; the array is empty until it
   //     lands.
   //   - stageSelection: per-stage node-ID + currentStage int written
-  //     by the Liver shell (ADR-0023 §"Stage transitions").  v2.0
+  //     by the Liver shell (ADR-0023 §"Persistence" —
+  //     per-stage last-selection bullet).  v2.0
   //     emits the block as an empty object — the reader's HasMember
   //     guards keep it forward-compatible with the shell's eventual
   //     populated form.
@@ -890,11 +891,12 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
     }
   }
 
-  // v3 resection block (ADR-0023 §"Persistence").  Defensive
-  // ``HasMember`` guard — a v1 / v2 file has no block and the v3
-  // fields take documented defaults (name = MRML display name,
-  // margins = 0.0, orderIndex = -1) which are already in place by
-  // virtue of the node's default-constructed state.  Surgeon-facing
+  // v2 resection block (ADR-0023 §"Persistence").  Defensive
+  // ``HasMember`` guard — a v2 file may omit the block (e.g. a
+  // preview-tracking write before the fields were wired) and the
+  // surgeon-facing fields take documented defaults (name = MRML
+  // display name, margins = 0.0, orderIndex = -1) which are already
+  // in place by virtue of the node's default-constructed state.  Surgeon-facing
   // values are stashed both in typed members (OrderIndex) AND in the
   // attribute map (margins, name override) so the round-trip writer
   // picks them up symmetrically.  The attribute-map detour for
@@ -942,7 +944,7 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
     }
   }
 
-  // v3 scene block (ADR-0023 §"Persistence").  Defensive parsing:
+  // v2 scene block (ADR-0023 §"Persistence").  Defensive parsing:
   //   - classification: stash {nodeId, subtype} into attributes so
   //     the next write re-emits them.  When the Liver shell wiring
   //     lands, this path will set typed node references instead.

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.cxx
@@ -533,7 +533,8 @@ int vtkMRMLBezierSurfaceStorageNode::WriteJson(const std::string& filePath, vtkM
   // the C++ test driver share a single override path; the typed
   // accessor on ``vtkMRMLBezierSurfaceNode`` is the canonical v2.0
   // storage when no override is set.
-  auto readDoubleAttr = [&](const char* key) -> double {
+  auto readDoubleAttr = [&](const char* key) -> double
+  {
     const char* raw = surfaceNode->GetAttribute(key);
     if (raw == nullptr)
     {
@@ -925,7 +926,8 @@ int vtkMRMLBezierSurfaceStorageNode::ReadJson(const std::string& filePath, vtkMR
           surfaceNode->SetName(name.c_str());
         }
       }
-      auto stashDoubleAttr = [&](const char* key) {
+      auto stashDoubleAttr = [&](const char* key)
+      {
         if (!resection->HasMember(key))
         {
           return;

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
@@ -75,33 +75,46 @@
  * ADR-0007's D-class compatibility-break category, the
  * ``.lrp.fcsv`` deprecation is part of the v2.0.0 MAJOR bump.
  *
- * \par JSON schema (v2 — ADR-0018 §1)
+ * \par JSON schema (v3 — ADR-0023 §"Persistence")
  *
  * See the in-source documentation at the top of
  * ``vtkMRMLBezierSurfaceStorageNode.cxx`` for the canonical
  * schema description.  Briefly:
  *
- *   - ``schemaVersion``: int, currently 2 (writer); reader accepts
- *     v1 + v2.
- *   - ``state``: "Init" | "Planning"
+ *   - ``schemaVersion``: int, currently 3 (writer); reader accepts
+ *     v1, v2, and v3.
+ *   - ``state``: "Init" | "Planning" | "Confirmed"
  *   - ``initMode``: "SlicingPlane" | "DistanceSpheroid"
  *   - ``rows`` / ``cols``: control-polygon shape (v2 only; in v1
  *     these are implicit 4×4).  Per ADR-0018 §1, square only and
  *     in ``{(3, 3), (4, 4)}``.
  *   - ``controlGrid``: array of ``3 * rows * cols`` doubles
  *     (row-major; 27 for 3×3, 48 for 4×4).
- *   - ``slicingPlane``: {origin, normal, initPoints}
- *   - ``distanceSpheroid``: {center, radius{x,y,z}, initPoints}
+ *   - ``slicingPlane``: {origin, normal, initPointsFlat}
+ *   - ``distanceSpheroid``: {center, radius{x,y,z}, initPointsFlat}
  *   - ``metadata``: object (empty in v1; reserved for v2's
  *     timestamps + surgeon ID per ADR-0014 §5)
+ *   - ``resection`` (v3): {name, safetyMargin_mm, riskMargin_mm,
+ *     orderIndex} — surgeon-facing field roster (ADR-0023
+ *     §"Persistence").  The on-disk margin fields source from the
+ *     existing ``vtkMRMLLiverResectionNode::ResectionMargin`` and
+ *     ``UncertaintyMargin`` members; the storage path renames them
+ *     to surgeon-facing labels without touching the in-memory MRML
+ *     class.  See the schema-header comment in the .cxx for the
+ *     full mapping table.
+ *   - ``scene`` (v3): {classification, volumetryPartitions,
+ *     stageSelection} — scene-wide context the Liver shell restores
+ *     on file open (ADR-0023 §"Stage transitions").
  *
- * \par v1 → v2 migration
+ * \par v1 / v2 → v3 migration
  *
  * The reader infers ``rows = cols = 4`` for v1 files (no ``rows`` /
  * ``cols`` fields) and validates the ``controlGrid`` array length
- * is 48.  The writer always emits v2 with explicit ``rows`` +
- * ``cols``.  Round-trip of a v1 file produces a v2 file on the
- * next save.
+ * is 48.  v2 files load with the new v3 fields taking documented
+ * defaults (name = MRML display name, margins = 0.0, orderIndex =
+ * -1, classification absent, volumetry partitions empty,
+ * stageSelection absent).  The writer always emits v3.  Round-trip
+ * of a v1 / v2 file produces a v3 file on the next save.
  *
  * \par See also
  *
@@ -124,10 +137,11 @@ public:
   /// Current JSON schema version emitted by ``WriteDataInternal``.
   /// Bump this integer in lock-step with any documented schema
   /// extension; ``ReadDataInternal`` MUST grow an explicit branch
-  /// for every old version it intends to keep loading.  Per ADR-0018
-  /// §1 the reader accepts both v1 (implicit 4×4 control polygon)
-  /// and v2 (explicit ``rows`` / ``cols``).
-  static constexpr int SchemaVersion = 2;
+  /// for every old version it intends to keep loading.  Per
+  /// ADR-0023 §"Persistence" the reader accepts v1 (implicit 4×4
+  /// control polygon), v2 (explicit ``rows`` / ``cols``), and v3
+  /// (the surgeon-facing ``resection`` + ``scene`` blocks).
+  static constexpr int SchemaVersion = 3;
 
   /// Lowest schema version the reader admits.  v1 files (no
   /// ``rows`` / ``cols``) load with an inferred 4×4 control polygon

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
@@ -104,7 +104,7 @@
  *     full mapping table.
  *   - ``scene``: {classification, volumetryPartitions,
  *     stageSelection} — scene-wide context the Liver shell restores
- *     on file open (ADR-0023 §"Stage transitions").
+ *     on file open (ADR-0023 §"Persistence" — per-stage last-selection).
  *
  * \par Optional-field tolerance (within v2)
  *

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceStorageNode.h
@@ -75,26 +75,26 @@
  * ADR-0007's D-class compatibility-break category, the
  * ``.lrp.fcsv`` deprecation is part of the v2.0.0 MAJOR bump.
  *
- * \par JSON schema (v3 — ADR-0023 §"Persistence")
+ * \par JSON schema (v2 — ADR-0023 §"Persistence")
  *
  * See the in-source documentation at the top of
  * ``vtkMRMLBezierSurfaceStorageNode.cxx`` for the canonical
  * schema description.  Briefly:
  *
- *   - ``schemaVersion``: int, currently 3 (writer); reader accepts
- *     v1, v2, and v3.
+ *   - ``schemaVersion``: int, currently 2 (writer + reader).  v1
+ *     was preview-only and never shipped; the reader rejects it.
  *   - ``state``: "Init" | "Planning" | "Confirmed"
  *   - ``initMode``: "SlicingPlane" | "DistanceSpheroid"
- *   - ``rows`` / ``cols``: control-polygon shape (v2 only; in v1
- *     these are implicit 4×4).  Per ADR-0018 §1, square only and
- *     in ``{(3, 3), (4, 4)}``.
+ *   - ``rows`` / ``cols``: control-polygon shape per ADR-0018 §1
+ *     (square only; in ``{(3, 3), (4, 4)}``).
  *   - ``controlGrid``: array of ``3 * rows * cols`` doubles
  *     (row-major; 27 for 3×3, 48 for 4×4).
  *   - ``slicingPlane``: {origin, normal, initPointsFlat}
  *   - ``distanceSpheroid``: {center, radius{x,y,z}, initPointsFlat}
- *   - ``metadata``: object (empty in v1; reserved for v2's
- *     timestamps + surgeon ID per ADR-0014 §5)
- *   - ``resection`` (v3): {name, safetyMargin_mm, riskMargin_mm,
+ *   - ``metadata``: object (empty for v2.0; reserved for richer
+ *     metadata — timestamps, surgeon ID — in a later schema
+ *     revision per ADR-0014 §5).
+ *   - ``resection``: {name, safetyMargin_mm, riskMargin_mm,
  *     orderIndex} — surgeon-facing field roster (ADR-0023
  *     §"Persistence").  The on-disk margin fields source from the
  *     existing ``vtkMRMLLiverResectionNode::ResectionMargin`` and
@@ -102,19 +102,19 @@
  *     to surgeon-facing labels without touching the in-memory MRML
  *     class.  See the schema-header comment in the .cxx for the
  *     full mapping table.
- *   - ``scene`` (v3): {classification, volumetryPartitions,
+ *   - ``scene``: {classification, volumetryPartitions,
  *     stageSelection} — scene-wide context the Liver shell restores
  *     on file open (ADR-0023 §"Stage transitions").
  *
- * \par v1 / v2 → v3 migration
+ * \par Optional-field tolerance (within v2)
  *
- * The reader infers ``rows = cols = 4`` for v1 files (no ``rows`` /
- * ``cols`` fields) and validates the ``controlGrid`` array length
- * is 48.  v2 files load with the new v3 fields taking documented
- * defaults (name = MRML display name, margins = 0.0, orderIndex =
- * -1, classification absent, volumetry partitions empty,
- * stageSelection absent).  The writer always emits v3.  Round-trip
- * of a v1 / v2 file produces a v3 file on the next save.
+ * The ``resection`` and ``scene`` blocks are optional on read.  A
+ * preview-tracking v2 file written before the surgeon-state fields
+ * were wired (no such files in the public release contract) loads
+ * with documented defaults: name = MRML display name, margins =
+ * 0.0, orderIndex = -1, classification absent, volumetry partitions
+ * empty, stageSelection absent.  The writer always emits the full
+ * v2 shape.
  *
  * \par See also
  *
@@ -138,15 +138,20 @@ public:
   /// Bump this integer in lock-step with any documented schema
   /// extension; ``ReadDataInternal`` MUST grow an explicit branch
   /// for every old version it intends to keep loading.  Per
-  /// ADR-0023 §"Persistence" the reader accepts v1 (implicit 4×4
-  /// control polygon), v2 (explicit ``rows`` / ``cols``), and v3
-  /// (the surgeon-facing ``resection`` + ``scene`` blocks).
-  static constexpr int SchemaVersion = 3;
+  /// ADR-0023 §"Persistence" v2 is the unified schema for the
+  /// 2026 v2.0.0 release — it carries the variable-size Bezier
+  /// shape (``rows`` / ``cols``), the surgeon-facing ``resection``
+  /// block (name + Safety/Risk margins + orderIndex), and the
+  /// scene-wide ``scene`` block (classification, volumetry
+  /// partitions, stage selection).  v1 was preview-only and never
+  /// shipped; the reader rejects it.
+  static constexpr int SchemaVersion = 2;
 
-  /// Lowest schema version the reader admits.  v1 files (no
-  /// ``rows`` / ``cols``) load with an inferred 4×4 control polygon
-  /// per the ADR-0018 §1 migration path.
-  static constexpr int MinReadableSchemaVersion = 1;
+  /// Lowest schema version the reader admits.  Equal to
+  /// ``SchemaVersion`` for v2.0.0 since v1 was preview-only and is
+  /// not part of the released contract.  A future v3 bump should
+  /// widen this band to keep v2 files readable.
+  static constexpr int MinReadableSchemaVersion = 2;
 
   vtkMRMLNode* CreateNodeInstance() override;
 


### PR DESCRIPTION
## Summary

Bumps `vtkMRMLBezierSurfaceStorageNode`'s `.lrp.json` writer from schema v1 (PR #361, preview-only) to schema **v2** — the unified surgeon-state schema for the 2026 v2.0.0 release per [ADR-0023 §"Persistence"](Docs/adr/0023-unified-gui-stage-workflow.md).  Captures five new categories of v2.0 surgeon-facing state on disk; rejects v1 (no released files in the wild).

Resolves issue #411 (T5.2-e on the v2.0.0 tracker #305).

## Versioning policy

Schema versions track *released* compatibility.  Neither the original `.lrp.json` (PR #361, fixed-size Bezier) nor the variable-size-Bezier extension (PR #383) ever shipped in a public release of Slicer-Liver, so this PR collapses them into a single **v2** — the schema users will first see in the v2.0.0 release.

- **v1** — preview-only, never released.  Reader rejects outright with the unsupported-version error.
- **v2** — variable-size Bezier (`rows` / `cols` / `controlGrid`) plus the ADR-0023 surgeon-facing `resection` + `scene` blocks.

`MinReadableSchemaVersion = SchemaVersion = 2` — exactly one accepted version.  Future schema work widens the band; for v2.0.0's first cut the contract is tight.

## What the v2 sidecar adds (vs. the preview v1 shape)

| Field | Source at write-time | v2-optional-default |
|---|---|---|
| `resection.name` | `vtkMRMLBezierSurfaceNode::GetName()` | MRML display name |
| `resection.safetyMargin_mm` | `vtkMRMLLiverResectionNode::ResectionMargin` | `0.0` |
| `resection.riskMargin_mm` | `vtkMRMLLiverResectionNode::UncertaintyMargin` | `0.0` |
| `resection.orderIndex` | new `vtkMRMLBezierSurfaceNode::OrderIndex` attr | `-1` (unordered sentinel) |
| `scene.classification.{nodeId,subtype}` | active `vtkMRMLAbstractTerritoriesNode` + concrete-class string | absent → unset |
| `scene.volumetryPartitions[]` | scene query for `vtkMRMLLiverVolumetryPartitionNode` (forward-compat) | empty array |
| `scene.stageSelection.{stage1..5,currentStage}` | Liver shell (issue #410, future) | absent → no surgeon-position restore |

All references are scene-local `vtkMRMLNode::GetID()` strings, sidecar-only.  Cross-machine plan transfer stays out of scope per ADR-0023.

## Decisions locked during planning

1. **Margin mapping at storage layer** — writer reads existing `ResectionMargin` / `UncertaintyMargin` and emits the ADR-0023-named `safetyMargin_mm` / `riskMargin_mm` fields.  No in-memory rename.  Mapping documented at the top of `vtkMRMLBezierSurfaceStorageNode.cxx`.
2. **`OrderIndex` lives on `vtkMRMLBezierSurfaceNode`** as a new int attribute (sentinel `-1`).  Stable canonical source; not derived from Subject Hierarchy folder ordering.
3. **`scene.stageSelection` writer is the Liver shell** (issue #410, future).  Storage node reads defensively with `HasMember` guards.  Until #410 lands, the writer emits the block with all-null fields — still a valid v2 file.
4. **Schema v3 not allocated** — saved for a genuine third schema iteration that follows a v2.0 release (per maintainer review of the original v3-naming attempt).

## ADR / scope notes

- **In scope (this PR)**: schema v2 writer + reader, `OrderIndex` attribute on `vtkMRMLBezierSurfaceNode`, ctest coverage of the round-trip + fallback + subtype-discriminator + boundary-rejection invariants.
- **Out of scope (explicit)**:
  - Atlas-resolved / cross-machine stable IDs (deferred to a future schema bump per ADR-0023 §"Persistence" end paragraph).
  - Rename of `ResectionMargin` / `UncertaintyMargin` MRML attributes to `Safety` / `Risk` (T2.7 territory).
  - The `vtkMRMLLiverVolumetryPartitionNode` class itself (separate v2.0 deliverable; schema is forward-compatible — writer emits an empty array until the class lands and registers in the scene).
  - Liver shell wiring of `scene.stageSelection` writes (issue #410).

## Invariants pinned

Test-first per [ADR-0027](Docs/adr/0027-invariant-test-first-v2-implementation.md).  Test functions in `vtkMRMLBezierSurfaceStorageNodeTest2.cxx`:

| Test | Invariant |
|---|---|
| `testV2WriteEmitsSchemaVersion2` | Writer emits `"schemaVersion": 2`, not 3 |
| `testV2RoundTripFullFields` | name + Safety/Risk margins + orderIndex + classification + volumetry partitions survive write→read |
| `testV2OptionalFieldsFallbackDefaults` | Minimal v2 file (no surgeon-state blocks) loads with all documented defaults |
| `testV2ClassificationSubtypeDiscriminator` | `subtype` string distinguishes `vtkMRMLStdCouinaudTerritoriesNode` vs `vtkMRMLCustomTerritoriesNode` |
| `testV2ReaderRejectsV99` | `schemaVersion: 99` still triggers the unsupported-version error path |
| `testV2SchemaVersionBoundaryRejection` | `schemaVersion: 1` (preview-only) AND `schemaVersion: 3` (future bump without reader update) both rejected |
| `testV2StageSelectionCurrentStageReader` | Reader stashes `scene.stageSelection.currentStage` as a node attribute for the Liver shell to consume on next launch |

Plus in `vtkMRMLBezierSurfaceNodeTest1.cxx`:

| Test | Invariant |
|---|---|
| `testXMLRoundTrip` (extended) | `OrderIndex` non-default value survives MRML scene XML write/read |
| `testOrderIndexDefaultSentinel` (new) | `OrderIndex == -1` default state survives XML round-trip |

Plus in `vtkMRMLBezierSurfaceStorageNodeTest1.cxx`:

| Test | Invariant |
|---|---|
| `testJsonReadV1Rejected` (was `testJsonReadV1Implicit4x4`) | v1 files rejected with the unsupported-version error |
| `testSchemaVersionMismatch` (existing) | `schemaVersion: 99` rejection |
| `testJsonRoundTrip3x3` (existing, future-proofed) | Writer emits the runtime `SchemaVersion` constant, not a hardcoded literal |

## Commit chain

The chain documents the design evolution end-to-end:

| SHA | Subject |
|---|---|
| `0c78be8` | `ENH: Add invariant test scaffolding for .lrp.json schema v3` (test-first; fails red against the v2 reader) |
| `a0f7130` | `ENH: Implement .lrp.json schema v3 — capture v2.0 surgeon state` (impl flips invariants green) |
| `82b30f0` | `STYLE: Apply clang-format-22 lambda brace placement` (CI lint fix) |
| `ceab94c` | `ENH: Close /slicer-review blockers for .lrp.json schema v3` (OrderIndex XML round-trip + stageSelection.currentStage reader coverage) |
| `6003c73` | `ENH: Pin schemaVersion 0/4 boundary rejection in v3 reader` (symmetric band defenders) |
| `222a850` | `ENH: Fold .lrp.json schema v3 → v2; reject v1 (preview-only)` (maintainer-review rename: v3 collapsed into v2; v1 dropped as it was preview-only) |

## Test plan

- [ ] CI green on the territory + Liver-Resections test suites (v2 acceptance path + v1 rejection + v99 rejection + boundary rejection).
- [ ] Schema v2 writes include all new fields per the table above.
- [ ] Minimal v2 `.lrp.json` files (no surgeon-state blocks) load with documented defaults.
- [ ] `schemaVersion: 1`, `3`, `99` all rejected.
- [ ] Codecov diff coverage on `vtkMRMLBezierSurfaceStorageNode.cxx` shows the new branches covered.

Validated locally inside the `slicer-build-ubuntu2404:latest` image — all four BezierSurface ctests pass.

## References

- [ADR-0023 §"Persistence"](Docs/adr/0023-unified-gui-stage-workflow.md) — authoritative spec for the v2 fields.
- [ADR-0018](Docs/adr/0018-nurbs-extension-surface.md) §1 — schema-versioning convention v2 follows.
- [ADR-0027](Docs/adr/0027-invariant-test-first-v2-implementation.md) — test-first discipline.
- [ADR-0014](Docs/adr/0014-livermarkups-dissolution.md) §5 — `.lrp.json` as canonical sidecar.

---

*AI-assisted authorship: planning, test scaffolding, implementation, simplify-pass review, and the v3 → v2 fold drafted by Claude Opus 4.7 (`claude-opus-4-7`) via Claude Code under the maintainer's brief.*