### PR TITLE
ENH: T3 ResectogramPipeline foundation (#465) — Pipeline + display node + (u,v) helpers

### DIFF
--- a/LiverResections/Algorithm/CMakeLists.txt
+++ b/LiverResections/Algorithm/CMakeLists.txt
@@ -58,6 +58,10 @@ set(${KIT}_SRCS
   vtkLiverBezierFitter.cxx
   vtkSlicerLiverBezierControlPolygonGeometry.h
   vtkSlicerLiverBezierControlPolygonGeometry.cxx
+  vtkLiverResectogramAspectRatio.h
+  vtkLiverResectogramAspectRatio.cxx
+  vtkLiverResectogramPixelMapping.h
+  vtkLiverResectogramPixelMapping.cxx
   )
 
 #

--- a/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
@@ -18,6 +18,8 @@ set(KIT_TEST_SRCS
   vtkLiverSpheroidRingExtractorEdgeCasesTest.cxx
   vtkLiverSpheroidRingExtractorConsistencyTest.cxx
   vtkSlicerLiverBezierControlPolygonGeometryTest1.cxx
+  vtkLiverResectogramAspectRatioTest.cxx
+  vtkLiverResectogramPixelMappingTest.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -57,5 +59,32 @@ set_property(SOURCE vtkLiverSpheroidRingExtractorConsistencyTest.cxx
   )
 SIMPLE_TEST(vtkLiverSpheroidRingExtractorConsistencyTest)
 set_tests_properties(vtkLiverSpheroidRingExtractorConsistencyTest PROPERTIES
+  SKIP_RETURN_CODE 125
+  )
+
+# T3 ResectogramPipeline — invariant-test-first scaffolding (ADR-0027).
+# Both helpers are extracted/introduced by the eventual T3 implementation;
+# until then the checked branch is compiled out behind its compile macro
+# and the test returns the CTest skip code (125).  The implementer adds
+# the pure-VTK helper (ADR-0015 §1, no MRML) and defines the matching
+# macro to lift each skip — see the test-file headers.
+#
+# vtkLiverResectogramAspectRatioTest pins the v1 Ratio() arc-length math
+# (square -> {1,1}; non-square -> non-{1,1}); the highest-value T3
+# invariant.  The active branch is gated on LIVER_RESECTOGRAM_ASPECT_RATIO
+# which is INTENTIONALLY left undefined here so the test skips (125)
+# until vtkLiverResectogramAspectRatio::ComputeAspectRatio lands; the
+# implementer adds the helper and appends that macro to lift the skip.
+SIMPLE_TEST(vtkLiverResectogramAspectRatioTest)
+set_tests_properties(vtkLiverResectogramAspectRatioTest PROPERTIES
+  SKIP_RETURN_CODE 125
+  )
+
+# vtkLiverResectogramPixelMappingTest pins the ADR-0025 §Context pixel ->
+# (u,v) correspondence the locator producer (issue #414) consumes.  Same
+# gating: LIVER_RESECTOGRAM_PIXEL_MAPPING is undefined until
+# vtkLiverResectogramPixelMapping::PixelToUV lands.
+SIMPLE_TEST(vtkLiverResectogramPixelMappingTest)
+set_tests_properties(vtkLiverResectogramPixelMappingTest PROPERTIES
   SKIP_RETURN_CODE 125
   )

--- a/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
@@ -71,19 +71,26 @@ set_tests_properties(vtkLiverSpheroidRingExtractorConsistencyTest PROPERTIES
 #
 # vtkLiverResectogramAspectRatioTest pins the v1 Ratio() arc-length math
 # (square -> {1,1}; non-square -> non-{1,1}); the highest-value T3
-# invariant.  The active branch is gated on LIVER_RESECTOGRAM_ASPECT_RATIO
-# which is INTENTIONALLY left undefined here so the test skips (125)
-# until vtkLiverResectogramAspectRatio::ComputeAspectRatio lands; the
-# implementer adds the helper and appends that macro to lift the skip.
+# invariant.  The pure-VTK helper
+# vtkLiverResectogramAspectRatio::ComputeAspectRatio() now exists, so the
+# active branch is enabled via -DLIVER_RESECTOGRAM_ASPECT_RATIO.
+# SKIP_RETURN_CODE retained so a future build that compiles the test
+# without the macro degrades to a skip rather than a hard failure.
+set_property(SOURCE vtkLiverResectogramAspectRatioTest.cxx
+  APPEND PROPERTY COMPILE_DEFINITIONS LIVER_RESECTOGRAM_ASPECT_RATIO
+  )
 SIMPLE_TEST(vtkLiverResectogramAspectRatioTest)
 set_tests_properties(vtkLiverResectogramAspectRatioTest PROPERTIES
   SKIP_RETURN_CODE 125
   )
 
 # vtkLiverResectogramPixelMappingTest pins the ADR-0025 §Context pixel ->
-# (u,v) correspondence the locator producer (issue #414) consumes.  Same
-# gating: LIVER_RESECTOGRAM_PIXEL_MAPPING is undefined until
-# vtkLiverResectogramPixelMapping::PixelToUV lands.
+# (u,v) correspondence the locator producer (issue #414) consumes.  The
+# pure-VTK helper vtkLiverResectogramPixelMapping::PixelToUV() now exists,
+# so the active branch is enabled via -DLIVER_RESECTOGRAM_PIXEL_MAPPING.
+set_property(SOURCE vtkLiverResectogramPixelMappingTest.cxx
+  APPEND PROPERTY COMPILE_DEFINITIONS LIVER_RESECTOGRAM_PIXEL_MAPPING
+  )
 SIMPLE_TEST(vtkLiverResectogramPixelMappingTest)
 set_tests_properties(vtkLiverResectogramPixelMappingTest PROPERTIES
   SKIP_RETURN_CODE 125

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverResectogramAspectRatioTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverResectogramAspectRatioTest.cxx
@@ -1,0 +1,206 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Pure-math invariant test for the resectogram aspect-ratio helper that
+  T3 extracts from the v1 monolith.
+
+  -- WHAT THIS PINS --
+
+  The v1 binding ``vtkSlicerBezierSurfaceRepresentation3D::Ratio(bool)``
+  (legacy ``LiverMarkups/VTKWidgets/`` representation) computes the
+  resectogram's anisotropic scaling factor.  It walks the 20x20 sampled
+  Bezier surface, sums Euclidean arc-length along the first u-edge
+  (sample indices 0..19) and along the first v-edge (sample indices
+  0, 20, 40, ... 19*20), then normalises the LONGER axis to 1:
+
+      if (disU >= disV) { matR = { 1, disV / disU }; }
+      else              { matR = { disU / disV, 1 }; }
+
+  When ``flexibleBoundary`` is false the function short-circuits to the
+  isotropic ``{1, 1}``.  That ``{1, 1}`` is the *square-domain* answer
+  and ALSO the not-flexible answer — the two are observationally
+  identical for a square domain, which is exactly why a stub that always
+  returns ``{1, 1}`` must be caught by a NON-square fixture.
+
+  T3 extracts this arc-length computation into a PURE-VTK Algorithm
+  helper so the resectogram Representation (LayerDM-bound, Python) and
+  any other caller can reach it without an MRML or GL dependency
+  (ADR-0015 §1 — Algorithm classes are pure VTK; ADR-0003 — the helper
+  is unit-testable in isolation, no MRML link).  The expected target
+  signature, mirroring ``vtkSlicerLiverBezierControlPolygonGeometry``:
+
+      static void vtkLiverResectogramAspectRatio::ComputeAspectRatio(
+          vtkPoints* sampledSurface,
+          unsigned int samplesU, unsigned int samplesV,
+          bool flexibleBoundary,
+          double ratioOut[2]);
+
+  -- WHY IT IS RED-BY-CONSTRUCTION --
+
+  Two fixtures pin the SPECIFIC invariant (per ADR-0027 — fail-against-
+  broken, pass-against-fixed):
+
+   1. A square (u,v) sample grid -> exactly ``{1, 1}``.  A ``{1,1}``
+      stub passes this case; alone it is a "colour-of-the-sky" assertion
+      and would not catch the bug, so it never stands alone.
+   2. A KNOWN non-square sample grid where the v-edge arc-length is
+      twice the u-edge arc-length -> ``{0.5, 1}`` (longer axis v
+      normalised to 1, shorter axis u scaled by disU/disV = 1/2).  A
+      ``{1,1}`` stub FAILS this case.  This is the load-bearing
+      assertion.
+
+  Until the implementer adds
+  ``vtkLiverResectogramAspectRatio::ComputeAspectRatio`` the helper does
+  not exist, so the checked branch is compiled out behind
+  ``LIVER_RESECTOGRAM_ASPECT_RATIO`` (undefined now) and the test
+  returns the CTest skip code (125).  The skip lifts when the helper
+  lands and the CMakeLists defines the macro.
+
+  Tag: ADR-0015 §1 (pure-VTK Algorithm helper, no MRML), ADR-0003
+  (testability invariant), ADR-0027 (invariant-test-first; the specific
+  invariant is the non-square -> non-{1,1} mapping, not merely "some
+  ratio is returned"), ADR-0013 §6 (Representation-owned scaling state).
+
+  Define -DLIVER_RESECTOGRAM_ASPECT_RATIO once
+  vtkLiverResectogramAspectRatio::ComputeAspectRatio exists.
+
+==============================================================================*/
+
+#ifdef LIVER_RESECTOGRAM_ASPECT_RATIO
+# include "vtkLiverResectogramAspectRatio.h"
+
+// VTK includes
+# include <vtkNew.h>
+# include <vtkPoints.h>
+#endif
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace
+{
+// CTest skip return code (kept in sync with the SKIP_RETURN_CODE the
+// CMakeLists sets on this test).
+constexpr int kSkipReturnCode = 125;
+
+#ifdef LIVER_RESECTOGRAM_ASPECT_RATIO
+// The v1 Ratio() samples a fixed 20x20 grid (sample indices run 0..399,
+// the u-edge being 0..19 and the v-edge being 0, 20, 40, ...).  The
+// extracted helper takes the sample counts explicitly so it is not
+// hard-wired to 20x20.
+constexpr unsigned int kSamplesU = 20;
+constexpr unsigned int kSamplesV = 20;
+
+// Build a planar samplesU x samplesV grid with row-major flat index
+// ``i * samplesV + j`` (matching the v1 ``GetTuple3(20 * i)`` v-edge
+// stride and ``GetTuple3(i)`` u-edge stride).  ``spanU`` and ``spanV``
+// are the total edge lengths in each parametric direction so the test
+// can dial in a known arc-length ratio.
+vtkSmartPointer<vtkPoints> makeGrid(double spanU, double spanV)
+{
+  auto pts = vtkSmartPointer<vtkPoints>::New();
+  pts->SetNumberOfPoints(kSamplesU * kSamplesV);
+  const double du = spanU / static_cast<double>(kSamplesU - 1);
+  const double dv = spanV / static_cast<double>(kSamplesV - 1);
+  for (unsigned int i = 0; i < kSamplesU; ++i)
+  {
+    for (unsigned int j = 0; j < kSamplesV; ++j)
+    {
+      const vtkIdType flat = static_cast<vtkIdType>(i) * kSamplesV + j;
+      pts->SetPoint(flat, du * i, dv * j, 0.0);
+    }
+  }
+  return pts;
+}
+
+bool approx(double a, double b, double tol = 1e-9)
+{
+  return std::fabs(a - b) <= tol;
+}
+#endif
+
+} // namespace
+
+int vtkLiverResectogramAspectRatioTest(int, char*[])
+{
+#ifndef LIVER_RESECTOGRAM_ASPECT_RATIO
+  std::fprintf(stderr,
+               "[ResectogramAspectRatio] SKIP: the pure-VTK helper "
+               "vtkLiverResectogramAspectRatio::ComputeAspectRatio() does "
+               "not exist yet.  T3 extracts the v1 "
+               "vtkSlicerBezierSurfaceRepresentation3D::Ratio(bool) "
+               "arc-length computation into the Algorithm library (ADR-0015 "
+               "Section 1, pure VTK, no MRML).  Add it and define "
+               "-DLIVER_RESECTOGRAM_ASPECT_RATIO to lift this skip.\n");
+  return kSkipReturnCode;
+#else
+  // ---------------------------------------------------------------- //
+  // Case 1 — square (u,v) domain -> isotropic {1, 1}.
+  // (Necessary but not sufficient: a {1,1} stub also passes this.)
+  // ---------------------------------------------------------------- //
+  {
+    vtkSmartPointer<vtkPoints> square = makeGrid(10.0, 10.0);
+    double ratio[2] = { -1.0, -1.0 };
+    vtkLiverResectogramAspectRatio::ComputeAspectRatio(square, kSamplesU, kSamplesV, /*flexibleBoundary=*/true, ratio);
+    if (!approx(ratio[0], 1.0) || !approx(ratio[1], 1.0))
+    {
+      std::fprintf(stderr,
+                   "[ResectogramAspectRatio] FAIL: square domain expected "
+                   "{1, 1}, got {%g, %g}\n",
+                   ratio[0],
+                   ratio[1]);
+      return EXIT_FAILURE;
+    }
+  }
+
+  // ---------------------------------------------------------------- //
+  // Case 2 — LOAD-BEARING: known non-square domain.
+  // v-edge arc-length is twice the u-edge arc-length (spanV = 2*spanU),
+  // so disV >= disU and the helper normalises the longer (v) axis to 1
+  // and scales u by disU/disV = 0.5  ->  {0.5, 1}.
+  // A {1,1} stub FAILS here; this is the assertion that pins the bug.
+  // ---------------------------------------------------------------- //
+  {
+    vtkSmartPointer<vtkPoints> wide = makeGrid(10.0, 20.0);
+    double ratio[2] = { -1.0, -1.0 };
+    vtkLiverResectogramAspectRatio::ComputeAspectRatio(wide, kSamplesU, kSamplesV, /*flexibleBoundary=*/true, ratio);
+    if (!approx(ratio[0], 0.5) || !approx(ratio[1], 1.0))
+    {
+      std::fprintf(stderr,
+                   "[ResectogramAspectRatio] FAIL: non-square domain "
+                   "(spanV = 2*spanU) expected {0.5, 1}, got {%g, %g}.  A "
+                   "{1, 1} stub fails here by design (ADR-0027 fail-against-"
+                   "broken).\n",
+                   ratio[0],
+                   ratio[1]);
+      return EXIT_FAILURE;
+    }
+  }
+
+  // ---------------------------------------------------------------- //
+  // Case 3 — non-flexible boundary short-circuits to {1, 1} regardless
+  // of the domain shape (the v1 else-branch).
+  // ---------------------------------------------------------------- //
+  {
+    vtkSmartPointer<vtkPoints> wide = makeGrid(10.0, 20.0);
+    double ratio[2] = { -1.0, -1.0 };
+    vtkLiverResectogramAspectRatio::ComputeAspectRatio(wide, kSamplesU, kSamplesV, /*flexibleBoundary=*/false, ratio);
+    if (!approx(ratio[0], 1.0) || !approx(ratio[1], 1.0))
+    {
+      std::fprintf(stderr,
+                   "[ResectogramAspectRatio] FAIL: non-flexible boundary must "
+                   "force {1, 1} regardless of domain shape, got {%g, %g}\n",
+                   ratio[0],
+                   ratio[1]);
+      return EXIT_FAILURE;
+    }
+  }
+
+  std::printf("vtkLiverResectogramAspectRatioTest completed successfully\n");
+  return EXIT_SUCCESS;
+#endif
+}

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverResectogramAspectRatioTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverResectogramAspectRatioTest.cxx
@@ -75,6 +75,7 @@
 // VTK includes
 # include <vtkNew.h>
 # include <vtkPoints.h>
+# include <vtkSmartPointer.h>
 #endif
 
 #include <cmath>

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverResectogramPixelMappingTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverResectogramPixelMappingTest.cxx
@@ -1,0 +1,193 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Non-regression test for the resectogram pixel -> (u, v) parametric
+  mapping that the ADR-0025 locator producer consumes.
+
+  -- WHAT THIS PROTECTS --
+
+  ADR-0025 §Context establishes that "the resectogram is a 1:1 image of
+  the Bezier (u, v) parameter domain.  A resectogram pixel maps to a
+  (u, v) pair maps to a world point by direct Bezier surface evaluation
+  — an EXACT correspondence, with no geometric search required."  The
+  locator architecture (issue #414, depends on T3) plugs into T3's host
+  resectogram Pipeline and relies on that mapping being STABLE: any
+  geometry/scaling change T3 makes to the flattened-surface
+  Representation (e.g. the aspect-ratio normalisation lifted from the v1
+  Ratio(), see vtkLiverResectogramAspectRatioTest) must NOT silently
+  regress where a given pixel lands in (u, v).
+
+  The on-screen placement applies the anisotropic ``MatRatio`` scaling
+  (the v1 vertex shader multiplies ``gl_Position`` by a matrix with
+  ``m[0][0] = uMatRatio[0]`` / ``m[1][1] = uMatRatio[1]``;
+  vtkOpenGLResection2DPolyDataMapper, post-relocation home
+  ``LiverResections/VTKWidgets/``).  The locator producer must invert
+  that placement to recover the un-scaled (u, v) in [0, 1]^2.  This
+  test pins the inverse map for a representative resectogram domain so
+  the contract is characterised BEFORE T3 touches the placement code.
+
+  The expected target signature, mirroring the other pure-VTK helpers:
+
+      static void vtkLiverResectogramPixelMapping::PixelToUV(
+          const double pixel[2],          // viewport pixel (origin BL)
+          const int viewportSize[2],      // {width, height} in pixels
+          const double matRatio[2],       // {su, sv} aspect scaling
+          double uvOut[2]);               // -> (u, v) in [0,1]^2
+
+  -- WHY IT IS RED-BY-CONSTRUCTION --
+
+  The helper does not exist yet, so the checked branch is compiled out
+  behind ``LIVER_RESECTOGRAM_PIXEL_MAPPING`` (undefined now) and the
+  test returns the CTest skip code (125).  The skip lifts when the
+  implementer adds the helper and the CMakeLists defines the macro.
+
+  The pinned values below come from the geometry the v1 shader
+  implements: the flattened quad fills the viewport, (u, v) = (0, 0) at
+  the bottom-left corner and (1, 1) at the top-right, with the MatRatio
+  shrinking the SHORTER axis toward the viewport centre.  A pixel at the
+  exact viewport centre maps to (0.5, 0.5) for ANY MatRatio (the centre
+  is the scaling fixed point); off-centre pixels divide out the ratio.
+
+  Tag: ADR-0025 §Context (the exact pixel -> (u,v) correspondence the
+  locator producer consumes), ADR-0015 §1 (pure-VTK Algorithm helper,
+  no MRML), ADR-0003 (testability invariant), ADR-0027 (invariant-test-
+  first; the specific invariant is the off-centre pixel mapping that a
+  ratio change would move, not merely the centre fixed point).
+
+  Define -DLIVER_RESECTOGRAM_PIXEL_MAPPING once
+  vtkLiverResectogramPixelMapping::PixelToUV exists.
+
+==============================================================================*/
+
+#ifdef LIVER_RESECTOGRAM_PIXEL_MAPPING
+# include "vtkLiverResectogramPixelMapping.h"
+#endif
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace
+{
+// CTest skip return code (kept in sync with the SKIP_RETURN_CODE the
+// CMakeLists sets on this test).
+constexpr int kSkipReturnCode = 125;
+
+#ifdef LIVER_RESECTOGRAM_PIXEL_MAPPING
+bool approx(double a, double b, double tol = 1e-6)
+{
+  return std::fabs(a - b) <= tol;
+}
+#endif
+
+} // namespace
+
+int vtkLiverResectogramPixelMappingTest(int, char*[])
+{
+#ifndef LIVER_RESECTOGRAM_PIXEL_MAPPING
+  std::fprintf(stderr,
+               "[ResectogramPixelMapping] SKIP: the pure-VTK helper "
+               "vtkLiverResectogramPixelMapping::PixelToUV() does not exist "
+               "yet.  ADR-0025 Section Context fixes the resectogram pixel -> "
+               "(u, v) correspondence the locator producer (issue #414) "
+               "consumes; T3 must characterise it before touching the "
+               "flattened-surface placement.  Add the helper and define "
+               "-DLIVER_RESECTOGRAM_PIXEL_MAPPING to lift this skip.\n");
+  return kSkipReturnCode;
+#else
+  // Representative resectogram viewport: a 600 x 400 panel.  The
+  // flattened quad fills the panel; (u, v) runs (0,0) bottom-left to
+  // (1,1) top-right.
+  const int viewport[2] = { 600, 400 };
+
+  // ---------------------------------------------------------------- //
+  // Case 1 — isotropic MatRatio {1, 1}: the panel maps linearly to the
+  // unit square.  Bottom-left pixel -> (0, 0); top-right -> (1, 1);
+  // centre -> (0.5, 0.5).
+  // ---------------------------------------------------------------- //
+  {
+    const double matRatio[2] = { 1.0, 1.0 };
+    struct
+    {
+      double pixel[2];
+      double uv[2];
+    } cases[] = {
+      { { 0.0, 0.0 }, { 0.0, 0.0 } },
+      { { 600.0, 400.0 }, { 1.0, 1.0 } },
+      { { 300.0, 200.0 }, { 0.5, 0.5 } },
+      { { 150.0, 100.0 }, { 0.25, 0.25 } },
+    };
+    for (const auto& c : cases)
+    {
+      double uv[2] = { -1.0, -1.0 };
+      vtkLiverResectogramPixelMapping::PixelToUV(c.pixel, viewport, matRatio, uv);
+      if (!approx(uv[0], c.uv[0]) || !approx(uv[1], c.uv[1]))
+      {
+        std::fprintf(stderr,
+                     "[ResectogramPixelMapping] FAIL (isotropic): pixel "
+                     "(%g, %g) expected (u,v)=(%g, %g), got (%g, %g)\n",
+                     c.pixel[0],
+                     c.pixel[1],
+                     c.uv[0],
+                     c.uv[1],
+                     uv[0],
+                     uv[1]);
+        return EXIT_FAILURE;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------- //
+  // Case 2 — LOAD-BEARING: anisotropic MatRatio {0.5, 1}.  The u-axis
+  // is drawn at half width about the viewport centre, so the visible
+  // quad occupies the central half of the panel in x.  Inverting that
+  // placement: the panel centre still maps to u = 0.5 (the scaling
+  // fixed point), but an off-centre pixel divides out the 0.5 factor —
+  // doubling its distance from centre in (u) space.
+  //
+  // Pixel x = 300 (centre)            -> u = 0.5
+  // Pixel x = 450 (3/4 across panel)  -> centre-offset +0.25 panel ->
+  //                                      /0.5 -> +0.5 in u -> u = 1.0
+  // The v-axis ratio is 1.0 so v maps linearly as in Case 1.
+  // A change to the placement scaling moves these off-centre values.
+  // ---------------------------------------------------------------- //
+  {
+    const double matRatio[2] = { 0.5, 1.0 };
+    struct
+    {
+      double pixel[2];
+      double uv[2];
+    } cases[] = {
+      { { 300.0, 200.0 }, { 0.5, 0.5 } }, // centre: fixed point
+      { { 450.0, 200.0 }, { 1.0, 0.5 } }, // off-centre x divides out 0.5
+      { { 150.0, 200.0 }, { 0.0, 0.5 } }, // symmetric on the other side
+    };
+    for (const auto& c : cases)
+    {
+      double uv[2] = { -1.0, -1.0 };
+      vtkLiverResectogramPixelMapping::PixelToUV(c.pixel, viewport, matRatio, uv);
+      if (!approx(uv[0], c.uv[0]) || !approx(uv[1], c.uv[1]))
+      {
+        std::fprintf(stderr,
+                     "[ResectogramPixelMapping] FAIL (anisotropic): pixel "
+                     "(%g, %g) with MatRatio {0.5, 1} expected (u,v)=(%g, %g), "
+                     "got (%g, %g).  Off-centre u is the load-bearing "
+                     "assertion (ADR-0027 fail-against-broken).\n",
+                     c.pixel[0],
+                     c.pixel[1],
+                     c.uv[0],
+                     c.uv[1],
+                     uv[0],
+                     uv[1]);
+        return EXIT_FAILURE;
+      }
+    }
+  }
+
+  std::printf("vtkLiverResectogramPixelMappingTest completed successfully\n");
+  return EXIT_SUCCESS;
+#endif
+}

--- a/LiverResections/Algorithm/vtkLiverResectogramAspectRatio.cxx
+++ b/LiverResections/Algorithm/vtkLiverResectogramAspectRatio.cxx
@@ -1,0 +1,95 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+==============================================================================*/
+
+#include "vtkLiverResectogramAspectRatio.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+#include <vtkPoints.h>
+
+// STD includes
+#include <cmath>
+
+vtkStandardNewMacro(vtkLiverResectogramAspectRatio);
+
+namespace
+{
+// Sum the Euclidean arc-length of the first edge that starts at flat
+// index 0 and advances by ``stride`` for ``count`` samples.  The u-edge
+// uses stride ``samplesV`` (row to row); the v-edge uses stride 1
+// (column to column).
+double EdgeArcLength(vtkPoints* points, vtkIdType stride, unsigned int count)
+{
+  double length = 0.0;
+  double prev[3];
+  points->GetPoint(0, prev);
+  for (unsigned int k = 1; k < count; ++k)
+  {
+    double curr[3];
+    points->GetPoint(stride * static_cast<vtkIdType>(k), curr);
+    length += std::sqrt((prev[0] - curr[0]) * (prev[0] - curr[0]) + (prev[1] - curr[1]) * (prev[1] - curr[1]) + (prev[2] - curr[2]) * (prev[2] - curr[2]));
+    prev[0] = curr[0];
+    prev[1] = curr[1];
+    prev[2] = curr[2];
+  }
+  return length;
+}
+} // namespace
+
+//------------------------------------------------------------------------------
+vtkLiverResectogramAspectRatio::vtkLiverResectogramAspectRatio() = default;
+
+//------------------------------------------------------------------------------
+vtkLiverResectogramAspectRatio::~vtkLiverResectogramAspectRatio() = default;
+
+//------------------------------------------------------------------------------
+void vtkLiverResectogramAspectRatio::ComputeAspectRatio(vtkPoints* sampledSurface, unsigned int samplesU, unsigned int samplesV, bool flexibleBoundary, double ratioOut[2])
+{
+  // Non-flexible boundary short-circuits to the isotropic answer (the
+  // v1 else-branch).  This is also the square-domain answer.
+  if (!flexibleBoundary)
+  {
+    ratioOut[0] = 1.0;
+    ratioOut[1] = 1.0;
+    return;
+  }
+
+  if (!sampledSurface || samplesU < 2 || samplesV < 2)
+  {
+    vtkGenericWarningMacro("vtkLiverResectogramAspectRatio::ComputeAspectRatio: "
+                           "a sampled surface with at least 2x2 samples is "
+                           "required; falling back to the isotropic {1, 1}.");
+    ratioOut[0] = 1.0;
+    ratioOut[1] = 1.0;
+    return;
+  }
+
+  // Row-major flat index: sample (i, j) lives at i * samplesV + j.
+  // The first u-edge walks i = 0..samplesU-1 at j = 0 (stride samplesV);
+  // the first v-edge walks j = 0..samplesV-1 at i = 0 (stride 1).
+  const double disU = EdgeArcLength(sampledSurface, static_cast<vtkIdType>(samplesV), samplesU);
+  const double disV = EdgeArcLength(sampledSurface, 1, samplesV);
+
+  // Normalise the longer axis to 1 (the v1 Ratio() branch).
+  if (disU >= disV)
+  {
+    ratioOut[0] = 1.0;
+    ratioOut[1] = (disU > 0.0) ? disV / disU : 1.0;
+  }
+  else
+  {
+    ratioOut[0] = (disV > 0.0) ? disU / disV : 1.0;
+    ratioOut[1] = 1.0;
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverResectogramAspectRatio::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}

--- a/LiverResections/Algorithm/vtkLiverResectogramAspectRatio.h
+++ b/LiverResections/Algorithm/vtkLiverResectogramAspectRatio.h
@@ -1,0 +1,88 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  This file was originally developed for the Slicer-Liver extension as
+  the Algorithm-library home of the resectogram aspect-ratio helper
+  extracted from the v1 ``vtkSlicerBezierSurfaceRepresentation3D::Ratio``
+  binding (per ADR-0015 §1 — pure-VTK helpers reachable from both the
+  legacy ``LiverMarkups`` representations and the v2 ``LiverResections``
+  Pipeline representations, with no MRML or VTKWidgets linkage).
+
+==============================================================================*/
+
+#ifndef __vtkLiverResectogramAspectRatio_h_
+#define __vtkLiverResectogramAspectRatio_h_
+
+#include "vtkSlicerLiverResectionsModuleAlgorithmExport.h"
+
+// VTK includes
+#include <vtkObject.h>
+
+class vtkPoints;
+
+/**
+ * \class vtkLiverResectogramAspectRatio
+ *
+ * \brief Pure-VTK helper that computes the resectogram's anisotropic
+ * aspect-ratio scaling from a sampled Bezier surface.
+ *
+ * Centralises the arc-length computation previously embedded in
+ * ``vtkSlicerBezierSurfaceRepresentation3D::Ratio(bool)`` (legacy v1
+ * binding under ``LiverMarkups/VTKWidgets/``).  Lives in the Algorithm
+ * library so the LayerDM-bound resectogram Representation and any other
+ * caller can reach it without picking up an MRML or OpenGL dependency
+ * (per ADR-0015 §1 — Algorithm classes are pure VTK).
+ *
+ * \par Contract
+ *  - ``ComputeAspectRatio(sampledSurface, samplesU, samplesV,
+ *    flexibleBoundary, ratioOut)`` walks the sampled surface grid,
+ *    indexed row-major (sample ``(i, j)`` has flat index
+ *    ``i * samplesV + j``).  It sums the Euclidean arc-length along the
+ *    first u-edge (``i`` running ``0..samplesU-1`` at ``j = 0``) and
+ *    along the first v-edge (``j`` running ``0..samplesV-1`` at
+ *    ``i = 0``), then normalises the LONGER axis to 1:
+ *
+ *        if (disU >= disV) { ratioOut = { 1, disV / disU }; }
+ *        else              { ratioOut = { disU / disV, 1 }; }
+ *
+ *  - When ``flexibleBoundary`` is false the function short-circuits to
+ *    the isotropic ``{1, 1}`` (the v1 else-branch).
+ *  - A square domain yields ``{1, 1}`` (disU == disV); this is also the
+ *    not-flexible answer, so the two are observationally identical for a
+ *    square domain.
+ *
+ * \par MRML invariant
+ *  No ``vtkMRMLNode`` references.  Per ADR-0015 §1 the Algorithm library
+ *  is pure VTK; this class follows the same invariant so it remains
+ *  reachable from both the LayerDM-bound v2 path and the legacy
+ *  MRML-bound v1 path without inverting the dependency.  Per ADR-0013 §6
+ *  the resulting scaling is Representation-owned state.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverResectogramAspectRatio : public vtkObject
+{
+public:
+  static vtkLiverResectogramAspectRatio* New();
+  vtkTypeMacro(vtkLiverResectogramAspectRatio, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Compute the resectogram's anisotropic aspect-ratio scaling from a
+  /// row-major sampled surface grid (sample ``(i, j)`` at flat index
+  /// ``i * samplesV + j``).  Sums arc-length along the first u-edge and
+  /// first v-edge, then normalises the longer axis to 1.  When
+  /// ``flexibleBoundary`` is false, forces the isotropic ``{1, 1}``.
+  /// Writes the result into ``ratioOut[2]``.
+  static void ComputeAspectRatio(vtkPoints* sampledSurface, unsigned int samplesU, unsigned int samplesV, bool flexibleBoundary, double ratioOut[2]);
+
+protected:
+  vtkLiverResectogramAspectRatio();
+  ~vtkLiverResectogramAspectRatio() override;
+
+private:
+  vtkLiverResectogramAspectRatio(const vtkLiverResectogramAspectRatio&) = delete;
+  void operator=(const vtkLiverResectogramAspectRatio&) = delete;
+};
+
+#endif // __vtkLiverResectogramAspectRatio_h_

--- a/LiverResections/Algorithm/vtkLiverResectogramPixelMapping.cxx
+++ b/LiverResections/Algorithm/vtkLiverResectogramPixelMapping.cxx
@@ -1,0 +1,54 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+==============================================================================*/
+
+#include "vtkLiverResectogramPixelMapping.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+
+vtkStandardNewMacro(vtkLiverResectogramPixelMapping);
+
+namespace
+{
+// Invert the centre-anchored aspect scaling for one axis.  The flattened
+// quad fills the viewport linearly, then matRatio scales it about the
+// 0.5 fixed point: linear = 0.5 + ratio * (uv - 0.5).  Inverting:
+// uv = 0.5 + (linear - 0.5) / ratio.
+double InvertAxis(double pixel, int extent, double ratio)
+{
+  if (extent <= 0)
+  {
+    return 0.0;
+  }
+  const double linear = pixel / static_cast<double>(extent);
+  if (ratio == 0.0)
+  {
+    return linear;
+  }
+  return 0.5 + (linear - 0.5) / ratio;
+}
+} // namespace
+
+//------------------------------------------------------------------------------
+vtkLiverResectogramPixelMapping::vtkLiverResectogramPixelMapping() = default;
+
+//------------------------------------------------------------------------------
+vtkLiverResectogramPixelMapping::~vtkLiverResectogramPixelMapping() = default;
+
+//------------------------------------------------------------------------------
+void vtkLiverResectogramPixelMapping::PixelToUV(const double pixel[2], const int viewportSize[2], const double matRatio[2], double uvOut[2])
+{
+  uvOut[0] = InvertAxis(pixel[0], viewportSize[0], matRatio[0]);
+  uvOut[1] = InvertAxis(pixel[1], viewportSize[1], matRatio[1]);
+}
+
+//------------------------------------------------------------------------------
+void vtkLiverResectogramPixelMapping::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}

--- a/LiverResections/Algorithm/vtkLiverResectogramPixelMapping.h
+++ b/LiverResections/Algorithm/vtkLiverResectogramPixelMapping.h
@@ -1,0 +1,78 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  This file was originally developed for the Slicer-Liver extension as
+  the Algorithm-library home of the resectogram pixel -> (u, v) mapping
+  the ADR-0025 locator producer consumes (per ADR-0015 §1 — pure-VTK
+  helpers reachable from the v2 ``LiverResections`` Pipeline
+  representations with no MRML or OpenGL linkage).
+
+==============================================================================*/
+
+#ifndef __vtkLiverResectogramPixelMapping_h_
+#define __vtkLiverResectogramPixelMapping_h_
+
+#include "vtkSlicerLiverResectionsModuleAlgorithmExport.h"
+
+// VTK includes
+#include <vtkObject.h>
+
+/**
+ * \class vtkLiverResectogramPixelMapping
+ *
+ * \brief Pure-VTK helper that inverts the resectogram's on-screen
+ * placement to recover the Bezier ``(u, v)`` parameter pair from a
+ * viewport pixel.
+ *
+ * ADR-0025 §Context establishes that the resectogram is a 1:1 image of
+ * the Bezier ``(u, v)`` parameter domain: a resectogram pixel maps to a
+ * ``(u, v)`` pair maps to a world point by direct Bezier surface
+ * evaluation — an exact correspondence, no geometric search.  The
+ * locator architecture (issue #414, depends on T3) relies on this
+ * mapping being stable.
+ *
+ * \par Contract
+ *  - The flattened quad fills the viewport; ``(u, v) = (0, 0)`` at the
+ *    bottom-left corner and ``(1, 1)`` at the top-right.
+ *  - The anisotropic ``matRatio`` ``{su, sv}`` scales the quad about the
+ *    viewport centre (the v1 vertex shader multiplies ``gl_Position`` by
+ *    a matrix with ``m[0][0] = su`` / ``m[1][1] = sv``;
+ *    ``vtkOpenGLResection2DPolyDataMapper``, post-relocation home
+ *    ``LiverResections/VTKWidgets/``).  ``PixelToUV`` inverts that
+ *    placement: a pixel at the viewport centre maps to ``(0.5, 0.5)``
+ *    for ANY ratio (the scaling fixed point); off-centre pixels divide
+ *    out the ratio.
+ *  - For an isotropic ``{1, 1}`` the map is the plain linear
+ *    ``u = pixel.x / width``, ``v = pixel.y / height``.
+ *
+ * \par MRML invariant
+ *  No ``vtkMRMLNode`` references.  Per ADR-0015 §1 the Algorithm library
+ *  is pure VTK.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverResectogramPixelMapping : public vtkObject
+{
+public:
+  static vtkLiverResectogramPixelMapping* New();
+  vtkTypeMacro(vtkLiverResectogramPixelMapping, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Map a viewport ``pixel`` (origin bottom-left) to the Bezier
+  /// ``(u, v)`` parameter pair in ``[0, 1]^2``, inverting the
+  /// anisotropic ``matRatio`` ``{su, sv}`` placement about the viewport
+  /// centre.  ``viewportSize`` is ``{width, height}`` in pixels.  Writes
+  /// the result into ``uvOut[2]``.
+  static void PixelToUV(const double pixel[2], const int viewportSize[2], const double matRatio[2], double uvOut[2]);
+
+protected:
+  vtkLiverResectogramPixelMapping();
+  ~vtkLiverResectogramPixelMapping() override;
+
+private:
+  vtkLiverResectogramPixelMapping(const vtkLiverResectogramPixelMapping&) = delete;
+  void operator=(const vtkLiverResectogramPixelMapping&) = delete;
+};
+
+#endif // __vtkLiverResectogramPixelMapping_h_

--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -25,11 +25,14 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   __init__.py
   DistanceMaps.py
   LiverBezierSurfacePipeline.py
+  ResectogramPipeline.py
   Representations/__init__.py
   Representations/BezierPlanningRepresentation.py
   Representations/ConfirmedRepresentation.py
   Representations/DistanceSpheroidInitRepresentation.py
   Representations/SlicingPlaneInitRepresentation.py
+  Representations/FlattenedSurfaceRepresentation.py
+  Representations/VascularContourRepresentation.py
   )
 
 set(LiverResectionsLib_PYTHON_RESOURCES

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -1,0 +1,442 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Representation that owns the resectogram's flattened-surface assembly.
+
+The resectogram is the flattened 2D image of the Bezier ``(u, v)``
+parameter domain (ADR-0025 §Context).  In the v1 monolith
+``vtkSlicerBezierSurfaceRepresentation3D`` this assembly is the 2D path:
+a ``BezierPlane`` source feeding the
+``vtkOpenGLResection2DPolyDataMapper`` (relocated home
+``LiverResections/VTKWidgets/``), rendered through a private
+``ResectogramCamera`` into a dedicated overlay renderer, with the
+distance-map texture bound to the mapper and the anisotropic
+``MatRatio`` scaling applied.
+
+This Representation is the v2.0 LayerDM-bound home of that assembly per
+ADR-0013 §6 (Representations are composable VTK pipelines).  It owns:
+
+* the ``BezierPlane`` flattened-quad source,
+* the 2D resection mapper + actor,
+* the ``ResectogramCamera``,
+* the distance-map texture binding, and
+* the ``MatRatio`` aspect-ratio scaling, computed via the pure-VTK
+  ``vtkLiverResectogramAspectRatio`` helper (Algorithm library,
+  ADR-0015 §1) rather than re-deriving the v1 ``Ratio(bool)`` math.
+
+Scope of this skeleton
+----------------------
+Per the T3 bounded slice this skeleton COMPOSES the assembly and wires
+the display-node fields it consumes, but it does NOT yet sever the
+assembly out of the v1 monolith (that is a separate follow-up; until
+then the monolith remains the live 2D renderer) and it does NOT add the
+Gaussian-blur pass (a later v2.0 toggle).  The aspect-ratio math is
+routed through the extracted Algorithm helper; the Gaussian-blur hook
+is intentionally absent.
+
+The VTK objects are soft dependencies — same pattern as
+``ConfirmedRepresentation``: a pure-Python pytest run skips the VTK-only
+branches, while a Slicer process (or any environment with VTK on
+``PYTHONPATH``) exercises the full pipeline.  The relocated 2D mapper
+(``vtkOpenGLResection2DPolyDataMapper``) and the ``vtkBezierSurfaceSource``
+are reachable only inside a Slicer process, so their use is gated behind
+``hasattr`` / import guards and the generic VTK fallbacks keep the
+skeleton importable everywhere.
+
+References
+----------
+* `ADR-0013`_ §6 — Representations as composable VTK pipelines.
+* `ADR-0015`_ §1 — Algorithm-library pure-VTK helpers
+  (``vtkLiverResectogramAspectRatio``).
+* `ADR-0025`_ §Context — the resectogram is a 1:1 image of the Bezier
+  ``(u, v)`` parameter domain.
+
+.. _ADR-0013: ../../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0015: ../../../Docs/adr/0015-cpp-algorithm-library.md
+.. _ADR-0025: ../../../Docs/adr/0025-locator-architecture.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# VTK is a soft dependency (see module docstring).
+# --------------------------------------------------------------------------- #
+
+try:  # pragma: no cover — exercised inside Slicer / when VTK is available
+    import vtk
+
+    _HAS_VTK = True
+except ImportError:  # pragma: no cover — pure-Python path
+    vtk = None  # type: ignore[assignment]
+    _HAS_VTK = False
+
+
+# --------------------------------------------------------------------------- #
+# Overlay-renderer layer for the resectogram (matches the v1 monolith's
+# RENDERER_LAYER for the 2D co-renderer).
+# --------------------------------------------------------------------------- #
+
+RESECTOGRAM_RENDERER_LAYER = 1
+
+
+class FlattenedSurfaceRepresentation:
+    """VTK assembly for the resectogram's flattened surface.
+
+    Constructor
+    -----------
+    ``FlattenedSurfaceRepresentation(renderer=None)``
+
+    * ``renderer`` — the ``vtkRenderer`` the resectogram actor is added
+      to.  Optional; ``None`` is supported for unit tests (the actor
+      exists but is unrendered).
+
+    Public methods
+    --------------
+    * ``update(display_node, data_node)`` — reads decoration from the
+      display node (``ShowResection2D`` / ``MirrorDisplay`` /
+      ``EnableFlexibleBoundary`` / ``TextureNumComps``), geometry from
+      the data node, recomputes ``MatRatio`` through the Algorithm
+      helper, and reconciles the resectogram actor.  Tolerant of
+      ``None`` arguments.
+    * ``cleanup()`` — detaches the actor from the renderer and releases
+      the VTK pipeline.
+
+    Introspection (used by unit tests)
+    ----------------------------------
+    * ``GetResectionMapper2D()`` / ``GetResectionActor2D()`` — the 2D
+      mapper + actor pair, or ``None`` when VTK is absent.
+    * ``GetResectogramCamera()`` — the private overlay camera.
+    * ``GetMatRatioApplied()`` — last ``MatRatio`` pushed onto the 2D
+      mapper, or ``None`` before the first ``update()`` / when the
+      mapper does not expose ``SetMatRatio``.
+    """
+
+    def __init__(self, renderer: Any | None = None) -> None:
+        self._renderer: Any | None = None
+
+        self._bezier_plane: Any | None = None
+        self._resection_mapper_2d: Any | None = None
+        self._resection_actor_2d: Any | None = None
+        self._resectogram_camera: Any | None = None
+
+        # Last MatRatio pushed onto the 2D mapper.  ``None`` until the
+        # first ``update()`` runs OR the mapper does not expose
+        # ``SetMatRatio`` (generic-mapper fallback path).
+        self._mat_ratio_applied: tuple[float, float] | None = None
+
+        # Memoised input — same idempotency strategy as
+        # ConfirmedRepresentation.
+        self._last_surface_signature: tuple | None = None
+        self._input_refresh_count: int = 0
+
+        if _HAS_VTK:
+            self._build_vtk_pipeline()
+
+        if renderer is not None:
+            self.SetRenderer(renderer)
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def SetRenderer(self, renderer: Any | None) -> None:
+        """Attach the resectogram actor to ``renderer``."""
+        if self._renderer is not None and self._renderer is not renderer:
+            self._detach_actors(self._renderer)
+        self._renderer = renderer
+        if renderer is not None:
+            self._attach_actors(renderer)
+
+    def GetRenderer(self) -> Any | None:
+        return self._renderer
+
+    def update(self, display_node: Any | None, data_node: Any | None) -> None:
+        """Reconcile the resectogram against the current display + data nodes.
+
+        Tolerant of ``None`` arguments — when either node is missing the
+        actor falls back to invisible / default state.
+        """
+        self._apply_display_node(display_node)
+        self._apply_data_node(display_node, data_node)
+
+    def cleanup(self) -> None:
+        """Detach actors from the renderer and drop the VTK pipeline."""
+        if self._renderer is not None:
+            self._detach_actors(self._renderer)
+            self._renderer = None
+        self._bezier_plane = None
+        self._resection_mapper_2d = None
+        self._resection_actor_2d = None
+        self._resectogram_camera = None
+
+    # ------------------------------------------------------------------ #
+    # Introspection — used by the unit-layer tests
+    # ------------------------------------------------------------------ #
+
+    def GetResectionMapper2D(self) -> Any | None:
+        return self._resection_mapper_2d
+
+    def GetResectionActor2D(self) -> Any | None:
+        return self._resection_actor_2d
+
+    def GetResectogramCamera(self) -> Any | None:
+        return self._resectogram_camera
+
+    def GetBezierPlane(self) -> Any | None:
+        return self._bezier_plane
+
+    def GetMatRatioApplied(self) -> tuple[float, float] | None:
+        return self._mat_ratio_applied
+
+    def GetInputRefreshCount(self) -> int:
+        return self._input_refresh_count
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _build_vtk_pipeline(self) -> None:
+        """Construct the flattened-quad source, 2D mapper, actor + camera.
+
+        Prefers the relocated ``vtkOpenGLResection2DPolyDataMapper`` and
+        ``vtkBezierSurfaceSource`` (reachable inside a Slicer process);
+        falls back to a generic ``vtkPolyDataMapper`` + ``vtkPlaneSource``
+        so the skeleton stays importable in a bare VTK environment.  The
+        public API is invariant across the fallback — only the concrete
+        mapper / source types flip.
+        """
+        assert vtk is not None  # gated by _HAS_VTK
+
+        self._bezier_plane = _make_flattened_quad_source()
+
+        mapper = _make_resection_mapper_2d()
+        if self._bezier_plane is not None and hasattr(mapper, "SetInputConnection"):
+            mapper.SetInputConnection(self._bezier_plane.GetOutputPort())
+        self._resection_mapper_2d = mapper
+
+        self._resection_actor_2d = vtk.vtkActor()
+        self._resection_actor_2d.SetMapper(self._resection_mapper_2d)
+        self._resection_actor_2d.SetVisibility(False)
+
+        self._resectogram_camera = vtk.vtkCamera()
+
+    def _attach_actors(self, renderer: Any) -> None:
+        if self._resection_actor_2d is not None and hasattr(renderer, "AddActor"):
+            renderer.AddActor(self._resection_actor_2d)
+
+    def _detach_actors(self, renderer: Any) -> None:
+        if self._resection_actor_2d is not None and hasattr(renderer, "RemoveActor"):
+            try:
+                renderer.RemoveActor(self._resection_actor_2d)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+    def _apply_display_node(self, display_node: Any | None) -> None:
+        """Push resectogram decoration fields onto the 2D mapper + actor."""
+        show_2d = _safe_get_bool(display_node, "GetShowResection2D", default=False)
+        texture_num_comps = _safe_get_int(
+            display_node, "GetTextureNumComps", default=0
+        )
+
+        if self._resection_actor_2d is not None:
+            self._resection_actor_2d.SetVisibility(bool(show_2d))
+
+        mapper = self._resection_mapper_2d
+        if mapper is not None:
+            setter = getattr(mapper, "SetTextureNumComps", None)
+            if setter is not None:
+                setter(texture_num_comps)
+
+    def _apply_data_node(
+        self, display_node: Any | None, data_node: Any | None
+    ) -> None:
+        """Push the sampled surface onto the quad source, then recompute
+        the anisotropic ``MatRatio`` via the Algorithm helper.
+
+        The ``MatRatio`` math is NOT re-derived here — it is routed
+        through the extracted pure-VTK ``vtkLiverResectogramAspectRatio``
+        helper (ADR-0015 §1), with ``flexibleBoundary`` taken from the
+        display node's ``EnableFlexibleBoundary`` field.
+        """
+        flexible = _safe_get_bool(
+            display_node, "GetEnableFlexibleBoundary", default=False
+        )
+
+        sampled = _safe_get_sampled_surface(data_node)
+        signature = (id(sampled) if sampled is not None else None, bool(flexible))
+        if signature != self._last_surface_signature:
+            self._last_surface_signature = signature
+            self._input_refresh_count += 1
+
+        self._apply_mat_ratio(sampled, flexible)
+
+    def _apply_mat_ratio(self, sampled: Any | None, flexible: bool) -> None:
+        """Compute + push the resectogram aspect-ratio scaling.
+
+        Delegates the arc-length math to
+        ``vtkLiverResectogramAspectRatio::ComputeAspectRatio`` (Algorithm
+        library) — the skeleton must not re-derive the v1 ``Ratio(bool)``
+        computation.  When the helper or the sampled surface is
+        unavailable (bare-VTK pytest path), falls back to the isotropic
+        ``{1, 1}`` so the actor still has a defined scaling.
+        """
+        mapper = self._resection_mapper_2d
+        if mapper is None:
+            return
+        setter = getattr(mapper, "SetMatRatio", None)
+        if setter is None:
+            return
+
+        ratio = self._compute_aspect_ratio(sampled, flexible)
+        if ratio is None:
+            return
+        setter(list(ratio))
+        self._mat_ratio_applied = (float(ratio[0]), float(ratio[1]))
+
+    def _compute_aspect_ratio(
+        self, sampled: Any | None, flexible: bool
+    ) -> tuple[float, float] | None:
+        """Return ``{su, sv}`` via the Algorithm helper, or ``{1, 1}``.
+
+        Not-flexible (or missing sampled surface) short-circuits to the
+        isotropic ``{1, 1}`` — matching the v1 ``Ratio`` else-branch — so
+        no ``vtkPoints`` is required for that path.
+        """
+        if not flexible or sampled is None:
+            return (1.0, 1.0)
+
+        helper = _import_aspect_ratio_helper()
+        if helper is None:
+            return (1.0, 1.0)
+
+        samples_u, samples_v = _sampled_surface_resolution(sampled)
+        ratio_out = [0.0, 0.0]
+        try:
+            helper.ComputeAspectRatio(sampled, samples_u, samples_v, True, ratio_out)
+        except Exception:  # pragma: no cover - defensive
+            return (1.0, 1.0)
+        return (float(ratio_out[0]), float(ratio_out[1]))
+
+
+# --------------------------------------------------------------------------- #
+# Helpers — small, self-contained per ADR-0013 §6 (Representations are
+# independently importable).
+# --------------------------------------------------------------------------- #
+
+
+def _make_flattened_quad_source() -> Any | None:
+    """Return the flattened-quad source feeding the 2D mapper.
+
+    Prefers the ``vtkBezierSurfaceSource`` the v1 monolith uses for the
+    ``BezierPlane`` (reachable in a Slicer process); falls back to a
+    generic ``vtkPlaneSource`` so the skeleton stays importable.
+    """
+    if not _HAS_VTK:
+        return None
+    factory = getattr(vtk, "vtkBezierSurfaceSource", None)
+    if factory is not None:
+        return factory()
+    return vtk.vtkPlaneSource()
+
+
+def _make_resection_mapper_2d() -> Any:
+    """Return the resectogram's 2D mapper.
+
+    Prefers the relocated ``vtkOpenGLResection2DPolyDataMapper``
+    (``LiverResections/VTKWidgets/``, reachable in a Slicer process);
+    falls back to a generic ``vtkPolyDataMapper``.
+    """
+    assert vtk is not None
+    factory = getattr(vtk, "vtkOpenGLResection2DPolyDataMapper", None)
+    if factory is None:
+        try:  # pragma: no cover — exercised inside Slicer
+            from slicer import vtkOpenGLResection2DPolyDataMapper as factory  # type: ignore[no-redef]
+        except Exception:
+            factory = None
+    if factory is not None:
+        return factory()
+    return vtk.vtkPolyDataMapper()
+
+
+def _import_aspect_ratio_helper() -> Any | None:
+    """Return the ``vtkLiverResectogramAspectRatio`` helper class.
+
+    Reachable from a Slicer process via the ``slicer`` namespace or the
+    wrapped Algorithm module.  Returns ``None`` in a bare-VTK pytest run
+    where the wrapped class is not importable.
+    """
+    if _HAS_VTK:
+        factory = getattr(vtk, "vtkLiverResectogramAspectRatio", None)
+        if factory is not None:
+            return factory
+    try:  # pragma: no cover — exercised inside Slicer
+        from slicer import vtkLiverResectogramAspectRatio  # type: ignore[import-not-found]
+
+        return vtkLiverResectogramAspectRatio
+    except Exception:
+        return None
+
+
+def _sampled_surface_resolution(sampled: Any) -> tuple[int, int]:
+    """Best-effort ``(samplesU, samplesV)`` for a sampled surface grid.
+
+    The v1 ``Ratio`` walks a 20×20 sampled grid; default to that when the
+    points object does not carry an explicit resolution.
+    """
+    default = 20
+    try:
+        n = int(sampled.GetNumberOfPoints())
+    except Exception:
+        return (default, default)
+    if n <= 0:
+        return (default, default)
+    side = int(round(n**0.5))
+    if side * side == n:
+        return (side, side)
+    return (default, default)
+
+
+def _safe_get_sampled_surface(data_node: Any | None) -> Any | None:
+    """Return the sampled-surface ``vtkPoints`` off the data node, if any.
+
+    Reads a small set of conventional accessors defensively; returns
+    ``None`` when none are present (stub data nodes in unit tests).
+    """
+    if data_node is None:
+        return None
+    for name in ("GetSampledSurfacePoints", "GetSurfacePoints"):
+        getter = getattr(data_node, name, None)
+        if getter is None:
+            continue
+        try:
+            value = getter()
+        except Exception:  # pragma: no cover - defensive
+            continue
+        if value is not None:
+            return value
+    return None
+
+
+def _safe_get_bool(node: Any | None, getter_name: str, *, default: bool) -> bool:
+    if node is None:
+        return default
+    getter = getattr(node, getter_name, None)
+    if getter is None:
+        return default
+    try:
+        return bool(getter())
+    except Exception:  # pragma: no cover - defensive
+        return default
+
+
+def _safe_get_int(node: Any | None, getter_name: str, *, default: int) -> int:
+    if node is None:
+        return default
+    getter = getattr(node, getter_name, None)
+    if getter is None:
+        return default
+    try:
+        return int(getter())
+    except Exception:  # pragma: no cover - defensive
+        return default

--- a/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Representation that owns the resectogram's vascular-contour overlays.
+
+The resectogram draws the hepatic / portal vascular contours on top of
+the flattened surface so the surgeon can read vessel proximity in the
+2D ``(u, v)`` image (ADR-0025 §Context).  In the v1 monolith those
+overlays are driven by two custom mappers — the distance-contour mapper
+and the slicing-contour mapper — relocated into
+``LiverResections/VTKWidgets/`` (``vtkOpenGLDistanceContourPolyDataMapper``
+and ``vtkOpenGLSlicingContourPolyDataMapper``).
+
+This Representation is the v2.0 LayerDM-bound home of that overlay per
+ADR-0013 §6 (Representations are composable VTK pipelines).  It wraps
+the two contour mappers + their actors and reconciles their visibility
+against the resectogram display node.
+
+Scope of this skeleton
+----------------------
+Per the T3 bounded slice this skeleton COMPOSES the contour overlays and
+wires the display-node fields it consumes, but it does NOT yet sever the
+overlays out of the v1 monolith (a separate follow-up).  The contour
+mappers are reachable only inside a Slicer process, so their use is
+gated behind ``hasattr`` / import guards and the generic VTK fallbacks
+keep the skeleton importable everywhere (same soft-VTK pattern as
+``ConfirmedRepresentation`` and ``FlattenedSurfaceRepresentation``).
+
+References
+----------
+* `ADR-0013`_ §6 — Representations as composable VTK pipelines.
+* `ADR-0014`_ §3 — mapper relocation (the contour mappers now live
+  under ``LiverResections/VTKWidgets/``).
+* `ADR-0025`_ §Context — the resectogram and its vascular overlays.
+
+.. _ADR-0013: ../../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0014: ../../../Docs/adr/0014-livermarkups-dissolution.md
+.. _ADR-0025: ../../../Docs/adr/0025-locator-architecture.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# VTK is a soft dependency (see module docstring).
+# --------------------------------------------------------------------------- #
+
+try:  # pragma: no cover — exercised inside Slicer / when VTK is available
+    import vtk
+
+    _HAS_VTK = True
+except ImportError:  # pragma: no cover — pure-Python path
+    vtk = None  # type: ignore[assignment]
+    _HAS_VTK = False
+
+
+class VascularContourRepresentation:
+    """VTK assembly for the resectogram's vascular-contour overlays.
+
+    Constructor
+    -----------
+    ``VascularContourRepresentation(renderer=None)``
+
+    * ``renderer`` — the ``vtkRenderer`` the contour actors are added
+      to.  Optional; ``None`` is supported for unit tests.
+
+    Public methods
+    --------------
+    * ``update(display_node, data_node)`` — reconciles the contour
+      actors' visibility against the display node's ``ShowResection2D``
+      field.  Tolerant of ``None`` arguments.
+    * ``cleanup()`` — detaches the actors and releases the VTK pipeline.
+
+    Introspection (used by unit tests)
+    ----------------------------------
+    * ``GetDistanceContourMapper()`` / ``GetSlicingContourMapper()`` —
+      the two contour mappers, or ``None`` when VTK is absent.
+    * ``GetDistanceContourActor()`` / ``GetSlicingContourActor()`` —
+      the matching actors.
+    """
+
+    def __init__(self, renderer: Any | None = None) -> None:
+        self._renderer: Any | None = None
+
+        self._distance_contour_mapper: Any | None = None
+        self._distance_contour_actor: Any | None = None
+        self._slicing_contour_mapper: Any | None = None
+        self._slicing_contour_actor: Any | None = None
+
+        self._update_count: int = 0
+
+        if _HAS_VTK:
+            self._build_vtk_pipeline()
+
+        if renderer is not None:
+            self.SetRenderer(renderer)
+
+    # ------------------------------------------------------------------ #
+    # Public API
+    # ------------------------------------------------------------------ #
+
+    def SetRenderer(self, renderer: Any | None) -> None:
+        """Attach the contour actors to ``renderer``."""
+        if self._renderer is not None and self._renderer is not renderer:
+            self._detach_actors(self._renderer)
+        self._renderer = renderer
+        if renderer is not None:
+            self._attach_actors(renderer)
+
+    def GetRenderer(self) -> Any | None:
+        return self._renderer
+
+    def update(self, display_node: Any | None, data_node: Any | None) -> None:
+        """Reconcile the contour actors' visibility against the display node."""
+        del data_node  # geometry feed lands with the monolith-sever follow-up
+        show = _safe_get_bool(display_node, "GetShowResection2D", default=False)
+        for actor in (self._distance_contour_actor, self._slicing_contour_actor):
+            if actor is not None:
+                actor.SetVisibility(bool(show))
+        self._update_count += 1
+
+    def cleanup(self) -> None:
+        """Detach actors from the renderer and drop the VTK pipeline."""
+        if self._renderer is not None:
+            self._detach_actors(self._renderer)
+            self._renderer = None
+        self._distance_contour_mapper = None
+        self._distance_contour_actor = None
+        self._slicing_contour_mapper = None
+        self._slicing_contour_actor = None
+
+    # ------------------------------------------------------------------ #
+    # Introspection — used by the unit-layer tests
+    # ------------------------------------------------------------------ #
+
+    def GetDistanceContourMapper(self) -> Any | None:
+        return self._distance_contour_mapper
+
+    def GetSlicingContourMapper(self) -> Any | None:
+        return self._slicing_contour_mapper
+
+    def GetDistanceContourActor(self) -> Any | None:
+        return self._distance_contour_actor
+
+    def GetSlicingContourActor(self) -> Any | None:
+        return self._slicing_contour_actor
+
+    def GetUpdateCount(self) -> int:
+        return self._update_count
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _build_vtk_pipeline(self) -> None:
+        """Construct the two contour mappers + their actors.
+
+        Prefers the relocated ``vtkOpenGLDistanceContourPolyDataMapper``
+        / ``vtkOpenGLSlicingContourPolyDataMapper``
+        (``LiverResections/VTKWidgets/``); falls back to a generic
+        ``vtkPolyDataMapper`` so the skeleton stays importable in a bare
+        VTK environment.
+        """
+        assert vtk is not None  # gated by _HAS_VTK
+
+        self._distance_contour_mapper = _make_contour_mapper(
+            "vtkOpenGLDistanceContourPolyDataMapper"
+        )
+        self._distance_contour_actor = vtk.vtkActor()
+        self._distance_contour_actor.SetMapper(self._distance_contour_mapper)
+        self._distance_contour_actor.SetVisibility(False)
+
+        self._slicing_contour_mapper = _make_contour_mapper(
+            "vtkOpenGLSlicingContourPolyDataMapper"
+        )
+        self._slicing_contour_actor = vtk.vtkActor()
+        self._slicing_contour_actor.SetMapper(self._slicing_contour_mapper)
+        self._slicing_contour_actor.SetVisibility(False)
+
+    def _attach_actors(self, renderer: Any) -> None:
+        if not hasattr(renderer, "AddActor"):
+            return
+        for actor in (self._distance_contour_actor, self._slicing_contour_actor):
+            if actor is not None:
+                renderer.AddActor(actor)
+
+    def _detach_actors(self, renderer: Any) -> None:
+        if not hasattr(renderer, "RemoveActor"):
+            return
+        for actor in (self._distance_contour_actor, self._slicing_contour_actor):
+            if actor is not None:
+                try:
+                    renderer.RemoveActor(actor)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_contour_mapper(class_name: str) -> Any:
+    """Return a relocated contour mapper by class name, or a generic fallback.
+
+    The custom contour mappers are reachable from a Slicer process via
+    the ``vtk`` module (wrapped) or the ``slicer`` namespace; a bare-VTK
+    pytest run gets the generic ``vtkPolyDataMapper`` fallback.
+    """
+    assert vtk is not None
+    factory = getattr(vtk, class_name, None)
+    if factory is None:
+        try:  # pragma: no cover — exercised inside Slicer
+            import slicer
+
+            factory = getattr(slicer, class_name, None)
+        except Exception:
+            factory = None
+    if factory is not None:
+        return factory()
+    return vtk.vtkPolyDataMapper()
+
+
+def _safe_get_bool(node: Any | None, getter_name: str, *, default: bool) -> bool:
+    if node is None:
+        return default
+    getter = getattr(node, getter_name, None)
+    if getter is None:
+        return default
+    try:
+        return bool(getter())
+    except Exception:  # pragma: no cover - defensive
+        return default

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -1,0 +1,414 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""LayerDM Pipeline for the resectogram concept.
+
+The resectogram is the flattened 2D image of the Bezier ``(u, v)``
+parameter domain (`ADR-0025`_ §Context).  Per `ADR-0013`_ §1 there is
+exactly ONE Pipeline per display-node TYPE: the 3D Bezier-surface
+Pipeline already owns ``vtkMRMLParametricSurfaceDisplayNode``, so the
+resectogram gets its own dedicated ``vtkMRMLResectogramDisplayNode``
+and the ``ResectogramPipeline`` is keyed on THAT type.  Keying a second
+Pipeline on the shared parametric-surface display node would violate
+§1; the dedicated display node is the maintainer's resolution of that
+fork.
+
+This Pipeline is the v2.0 LayerDM-bound home of the resectogram render
+path that the v1 monolith ``vtkSlicerBezierSurfaceRepresentation3D``
+currently drives.  It composes two Representations (`ADR-0013`_ §6):
+
+* ``FlattenedSurfaceRepresentation`` — the flattened-quad source, the
+  2D resection mapper + actor, the private overlay camera, the
+  distance-map texture binding, and the anisotropic ``MatRatio``
+  scaling routed through the ``vtkLiverResectogramAspectRatio`` /
+  ``vtkLiverResectogramPixelMapping`` Algorithm helpers (`ADR-0015`_
+  §1) — no re-derivation of the v1 math.
+* ``VascularContourRepresentation`` — the distance- and
+  slicing-contour overlays the surgeon reads vessel proximity from.
+
+Unlike the Bezier Pipeline there is no ``(state, initMode)`` dispatch:
+the resectogram is a single composite render path.  ``UpdatePipeline()``
+forwards the current display + data nodes to BOTH Representations and
+short-circuits when nothing has changed (`ADR-0013`_ §3 idempotency
+contract).
+
+Pipeline base class
+-------------------
+`ADR-0013`_ §5 names ``vtkMRMLLayerDMScriptedPipeline`` (imported as
+``from LayerDMLib import vtkMRMLLayerDMScriptedPipeline``) as the
+canonical base.  This module ``pytest.importorskip("LayerDMLib")`` at
+import time — it executes only inside a Slicer process where LayerDMLib
+is importable (the launched-harness path, gated on issue #460 for CI).
+
+Lifecycle (LayerDM-managed)
+---------------------------
+Mirrors the Bezier Pipeline lifecycle (`ADR-0013`_ §5): no-arg
+``__init__``; ``SetViewNode`` / ``SetDisplayNode`` assigned by the
+manager; ``UpdatePipeline()`` reconciles the Representations;
+``OnRendererAdded`` builds the Representations once a renderer is
+available; ``OnRendererRemoved`` / ``cleanup`` tear them down.
+
+Pipeline-creator registration
+-----------------------------
+``registerResectogramPipelineCreator()`` (module bottom) performs
+`ADR-0013`_ §5 call 3 — ``vtkMRMLLayerDMPipelineFactory::GetInstance()
+->AddPipelineCreator(...)`` keyed on ``vtkMRMLResectogramDisplayNode``.
+``qSlicerLiverResectionsModule::setup()`` delegates to it via the
+loadable module's ``pythonManager()->executeString(...)``, alongside
+the Bezier creator's ``registerPipelineCreator()``.
+
+References
+----------
+* `ADR-0013`_ §1, §3, §5, §6 — Pipeline pattern, idempotency, the three
+  registration calls, Representations as composable VTK pipelines.
+* `ADR-0015`_ §1 — Algorithm-library pure-VTK helpers.
+* `ADR-0025`_ §Context — the resectogram as a 1:1 image of the Bezier
+  ``(u, v)`` parameter domain.
+
+.. _ADR-0013: ../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0015: ../../Docs/adr/0015-cpp-algorithm-library.md
+.. _ADR-0025: ../../Docs/adr/0025-locator-architecture.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Pipeline base — hard-required on the upstream LayerDM library per ADR-0013
+# §5.  Importable from any Slicer process that loaded the
+# SlicerLayerDisplayableManager extension.  Tests that exercise this module
+# outside Slicer ``pytest.importorskip("LayerDMLib")`` at module level.
+# --------------------------------------------------------------------------- #
+
+from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+
+
+class ResectogramPipeline(_PipelineBase):
+    """Composite Pipeline for the resectogram concept.
+
+    Constructed by LayerDM's ``vtkMRMLLayerDMPipelineManager`` via the
+    creator registered by ``registerResectogramPipelineCreator()`` at
+    module bottom.  No-arg constructor per the LayerDM contract.
+
+    Owns two Representations (the flattened surface + the vascular
+    contours).  ``UpdatePipeline()`` forwards the current display + data
+    nodes to both and is idempotent: it records the
+    ``(dataMTime, displayMTime)`` tuple it last ran against and
+    short-circuits when nothing has changed.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        # Node handles — populated when the manager calls the setters.
+        # ``SetDisplayNode`` derives ``_data_node`` from the display
+        # node's ``GetDisplayableNode()`` back-reference.
+        self._data_node: Any | None = None
+        self._display_node: Any | None = None
+
+        # Observer tags so ``cleanup()`` can detach precisely.  Index by
+        # ``id(node)`` because ``vtkObject`` subclasses are not
+        # universally hashable on identity.
+        self._observer_tags: dict[int, list[int]] = {}
+        self._observed_node_refs: list[Any] = []
+
+        # Memoised dispatch input — see ``UpdatePipeline``.
+        self._last_update_key: tuple | None = None
+
+        # Counter workflow tests assert idempotency against: advances
+        # only on real reconciliation work, not on short-circuits.
+        self._update_count: int = 0
+
+        # Composed Representations.  Built lazily by
+        # ``_ensure_representations()`` once a renderer is available.
+        self._flattened_surface: Any | None = None
+        self._vascular_contour: Any | None = None
+        self._representations_initialised = False
+
+    # ------------------------------------------------------------------ #
+    # LayerDM lifecycle overrides
+    # ------------------------------------------------------------------ #
+
+    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
+        """Attach the display node, derive the data node, wire observers.
+
+        Per `ADR-0013`_ §5 the manager calls this once after creating
+        the Pipeline.  Re-entrant: replacing an already-attached display
+        node detaches the old observers and re-derives the data node.
+        """
+        if self._display_node is not None:
+            self._detach_observer(self._display_node)
+        if self._data_node is not None:
+            self._detach_observer(self._data_node)
+
+        super().SetDisplayNode(displayNode)
+
+        self._display_node = displayNode
+        self._data_node = None
+        if displayNode is not None:
+            getter = getattr(displayNode, "GetDisplayableNode", None)
+            if getter is not None:
+                self._data_node = getter()
+            self._attach_observer(displayNode)
+            if self._data_node is not None:
+                self._attach_observer(self._data_node)
+
+        self._last_update_key = None
+
+    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        """Reconcile both Representations against the current node set.
+
+        Idempotent: a second call with no intervening node mutation is a
+        no-op observationally — the memoised ``(dataMTime, displayMTime)``
+        key short-circuits the work (`ADR-0013`_ §3).
+        """
+        self._ensure_representations()
+
+        data_mtime = _safe_get_mtime(self._data_node)
+        display_mtime = _safe_get_mtime(self._display_node)
+
+        key = (data_mtime, display_mtime)
+        if key == self._last_update_key:
+            return  # idempotent short-circuit
+        self._last_update_key = key
+
+        if self._flattened_surface is not None:
+            self._flattened_surface.update(self._display_node, self._data_node)
+        if self._vascular_contour is not None:
+            self._vascular_contour.update(self._display_node, self._data_node)
+
+        self._update_count += 1
+
+    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        """Build Representations once a renderer is attached.
+
+        Per `ADR-0013`_ §5 the renderer is supplied by the manager; the
+        Pipeline cannot construct its actor-bearing Representations until
+        ``GetRenderer()`` returns a non-None value.
+        """
+        del renderer  # accessed via self.GetRenderer() inside the helper
+        self._ensure_representations()
+        # Re-emit a dispatch so the Representations re-attach their actors
+        # against the new renderer.
+        self._last_update_key = None
+        self.UpdatePipeline()
+
+    def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        """Tear down Representations when the renderer goes away."""
+        del renderer
+        self.cleanup()
+
+    # ------------------------------------------------------------------ #
+    # Introspection — used by the workflow / unit tests
+    # ------------------------------------------------------------------ #
+
+    def GetDataNode(self) -> Any | None:
+        return self._data_node
+
+    def GetFlattenedSurfaceRepresentation(self) -> Any | None:
+        return self._flattened_surface
+
+    def GetVascularContourRepresentation(self) -> Any | None:
+        return self._vascular_contour
+
+    def GetUpdateCount(self) -> int:
+        """Total ``UpdatePipeline()`` calls that did real work
+        (short-circuits do not count).  Tests assert idempotency
+        against this."""
+        return self._update_count
+
+    def cleanup(self) -> None:
+        """Detach observers and tear down Representations.
+
+        Safe to call multiple times.  Per `ADR-0013`_ §5, normally
+        invoked from ``OnRendererRemoved`` when the display node leaves
+        the scene.
+        """
+        for node in list(self._observed_node_refs):
+            self._detach_observer(node)
+        self._observer_tags.clear()
+        self._observed_node_refs.clear()
+
+        for rep in (self._flattened_surface, self._vascular_contour):
+            if rep is not None:
+                try:
+                    rep.cleanup()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _ensure_representations(self) -> None:
+        """Build the two Representations once, on first dispatch.
+
+        Lazy construction lets the Pipeline survive the LayerDM
+        lifecycle ordering (``SetDisplayNode`` may fire before
+        ``OnRendererAdded``).  Per `ADR-0013`_ §6, Representations are
+        constructed once and reused.
+        """
+        if self._representations_initialised:
+            return
+
+        renderer = self._safe_get_renderer()
+
+        # Local imports to avoid a circular import.  Two import paths
+        # supported, mirroring the Bezier Pipeline:
+        #
+        # * Package-relative — when imported as
+        #   ``LiverResectionsLib.ResectogramPipeline`` from a
+        #   Slicer-installed loadable module.
+        # * Top-level — when the directory containing this file is on
+        #   ``sys.path`` directly (the unit-layer test convention).
+        try:  # pragma: no cover - exercised once per import path
+            from .Representations.FlattenedSurfaceRepresentation import (
+                FlattenedSurfaceRepresentation,
+            )
+            from .Representations.VascularContourRepresentation import (
+                VascularContourRepresentation,
+            )
+        except ImportError:
+            from Representations.FlattenedSurfaceRepresentation import (  # type: ignore[no-redef]
+                FlattenedSurfaceRepresentation,
+            )
+            from Representations.VascularContourRepresentation import (  # type: ignore[no-redef]
+                VascularContourRepresentation,
+            )
+
+        self._flattened_surface = FlattenedSurfaceRepresentation(renderer=renderer)
+        self._vascular_contour = VascularContourRepresentation(renderer=renderer)
+
+        self._representations_initialised = True
+
+    def _safe_get_renderer(self) -> Any | None:
+        """Return ``self.GetRenderer()`` if available, else ``None``.
+
+        The base ``vtkMRMLLayerDMPipelineI::GetRenderer`` is supplied
+        once the manager attaches the Pipeline to a renderer.  Tests that
+        construct the Pipeline before a renderer is wired need the
+        ``None`` fallback.
+        """
+        getter = getattr(self, "GetRenderer", None)
+        if getter is None:
+            return None
+        try:
+            return getter()
+        except Exception:  # pragma: no cover - defensive
+            return None
+
+    def _attach_observer(self, node: Any) -> None:
+        """Add a ``vtkCommand::ModifiedEvent`` observer to ``node``.
+
+        Routes the callback into ``UpdatePipeline()``.  Stores the
+        observer tag so ``cleanup()`` / ``_detach_observer`` can detach
+        precisely.
+        """
+        if node is None or not hasattr(node, "AddObserver"):
+            return
+
+        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
+        self._observer_tags.setdefault(id(node), []).append(tag)
+        if node not in self._observed_node_refs:
+            self._observed_node_refs.append(node)
+
+    def _detach_observer(self, node: Any) -> None:
+        if node is None:
+            return
+        tags = self._observer_tags.pop(id(node), [])
+        for tag in tags:
+            try:
+                node.RemoveObserver(tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        try:
+            self._observed_node_refs.remove(node)
+        except ValueError:
+            pass
+
+    def _on_node_modified(self, caller: Any, event: str) -> None:
+        """VTK observer callback — re-runs ``UpdatePipeline()``."""
+        del caller, event  # observers route uniformly into UpdatePipeline()
+        self.UpdatePipeline()
+
+
+# --------------------------------------------------------------------------- #
+# Safe accessors — tolerant of stub nodes that omit GetMTime etc.
+# --------------------------------------------------------------------------- #
+
+
+def _safe_get_mtime(node: Any) -> int:
+    """Read ``GetMTime()`` off ``node`` defensively; 0 when unavailable."""
+    if node is None:
+        return 0
+    getter = getattr(node, "GetMTime", None)
+    if getter is None:
+        return 0
+    try:
+        return int(getter())
+    except Exception:  # pragma: no cover - defensive
+        return 0
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline-creator registration — ADR-0013 §5 call 3
+# --------------------------------------------------------------------------- #
+
+
+_REGISTERED = False
+
+
+def registerResectogramPipelineCreator() -> None:
+    """Register the ``ResectogramPipeline`` creator with LayerDM.
+
+    Performs `ADR-0013`_ §5 call 3 keyed on
+    ``vtkMRMLResectogramDisplayNode`` — the dedicated display-node type
+    that resolves the §1 one-Pipeline-per-type fork (a second creator on
+    the shared ``vtkMRMLParametricSurfaceDisplayNode`` the Bezier
+    Pipeline owns would violate §1).
+
+    Idempotent via the module-level ``_REGISTERED`` flag.  The upstream
+    ``vtkMRMLLayerDMPipelineFactory::ContainsPipelineCreator`` compares
+    creators by smart-pointer identity, and every call to this function
+    constructs a *fresh* ``vtkMRMLLayerDMPipelineScriptedCreator``;
+    without the guard a second ``setup()`` invocation (module reload,
+    Slicer restart in embedded contexts) would append a duplicate.
+
+    The creator returns a fresh ``ResectogramPipeline`` only when the
+    ``(viewNode, node)`` pair matches
+    ``(vtkMRMLViewNode, vtkMRMLResectogramDisplayNode)``.  Other
+    combinations short-circuit to ``None`` so the Bezier creator (and any
+    other registered creator) gets a chance to handle them — no
+    cross-fire (`ADR-0013`_ §1).
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return
+
+    # Imports deferred so this module stays importable in plain Python
+    # (tests ``pytest.importorskip("LayerDMLib")`` already; the
+    # ``slicer``-prefixed symbols below are only reachable inside a
+    # Slicer process).
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLLayerDMPipelineFactory,
+        vtkMRMLLayerDMPipelineScriptedCreator,
+        vtkMRMLResectogramDisplayNode,
+        vtkMRMLViewNode,
+    )
+
+    def tryCreate(viewNode, node):
+        # 3D-only gating: the resectogram renders into an overlay
+        # renderer of a 3D view.  ``RegisterInDefaultViews`` registers the
+        # generic LayerDM DM in both 3D and slice factories, so this
+        # creator is invoked for slice-view nodes too — short-circuit to
+        # None there so other creators (or none) handle the slice path.
+        if not isinstance(viewNode, vtkMRMLViewNode):
+            return None
+        if not isinstance(node, vtkMRMLResectogramDisplayNode):
+            return None
+        return ResectogramPipeline()
+
+    creator = vtkMRMLLayerDMPipelineScriptedCreator()
+    creator.SetPythonCallback(tryCreate)
+    vtkMRMLLayerDMPipelineFactory.GetInstance().AddPipelineCreator(creator)
+    _REGISTERED = True

--- a/LiverResections/LiverResectionsLib/__init__.py
+++ b/LiverResections/LiverResectionsLib/__init__.py
@@ -20,8 +20,14 @@ from .LiverBezierSurfacePipeline import (
     LiverBezierSurfacePipeline,
     registerPipelineCreator,
 )
+from .ResectogramPipeline import (
+    ResectogramPipeline,
+    registerResectogramPipelineCreator,
+)
 
 __all__ = [
     "LiverBezierSurfacePipeline",
     "registerPipelineCreator",
+    "ResectogramPipeline",
+    "registerResectogramPipelineCreator",
 ]

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -52,6 +52,7 @@
 // recognise the new ``.lrp.json`` storage format.
 #include "vtkMRMLBezierSurfaceNode.h"
 #include "vtkMRMLParametricSurfaceDisplayNode.h"
+#include "vtkMRMLResectogramDisplayNode.h"
 #include "vtkMRMLResectionPlanNode.h"
 #include "vtkMRMLResectionPlanStorageNode.h"
 
@@ -135,6 +136,14 @@ void vtkSlicerLiverResectionsLogic::RegisterNodes()
   // persistence flows through the plan storage node below.
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLParametricSurfaceDisplayNode>::New());
+
+  // T3 ResectogramPipeline display node (ADR-0013 §1 + §5).  The
+  // resectogram is the flattened 2D image of the Bezier (u, v) domain
+  // (ADR-0025 §Context); it gets its OWN display-node type so the
+  // ResectogramPipeline can be keyed on it without sharing
+  // vtkMRMLParametricSurfaceDisplayNode (which the 3D Bezier-surface
+  // Pipeline owns) — one Pipeline per display-node type (ADR-0013 §1).
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectogramDisplayNode>::New());
 
   // Resection-plan family (2026-05-25 wrapper-vs-carrier amendment to
   // ADR-0014 §"Fourth layer" + ADR-0023 §"Persistence").  The plan

--- a/LiverResections/MRML/CMakeLists.txt
+++ b/LiverResections/MRML/CMakeLists.txt
@@ -15,6 +15,8 @@ set(${KIT}_SRCS
   vtkMRMLBezierSurfaceNode.cxx
   vtkMRMLParametricSurfaceDisplayNode.h
   vtkMRMLParametricSurfaceDisplayNode.cxx
+  vtkMRMLResectogramDisplayNode.h
+  vtkMRMLResectogramDisplayNode.cxx
   vtkMRMLResectionPlanNode.h
   vtkMRMLResectionPlanNode.cxx
   vtkMRMLResectionPlanStorageNode.h

--- a/LiverResections/MRML/vtkMRMLResectogramDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLResectogramDisplayNode.cxx
@@ -1,0 +1,120 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the T3 ResectogramPipeline work (see ADR-0013 §1 + §5 and
+  ADR-0025 §Context).
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLResectogramDisplayNode.h"
+
+// MRML includes
+#include <vtkMRMLNodePropertyMacros.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLResectogramDisplayNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLResectogramDisplayNode::vtkMRMLResectogramDisplayNode()
+  : ShowResection2D(false)
+  , MirrorDisplay(false)
+  , EnableFlexibleBoundary(false)
+  , TextureNumComps(0)
+{
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLResectogramDisplayNode::~vtkMRMLResectogramDisplayNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLResectogramDisplayNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent);
+
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLBooleanMacro(showResection2D, ShowResection2D);
+  vtkMRMLWriteXMLBooleanMacro(mirrorDisplay, MirrorDisplay);
+  vtkMRMLWriteXMLBooleanMacro(enableFlexibleBoundary, EnableFlexibleBoundary);
+  vtkMRMLWriteXMLIntMacro(textureNumComps, TextureNumComps);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLResectogramDisplayNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+
+  Superclass::ReadXMLAttributes(atts);
+
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLBooleanMacro(showResection2D, ShowResection2D);
+  vtkMRMLReadXMLBooleanMacro(mirrorDisplay, MirrorDisplay);
+  vtkMRMLReadXMLBooleanMacro(enableFlexibleBoundary, EnableFlexibleBoundary);
+  vtkMRMLReadXMLIntMacro(textureNumComps, TextureNumComps);
+  vtkMRMLReadXMLEndMacro();
+
+  this->EndModify(disabledModify);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLResectogramDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyBooleanMacro(ShowResection2D);
+  vtkMRMLCopyBooleanMacro(MirrorDisplay);
+  vtkMRMLCopyBooleanMacro(EnableFlexibleBoundary);
+  vtkMRMLCopyIntMacro(TextureNumComps);
+  vtkMRMLCopyEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLResectogramDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintBooleanMacro(ShowResection2D);
+  vtkMRMLPrintBooleanMacro(MirrorDisplay);
+  vtkMRMLPrintBooleanMacro(EnableFlexibleBoundary);
+  vtkMRMLPrintIntMacro(TextureNumComps);
+  vtkMRMLPrintEndMacro();
+}

--- a/LiverResections/MRML/vtkMRMLResectogramDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLResectogramDisplayNode.h
@@ -1,0 +1,153 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the T3 ResectogramPipeline work (see ADR-0013 §1 + §5 and
+  ADR-0025 §Context).
+
+==============================================================================*/
+
+#ifndef __vtkmrmlresectogramdisplaynode_h_
+#define __vtkmrmlresectogramdisplaynode_h_
+
+#include "vtkSlicerLiverResectionsModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLDisplayNode.h>
+
+// VTK includes
+#include <vtkSetGet.h>
+
+/**
+ * \class vtkMRMLResectogramDisplayNode
+ *
+ * \brief Display-only MRML node that keys the ResectogramPipeline.
+ *
+ * Per [ADR-0013 §1](../../Docs/adr/0013-layerdm-pipeline-pattern.md)
+ * there is exactly ONE LayerDM Pipeline per display-node TYPE.  The 3D
+ * Bezier-surface Pipeline already owns
+ * ``vtkMRMLParametricSurfaceDisplayNode``; keying a second Pipeline on
+ * that same type would violate §1.  The resectogram — the flattened 2D
+ * image of the Bezier ``(u, v)`` parameter domain (ADR-0025 §Context) —
+ * therefore gets its OWN display-node type, and the
+ * ``ResectogramPipeline`` is keyed on THIS class via the
+ * ``AddPipelineCreator`` registration of ADR-0013 §5.
+ *
+ * \par Field roster
+ *
+ * The fields are the resectogram-relevant subset of the legacy
+ * ``vtkMRMLMarkupsBezierSurfaceDisplayNode`` that the v1 monolith
+ * ``vtkSlicerBezierSurfaceRepresentation3D`` reads when driving the 2D
+ * mapper (``vtkOpenGLResection2DPolyDataMapper``):
+ *
+ *   - ``ShowResection2D`` — whether the resectogram strip renders.
+ *   - ``MirrorDisplay`` — whether the resectogram is mirrored to the
+ *     partner side panel (drives ``ResectogramPlaneCenter``).
+ *   - ``EnableFlexibleBoundary`` — whether the anisotropic aspect-ratio
+ *     scaling is applied (drives ``vtkLiverResectogramAspectRatio`` /
+ *     the v1 ``Ratio(bool)`` toggle); ``false`` forces the isotropic
+ *     ``{1, 1}``.
+ *   - ``TextureNumComps`` — number of components in the distance-map
+ *     texture the 2D mapper samples (the v1 ``SetTextureNumComps``
+ *     feed).
+ *
+ * \par Defaults
+ *
+ * Defaults match the legacy ``vtkMRMLMarkupsBezierSurfaceDisplayNode``
+ * constructor so a side-by-side comparison of the v1 monolith and the
+ * v2.0 ResectogramPipeline starts from an identical visual baseline
+ * (characterisation discipline, ADR-0003).
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLResectogramDisplayNode : public vtkMRMLDisplayNode
+{
+public:
+  static vtkMRMLResectogramDisplayNode* New();
+  vtkTypeMacro(vtkMRMLResectogramDisplayNode, vtkMRMLDisplayNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Get node XML tag name (like Volume, Model).
+  const char* GetNodeTagName() override { return "ResectogramDisplay"; }
+
+  /// Read node attributes from XML.
+  void ReadXMLAttributes(const char** atts) override;
+
+  /// Write this node's information to a MRML file in XML format.
+  void WriteXML(ostream& of, int indent) override;
+
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  void CopyContent(vtkMRMLNode* anode, bool deepCopy = true) override;
+
+  //--------------------------------------------------------------------------
+  // Resectogram display fields (subset of the legacy markups display node
+  // read by vtkOpenGLResection2DPolyDataMapper)
+  //--------------------------------------------------------------------------
+
+  /// Whether the resection renders as a 2D resectogram strip.
+  vtkSetMacro(ShowResection2D, bool);
+  vtkGetMacro(ShowResection2D, bool);
+
+  /// Whether the resectogram is mirrored to a partner display.
+  vtkSetMacro(MirrorDisplay, bool);
+  vtkGetMacro(MirrorDisplay, bool);
+
+  /// Whether the anisotropic aspect-ratio scaling is applied (drives
+  /// ``vtkLiverResectogramAspectRatio``); ``false`` forces ``{1, 1}``.
+  vtkSetMacro(EnableFlexibleBoundary, bool);
+  vtkGetMacro(EnableFlexibleBoundary, bool);
+
+  /// Number of components in the distance-map texture the resectogram
+  /// mapper samples.
+  vtkSetMacro(TextureNumComps, int);
+  vtkGetMacro(TextureNumComps, int);
+
+protected:
+  vtkMRMLResectogramDisplayNode();
+  ~vtkMRMLResectogramDisplayNode() override;
+
+private:
+  vtkMRMLResectogramDisplayNode(const vtkMRMLResectogramDisplayNode&) = delete;
+  void operator=(const vtkMRMLResectogramDisplayNode&) = delete;
+
+  bool ShowResection2D;
+  bool MirrorDisplay;
+  bool EnableFlexibleBoundary;
+  int TextureNumComps;
+};
+
+#endif //__vtkmrmlresectogramdisplaynode_h_

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -238,6 +238,16 @@ set(_visual_test_scenarios
   # COMMAND below supplies --additional-module-paths rather than
   # --disable-modules.
   DistanceSpheroidContourShader
+  # T3 ResectogramPipeline baseline targets (ADR-0027 invariant-test-
+  # first).  Each captures against the v1 monolith first, then is
+  # re-baselined to the v2.0 ResectogramPipeline.  Until the maintainer
+  # commits the .sha512 stubs the replay driver skips each at runtime.
+  Resectogram4x4BlurOff
+  Resectogram4x4NonSquareScaling
+  # SPLITTABLE / LAST — blur stays a v2.0 toggle; this baseline lands
+  # after the blur-off resectogram baselines are green (maintainer
+  # decision).  Listed here so the test surface is complete.
+  Resectogram4x4BlurOn
 )
 
 # Bundle extensions per scenario.  ``.png`` is the comparison target;

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Visual-regression scenario: 4x4 resectogram, BLUR OFF, square scaling.
+
+T3 ResectogramPipeline baseline target (ADR-0027 invariant-test-first).
+This is the reference resectogram appearance: the flattened parametric
+image of a square (u, v) domain Bezier surface, rendered through the T3
+ResectogramPipeline's flattened-surface Representation, with the
+Gaussian-blur post-pass DISABLED.
+
+Capture-then-rebaseline contract
+--------------------------------
+Per the T3 plan these baselines capture against the v1 monolith
+(``vtkSlicerBezierSurfaceRepresentation3D`` 5th-renderer resectogram)
+FIRST, establishing the pixels v2.0 must reproduce, then are RE-BASELINED
+to the v2.0 ResectogramPipeline once it lands.  The capture is
+maintainer-driven (``capture_baseline.py``); until a ``.sha512`` stub is
+committed under ``../Data/Baseline/`` the replay driver skips this
+scenario with a clear log line.
+
+Module-layer test, ADR-0008 §2/§3 (workflow row, ``render_interactive``
+fixture).  Importable from a pristine ``--no-main-window`` Slicer boot;
+``setup_scene`` exercises the production ResectogramPipeline path rather
+than hand-building MRML.
+
+References
+----------
+* ADR-0008 §2/§3 — module/workflow visual-regression discipline +
+  capture-then-replay harness.
+* ADR-0013 §6 — the flattened-surface Representation owned by the
+  ResectogramPipeline.
+* ADR-0027 — invariant-test-first; baseline captured before the v2.0
+  rewrite, re-baselined after.
+"""
+
+from __future__ import annotations
+
+# Shared viewport configuration for the resectogram panel.  The
+# resectogram is a 2D flattened image, so a parallel-projection square
+# panel is used; the exact numbers are pinned at first capture.
+VIEWPORT_WIDTH = 600
+VIEWPORT_HEIGHT = 600
+BACKGROUND_RGB = (0.0, 0.0, 0.0)
+ANTI_ALIASING_FRAMES = 0  # deterministic; AA introduces sub-pixel jitter
+
+# Whether the Gaussian-blur post-pass is engaged.  This scenario pins the
+# blur-OFF reference; Resectogram4x4BlurOn pins blur-ON.
+BLUR_ENABLED = False
+
+# Square (u, v) domain — control points span equal extents in u and v so
+# the aspect-ratio helper yields {1, 1} (no anisotropic squeeze).  This
+# is the counterpart to Resectogram4x4NonSquareScaling.
+PATCH_HALF_EXTENT_U = 45.0
+PATCH_HALF_EXTENT_V = 45.0
+
+
+def setup_scene():
+    """Populate the scene with the blur-off square-domain resectogram fixture.
+
+    TODO(liver-implementer): build the scene via the production
+    LiverResections logic + the T3 ResectogramPipeline, mirroring
+    ``BezierSurface4x4Planning.setup_scene`` but adding a
+    ``vtkMRMLResectogramDisplayNode`` (ADR-0013 §5 KEYING) with
+    ``BLUR_ENABLED = False`` and a square (u, v) control-point layout.
+    Return the created resection node.
+    """
+    raise NotImplementedError(
+        "Resectogram4x4BlurOff.setup_scene is a T3 baseline target; the "
+        "ResectogramPipeline + vtkMRMLResectogramDisplayNode do not exist "
+        "yet.  This body is reached only once a baseline .sha512 stub is "
+        "committed (see module docstring); until then the replay driver "
+        "skips before calling it."
+    )
+
+
+def setup_camera(view_node=None):
+    """Fix the resectogram panel's deterministic (parallel) view.
+
+    TODO(liver-implementer): set the parallel-projection pose that frames
+    the full flattened [0,1]^2 domain; pin the numbers at first capture.
+    """
+    raise NotImplementedError(
+        "Resectogram4x4BlurOff.setup_camera is a T3 baseline target."
+    )
+
+
+def setup_viewport(view_node=None):
+    """Set resectogram panel pixel size, background, anti-aliasing.
+
+    TODO(liver-implementer): mirror ``BezierSurface4x4Planning`` viewport
+    fixing (AA off for reproducibility).
+    """
+    raise NotImplementedError(
+        "Resectogram4x4BlurOff.setup_viewport is a T3 baseline target."
+    )
+
+
+def describe() -> dict:
+    """Metadata persisted alongside the captured bundle."""
+    return {
+        "scenario": "Resectogram4x4BlurOff",
+        "blur_enabled": BLUR_ENABLED,
+        "viewport": {
+            "size": [VIEWPORT_WIDTH, VIEWPORT_HEIGHT],
+            "background": list(BACKGROUND_RGB),
+            "anti_aliasing_frames": ANTI_ALIASING_FRAMES,
+        },
+    }

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOn.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOn.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Visual-regression scenario: 4x4 resectogram, BLUR ON, square scaling.
+
+T3 ResectogramPipeline baseline target (ADR-0027 invariant-test-first).
+
+SPLITTABLE / LAST.  Per the maintainer decision the Gaussian-blur
+post-pass stays a v2.0 feature behind a toggle, and this baseline is
+explicitly splittable from the rest of T3: if the launched harness
+(issue #460) blocks baseline capture, the blur work — and this scenario
+— land last, after the blur-OFF resectogram baselines are green.  It
+exists now as a placed target so the test surface is complete and the
+implementer knows GREEN here is the final T3 step, not a gate on the
+core resectogram landing.
+
+It differs from ``Resectogram4x4BlurOff`` only in ``BLUR_ENABLED`` —
+same square (u, v) domain, same camera/viewport — so the pixel delta
+isolates the blur post-pass.
+
+Capture-then-rebaseline contract: captured against the v1 monolith first
+(the v1 resectogram has no blur pass — see the T3 plan: "No
+vtkGaussianBlurPass anywhere in tree => blur is net-new"), so the FIRST
+baseline for this scenario is captured against the v2.0 path once the
+blur toggle exists.  There is no v1 blur appearance to reproduce; this
+scenario pins the v2.0 blur-on appearance directly.
+
+References
+----------
+* ADR-0008 §2/§3 — visual-regression harness.
+* ADR-0013 §6 — the blur is a per-frame state on the flattened-surface
+  Representation owned by the ResectogramPipeline.
+* ADR-0027 — invariant-test-first; this target is splittable/last.
+"""
+
+from __future__ import annotations
+
+VIEWPORT_WIDTH = 600
+VIEWPORT_HEIGHT = 600
+BACKGROUND_RGB = (0.0, 0.0, 0.0)
+ANTI_ALIASING_FRAMES = 0
+
+# The one variable that distinguishes this scenario from
+# Resectogram4x4BlurOff.
+BLUR_ENABLED = True
+
+PATCH_HALF_EXTENT_U = 45.0
+PATCH_HALF_EXTENT_V = 45.0
+
+
+def setup_scene():
+    """Populate the scene with the blur-on square-domain resectogram fixture.
+
+    TODO(liver-implementer): identical to ``Resectogram4x4BlurOff`` but
+    engage the Gaussian-blur post-pass via the
+    ``vtkMRMLResectogramDisplayNode`` blur toggle (ADR-0013 §6 per-frame
+    Representation state).  Author/land this LAST per the maintainer's
+    splittable-blur decision.
+    """
+    raise NotImplementedError(
+        "Resectogram4x4BlurOn.setup_scene is the SPLITTABLE/LAST T3 baseline "
+        "target; reached only once a baseline .sha512 stub is committed."
+    )
+
+
+def setup_camera(view_node=None):
+    """Fix the resectogram panel's deterministic (parallel) view."""
+    raise NotImplementedError(
+        "Resectogram4x4BlurOn.setup_camera is a T3 baseline target."
+    )
+
+
+def setup_viewport(view_node=None):
+    """Set resectogram panel pixel size, background, anti-aliasing."""
+    raise NotImplementedError(
+        "Resectogram4x4BlurOn.setup_viewport is a T3 baseline target."
+    )
+
+
+def describe() -> dict:
+    """Metadata persisted alongside the captured bundle."""
+    return {
+        "scenario": "Resectogram4x4BlurOn",
+        "blur_enabled": BLUR_ENABLED,
+        "viewport": {
+            "size": [VIEWPORT_WIDTH, VIEWPORT_HEIGHT],
+            "background": list(BACKGROUND_RGB),
+            "anti_aliasing_frames": ANTI_ALIASING_FRAMES,
+        },
+    }

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4NonSquareScaling.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4NonSquareScaling.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Visual-regression scenario: 4x4 resectogram, NON-SQUARE aspect scaling.
+
+T3 ResectogramPipeline baseline target (ADR-0027 invariant-test-first).
+This scenario is the VISUAL counterpart of the pure-math
+``vtkLiverResectogramAspectRatioTest``: it pins the on-screen effect of
+the anisotropic ``MatRatio`` scaling for a non-square (u, v) domain — the
+longer parametric axis is normalised to fill the panel and the shorter
+axis is squeezed by ``shorter/longer``.  A regression in the aspect-ratio
+helper (e.g. a stub that always emits ``{1, 1}``) shows up here as a
+square render where the baseline is rectangular.
+
+Blur is OFF in this scenario so the only visual variable versus
+``Resectogram4x4BlurOff`` is the domain aspect ratio.
+
+Capture-then-rebaseline contract: same as ``Resectogram4x4BlurOff`` —
+captured against the v1 monolith first, re-baselined to v2.0.
+
+References
+----------
+* ADR-0008 §2/§3 — visual-regression harness.
+* ADR-0013 §6 — flattened-surface Representation (carries the MatRatio
+  scaling state per the maintainer decision).
+* ADR-0027 — pairs with ``vtkLiverResectogramAspectRatioTest`` (the
+  pure-math pin) as the pixel-level pin of the same invariant.
+"""
+
+from __future__ import annotations
+
+VIEWPORT_WIDTH = 600
+VIEWPORT_HEIGHT = 600
+BACKGROUND_RGB = (0.0, 0.0, 0.0)
+ANTI_ALIASING_FRAMES = 0
+
+BLUR_ENABLED = False
+
+# Non-square (u, v) domain — the v extent is twice the u extent, so the
+# aspect-ratio helper yields {0.5, 1} (u squeezed to half).  This is the
+# pixel-level counterpart of vtkLiverResectogramAspectRatioTest Case 2.
+PATCH_HALF_EXTENT_U = 22.5
+PATCH_HALF_EXTENT_V = 45.0
+
+
+def setup_scene():
+    """Populate the scene with the non-square-domain resectogram fixture.
+
+    TODO(liver-implementer): lay out the 4x4 control points so the v
+    parametric extent is twice the u extent (PATCH_HALF_EXTENT_V =
+    2 * PATCH_HALF_EXTENT_U), and add a ``vtkMRMLResectogramDisplayNode``
+    with blur OFF.  The rendered panel must show the v1 anisotropic
+    squeeze; re-baseline to v2.0 once the ResectogramPipeline lands.
+    """
+    raise NotImplementedError(
+        "Resectogram4x4NonSquareScaling.setup_scene is a T3 baseline target; "
+        "reached only once a baseline .sha512 stub is committed."
+    )
+
+
+def setup_camera(view_node=None):
+    """Fix the resectogram panel's deterministic (parallel) view."""
+    raise NotImplementedError(
+        "Resectogram4x4NonSquareScaling.setup_camera is a T3 baseline target."
+    )
+
+
+def setup_viewport(view_node=None):
+    """Set resectogram panel pixel size, background, anti-aliasing."""
+    raise NotImplementedError(
+        "Resectogram4x4NonSquareScaling.setup_viewport is a T3 baseline target."
+    )
+
+
+def describe() -> dict:
+    """Metadata persisted alongside the captured bundle."""
+    return {
+        "scenario": "Resectogram4x4NonSquareScaling",
+        "blur_enabled": BLUR_ENABLED,
+        "viewport": {
+            "size": [VIEWPORT_WIDTH, VIEWPORT_HEIGHT],
+            "background": list(BACKGROUND_RGB),
+            "anti_aliasing_frames": ANTI_ALIASING_FRAMES,
+        },
+    }

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -195,6 +195,7 @@ void qSlicerLiverResectionsModule::setup()
       pythonManager->executeString("try:\n"
                                    "    import LiverResectionsLib\n"
                                    "    LiverResectionsLib.registerPipelineCreator()\n"
+                                   "    LiverResectionsLib.registerResectogramPipelineCreator()\n"
                                    "except ImportError as exc:\n"
                                    "    import logging\n"
                                    "    logging.critical('LiverResections: LayerDM Pipeline creator not registered (%s)'\n"

--- a/Testing/Python/workflow/test_resectogram_pipeline_dispatch.py
+++ b/Testing/Python/workflow/test_resectogram_pipeline_dispatch.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Workflow-layer registration + dispatch test for the T3 ResectogramPipeline.
+
+Per ADR-0013 §1 there is exactly ONE Pipeline per display-node TYPE.  The
+maintainer decision for T3 is KEYING = a dedicated display node: T3 adds a
+new ``vtkMRMLResectogramDisplayNode`` and the ResectogramPipeline is a
+standalone Pipeline keyed on THAT type — NOT on the shared
+``vtkMRMLParametricSurfaceDisplayNode`` that the T2 Bezier 3D-surface
+Pipeline owns.  ADR-0013 §5 for T3 is therefore:
+
+* RegisterNodeClass(``vtkMRMLResectogramDisplayNode``) — NEW.
+* the upstream LayerDM displayable-manager RegisterInDefaultViews() —
+  already present (T2 wired it; idempotent).
+* AddPipelineCreator keyed on ``vtkMRMLResectogramDisplayNode`` — the
+  only new §5 wiring.
+
+This test pins TWO specific invariants (ADR-0027 — the specific
+invariant, not "some pipeline exists"):
+
+1. **Dispatch fires for the new type.**  Adding a
+   ``vtkMRMLResectogramDisplayNode`` to a scene with a LayerDM-aware 3D
+   view causes the manager to instantiate a live ResectogramPipeline /
+   bridge for it.
+2. **No collision with the Bezier Pipeline.**  Adding a
+   ``vtkMRMLParametricSurfaceDisplayNode`` must NOT produce a
+   ResectogramPipeline, and adding a ``vtkMRMLResectogramDisplayNode``
+   must NOT produce a Bezier-surface Pipeline.  Two creators keyed on
+   two distinct display-node types do not cross-fire (ADR-0013 §1 —
+   one Pipeline per display-node type).
+
+CRITICAL — launched-harness-gated (issue #460).  This file
+``pytest.importorskip("LayerDMLib")`` at module level: it executes only
+inside a launched ``qSlicerApplication`` where the upstream LayerDM
+extension AND the built LiverResectionsLib module paths are on the
+process path.  In the bare pytest row (the default local + pre-commit
+path) and in any environment lacking SlicerLayerDM on the launched
+path, the WHOLE FILE SKIPS with the reason string below.  Per
+``feedback_launched_pytest_harness_skips.md`` the green-but-skipping
+trap is real here: this test's verdict is ONLY meaningful in the
+``pytest_launched`` CI row.  Verify run-vs-skip in the CI log — a green
+overall run that skipped this file has NOT exercised the dispatch.
+
+References
+----------
+* ADR-0013 §1 — one Pipeline per display-node type.
+* ADR-0013 §5 — the three registration calls; T3's NEW
+  RegisterNodeClass + AddPipelineCreator keyed on
+  ``vtkMRMLResectogramDisplayNode``.
+* ADR-0027 — invariant-test-first; the specific invariant is
+  type-keyed dispatch WITHOUT cross-fire, not mere pipeline existence.
+* Mirrors the ``importorskip("LayerDMLib")`` gating used by the T2
+  Bezier Pipeline tests under ``Testing/Python/unit/``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Module-level skip — runs only inside a launched Slicer process with the
+# upstream LayerDM extension loaded AND LiverResectionsLib reachable.
+# The reason string is intentionally explicit so run-vs-skip is greppable
+# in the CI log (issue #460 green-but-skipping guard).
+pytest.importorskip(
+    "LayerDMLib",
+    reason=(
+        "ResectogramPipeline dispatch requires a launched qSlicerApplication "
+        "with SlicerLayerDM + LiverResectionsLib on the process path; skipped "
+        "in the bare pytest row.  Verdict is real only in the pytest_launched "
+        "CI row (issue #460)."
+    ),
+)
+
+
+@pytest.fixture
+def layerdm_threed_view():
+    """Yield a LayerDM-aware 3D view + its displayable manager.
+
+    TODO(liver-implementer): build the minimal launched-app 3D view that
+    hosts a ``vtkMRMLLayerDMDisplayableManager`` (mirror the T2
+    real-view fixture delivered with the Bezier Pipeline per ADR-0013
+    §9).  Until that fixture lands the dispatch tests below skip with a
+    clear reason rather than silently passing.
+    """
+    pytest.skip(
+        "Invariant not yet implemented: launched LayerDM 3D-view fixture for "
+        "ResectogramPipeline dispatch is not yet provided (ADR-0013 §9 "
+        "real-view fixture)."
+    )
+
+
+def test_resectogram_display_node_registers():
+    """``vtkMRMLResectogramDisplayNode`` is a registered MRML node class.
+
+    Pins ADR-0013 §5 — T3's NEW ``RegisterNodeClass`` call.  The node
+    must instantiate via the scene factory once LiverResections'
+    ``setup()`` has run inside the launched app.
+    """
+    import slicer
+
+    node = slicer.mrmlScene.CreateNodeByClass("vtkMRMLResectogramDisplayNode")
+    assert node is not None, (
+        "vtkMRMLResectogramDisplayNode did not instantiate from the scene "
+        "factory — ADR-0013 §5 RegisterNodeClass for the new display node "
+        "has not run (T3 not yet implemented)."
+    )
+    node.UnRegister(None)
+
+
+def test_resectogram_creator_fires_for_its_display_node(layerdm_threed_view):
+    """Adding a ``vtkMRMLResectogramDisplayNode`` builds a ResectogramPipeline.
+
+    Pins ADR-0013 §5 — the ``AddPipelineCreator`` keyed on the new type
+    produces a LIVE pipeline/bridge in the active view's pipeline set.
+    """
+    import slicer
+
+    view, manager = layerdm_threed_view
+    display = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLResectogramDisplayNode")
+
+    # TODO(liver-implementer): query the LayerDM manager for the pipeline
+    # bound to ``display`` and assert it is a ResectogramPipeline instance
+    # (the creator keyed on vtkMRMLResectogramDisplayNode fired).
+    pipeline = manager.GetPipelineForDisplayNode(display)
+    assert pipeline is not None, (
+        "No pipeline created for vtkMRMLResectogramDisplayNode — the T3 "
+        "AddPipelineCreator (ADR-0013 §5) has not been wired."
+    )
+    assert type(pipeline).__name__ == "ResectogramPipeline"
+
+
+def test_resectogram_creator_does_not_collide_with_bezier(layerdm_threed_view):
+    """The two creators are keyed on disjoint display-node types.
+
+    Pins ADR-0013 §1 — one Pipeline per display-node type, NO cross-fire:
+
+    * a ``vtkMRMLParametricSurfaceDisplayNode`` must NOT yield a
+      ResectogramPipeline (the Bezier 3D-surface Pipeline owns it), and
+    * a ``vtkMRMLResectogramDisplayNode`` must NOT yield a
+      Bezier-surface Pipeline.
+
+    This is the load-bearing assertion behind the maintainer's KEYING =
+    dedicated-display-node decision: keying the ResectogramPipeline on
+    the SHARED ``vtkMRMLParametricSurfaceDisplayNode`` would violate
+    ADR-0013 §1 (two creators on one type).
+    """
+    import slicer
+
+    view, manager = layerdm_threed_view
+
+    parametric = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLParametricSurfaceDisplayNode"
+    )
+    resectogram = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLResectogramDisplayNode"
+    )
+
+    # TODO(liver-implementer): resolve the pipeline bound to each display
+    # node and assert the type mapping is disjoint.
+    parametric_pipeline = manager.GetPipelineForDisplayNode(parametric)
+    resectogram_pipeline = manager.GetPipelineForDisplayNode(resectogram)
+
+    assert type(parametric_pipeline).__name__ != "ResectogramPipeline", (
+        "vtkMRMLParametricSurfaceDisplayNode wrongly produced a "
+        "ResectogramPipeline — the creators cross-fire (ADR-0013 §1 "
+        "violation)."
+    )
+    assert type(resectogram_pipeline).__name__ != "LiverBezierSurfacePipeline", (
+        "vtkMRMLResectogramDisplayNode wrongly produced a Bezier-surface "
+        "Pipeline — the creators cross-fire (ADR-0013 §1 violation)."
+    )


### PR DESCRIPTION
## Summary

T3 ResectogramPipeline (#465) **foundation**: the LayerDM Pipeline + dedicated display node + the (u,v) Algorithm helpers, re-authoring the superseded #259 toward an ADR-0013 Pipeline. **This PR is deliberately non-regressive infrastructure** — the actual monolith-sever (the render-path flip) is *not* in it; see "Deferred" below.

## What's in this PR

- **Algorithm helpers** (`vtkLiverResectogramAspectRatio`, `vtkLiverResectogramPixelMapping`) under `LiverResections/Algorithm/` — the (u,v) aspect-ratio + pixel→(u,v) math extracted as pure, CI-testable functions (ADR-0015). Two RED→green unit tests, **run in CI**.
- **`vtkMRMLResectogramDisplayNode`** — a dedicated display-node type so the resectogram Pipeline keys on its own type rather than sharing `vtkMRMLParametricSurfaceDisplayNode` (one Pipeline per display-node type, ADR-0013 §1). Registered via `RegisterNodes()`.
- **`ResectogramPipeline`** + `FlattenedSurface`/`VascularContour` Representations + `registerResectogramPipelineCreator()` (the ADR-0013 §5 `AddPipelineCreator`, keyed on the new display node), wired in `qSlicerLiverResectionsModule::setup()`. No custom DM.
- Test-first scaffolding (ADR-0027): the dispatch test (launched, #460-gated) + visual-regression scenario stubs for the eventual sever/blur.

## Why it's safe to land now (non-regressive)

The Pipeline is **dormant**: nothing in production creates a `vtkMRMLResectogramDisplayNode`, so the creator never fires. The resectogram is **still rendered by the v1 monolith** (`vtkSlicerBezierSurfaceRepresentation3D`) exactly as before. This PR only adds registered, currently-unexercised infrastructure + CI-verified pure-math helpers — no rendering behaviour changes.

## Deferred (NOT in this PR)

- **Monolith-sever** (move the resectogram render off `vtkSlicerBezierSurfaceRepresentation3D` onto the Pipeline) and the **Gaussian blur pass** — these are render-path changes whose equivalence can only be verified by the visual-regression render, which currently **aborts/hangs on every available host** (#475; gate hardening #474). Severing a working render without verification is exactly the risk the soft-gate would hide, so it waits for a working render gate. Tracked under #465.

## Conformance

- ADR-0013 §1 (one Pipeline per display node → dedicated `vtkMRMLResectogramDisplayNode`) + §5 (RegisterNodeClass + RegisterInDefaultViews + AddPipelineCreator).
- ADR-0015 (pure-VTK Algorithm library for the (u,v) math).
- ADR-0025 (the pixel→(u,v) mapping the locator producer consumes).
- ADR-0027 (invariant tests precede implementation).

## Related

- #465 — the T3 issue (this is its foundation slice; sever + blur remain).
- #475 / #474 — the render abort / headless-GL gate that blocks verifying the deferred sever.
- Builds on the just-merged T2.7-2b (#476): a clean rebase merged the `RegisterNodes()` changes (2b removed the legacy registration; this adds the resectogram one).
