### PR TITLE
ENH: Skip the visual replay fast on software GL

### DIFF
--- a/LiverResections/Testing/Python/replay_test.py
+++ b/LiverResections/Testing/Python/replay_test.py
@@ -46,6 +46,24 @@ import sys
 # catching real visual regressions.
 DEFAULT_TOLERANCE = 0.15
 
+# Substrings that mark a GL renderer string as a software rasteriser.
+# When the replay runs on one of these (e.g. CI's xvfb + llvmpipe
+# stack), the bezier distance-map render is unreliable and has been
+# observed to hang to the CTest TIMEOUT (see the visual-regression
+# hardening issue tracked in ADR-0020 §"Rollout plan").  We detect
+# this up front and skip BEFORE the hanging render rather than burning
+# the full per-test timeout.  Matched case-insensitively against the
+# renderer + version strings reported by ``vtkRenderWindow``.
+SOFTWARE_GL_MARKERS = (
+    "llvmpipe",
+    "softpipe",
+    "swrast",
+    "software rasterizer",
+    "software rasteriser",
+    "gallium llvmpipe",
+    "mesa offscreen",
+)
+
 
 def _parse_argv() -> argparse.Namespace:
     """Slice out the ``--`` separated args; same convention as the
@@ -119,6 +137,111 @@ def _has_baseline(baseline_dir: pathlib.Path, test_name: str) -> bool:
     png = _resolve_baseline_png(baseline_dir, test_name)
     stub = baseline_dir / f"{test_name}.png.sha512"
     return png.exists() and stub.exists()
+
+
+def _is_software_renderer(capabilities: str) -> bool:
+    """True iff ``capabilities`` names a software GL rasteriser.
+
+    ``capabilities`` is the free-form string reported by
+    ``vtkRenderWindow.ReportCapabilities()`` (which embeds ``GL_RENDERER``
+    + ``GL_VERSION``).  We scan it case-insensitively for any of
+    ``SOFTWARE_GL_MARKERS``.  Kept as a pure helper so the skip
+    decision is unit-testable without bringing up a GL context.
+    """
+    haystack = capabilities.lower()
+    return any(marker in haystack for marker in SOFTWARE_GL_MARKERS)
+
+
+def _probe_gl_renderer() -> str | None:
+    """Bring up a throwaway offscreen GL context and report its renderer.
+
+    Returns the ``vtkRenderWindow.ReportCapabilities()`` string, or
+    ``None`` if a context could not be created at all.  This is a cheap
+    probe: a bare ``vtkRenderWindow`` + capability query exercises only
+    context creation and ``glGetString`` reads, which work even on
+    llvmpipe — it does NOT touch the bezier distance-map mapper that is
+    the actual source of the software-GL hang.
+
+    Guarded so the probe can never itself crash the run: any exception
+    (and a context that fails to initialise) yields ``None``, which the
+    caller treats as "skip with notice" rather than proceeding into the
+    hanging render.
+    """
+    import vtk  # type: ignore[import-not-found]
+
+    render_window = None
+    try:
+        render_window = vtk.vtkRenderWindow()
+        render_window.SetOffScreenRendering(1)
+        render_window.SetSize(1, 1)
+        render_window.SetMultiSamples(0)
+        # The GL context is created lazily on the first ``Render``; until
+        # then ``ReportCapabilities`` only reports "display id not set"
+        # (verified offscreen on Mesa).  An EMPTY render — no renderer,
+        # no actors, no mapper — is the cheapest way to force context
+        # creation.  It exercises only context + framebuffer setup, NOT
+        # the bezier distance-map mapper that is the actual source of the
+        # software-GL hang, so it stays cheap even on llvmpipe.
+        render_window.Render()
+        # ``ReportCapabilities`` embeds ``GL_RENDERER`` + ``GL_VERSION``
+        # once the context is up.
+        capabilities = render_window.ReportCapabilities()
+        return capabilities if capabilities else None
+    except Exception:  # noqa: BLE001 — any failure means "cannot render here".
+        return None
+    finally:
+        if render_window is not None:
+            render_window.Finalize()
+
+
+def _software_gl_skip_reason(capabilities: str | None) -> str | None:
+    """Return a skip message if the probed GL stack cannot render here.
+
+    ``capabilities is None`` means the probe could not even create a
+    context — treat that as un-renderable too (skip, do not proceed).
+    A software rasteriser match returns a greppable ``[skip]`` reason.
+    A real GPU returns ``None`` (proceed with render + diff).
+
+    This is deliberately distinct from the missing-baseline logic: a
+    software-GL skip is about the *renderer*, not the baseline, so it
+    fires regardless of whether a baseline blob resolved.
+    """
+    if capabilities is None:
+        return (
+            "[skip] offscreen GL context could not be created — cannot "
+            "render the bezier distance-map here (see the visual-regression "
+            "hardening issue); skipping render+diff"
+        )
+    if _is_software_renderer(capabilities):
+        # Pull a short single-line renderer token out for the message;
+        # the full capabilities blob is multi-line.
+        renderer = _renderer_token(capabilities)
+        return (
+            f"[skip] offscreen software GL ({renderer}) — bezier "
+            "distance-map render is unreliable on this stack (see the "
+            "visual-regression hardening issue); skipping render+diff"
+        )
+    return None
+
+
+def _renderer_token(capabilities: str) -> str:
+    """Extract a compact renderer label from a capabilities blob.
+
+    ``ReportCapabilities`` emits lines like ``OpenGL renderer string:
+    llvmpipe (LLVM 15.0.7, 256 bits)``.  Return the value after that
+    label when present, else the first software marker found, else a
+    generic fallback — purely for a readable skip message.
+    """
+    for line in capabilities.splitlines():
+        if "renderer string" in line.lower():
+            value = line.partition(":")[2].strip()
+            if value:
+                return value
+    lowered = capabilities.lower()
+    for marker in SOFTWARE_GL_MARKERS:
+        if marker in lowered:
+            return marker
+    return "software"
 
 
 def _render_scenario(scenario, width: int, height: int):
@@ -239,6 +362,19 @@ def main() -> int:
 
     baseline_dir = pathlib.Path(args.baseline_dir)
     scenario = _load_scenario(args.scenarios_dir, args.test)
+
+    # Software-GL fast skip.  Probe the offscreen GL renderer up front
+    # (cheap context + capability query, NOT the bezier mapper) and
+    # bail out before the scenario render when we land on a software
+    # rasteriser, or when no GL context can be created at all.  This is
+    # what stops CI's xvfb + llvmpipe stack from burning the full
+    # per-test TIMEOUT on a render that hangs.  Distinct from the
+    # missing-baseline branch below: a software-GL skip is about the
+    # renderer, so it fires regardless of baseline presence.
+    skip_reason = _software_gl_skip_reason(_probe_gl_renderer())
+    if skip_reason is not None:
+        print(skip_reason)
+        return 0
 
     # When the visual-regression suite is explicitly enabled (the CI
     # hard-gate sets LIVER_RUN_VISUAL_TESTS=1), a registered scenario

--- a/LiverResections/Testing/Python/test_harness/test_software_gl_skip.py
+++ b/LiverResections/Testing/Python/test_harness/test_software_gl_skip.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Harness self-tests for the replay driver's software-GL fast skip.
+
+The replay driver probes the offscreen GL renderer up front and skips
+BEFORE the bezier distance-map render when it lands on a software
+rasteriser (e.g. CI's xvfb + llvmpipe stack), where that render is
+unreliable and has been observed to hang to the CTest TIMEOUT.  See
+``replay_test.SOFTWARE_GL_MARKERS`` + ``_software_gl_skip_reason`` and
+ADR-0020 §"Rollout plan".
+
+These tests exercise the pure decision helpers without bringing up a
+real GL context: ``_is_software_renderer`` (string classification),
+``_software_gl_skip_reason`` (render-vs-skip + message), and
+``_renderer_token`` (message formatting).  The skip is deliberately
+distinct from the missing-baseline logic, so it is asserted in
+isolation here.
+
+References
+----------
+* ADR-0008 §"observability" — pure-Python helpers carry self-tests.
+* ADR-0020 §"Rollout plan" — visual-regression rollout + hardening.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+
+# Same path-injection pattern as the sibling ``test_has_baseline``: the
+# replay module imports cleanly in plain Python (slicer / vtk imports
+# are deferred inside the render helpers), so drop the harness directory
+# on ``sys.path`` and import it directly.
+_HERE = pathlib.Path(__file__).resolve()
+_HARNESS_DIR = _HERE.parent.parent  # LiverResections/Testing/Python/
+if str(_HARNESS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HARNESS_DIR))
+
+import replay_test  # noqa: E402 — path injection above must run first.
+
+
+# A representative llvmpipe ``ReportCapabilities()`` blob.  VTK emits one
+# labelled line per GL string; only the substrings matter to the
+# classifier, but the multi-line shape exercises ``_renderer_token``.
+_LLVMPIPE_CAPS = (
+    "OpenGL vendor string:  Mesa\n"
+    "OpenGL renderer string:  llvmpipe (LLVM 15.0.7, 256 bits)\n"
+    "OpenGL version string:  4.5 (Core Profile) Mesa 23.2.1\n"
+)
+
+_REAL_GPU_CAPS = (
+    "OpenGL vendor string:  NVIDIA Corporation\n"
+    "OpenGL renderer string:  NVIDIA GeForce RTX 3080/PCIe/SSE2\n"
+    "OpenGL version string:  4.6.0 NVIDIA 535.104.05\n"
+)
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        _LLVMPIPE_CAPS,
+        "OpenGL renderer string: softpipe\n",
+        "OpenGL renderer string: swrast\n",
+        "OpenGL renderer string: Gallium llvmpipe (LLVM 16)\n",
+        "renderer: llVMpipe",  # case-insensitive match
+    ],
+)
+def test_is_software_renderer_matches_software_stacks(capabilities: str) -> None:
+    assert replay_test._is_software_renderer(capabilities) is True
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        _REAL_GPU_CAPS,
+        "OpenGL renderer string: AMD Radeon RX 6800 (RADV NAVI21)\n",
+        "OpenGL renderer string: Intel(R) Arc(TM) A770 Graphics\n",
+        "",  # empty string is not, on its own, a software match
+    ],
+)
+def test_is_software_renderer_passes_real_gpus(capabilities: str) -> None:
+    assert replay_test._is_software_renderer(capabilities) is False
+
+
+def test_skip_reason_none_for_real_gpu() -> None:
+    """A real GPU yields no skip — the caller proceeds to render+diff."""
+    assert replay_test._software_gl_skip_reason(_REAL_GPU_CAPS) is None
+
+
+def test_skip_reason_set_for_software_gl() -> None:
+    """A software rasteriser yields a greppable ``[skip]`` reason that
+    names the renderer and points at the hardening issue."""
+    reason = replay_test._software_gl_skip_reason(_LLVMPIPE_CAPS)
+    assert reason is not None
+    assert reason.startswith("[skip]")
+    assert "software GL" in reason
+    assert "llvmpipe" in reason
+    assert "hardening" in reason
+
+
+def test_skip_reason_set_when_no_context() -> None:
+    """A failed probe (``None`` capabilities) skips rather than proceeds:
+    if no GL context can be created the render cannot run either."""
+    reason = replay_test._software_gl_skip_reason(None)
+    assert reason is not None
+    assert reason.startswith("[skip]")
+    assert "could not be created" in reason
+
+
+def test_skip_reason_independent_of_baseline() -> None:
+    """The software-GL skip is about the renderer, not the baseline.
+
+    ``_software_gl_skip_reason`` takes only the capabilities string —
+    it has no baseline parameter — so a software stack skips regardless
+    of whether a baseline blob has resolved.  This pins the contract
+    that the skip path is decided before (and independently of) the
+    ``_has_baseline`` check.
+    """
+    assert replay_test._software_gl_skip_reason(_LLVMPIPE_CAPS) is not None
+    assert replay_test._software_gl_skip_reason(_REAL_GPU_CAPS) is None
+
+
+def test_renderer_token_extracts_renderer_line() -> None:
+    token = replay_test._renderer_token(_LLVMPIPE_CAPS)
+    assert token == "llvmpipe (LLVM 15.0.7, 256 bits)"
+
+
+def test_renderer_token_falls_back_to_marker() -> None:
+    """With no labelled renderer line, fall back to the matched marker."""
+    token = replay_test._renderer_token("backend uses swrast internally")
+    assert token == "swrast"


### PR DESCRIPTION
## Summary for humans

The LiverResections visual-regression mirror tests run on CI under
`xvfb` + `LIBGL_ALWAYS_SOFTWARE` (llvmpipe). On that software-GL stack
the bezier distance-map render is unreliable and hangs until each
scenario hits its 180s CTest `TIMEOUT` — roughly ten minutes of dead
time on every CI run, repo-wide.

This adds a fast renderer probe at the top of `replay_test.py`: bring
up a throwaway offscreen `vtkRenderWindow`, force context creation with
an *empty* render, and read `ReportCapabilities()`. An empty render
touches only context + framebuffer setup, **not** the bezier mapper
that actually hangs, so the probe stays cheap even on llvmpipe. When
the renderer string matches a software rasteriser (`llvmpipe`,
`softpipe`, `swrast`, ...), or when no context can be created at all,
the driver prints a greppable `[skip]` line naming the renderer and
returns 0 — before the hanging render. Real GPUs proceed exactly as
before.

The root-cause render hang itself is out of scope here and tracked
separately under the visual-regression hardening work.

## ADR references

1. ADR-0020 §"Rollout plan" — visual-regression capture/replay rollout
   and hardening; the render-hang root cause lives here.
2. ADR-0003 — characterisation tests gate behaviour-changing PRs.
3. ADR-0008 §"observability" — pure-Python helpers carry self-tests.

## Conformance

- **Software-GL skip is distinct from the missing-baseline skip** — it
  is decided on the *renderer*, before and independently of
  `_has_baseline`. Proven by
  `test_software_gl_skip.py::test_skip_reason_independent_of_baseline`.
- **Renderer classification** (software vs real GPU) is a pure,
  unit-tested helper. Proven by
  `test_is_software_renderer_matches_software_stacks` /
  `_passes_real_gpus`.
- **A failed probe skips rather than proceeds** (no context → cannot
  render). Proven by `test_skip_reason_set_when_no_context`.
- **Probe never crashes the run** — the context probe is wrapped in
  try/except, returning `None` (→ skip) on any failure.

## UX impact

N/A — non-UI change (CI test driver only).

<details>
<summary>Agent context (long form)</summary>

### Why an empty render forces the context

A bare offscreen `vtkRenderWindow` creates its GL context lazily on the
first `Render()`. Before that, `ReportCapabilities()` returns only
`display id not set` — verified offscreen on Mesa — so a capability
query alone is insufficient to classify the renderer. An empty
`Render()` (no renderer, no actors, no mapper) is the cheapest way to
force context creation and populate the GL strings.

### Local verification

Run on an AMD Radeon (radeonsi) host, Slicer launcher under
`--no-main-window`:

- **Real GL** (`DISPLAY=:0`): probe reports
  `OpenGL renderer string: AMD Radeon Graphics (radeonsi, ...)`,
  classified non-software → decision PROCEED. The full replay then
  proceeds past the probe into the render.
- **Forced software GL** (`LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe`):
  the empty-render probe comes up under llvmpipe without hanging,
  reports `llvmpipe (LLVM 18.1.8, 256 bits)`, classified software →
  the full `replay_test.py` prints the `[skip]` line and returns 0 in
  ~5s (wrapped in `timeout 90`, no `rc=124`). This is the path that
  previously consumed the 180s timeout.

The probe itself does **not** hang on llvmpipe — the specific risk the
task flagged — because it never reaches the bezier mapper.

### Test additions

`test_harness/test_software_gl_skip.py` (13 cases): renderer-string
classification both directions, render-vs-skip decision + message
shape, no-context skip, baseline-independence, and renderer-token
formatting. Pure-Python, no GL context, runs under the existing
`LiverResections_harness_self_tests` CTest entry. Full harness suite:
36 passed.

</details>

_Drafted by Claude (claude-opus-4-8); reviewed by Rafael Palomar_