### PR TITLE
BUG: Reach loadable-module Python in pytest_launched harness (built module dirs)

### DIFF
--- a/Liver/Testing/Python/CMakeLists.txt
+++ b/Liver/Testing/Python/CMakeLists.txt
@@ -118,20 +118,24 @@ else()
   return()
 endif()
 
-# Full in-tree module set for ``--additional-module-paths``.  Each entry is a
-# module source dir whose scripted/loadable module Slicer must discover so the
-# launched widget-level tests can import it.  Keep in sync with the top-level
-# CMakeLists.txt module list.
+# Module paths for ``--additional-module-paths``: the BUILT module
+# directories, NOT the in-tree source dirs.
+#
+# A module source dir only makes a *scripted* module's Python importable.
+# A *loadable* (C++) module's Python sub-package (e.g. ``LiverResectionsLib``,
+# which carries the LayerDM Pipelines + Representations) is staged into the
+# built ``qt-scripted-modules`` tree and only lands on ``sys.path`` when the
+# module loads from a built path — never from the source dir.  Pointing the
+# launched harness at the source dirs therefore made every test that imports
+# a loadable module's Python sub-package SKIP with ``No module named
+# 'LiverResectionsLib'`` (e.g. the resection-plan SH-collection and ring-
+# extraction-on-commit launched tests), silently under-verifying shipped
+# behaviour.  The two built module dirs below cover all six modules
+# (scripted + loadable), so their Python is uniformly importable and every
+# module registers in the launched ``qSlicerApplication``.
 set(_liver_additional_module_paths
-  "${CMAKE_SOURCE_DIR}/Liver"
-  "${CMAKE_SOURCE_DIR}/LiverResections"
-  "${CMAKE_SOURCE_DIR}/LiverMarkups"
-  "${CMAKE_SOURCE_DIR}/LiverVolumetry"
-  "${CMAKE_SOURCE_DIR}/VascularTerritories"
-  # Stage-2 orchestrator + surgeon-UI module: its launched scene/widget
-  # invariant tests (LiverSegmentation/Testing/Python) need the module
-  # importable + registered as `liversegmentation` (ADR-0024).
-  "${CMAKE_SOURCE_DIR}/LiverSegmentation"
+  "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
+  "${CMAKE_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}"
 )
 
 # Same test roots as the bare ``pytest_scaffold`` entries, plus the Stage-2


### PR DESCRIPTION
## Summary

Fix the `pytest_launched` harness so it can reach **loadable-module Python sub-packages**, ending the class of silent skips where launched tests for C++ modules' Python (LayerDM Pipelines/Representations) never actually run.

## Root cause

The harness added each module's **source** dir to `--additional-module-paths`. That makes a *scripted* module's Python importable, but a *loadable* (C++) module's Python sub-package — e.g. `LiverResectionsLib` — is staged into the built `qt-scripted-modules` tree and only reaches `sys.path` when the module loads from a **built** path. So launched tests importing such a sub-package SKIPPED with `No module named 'LiverResectionsLib'`, silently under-verifying shipped behaviour.

## Fix

Point `--additional-module-paths` at the two built module dirs
(`${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}` and `…QTSCRIPTEDMODULES…`) instead of the source dirs. These cover all six modules (scripted + loadable).

## Verification

- **Headless launched probe (local):** with the built dirs, all six modules register (`Liver`, `LiverResections`, `LiverMarkups`, `LiverVolumetry`, `VascularTerritories`, `LiverSegmentation` all `True`) and `import LiverResectionsLib.LiverBezierSurfacePipeline` succeeds — versus `No module named 'LiverResectionsLib'` from the source dirs.
- **Generated CTest command:** confirmed it now resolves to `.../build/lib/Slicer-5.11/qt-{loadable,scripted}-modules`.
- **CI proves the payoff:** the already-merged `test_resections_subject_hierarchy_collection.py` (from #454) currently SKIPS on `liverresections not registered`; with this change it should **execute** under `pytest_launched`. (Once #459 merges, its ring-extraction-on-commit + weakref launched tests also un-skip.)

## Notes

Scripted-module reachability (e.g. LiverSegmentation's #449 tests) is preserved — the built `qt-scripted-modules` dir carries them too (verified by the all-modules-register probe). No source-dir dependency remains.

---

🤖 Drafted with the assistance of Claude (Anthropic), model claude-opus-4-8, under human review.
