### PR TITLE
BUG: Collect the production resection wrapper under the Resections SH folder (#466)

### DIFF
--- a/LiverResections/Logic/Testing/Cxx/vtkSlicerLiverResectionsLogicSubjectHierarchyCharacterizationTest.cxx
+++ b/LiverResections/Logic/Testing/Cxx/vtkSlicerLiverResectionsLogicSubjectHierarchyCharacterizationTest.cxx
@@ -53,7 +53,7 @@
  * Behaviour pinned (matches OnMRMLSceneNodeAdded ->
  * vtkSlicerSubjectHierarchyFolders::CollectUnderFolder):
  *
- *   1. A ``vtkMRMLLiverResectionNode`` (the WRAPPER) added to the
+ *   1. A ``vtkMRMLResectionPlanNode`` (the WRAPPER) added to the
  *      logic's observed scene is re-parented under a Subject-Hierarchy
  *      folder named per ``GetResectionsFolderName()`` that is a DIRECT
  *      CHILD of the scene root (scene-root-scoped lookup).
@@ -71,7 +71,7 @@
 
 // LiverResections Logic + MRML includes
 #include "vtkMRMLBezierSurfaceNode.h"
-#include "vtkMRMLLiverResectionNode.h"
+#include "vtkMRMLResectionPlanNode.h"
 #include "vtkSlicerLiverResectionsLogic.h"
 
 // SubjectHierarchyFolders includes (single source of truth for the
@@ -127,7 +127,7 @@ int testWrapperResectionNodeCollectedUnderFolder()
 
   const std::string folderName = vtkSlicerSubjectHierarchyFolders::GetResectionsFolderName();
 
-  vtkNew<vtkMRMLLiverResectionNode> resection;
+  vtkNew<vtkMRMLResectionPlanNode> resection;
   scene->AddNode(resection.GetPointer());
 
   vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene.GetPointer());
@@ -157,7 +157,7 @@ int testHiddenCarrierNotCollectedUnderFolder()
   const std::string folderName = vtkSlicerSubjectHierarchyFolders::GetResectionsFolderName();
 
   // A hidden carrier -- the kind the wrapper-vs-carrier split keeps out
-  // of the Subject-Hierarchy view.  It is not a vtkMRMLLiverResectionNode,
+  // of the Subject-Hierarchy view.  It is not a vtkMRMLResectionPlanNode,
   // so OnMRMLSceneNodeAdded's SafeDownCast guard rejects it.
   vtkNew<vtkMRMLBezierSurfaceNode> carrier;
   carrier->SetHideFromEditors(true);
@@ -191,8 +191,8 @@ int testFolderReusedAcrossTwoWrappers()
 
   const std::string folderName = vtkSlicerSubjectHierarchyFolders::GetResectionsFolderName();
 
-  vtkNew<vtkMRMLLiverResectionNode> first;
-  vtkNew<vtkMRMLLiverResectionNode> second;
+  vtkNew<vtkMRMLResectionPlanNode> first;
+  vtkNew<vtkMRMLResectionPlanNode> second;
   scene->AddNode(first.GetPointer());
   scene->AddNode(second.GetPointer());
 

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -269,6 +269,17 @@ void vtkSlicerLiverResectionsLogic::OnMRMLSceneNodeAdded(vtkMRMLNode* node)
 {
   Superclass::OnMRMLSceneNodeAdded(node);
 
+  // ADR-0023 §"Subject Hierarchy management convention": collect the
+  // surgeon-facing wrapper vtkMRMLResectionPlanNode (the node production
+  // creates per ADR-0014's wrapper-vs-carrier split) under the per-stage
+  // "Resections" Subject Hierarchy folder (lazily created, reused).  Only
+  // the wrapper is collected; the hidden SetHideFromEditors(true)
+  // Bezier/contour carriers are deliberately left unparented.
+  if (auto resectionPlanNode = vtkMRMLResectionPlanNode::SafeDownCast(node))
+  {
+    vtkSlicerSubjectHierarchyFolders::CollectUnderFolder(this->GetMRMLScene(), resectionPlanNode, vtkSlicerSubjectHierarchyFolders::GetResectionsFolderName());
+  }
+
   auto resectionNode = vtkMRMLLiverResectionNode::SafeDownCast(node);
 
   // check for nullptr and target organ
@@ -276,14 +287,6 @@ void vtkSlicerLiverResectionsLogic::OnMRMLSceneNodeAdded(vtkMRMLNode* node)
   {
     return;
   }
-
-  // ADR-0023 §"Subject Hierarchy management convention": collect the
-  // surgeon-facing wrapper vtkMRMLLiverResectionNode under the per-stage
-  // "Resections" Subject Hierarchy folder (lazily created, reused).  Only
-  // the wrapper is collected here; the hidden SetHideFromEditors(true)
-  // Bezier/contour carriers are deliberately left unparented per the
-  // wrapper-vs-carrier split (ADR-0014).
-  vtkSlicerSubjectHierarchyFolders::CollectUnderFolder(this->GetMRMLScene(), resectionNode, vtkSlicerSubjectHierarchyFolders::GetResectionsFolderName());
 
   // Add callbacks dealing with the modification of the resection node. Its
   // modification may trigger changes on the underlying initialization/bezier status


### PR DESCRIPTION
## Bug

The "Resections" Subject-Hierarchy folder **never populated in production**. `vtkSlicerLiverResectionsLogic::OnMRMLSceneNodeAdded` keyed the collection on `vtkMRMLLiverResectionNode` (the legacy node, never created in production); production creates `vtkMRMLResectionPlanNode` (the wrapper, per ADR-0014). So the `SafeDownCast` returned null and the method early-returned — no plan was ever collected. Introduced by #454; #455's test passed only because it created a legacy node by hand (the dead path).

## Fix

- Collect `vtkMRMLResectionPlanNode` under the folder, in its **own guarded block** (the legacy `vtkMRMLLiverResectionNode` observer wiring is left untouched — it's retired separately in the T2.7 work, which this de-conflicts).
- Retarget the characterization test (`vtkSlicerLiverResectionsLogicSubjectHierarchyCharacterizationTest`) to create/assert a `vtkMRMLResectionPlanNode`.

## Verified (local C++, `Slicer --launch`)

- **RED** against the old wiring (test retargeted, fix reverted): `countSceneRootFoldersNamed != 1` — the plan node is not collected (the bug).
- **GREEN** with the fix: exit 0, "completed successfully".

Carriers (`vtkMRMLBezierSurfaceNode`, hidden) remain uncollected (distinct class, correctly not downcast). Fixes #466.

---

🤖 Drafted with the assistance of Claude (Anthropic), model claude-opus-4-8, under human review.
