### PR TITLE
COMP: Repin prettier to maintained fork + system node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,10 +44,11 @@ repos:
       - id: pyupgrade
         args: [--py312-plus]
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: "v3.8.3"
     hooks:
       - id: prettier
+        language_version: system
         types_or: [yaml]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema


### PR DESCRIPTION
## What

`pre-commit/mirrors-prettier` is archived upstream and the pinned `v4.0.0-alpha.8` lacks a usable `package.json` at the hook prefix, so pre-commit cannot build its node environment (`AssertionError` in `node.install_environment`). This is **latent**: the prettier hook is scoped `types_or: [yaml]`, so it only fires when a commit touches a YAML file with a cold pre-commit cache.

This repins to the maintained **`rbubley/mirrors-prettier` v3.8.3** (valid `package.json`) and sets `language_version: system` so prettier uses the node already on `PATH` rather than a `nodeenv`-downloaded binary (which cannot be provisioned on every developer platform, e.g. Guix).

## Verification

- `pre-commit run prettier --all-files` **passes with zero reformatting** of the existing tree — no version-drift churn.
- This PR's own commit passed the full local hook chain (prettier on `.pre-commit-config.yaml` via system node, plus the commit-message + copyright hooks).
- CI's Lint job (`pre-commit/action`) will confirm the `language_version: system` path on the ubuntu runner.

## Why now

Unblocks YAML-touching commits across the active feature branches. Tooling-only; no source or behaviour change.