### PR TITLE
ENH: Migrate legacy .lrp.fcsv to a v2 resection plan on load

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -73,3 +73,10 @@ architecture/ui-stage-4-resection-planning.md
 architecture/ui-stage-5-volumetry.md
 architecture/ui-stage-6-export.md
 ```
+
+```{toctree}
+:maxdepth: 1
+:caption: Migrations
+
+migrations/v1-to-v2.md
+```

--- a/Docs/migrations/v1-to-v2.md
+++ b/Docs/migrations/v1-to-v2.md
@@ -1,0 +1,65 @@
+# v1 to v2 resection-plan migration
+
+This note documents how Slicer-Liver migrates a legacy **v1
+`.lrp.fcsv`** resection file to the **v2 `.lrp.json`** plan format, and
+which information is irrecoverably lost in the upgrade.
+
+## What v1 carried
+
+The v1 resection format (`.lrp.fcsv`) is a 15-column
+Markups-fiducial CSV. It stores **only the 16 Bezier control points**
+of the resection surface (a 4x4 control polygon) in the LPS coordinate
+system. It carries no clinical or plan-level metadata.
+
+## What v2 expects
+
+The v2 plan format (`.lrp.json`, schema version 2) is rooted on the
+resection **plan**, with the surface persisted as a polymorphic
+`surface` block. Beyond the control polygon, the plan carries:
+
+- `safetyMargin_mm` — clinical safety margin (mm).
+- `riskMargin_mm` — clinical risk margin (mm).
+- `orderIndex` — zero-based position in the operative sequence.
+- `state` — plan-level state machine (`Init` / `Planning` /
+  `Confirmed`).
+
+See `Docs/design/resection-plan-architecture/05-lrp-json-schema.md`
+for the full schema.
+
+## The gap and its defaults
+
+Every v2 field except the control points is **absent from v1** and
+therefore **not recoverable** from a legacy file. On load, the
+migration applies the documented v2 reader defaults:
+
+| Field             | Default on migration |
+| ----------------- | -------------------- |
+| `safetyMargin_mm` | `0.0`                |
+| `riskMargin_mm`   | `0.0`                |
+| `orderIndex`      | `-1`                 |
+| `state`           | `Init`               |
+
+A safety margin of 0 mm is **not** a clinical statement — it is the
+neutral default for an unknown value. **Review the margins, order, and
+state before using a migrated plan clinically.**
+
+## How the migration runs
+
+The upgrade is seamless: opening a `.lrp.fcsv` through the normal load
+path routes it to `vtkMRMLResectionPlanStorageNode::ReadFcsv`, which:
+
+1. Parses the 16 control points through the legacy
+   `vtkMRMLLiverResectionCSVStorageNode` (read-only parse vehicle).
+   The parse converts the file's LPS coordinates to the markups RAS
+   convention (X and Y are negated, Z unchanged).
+2. Materialises a `vtkMRMLBezierSurfaceNode` carrier holding those 16
+   RAS control points and wires it under a `vtkMRMLResectionPlanNode`
+   (the wrapper-vs-carrier split — ADR-0014 §"Fourth layer").
+3. Applies the v2 defaults above for every legacy-absent field.
+4. Records a **loud** warning on the storage node's user-message
+   collection naming the margins, order, and state as defaulted, so
+   the gap is visible rather than silent.
+
+Saving a migrated plan always writes the v2 `.lrp.json`. The
+`.lrp.fcsv` format is **read-only** in v2; there is no v2 writer for
+it.

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -14,12 +14,14 @@ set(KIT_TEST_SRCS
   vtkMRMLAbstractParametricSurfaceNodeTest1.cxx
   vtkMRMLResectionPlanNodeTest1.cxx
   vtkMRMLResectionPlanStorageNodeTest1.cxx
+  vtkMRMLResectionPlanLegacyFcsvMigrationTest.cxx
   )
 
 #-----------------------------------------------------------------------------
 # Pass the in-source Fixtures/ directory through to the test driver.
-# Fixtures kept available for a follow-up legacy ``.lrp.fcsv``
-# migration; the v2 storage tests do not consume them.
+# Consumed by vtkMRMLResectionPlanLegacyFcsvMigrationTest, which reads
+# the committed legacy ``.lrp.fcsv`` fixture through the v2 plan-storage
+# migration path.
 add_definitions(-DLIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/Fixtures\")
 
 #-----------------------------------------------------------------------------
@@ -48,3 +50,4 @@ SIMPLE_TEST(vtkMRMLParametricSurfaceDisplayNodeTest1)
 SIMPLE_TEST(vtkMRMLAbstractParametricSurfaceNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanStorageNodeTest1)
+SIMPLE_TEST(vtkMRMLResectionPlanLegacyFcsvMigrationTest)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanLegacyFcsvMigrationTest.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanLegacyFcsvMigrationTest.cxx
@@ -1,0 +1,338 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==============================================================================*/
+
+/**
+ * \file vtkMRMLResectionPlanLegacyFcsvMigrationTest.cxx
+ *
+ * Test-first scaffolding for the seamless v1 ``.lrp.fcsv`` ->
+ * v2 ``.lrp.json`` resection-plan migration.  Pins the "Fork C"
+ * red->green invariant: opening a legacy ``.lrp.fcsv`` (16 Bezier
+ * control points only) through the v2 plan-storage path must
+ * materialise a ``vtkMRMLBezierSurfaceNode`` carrier with the 16
+ * control points, wrap it in a ``vtkMRMLResectionPlanNode``, and
+ * apply the documented v2 defaults for every field absent from the
+ * legacy format.
+ *
+ * The legacy ``vtkMRMLLiverResectionCSVStorageNode`` stays as the
+ * read-only parse vehicle; this test pins the seam where its parse
+ * output is lifted into the v2 carrier + wrapper.  Architectural
+ * anchors:
+ *
+ *   - ADR-0014 §"Fourth layer: clinical/method wrapper" + ADR-0023
+ *     §"Persistence -- .lrp.json schema v2" -- the wrapper-vs-carrier
+ *     split that the migration must produce on load.
+ *   - ``Docs/design/resection-plan-architecture/03-storage-ownership.md``
+ *     §"Plan node" -- the storage node owns the legacy upgrade seam.
+ *   - ``vtkMRMLResectionPlanStorageNode.h`` §"Optional-field tolerance"
+ *     -- the documented v2 reader defaults (margins = 0.0,
+ *     orderIndex = -1, state = "Init") that every legacy-absent field
+ *     falls back to.
+ *
+ * RED-fail state (intentional, per the test-first convention):
+ *   The current ``ReadDataInternal`` rejects any non-``.lrp.json`` /
+ *   ``.json`` extension outright (the legacy ``.fcsv`` branch does not
+ *   exist yet) and builds the OLD ``vtkMRMLLiverResectionNode`` family,
+ *   not a plan node.  Every assertion below therefore fails red against
+ *   the current tree; the follow-up implementer commit lands the legacy
+ *   branch and flips them green.
+ *
+ * Fixture decision:
+ *   This test consumes the committed static fixture
+ *   ``Fixtures/legacy_resection.lrp.fcsv`` (16 points, 4x4 grid,
+ *   15-column Markups CSV, LPS) rather than generating one at test
+ *   time via the legacy CSV writer.  Rationale: the migration path the
+ *   implementer wires is exercised against a byte-for-byte on-disk v1
+ *   artefact -- the same shape a real v1 user file has -- so the test
+ *   characterises the actual upgrade rather than a writer/reader fixed
+ *   point.  Generating via the writer would couple the migration test
+ *   to the legacy writer's own correctness; the static fixture decouples
+ *   them.  The fixture is reached through the
+ *   ``LIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR`` macro already wired by
+ *   ``Testing/Cxx/CMakeLists.txt``.
+ */
+
+// This module MRML includes -- forward-included so the test driver
+// pins the v2 surface/plan/storage API.  The legacy CSV storage node
+// is the read-only parse vehicle the migration seam delegates to.
+#include "vtkMRMLResectionPlanNode.h"
+#include "vtkMRMLResectionPlanStorageNode.h"
+#include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLLiverResectionCSVStorageNode.h"
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLMessageCollection.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkCollection.h>
+#include <vtkNew.h>
+#include <vtkSmartPointer.h>
+#include <vtksys/SystemTools.hxx>
+
+// STD includes
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+// Portable getpid -- temp-file collision avoidance, same scheme as the
+// sibling vtkMRMLResectionPlanStorageNodeTest1.cxx.
+#if defined(_WIN32)
+# include <process.h>
+# define LIVER_LEGACY_GETPID _getpid
+#else
+# include <unistd.h>
+# define LIVER_LEGACY_GETPID ::getpid
+#endif
+
+namespace
+{
+
+constexpr int kBezierControlPointCount = 16;
+constexpr double kCoordinateTolerance = 1e-6;
+
+/// The 16 control-point coordinates the migrated Bezier carrier must
+/// hold, row-major the same way the fixture lists P-1..P-16.
+///
+/// IMPORTANT -- coordinate system.  The committed fixture
+/// ``Fixtures/legacy_resection.lrp.fcsv`` declares
+/// ``# CoordinateSystem = LPS``.  The legacy parse vehicle
+/// (``vtkMRMLLiverResectionCSVStorageNode`` delegating to the Markups
+/// superclass) converts LPS -> the carrier's RAS storage convention on
+/// read, which negates X and Y and leaves Z unchanged.  These expected
+/// values are therefore the RAS coordinates (fixture LPS with X,Y
+/// negated), NOT the raw fcsv columns.  If the implementer's migration
+/// seam preserves LPS instead, this assertion is the place that catches
+/// it -- the coordinate-system contract is the invariant.  Kept
+/// file-local per the no-shared-helpers convention.
+const double kFixtureControlPoints[kBezierControlPointCount][3] = { { -0.0, -0.0, 0.0 },  { -10.0, -0.0, 0.0 },  { -20.0, -0.0, 0.0 },  { -30.0, -0.0, 0.0 },
+                                                                    { -0.0, -10.0, 0.0 }, { -10.0, -10.0, 0.0 }, { -20.0, -10.0, 0.0 }, { -30.0, -10.0, 0.0 },
+                                                                    { -0.0, -20.0, 0.0 }, { -10.0, -20.0, 0.0 }, { -20.0, -20.0, 0.0 }, { -30.0, -20.0, 0.0 },
+                                                                    { -0.0, -30.0, 0.0 }, { -10.0, -30.0, 0.0 }, { -20.0, -30.0, 0.0 }, { -30.0, -30.0, 0.0 } };
+
+/// Absolute path to the committed legacy fixture, under the in-source
+/// Fixtures/ directory wired by CMake.
+std::string fixturePath()
+{
+  return std::string(LIVER_BEZIER_STORAGE_TEST_FIXTURE_DIR) + "/legacy_resection.lrp.fcsv";
+}
+
+/// Generate a unique temp path with the given extension under the
+/// CMake binary tree's Testing/Temporary directory.
+std::string makeTempPath(const std::string& extension)
+{
+  static int counter = 0;
+  ++counter;
+  std::ostringstream ss;
+  ss << LIVER_BEZIER_STORAGE_TEST_TEMP_DIR << "/vtkMRMLResectionPlanLegacyFcsvMigrationTest_" << static_cast<long long>(LIVER_LEGACY_GETPID()) << "_" << counter << "."
+     << extension;
+  return ss.str();
+}
+
+/// Read the i-th migrated control point off the carrier's flat control
+/// grid (3 * point-index .. +2).  The carrier stores 3 * rows * cols
+/// doubles; for a 4x4 grid that is the 48 doubles backing the 16
+/// points.
+void carrierControlPoint(vtkMRMLBezierSurfaceNode* carrier, int i, double out[3])
+{
+  const double* grid = carrier->GetControlGrid();
+  out[0] = grid[i * 3 + 0];
+  out[1] = grid[i * 3 + 1];
+  out[2] = grid[i * 3 + 2];
+}
+
+//------------------------------------------------------------------------------
+// Fork C -- the seamless legacy migration invariant.
+//
+// Loads the committed legacy ``.lrp.fcsv`` through the v2 plan-storage
+// path and asserts the full migration contract:
+//
+//   1. Control-point equality  -- all 16 control points land on the
+//      materialised Bezier carrier matching the fixture (within
+//      kCoordinateTolerance).
+//   2. Documented defaults     -- every field absent from the legacy
+//      format gets the v2 reader default (SafetyMargin_mm == 0.0,
+//      RiskMargin_mm == 0.0, OrderIndex == -1, state == Init).
+//      Source of truth: vtkMRMLResectionPlanStorageNode.h §"Optional-
+//      field tolerance".
+//   3. Loud gap                -- the storage node's GetUserMessages()
+//      carries a non-empty warning naming margins AND order AND state
+//      as defaulted (not just margins).  This is the storage node's own
+//      user-message collection, DISTINCT from the Markups-fiducial
+//      deprecation warning the fcsv parse emits.
+//   4. Round-trip              -- fcsv read -> .lrp.json write preserves
+//      the 16 control points value-identically.
+int testLegacyFcsvMigratesToPlanWithDefaults()
+{
+  // RED-fail (not skip): the legacy ``.fcsv`` migration branch does not
+  // exist yet, so the ReadData below returns 0 and the first CHECK_INT
+  // fails hard against the current tree.  The follow-up implementer
+  // commit lands the branch and flips this green.  ctkTest's SIMPLE_TEST
+  // driver has no skip primitive; the deliberate red is the signal.
+
+  // --------------------------------------------------------------------------
+  // Load the legacy fcsv through the v2 plan-storage path.
+  // --------------------------------------------------------------------------
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanStorageNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLiverResectionCSVStorageNode>::New());
+
+  vtkNew<vtkMRMLResectionPlanNode> plan;
+  scene->AddNode(plan.GetPointer());
+
+  vtkNew<vtkMRMLResectionPlanStorageNode> storage;
+  scene->AddNode(storage.GetPointer());
+  storage->SetFileName(fixturePath().c_str());
+  plan->SetAndObserveStorageNodeID(storage->GetID());
+
+  // The fcsv parse pulls the Markups-fiducial deprecation warning
+  // ("fcsv format is deprecated ... use .mrk.json"); suppress it so
+  // CTest's WITH_VTK_ERROR_OUTPUT_CHECK does not flag it.  Precedent:
+  // vtkMRMLLiverResectionStorageRoundTripTest.cxx Phase 1.  Note: this
+  // suppression is ORTHOGONAL to assertion 3 below -- that asserts the
+  // storage node's OWN GetUserMessages collection, not this VTK error
+  // stream.
+  TESTING_OUTPUT_IGNORE_WARNINGS_ERRORS_BEGIN();
+  const int readStatus = storage->ReadData(plan.GetPointer());
+  TESTING_OUTPUT_IGNORE_WARNINGS_ERRORS_END();
+  CHECK_INT(readStatus, 1);
+
+  // --------------------------------------------------------------------------
+  // Assertion 1 -- control-point equality.  The migration must
+  // materialise a Bezier carrier wired through the plan's geometry ref.
+  // --------------------------------------------------------------------------
+  vtkMRMLBezierSurfaceNode* carrier = vtkMRMLBezierSurfaceNode::SafeDownCast(plan->GetGeometryNode());
+  CHECK_NOT_NULL(carrier);
+  CHECK_INT(static_cast<int>(carrier->GetControlGridLength()), kBezierControlPointCount * 3);
+  for (int i = 0; i < kBezierControlPointCount; ++i)
+  {
+    double p[3] = { 0.0, 0.0, 0.0 };
+    carrierControlPoint(carrier, i, p);
+    for (int d = 0; d < 3; ++d)
+    {
+      CHECK_DOUBLE_TOLERANCE(p[d], kFixtureControlPoints[i][d], kCoordinateTolerance);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Assertion 2 -- documented defaults applied for every legacy-absent
+  // field.  vtkMRMLResectionPlanStorageNode.h §"Optional-field
+  // tolerance".
+  // --------------------------------------------------------------------------
+  CHECK_DOUBLE(plan->GetSafetyMargin_mm(), 0.0);
+  CHECK_DOUBLE(plan->GetRiskMargin_mm(), 0.0);
+  CHECK_INT(plan->GetOrderIndex(), -1);
+  CHECK_INT(plan->GetState(), vtkMRMLResectionPlanNode::Init);
+
+  // --------------------------------------------------------------------------
+  // Assertion 3 -- loud gap.  The storage node's OWN user-message
+  // collection carries a non-empty warning naming margins AND order AND
+  // state as defaulted (a loud, not silent, upgrade).  Distinct from
+  // the fcsv deprecation warning suppressed above.
+  // --------------------------------------------------------------------------
+  vtkMRMLMessageCollection* messages = storage->GetUserMessages();
+  CHECK_NOT_NULL(messages);
+  if (messages->GetNumberOfMessages() < 1)
+  {
+    std::cerr << "Legacy migration did not record any user message -- the upgrade must be loud" << std::endl;
+    return EXIT_FAILURE;
+  }
+  const std::string allMessages = messages->GetAllMessagesAsString();
+  const char* mustName[] = { "margin", "order", "state" };
+  for (const char* token : mustName)
+  {
+    if (allMessages.find(token) == std::string::npos)
+    {
+      std::cerr << "Legacy migration warning must name '" << token << "' as defaulted; got: " << allMessages << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Assertion 4 -- round-trip.  fcsv read -> .lrp.json write preserves
+  // the 16 control points value-identically.  Read the written JSON
+  // back into a fresh plan + carrier and compare against the fixture.
+  // --------------------------------------------------------------------------
+  const std::string jsonPath = makeTempPath("lrp.json");
+  vtkNew<vtkMRMLResectionPlanStorageNode> writeStorage;
+  writeStorage->SetFileName(jsonPath.c_str());
+  CHECK_INT(writeStorage->WriteData(plan.GetPointer()), 1);
+
+  vtkNew<vtkMRMLScene> sinkScene;
+  sinkScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanNode>::New());
+  sinkScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  sinkScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanStorageNode>::New());
+
+  vtkNew<vtkMRMLResectionPlanNode> sinkPlan;
+  vtkNew<vtkMRMLBezierSurfaceNode> sinkCarrier;
+  sinkScene->AddNode(sinkPlan.GetPointer());
+  sinkScene->AddNode(sinkCarrier.GetPointer());
+  sinkPlan->SetAndObserveGeometryNode(sinkCarrier.GetPointer());
+
+  vtkNew<vtkMRMLResectionPlanStorageNode> readStorage;
+  readStorage->SetFileName(jsonPath.c_str());
+  CHECK_INT(readStorage->ReadData(sinkPlan.GetPointer()), 1);
+
+  vtkMRMLBezierSurfaceNode* roundTripped = vtkMRMLBezierSurfaceNode::SafeDownCast(sinkPlan->GetGeometryNode());
+  CHECK_NOT_NULL(roundTripped);
+  for (int i = 0; i < kBezierControlPointCount; ++i)
+  {
+    double p[3] = { 0.0, 0.0, 0.0 };
+    carrierControlPoint(roundTripped, i, p);
+    for (int d = 0; d < 3; ++d)
+    {
+      CHECK_DOUBLE_TOLERANCE(p[d], kFixtureControlPoints[i][d], kCoordinateTolerance);
+    }
+  }
+
+  vtksys::SystemTools::RemoveFile(jsonPath);
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLResectionPlanLegacyFcsvMigrationTest(int, char*[])
+{
+  CHECK_EXIT_SUCCESS(testLegacyFcsvMigratesToPlanWithDefaults());
+
+  std::cout << "vtkMRMLResectionPlanLegacyFcsvMigrationTest completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRML/vtkMRMLLiverResectionCSVStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLLiverResectionCSVStorageNode.h
@@ -44,6 +44,25 @@
 
 #include <vtkMRMLMarkupsFiducialStorageNode.h>
 
+/**
+ * \class vtkMRMLLiverResectionCSVStorageNode
+ *
+ * \brief Read-only parse vehicle for the legacy v1 ``.lrp.fcsv``
+ *        resection format (a 15-column Markups-fiducial CSV).
+ *
+ * This node's sole live role is the seamless v1 -> v2 migration: it
+ * parses the 16 Bezier control points off a legacy ``.lrp.fcsv`` into a
+ * ``vtkMRMLMarkupsBezierSurfaceNode`` (LPS -> the markups RAS
+ * convention), and ``vtkMRMLResectionPlanStorageNode::ReadFcsv`` lifts
+ * those points into a v2 ``vtkMRMLBezierSurfaceNode`` carrier under a
+ * ``vtkMRMLResectionPlanNode`` (wrapper-vs-carrier per ADR-0014
+ * §"Fourth layer").
+ *
+ * The write path is dead: v2 persists exclusively through
+ * ``vtkMRMLResectionPlanStorageNode`` (``.lrp.json``).  Removal of the
+ * ``WriteDataInternal`` body and the dependency on the old
+ * ``vtkMRMLLiverResectionNode`` family is a T2.7 follow-up.
+ */
 class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLLiverResectionCSVStorageNode : public vtkMRMLMarkupsFiducialStorageNode
 {
 

--- a/LiverResections/MRML/vtkMRMLResectionPlanStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLResectionPlanStorageNode.cxx
@@ -17,6 +17,12 @@
 #include "vtkMRMLResectionPlanNode.h"
 #include "vtkMRMLAbstractParametricSurfaceNode.h"
 #include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLLiverResectionCSVStorageNode.h"
+#include "vtkMRMLLiverResectionNode.h"
+
+// LiverMarkups MRML includes -- the legacy parse vehicle reads into a
+// markups Bezier-surface node (RAS control points).
+#include "vtkMRMLMarkupsBezierSurfaceNode.h"
 
 // MRML includes
 #include <vtkMRMLJsonElement.h>
@@ -72,6 +78,9 @@ bool vtkMRMLResectionPlanStorageNode::CanWriteFromReferenceNode(vtkMRMLNode* ref
 void vtkMRMLResectionPlanStorageNode::InitializeSupportedReadFileTypes()
 {
   this->SupportedReadFileTypes->InsertNextValue("Liver resection plan (.lrp.json)");
+  // Legacy v1 read-only upgrade path -- migrated to a v2 plan + carrier
+  // on load (see the header §"Legacy `.lrp.fcsv`").
+  this->SupportedReadFileTypes->InsertNextValue("Liver resection plan v1 (.lrp.fcsv)");
 }
 
 //------------------------------------------------------------------------------
@@ -125,11 +134,21 @@ int vtkMRMLResectionPlanStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
     return 0;
   }
 
+  // Seamless v1 upgrade: a legacy ``.lrp.fcsv`` carries only the 16
+  // Bezier control points (per the v1 Markups-fiducial CSV format).
+  // The migration materialises a carrier + applies documented v2
+  // defaults for every legacy-absent field.  See the header
+  // §"Legacy `.lrp.fcsv`" and Docs/migrations/v1-to-v2.md.
+  if (endsWithLower(fullName, ".lrp.fcsv") || endsWithLower(fullName, ".fcsv"))
+  {
+    return this->ReadFcsv(fullName, plan);
+  }
+
   if (!endsWithLower(fullName, ".lrp.json") && !endsWithLower(fullName, ".json"))
   {
     vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
                                      "vtkMRMLResectionPlanStorageNode::ReadDataInternal",
-                                     "Reading resection plan failed: unsupported file extension for '" << fullName << "' (expected .lrp.json)");
+                                     "Reading resection plan failed: unsupported file extension for '" << fullName << "' (expected .lrp.json or .lrp.fcsv)");
     return 0;
   }
   return this->ReadJson(fullName, plan);
@@ -319,6 +338,107 @@ private:
   bool Prev;
 };
 } // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLResectionPlanStorageNode::ReadFcsv(const std::string& filePath, vtkMRMLResectionPlanNode* plan)
+{
+  // The v1 ``.lrp.fcsv`` is a 15-column Markups-fiducial CSV carrying
+  // only the Bezier control points.  Parse it with the legacy
+  // ``vtkMRMLLiverResectionCSVStorageNode`` as a read-only parse
+  // vehicle: it reads the LPS columns into a markups Bezier-surface
+  // node, converting to the markups RAS convention (negating X, Y).
+  // The 16 RAS control points are then lifted into a v2 Bezier carrier
+  // wired under the plan (wrapper-vs-carrier per ADR-0014 §"Fourth
+  // layer").  Every field absent from the legacy format (margins,
+  // order, state) is non-recoverable and keeps the plan node's
+  // construction-time defaults (margins = 0.0, orderIndex = -1,
+  // state = Init); see Docs/migrations/v1-to-v2.md.
+  //
+  // The parse vehicle is built off-scene (vtkNew) so the migration
+  // does not depend on the LiverMarkups / LiverResection node classes
+  // being registered in the plan's scene.
+  vtkNew<vtkMRMLMarkupsBezierSurfaceNode> parseSurface;
+  vtkNew<vtkMRMLLiverResectionNode> parseResection;
+  parseResection->SetBezierSurfaceNode(parseSurface);
+
+  vtkNew<vtkMRMLLiverResectionCSVStorageNode> csvStorage;
+  csvStorage->SetFileName(filePath.c_str());
+  if (!csvStorage->ReadData(parseResection))
+  {
+    this->GetUserMessages()->AddMessages(csvStorage->GetUserMessages());
+    vtkErrorToMessageCollectionMacro(
+      this->GetUserMessages(), "vtkMRMLResectionPlanStorageNode::ReadFcsv", "Reading legacy resection plan failed: could not parse control points from '" << filePath << "'");
+    return 0;
+  }
+
+  const int pointCount = parseSurface->GetNumberOfControlPoints();
+  const int expectedRows = 4;
+  const int expectedPoints = expectedRows * expectedRows;
+  if (pointCount != expectedPoints)
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
+                                     "vtkMRMLResectionPlanStorageNode::ReadFcsv",
+                                     "Reading legacy resection plan failed: '" << filePath << "' carries " << pointCount
+                                                                               << " control points; the v1 Bezier control polygon requires " << expectedPoints << " (a "
+                                                                               << expectedRows << "x" << expectedRows << " grid)");
+    return 0;
+  }
+
+  // Materialise / resolve the v2 Bezier carrier and wire it under the
+  // plan.  Same resolve-or-create discipline as ReadJson.
+  vtkMRMLAbstractParametricSurfaceNode* surface = plan->GetGeometryNode();
+  vtkMRMLBezierSurfaceNode* carrier = vtkMRMLBezierSurfaceNode::SafeDownCast(surface);
+  if (carrier == nullptr)
+  {
+    vtkMRMLScene* scene = plan->GetScene();
+    if (scene == nullptr)
+    {
+      vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
+                                       "vtkMRMLResectionPlanStorageNode::ReadFcsv",
+                                       "Reading legacy resection plan failed: plan '" << (plan->GetName() ? plan->GetName() : "<unnamed>")
+                                                                                      << "' has no scene; cannot instantiate the Bezier carrier");
+      return 0;
+    }
+    carrier = vtkMRMLBezierSurfaceNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLBezierSurfaceNode"));
+    if (carrier == nullptr)
+    {
+      vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
+                                       "vtkMRMLResectionPlanStorageNode::ReadFcsv",
+                                       "Reading legacy resection plan failed: could not instantiate the Bezier carrier for '" << filePath << "'");
+      return 0;
+    }
+    plan->SetAndObserveGeometryNode(carrier);
+  }
+
+  // SetSize / SetControlGrid are not state-guarded (unlike the
+  // init-mode subordinate setters), and a freshly-created carrier is in
+  // Init regardless, so no ScopedLoadingFromXML bypass is needed here.
+  carrier->SetSize(static_cast<unsigned int>(expectedRows));
+
+  double grid[vtkMRMLAbstractParametricSurfaceNode::MaxControlGridSize];
+  for (int i = 0; i < expectedPoints; ++i)
+  {
+    double position[3] = { 0.0, 0.0, 0.0 };
+    parseSurface->GetNthControlPointPosition(i, position);
+    grid[i * 3 + 0] = position[0];
+    grid[i * 3 + 1] = position[1];
+    grid[i * 3 + 2] = position[2];
+  }
+  carrier->SetControlGrid(grid);
+
+  // Loud upgrade: name every non-recoverable field that took a
+  // documented default, so the gap is visible to the user rather than
+  // silent.  Distinct from the Markups-fiducial deprecation warning the
+  // CSV parse itself emits.
+  vtkWarningToMessageCollectionMacro(this->GetUserMessages(),
+                                     "vtkMRMLResectionPlanStorageNode::ReadFcsv",
+                                     "Migrated legacy '" << filePath
+                                                         << "' to a v2 resection plan.  The v1 format carried only the Bezier control points; "
+                                                            "the safety margin and risk margin (defaulted to 0.0 mm), the resection order (orderIndex defaulted to -1), "
+                                                            "and the plan state (defaulted to Init) are not recoverable from the legacy file and took documented defaults.  "
+                                                            "Review these before clinical use (see Docs/migrations/v1-to-v2.md).");
+  return 1;
+}
 
 //------------------------------------------------------------------------------
 int vtkMRMLResectionPlanStorageNode::ReadJson(const std::string& filePath, vtkMRMLResectionPlanNode* plan)

--- a/LiverResections/MRML/vtkMRMLResectionPlanStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLResectionPlanStorageNode.h
@@ -97,10 +97,21 @@ class vtkMRMLAbstractParametricSurfaceNode;
  *
  * \par Legacy ``.lrp.fcsv``
  *
- * Out of scope for this storage node.  v1 ``.lrp.fcsv`` files upgrade
- * via a one-shot manual path (open in v1, save as ``.lrp.json``,
- * re-open in v2) until a seamless migration path lands as a
- * follow-up to the resection-plan-architecture work.
+ * The reader migrates a v1 ``.lrp.fcsv`` seamlessly on load.  The v1
+ * format is a 15-column Markups-fiducial CSV carrying only the 16
+ * Bezier control points (LPS).  ``ReadDataInternal`` delegates such a
+ * file to ``ReadFcsv``, which parses the points through the legacy
+ * ``vtkMRMLLiverResectionCSVStorageNode`` (read-only parse vehicle;
+ * LPS -> the markups RAS convention), materialises a
+ * ``vtkMRMLBezierSurfaceNode`` carrier under the plan
+ * (wrapper-vs-carrier per ADR-0014 §"Fourth layer"), and applies the
+ * documented v2 defaults for every legacy-absent field
+ * (``safetyMargin_mm`` = 0.0, ``riskMargin_mm`` = 0.0,
+ * ``orderIndex`` = -1, ``state`` = ``Init``).  Because those defaults
+ * are not recoverable from the legacy file, the migration records a
+ * loud warning on ``GetUserMessages()`` naming the defaulted fields.
+ * The write path always emits ``.lrp.json``; ``.lrp.fcsv`` is
+ * read-only.  See ``Docs/migrations/v1-to-v2.md``.
  */
 class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLResectionPlanStorageNode : public vtkMRMLStorageNode
 {
@@ -151,6 +162,15 @@ private:
   /// Read the v2 ``.lrp.json`` from ``filePath`` into ``plan``.
   /// Returns 1 on success, 0 on failure.
   int ReadJson(const std::string& filePath, vtkMRMLResectionPlanNode* plan);
+
+  /// Migrate a legacy v1 ``.lrp.fcsv`` from ``filePath`` into ``plan``:
+  /// parse the 16 Bezier control points through the legacy CSV parse
+  /// vehicle, materialise a ``vtkMRMLBezierSurfaceNode`` carrier under
+  /// the plan, apply the documented v2 defaults for every legacy-absent
+  /// field, and record a loud user message naming the defaulted fields.
+  /// Returns 1 on success, 0 on failure.  See the class docstring
+  /// §"Legacy `.lrp.fcsv`".
+  int ReadFcsv(const std::string& filePath, vtkMRMLResectionPlanNode* plan);
 };
 
 #endif // __vtkmrmlresectionplanstoragenode_h_

--- a/LiverResections/qSlicerLiverResectionsReader.cxx
+++ b/LiverResections/qSlicerLiverResectionsReader.cxx
@@ -59,6 +59,7 @@
 #include "vtkMRMLScene.h"
 
 // VTK includes
+#include <vtkCommand.h>
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 #include <vtksys/SystemTools.hxx>
@@ -166,8 +167,14 @@ bool qSlicerLiverResectionsReader::load(const IOProperties& properties)
   // plan storage node.  The storage node's reader walks the
   // ``surface.type`` discriminator and instantiates the right
   // concrete surface subclass into the scene.
+  // A legacy v1 ``.lrp.fcsv`` is migrated seamlessly through the same
+  // plan-storage path: ``vtkMRMLResectionPlanStorageNode::ReadData``
+  // detects the legacy extension and lifts the 16 Bezier control points
+  // into a v2 plan + carrier (see that node's §"Legacy `.lrp.fcsv`"
+  // and Docs/migrations/v1-to-v2.md).  Both extensions therefore yield
+  // a ``vtkMRMLResectionPlanNode`` that the LayerDM Pipeline renders.
   const QString lowerName = fileName.toLower();
-  if (lowerName.endsWith(".lrp.json"))
+  if (lowerName.endsWith(".lrp.json") || lowerName.endsWith(".lrp.fcsv"))
   {
     vtkMRMLScene* scene = d->LiverResectionsLogic->GetMRMLScene();
     if (!scene)
@@ -229,29 +236,11 @@ bool qSlicerLiverResectionsReader::load(const IOProperties& properties)
     return true;
   }
 
-  // Legacy ``.lrp.fcsv`` (and any other recognised extension) — delegate
-  // to the existing logic-side loader (load-only migration; ADR-0014
-  // §5 retires writes of this format).  Migration to the plan-rooted
-  // path is a follow-up to the resection-plan-architecture work.
-  char* nodeIDs = d->LiverResectionsLogic->LoadLiverResection(std::string(fileName.toUtf8()), std::string(name.toUtf8()), this->userMessages());
-  if (nodeIDs)
-  {
-    // returned a comma separated list of ids of the nodes that were loaded
-    QStringList nodeIDList;
-    char* ptr = strtok(nodeIDs, ",");
-
-    while (ptr)
-    {
-      nodeIDList.append(ptr);
-      ptr = strtok(nullptr, ",");
-    }
-    this->setLoadedNodes(nodeIDList);
-  }
-  else
-  {
-    this->setLoadedNodes(QStringList());
-    return false;
-  }
-
-  return nodeIDs != nullptr;
+  // No other extension is advertised by supportedFileTypes(); both the
+  // v2 ``.lrp.json`` and the legacy v1 ``.lrp.fcsv`` route through the
+  // plan-storage path above.  The old vtkMRMLLiverResectionNode-family
+  // loader is intentionally no longer reached from here.
+  this->userMessages()->AddMessage(vtkCommand::ErrorEvent, (QString("Unsupported file extension for '%1'").arg(fileName)).toUtf8().constData());
+  this->setLoadedNodes(QStringList());
+  return false;
 }


### PR DESCRIPTION
## Summary for humans

Opening a legacy v1 `.lrp.fcsv` resection file now upgrades it seamlessly to a v2 resection plan in one load — no manual "save-as-json, re-open" dance. The v1 file carried only the 16 Bezier control points; the migration materialises a `vtkMRMLBezierSurfaceNode` carrier with those points (converted to the markups RAS convention), wraps it in a `vtkMRMLResectionPlanNode`, and applies documented defaults for every field the v1 format never stored: safety/risk margins (0.0 mm), resection order (-1), and plan state (Init). Because those defaults are clinical placeholders, not recovered values, the load records a loud user-facing warning naming them, and `Docs/migrations/v1-to-v2.md` tells users to review before clinical use. The legacy file is read-only; saves always emit `.lrp.json`.

Closes #433.

## ADR references

1. ADR-0014 §"Fourth layer: clinical/method wrapper" — the wrapper-vs-carrier split the migration produces (plan wraps the Bezier carrier).
2. ADR-0023 §"Persistence — .lrp.json schema v2" — the v2 plan-rooted format the migration upgrades into.
3. `Docs/design/resection-plan-architecture/03-storage-ownership.md` §"Plan node" — the storage node owns the legacy upgrade seam.

## Conformance

- **Invariant: a v1 `.lrp.fcsv` loads as a v2 plan with the 16 control points on a Bezier carrier (RAS), documented defaults for every legacy-absent field, a loud gap warning, and a value-preserving `.lrp.json` round-trip.** Proven by `vtkMRMLResectionPlanLegacyFcsvMigrationTest::testLegacyFcsvMigratesToPlanWithDefaults` (the Fork C red test, now green).
- **Coordinate-system contract: the carrier holds RAS** (markups convention; LPS fixture with X,Y negated). Pinned by assertion 1's expected values.
- **Loud-not-silent upgrade**: the storage node's own `GetUserMessages()` names margins + order + state. Pinned by assertion 3.
- All 6 `vtkSlicerLiverResectionsModuleMRML` C++ tests pass; no regressions.

## UX impact

A v1 `.lrp.fcsv` now opens directly as a renderable v2 resection plan (previously it loaded into the retired `vtkMRMLLiverResectionNode` family). On load the user sees a warning that margins, resection order, and plan state were not in the legacy file and took defaults, with a pointer to the migration doc — they must review these before clinical use. No new dialogs or controls.

<details>
<summary>Agent context (long-form)</summary>

### Implementation seam

`vtkMRMLResectionPlanStorageNode::ReadDataInternal` previously rejected any non-`.lrp.json`/`.json` extension. It now detects `.lrp.fcsv` (and `.fcsv`) and delegates to a new private `ReadFcsv`:

1. Build an off-scene parse vehicle: `vtkMRMLLiverResectionNode` + `vtkMRMLMarkupsBezierSurfaceNode` wired via `SetBezierSurfaceNode`, plus a `vtkMRMLLiverResectionCSVStorageNode` pointed at the file. `vtkNew` (not scene factory) so the migration does not require the LiverMarkups / LiverResection classes to be registered in the plan's scene — important for the bare-scene test context.
2. `csvStorage->ReadData(parseResection)` parses the 15-column Markups CSV; the markups superclass converts the file's LPS coordinates to the markups RAS convention (X,Y negated).
3. Validate 16 control points (4x4), resolve-or-create a `vtkMRMLBezierSurfaceNode` carrier in the plan's scene (same discipline as `ReadJson`), `SetSize(4)` + `SetControlGrid`, wire via `SetAndObserveGeometryNode`.
4. Leave the plan node's construction-time defaults (margins 0.0, orderIndex -1, state Init) untouched — those already equal the documented v2 reader defaults the test asserts.
5. Emit a loud `vtkWarningToMessageCollectionMacro` naming the defaulted fields, distinct from the Markups-fiducial fcsv deprecation warning the CSV parse itself emits.

`qSlicerLiverResectionsReader::load` broadens its plan-storage branch to match both `.lrp.json` and `.lrp.fcsv`; the now-unreachable `LoadLiverResection` fallback (old node family) is replaced with a defensive unsupported-extension guard. `CreateDefaultDisplayNodes()` still fires so the LayerDM Pipeline renders.

### Coordinate-system note

The test-designer flagged LPS→RAS as the load-bearing contract. The markups parse vehicle does the conversion for free (markups store RAS), so the carrier holds RAS without any explicit negation in `ReadFcsv`. The test's expected values are the RAS coordinates; no test values were altered.

### Scope / boundaries

- Touched LiverResections/ storage only — no LiverSegmentation/ (parallel lane #445), no cross-module Subject Hierarchy.
- No per-module displayable manager (ADR-0013 §5).
- `vtkMRMLLiverResectionCSVStorageNode`'s write path stays dead; its docstring now records the read-only parse-vehicle role and flags `WriteDataInternal` + old-family-dependency removal as a T2.7 follow-up.

### Local verification

- Built `vtkSlicerLiverResectionsModuleMRMLCxxTests` and `qSlicerLiverResectionsModule` (Debug); clean except unrelated `_FORTIFY_SOURCE` toolchain warnings.
- `ctest` LiverResections/MRML: 6/6 pass including the migration test.
- `pre-commit run` on all changed files: pass (clang-format reformatted the long warning string; re-staged).
- Platform-neutrality grep on changed files: clean.

### simplify

Ran the `simplify` skill: removed a dead `ScopedLoadingFromXML` guard in `ReadFcsv` (the control-grid setters it would bypass are unguarded and a fresh carrier is already Init). Kept the resolve-or-create block and control-point copy loop as-is (mirror `ReadJson` at the right altitude; sharing would exceed this diff's scope).

</details>

_Drafted by Claude (claude-opus-4-8); reviewed by Rafael Palomar_
