### PR TITLE
ENH: Unshadow PyPI packaging in the launched pytest driver

### DIFF
--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -83,6 +83,37 @@ def _test_roots(argv: list[str]) -> list[str]:
     return argv[1:]
 
 
+def _unshadow_pypi_packaging() -> None:
+    """Drop a ``slicer`` package dir from ``sys.path`` when it shadows ``packaging``.
+
+    In some Slicer builds the ``slicer`` *package directory itself* lands on
+    ``sys.path`` (not merely its parent), so the ``packaging.py`` it bundles
+    shadows the real ``site-packages/packaging`` package.  pytest's
+    ``_checkversion`` then runs ``from packaging.version import Version`` and
+    crashes at startup with ``'packaging' is not a package`` -- which is why a
+    launched pytest run could only be exercised on CI, never locally.
+
+    Remove any ``sys.path`` entry that is a ``slicer`` package dir carrying a
+    ``packaging.py``, and evict a half-imported single-module ``packaging`` so
+    the next import resolves to the real package.  No-op when the shadow is
+    absent (e.g. CI), so it is safe everywhere.
+    """
+    cleaned = [
+        p
+        for p in sys.path
+        if not (
+            p
+            and os.path.basename(os.path.normpath(p)) == "slicer"
+            and os.path.isfile(os.path.join(p, "packaging.py"))
+        )
+    ]
+    if len(cleaned) != len(sys.path):
+        sys.path[:] = cleaned
+        shadow = sys.modules.get("packaging")
+        if shadow is not None and not hasattr(shadow, "__path__"):
+            sys.modules.pop("packaging", None)
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run pytest against the supplied roots and return its exit code.
 
@@ -92,6 +123,8 @@ def main(argv: list[str] | None = None) -> int:
     """
     if argv is None:
         argv = sys.argv
+
+    _unshadow_pypi_packaging()
 
     import pytest
 


### PR DESCRIPTION
## What

Follow-up to #480: fold the `packaging` self-shadow workaround into the launched pytest driver (`run_pytest_launched.py`). This commit was validated and pushed just after #480 merged, so it missed the merge — landing it here.

Some Slicer builds place the `slicer` **package directory itself** on `sys.path` (not just its parent), so the `packaging.py` it bundles shadows the real `site-packages/packaging`. pytest's `_checkversion` then runs `from packaging.version import Version` and crashes at startup with `'packaging' is not a package` — which is why the launched pytest suite could only be exercised on CI, never locally.

## Fix

Before importing pytest, drop any `sys.path` entry that is a `slicer` package dir carrying a `packaging.py`, and evict a half-imported single-module `packaging` so the next import resolves to the real package. No-op when the shadow is absent (e.g. CI), so it's safe everywhere.

## Why it matters

Locally it lets the full launched suite + the `vtkDebugLeaks` shutdown check run via the real driver — lifting the long-standing "CI is the only place the launched pytest verdict is real" limitation. (That's how #480's `vtkDebugLeaks` leak was reproduced and bisected locally rather than via CI cycles.)

## Verification

- Real driver runs the full launched suite locally: **158 passed, 6 skipped, 1 xfailed, 0 leaks**, no packaging crash.
- Driver exit-code contract unchanged — `test_run_pytest_launched_contract.py` green (4 passed).