### PR TITLE
ENH: Disable ClosedCurve resection radio (v2.0 dead-end)

### DIFF
--- a/Liver/Resources/UI/ResectionsWidget.ui
+++ b/Liver/Resources/UI/ResectionsWidget.ui
@@ -113,10 +113,13 @@
               <item>
                <widget class="QRadioButton" name="ClosedCurveButton">
                 <property name="enabled">
-                 <bool>true</bool>
+                 <bool>false</bool>
                 </property>
                 <property name="text">
                  <string>MarkupClosedCurve</string>
+                </property>
+                <property name="toolTip">
+                 <string>Closed-curve initialisation is planned for v2.1.</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
## Summary

Disable the **MarkupClosedCurve** resection-initialisation radio button in
the Resections widget. The closed-curve initialisation path is not wired for
the v2.0 resection workflow — it is deferred to v2.1 — so exposing a
selectable control that silently does nothing is a UX dead-end.

This sets the radio `enabled: false` and adds a tooltip
("Closed-curve initialisation is planned for v2.1.") so the unfinished path
is visibly parked rather than removed.

## Why a separate tiny PR

ClosedCurve resection was deferred to v2.1. This is the small v2.0 loose-end
of that deferral: keep the control discoverable (so users know it is coming)
but not selectable. Re-enabling it is the entry point for the v2.1 work.

## Scope

- `Liver/Resources/UI/ResectionsWidget.ui` — one widget, `enabled` flipped to
  `false` + a `toolTip`.

Relates to #321 (does not close it — #321 tracks the full ClosedCurve
initialisation, which lands in v2.1).

---

🤖 Drafted with the assistance of Claude (Anthropic), model claude-opus-4-8, under human review.
