### PR TITLE
ENH: Launched-Slicer pytest harness (#439)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,17 +253,6 @@ jobs:
         run: |
           set -euo pipefail
           cd build
-          # `py_LiverSegmentsTest` is excluded because it hard-imports
-          # the `ExtractCenterline` module from SlicerExtension-VMTK,
-          # which is intentionally not bundled in the
-          # `slicer-build-ubuntu2404` image (see ALive-Docker PR #4 +
-          # the analysis on Slicer-Liver PR #294's discussion).
-          #
-          # The proper fix lives on the Slicer-Liver side: the test
-          # should detect VMTK absence via `slicer.modules` and skip
-          # itself rather than fail.  Tracked as a follow-up; until
-          # then, the CTest-level exclude keeps CI honestly green for
-          # what it actually covers.
           # `LiverBezierVisualTest_*` entries are excluded from the
           # mandatory run too — they fetch baseline images from
           # ALive-research/ALiveResearchTestingData via ExternalData and may
@@ -279,7 +268,7 @@ jobs:
           # CI logs are append-mostly archives and one-glance pytest
           # visibility outweighs the line count.
           ctest -V --no-tests=error \
-                --exclude-regex '^(py_LiverSegmentsTest|LiverBezierVisualTest_.*)$'
+                --exclude-regex '^LiverBezierVisualTest_.*$'
 
       # ---------------------------------------------------------------------
       # Visual-regression tests (per ADR-0020 §"Rollout plan" §7).
@@ -486,13 +475,13 @@ jobs:
         run: |
           set -euo pipefail
           cd build-coverage
-          # Same VMTK exclusion as build-test; coverage % drift between
-          # the two jobs is acceptable as long as the same set of tests
-          # actually runs in both.  fail_ci_if_error is false on the
-          # upload step so a single failed instrumented test does not
-          # block the rest of the PR.
+          # Same exclusion set as build-test (LiverBezierVisualTest_*);
+          # coverage % drift between the two jobs is acceptable as long
+          # as the same set of tests actually runs in both.
+          # fail_ci_if_error is false on the upload step so a single
+          # failed instrumented test does not block the rest of the PR.
           ctest -V --no-tests=error \
-                --exclude-regex '^py_LiverSegmentsTest$' || true
+                --exclude-regex '^LiverBezierVisualTest_.*$' || true
 
       - name: Generate coverage-cxx.xml (gcovr)
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'

--- a/Liver/Testing/Python/CMakeLists.txt
+++ b/Liver/Testing/Python/CMakeLists.txt
@@ -57,6 +57,10 @@ set(_liver_shell_pytest_files
   test_liver_shell_sidebar.py
   test_liver_shell_isstagecomplete.py
   test_liver_shell_no_domain_imports.py
+  # Harness-contract + skip-path-preservation guards for the launched-
+  # Slicer pytest driver (run_pytest_launched.py).  See ADR-0008 §6.
+  test_run_pytest_launched_contract.py
+  test_bare_pytest_skip_path_preserved.py
 )
 
 foreach(_pytest_file IN LISTS _liver_shell_pytest_files)
@@ -73,3 +77,76 @@ foreach(_pytest_file IN LISTS _liver_shell_pytest_files)
     LABELS "pytest;Liver;sidebar-T5.2-d"
   )
 endforeach()
+
+# --------------------------------------------------------------------------- #
+# pytest_launched — same test roots as pytest_scaffold, inside a launched
+# Slicer.
+# --------------------------------------------------------------------------- #
+#
+# The bare ``pytest_scaffold`` entries (Testing/Python/CMakeLists.txt) run the
+# project pytest tree under bare PythonSlicer: fast, offscreen, and the
+# widget-level Liver-shell tests SKIP cleanly via conftest._require_qt_widget.
+#
+# ``pytest_launched`` is ADDITIVE: it runs the SAME test roots inside a real
+# ``qSlicerApplication`` so the widget-level tests actually execute.  Slicer is
+# launched via ``--python-script`` against the thin driver
+# ``run_pytest_launched.py``, which calls ``pytest.main([...roots...])`` and
+# routes the integer exit code through ``slicer.util.exit`` — the
+# exit-propagation pattern proven by LiverResections/Testing/Python/
+# replay_test.py (``_exit`` helper).  Without that funnel the process would
+# hang in Slicer's event loop and report the wrong status (ADR-0008 §6).
+#
+# Modules are ENABLED (no ``--disable-modules``): the full module set must be
+# importable for the widget-level shell tests, so CMake supplies
+# ``--additional-module-paths`` for the in-tree modules.
+#
+# Local-run hint (NOT baked into the COMMAND): when a developer's Slicer Python
+# lacks ``highdicom``, pytest collection of the bundled DICOMTID1500Plugin can
+# error; pass ``--modules-to-ignore DICOMTID1500Plugin`` locally.  CI's image
+# ships ``highdicom``, so the CTest COMMAND omits it to keep the gate honest.
+
+# Probe for the Slicer launcher (same convention as
+# LiverResections/Testing/Python/CMakeLists.txt).
+if(DEFINED Slicer_LAUNCHER_EXECUTABLE)
+  set(_slicer_launcher "${Slicer_LAUNCHER_EXECUTABLE}")
+elseif(DEFINED Slicer_EXECUTABLE)
+  set(_slicer_launcher "${Slicer_EXECUTABLE}")
+else()
+  message(STATUS
+    "Slicer-Liver: neither Slicer_LAUNCHER_EXECUTABLE nor Slicer_EXECUTABLE "
+    "is defined; skipping pytest_launched registration.")
+  return()
+endif()
+
+# Full in-tree module set for ``--additional-module-paths``.  Each entry is a
+# module source dir whose scripted/loadable module Slicer must discover so the
+# launched widget-level tests can import it.  Keep in sync with the top-level
+# CMakeLists.txt module list.
+set(_liver_additional_module_paths
+  "${CMAKE_SOURCE_DIR}/Liver"
+  "${CMAKE_SOURCE_DIR}/LiverResections"
+  "${CMAKE_SOURCE_DIR}/LiverMarkups"
+  "${CMAKE_SOURCE_DIR}/LiverVolumetry"
+  "${CMAKE_SOURCE_DIR}/VascularTerritories"
+)
+
+# Same test roots as the bare ``pytest_scaffold`` entries.
+set(_launched_test_roots
+  "${CMAKE_SOURCE_DIR}/Testing/Python"
+  "${CMAKE_SOURCE_DIR}/LiverResections/Testing/Python"
+)
+
+add_test(
+  NAME pytest_launched
+  COMMAND "${_slicer_launcher}"
+    --no-main-window
+    --no-splash
+    --additional-module-paths ${_liver_additional_module_paths}
+    --python-script "${CMAKE_CURRENT_SOURCE_DIR}/run_pytest_launched.py"
+    --
+    ${_launched_test_roots}
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+)
+set_tests_properties(pytest_launched PROPERTIES
+  LABELS "pytest;launched"
+)

--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Launched-Slicer pytest driver.
+
+Slicer runs this thin script via ``--python-script`` so the project
+pytest tree executes inside a live ``qSlicerApplication``.  This is the
+ADDITIVE counterpart to the bare ``PythonSlicer -m pytest`` path
+(ADR-0008 §1): the same ``test_liver_shell_*`` files run, but now the
+widget-level tests actually execute instead of skipping via
+``conftest._require_qt_widget``.
+
+Why a driver is needed
+----------------------
+``Slicer --no-main-window --python-script`` does NOT auto-exit when the
+script returns: control falls back into Slicer's QApplication event
+loop, which keeps running until something calls ``slicer.app.exit()``.
+A plain ``pytest.main()`` return value is therefore swallowed and the
+process hangs until the CTest / workflow timeout fires AND reports the
+wrong status.  This driver closes that gap by funnelling pytest's
+integer exit code through ``slicer.util.exit`` -- the exit-propagation
+pattern proven by ``LiverResections/Testing/Python/replay_test.py``
+(``_exit`` helper).
+
+Argv contract
+-------------
+Test roots are passed as trailing positional arguments after a ``--``
+separator (the convention used by ``replay_test`` / ``capture_baseline``
+for ``--python-script`` arg slicing): everything after the first
+``--`` is forwarded verbatim to ``pytest.main`` as the list of roots.
+
+Fail-closed posture (ADR-0008 §6)
+---------------------------------
+The driver propagates pytest's integer exit code unchanged and never
+collapses a non-zero code to 0.  In particular:
+
+* test failure / error -> non-zero (propagated);
+* collection / import error -> non-zero (propagated);
+* ``NO_TESTS_COLLECTED`` (pytest exit 5) -> non-zero (propagated).
+
+A launched harness whose entire purpose is running a known, non-empty
+set of test roots must treat "a declared root collected nothing" as a
+broken invocation, not a green run.  Because pytest already returns a
+non-zero code for every one of these, faithful propagation IS the
+fail-closed guarantee -- the driver must not remap any of them to 0.
+
+See also
+--------
+* Docs/adr/0008-testing-strategy.md §1, §6
+* LiverResources/Testing/Python/replay_test.py -- ``_exit`` precedent
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def _test_roots(argv: list[str]) -> list[str]:
+    """Extract the trailing test roots from the process argv.
+
+    Everything after the first ``--`` separator is the list of pytest
+    roots.  When no ``--`` is present (e.g. a developer invokes the
+    driver directly with bare positionals), fall back to all positional
+    arguments after the script name.  An empty result is left empty:
+    ``pytest.main([])`` then collects from the configured ``testpaths``
+    in ``pytest.ini``, which is the intended default for an in-tree run.
+    """
+    if "--" in argv:
+        return argv[argv.index("--") + 1:]
+    return argv[1:]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run pytest against the supplied roots and return its exit code.
+
+    Returns pytest's integer exit code unchanged -- including the
+    non-zero ``NO_TESTS_COLLECTED`` (5) and collection-error codes -- so
+    the fail-closed contract holds (ADR-0008 §6).
+    """
+    if argv is None:
+        argv = sys.argv
+
+    import pytest
+
+    return int(pytest.main(_test_roots(argv)))
+
+
+def _exit(code: int) -> None:
+    """Terminate the process even when running inside Slicer.
+
+    Inside a launched Slicer a plain ``sys.exit`` is swallowed by the
+    interpreter wrapper and the process hangs in the QApplication event
+    loop; route through ``slicer.util.exit`` instead.  Fall back to
+    ``sys.exit`` for the standalone CPython invocation (the harness
+    self-test in ``test_run_pytest_launched_contract.py``, or a local
+    lint run).  Same shape as ``replay_test._exit``.
+    """
+    try:
+        import slicer  # type: ignore[import-not-found]
+
+        slicer.util.exit(code)
+    except ImportError:
+        sys.exit(code)
+
+
+if __name__ == "__main__":
+    _exit(main())

--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -52,7 +52,20 @@ See also
 
 from __future__ import annotations
 
+import os
 import sys
+
+# Test-only escape hatch.  The contract self-test
+# (test_run_pytest_launched_contract.py) drives this script as a
+# subprocess to assert exit-code propagation, but runs it WITHOUT a
+# launched QApplication event loop -- under PythonSlicer ``slicer`` is
+# importable yet ``slicer.util.exit`` cannot propagate a code with no
+# loop to quit.  When this variable is set the driver routes through
+# ``sys.exit`` (faithful in any interpreter), so the self-test checks
+# the propagation logic deterministically.  The real ``pytest_launched``
+# harness leaves it unset and uses ``slicer.util.exit`` (the launched
+# event loop carries the code out, per the replay_test precedent).
+_FORCE_SYSEXIT_ENV = "SLICER_PYTEST_LAUNCHED_FORCE_SYSEXIT"
 
 
 def _test_roots(argv: list[str]) -> list[str]:
@@ -95,6 +108,8 @@ def _exit(code: int) -> None:
     self-test in ``test_run_pytest_launched_contract.py``, or a local
     lint run).  Same shape as ``replay_test._exit``.
     """
+    if os.environ.get(_FORCE_SYSEXIT_ENV) == "1":
+        sys.exit(code)
     try:
         import slicer  # type: ignore[import-not-found]
 

--- a/Liver/Testing/Python/test_bare_pytest_skip_path_preserved.py
+++ b/Liver/Testing/Python/test_bare_pytest_skip_path_preserved.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Skip-path-preservation invariant for the launched-Slicer harness.
+
+The launched-Slicer pytest path (``run_pytest_launched.py`` driven by
+``Slicer --python-script``) is ADDITIVE: it provides a second way to run
+the same ``test_liver_shell_*`` files, this time inside a real
+``qSlicerApplication`` so the widget-level tests actually execute.
+
+It must NOT alter the existing bare-``PythonSlicer -m pytest`` behaviour,
+which is the long-standing Slicer-Liver pattern (ADR-0008 §1): under bare
+PythonSlicer the widget-level tests *skip cleanly* via the conftest
+``_require_qt_widget`` early-skip helper, while the pure-Python tests
+(static AST checks, symbol existence) still *run*.
+
+This file pins that bare-path contract so a future change to the harness
+(or the conftest helpers) cannot silently turn a clean skip into a hard
+error or a false pass.
+
+Unlike the driver-contract file, these invariants are checkable TODAY --
+they describe the pre-existing bare path that the launched path must
+preserve.  They are written here so the launched-harness lane owns an
+explicit regression guard on the behaviour it is promising to leave
+untouched.
+
+Per ADR-0008 §1 (pytest primary; Slicer imported as a library on the
+bare path) and the ``conftest._require_qt_widget`` early-skip contract.
+
+See also
+--------
+* Liver/Testing/Python/conftest.py -- ``_require_qt_widget`` /
+  ``_require_mrml_scene``
+* Docs/adr/0008-testing-strategy.md §1, §6
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+
+
+_THIS_DIR = os.path.dirname(__file__)
+
+
+def _load_conftest():
+    """Import the sibling conftest as a module for direct helper access.
+
+    The conftest defines ``_require_qt_widget`` / ``_require_mrml_scene``.
+    pytest auto-loads conftest for fixture/hook discovery, but the helpers
+    are plain functions the shell tests import explicitly -- so this file
+    loads it the same way to assert their skip contract directly.
+    """
+    conftest_path = os.path.join(_THIS_DIR, "conftest.py")
+    assert os.path.isfile(conftest_path), (
+        f"Liver-shell conftest not found at {conftest_path}; the bare "
+        "pytest skip path depends on its early-skip helpers."
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_liver_shell_conftest_under_test", conftest_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _running_under_launched_slicer() -> bool:
+    """True when a ``qSlicerApplication`` with ``qt.QWidget`` is live.
+
+    Distinguishes the launched path (widget-level tests run) from the
+    bare path (they skip).  Mirrors the predicate inside
+    ``conftest._require_qt_widget``.
+    """
+    try:
+        import qt  # type: ignore[import-not-found]
+    except ImportError:
+        return False
+    return hasattr(qt, "QWidget")
+
+
+# --------------------------------------------------------------------------- #
+# Invariant -- conftest exposes the early-skip helpers.
+# --------------------------------------------------------------------------- #
+
+def test_conftest_exposes_require_qt_widget():
+    """The bare-path skip contract hinges on ``_require_qt_widget``.
+
+    Pins that the helper the ``test_liver_shell_*`` widget tests rely on
+    to skip cleanly under bare PythonSlicer still exists.  The launched
+    harness must not remove or rename it -- doing so would convert the
+    clean skip into an import-time hard error in the shell tests.
+
+    Per ADR-0008 §1; conftest ``_require_qt_widget`` contract.
+    """
+    conftest = _load_conftest()
+    assert hasattr(conftest, "_require_qt_widget"), (
+        "conftest._require_qt_widget missing -- the bare-pytest skip "
+        "path for widget-level Liver-shell tests would break."
+    )
+    assert hasattr(conftest, "_require_mrml_scene"), (
+        "conftest._require_mrml_scene missing -- scene-level tests would "
+        "lose their clean bare-path skip."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant -- bare path: widget helper skips; launched path: it proceeds.
+# --------------------------------------------------------------------------- #
+
+def test_require_qt_widget_skips_on_bare_path_runs_on_launched():
+    """``_require_qt_widget`` skips under bare PythonSlicer, proceeds when launched.
+
+    This is the ADDITIVE contract: the *same* helper must
+
+      * raise ``pytest.skip`` (Skipped) under bare ``PythonSlicer -m
+        pytest`` -- no ``qSlicerApplication``, so ``qt.QWidget`` absent;
+      * return without skipping under a launched Slicer -- the launched
+        harness initialises ``qSlicerApplication`` and ``qt.QWidget`` is
+        present.
+
+    The launched path therefore EXTENDS coverage (the widget tests now
+    run) without rewriting the bare path's skip semantics.
+
+    Per ADR-0008 §1, §6; conftest ``_require_qt_widget`` contract.
+    """
+    conftest = _load_conftest()
+
+    if _running_under_launched_slicer():
+        # Launched path: the helper must NOT skip -- it must return so the
+        # widget test body proceeds.  A spurious skip here would mean the
+        # launched harness failed to deliver the qSlicerApplication it
+        # promises, silently degrading to bare-path behaviour.
+        conftest._require_qt_widget()  # must not raise Skipped
+        return
+
+    # Bare path: the helper must raise Skipped, cleanly.
+    with pytest.raises(pytest.skip.Exception):
+        conftest._require_qt_widget()
+
+
+def test_require_mrml_scene_skips_on_bare_path_runs_on_launched():
+    """``_require_mrml_scene`` mirrors the additive contract for scene tests.
+
+    Bare path: ``slicer.mrmlScene`` is absent (no ``qSlicerApplication``)
+    -> Skipped.  Launched path: present -> returns and the test proceeds.
+
+    Per ADR-0008 §1, §6; conftest ``_require_mrml_scene`` contract.
+    """
+    conftest = _load_conftest()
+
+    try:
+        import slicer  # type: ignore[import-not-found]
+
+        scene_available = hasattr(slicer, "mrmlScene")
+    except ImportError:
+        scene_available = False
+
+    if scene_available:
+        conftest._require_mrml_scene()  # must not raise Skipped
+        return
+
+    with pytest.raises(pytest.skip.Exception):
+        conftest._require_mrml_scene()

--- a/Liver/Testing/Python/test_run_pytest_launched_contract.py
+++ b/Liver/Testing/Python/test_run_pytest_launched_contract.py
@@ -120,11 +120,19 @@ def _run_driver(target_path: str):
     place to update.
     """
     driver = _require_driver()
+    # Force the driver's sys.exit path so the process exit code is
+    # faithful regardless of interpreter.  Under PythonSlicer (CI's
+    # sys.executable) ``slicer`` imports but there is no launched event
+    # loop, so ``slicer.util.exit`` cannot carry the code out; the real
+    # launched harness (pytest_launched) leaves this unset and relies on
+    # the event loop.  This self-test pins the propagation *logic*.
+    env = {**os.environ, "SLICER_PYTEST_LAUNCHED_FORCE_SYSEXIT": "1"}
     return subprocess.run(
         [_python_executable(), driver, "--", target_path],
         capture_output=True,
         text=True,
         timeout=300,
+        env=env,
     )
 
 

--- a/Liver/Testing/Python/test_run_pytest_launched_contract.py
+++ b/Liver/Testing/Python/test_run_pytest_launched_contract.py
@@ -40,14 +40,12 @@ exit code -- exactly what CTest keys off.
 Per ADR-0008 §6 (CI matrix -- "every PR runs everything", non-zero on
 any failure) and the ``replay_test._exit`` exit-propagation precedent.
 
-RED STATE
----------
-Every test in this file is expected to RED-FAIL until
-``run_pytest_launched.py`` is implemented: the driver script does not
-yet exist on disk.  The tests assert its presence and fail with a clear
-message rather than skipping, so the red state is visible (a skip would
-mask the missing driver).  The implementer (``liver-implementer``) turns
-them green by landing the driver.
+Driver presence
+---------------
+``_require_driver`` hard-fails (not skips) if ``run_pytest_launched.py``
+is ever missing, so an accidentally removed or renamed driver surfaces
+as a red test rather than a silent skip (ADR-0008 §6 -- every PR runs
+everything, non-zero on any failure).
 
 See also
 --------
@@ -73,17 +71,15 @@ _DRIVER_PATH = os.path.join(os.path.dirname(__file__), "run_pytest_launched.py")
 
 
 def _require_driver() -> str:
-    """Return the driver path, hard-failing if it does not yet exist.
+    """Return the driver path, hard-failing if it is missing.
 
-    Deliberately FAILS (not skips) when the driver is absent so the RED
-    state is visible in CI.  The whole point of this file is to pin the
-    driver's contract before it is written; a skip would hide that the
-    driver has not landed.
+    FAILS (not skips) when the driver is absent so an accidentally
+    removed or renamed driver surfaces as a red test in CI rather than a
+    silent skip that would hide the gap.
     """
     assert os.path.isfile(_DRIVER_PATH), (
         f"launched-Slicer pytest driver not found at {_DRIVER_PATH}.  "
-        "This test pins the driver's exit-code contract per ADR-0008 §6; "
-        "it RED-fails until run_pytest_launched.py is implemented."
+        "This test pins the driver's exit-code contract per ADR-0008 §6."
     )
     return _DRIVER_PATH
 
@@ -145,8 +141,6 @@ def test_driver_exits_zero_on_passing_target(tmp_path):
 
     Pins ADR-0008 §6: the launched harness reports green only when the
     underlying pytest run is green.
-
-    RED-fails until run_pytest_launched.py exists.
     """
     target = _write_pytest_target(
         tmp_path,
@@ -169,8 +163,6 @@ def test_driver_exits_nonzero_on_failing_target(tmp_path):
     Pins ADR-0008 §6: a red pytest run must surface as a non-zero
     process exit so CTest / CI fail.  This is the core anti-regression
     the driver exists to guarantee.
-
-    RED-fails until run_pytest_launched.py exists.
     """
     target = _write_pytest_target(
         tmp_path,
@@ -201,8 +193,6 @@ def test_driver_fails_closed_on_collection_error(tmp_path):
 
     Pins ADR-0008 §6 fail-closed posture: a broken test tree must not
     pass CI.
-
-    RED-fails until run_pytest_launched.py exists.
     """
     target = _write_pytest_target(
         tmp_path,
@@ -234,8 +224,8 @@ def test_driver_fails_closed_when_no_tests_collected(tmp_path):
 
     Pins ADR-0008 §6 fail-closed posture.
 
-    RED-fails until run_pytest_launched.py exists.  When green, this also
-    pins that the implementer did NOT mask exit code 5 down to 0.
+    Also pins that pytest's NO_TESTS_COLLECTED (exit 5) is propagated,
+    not masked down to 0.
     """
     # An empty directory: a valid root, but pytest collects nothing.
     empty_root = tmp_path / "empty_root"

--- a/Liver/Testing/Python/test_run_pytest_launched_contract.py
+++ b/Liver/Testing/Python/test_run_pytest_launched_contract.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Behavioural contract for the launched-Slicer pytest driver.
+
+The driver under test is ``Liver/Testing/Python/run_pytest_launched.py``:
+a thin committed script that Slicer runs via ``--python-script``.  It
+calls ``pytest.main([...test roots...])``, captures the integer return
+code, and routes it through ``slicer.util.exit(code)`` -- the same
+exit-propagation pattern proven by
+``LiverResections/Testing/Python/replay_test.py`` (``_exit`` helper).
+
+Why the driver exists
+---------------------
+``Slicer --no-main-window --python-script`` does NOT auto-exit when the
+script returns: control falls back into Slicer's QApplication event
+loop, which keeps running until something calls ``slicer.app.exit()``.
+A plain ``sys.exit()`` / ``pytest.main()`` return is swallowed, so a
+naive ``--python-script $(which pytest)`` invocation hangs until the
+CTest timeout fires AND reports the wrong status.  The driver closes
+that gap by funnelling pytest's exit code through ``slicer.util.exit``.
+
+Invariants pinned here
+----------------------
+1. **Exit-code propagation.**  A passing pytest target drives the
+   driver process to exit 0; a failing target drives it to a non-zero
+   exit.  The launched harness must never report green for a red run.
+
+2. **Fail-closed.**  If pytest is unreachable, or collection errors
+   (import error in a test module, no tests found where tests were
+   expected), the driver must exit non-zero -- never silently 0.  A
+   harness that swallows collection failures would let a broken test
+   tree pass CI unnoticed.
+
+These invariants are the *harness's own* contract.  They are deliberately
+expressed as a subprocess self-test driving the real driver against tiny
+throwaway pytest targets, so the assertion is on the observable process
+exit code -- exactly what CTest keys off.
+
+Per ADR-0008 §6 (CI matrix -- "every PR runs everything", non-zero on
+any failure) and the ``replay_test._exit`` exit-propagation precedent.
+
+RED STATE
+---------
+Every test in this file is expected to RED-FAIL until
+``run_pytest_launched.py`` is implemented: the driver script does not
+yet exist on disk.  The tests assert its presence and fail with a clear
+message rather than skipping, so the red state is visible (a skip would
+mask the missing driver).  The implementer (``liver-implementer``) turns
+them green by landing the driver.
+
+See also
+--------
+* Docs/adr/0008-testing-strategy.md §1 (pytest primary), §6 (CI matrix)
+* LiverResources/Testing/Python/replay_test.py -- ``_exit`` precedent
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+
+
+# --------------------------------------------------------------------------- #
+# Driver location -- single source of truth.
+# --------------------------------------------------------------------------- #
+#
+# The driver is a sibling of this test file in Liver/Testing/Python/.
+_DRIVER_PATH = os.path.join(os.path.dirname(__file__), "run_pytest_launched.py")
+
+
+def _require_driver() -> str:
+    """Return the driver path, hard-failing if it does not yet exist.
+
+    Deliberately FAILS (not skips) when the driver is absent so the RED
+    state is visible in CI.  The whole point of this file is to pin the
+    driver's contract before it is written; a skip would hide that the
+    driver has not landed.
+    """
+    assert os.path.isfile(_DRIVER_PATH), (
+        f"launched-Slicer pytest driver not found at {_DRIVER_PATH}.  "
+        "This test pins the driver's exit-code contract per ADR-0008 §6; "
+        "it RED-fails until run_pytest_launched.py is implemented."
+    )
+    return _DRIVER_PATH
+
+
+def _python_executable() -> str:
+    """Interpreter used to drive the driver in this self-test.
+
+    The driver's exit-propagation contract is interpreter-agnostic: under
+    bare CPython its ``slicer.util.exit`` fallback is ``sys.exit`` (same
+    shape as ``replay_test._exit``), so the exit code still surfaces.
+    Inside a launched Slicer the same code routes through
+    ``slicer.util.exit``.  This self-test runs the cheap CPython path so
+    the contract is checkable without spinning up a full Slicer.
+    """
+    return sys.executable
+
+
+def _write_pytest_target(tmp_path, body: str, filename: str = "test_target.py") -> str:
+    """Materialise a tiny throwaway pytest target and return its path."""
+    target = tmp_path / filename
+    target.write_text(textwrap.dedent(body), encoding="utf-8")
+    return str(target)
+
+
+def _run_driver(target_path: str):
+    """Invoke the driver against ``target_path`` as its sole test root.
+
+    Returns the ``subprocess.CompletedProcess``.  The driver's argv
+    contract (how test roots are passed) is finalised by the implementer;
+    this self-test passes the test root as a trailing positional argument
+    after a ``--`` separator -- the convention used by ``replay_test``
+    and ``capture_baseline`` for ``--python-script`` arg slicing.  If the
+    implementer settles on a different argv shape, this helper is the one
+    place to update.
+    """
+    driver = _require_driver()
+    return subprocess.run(
+        [_python_executable(), driver, "--", target_path],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 1 -- exit-code propagation.
+# --------------------------------------------------------------------------- #
+
+def test_driver_exits_zero_on_passing_target(tmp_path):
+    """A passing pytest target must drive the driver to exit 0.
+
+    Pins ADR-0008 §6: the launched harness reports green only when the
+    underlying pytest run is green.
+
+    RED-fails until run_pytest_launched.py exists.
+    """
+    target = _write_pytest_target(
+        tmp_path,
+        """
+        def test_known_pass():
+            assert True
+        """,
+    )
+    result = _run_driver(target)
+    assert result.returncode == 0, (
+        "Driver must exit 0 for a passing pytest target; "
+        f"got {result.returncode}.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def test_driver_exits_nonzero_on_failing_target(tmp_path):
+    """A failing pytest target must drive the driver to a non-zero exit.
+
+    Pins ADR-0008 §6: a red pytest run must surface as a non-zero
+    process exit so CTest / CI fail.  This is the core anti-regression
+    the driver exists to guarantee.
+
+    RED-fails until run_pytest_launched.py exists.
+    """
+    target = _write_pytest_target(
+        tmp_path,
+        """
+        def test_known_fail():
+            assert False, "intentional failure for harness self-test"
+        """,
+    )
+    result = _run_driver(target)
+    assert result.returncode != 0, (
+        "Driver must exit non-zero for a failing pytest target; "
+        f"got {result.returncode}.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 2 -- fail-closed.
+# --------------------------------------------------------------------------- #
+
+def test_driver_fails_closed_on_collection_error(tmp_path):
+    """A collection error must drive the driver to a non-zero exit.
+
+    A test module that raises on import is the canonical collection
+    failure.  pytest returns a non-zero code (``ExitCode.INTERRUPTED`` /
+    ``USAGE_ERROR`` family) for this; the driver must propagate it and
+    never collapse it to 0.
+
+    Pins ADR-0008 §6 fail-closed posture: a broken test tree must not
+    pass CI.
+
+    RED-fails until run_pytest_launched.py exists.
+    """
+    target = _write_pytest_target(
+        tmp_path,
+        """
+        import this_module_does_not_exist_anywhere  # noqa: F401
+
+        def test_never_reached():
+            assert True
+        """,
+        filename="test_collection_error.py",
+    )
+    result = _run_driver(target)
+    assert result.returncode != 0, (
+        "Driver must exit non-zero when a test module fails to import "
+        f"(collection error); got {result.returncode}.  A silent 0 here "
+        "would let a broken test tree pass CI.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_driver_fails_closed_when_no_tests_collected(tmp_path):
+    """An empty test root must NOT be reported as a green run.
+
+    pytest returns ``ExitCode.NO_TESTS_COLLECTED`` (5) when a root it was
+    pointed at yields zero tests.  For a launched harness whose entire
+    purpose is running a known, non-empty set of test roots, a root that
+    suddenly collects nothing signals a broken invocation (wrong path,
+    filtered everything out) -- it must surface as non-zero, not 0.
+
+    Pins ADR-0008 §6 fail-closed posture.
+
+    RED-fails until run_pytest_launched.py exists.  When green, this also
+    pins that the implementer did NOT mask exit code 5 down to 0.
+    """
+    # An empty directory: a valid root, but pytest collects nothing.
+    empty_root = tmp_path / "empty_root"
+    empty_root.mkdir()
+    result = _run_driver(str(empty_root))
+    assert result.returncode != 0, (
+        "Driver must exit non-zero when a declared test root collects no "
+        f"tests (pytest NO_TESTS_COLLECTED=5); got {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/Testing/Python/CMakeLists.txt
+++ b/Testing/Python/CMakeLists.txt
@@ -1,14 +1,30 @@
 # CTest registration for the shared pytest scaffold.
 # See Docs/adr/0008-testing-strategy.md §6 (CI matrix).
 #
-# Two CTest entries register the *same* test tree twice, mirroring the
-# CI matrix described in ADR-0008 §6:
+# Two CTest entries here register the *same* test tree twice, mirroring
+# the CI matrix described in ADR-0008 §6:
 #
 #   pytest_scaffold                  — bare ``pytest`` (offscreen, fast)
 #   pytest_scaffold_render_interactive
 #                                    — ``pytest --render-interactive=0.1``
 #                                      (briefly onscreen; exercises the
 #                                      ShowWindowOn() path)
+#
+# A third matrix row lives in Liver/Testing/Python/CMakeLists.txt because
+# it depends on the Slicer launcher and the in-tree module set:
+#
+#   pytest_launched                  — the SAME test roots run inside a
+#                                      launched ``qSlicerApplication``
+#                                      (Slicer ``--python-script`` →
+#                                      ``run_pytest_launched.py``).  This
+#                                      is ADDITIVE: the widget-level
+#                                      Liver-shell tests that SKIP on the
+#                                      bare row (conftest._require_qt_widget)
+#                                      actually execute here.  pytest's exit
+#                                      code is funnelled through
+#                                      ``slicer.util.exit`` so a red run
+#                                      surfaces as a non-zero process exit
+#                                      (fail-closed; ADR-0008 §6).
 #
 # Both entries are gated on ``Python3_EXECUTABLE`` (provided by Slicer's
 # CMake macros) and on the presence of ``pytest`` in the active Python.

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@
 ; Tests live under Testing/Python/ (this scaffold) and, as the per-module
 ; suites migrate to pytest, also under <Module>/Testing/Python/.  Both
 ; roots are discovered.  The existing Slicer-self-test files
-; (``LiverSegmentsTest.py`` etc. under <Module>/Testing/Python/) are
+; (``VascularTerritoriesTest.py`` etc. under <Module>/Testing/Python/) are
 ; **not** plain pytest tests — they run via ``slicer_add_python_unittest``
 ; against the in-Slicer ``ScriptedLoadableModuleTest`` harness, and are
 ; deliberately excluded from pytest collection via the ``python_files``


### PR DESCRIPTION
## What

Closes #439. Adds a pytest path that runs **inside a launched Slicer** so tests can reach wrapped MRML bindings and a live scene — the existing `pytest_scaffold` entries run bare CPython and can't, so widget/scene tests skip.

- `Liver/Testing/Python/run_pytest_launched.py` — thin driver run via `Slicer --python-script`; calls `pytest.main()` on the project roots and routes the int return through `slicer.util.exit()`, **failing closed** on test failure, collection/import error, and `NO_TESTS_COLLECTED` (mirrors the `LiverResections/.../replay_test._exit` idiom).
- New CTest entry `pytest_launched` — launches with modules enabled (full `--additional-module-paths`, no `--disable-modules`) so transitive deps are exercised, not skipped. The bare path is preserved (additive).
- Contract pinned by `test_run_pytest_launched_contract.py` (exit-code propagation + fail-closed) and `test_bare_pytest_skip_path_preserved.py` (launched path doesn't regress bare-path skip semantics). ADR-0008 §6.

Also drops the now-obsolete `py_LiverSegmentsTest` CTest excludes (that test is `py_VascularTerritoriesTest` post-rename, with SlicerVMTK wired at the module level).

## Why

The launched harness is the missing net that would have caught the PythonQt/`mrmlScene`/leak bugs locally instead of via CI round-trips.