### PR TITLE
ENH: Drop blocking volumetry-complete dialog; rely on the wait cursor

### DIFF
--- a/LiverVolumetry/LiverVolumetry.py
+++ b/LiverVolumetry/LiverVolumetry.py
@@ -224,8 +224,10 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     self.logic.computeVolume(segmentsVolumeNode, targetSegmentVolumeNode, self.ui.InputSegmentationSelector.currentNode(), outputTable, ROIMarkersList, resectionNodes)
 
+    # The wait cursor (set above) is the in-progress feedback; the
+    # populated volumetry table is the result, so no blocking completion
+    # dialog is shown (non-blocking feedback, ADR-0009 UX discipline).
     qt.QApplication.restoreOverrideCursor()
-    qt.QMessageBox.information(None, "Information", "The targeted liver volumetry was computed.")
 
     self.showTable(outputTable)
     slicer.mrmlScene.RemoveNode(segmentsVolumeNode)


### PR DESCRIPTION
Closes #322.

## What
The only post-long-op `QMessageBox.information` in the codebase was `LiverVolumetry.onComputeAdvancedVolumeButtonClicked`'s *"The targeted liver volumetry was computed"* box — a **blocking modal with no actionable content**.

A wait cursor **already** wraps the computation (`setOverrideCursor(Qt.WaitCursor)` at the top of the handler, `restoreOverrideCursor()` after), so in-progress feedback is covered and the populated volumetry table is the result. This removes the redundant blocking dialog — no non-blocking notification framework needed.

## Note (out of scope, flagged)
The existing `setOverrideCursor`/`restoreOverrideCursor` pair is not exception-safe — if `computeVolume` raises, the cursor stays stuck. Pre-existing; not fixed here to keep the change minimal. Easy follow-up: wrap the compute in `try/finally`.