### PR TITLE
ENH: Harden launched-Slicer exit against a drifted slicer.util

### DIFF
--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -107,15 +107,41 @@ def _exit(code: int) -> None:
     ``sys.exit`` for the standalone CPython invocation (the harness
     self-test in ``test_run_pytest_launched_contract.py``, or a local
     lint run).  Same shape as ``replay_test._exit``.
+
+    ``slicer.util.exit`` is preferred, but a drifted Slicer image has
+    been observed to ship a partial ``slicer.util`` with no ``exit``
+    attribute.  Routing the code through it inside a bare ``except
+    ImportError`` let the resulting ``AttributeError`` escape: the
+    script aborted while Slicer's Qt event loop kept running, hanging
+    until the CTest timeout fired.  So degrade across the same primitive
+    ``slicer.util.exit`` itself uses -- clear ``runPythonAndExit`` so
+    Slicer does not overwrite our code, then ``app.exit`` -- and only
+    then ``sys.exit``, so a missing API yields a coded exit, never a
+    hang.
     """
     if os.environ.get(_FORCE_SYSEXIT_ENV) == "1":
         sys.exit(code)
     try:
         import slicer  # type: ignore[import-not-found]
-
-        slicer.util.exit(code)
     except ImportError:
         sys.exit(code)
+        return
+
+    util_exit = getattr(getattr(slicer, "util", None), "exit", None)
+    if callable(util_exit):
+        util_exit(code)
+        return
+
+    app = getattr(slicer, "app", None)
+    if app is not None:
+        try:
+            app.commandOptions().runPythonAndExit = False
+        except Exception:  # noqa: BLE001 -- best-effort; still drive app.exit below
+            pass
+        app.exit(code)
+        return
+
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/Liver/Testing/Python/test_run_pytest_launched_contract.py
+++ b/Liver/Testing/Python/test_run_pytest_launched_contract.py
@@ -55,10 +55,14 @@ See also
 
 from __future__ import annotations
 
+import importlib
 import os
 import subprocess
 import sys
 import textwrap
+import types
+
+import pytest
 
 
 
@@ -236,3 +240,99 @@ def test_driver_fails_closed_when_no_tests_collected(tmp_path):
         f"tests (pytest NO_TESTS_COLLECTED=5); got {result.returncode}.\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 3 -- never hang on a drifted slicer.util.
+# --------------------------------------------------------------------------- #
+#
+# Regression: ``_exit`` routed the code through ``slicer.util.exit(code)``
+# inside a bare ``except ImportError``.  A drifted Slicer image that ships
+# a partial ``slicer.util`` with no ``exit`` attribute raised
+# ``AttributeError`` -- NOT caught -- so the script aborted while Slicer's
+# Qt event loop kept running.  ``pytest_launched`` then hung until the
+# 1500 s CTest timeout and reported the wrong status.  ``_exit`` must
+# degrade to ``slicer.app.exit`` (the same primitive ``slicer.util.exit``
+# uses) so a missing API yields a coded exit, never a hang.
+
+def _import_driver_module():
+    """Import ``run_pytest_launched`` as a module (defs only; __main__ guarded)."""
+    sys.path.insert(0, os.path.dirname(_require_driver()))
+    try:
+        return importlib.import_module("run_pytest_launched")
+    finally:
+        sys.path.pop(0)
+
+
+def _fake_app():
+    """A stand-in qSlicerApplication recording ``exit`` + ``runPythonAndExit``."""
+    class _Opts:
+        runPythonAndExit = True
+
+    class _App:
+        def __init__(self):
+            self.exited_with = None
+            self.opts = _Opts()
+
+        def commandOptions(self):
+            return self.opts
+
+        def exit(self, code):
+            self.exited_with = code
+
+    return _App()
+
+
+def test_exit_uses_slicer_util_exit_when_present(monkeypatch):
+    """When ``slicer.util.exit`` exists it is the route taken (app.exit untouched)."""
+    monkeypatch.delenv("SLICER_PYTEST_LAUNCHED_FORCE_SYSEXIT", raising=False)
+    driver = _import_driver_module()
+
+    recorded = {}
+    fake = types.ModuleType("slicer")
+    fake.util = types.ModuleType("slicer.util")
+    fake.util.exit = lambda code: recorded.setdefault("util_exit", code)
+    fake.app = _fake_app()
+    monkeypatch.setitem(sys.modules, "slicer", fake)
+
+    driver._exit(0)
+
+    assert recorded.get("util_exit") == 0
+    assert fake.app.exited_with is None, "app.exit must not be used when util.exit exists"
+
+
+def test_exit_falls_back_to_app_exit_when_util_exit_missing(monkeypatch):
+    """A ``slicer.util`` with no ``exit`` must degrade, not raise/hang.
+
+    Pins the regression that timed out ``pytest_launched`` for 1500 s.
+    The fallback mirrors ``slicer.util.exit``: clear ``runPythonAndExit``
+    so Slicer cannot overwrite the code, then ``app.exit(code)``.
+    """
+    monkeypatch.delenv("SLICER_PYTEST_LAUNCHED_FORCE_SYSEXIT", raising=False)
+    driver = _import_driver_module()
+
+    fake = types.ModuleType("slicer")
+    fake.util = types.ModuleType("slicer.util")  # deliberately NO exit attribute
+    fake.app = _fake_app()
+    monkeypatch.setitem(sys.modules, "slicer", fake)
+
+    # Must NOT raise AttributeError and must NOT call sys.exit (no hang, no SystemExit).
+    driver._exit(7)
+
+    assert fake.app.exited_with == 7, "code must be carried out through app.exit"
+    assert fake.app.opts.runPythonAndExit is False, (
+        "runPythonAndExit must be cleared so Slicer does not overwrite the exit code"
+    )
+
+
+def test_exit_falls_back_to_sysexit_when_slicer_unimportable(monkeypatch):
+    """No ``slicer`` at all (standalone CPython) still yields a coded exit."""
+    monkeypatch.delenv("SLICER_PYTEST_LAUNCHED_FORCE_SYSEXIT", raising=False)
+    driver = _import_driver_module()
+
+    # Ensure `import slicer` fails inside _exit.
+    monkeypatch.setitem(sys.modules, "slicer", None)  # forces ImportError on import
+
+    with pytest.raises(SystemExit) as excinfo:
+        driver._exit(3)
+    assert excinfo.value.code == 3

--- a/LiverResections/Testing/Python/replay_test.py
+++ b/LiverResections/Testing/Python/replay_test.py
@@ -259,13 +259,35 @@ def _exit(code: int) -> None:
     Route through ``slicer.util.exit`` when running inside Slicer; fall
     back to ``sys.exit`` for the rare standalone CPython invocation
     (e.g. local lint).
+
+    A drifted Slicer image can ship a partial ``slicer.util`` with no
+    ``exit`` attribute; routing through it inside a bare ``except
+    ImportError`` lets the ``AttributeError`` escape and the Qt loop
+    hang until the test timeout.  Degrade across the same primitive
+    ``slicer.util.exit`` uses (``app.exit`` after clearing
+    ``runPythonAndExit``), then ``sys.exit``.
     """
     try:
         import slicer  # type: ignore[import-not-found]
-
-        slicer.util.exit(code)
     except ImportError:
         sys.exit(code)
+        return
+
+    util_exit = getattr(getattr(slicer, "util", None), "exit", None)
+    if callable(util_exit):
+        util_exit(code)
+        return
+
+    app = getattr(slicer, "app", None)
+    if app is not None:
+        try:
+            app.commandOptions().runPythonAndExit = False
+        except Exception:  # noqa: BLE001 -- best-effort; still drive app.exit below
+            pass
+        app.exit(code)
+        return
+
+    sys.exit(code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Harden the launched-Slicer pytest exit path so a drifted Slicer image can
never hang CI for the full test timeout.

## The bug

`Liver/Testing/Python/run_pytest_launched.py` (and the older
`LiverResections/Testing/Python/replay_test.py`) routed pytest's exit code
through `slicer.util.exit(code)` inside a bare `except ImportError`:

```python
try:
    import slicer
    slicer.util.exit(code)
except ImportError:
    sys.exit(code)
```

A transient `slicer-main` image shipped a **partial `slicer.util` with no
`exit` attribute**. That raises `AttributeError` — *not* `ImportError` — so it
escaped the handler. The script aborted while Slicer's Qt event loop kept
running, and `pytest_launched` hung until the **1500 s CTest timeout**,
reporting the wrong status even though the underlying run was green
(`94 passed, 43 skipped in 2.66s`, then the traceback).

## The fix

Degrade across the same primitive `slicer.util.exit` itself uses
(`app.commandOptions().runPythonAndExit = False; app.exit(code)`), then
`sys.exit` as the last resort:

- `slicer.util.exit(code)` when present (unchanged happy path)
- else `slicer.app.exit(code)` after clearing `runPythonAndExit` (so Slicer
  doesn't overwrite our code) — the faithful equivalent
- else `sys.exit(code)` (standalone CPython)

A missing API now yields a coded exit, never a hang. Same one-spot fix in
`replay_test._exit`, which shared the bug.

## Conformance

Three exit-routing invariants pinned in the driver's contract self-test
(`test_run_pytest_launched_contract.py`):

| Invariant | Test |
|---|---|
| `slicer.util.exit` is preferred when present | `test_exit_uses_slicer_util_exit_when_present` |
| missing `slicer.util.exit` → `app.exit` fallback (no hang/raise) | `test_exit_falls_back_to_app_exit_when_util_exit_missing` |
| no `slicer` at all → coded `sys.exit` | `test_exit_falls_back_to_sysexit_when_slicer_unimportable` |

The fallback test reproduces the exact `AttributeError: module 'slicer.util'
has no attribute 'exit'` against the pre-fix body (verified red→green
locally).

Per ADR-0008 §6 (fail-closed CI posture) and the `replay_test._exit`
exit-propagation precedent.

---

🤖 Drafted with the assistance of Claude (Anthropic), model claude-opus-4-8, under human review.
