### PR TITLE
DOC: Mark merged ADRs Accepted (decision-register release gate)

### DIFF
--- a/Docs/adr/0002-migrate-to-slicerlayerdm.md
+++ b/Docs/adr/0002-migrate-to-slicerlayerdm.md
@@ -1,6 +1,6 @@
 # 0002. Migrate SlicerLiver from Markups + MRMLDM to SlicerLayerDisplayableManager
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-13
 - **Deciders:** Rafael Palomar
 - **Diagrams:** [current-mrml-node-hierarchy](../architecture/current-mrml-node-hierarchy.md)

--- a/Docs/adr/0003-testability-invariant.md
+++ b/Docs/adr/0003-testability-invariant.md
@@ -1,6 +1,6 @@
 # 0003. Every behaviour-changing PR carries a test that pins the behaviour
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-13
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0004-python-cpp-boundary.md
+++ b/Docs/adr/0004-python-cpp-boundary.md
@@ -1,6 +1,6 @@
 # 0004. Python by default; C++ only for MRML node classes and algorithm libraries
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-13
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0005-github-actions-ci.md
+++ b/Docs/adr/0005-github-actions-ci.md
@@ -1,6 +1,6 @@
 # 0005. CI runs on every PR via GitHub Actions
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-13
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0007-version-numbering-policy.md
+++ b/Docs/adr/0007-version-numbering-policy.md
@@ -1,6 +1,6 @@
 # 0007. Version-numbering policy
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0008-testing-strategy.md
+++ b/Docs/adr/0008-testing-strategy.md
@@ -1,6 +1,6 @@
 # 0008. Testing strategy for v2.0.0
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0009-ux-and-design-discipline.md
+++ b/Docs/adr/0009-ux-and-design-discipline.md
@@ -1,6 +1,6 @@
 # 0009. UX and design discipline
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A (this ADR establishes the requirement for per-module

--- a/Docs/adr/0010-accessibility-and-i18n.md
+++ b/Docs/adr/0010-accessibility-and-i18n.md
@@ -1,6 +1,6 @@
 # 0010. Accessibility and internationalisation stance
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0011-sct-terminology-dispatch.md
+++ b/Docs/adr/0011-sct-terminology-dispatch.md
@@ -1,6 +1,6 @@
 # 0011. SNOMED-CT terminology as the dispatch key
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0012-layerdm-migration-v2-scope.md
+++ b/Docs/adr/0012-layerdm-migration-v2-scope.md
@@ -1,6 +1,6 @@
 # 0012. Scope of LayerDM migration for v2.0.0
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0013-layerdm-pipeline-pattern.md
+++ b/Docs/adr/0013-layerdm-pipeline-pattern.md
@@ -1,6 +1,6 @@
 # 0013. The Slicer-Liver LayerDM Pipeline pattern
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A (target MRML diagram and per-module UI diagrams

--- a/Docs/adr/0014-livermarkups-dissolution.md
+++ b/Docs/adr/0014-livermarkups-dissolution.md
@@ -1,6 +1,6 @@
 # 0014. Dissolve LiverMarkups; fold interactive resection primitives into LiverResections
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A (target MRML diagram and per-module UI diagrams land

--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -1,6 +1,6 @@
 # 0015. Lift parameterisation and fitting algorithms from Python to a C++ algorithm library under LiverResections
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-15
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0016-code-style-and-lint.md
+++ b/Docs/adr/0016-code-style-and-lint.md
@@ -1,6 +1,6 @@
 # 0016. Code style discipline and CI enforcement (adopt Slicer's infrastructure)
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-16
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0017-sphinx-readthedocs.md
+++ b/Docs/adr/0017-sphinx-readthedocs.md
@@ -1,6 +1,6 @@
 # 0017. Sphinx + ReadTheDocs documentation infrastructure
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-18
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A

--- a/Docs/adr/0018-nurbs-extension-surface.md
+++ b/Docs/adr/0018-nurbs-extension-surface.md
@@ -1,6 +1,6 @@
 # 0018. NURBS as a sibling representation; variable-size control polygon
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-18
 - **Deciders:** Rafael Palomar
 - **Diagrams:**

--- a/Docs/adr/0019-resection-state-machine.md
+++ b/Docs/adr/0019-resection-state-machine.md
@@ -1,6 +1,6 @@
 # 0019. Resection state machine: extend to a third `Confirmed` state
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-18
 - **Deciders:** Rafael Palomar
 - **Diagrams:** `Docs/architecture/resection-state-machine.md`

--- a/Docs/adr/0020-gpu-tessellation.md
+++ b/Docs/adr/0020-gpu-tessellation.md
@@ -1,6 +1,6 @@
 # 0020. GPU rendering of parametric surfaces and their widgets (v2.1 target)
 
-- **Status:** Proposed (target v2.1)
+- **Status:** Accepted (target v2.1)
 - **Date:** 2026-05-18
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A (deferred; class diagram lands with the ADR-0020 enabler PR)

--- a/Docs/adr/0022-nurbs-v2-1-design.md
+++ b/Docs/adr/0022-nurbs-v2-1-design.md
@@ -1,6 +1,6 @@
 # 0022. NURBS v2.1 design (data node, schema v3, fitter library, rendering integration)
 
-- **Status:** Proposed (target v2.1)
+- **Status:** Accepted (target v2.1)
 - **Date:** 2026-05-19
 - **Deciders:** Rafael Palomar
 - **Diagrams:**

--- a/Docs/adr/0023-unified-gui-stage-workflow.md
+++ b/Docs/adr/0023-unified-gui-stage-workflow.md
@@ -1,6 +1,6 @@
 # 0023. Unified GUI — six-stage surgeon workflow
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-21
 - **Deciders:** R. Palomar
 - **Diagrams:** [`Docs/architecture/gui-stage-flow.md`](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md), [`Docs/architecture/territories-class-hierarchy.md`](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/territories-class-hierarchy.md)

--- a/Docs/adr/0024-segmentation-orchestration.md
+++ b/Docs/adr/0024-segmentation-orchestration.md
@@ -1,6 +1,6 @@
 # 0024. Segmentation orchestration — Stage 2 per-structure micro-workflows
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-21
 - **Deciders:** R. Palomar
 - **Diagrams:** inline below; see also [`Docs/architecture/gui-stage-flow.md`](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/architecture/gui-stage-flow.md) for the cross-stage context.

--- a/Docs/adr/0026-segment-editor-effects.md
+++ b/Docs/adr/0026-segment-editor-effects.md
@@ -1,6 +1,6 @@
 # 0026. Segment Editor effects in Slicer-Liver
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-21
 - **Deciders:** R. Palomar
 - **Diagrams:** inline below.

--- a/Docs/adr/0027-invariant-test-first-v2-implementation.md
+++ b/Docs/adr/0027-invariant-test-first-v2-implementation.md
@@ -1,6 +1,6 @@
 # 0027. Invariant-test-first discipline for v2.0 implementation
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-21
 - **Deciders:** R. Palomar
 - **Diagrams:** inline below.

--- a/Docs/adr/0028-parameter-node-wrapper.md
+++ b/Docs/adr/0028-parameter-node-wrapper.md
@@ -1,6 +1,6 @@
 # 0028. Parameter node wrapper + UI custom attributes for v2.0 widgets
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-21
 - **Deciders:** R. Palomar
 - **Diagrams:** code-shape examples inline.

--- a/Docs/adr/0029-stage1-case-setup-contract.md
+++ b/Docs/adr/0029-stage1-case-setup-contract.md
@@ -1,6 +1,6 @@
 # 0029. Stage 1 — case-setup functional contract
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-22
 - **Deciders:** R. Palomar
 - **Diagrams:** inline below.


### PR DESCRIPTION
## Summary

Flip the header `Status` of all merged ADRs from `Proposed` to `Accepted`, satisfying the #305 decision-register gate ("all ADRs MUST be `Accepted` before the release tag") ahead of the v2.0.0 tag.

## Rationale

Per the project convention, an ADR is **accepted by its PR merge** — there is no separate Proposed→Accepted transition to track, so the lingering `Proposed` labels were stale. This is a bookkeeping sweep, not a re-decision.

## Scope

- 25 ADRs flipped `Proposed` → `Accepted` (header status line only — one line per file, verified `25 insertions / 25 deletions`).
- `ADR-0000` (template) keeps its `Proposed | Accepted | Superseded | Deprecated` options list.
- `ADR-0020` / `ADR-0022` keep their `(target v2.1)` scope note (`Accepted (target v2.1)`).
- Already-`Accepted` ADRs (0001, 0006, 0021, 0025, 0030) untouched.

---

🤖 Drafted with the assistance of Claude (Anthropic), model claude-opus-4-8, under human review.
