### PR TITLE
BUG: Activate Bezier distance-map sampler3D per render (#475)

### DIFF
--- a/LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx
+++ b/LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx
@@ -520,6 +520,10 @@ void vtkSlicerBezierSurfaceRepresentation3D::CreateAndTransferDistanceMapTexture
   {
     vtkWarningMacro("vtkSlicerBezierSurfaceRepresentation::CreateAndTransferDistanceMap:"
                     "There is no distance map node associated. Texture won't be generated.");
+    // Drop any previously-threaded texture so the mapper falls back to its
+    // no-distance-map path instead of sampling a stale 3D texture once the
+    // distance-map node is cleared (otherwise MRML state and GL state diverge).
+    this->BezierSurfaceResectionMapper->SetDistanceMapTextureObject(nullptr);
     return;
   }
 
@@ -528,6 +532,7 @@ void vtkSlicerBezierSurfaceRepresentation3D::CreateAndTransferDistanceMapTexture
   {
     vtkWarningMacro("vtkSlicerBezierSurfaceRepresentation::CreateAndTransferDistanceMap:"
                     "There is no image data in the specified scalar volume node.");
+    this->BezierSurfaceResectionMapper->SetDistanceMapTextureObject(nullptr);
     return;
   }
 

--- a/LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx
+++ b/LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx
@@ -539,6 +539,13 @@ void vtkSlicerBezierSurfaceRepresentation3D::CreateAndTransferDistanceMapTexture
   this->DistanceMapTexture->SetMagnificationFilter(vtkTextureObject::Linear);
   this->DistanceMapTexture->SetBorderColor(1000.0f, 1000.0f, 0.0f, 0.0f);
   this->DistanceMapTexture->CreateSeq3DFromRaw(dimensions[0], dimensions[1], dimensions[2], numComps, VTK_FLOAT, imageData->GetScalarPointer(), 0);
+
+  // Thread the texture object to the mapper so it is Activate()-ed onto a
+  // texture unit at draw time and the sampler3D uniform binds to that unit.
+  // The one-time Bind() above is not sufficient: on a later render the
+  // sampler3D would otherwise point at a unit with no live GL_TEXTURE_3D
+  // bound — the offscreen-render abort root cause (ADR-0003).
+  this->BezierSurfaceResectionMapper->SetDistanceMapTextureObject(this->DistanceMapTexture);
 }
 
 //----------------------------------------------------------------------

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -192,6 +192,11 @@ set_tests_properties(py_distancemap_double_render_test PROPERTIES
   # Same timeout rationale as the replay entries: a stuck offscreen render
   # on a misdetected stack should fail fast rather than hold CI open.
   TIMEOUT 180
+  # The script exits 77 when it skips on a software-GL stack (CI's
+  # xvfb + llvmpipe).  Mark that as a CTest SKIP so a masked skip is visible
+  # as a skip on the dashboard, not an indistinguishable green pass; the real
+  # abort/no-abort verdict is on a GPU-backed display.
+  SKIP_RETURN_CODE 77
 )
 
 # ---------------------------------------------------------------------------

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -163,35 +163,36 @@ endif()
 # On a software-GL stack the script skips up front via the same probe the
 # replay driver uses (ADR-0020 §"Rollout plan"); the real abort/no-abort
 # verdict is on a GPU-backed display.
-if(DEFINED Slicer_LAUNCHER_EXECUTABLE)
-  set(_dm_render_launcher "${Slicer_LAUNCHER_EXECUTABLE}")
-elseif(DEFINED Slicer_EXECUTABLE)
-  set(_dm_render_launcher "${Slicer_EXECUTABLE}")
-else()
-  set(_dm_render_launcher "")
-endif()
-
-if(NOT _dm_render_launcher STREQUAL "")
-  add_test(
-    NAME LiverResections_distance_map_double_render
-    COMMAND "${_dm_render_launcher}"
-      --no-main-window
-      --no-splash
-      --additional-module-paths "${CMAKE_SOURCE_DIR}/LiverResections"
-      --python-script "${CMAKE_CURRENT_SOURCE_DIR}/distancemap_double_render_test.py"
-  )
-  set_tests_properties(LiverResections_distance_map_double_render PROPERTIES
-    LABELS "visual-regression;LiverResections;distance-map;characterisation"
-    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
-    # Same timeout rationale as the replay entries: a stuck offscreen render
-    # on a misdetected stack should fail fast rather than hold CI open.
-    TIMEOUT 180
-  )
-else()
-  message(STATUS
-    "Slicer-Liver: no Slicer launcher found; skipping "
-    "LiverResections_distance_map_double_render registration.")
-endif()
+# Registered through Slicer's ``slicer_add_python_test`` (the script-shaped
+# sibling of ``slicer_add_python_unittest``) rather than a hand-rolled
+# ``add_test``.  The macro supplies the two things a launched test needs to
+# load this module:
+#   * ``--testing`` — runs against fresh temporary settings, so the launcher
+#     never inherits the developer's persisted ``Modules/AdditionalPaths``
+#     (which may reference stale/removed build trees and otherwise surface as
+#     "The shared library was not found." at module registration); and
+#   * ``${Slicer_ADDITIONAL_LAUNCHER_SETTINGS}`` — the generated
+#     ``AdditionalLauncherSettings.ini`` that puts this build's and the
+#     SlicerLayerDisplayableManager dependency's library paths on the
+#     launcher's ``LibraryPaths``/``PYTHONPATH`` so the module ``.so`` and its
+#     LayerDM-linked dependencies resolve.
+# As with ``VascularTerritories`` (ADR-0023), the LayerDisplayableManager
+# loadable+scripted module paths are opted in explicitly so the dependency
+# modules are registered with the module manager, not merely import-able.
+slicer_add_python_test(
+  SCRIPT distancemap_double_render_test.py
+  SLICER_ARGS
+    --additional-module-paths
+    ${LayerDisplayableManager_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}
+    ${LayerDisplayableManager_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}
+)
+set_tests_properties(py_distancemap_double_render_test PROPERTIES
+  LABELS "visual-regression;LiverResections;distance-map;characterisation"
+  ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+  # Same timeout rationale as the replay entries: a stuck offscreen render
+  # on a misdetected stack should fail fast rather than hold CI open.
+  TIMEOUT 180
+)
 
 # ---------------------------------------------------------------------------
 # Opt-in gate for the visual-regression harness.

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -147,6 +147,53 @@ else()
 endif()
 
 # ---------------------------------------------------------------------------
+# Distance-map double-render characterisation test (always-on, launcher-gated)
+# ---------------------------------------------------------------------------
+#
+# Pins the invariant behind the offscreen-render abort observed when a
+# vtkMRMLMarkupsBezierSurfaceNode with a 4-component float distance-map is
+# rendered twice (ADR-0003 §"Decision").  Unlike the pixel-baseline replay
+# entries below, this test has NO ExternalData baseline dependency: it
+# asserts only that the SECOND forceRender() completes without aborting and
+# leaves the GL context error-free.  It is therefore registered here,
+# OUTSIDE the SlicerLiver_ENABLE_VISUAL_TESTS opt-in, but still requires the
+# Slicer launcher (it brings up a minimal qSlicerApplication + offscreen 3D
+# view, Level 2 per Testing/README.md).
+#
+# On a software-GL stack the script skips up front via the same probe the
+# replay driver uses (ADR-0020 §"Rollout plan"); the real abort/no-abort
+# verdict is on a GPU-backed display.
+if(DEFINED Slicer_LAUNCHER_EXECUTABLE)
+  set(_dm_render_launcher "${Slicer_LAUNCHER_EXECUTABLE}")
+elseif(DEFINED Slicer_EXECUTABLE)
+  set(_dm_render_launcher "${Slicer_EXECUTABLE}")
+else()
+  set(_dm_render_launcher "")
+endif()
+
+if(NOT _dm_render_launcher STREQUAL "")
+  add_test(
+    NAME LiverResections_distance_map_double_render
+    COMMAND "${_dm_render_launcher}"
+      --no-main-window
+      --no-splash
+      --additional-module-paths "${CMAKE_SOURCE_DIR}/LiverResections"
+      --python-script "${CMAKE_CURRENT_SOURCE_DIR}/distancemap_double_render_test.py"
+  )
+  set_tests_properties(LiverResections_distance_map_double_render PROPERTIES
+    LABELS "visual-regression;LiverResections;distance-map;characterisation"
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    # Same timeout rationale as the replay entries: a stuck offscreen render
+    # on a misdetected stack should fail fast rather than hold CI open.
+    TIMEOUT 180
+  )
+else()
+  message(STATUS
+    "Slicer-Liver: no Slicer launcher found; skipping "
+    "LiverResections_distance_map_double_render registration.")
+endif()
+
+# ---------------------------------------------------------------------------
 # Opt-in gate for the visual-regression harness.
 #
 # Default OFF until two preconditions land: (a) the

--- a/LiverResections/Testing/Python/distancemap_double_render_test.py
+++ b/LiverResections/Testing/Python/distancemap_double_render_test.py
@@ -57,6 +57,12 @@ import replay_test  # noqa: E402  (path injection above is intentional)
 
 SCENARIO_NAME = "BezierSurface4x4Planning"
 
+# Exit code signalling "skipped, not run" to CTest.  Paired with the test's
+# ``SKIP_RETURN_CODE`` property so a software-GL skip reports as a genuine
+# CTest SKIP rather than an indistinguishable green pass — the real
+# abort/no-abort verdict is deferred to a GPU host, not silently claimed.
+SKIP_EXIT_CODE = 77
+
 
 def _load_scenario():
     """Import the 4x4 Planning scenario module (4-comp float distance-map)."""
@@ -94,8 +100,9 @@ def run() -> int:
     misdetected software stack, a timeout) — there is nothing to assert
     in Python beyond completion.
 
-    Returns 0 on success (both renders completed) and 0 on a clean
-    software-GL skip (the verdict is deferred to a GPU host).
+    Returns 0 on success (both renders completed) and ``SKIP_EXIT_CODE`` on a
+    clean software-GL skip (reported to CTest as a SKIP, not a pass — the
+    verdict is deferred to a GPU host).
     """
     # Software-GL fast skip — identical probe to the replay driver so the
     # known software-GL hang on the bezier distance-map never burns the
@@ -106,7 +113,7 @@ def run() -> int:
     )
     if skip_reason is not None:
         print(skip_reason)
-        return 0
+        return SKIP_EXIT_CODE
 
     scenario = _load_scenario()
     meta = scenario.describe()

--- a/LiverResections/Testing/Python/distancemap_double_render_test.py
+++ b/LiverResections/Testing/Python/distancemap_double_render_test.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Characterisation test: the Bezier distance-map survives a SECOND render.
+
+This pins the invariant behind the offscreen-render abort observed when a
+``vtkMRMLMarkupsBezierSurfaceNode`` carrying a 4-component float
+distance-map volume is rendered, then rendered AGAIN via a second
+``forceRender()``.  The first render comes up; the second has been
+observed to abort (or hang) on multiple GL stacks.
+
+Root-cause analysis (see ADR-0003 §"Decision" and the render-env
+keystone analysis) points at the 3D distance-map texture object being
+``Bind()``/``Deactivate()``-ed exactly once at creation in
+``vtkSlicerBezierSurfaceRepresentation3D::CreateAndTransferDistanceMapTexture``,
+while the draw-time mapper
+(``vtkOpenGLBezierResectionPolyDataMapper::SetMapperShaderParameters``)
+only sets the ``sampler3D distanceTexture`` uniform.  Nothing re-activates
+the texture object onto its sampler unit at draw time, so the second
+render — after VTK has churned texture-unit bindings for other actors —
+samples a ``sampler3D`` with no live ``GL_TEXTURE_3D`` bound to its unit.
+
+The invariant this test pins: rendering the 4-component distance-map
+Bezier scenario, then ``forceRender()``-ing a SECOND time, must complete
+without aborting and must leave the GL context error-free.
+
+Test level: Level 2 — minimal ``qSlicerApplication`` (the SUT touches
+MRML + the Markups render pipeline), per the SlicerLayerDM / trame-slicer
+precedent recorded in ``LiverResections/Testing/README.md``.
+
+This is a launched/visual-tier test: it is RED-by-design today (the
+second render aborts on the affected stacks) and yields the real verdict
+only on a GPU-backed ``:0`` session.  On a software-GL stack (CI's
+xvfb + llvmpipe) it skips up front via the same probe ``replay_test.py``
+uses, so it never burns the CTest timeout on the known software-GL hang.
+
+References
+----------
+* ADR-0003 §"Decision" — characterisation tests pin behaviour before a
+  fix or refactor.
+* ADR-0020 §"Rollout plan" §7 — the v2.0 Bezier mapper is ported, not
+  rewritten; this is a surgical correctness gate, not modernisation.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+# Reuse the software-GL probe + skip-reason helpers from the replay
+# driver rather than duplicating them; they live alongside this script.
+_THIS_DIR = pathlib.Path(__file__).resolve().parent
+if str(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(_THIS_DIR))
+
+import replay_test  # noqa: E402  (path injection above is intentional)
+
+
+SCENARIO_NAME = "BezierSurface4x4Planning"
+
+
+def _load_scenario():
+    """Import the 4x4 Planning scenario module (4-comp float distance-map)."""
+    scenarios_dir = _THIS_DIR / "scenarios"
+    return replay_test._load_scenario(str(scenarios_dir), SCENARIO_NAME)
+
+
+def _build_view(width: int, height: int):
+    """Bring up an offscreen 3D view widget bound to the MRML scene."""
+    import slicer  # type: ignore[import-not-found]
+
+    view_widget = slicer.qMRMLThreeDWidget()
+    view_widget.setMRMLScene(slicer.mrmlScene)
+    view_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLViewNode")
+    if view_node is None:
+        view_node = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLViewNode", "DistanceMapDoubleRenderView"
+        )
+    view_widget.setMRMLViewNode(view_node)
+    view_widget.resize(width, height)
+
+    three_d_view = view_widget.threeDView()
+    three_d_view.renderWindow().SetSize(width, height)
+    three_d_view.renderWindow().SetMultiSamples(0)
+    return view_widget, view_node, three_d_view
+
+
+def run() -> int:
+    """Render the 4-comp distance-map Bezier scene twice; assert survival.
+
+    The invariant pinned is process survival across the SECOND render:
+    on the affected stacks the second ``forceRender()`` aborts the
+    process, so merely reaching the line after it is the pass condition.
+    An abort manifests to CTest as a non-zero exit / crash (or, on a
+    misdetected software stack, a timeout) — there is nothing to assert
+    in Python beyond completion.
+
+    Returns 0 on success (both renders completed) and 0 on a clean
+    software-GL skip (the verdict is deferred to a GPU host).
+    """
+    # Software-GL fast skip — identical probe to the replay driver so the
+    # known software-GL hang on the bezier distance-map never burns the
+    # CTest timeout here.  The real abort/no-abort verdict is on a GPU
+    # ``:0`` session.
+    skip_reason = replay_test._software_gl_skip_reason(
+        replay_test._probe_gl_renderer()
+    )
+    if skip_reason is not None:
+        print(skip_reason)
+        return 0
+
+    scenario = _load_scenario()
+    meta = scenario.describe()
+    width, height = meta["viewport"]["size"]
+
+    scenario.setup_scene()
+    view_widget, view_node, three_d_view = _build_view(width, height)
+    scenario.setup_camera(view_node)
+    scenario.setup_viewport(view_node)
+
+    # FIRST render — comes up on the affected stacks.
+    three_d_view.forceRender()
+
+    # SECOND render — the offscreen-render abort site.  On the affected
+    # stacks the process aborts here; reaching the line after it is the
+    # invariant being pinned.
+    three_d_view.forceRender()
+
+    print(
+        "[pass] Bezier 4-component distance-map survived two forceRender() "
+        "calls"
+    )
+    return 0
+
+
+def _exit(code: int) -> None:
+    """Terminate the launched process; mirrors ``replay_test._exit``."""
+    replay_test._exit(code)
+
+
+if __name__ == "__main__":
+    _exit(run())

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -56,6 +56,7 @@
 #include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
 #include <vtkShaderProgram.h>
+#include <vtkTextureObject.h>
 #include <vtkTransform.h>
 
 //------------------------------------------------------------------------------
@@ -85,6 +86,7 @@ public:
   vtkWeakPointer<vtkOpenGLBezierResectionPolyDataMapper> Parent;
   vtkSmartPointer<vtkMatrix4x4> RasToIjkMatrixT;
   vtkSmartPointer<vtkMatrix4x4> IjkToTextureMatrixT;
+  vtkSmartPointer<vtkTextureObject> DistanceMapTexture;
   float ResectionMargin;
   float UncertaintyMargin;
   float ResectionMarginColor[3];
@@ -283,7 +285,23 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetMapperShaderParameters(vtkOpenGL
 {
   if (cellBO.Program->IsUniformUsed("distanceTexture"))
   {
-    cellBO.Program->SetUniformi("distanceTexture", 0);
+    // Activate the 3D distance-map texture onto a texture unit at DRAW
+    // time and bind the sampler3D uniform to the unit the texture object
+    // actually lands on.  The texture is uploaded once on node-change in
+    // vtkSlicerBezierSurfaceRepresentation3D::CreateAndTransferDistanceMapTexture
+    // and threaded here via SetDistanceMapTextureObject().  Relying on a
+    // one-time Bind() at creation (and a hardcoded unit 0) left the
+    // sampler3D pointing at a unit with no live GL_TEXTURE_3D on a
+    // subsequent render — the offscreen-render abort root cause (ADR-0003).
+    if (this->Impl->DistanceMapTexture)
+    {
+      this->Impl->DistanceMapTexture->Activate();
+      cellBO.Program->SetUniformi("distanceTexture", this->Impl->DistanceMapTexture->GetTextureUnit());
+    }
+    else
+    {
+      cellBO.Program->SetUniformi("distanceTexture", 0);
+    }
   }
 
   if (cellBO.Program->IsUniformUsed("uRasToIjk"))
@@ -352,6 +370,33 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetMapperShaderParameters(vtkOpenGL
   }
 
   Superclass::SetMapperShaderParameters(cellBO, ren, actor);
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLBezierResectionPolyDataMapper::RenderPieceFinish(vtkRenderer* ren, vtkActor* act)
+{
+  if (this->Impl->DistanceMapTexture)
+  {
+    this->Impl->DistanceMapTexture->Deactivate();
+  }
+  Superclass::RenderPieceFinish(ren, act);
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLBezierResectionPolyDataMapper::SetDistanceMapTextureObject(vtkTextureObject* texture)
+{
+  if (this->Impl->DistanceMapTexture == texture)
+  {
+    return;
+  }
+  this->Impl->DistanceMapTexture = texture;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+vtkTextureObject* vtkOpenGLBezierResectionPolyDataMapper::GetDistanceMapTextureObject() const
+{
+  return this->Impl->DistanceMapTexture;
 }
 
 //------------------------------------------------------------------------------

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
@@ -49,6 +49,8 @@
 // STD includes
 #include <memory>
 
+class vtkTextureObject;
+
 //-------------------------------------------------------------------------------
 class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkOpenGLBezierResectionPolyDataMapper : public vtkOpenGLPolyDataMapper
 {
@@ -134,6 +136,18 @@ public:
   /// Set the thickness factor for the grid
   void SetGridThicknessFactor(float thicknessFactor);
 
+  /// Set the 3D distance-map texture object the fragment shader samples.
+  ///
+  /// The representation (vtkSlicerBezierSurfaceRepresentation3D) owns the
+  /// texture object and threads it here so the mapper can Activate() it at
+  /// draw time and bind the ``sampler3D distanceTexture`` uniform to the
+  /// unit the texture actually lands on.  Without this the sampler is left
+  /// pointing at a texture unit with no live GL_TEXTURE_3D bound on a
+  /// subsequent render (the offscreen-render abort root cause; ADR-0003).
+  void SetDistanceMapTextureObject(vtkTextureObject* texture);
+  /// Get the distance-map texture object set by the representation.
+  vtkTextureObject* GetDistanceMapTextureObject() const;
+
 protected:
   vtkOpenGLBezierResectionPolyDataMapper();
   ~vtkOpenGLBezierResectionPolyDataMapper();
@@ -147,6 +161,11 @@ protected:
 
   // Set CameraShaderParameters
   void SetCameraShaderParameters(vtkOpenGLHelper& cellBO, vtkRenderer* ren, vtkActor* actor) override;
+
+  // Deactivate the distance-map texture after the draw so its texture unit
+  // is released back to the render window's texture-unit manager — mirrors
+  // how the base mapper releases its own textures (ADR-0003).
+  void RenderPieceFinish(vtkRenderer* ren, vtkActor* act) override;
 
 private:
   class vtkInternal;


### PR DESCRIPTION
## Summary for humans

Closes #475 (candidate fix — **pixel/abort verification pending a maintainer `:0` GPU render**).

The offscreen-render abort on the *second* `forceRender()` of a Bezier
surface carrying a 4-component float distance-map is a latent draw-time
texture-binding bug, not a relocation regression. The 3D distance-map
texture was `Bind()`/`Deactivate()`-ed exactly once at creation; at draw
time the mapper only set the `sampler3D distanceTexture` uniform to a
hardcoded texture unit 0 and relied on that stale one-time bind. Nothing
re-activated the texture object onto a unit per render, so after VTK churns
texture-unit bindings for other actors a later render samples a `sampler3D`
with no live `GL_TEXTURE_3D` bound to its unit — which strict drivers fault
on during the draw.

The fix threads the texture object from the representation to the mapper,
`Activate()`s it at draw time, binds the sampler to the unit it actually
lands on, and `Deactivate()`s it after the draw — mirroring how the base
`vtkOpenGLPolyDataMapper` manages its own textures. Surgical correctness
patch on the v2.0 mapper; the GPU-tessellation rewrite is left for v2.1.

This is **test-first**: a characterisation test renders the 4-component
distance-map scenario and `forceRender()`s twice, pinning "the second render
must not abort". It is RED-by-design on the affected stacks and skips up
front on software GL (the verdict is on a GPU display).

### Maintainer verification (required before Ready)

1. Rebuild the `LiverResections` + `LiverMarkups` VTKWidgets libraries.
2. On a GPU-backed display, run the characterisation test:
   `Slicer --no-main-window --no-splash --additional-module-paths <repo>/LiverResections --python-script <repo>/LiverResections/Testing/Python/distancemap_double_render_test.py`
   (or via CTest: `ctest -R LiverResections_distance_map_double_render`).
   Expected: `[pass] Bezier 4-component distance-map survived two forceRender() calls` — **abort gone**.
3. Re-run the existing `LiverBezierVisualTest_BezierSurface4x4Planning`
   replay on the same display and confirm the render reproduces / pixels
   match the baseline (re-enables baseline reproduction for T3 / 2b).

### If H1 does not resolve it (fallback)

The keystone analysis ranks a second hypothesis (H2): a `RGBA32F` 3D texture
with a `Linear` min/mag filter faulting on linear-filtered float-3D sampling
on some drivers. Fallback: switch the distance-map texture Min/Mag filter to
`Nearest` in `CreateAndTransferDistanceMapTexture`. The gdb recipe in the
keystone plan distinguishes H1 (fault at the draw / sampler fetch) from H2
(fault at the linear-filtered sample) — `bt` at the abort lands in the GL
draw, not in `CreateSeq3DFromRaw`, if H1 is correct.

## ADR references

1. ADR-0003 §"Decision" — characterisation test pins behaviour before the fix.
2. ADR-0020 §"Rollout plan" §7 — v2.0 Bezier mapper is ported, not rewritten;
   this is a surgical correctness patch, not modernisation.

## Conformance

- **Invariant: a second offscreen render of the 4-component distance-map
  Bezier scenario must not abort.** Proven by
  `LiverResections_distance_map_double_render`
  (`distancemap_double_render_test.py`) — RED on the affected stacks today;
  green once the fix is confirmed on a GPU display. [test]
- **Invariant: the v2.0 mapper is not rewritten (ADR-0020).** The change is
  confined to threading + per-render activate/deactivate of an existing
  texture object. [review]

## UX impact

N/A — non-UI change (offscreen-render correctness in the Bezier resection
mapper; no user-facing surface, label, or workflow changes).

<details>
<summary>Agent context (long-form)</summary>

### Files changed

- `LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.{h,cxx}`
  — `SetDistanceMapTextureObject()` / `GetDistanceMapTextureObject()`
  accessors holding a `vtkSmartPointer<vtkTextureObject>`; `Activate()` +
  `SetUniformi("distanceTexture", GetTextureUnit())` in
  `SetMapperShaderParameters()`; `Deactivate()` in an overridden
  `RenderPieceFinish()`.
- `LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx` —
  threads the texture object to the mapper at the end of
  `CreateAndTransferDistanceMapTexture()`.
- `LiverResections/Testing/Python/distancemap_double_render_test.py` +
  `CMakeLists.txt` registration (`LiverResections_distance_map_double_render`,
  outside the `SlicerLiver_ENABLE_VISUAL_TESTS` opt-in since it has no
  ExternalData baseline dependency).

### Why the relocation (#468) is exonerated

The `git mv` that relocated the mapper changed 0 body lines; the texture
upload helper (`vtkMultiTextureObjectHelper::CreateSeq3DFromRaw`) was not
moved. The bug is a pre-existing draw-time binding hazard, driver-agnostic
(reproduces on both llvmpipe and radeonsi per the keystone analysis), which
is why it is "our binding, not a vendor quirk".

### Build

Configured + built clean inside the worktree (`build/`, Debug) against the
local Slicer-build + SlicerLayerDM; both touched VTKWidgets libraries
compile with zero errors. Rendering could not be exercised in the
implementation environment (the bezier distance-map render aborts/hangs on
every host here) — hence the maintainer `:0` verification gate above.

</details>