### PR TITLE
ENH: Pin stray-node invariant + fix stale schema comment (post-#446)

### DIFF
--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanLegacyFcsvMigrationTest.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanLegacyFcsvMigrationTest.cxx
@@ -262,6 +262,19 @@ int testLegacyFcsvMigratesToPlanWithDefaults()
   CHECK_INT(plan->GetState(), vtkMRMLResectionPlanNode::Init);
 
   // --------------------------------------------------------------------------
+  // Assertion 2b -- stray-node lifetime.  The fcsv is parsed through an
+  // off-scene vtkMRMLLiverResectionCSVStorageNode vehicle; it must NOT be
+  // added to the working scene.  The migration adds exactly one Bezier
+  // carrier (wired in Assertion 1) and one plan -- no duplicate carriers,
+  // no leaked parse vehicle.  Pins the off-scene-parse invariant so a
+  // future refactor that accidentally AddNode()s the scratch vehicles
+  // fails here.
+  // --------------------------------------------------------------------------
+  CHECK_INT(scene->GetNumberOfNodesByClass("vtkMRMLLiverResectionCSVStorageNode"), 0);
+  CHECK_INT(scene->GetNumberOfNodesByClass("vtkMRMLBezierSurfaceNode"), 1);
+  CHECK_INT(scene->GetNumberOfNodesByClass("vtkMRMLResectionPlanNode"), 1);
+
+  // --------------------------------------------------------------------------
   // Assertion 3 -- loud gap.  The storage node's OWN user-message
   // collection carries a non-empty warning naming margins AND order AND
   // state as defaulted (a loud, not silent, upgrade).  Distinct from

--- a/LiverResections/qSlicerLiverResectionsReader.cxx
+++ b/LiverResections/qSlicerLiverResectionsReader.cxx
@@ -119,7 +119,7 @@ qSlicerIO::IOFileType qSlicerLiverResectionsReader::fileType() const
 //-----------------------------------------------------------------------------
 QStringList qSlicerLiverResectionsReader::extensions() const
 {
-  // ``.lrp.json`` is the v1 schema landed by the prior T2.5 commit
+  // ``.lrp.json`` is the v2 schema landed by the prior T2.5 commit
   // (ADR-0014 §5).  The Add Data filter entry was previously
   // withheld pending T2.6-LayerDM — without a Pipeline registered
   // for ``vtkMRMLParametricSurfaceDisplayNode``, a user-driven Add Data


### PR DESCRIPTION
## Summary

Two follow-up nits from the `/slicer-review` of #446 (legacy `.lrp.fcsv` →
v2 resection-plan migration), now that #446 has merged. Both are small and
non-behavioural for the load path itself.

## Changes

1. **Pin the stray-node lifetime invariant** (the one substantive review
   finding). The fcsv is parsed through an *off-scene*
   `vtkMRMLLiverResectionCSVStorageNode` vehicle; the working scene must
   never receive it. Adds a scene-population assertion to
   `vtkMRMLResectionPlanLegacyFcsvMigrationTest`:
   - `vtkMRMLLiverResectionCSVStorageNode` count == 0 (parse vehicle did not leak)
   - `vtkMRMLBezierSurfaceNode` count == 1 (exactly one carrier, no duplicates)
   - `vtkMRMLResectionPlanNode` count == 1

   This makes a future refactor that accidentally `AddNode()`s the scratch
   vehicles fail the test, rather than silently polluting the scene.

2. **Stale-comment fix** in `qSlicerLiverResectionsReader::extensions()`:
   `.lrp.json` is the **v2** schema (#430), not v1.

## Scope

- `LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanLegacyFcsvMigrationTest.cxx`
- `LiverResections/qSlicerLiverResectionsReader.cxx` (comment only)

Follow-up to #446.

---

🤖 Drafted with the assistance of Claude (Anthropic), model claude-opus-4-8, under human review.
