### PR TITLE
ENH: Add weak target-model reference to vtkMRMLBezierSurfaceNode (ADR-0014 §1)

### DIFF
--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
@@ -1467,7 +1467,6 @@ int testTargetReferenceSetGet()
 {
   vtkNew<vtkMRMLScene> scene;
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
 
   vtkNew<vtkMRMLBezierSurfaceNode> surface;
   vtkNew<vtkMRMLModelNode> target;
@@ -1517,7 +1516,6 @@ int testTargetReferenceWeakSemantics()
 {
   vtkNew<vtkMRMLScene> scene;
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
 
   vtkNew<vtkMRMLBezierSurfaceNode> surface;
   vtkNew<vtkMRMLModelNode> target;
@@ -1562,7 +1560,6 @@ int testTargetReferenceSceneRoundTrip()
 {
   vtkNew<vtkMRMLScene> scene;
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
 
   vtkNew<vtkMRMLBezierSurfaceNode> surface;
   vtkNew<vtkMRMLModelNode> target;
@@ -1583,7 +1580,6 @@ int testTargetReferenceSceneRoundTrip()
 
   vtkNew<vtkMRMLScene> sinkScene;
   sinkScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
-  sinkScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
   sinkScene->SetLoadFromXMLString(1);
   sinkScene->SetSceneXMLString(xml);
   sinkScene->Connect();
@@ -1632,7 +1628,6 @@ int testTargetReferenceAbsentReturnsNull()
   // In a scene, set then clear — clearing returns to the absent state.
   vtkNew<vtkMRMLScene> scene;
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
 
   vtkNew<vtkMRMLBezierSurfaceNode> sceneSurface;
   vtkNew<vtkMRMLModelNode> target;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx
@@ -30,6 +30,7 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLParametricSurfaceDisplayNode.h"
 #include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLModelNode.h"
 #include "vtkMRMLScene.h"
 
 // VTK includes
@@ -1435,6 +1436,226 @@ int testReadXMLIgnoresControlGrid()
   return EXIT_SUCCESS;
 }
 
+// ----------------------------------------------------------------------------
+// testTargetReferenceSetGet
+//
+// RED (ADR-0027 red-then-green discipline; ADR-0008 §7) — fails until
+// the implementer adds the weak target-organ-model node reference to
+// ``vtkMRMLBezierSurfaceNode``.  Pins the basic set/get contract.
+//
+// Per ADR-0014 §1, the Bezier surface node weakrefs the target organ
+// (liver) model node — the missing prerequisite that unblocks T2 ring
+// extraction (both Init-mode Representations carry the
+// ``TODO(T2-target-mesh-weakref)`` marker).  The reference follows the
+// same typed node-reference-role convention the wrapper-vs-carrier
+// amendment fixed for the ``geometry`` role on
+// ``vtkMRMLResectionPlanNode`` (single-source-of-truth role name via a
+// static accessor; closed-vocabulary naming — no ``Liver`` prefix on
+// the new symbol).
+//
+// Single source of truth for the role name: the implementer must
+// provide ``vtkMRMLBezierSurfaceNode::GetTargetReferenceRole()`` (a
+// static accessor mirroring ``GetGeometryReferenceRole()`` on the plan
+// node).  This test references that accessor, never a string literal,
+// so the implementer's chosen role string and the test cannot drift.
+//
+// Accessor pair the implementer must provide (mirroring
+// ``GetGeometryNode`` / ``SetAndObserveGeometryNode``):
+//   - ``vtkMRMLModelNode* GetTargetModelNode();``
+//   - ``void SetAndObserveTargetModelNode(vtkMRMLModelNode* target);``
+int testTargetReferenceSetGet()
+{
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
+
+  vtkNew<vtkMRMLBezierSurfaceNode> surface;
+  vtkNew<vtkMRMLModelNode> target;
+  scene->AddNode(surface.GetPointer());
+  scene->AddNode(target.GetPointer());
+
+  // The role-name accessor is the single source of truth; assert it is
+  // a usable, stable string (non-null, non-empty).  No string literal
+  // is asserted here — the role string is the implementer's choice.
+  const char* role = vtkMRMLBezierSurfaceNode::GetTargetReferenceRole();
+  CHECK_NOT_NULL(role);
+  CHECK_BOOL(role[0] != '\0', true);
+
+  // Wire via the typed setter, retrieve via the typed accessor.
+  surface->SetAndObserveTargetModelNode(target.GetPointer());
+  vtkMRMLModelNode* got = surface->GetTargetModelNode();
+  CHECK_NOT_NULL(got);
+  CHECK_POINTER(got, target.GetPointer());
+
+  // The reference must be reachable under the canonical role string too
+  // (the getter is a thin typed wrapper over GetNodeReference(role)).
+  vtkMRMLNode* viaRole = surface->GetNodeReference(role);
+  CHECK_POINTER(viaRole, target.GetPointer());
+  return EXIT_SUCCESS;
+}
+
+// ----------------------------------------------------------------------------
+// testTargetReferenceWeakSemantics
+//
+// RED — pins the "weak" half of the ADR-0014 §1 contract.  The Bezier
+// surface node *weakrefs* the target: it must not observe the target's
+// modification events.  Concretely (Slicer MRML expresses "weak" as a
+// node-reference role registered with no VTK event array and no
+// content-modified observation — the same shape as the ``geometry``
+// role, whose constructor passes neither an ``events`` array nor
+// ``observeContentModifiedEvents=true``):
+//
+//   - Mutating the target organ model node after wiring the reference
+//     must NOT advance the surface node's MTime.  An owning/observing
+//     (strong) reference would propagate the target's Modified() to the
+//     referencing node; a weak reference does not.
+//
+// This is the observable, non-invented proxy for "weak / non-owning,
+// non-observing" the ADR prescribes — it does not assert any semantics
+// beyond what ADR-0014 §1 mandates.
+int testTargetReferenceWeakSemantics()
+{
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
+
+  vtkNew<vtkMRMLBezierSurfaceNode> surface;
+  vtkNew<vtkMRMLModelNode> target;
+  scene->AddNode(surface.GetPointer());
+  scene->AddNode(target.GetPointer());
+
+  surface->SetAndObserveTargetModelNode(target.GetPointer());
+
+  // Baseline the surface node's MTime, then mutate the target.  A weak
+  // (non-observing) reference must leave the surface node's MTime
+  // untouched.
+  const vtkMTimeType preMTime = surface->GetMTime();
+  target->Modified();
+  // Touch a real model-node property too, so the assertion does not
+  // rely on Modified() alone.
+  target->SetName("target-mutated");
+  if (surface->GetMTime() != preMTime)
+  {
+    std::cerr << "Target reference is observing the target's events; "
+              << "ADR-0014 §1 mandates a weak (non-observing) reference "
+              << "(surface MTime advanced from " << preMTime << " to " << surface->GetMTime() << ")\n";
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+// ----------------------------------------------------------------------------
+// testTargetReferenceSceneRoundTrip
+//
+// RED — pins persistence per ADR-0014 §1.  The target reference must
+// round-trip through the .mrml scene (WriteXML → ReadXMLAttributes,
+// driven here via the in-memory scene Commit/Connect path used by
+// ``testDisplayNodeAttachedSceneRoundTrip``) and reconnect to the
+// target organ model node by ID after a scene reload.  Also exercises
+// the in-memory ``Copy`` path so the reference survives node copy.
+//
+// Node references persist as their target's ID and re-resolve scene-
+// side on load — this is the structural guarantee the T2 ring
+// extractor consumer depends on: after a save/load cycle the surface
+// node still reaches its target mesh.
+int testTargetReferenceSceneRoundTrip()
+{
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
+
+  vtkNew<vtkMRMLBezierSurfaceNode> surface;
+  vtkNew<vtkMRMLModelNode> target;
+  scene->AddNode(surface.GetPointer());
+  scene->AddNode(target.GetPointer());
+  target->SetName("LiverTargetMesh");
+  surface->SetAndObserveTargetModelNode(target.GetPointer());
+
+  // Round-trip via the in-memory XML string path.
+  scene->SetSaveToXMLString(1);
+  scene->Commit();
+  const std::string xml = scene->GetSceneXMLString();
+  if (xml.empty())
+  {
+    std::cerr << "Commit produced empty XML string\n";
+    return EXIT_FAILURE;
+  }
+
+  vtkNew<vtkMRMLScene> sinkScene;
+  sinkScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  sinkScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
+  sinkScene->SetLoadFromXMLString(1);
+  sinkScene->SetSceneXMLString(xml);
+  sinkScene->Connect();
+
+  auto* sinkSurface = vtkMRMLBezierSurfaceNode::SafeDownCast(sinkScene->GetFirstNodeByClass("vtkMRMLBezierSurfaceNode"));
+  CHECK_NOT_NULL(sinkSurface);
+
+  // The reference must have round-tripped and re-resolved to the
+  // reloaded target model node.
+  vtkMRMLModelNode* sinkTarget = sinkSurface->GetTargetModelNode();
+  CHECK_NOT_NULL(sinkTarget);
+  CHECK_STRING(sinkTarget->GetName(), "LiverTargetMesh");
+
+  // In-memory Copy path: the reference string survives a scene-less
+  // Copy (isolates CopyReferences from scene-side resolution), mirroring
+  // ``testCopyCarriesDisplayNodeRef``.
+  {
+    vtkNew<vtkMRMLBezierSurfaceNode> copySource;
+    vtkNew<vtkMRMLBezierSurfaceNode> copySink;
+    const char* targetId = "vtkMRMLModelNode7";
+    copySource->SetNodeReferenceID(vtkMRMLBezierSurfaceNode::GetTargetReferenceRole(), targetId);
+    copySink->Copy(copySource.GetPointer());
+    const char* sinkId = copySink->GetNodeReferenceID(vtkMRMLBezierSurfaceNode::GetTargetReferenceRole());
+    CHECK_NOT_NULL(sinkId);
+    CHECK_STRING(sinkId, targetId);
+  }
+  return EXIT_SUCCESS;
+}
+
+// ----------------------------------------------------------------------------
+// testTargetReferenceAbsentReturnsNull
+//
+// RED — pins the default-absent state per ADR-0014 §1.  With no target
+// wired, the typed getter must return nullptr cleanly (no crash).  This
+// is the state both Init-mode Representations rely on before the target
+// mesh is assigned — ``SlicingPlaneInitRepresentation`` and
+// ``DistanceSpheroidInitRepresentation`` (TODO(T2-target-mesh-weakref))
+// branch on the absence of the target.  Also pins that explicitly
+// clearing the reference (passing nullptr) returns to the absent state.
+int testTargetReferenceAbsentReturnsNull()
+{
+  // Scene-less fresh node: no target wired.
+  vtkNew<vtkMRMLBezierSurfaceNode> surface;
+  CHECK_NULL(surface->GetTargetModelNode());
+
+  // In a scene, set then clear — clearing returns to the absent state.
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLModelNode>::New());
+
+  vtkNew<vtkMRMLBezierSurfaceNode> sceneSurface;
+  vtkNew<vtkMRMLModelNode> target;
+  scene->AddNode(sceneSurface.GetPointer());
+  scene->AddNode(target.GetPointer());
+  CHECK_NULL(sceneSurface->GetTargetModelNode());
+
+  sceneSurface->SetAndObserveTargetModelNode(target.GetPointer());
+  CHECK_NOT_NULL(sceneSurface->GetTargetModelNode());
+
+  // Clear via nullptr — back to the absent default.
+  sceneSurface->SetAndObserveTargetModelNode(nullptr);
+  CHECK_NULL(sceneSurface->GetTargetModelNode());
+
+  // Removing the target from the scene also resolves the getter to
+  // nullptr cleanly (the weak reference does not keep a dangling
+  // pointer alive).
+  sceneSurface->SetAndObserveTargetModelNode(target.GetPointer());
+  scene->RemoveNode(target.GetPointer());
+  CHECK_NULL(sceneSurface->GetTargetModelNode());
+  return EXIT_SUCCESS;
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -1467,6 +1688,15 @@ int vtkMRMLBezierSurfaceNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testReadXMLNullMidStream());
   CHECK_EXIT_SUCCESS(testCopyCarriesDisplayNodeRef());
   CHECK_EXIT_SUCCESS(testReadXMLIgnoresControlGrid());
+
+  // ADR-0014 §1 — weak target-organ-model node reference.  RED until
+  // the implementer adds GetTargetReferenceRole() + the typed
+  // GetTargetModelNode / SetAndObserveTargetModelNode accessors.
+  // Unblocks T2 ring extraction (TODO(T2-target-mesh-weakref)).
+  CHECK_EXIT_SUCCESS(testTargetReferenceSetGet());
+  CHECK_EXIT_SUCCESS(testTargetReferenceWeakSemantics());
+  CHECK_EXIT_SUCCESS(testTargetReferenceSceneRoundTrip());
+  CHECK_EXIT_SUCCESS(testTargetReferenceAbsentReturnsNull());
 
   std::cout << "vtkMRMLBezierSurfaceNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
@@ -42,6 +42,7 @@
 #include "vtkMRMLParametricSurfaceDisplayNode.h"
 
 // MRML includes
+#include <vtkMRMLModelNode.h>
 #include <vtkMRMLNodePropertyMacros.h>
 #include <vtkMRMLScene.h>
 
@@ -87,10 +88,29 @@ vtkMRMLBezierSurfaceNode::vtkMRMLBezierSurfaceNode()
   : State(ResectionState::Init)
   , LoadingFromXML(false)
 {
+  // Weak reference to the target organ (liver) model node (ADR-0014
+  // §1).  Registered with no events array and no content-modified
+  // observation -- the same shape as the "geometry" role on
+  // vtkMRMLResectionPlanNode -- so mutating the target does not
+  // advance this node's MTime.  The downstream consumer is the T2
+  // ring-extraction work (TODO(T2-target-mesh-weakref)).
+  this->AddNodeReferenceRole(GetTargetReferenceRole(), GetTargetReferenceRole());
 }
 
 //------------------------------------------------------------------------------
 vtkMRMLBezierSurfaceNode::~vtkMRMLBezierSurfaceNode() = default;
+
+//------------------------------------------------------------------------------
+vtkMRMLModelNode* vtkMRMLBezierSurfaceNode::GetTargetModelNode()
+{
+  return vtkMRMLModelNode::SafeDownCast(this->GetNodeReference(GetTargetReferenceRole()));
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLBezierSurfaceNode::SetAndObserveTargetModelNode(vtkMRMLModelNode* target)
+{
+  this->SetAndObserveNodeReferenceID(GetTargetReferenceRole(), target ? target->GetID() : nullptr);
+}
 
 //------------------------------------------------------------------------------
 void vtkMRMLBezierSurfaceNode::SetState(int state)

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.h
@@ -50,6 +50,7 @@
 #include <vtkSetGet.h>
 
 class vtkPolyData;
+class vtkMRMLModelNode;
 
 /**
  * \class vtkMRMLBezierSurfaceNode
@@ -164,6 +165,27 @@ public:
   void SetDistanceSpheroidRadiusX(double r) override;
   void SetDistanceSpheroidRadiusY(double r) override;
   void SetDistanceSpheroidRadiusZ(double r) override;
+
+  //--------------------------------------------------------------------------
+  // Target organ-model node reference (ADR-0014 §1)
+  //--------------------------------------------------------------------------
+
+  /// Canonical, single-source-of-truth role string for the weak
+  /// reference to the target organ (liver) model node.  Mirrors the
+  /// ``geometry`` role convention on ``vtkMRMLResectionPlanNode``
+  /// (closed-vocabulary naming — no ``Liver`` prefix).
+  static const char* GetTargetReferenceRole() { return "target"; }
+
+  /// Resolve the weakly-referenced target organ model node, or
+  /// nullptr when none is wired / the target has left the scene.
+  vtkMRMLModelNode* GetTargetModelNode();
+
+  /// Wire (or, with nullptr, clear) the weak reference to the target
+  /// organ model node.  The reference is non-owning and non-observing
+  /// per ADR-0014 §1 — see the role registration in the constructor.
+  /// The T2 ring-extraction work (TODO(T2-target-mesh-weakref)) is the
+  /// downstream consumer.
+  void SetAndObserveTargetModelNode(vtkMRMLModelNode* target);
 
 protected:
   vtkMRMLBezierSurfaceNode();


### PR DESCRIPTION
## Summary for humans

Adds a typed **weak** node reference on `vtkMRMLBezierSurfaceNode` to its
target organ (liver) model node, per ADR-0014 §1. The reference is
non-owning and non-observing: it is registered in the node constructor via
`AddNodeReferenceRole` with no events array and no content-modified
observation — the same shape as the existing `geometry`-role precedent on
`vtkMRMLResectionPlanNode`. Mutating the target therefore does not advance
the surface node's MTime.

The change is the node API only:

- `static const char* GetTargetReferenceRole()` — single source of truth
  for the role string (closed-vocabulary naming, no `Liver` prefix).
- `vtkMRMLModelNode* GetTargetModelNode()` — typed resolver.
- `void SetAndObserveTargetModelNode(vtkMRMLModelNode*)` — wire / clear.

These mirror the `GetGeometryNode` / `SetAndObserveGeometryNode` accessor
pair on the plan node. Wiring the Init-mode Representations to set and
consume the reference is the downstream T2 ring-extraction work
(`TODO(T2-target-mesh-weakref)`) and is intentionally out of scope here, so
this lands as a clean prerequisite.

## ADR references

1. ADR-0014 §1 — Bezier surface node weak-refs the target organ model node.

## Conformance

Invariants honoured, with the four sub-tests in
`LiverResections/MRML/Testing/Cxx/vtkMRMLBezierSurfaceNodeTest1.cxx` that
prove each:

- `testTargetReferenceSetGet` — role accessor is a stable non-empty string;
  the typed setter/getter round-trip and the reference is reachable under
  the canonical role string.
- `testTargetReferenceWeakSemantics` — mutating the target (`Modified()` +
  `SetName`) does **not** advance the surface node's MTime (the weak,
  non-observing contract).
- `testTargetReferenceSceneRoundTrip` — the reference persists through a
  `.mrml` scene Commit/Connect cycle and re-resolves by ID, and survives an
  in-memory `Copy`.
- `testTargetReferenceAbsentReturnsNull` — absent reference returns nullptr
  cleanly; clearing via nullptr and removing the target from the scene both
  return to the absent state.

Local CTest result (Debug build, runs `WITH_VTK_DEBUG_LEAKS_CHECK`, so
green also proves no leak):

```
1/1 Test #9: vtkMRMLBezierSurfaceNodeTest1 ....   Passed    0.44 sec
100% tests passed, 0 tests failed out of 1
```

## UX impact

N/A — non-UI change (MRML node API only).

<details>
<summary>Agent context (long form)</summary>

The implementation rides the standard MRML node-reference machinery rather
than introducing any special case: `AddNodeReferenceRole(role, role)` with
the two-argument form (reference role + MRML attribute name, no events
array, `observeContentModifiedEvents` left at its non-observing default)
exactly mirrors the `geometry` role on `vtkMRMLResectionPlanNode`. The typed
accessors are thin wrappers over `GetNodeReference` /
`SetAndObserveNodeReferenceID` + `SafeDownCast`, so scene-XML round-trip and
`CopyContent`/`Copy` carry the reference for free once the role is
registered.

The four committed RED sub-tests each constructed a bare `vtkMRMLScene` and
then called `scene->RegisterNodeClass(vtkMRMLModelNode)`. `vtkMRMLScene`
already registers `vtkMRMLModelNode` at construction, so the
re-registration emitted five "Tag Model has already been registered"
warnings that the module test harness's error-output check counted as a
failure. Those redundant registration lines were scaffolding, not
assertions; dropping them aligns the new sub-tests with the pre-existing
passing tests (which register only the module classes the scene does not
already know) and changes no assertion.

</details>

_Drafted by Claude (claude-opus-4-8); reviewed by Rafael Palomar_

🤖 Drafted with the assistance of Claude (Anthropic), model claude-opus-4-8, under human review.
