### PR TITLE
BUG: Make volume-bounded-by-resection work in v2 (retarget volumetry to the parametric Bezier carrier)

### DIFF
--- a/LiverVolumetry/LiverVolumetry.py
+++ b/LiverVolumetry/LiverVolumetry.py
@@ -184,10 +184,15 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def getResectionNodes(self):
     resectionNodes = vtk.vtkCollection()
     if not self.ui.ResectionTargetNodeComboBox.noneChecked():
-      lvLogic = slicer.modules.liverresections.logic()
       checkedNodes = self.ui.ResectionTargetNodeComboBox.checkedNodes()
       for i in checkedNodes:
-        bs = lvLogic.GetBezierFromResection(i)
+        # The checked nodes are now vtkMRMLResectionPlanNode wrappers; their
+        # parametric geometry carrier (vtkMRMLBezierSurfaceNode) is the
+        # boundary surface used for the volume computation
+        # (ADR-0014 wrapper-vs-carrier split).
+        bs = i.GetGeometryNode()
+        if bs is None:
+          continue
         resectionNodes.AddItem(bs)
     else:
       resectionNodes = None

--- a/LiverVolumetry/Logic/CMakeLists.txt
+++ b/LiverVolumetry/Logic/CMakeLists.txt
@@ -33,3 +33,7 @@ SlicerMacroBuildModuleLogic(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
 )
+
+if(BUILD_TESTING)
+  add_subdirectory(Testing)
+endif()

--- a/LiverVolumetry/Logic/Testing/CMakeLists.txt
+++ b/LiverVolumetry/Logic/Testing/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Cxx)

--- a/LiverVolumetry/Logic/Testing/Cxx/CMakeLists.txt
+++ b/LiverVolumetry/Logic/Testing/Cxx/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(KIT ${PROJECT_NAME})
+
+#-----------------------------------------------------------------------------
+set(KIT_TEST_SRCS
+  # RED test-first scaffold for the LiverVolumetry surface-generation
+  # carrier-acceptance invariant.  The volumetry logic must read a v2
+  # resection-plan geometry carrier (vtkMRMLBezierSurfaceNode, the
+  # parametric hierarchy) via its flat GetControlGrid() and project a
+  # non-empty Bezier surface -- the boundary for "volume bounded by a
+  # resection".  RED until the logic stops downcasting to the disjoint
+  # v1 vtkMRMLMarkupsBezierSurfaceNode and re-sources control points.
+  # [ADR-0014 §"Fourth layer" wrapper-vs-carrier split]
+  vtkLiverVolumetryLogicResectionCarrierTest.cxx
+  )
+
+#-----------------------------------------------------------------------------
+slicerMacroConfigureModuleCxxTestDriver(
+  NAME ${KIT}
+  SOURCES ${KIT_TEST_SRCS}
+  TARGET_LIBRARIES
+    ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES}
+    vtkSlicerLiverVolumetryModuleLogic
+    # vtkMRMLBezierSurfaceNode (the v2 parametric carrier) lives in the
+    # LiverResections MRML library; the production volumetry logic needs
+    # the same link once it is retargeted to the carrier.
+    vtkSlicerLiverResectionsModuleMRML
+    # vtkMRMLMarkupsBezierSurfaceNode (the disjoint v1 hierarchy whose
+    # SafeDownCast drops the carrier) is characterized by the root-cause
+    # test; it lives in the LiverMarkups MRML library.
+    vtkSlicerLiverMarkupsModuleMRML
+  WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
+  )
+
+#-----------------------------------------------------------------------------
+simple_test(vtkLiverVolumetryLogicResectionCarrierTest)

--- a/LiverVolumetry/Logic/Testing/Cxx/vtkLiverVolumetryLogicResectionCarrierTest.cxx
+++ b/LiverVolumetry/Logic/Testing/Cxx/vtkLiverVolumetryLogicResectionCarrierTest.cxx
@@ -217,27 +217,17 @@ int testProductionDowncastDropsCarrier()
 int testCarrierProducesNonEmptySurface()
 {
   vtkSmartPointer<vtkMRMLBezierSurfaceNode> carrier = makePopulatedCarrier();
-  (void)carrier;
 
-  // TODO(liver-implementer): once the carrier-accepting surface-gen seam
-  // exists, replace this deliberate failure with, e.g.:
-  //
-  //   vtkNew<vtkLiverVolumetryLogic> logic;
-  //   vtkSmartPointer<vtkBezierSurfaceSource> surface =
-  //     logic->GenerateBezierSurface(10, carrier.GetPointer());
-  //   CHECK_NOT_NULL(surface.GetPointer());
-  //   CHECK_NOT_NULL(surface->GetOutput());
-  //   CHECK_BOOL(surface->GetOutput()->GetNumberOfPoints() > 0, true);
-  //
-  // Today the seam only accepts vtkMRMLMarkupsBezierSurfaceNode*, so the
-  // carrier cannot be passed and the surface stays empty -- this test
-  // FAILS on purpose to keep the invariant RED.
-  std::cerr << "FAIL: LiverVolumetry surface-generation path does not yet accept the "
-               "vtkMRMLBezierSurfaceNode parametric carrier; the resection boundary is "
-               "never projected. Implementer must retarget the downcast and re-source "
-               "control points from GetControlGrid() (see file docstring RED hook)."
-            << std::endl;
-  return EXIT_FAILURE;
+  // The surface-generation seam now accepts the parametric carrier and
+  // re-sources its 16 control points from GetControlGrid(); the projected
+  // Bezier surface must therefore be non-empty.
+  vtkNew<vtkLiverVolumetryLogic> logic;
+  vtkSmartPointer<vtkBezierSurfaceSource> surface = logic->GenerateBezierSurface(10, carrier.GetPointer());
+  CHECK_NOT_NULL(surface.GetPointer());
+  CHECK_NOT_NULL(surface->GetOutput());
+  CHECK_BOOL(surface->GetOutput()->GetNumberOfPoints() > 0, true);
+
+  return EXIT_SUCCESS;
 }
 
 } // namespace

--- a/LiverVolumetry/Logic/Testing/Cxx/vtkLiverVolumetryLogicResectionCarrierTest.cxx
+++ b/LiverVolumetry/Logic/Testing/Cxx/vtkLiverVolumetryLogicResectionCarrierTest.cxx
@@ -1,0 +1,253 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==============================================================================*/
+
+/**
+ * \file vtkLiverVolumetryLogicResectionCarrierTest.cxx
+ *
+ * RED test-first scaffold (test-before-implementation) pinning the
+ * carrier-acceptance invariant of the LiverVolumetry surface-generation
+ * path -- the seam that turns a resection-plan geometry carrier into the
+ * Bezier surface projected onto the target-segment label map, and thus
+ * the boundary used to compute "volume bounded by a resection".
+ *
+ * Why this test is RED now
+ * ------------------------
+ * In v2 the resection-plan geometry carrier is
+ * ``vtkMRMLBezierSurfaceNode : vtkMRMLAbstractParametricSurfaceNode``
+ * (the wrapper-vs-carrier geometry layer -- ADR-0014 §"Fourth layer").
+ * Its 16 control points are read from the flat row-major control grid
+ * ``GetControlGrid()`` (length ``3 * Rows * Cols``), per
+ * ``vtkMRMLAbstractParametricSurfaceNode`` §"Control-polygon shape".
+ *
+ * ``vtkLiverVolumetryLogic``, however, still reaches the resection
+ * geometry through the DISJOINT v1 Markups hierarchy
+ * ``vtkMRMLMarkupsBezierSurfaceNode : vtkMRMLMarkupsNode``:
+ *
+ *   - ``GetResectionsProjectionITKImage`` downcasts each collection item
+ *     with ``vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(item)``.
+ *   - ``GenerateBezierSurface`` / ``GetRes`` read control points through
+ *     the Markups API (``GetNumberOfControlPoints`` /
+ *     ``GetNthControlPointPosition``).
+ *
+ * Because ``vtkMRMLBezierSurfaceNode`` is NOT a ``vtkMRMLMarkupsNode``,
+ * the ``SafeDownCast`` returns ``nullptr``,
+ * ``GenerateBezierSurface(Res, nullptr)`` early-returns an unpopulated
+ * source, and the resection boundary is never projected -- the volume is
+ * computed with NO resection boundary. That is the non-functional
+ * behaviour this test characterises and then forbids.
+ *
+ * The RED hook (exact thing the fix must change)
+ * ----------------------------------------------
+ *   1. The downcast target in ``GetResectionsProjectionITKImage``
+ *      (``~vtkLiverVolumetryLogic.cxx`` resection loop):
+ *        ``vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(...)``
+ *      must become ``vtkMRMLBezierSurfaceNode::SafeDownCast(...)``.
+ *   2. The control-point re-sourcing in ``GenerateBezierSurface`` and
+ *      ``GetRes``: the per-point reads via
+ *      ``GetNumberOfControlPoints`` / ``GetNthControlPointPosition``
+ *      must be re-sourced from the parametric carrier's flat grid
+ *      ``GetControlGrid()`` (16 points at ``[i] -> grid[i*3 + {0,1,2}]``),
+ *      with the parameter type widened to ``vtkMRMLBezierSurfaceNode*``.
+ *
+ * Test seam
+ * ---------
+ * ``GenerateBezierSurface`` is the smallest public seam that consumes a
+ * single resection carrier and emits the projected-surface input (a
+ * ``vtkBezierSurfaceSource`` whose ``GetOutput()`` polydata must be
+ * non-empty once the 16 control points are read). This test builds a
+ * ``vtkMRMLBezierSurfaceNode`` carrier with a known 4x4 grid via the
+ * parametric ``SetControlGrid`` API and asserts the surface-generation
+ * path reads those 16 points into a NON-EMPTY surface.
+ *
+ * Until the implementer widens the seam to accept the parametric carrier
+ * (RED hook above), the new ``GenerateBezierSurfaceFromCarrier`` overload
+ * this test calls does not exist, so the carrier-acceptance assertion is
+ * gated behind a deliberate failure (see ``testCarrierProducesNonEmptySurface``).
+ *
+ * The companion characterization (``testProductionDowncastDropsCarrier``)
+ * compiles and runs GREEN today: it pins the ROOT CAUSE -- the production
+ * ``vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast`` of the v2 carrier
+ * returns nullptr -- so a future regression that silently "fixes" the
+ * symptom without retargeting the downcast is still caught.
+ */
+
+// LiverVolumetry Logic include (system under test).
+#include "vtkLiverVolumetryLogic.h"
+
+// Bezier surface source -- the projected-surface input the volumetry
+// path must populate (vtkBezierSurfaceSource : vtkPolyDataAlgorithm).
+#include <vtkBezierSurfaceSource.h>
+
+// v2 resection-plan geometry carrier (the parametric hierarchy).
+// ADR-0014 §"Fourth layer" wrapper-vs-carrier geometry layer.
+#include "vtkMRMLBezierSurfaceNode.h"
+
+// v1 Markups geometry node (the DISJOINT hierarchy the production logic
+// still downcasts to -- the root cause being pinned).
+#include "vtkMRMLMarkupsBezierSurfaceNode.h"
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+
+// STD includes
+#include <iostream>
+#include <vector>
+
+namespace
+{
+
+//------------------------------------------------------------------------------
+// Build a known, non-degenerate 4x4 control grid as a flat row-major
+// array of 48 doubles ([r*Cols + c]*3 + component), matching the
+// vtkMRMLAbstractParametricSurfaceNode control-grid layout.
+std::vector<double> makeKnownControlGrid()
+{
+  std::vector<double> grid(4 * 4 * 3, 0.0);
+  for (int r = 0; r < 4; ++r)
+  {
+    for (int c = 0; c < 4; ++c)
+    {
+      const int base = (r * 4 + c) * 3;
+      grid[base + 0] = static_cast<double>(c) * 10.0; // x spreads along columns
+      grid[base + 1] = static_cast<double>(r) * 10.0; // y spreads along rows
+      grid[base + 2] = static_cast<double>(r + c);    // z gives the surface curvature
+    }
+  }
+  return grid;
+}
+
+//------------------------------------------------------------------------------
+// Build a v2 parametric carrier populated with the known 4x4 grid via
+// the parametric SetControlGrid API (NOT the Markups control-point API).
+vtkSmartPointer<vtkMRMLBezierSurfaceNode> makePopulatedCarrier()
+{
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> carrier = vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New();
+  carrier->SetRows(4);
+  carrier->SetCols(4);
+  const std::vector<double> grid = makeKnownControlGrid();
+  carrier->SetControlGrid(grid.data());
+  return carrier;
+}
+
+//------------------------------------------------------------------------------
+// CHARACTERIZATION (GREEN today) -- pins the ROOT CAUSE of issue: the
+// production downcast in vtkLiverVolumetryLogic::GetResectionsProjectionITKImage
+// targets the DISJOINT v1 Markups hierarchy, so a v2 carrier is dropped
+// to nullptr and never projected.
+//
+// This is the exact downcast the fix must retarget. Keeping it as a
+// live assertion means a regression that re-introduces the markups
+// downcast (or feeds the markups node back into the collection) is
+// caught even after the symptom is fixed.
+// [ADR-0014 §"Fourth layer" wrapper-vs-carrier split]
+int testProductionDowncastDropsCarrier()
+{
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> carrier = makePopulatedCarrier();
+
+  // The v2 carrier carries its 16 control points (4x4) in the flat grid.
+  CHECK_INT(static_cast<int>(carrier->GetControlGridLength()), 4 * 4 * 3);
+
+  // The production code does exactly this downcast on every collection
+  // item; for the parametric carrier it yields nullptr because the two
+  // Bezier node families are disjoint subtrees of vtkMRMLNode.
+  vtkMRMLMarkupsBezierSurfaceNode* asMarkups = vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(carrier.GetPointer());
+  CHECK_NULL(asMarkups);
+
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// RED invariant -- the volumetry surface-generation path, given a v2
+// parametric carrier with 16 control points set via SetControlGrid, must
+// read those points and produce a NON-EMPTY projected Bezier surface.
+//
+// This is the load-bearing assertion: it is what makes "compute volume
+// bounded by a resection" functional again. It is RED until the
+// implementer:
+//   (a) widens the surface-generation seam to accept
+//       vtkMRMLBezierSurfaceNode* (the parametric carrier), and
+//   (b) re-sources the 16 control points from GetControlGrid()
+//       instead of the Markups GetNthControlPointPosition API.
+//
+// The implementer should expose a carrier-typed surface-generation entry
+// point (e.g. an overload
+//   vtkSmartPointer<vtkBezierSurfaceSource>
+//     GenerateBezierSurface(int Res, vtkMRMLBezierSurfaceNode* carrier);
+// or rename the existing one) consumed by
+// GetResectionsProjectionITKImage. Once that seam exists, replace the
+// GTEST-style skip below with the real call + non-empty assertion.
+// [ADR-0014 §"Fourth layer" wrapper-vs-carrier split]
+int testCarrierProducesNonEmptySurface()
+{
+  vtkSmartPointer<vtkMRMLBezierSurfaceNode> carrier = makePopulatedCarrier();
+  (void)carrier;
+
+  // TODO(liver-implementer): once the carrier-accepting surface-gen seam
+  // exists, replace this deliberate failure with, e.g.:
+  //
+  //   vtkNew<vtkLiverVolumetryLogic> logic;
+  //   vtkSmartPointer<vtkBezierSurfaceSource> surface =
+  //     logic->GenerateBezierSurface(10, carrier.GetPointer());
+  //   CHECK_NOT_NULL(surface.GetPointer());
+  //   CHECK_NOT_NULL(surface->GetOutput());
+  //   CHECK_BOOL(surface->GetOutput()->GetNumberOfPoints() > 0, true);
+  //
+  // Today the seam only accepts vtkMRMLMarkupsBezierSurfaceNode*, so the
+  // carrier cannot be passed and the surface stays empty -- this test
+  // FAILS on purpose to keep the invariant RED.
+  std::cerr << "FAIL: LiverVolumetry surface-generation path does not yet accept the "
+               "vtkMRMLBezierSurfaceNode parametric carrier; the resection boundary is "
+               "never projected. Implementer must retarget the downcast and re-source "
+               "control points from GetControlGrid() (see file docstring RED hook)."
+            << std::endl;
+  return EXIT_FAILURE;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkLiverVolumetryLogicResectionCarrierTest(int, char*[])
+{
+  CHECK_EXIT_SUCCESS(testProductionDowncastDropsCarrier());
+  CHECK_EXIT_SUCCESS(testCarrierProducesNonEmptySurface());
+
+  std::cout << "vtkLiverVolumetryLogicResectionCarrierTest completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverVolumetry/Logic/vtkLiverVolumetryLogic.cxx
+++ b/LiverVolumetry/Logic/vtkLiverVolumetryLogic.cxx
@@ -47,7 +47,7 @@
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLScalarVolumeNode.h>
-#include <vtkMRMLMarkupsBezierSurfaceNode.h>
+#include <vtkMRMLBezierSurfaceNode.h>
 
 #include <vtkImageToImageStencil.h>
 #include <vtkObjectFactory.h>
@@ -154,7 +154,7 @@ void vtkLiverVolumetryLogic::ComputeAdvancedPlanningVolumetry(vtkMRMLLabelMapVol
   }
 }
 
-vtkSmartPointer<vtkBezierSurfaceSource> vtkLiverVolumetryLogic::GenerateBezierSurface(int Res, vtkMRMLMarkupsBezierSurfaceNode* bezierSurfaceNode)
+vtkSmartPointer<vtkBezierSurfaceSource> vtkLiverVolumetryLogic::GenerateBezierSurface(int Res, vtkMRMLBezierSurfaceNode* bezierSurfaceNode)
 {
   if (!bezierSurfaceNode)
   {
@@ -163,14 +163,16 @@ vtkSmartPointer<vtkBezierSurfaceSource> vtkLiverVolumetryLogic::GenerateBezierSu
   auto Bezier = vtkSmartPointer<vtkBezierSurfaceSource>::New();
   Bezier->SetResolution(Res, Res);
   Bezier->SetNumberOfControlPoints(4, 4);
-  if (bezierSurfaceNode->GetNumberOfControlPoints() == 16)
+  // The resection-plan geometry carrier stores its 16 control points in the
+  // flat row-major control grid (ADR-0014 §"Fourth layer" wrapper-vs-carrier
+  // split); a 4x4 grid is GetControlGridLength() == 48 doubles.
+  if (bezierSurfaceNode->GetControlGridLength() == 48)
   {
+    const double* grid = bezierSurfaceNode->GetControlGrid();
     auto BezierSurfaceControlPoints = vtkSmartPointer<vtkPoints>::New();
     for (int i = 0; i < 16; i++)
     {
-      double point[3];
-      bezierSurfaceNode->GetNthControlPointPosition(i, point);
-      BezierSurfaceControlPoints->InsertNextPoint(static_cast<float>(point[0]), static_cast<float>(point[1]), static_cast<float>(point[2]));
+      BezierSurfaceControlPoints->InsertNextPoint(static_cast<float>(grid[i * 3 + 0]), static_cast<float>(grid[i * 3 + 1]), static_cast<float>(grid[i * 3 + 2]));
     }
     Bezier->SetControlPoints(BezierSurfaceControlPoints);
     Bezier->Update();
@@ -234,10 +236,11 @@ void vtkLiverVolumetryLogic::VolumetryTable(std::string Properties, double Targe
   }
 }
 
-int vtkLiverVolumetryLogic::GetRes(vtkMRMLMarkupsBezierSurfaceNode* bezierSurfaceNode, double space[3], int Steps)
+int vtkLiverVolumetryLogic::GetRes(vtkMRMLBezierSurfaceNode* bezierSurfaceNode, double space[3], int Steps)
 {
   // BezierCurve computation inspired from https://medium.com/geekculture/2d-and-3d-b%C3%A9zier-curves-in-c-499093ef45a9
 
+  const double* grid = bezierSurfaceNode->GetControlGrid();
   std::vector<std::vector<int>> ControlPointsIndexs{ { 3, 6, 9, 12 }, { 0, 5, 10, 15 } };
   double ArcLength[2];
 
@@ -256,11 +259,10 @@ int vtkLiverVolumetryLogic::GetRes(vtkMRMLMarkupsBezierSurfaceNode* bezierSurfac
 
     for (unsigned int p = 0; p < ControlPointsIndexs[l].size(); p++)
     {
-      double point[3];
-      bezierSurfaceNode->GetNthControlPointPosition(ControlPointsIndexs[l][p], point);
-      ControlPointsX.push_back(point[0]);
-      ControlPointsY.push_back(point[1]);
-      ControlPointsZ.push_back(point[2]);
+      const int base = ControlPointsIndexs[l][p] * 3;
+      ControlPointsX.push_back(grid[base + 0]);
+      ControlPointsY.push_back(grid[base + 1]);
+      ControlPointsZ.push_back(grid[base + 2]);
     }
 
     for (int i = 0; i < Steps; i++)
@@ -365,7 +367,7 @@ void vtkLiverVolumetryLogic::GetResectionsProjectionITKImage(vtkMRMLLabelMapVolu
     this->resectionNodes = ResectionNodes;
     for (int i = 0; i < this->resectionNodes->GetNumberOfItems(); i++)
     {
-      auto bezierSurfaceNode = vtkMRMLMarkupsBezierSurfaceNode::SafeDownCast(this->resectionNodes->GetItemAsObject(i));
+      auto bezierSurfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(this->resectionNodes->GetItemAsObject(i));
       auto Res = GetRes(bezierSurfaceNode, spacing, 300);
       if (Res < 500)
       {

--- a/LiverVolumetry/Logic/vtkLiverVolumetryLogic.cxx
+++ b/LiverVolumetry/Logic/vtkLiverVolumetryLogic.cxx
@@ -368,6 +368,10 @@ void vtkLiverVolumetryLogic::GetResectionsProjectionITKImage(vtkMRMLLabelMapVolu
     for (int i = 0; i < this->resectionNodes->GetNumberOfItems(); i++)
     {
       auto bezierSurfaceNode = vtkMRMLBezierSurfaceNode::SafeDownCast(this->resectionNodes->GetItemAsObject(i));
+      if (!bezierSurfaceNode)
+      {
+        continue;
+      }
       auto Res = GetRes(bezierSurfaceNode, spacing, 300);
       if (Res < 500)
       {

--- a/LiverVolumetry/Logic/vtkLiverVolumetryLogic.h
+++ b/LiverVolumetry/Logic/vtkLiverVolumetryLogic.h
@@ -49,7 +49,7 @@
 
 class vtkMRMLLabelMapVolumeNode;
 class vtkMRMLModelNode;
-class vtkMRMLMarkupsBezierSurfaceNode;
+class vtkMRMLBezierSurfaceNode;
 class vtkMRMLMarkupsFiducialNode;
 class vtkBezierSurfaceSource;
 class vtkMRMLLiverResectionNode;
@@ -73,10 +73,10 @@ public:
                                         double TargetSegmentationVolume = 0.0);
   int GetSegmentVoxels(vtkOrientedImageData* TargetSegmentLabelMap);
   std::vector<int> GetROIPointsLabelValue(vtkMRMLLabelMapVolumeNode* TargetSegmentsLabelMap, vtkMRMLMarkupsFiducialNode* ROIMarkersList);
-  vtkSmartPointer<vtkBezierSurfaceSource> GenerateBezierSurface(int Res, vtkMRMLMarkupsBezierSurfaceNode* bezierSurfaceNode);
+  vtkSmartPointer<vtkBezierSurfaceSource> GenerateBezierSurface(int Res, vtkMRMLBezierSurfaceNode* bezierSurfaceNode);
   itk::Index<3> GetITKRGSeedIndex(double* ROISeedPoint, itk::SmartPointer<itk::Image<short, 3>> SourceImage);
   void VolumetryTable(std::string Properties, double TargetSegmentationVolume, int ROIVoxels, double ROIVolume, vtkMRMLTableNode* OutputTableNode);
-  int GetRes(vtkMRMLMarkupsBezierSurfaceNode* bezierSurfaceNode, double space[3], int Steps);
+  int GetRes(vtkMRMLBezierSurfaceNode* bezierSurfaceNode, double space[3], int Steps);
   void GetResectionsProjectionITKImage(vtkMRMLLabelMapVolumeNode* SelectedSegmentsLabelMap, vtkCollection* ResectionNodes, int baseValue);
   void GenerateSegmentsLabelMap(vtkMRMLLabelMapVolumeNode* TargetSegmentLabelMapCopy,
                                 vtkMRMLLabelMapVolumeNode* newLabelMap,

--- a/LiverVolumetry/Resources/UI/LiverVolumetryWidget.ui
+++ b/LiverVolumetry/Resources/UI/LiverVolumetryWidget.ui
@@ -169,7 +169,7 @@
         </property>
         <property name="nodeTypes">
          <stringlist>
-          <string>vtkMRMLLiverResectionNode</string>
+          <string>vtkMRMLResectionPlanNode</string>
          </stringlist>
         </property>
         <property name="addEnabled">


### PR DESCRIPTION
## Summary for humans

In v2 the "compute volume bounded by a resection" feature was inert: the
resection-target combo in LiverVolumetry filtered on the legacy
`vtkMRMLLiverResectionNode` (never instantiated in v2), so it stayed empty,
and even if a node reached the logic, `vtkLiverVolumetryLogic` downcast each
collection item to the disjoint v1 Markups type
`vtkMRMLMarkupsBezierSurfaceNode`. The v2 resection-plan geometry carrier is
`vtkMRMLBezierSurfaceNode` (the parametric hierarchy), so the `SafeDownCast`
returned `nullptr`, the Bezier boundary was never projected onto the
target-segment label map, and the volume was computed with no resection
boundary at all.

This PR fixes the carrier/Markups type mismatch end to end:

- **C++ logic retarget**: the downcast in `GetResectionsProjectionITKImage`
  now targets `vtkMRMLBezierSurfaceNode`; `GenerateBezierSurface` and `GetRes`
  take the parametric carrier and re-source the 16 control points from its
  flat row-major `GetControlGrid()` instead of the Markups
  `GetNthControlPointPosition` API. Non-carrier collection items are skipped
  before the grid is read.
- **Scripted-module retarget**: the resection-target combo now filters on the
  v2 surgeon-facing wrapper `vtkMRMLResectionPlanNode`, and
  `getResectionNodes()` collects each checked plan's geometry carrier via
  `GetGeometryNode()` (guarding plans without geometry).

This removes the last `GetBezierFromResection` caller, unblocking T2.7-2b.

## ADR references

1. ADR-0014 §"Fourth layer" — wrapper-vs-carrier geometry split; the
   resection-plan wrapper references a parametric `vtkMRMLBezierSurfaceNode`
   carrier whose control polygon lives in a flat control grid.

## Conformance

- **Invariant**: the LiverVolumetry surface-generation path, given a v2
  parametric carrier with 16 control points set via `SetControlGrid`, reads
  those points and produces a non-empty projected Bezier surface.
- **Tests**: `vtkLiverVolumetryLogicResectionCarrierTest`
  - `testProductionDowncastDropsCarrier` — pins the root cause (the v1 Markups
    `SafeDownCast` of a v2 carrier yields `nullptr`); stays green.
  - `testCarrierProducesNonEmptySurface` — was RED, now green: the
    carrier-accepting seam emits a non-empty surface.

  Local run (Slicer-launched CxxTest driver): both cases exit 0; `ctest`
  reports `100% tests passed, 0 tests failed out of 1`.

## UX impact

The resection-target combo in LiverVolumetry now populates with the v2
resection-plan nodes (previously always empty), so a surgeon can select one
or more resections as the volume boundary and the computed volume reflects
that boundary. No layout or control changes; the existing combo simply lists
the correct node type.

<details>
<summary>Agent context (long-form)</summary>

Root cause was a node-family mismatch introduced by the v1→v2 resection
rework. The v1 path stored resection geometry as a Markups node
(`vtkMRMLMarkupsBezierSurfaceNode : vtkMRMLMarkupsNode`) and read control
points through the Markups control-point API. v2 moved the geometry to a
parametric carrier (`vtkMRMLBezierSurfaceNode :
vtkMRMLAbstractParametricSurfaceNode`) whose 16 control points live in a flat
row-major grid of `3 * Rows * Cols` doubles (a 4x4 grid = 48 doubles), read
via `GetControlGrid()`. The two Bezier node families are disjoint subtrees of
`vtkMRMLNode`, so the unretargeted `SafeDownCast` silently dropped every v2
carrier to `nullptr` and the projection step ran on an empty surface source.

The fix re-sources control points by index `i -> grid[i*3 + {0,1,2}]` in both
consumers (`GenerateBezierSurface` for the full 4x4 surface, `GetRes` for the
two boundary curves at control indices `{3,6,9,12}` and `{0,5,10,15}`). The
`GenerateBezierSurface` population guard switched from
`GetNumberOfControlPoints() == 16` to `GetControlGridLength() == 48`, the
parametric-carrier equivalent for the fixed 4x4 `vtkBezierSurfaceSource`. A
loop guard skips any collection item that fails the carrier downcast before
`GetRes` dereferences the raw grid pointer.

The logic library already links `vtkSlicerLiverResectionsModuleMRML`, so no
new link dependency was needed.

</details>

🤖 Drafted with the assistance of Claude (Anthropic), model claude-opus-4-8, under human review.
