### PR TITLE
STYLE: Hoist launched-Slicer pytest skip-guards into one shared module

### DIFF
--- a/Liver/Testing/Python/conftest.py
+++ b/Liver/Testing/Python/conftest.py
@@ -10,89 +10,34 @@ pytest invocations that target a single file under
 ``Liver/Testing/Python/...`` (pytest walks UP from the test file to
 find ``conftest.py``; siblings aren't visited).
 
-This conftest provides what the new T5.2-d sidebar tests need:
+This conftest re-exports the shared launched-Slicer skip-guards from
+``slicer_pytest_support`` under their historical underscore names:
 
   * **`_require_qt_widget`** — early-skip helper for tests that need
     ``qt.QWidget``.  Bare ``PythonSlicer -m pytest <file>`` invocations
     don't initialise a ``qSlicerApplication``, so PythonQt's ``qt``
-    module is importable but lacks the ``QWidget`` class.  Tests that
-    need a real Qt widget call this helper at the top of the function
-    body and skip cleanly when the harness can't satisfy them.
+    module is importable but lacks the ``QWidget`` class.
 
   * **`_require_mrml_scene`** — early-skip helper for tests that need
-    ``slicer.mrmlScene``.  Same shape: ``slicer.mrmlScene`` is a
-    ``qSlicerApplication`` runtime attribute, absent under bare
-    PythonSlicer.
+    ``slicer.mrmlScene`` (a ``qSlicerApplication`` runtime attribute,
+    absent under bare PythonSlicer).
 
-The brief for T5.2-d called for a "minimal qSlicerApplication
-harness".  The test-designer landed pytest-style tests but the CMake
-registration invokes bare ``PythonSlicer -m pytest`` -- which is the
-existing Slicer-Liver pattern per ADR-0008 §6 and only suits Python-
-side testing, NOT widget-level testing.  The full launched-Slicer
-harness for the widget-level tests (T1, T4, T5, T6) is tracked as a
-follow-up to T5.2-d: see the T5.2-d PR body's "Test plan" note.
+The canonical bodies live in ``Testing/Python/slicer_pytest_support.py``,
+on ``sys.path`` via the ``pythonpath`` ini option in ``pytest.ini``.  The
+underscore aliases here keep the existing ``from conftest import ...``
+call sites and the bare-path skip-contract test
+(``test_bare_pytest_skip_path_preserved.py``) working unchanged.
 
-Until that follow-up lands, the widget-level tests skip with a
-clear message pointing at the launched-Slicer pattern; the
-Python-side semantics tests (T2 symbol existence + T7 static AST
-check) continue to run under bare PythonSlicer and exercise the
-real invariants.
+Under bare ``PythonSlicer -m pytest`` the widget-/scene-level tests skip
+with a clear message pointing at the launched-Slicer pattern; the
+Python-side semantics tests (symbol existence + static AST checks)
+continue to run and exercise the real invariants (ADR-0008 §1, §6).
 """
 
 from __future__ import annotations
 
-import pytest
-
-
-def _require_qt_widget() -> None:
-    """Skip the current test if ``qt.QWidget`` is not available.
-
-    Use at the top of any test function that constructs a Qt widget.
-    Skips cleanly under bare ``PythonSlicer -m pytest <file>``;
-    proceeds when the harness has initialised a ``qSlicerApplication``
-    (e.g. via ``Slicer --no-splash --python-script $(which pytest)
-    -- <file>``).
-    """
-    try:
-        import qt  # type: ignore[import-not-found]
-    except ImportError as exc:
-        pytest.skip(
-            f"qt module not importable ({exc}); "
-            "run from PythonSlicer or a launched Slicer."
-        )
-        return
-    if not hasattr(qt, "QWidget"):
-        pytest.skip(
-            "qt module is loaded but qt.QWidget is missing -- the test "
-            "harness has not initialised a qSlicerApplication.  Re-run "
-            "this test from a launched Slicer:\n"
-            "  Slicer --no-splash --python-script $(which pytest) -- "
-            "<test_file>\n"
-            "Bare PythonSlicer -m pytest cannot satisfy widget-level "
-            "tests; see the T5.2-d follow-up issue for the launched-"
-            "Slicer harness."
-        )
-
-
-def _require_mrml_scene() -> None:
-    """Skip the current test if ``slicer.mrmlScene`` is not available.
-
-    Use at the top of any test function that touches the MRML scene.
-    Same shape as ``_require_qt_widget``: bare PythonSlicer lacks
-    ``slicer.mrmlScene``; a launched Slicer has it.
-    """
-    try:
-        import slicer  # type: ignore[import-not-found]
-    except ImportError as exc:
-        pytest.skip(
-            f"slicer module not importable ({exc}); "
-            "run from PythonSlicer or a launched Slicer."
-        )
-        return
-    if not hasattr(slicer, "mrmlScene"):
-        pytest.skip(
-            "slicer.mrmlScene not available -- bare PythonSlicer does "
-            "not initialise a qSlicerApplication.  Run from a launched "
-            "Slicer:  Slicer --no-splash --python-script $(which "
-            "pytest) -- <test_file>"
-        )
+from slicer_pytest_support import (  # noqa: F401  (re-exported for `from conftest import ...`)
+    import_slicer_or_skip as _import_slicer_or_skip,
+    require_mrml_scene as _require_mrml_scene,
+    require_qt_widget as _require_qt_widget,
+)

--- a/Liver/Testing/Python/test_bare_pytest_skip_path_preserved.py
+++ b/Liver/Testing/Python/test_bare_pytest_skip_path_preserved.py
@@ -36,6 +36,7 @@ See also
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import os
 
@@ -45,13 +46,67 @@ import pytest
 _THIS_DIR = os.path.dirname(__file__)
 
 
+def _repo_root() -> str:
+    """Walk up from this file to the directory holding ``pytest.ini``.
+
+    Anchoring on the ini file (rather than a fixed ``..`` count) keeps the
+    tree scan inside *this* checkout.  In a worktree layout the parent of the
+    checkout holds sibling worktrees; a hard-coded level count would escape
+    into them and miscount guard definitions.
+    """
+    current = _THIS_DIR
+    while True:
+        if os.path.isfile(os.path.join(current, "pytest.ini")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:  # filesystem root reached
+            raise AssertionError(
+                "pytest.ini not found walking up from "
+                f"{_THIS_DIR}; cannot anchor the dedup tree scan."
+            )
+        current = parent
+
+
+_REPO_ROOT = _repo_root()
+
+# The canonical guard names live in the shared support module; the conftests
+# re-export them under these underscore aliases.  Single source of truth for
+# the dedup invariant below.
+_CANONICAL_GUARD_NAMES = (
+    "import_slicer_or_skip",
+    "require_mrml_scene",
+    "require_qt_widget",
+)
+
+# Historical underscore aliases that previously named copy-pasted bodies.
+# ``_require_mrml_scene_or_skip`` was a thin wrapper around the scene guard.
+_GUARD_ALIASES = {
+    "_import_slicer_or_skip": "import_slicer_or_skip",
+    "_require_mrml_scene": "require_mrml_scene",
+    "_require_mrml_scene_or_skip": "require_mrml_scene",
+    "_require_qt_widget": "require_qt_widget",
+}
+
+
+def _canonical_for(func_name: str):
+    """Map a ``def`` name to its canonical guard, or ``None`` if unrelated.
+
+    Matches both the canonical public names and the historical underscore
+    aliases, so a re-definition under either spelling is flagged.
+    """
+    if func_name in _CANONICAL_GUARD_NAMES:
+        return func_name
+    return _GUARD_ALIASES.get(func_name)
+
+
 def _load_conftest():
     """Import the sibling conftest as a module for direct helper access.
 
-    The conftest defines ``_require_qt_widget`` / ``_require_mrml_scene``.
-    pytest auto-loads conftest for fixture/hook discovery, but the helpers
-    are plain functions the shell tests import explicitly -- so this file
-    loads it the same way to assert their skip contract directly.
+    The conftest re-exports ``_require_qt_widget`` / ``_require_mrml_scene``
+    from the shared ``slicer_pytest_support`` module.  pytest auto-loads
+    conftest for fixture/hook discovery, but the helpers are plain functions
+    the shell tests import explicitly -- so this file loads it the same way
+    to assert their skip contract (and the dedup identity) directly.
     """
     conftest_path = os.path.join(_THIS_DIR, "conftest.py")
     assert os.path.isfile(conftest_path), (
@@ -163,3 +218,84 @@ def test_require_mrml_scene_skips_on_bare_path_runs_on_launched():
 
     with pytest.raises(pytest.skip.Exception):
         conftest._require_mrml_scene()
+
+
+# --------------------------------------------------------------------------- #
+# Invariant -- the skip-guards are deduplicated onto one shared module.
+# --------------------------------------------------------------------------- #
+#
+# Pins the post-hoc dedup: the launched-Slicer skip-guards used to be
+# copy-pasted across the per-module conftests and a couple of test files
+# (their docstrings literally said "Same shape as
+# ``Liver/Testing/Python/conftest.py``").  These two tests fail against the
+# pre-dedup tree (multiple ``def`` bodies) and pass once the guards live in
+# ``Testing/Python/slicer_pytest_support.py`` and the conftests re-export them.
+
+
+def test_skip_guards_defined_exactly_once_in_tree():
+    """Each guard body must be defined exactly once across the test tree.
+
+    Walks every ``test_*.py`` and ``conftest.py`` under the repo, parsing
+    each for top-level ``def <guard>`` statements.  A guard may be *defined*
+    only in the shared support module; everything else must import / re-export
+    it.  The canonical names plus their historical underscore aliases are both
+    counted -- a stray re-definition under either spelling re-introduces the
+    duplication the shared ``slicer_pytest_support`` module exists to remove.
+
+    Red against the pre-dedup tree (``_require_qt_widget`` defined in two
+    conftests, ``_require_mrml_scene`` in two, ``_import_slicer_or_skip`` /
+    ``_require_mrml_scene_or_skip`` inline in two shell test files); green
+    once only ``slicer_pytest_support`` carries the bodies.
+    """
+    guard_defs = {name: [] for name in _CANONICAL_GUARD_NAMES}
+
+    for dirpath, _dirnames, filenames in os.walk(_REPO_ROOT):
+        # Skip build trees and VCS metadata.
+        if os.sep + "build" in dirpath or os.sep + ".bare" in dirpath:
+            continue
+        for filename in filenames:
+            is_scanned = (
+                filename.startswith("test_")
+                or filename == "conftest.py"
+                or filename == "slicer_pytest_support.py"
+            )
+            if not (is_scanned and filename.endswith(".py")):
+                continue
+            path = os.path.join(dirpath, filename)
+            with open(path, encoding="utf-8") as handle:
+                tree = ast.parse(handle.read(), filename=path)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.FunctionDef):
+                    continue
+                canonical = _canonical_for(node.name)
+                if canonical is not None:
+                    guard_defs[canonical].append(os.path.relpath(path, _REPO_ROOT))
+
+    support_rel = os.path.join("Testing", "Python", "slicer_pytest_support.py")
+    for name, locations in guard_defs.items():
+        assert locations == [support_rel], (
+            f"Guard {name!r} must be defined exactly once, in "
+            f"{support_rel}; found definitions in {locations}.  The "
+            "launched-Slicer skip-guards are deduplicated onto "
+            "slicer_pytest_support; conftests re-export, tests import."
+        )
+
+
+def test_conftest_aliases_are_the_shared_objects():
+    """Each conftest alias must be the SAME object as the shared guard.
+
+    Re-export, not re-implementation: ``conftest._require_qt_widget`` must be
+    ``slicer_pytest_support.require_qt_widget`` (identity), likewise for the
+    scene + import guards.  This catches a future maintainer copy-pasting a
+    body back into a conftest "just to tweak the message" -- which would pass
+    a name-existence check but silently re-fork the contract.
+    """
+    import slicer_pytest_support  # on sys.path via pytest.ini ``pythonpath``
+
+    conftest = _load_conftest()
+    assert conftest._require_qt_widget is slicer_pytest_support.require_qt_widget
+    assert conftest._require_mrml_scene is slicer_pytest_support.require_mrml_scene
+    assert (
+        conftest._import_slicer_or_skip
+        is slicer_pytest_support.import_slicer_or_skip
+    )

--- a/Liver/Testing/Python/test_liver_shell_isstagecomplete.py
+++ b/Liver/Testing/Python/test_liver_shell_isstagecomplete.py
@@ -45,25 +45,16 @@ import pytest
 
 
 # --------------------------------------------------------------------------- #
-# File-local helpers
+# File-local helpers — the launched-Slicer skip-guards are the shared ones
+# re-exported by the sibling conftest (canonical bodies in
+# Testing/Python/slicer_pytest_support.py).
 # --------------------------------------------------------------------------- #
 
-def _import_slicer_or_skip():
-    """Return ``slicer`` or skip the test cleanly."""
-    try:
-        import slicer  # type: ignore[import-not-found]
-    except ImportError as exc:  # pragma: no cover
-        pytest.skip(
-            f"slicer module not importable ({exc}); "
-            "IsStageComplete tests require Slicer's Python."
-        )
-    return slicer
-
-
-def _require_mrml_scene_or_skip():
-    """Skip when ``slicer.mrmlScene`` isn't initialised (bare PythonSlicer)."""
-    from conftest import _require_mrml_scene  # type: ignore[import-not-found]
-    _require_mrml_scene()
+# Re-export under the names this file's call sites already use.
+from conftest import (  # type: ignore[import-not-found]  # noqa: E402
+    _import_slicer_or_skip,
+    _require_mrml_scene as _require_mrml_scene_or_skip,
+)
 
 
 def _clear_scene():

--- a/Liver/Testing/Python/test_liver_shell_sidebar.py
+++ b/Liver/Testing/Python/test_liver_shell_sidebar.py
@@ -69,26 +69,10 @@ EXPECTED_STAGE_NAMES = [
 
 
 # --------------------------------------------------------------------------- #
-# Module-scoped helpers (file-local; per feedback_agent_brief_pre_push_hygiene)
+# Module-scoped helpers — the launched-Slicer skip-guards are the shared ones
+# re-exported by the sibling conftest (canonical bodies in
+# Testing/Python/slicer_pytest_support.py).
 # --------------------------------------------------------------------------- #
-
-def _import_slicer_or_skip():
-    """Return the ``slicer`` module, skipping the test if unavailable.
-
-    The Liver shell widget is a Slicer scripted module — it cannot be
-    instantiated outside a running Slicer Python.  Tests using this
-    helper are CI-runnable under Slicer's bundled pytest invocation
-    only.
-    """
-    try:
-        import slicer  # type: ignore[import-not-found]
-    except ImportError as exc:  # pragma: no cover — exercised only outside Slicer
-        pytest.skip(
-            f"slicer module not importable ({exc}); "
-            "Liver-shell sidebar tests require Slicer's Python."
-        )
-    return slicer
-
 
 def _instantiate_liver_widget():
     """Build a fresh ``LiverWidget`` rooted on a throwaway parent.
@@ -100,7 +84,10 @@ def _instantiate_liver_widget():
     # Widget-level tests need qt.QWidget — bare ``PythonSlicer -m pytest``
     # leaves PythonQt's qt module importable but without QWidget.  Skip
     # gracefully when the launched-Slicer harness isn't in play.
-    from conftest import _require_qt_widget  # type: ignore[import-not-found]
+    from conftest import (  # type: ignore[import-not-found]
+        _import_slicer_or_skip,
+        _require_qt_widget,
+    )
     _require_qt_widget()
 
     _import_slicer_or_skip()

--- a/LiverSegmentation/Testing/Python/conftest.py
+++ b/LiverSegmentation/Testing/Python/conftest.py
@@ -20,6 +20,13 @@ Two audiences, same skip-clean discipline as the Liver-shell suite
   * **Import-purity + conformance-grep tests** are pure-Python: no Slicer,
     no Qt, no network.  They never call the helpers below.  This is the
     invariant that lets CI exercise the suite without provisioning Slicer.
+
+This conftest re-exports the shared launched-Slicer skip-guards from
+``slicer_pytest_support`` (canonical bodies in
+``Testing/Python/slicer_pytest_support.py``, on ``sys.path`` via the
+``pythonpath`` ini option) under their historical underscore names, so the
+existing ``from conftest import _import_slicer_or_skip, _require_mrml_scene``
+call sites keep working.
 """
 
 from __future__ import annotations
@@ -30,6 +37,12 @@ import subprocess
 import sys
 
 import pytest
+
+from slicer_pytest_support import (  # noqa: F401  (re-exported for `from conftest import ...`)
+    import_slicer_or_skip as _import_slicer_or_skip,
+    require_mrml_scene as _require_mrml_scene,
+    require_qt_widget as _require_qt_widget,
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -299,61 +312,3 @@ def qt_widgets():
                 target.deleteLater()
         except Exception:  # noqa: BLE001 — teardown is best-effort across versions
             pass
-
-
-def _import_slicer_or_skip():
-    """Return the ``slicer`` module or skip the current test cleanly."""
-    try:
-        import slicer  # type: ignore[import-not-found]
-    except ImportError as exc:  # pragma: no cover — exercised only outside Slicer
-        pytest.skip(
-            f"slicer module not importable ({exc}); "
-            "LiverSegmentation scene tests require Slicer's Python."
-        )
-        return None
-    return slicer
-
-
-def _require_mrml_scene():
-    """Skip the current test if ``slicer.mrmlScene`` is not available.
-
-    Bare ``PythonSlicer`` does not initialise a ``qSlicerApplication`` and
-    therefore has no ``slicer.mrmlScene``; a launched Slicer does.  Same
-    shape as ``Liver/Testing/Python/conftest.py``.
-    """
-    slicer = _import_slicer_or_skip()
-    if slicer is None:
-        return
-    if not hasattr(slicer, "mrmlScene") or slicer.mrmlScene is None:
-        pytest.skip(
-            "slicer.mrmlScene not available -- bare PythonSlicer does not "
-            "initialise a qSlicerApplication.  Run from a launched Slicer:\n"
-            "  Slicer --no-splash --python-script $(which pytest) -- <test_file>"
-        )
-
-
-def _require_qt_widget():
-    """Skip the current test if ``qt.QWidget`` is not available.
-
-    The Stage-2 surgeon-UI tests construct the ``LiverSegmentationWidget``
-    (a ``QTabWidget`` of four structure cards) and therefore need a real Qt
-    widget surface.  Bare ``PythonSlicer -m pytest <file>`` loads PythonQt's
-    ``qt`` module but does NOT initialise a ``qSlicerApplication``, so
-    ``qt.QWidget`` is missing; the launched-Slicer harness from
-    ``Liver/Testing/Python/run_pytest_launched.py`` (``pytest_launched``)
-    has it.  Same shape as ``Liver/Testing/Python/conftest._require_qt_widget``.
-    """
-    try:
-        import qt  # type: ignore[import-not-found]
-    except ImportError as exc:
-        pytest.skip(
-            f"qt module not importable ({exc}); "
-            "LiverSegmentation widget tests require a launched Slicer."
-        )
-        return
-    if not hasattr(qt, "QWidget"):
-        pytest.skip(
-            "qt module is loaded but qt.QWidget is missing -- no "
-            "qSlicerApplication.  Run under the launched-Slicer harness "
-            "(pytest_launched / run_pytest_launched.py)."
-        )

--- a/Testing/Python/slicer_pytest_support.py
+++ b/Testing/Python/slicer_pytest_support.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Shared launched-Slicer pytest skip-guards.
+
+Single source of truth for the early-skip helpers the per-module test
+suites use to run the *same* test files under two harnesses (ADR-0008 §1):
+
+  * **bare ``PythonSlicer -m pytest <file>``** — ``slicer`` imports as a
+    library but no ``qSlicerApplication`` is initialised, so ``qt.QWidget``
+    and ``slicer.mrmlScene`` are absent.  Widget- and scene-level tests
+    skip cleanly via these guards; pure-Python tests still run.
+
+  * **launched Slicer** (``run_pytest_launched.py`` driven by
+    ``Slicer --no-splash --python-script $(which pytest) -- <file>``) — a
+    live ``qSlicerApplication`` is present, so the guards return and the
+    widget-/scene-level tests actually execute.
+
+These helpers used to be copy-pasted across the per-module conftests and a
+couple of test files (the docstrings literally said "Same shape as
+``Liver/Testing/Python/conftest.py``").  They now live here once and are
+re-exported by each module conftest under the historical underscore names.
+
+Importable from any subtree because ``pytest.ini`` puts ``Testing/Python``
+on ``pythonpath`` (honoured by bare ``pytest`` and by the in-process
+``pytest.main()`` the launched driver calls).
+
+See also:
+  * Docs/adr/0008-testing-strategy.md §1, §6  (the dual-harness strategy)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def import_slicer_or_skip():
+    """Return the ``slicer`` module, or skip the current test cleanly.
+
+    Bare CPython / a plain pytest environment without a built Slicer
+    cannot import ``slicer``; the consuming test skips rather than erroring
+    so the suite can be exercised in isolation.
+    """
+    try:
+        import slicer  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover — exercised only outside Slicer
+        pytest.skip(
+            f"slicer module not importable ({exc}); "
+            "run from PythonSlicer or a launched Slicer."
+        )
+        return None
+    return slicer
+
+
+def require_mrml_scene() -> None:
+    """Skip the current test if ``slicer.mrmlScene`` is not available.
+
+    Use at the top of any test function that touches the MRML scene.
+    Bare ``PythonSlicer`` does not initialise a ``qSlicerApplication`` and
+    therefore has no ``slicer.mrmlScene``; a launched Slicer does.
+    """
+    slicer = import_slicer_or_skip()
+    if slicer is None:
+        return
+    if not hasattr(slicer, "mrmlScene") or slicer.mrmlScene is None:
+        pytest.skip(
+            "slicer.mrmlScene not available -- bare PythonSlicer does not "
+            "initialise a qSlicerApplication.  Run from a launched Slicer:\n"
+            "  Slicer --no-splash --python-script $(which pytest) -- <test_file>"
+        )
+
+
+def require_qt_widget() -> None:
+    """Skip the current test if ``qt.QWidget`` is not available.
+
+    Use at the top of any test function that constructs a Qt widget.
+    Skips cleanly under bare ``PythonSlicer -m pytest <file>``;
+    proceeds when the harness has initialised a ``qSlicerApplication``
+    (e.g. via ``Slicer --no-splash --python-script $(which pytest)
+    -- <file>``).
+    """
+    try:
+        import qt  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(
+            f"qt module not importable ({exc}); "
+            "run from PythonSlicer or a launched Slicer."
+        )
+        return
+    if not hasattr(qt, "QWidget"):
+        pytest.skip(
+            "qt module is loaded but qt.QWidget is missing -- the test "
+            "harness has not initialised a qSlicerApplication.  Re-run "
+            "this test from a launched Slicer:\n"
+            "  Slicer --no-splash --python-script $(which pytest) -- "
+            "<test_file>\n"
+            "Bare PythonSlicer -m pytest cannot satisfy widget-level "
+            "tests; see the launched-Slicer harness (run_pytest_launched.py)."
+        )

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,14 @@
 minversion = 7.0
 testpaths =
     Testing/Python
+; Put the shared support package on sys.path for every collection root.
+; The launched-Slicer skip-guards (import_slicer_or_skip / require_mrml_scene
+; / require_qt_widget) live in Testing/Python/slicer_pytest_support.py and are
+; re-exported by each per-module conftest; this lets a test under any subtree
+; import them under both bare ``PythonSlicer -m pytest <file>`` and the
+; in-process ``pytest.main()`` the launched driver runs.  Path is relative to
+; this pytest.ini (the repo root).
+pythonpath = Testing/Python
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*


### PR DESCRIPTION
## Summary for humans

The launched-Slicer pytest skip-guards were copy-pasted across the test
tree — their docstrings literally read *"Same shape as
`Liver/Testing/Python/conftest.py`"*. The duplication count was **3
conftest definitions + 2 inline copies**:

- `_require_qt_widget` — defined in `Liver/` **and** `LiverSegmentation/`
  conftests
- `_require_mrml_scene` — defined in both conftests
- `_import_slicer_or_skip` / `_require_mrml_scene_or_skip` — inline in
  `test_liver_shell_sidebar.py` and `test_liver_shell_isstagecomplete.py`

This PR hoists the three guards into one shared module,
`Testing/Python/slicer_pytest_support.py`, as public names
(`import_slicer_or_skip`, `require_mrml_scene`, `require_qt_widget`), using
the most robust existing bodies (the scene guard checks both `hasattr` and
`is None`; the widget guard keeps the fuller launched-Slicer guidance
string). `pytest.ini` gains the pytest-7 `pythonpath = Testing/Python`
option so the module imports from any subtree under both bare
`PythonSlicer -m pytest <file>` and the in-process `pytest.main()` the
launched driver runs. Each module conftest now **re-exports** the guards
under their historical underscore names, so every existing
`from conftest import _require_*` call site and the path-based
skip-contract test keep working byte-for-byte.

This is a pure test-infra de-duplication: the skip semantics are
unchanged.

## ADR references

1. ADR-0008 §1, §6 — dual-harness testing strategy (bare pytest primary;
   launched Slicer additive).
2. ADR-0027 — invariant test-first for v2 implementation.

## Conformance

The preserved contract: each module conftest must still expose
`_require_qt_widget` / `_require_mrml_scene` / `_import_slicer_or_skip` as
attributes, and the bare path must skip cleanly (not error) while the
launched path proceeds.

| Invariant | Proven by [test] |
|---|---|
| Skip semantics unchanged — each guard skips under bare PythonSlicer, returns under launched Slicer | `test_require_qt_widget_skips_on_bare_path_runs_on_launched`, `test_require_mrml_scene_skips_on_bare_path_runs_on_launched` |
| Conftest still exposes the underscore guard attributes | `test_conftest_exposes_require_qt_widget` |
| Each guard body defined exactly once across the tree (the dedup itself) | `test_skip_guards_defined_exactly_once_in_tree` |
| Conftest aliases are the *same function object* as the shared guard (re-export, not re-fork) | `test_conftest_aliases_are_the_shared_objects` |

The two new invariants fail against the pre-dedup tree (multiple `def`
bodies) and pass after — verified by stashing the change and re-running.

## UX impact

N/A — non-UI change (test infrastructure only).

<details>
<summary>Agent context (long-form)</summary>

### Canonical-body choices

- `require_mrml_scene` uses the `LiverSegmentation` conftest body, which
  guards both `not hasattr(slicer, "mrmlScene")` **and**
  `slicer.mrmlScene is None` (the `Liver` copy only checked `hasattr`). In a
  launched Slicer `mrmlScene` is non-None, so the skip-contract test's
  "must not skip when launched" assertion still holds.
- `require_qt_widget` uses the fuller `Liver` conftest body (the longer
  launched-Slicer guidance string). The skip message's pointer to a
  "follow-up issue" was retargeted to the in-repo `run_pytest_launched.py`
  to keep source free of issue references.

### Re-export wiring

Each conftest does
`from slicer_pytest_support import require_qt_widget as _require_qt_widget`
(plus the other two), annotated `# noqa: F401`. The path-based
`_load_conftest()` in the skip-contract test exec's the conftest by file
location; `slicer_pytest_support` resolves via the `pythonpath` ini entry
(pytest discovers the repo-root `pytest.ini` walking up from any file).

`test_liver_shell_isstagecomplete.py` previously had a local
`_require_mrml_scene_or_skip` wrapper around the conftest scene guard; it is
now a module-level `from conftest import _require_mrml_scene as
_require_mrml_scene_or_skip` alias, keeping all call sites intact.

### Dedup invariant scoping

`test_skip_guards_defined_exactly_once_in_tree` anchors its tree walk on the
directory holding `pytest.ini` (walking up from the test file) rather than a
fixed `..` count — a hard-coded level count would escape the checkout into
sibling worktrees in a worktree-based layout. It parses every `test_*.py`,
`conftest.py`, and the support module via `ast`, counting `def`s under both
the canonical names and the historical underscore aliases.

### Local verification

No runnable launched-Slicer harness on the dev box (the known
pytest-under-launcher defect; PythonSlicer is only present inside container
overlay storage). Verified instead with a throwaway CPython venv + pytest
9.0.3:

- `test_bare_pytest_skip_path_preserved.py` — **5 passed** (the 2 new
  invariants + 3 preserved contract tests).
- `Liver/Testing/Python` collected in isolation — **11 passed, 17 skipped,
  0 errors**; guards skip cleanly with the messages now sourced from
  `slicer_pytest_support.py`.
- `LiverSegmentation/Testing/Python` in isolation — **4 passed, 7 skipped**.

Pre-existing observation (not a regression): collecting `Liver/` **and**
`LiverSegmentation/` in a *single* pytest session triggers a `conftest`
module-name collision under prepend-import mode (`sys.modules["conftest"]`
resolves to whichever loaded last). This fails identically on the pre-change
tree (confirmed by stash + re-run) and never occurs under the per-suite
CMake / per-file launched invocations. Left untouched — out of scope for a
dedup PR.

_Drafted by Claude (claude-opus-4-8); reviewed by Rafael Palomar_
</details>
