### PR TITLE
ENH: T3 ResectogramPipeline — §9 fixture, Representations, scaling, visual scaffold (#465)

### DIFF
--- a/Docs/adr/0013-layerdm-pipeline-pattern.md
+++ b/Docs/adr/0013-layerdm-pipeline-pattern.md
@@ -284,9 +284,10 @@ ships **three** tests, one per layer:
   `pytest --render-interactive=5` a developer sees the same
   assertions execute on visible pixels.
 
-The T2 LiverResections PR therefore **delivers the "real-view
-fixture" deferred by PR #316** — the missing piece of the ADR-0008
-test pyramid that the pytest scaffold left as a TODO.
+The T3 ResectogramPipeline tranche therefore **delivers the "real-view
+fixture" deferred by PR #316** (carried through T2 LiverResections to
+T3) — the missing piece of the ADR-0008 test pyramid that the pytest
+scaffold left as a TODO; it un-skips the launched Pipeline-dispatch test.
 
 ### 10. Pipeline class skeleton (illustrative)
 
@@ -421,7 +422,8 @@ under a follow-up ADR.
   test, Representation tests, workflow test with
   `render_interactive`.  The pytest scaffold is in place per PR
   #316; the *real-view fixture* the scaffold left as a TODO lands
-  in T2 LiverResections and is the precondition for T3.
+  in T3 (the ResectogramPipeline tranche), un-skipping the launched
+  Pipeline-dispatch test.
 - **Two architectures coexist during v2.0.0.**  Per
   [ADR-0002](0002-migrate-to-slicerlayerdm.md) Consequences, the
   legacy Markups path stays alive feature-flagged until the
@@ -462,9 +464,9 @@ pattern once:
    `vtkMRMLLiverResectionNode` and land on the new
    `vtkMRMLLiverBezierSurfaceDisplayNode` (per §8 above).
    Establishes `Liver<Module>/<Module>Pipeline.py` and the
-   `Representations/` subdirectory; delivers the real-view fixture
-   deferred by PR #316; provides the worked example T3 reviews
-   against.
+   `Representations/` subdirectory; provides the worked example T3
+   reviews against.  (The real-view fixture deferred by PR #316 lands
+   in T3 itself, not here.)
 2. **T3 — Resectogram + distance maps.**  Splits the resectogram
    into its own Pipeline composing the locator-crosshair,
    flattened-surface, and vascular-contour Representations.  The
@@ -496,7 +498,7 @@ the same pattern.
     nodes in C++.
   - [ADR-0008](0008-testing-strategy.md) — the three-layer test
     discipline this ADR applies to every Pipeline and
-    Representation; T2 delivers the deferred real-view fixture.
+    Representation; T3 delivers the deferred real-view fixture.
   - [ADR-0009](0009-ux-and-design-discipline.md) — UI diagrams
     under `Docs/architecture/ui/<module>.md` and combo-box
     elimination, both downstream of this pattern.

--- a/Docs/adr/0015-cpp-algorithm-library.md
+++ b/Docs/adr/0015-cpp-algorithm-library.md
@@ -145,8 +145,10 @@ testability is the load-bearing reason.
 ## Decision
 
 Slicer-Liver creates a new `LiverResections/Algorithm/` subdirectory
-hosting a C++ algorithm library with four `vtkAlgorithm`-style
-classes.  The library is pure VTK with **no MRML dependency**, is
+hosting a C++ algorithm library of `vtkAlgorithm`-style classes (the
+four original fitting/extraction classes plus the two `vtkLiverResectogram*`
+helpers added in T3 — see the §1 roster).  The library is pure VTK with
+**no MRML dependency**, is
 Python-wrapped via Slicer's existing VTK wrapping, ships its own C++
 test set under `Algorithm/Testing/Cxx/`, and is consumed by the
 state-aware LiverResections Pipeline introduced in
@@ -163,9 +165,13 @@ elsewhere in `LiverResections/` (`Logic/`, `MRML/`, `MRMLDM/`,
 | `vtkLiverSpheroidRingExtractor` | target `vtkPolyData` + spheroid | ordered ring `vtkPolyData` | `DistanceSpheroidInitRepresentation` |
 | `vtkLiverContourParameterizer` | ring + mode (corner-mapping / EFD) | parameterised curve | `vtkLiverBezierFitter` |
 | `vtkLiverBezierFitter` | parameterised curve | 4×4 grid + ring roles | Init→Planning transition |
+| `vtkLiverResectogramAspectRatio` | sampled grid + (u,v) sample counts | anisotropic `MatRatio` | `FlattenedSurfaceRepresentation` (T3) |
+| `vtkLiverResectogramPixelMapping` | (u,v) domain + viewport | pixel→(u,v) mapping | resectogram locator (T3; ADR-0025) |
 
-All four subclass `vtkPolyDataAlgorithm` (or `vtkAlgorithm` where the
-output is not a `vtkPolyData`).  Inputs come in through the standard
+All of these subclass `vtkPolyDataAlgorithm` (or `vtkAlgorithm` where the
+output is not a `vtkPolyData`).  The two `vtkLiverResectogram*` helpers
+were added by the T3 ResectogramPipeline tranche (the resectogram math
+the original four did not cover).  Inputs come in through the standard
 VTK pipeline input ports; parameters come in through `Set/Get`
 accessors.  No `vtkMRMLNode` reference appears in any of these
 classes — MRML lives entirely in the Python orchestration layer

--- a/LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx
+++ b/LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx
@@ -45,7 +45,6 @@
 #include "vtkMRMLScalarVolumeNode.h"
 #include "vtkSlicerMarkupsWidgetRepresentation.h"
 #include "vtkOpenGLBezierResectionPolyDataMapper.h"
-#include "vtkOpenGLResection2DPolyDataMapper.h"
 
 // LiverResections Algorithm includes (cross-module, ADR-0015 §1)
 #include "vtkSlicerLiverBezierControlPolygonGeometry.h"
@@ -82,7 +81,7 @@
 #include <vtkPolyDataMapper.h>
 #include <vtkPolyDataNormals.h>
 #include <vtkProperty.h>
-#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
 #include <vtkSetGet.h>
 #include <vtkShaderProperty.h>
 #include <vtkSmartPointer.h>
@@ -90,7 +89,6 @@
 #include <vtkTextureObject.h>
 #include <vtkUniforms.h>
 #include <vtkMatrix3x3.h>
-#include "vtkRendererCollection.h"
 #include <vtkNamedColors.h>
 #include <vtkTypeFloat32Array.h>
 #include <vtkImageCast.h>
@@ -98,7 +96,6 @@
 
 //------------------------------------------------------------------------------
 vtkStandardNewMacro(vtkSlicerBezierSurfaceRepresentation3D);
-static const int RENDERER_LAYER = 1;
 
 //------------------------------------------------------------------------------
 vtkSlicerBezierSurfaceRepresentation3D::vtkSlicerBezierSurfaceRepresentation3D()
@@ -114,28 +111,6 @@ vtkSlicerBezierSurfaceRepresentation3D::vtkSlicerBezierSurfaceRepresentation3D()
   this->BezierSurfaceNormals = vtkSmartPointer<vtkPolyDataNormals>::New();
   this->BezierSurfaceNormals->SetInputConnection(this->BezierSurfaceSource->GetOutputPort());
 
-  this->BezierPlane = vtkSmartPointer<vtkBezierSurfaceSource>::New();
-  this->BezierPlane->SetResolution(20, 20);
-  auto PlaneControlPoints = vtkSmartPointer<vtkPoints>::New();
-
-  for (int i = 0; i < 4; i++)
-  {
-    PlaneControlPoints->InsertNextPoint(-60, (i * 40), 0);
-    PlaneControlPoints->InsertNextPoint(-20, (i * 40), 0);
-    PlaneControlPoints->InsertNextPoint(20, (i * 40), 0);
-    PlaneControlPoints->InsertNextPoint(60, (i * 40), 0);
-  }
-
-  this->BezierPlane->SetControlPoints(PlaneControlPoints);
-  this->BezierPlane->Update();
-
-  this->ResectogramCamera = vtkSmartPointer<vtkCamera>::New();
-  ResectogramPlaneCenter(true);
-
-  auto BezierPlanePoints = BezierPlane->GetOutput()->GetPoints()->GetData();
-  BezierPlanePoints->SetName("BSPlanePoints");
-  this->BezierSurfaceNormals->GetOutput()->GetPointData()->AddArray(BezierPlanePoints);
-
   this->BezierSurfaceControlPoints = vtkSmartPointer<vtkPoints>::New();
   this->BezierSurfaceControlPoints->SetNumberOfPoints(16);
   this->BezierSurfaceControlPoints->DeepCopy(planeSource->GetOutput()->GetPoints());
@@ -145,11 +120,6 @@ vtkSlicerBezierSurfaceRepresentation3D::vtkSlicerBezierSurfaceRepresentation3D()
   this->BezierSurfaceResectionMapper->SetInputConnection(this->BezierSurfaceNormals->GetOutputPort());
   this->BezierSurfaceActor = vtkSmartPointer<vtkOpenGLActor>::New();
   this->BezierSurfaceActor->SetMapper(this->BezierSurfaceResectionMapper);
-
-  this->BezierSurfaceResectionMapper2D = vtkSmartPointer<vtkOpenGLResection2DPolyDataMapper>::New();
-  this->BezierSurfaceResectionMapper2D->SetInputConnection(BezierPlane->GetOutputPort());
-  this->BezierSurfaceActor2D = vtkSmartPointer<vtkOpenGLActor>::New();
-  this->BezierSurfaceActor2D->SetMapper(this->BezierSurfaceResectionMapper2D);
 
   this->ControlPolygonPolyData = vtkSmartPointer<vtkPolyData>::New();
   this->ControlPolygonTubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
@@ -233,45 +203,10 @@ void vtkSlicerBezierSurfaceRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller,
 
       this->BezierSurfaceResectionMapper->SetRasToIjkMatrixT(rasToIjkT);
       this->BezierSurfaceResectionMapper->SetIjkToTextureMatrixT(ijkToTextureT);
-      this->BezierSurfaceResectionMapper2D->SetRasToIjkMatrixT(rasToIjkT);
-      this->BezierSurfaceResectionMapper2D->SetIjkToTextureMatrixT(ijkToTextureT);
     }
 
     this->DistanceMapVolumeNode = distanceMap;
   }
-
-  //------------------- add new renderer here ----------------------//
-  if (BezierSurfaceDisplayNode->GetShowResection2D())
-  {
-    auto renderWindow1 = vtkRenderWindow::SafeDownCast(this->GetRenderer()->GetRenderWindow());
-    auto renderers = renderWindow1->GetRenderers();
-    if (renderers->GetNumberOfItems() != 5)
-    {
-      double yViewport[4] = { 0, 0.6, 0.3, 1.0 };
-
-      if (renderWindow1->GetNumberOfLayers() < RENDERER_LAYER + 1)
-      {
-        renderWindow1->SetNumberOfLayers(RENDERER_LAYER + 1);
-      }
-      auto CoRenderer2D = vtkSmartPointer<vtkRenderer>::New();
-      CoRenderer2D->SetLayer(RENDERER_LAYER);
-      CoRenderer2D->InteractiveOff();
-      CoRenderer2D->SetActiveCamera(this->ResectogramCamera);
-      CoRenderer2D->AddActor(this->BezierSurfaceActor2D);
-      CoRenderer2D->SetViewport(yViewport);
-      renderWindow1->AddRenderer(CoRenderer2D);
-      renderWindow1->Render();
-    }
-  }
-
-  if (BezierSurfaceDisplayNode->GetMirrorDisplay())
-  {
-    ResectogramPlaneCenter(true);
-  }
-  else
-  {
-    ResectogramPlaneCenter(false);
-  };
 
   this->NeedToRenderOn();
 }
@@ -289,7 +224,6 @@ void vtkSlicerBezierSurfaceRepresentation3D::ReleaseGraphicsResources(vtkWindow*
 {
   this->Superclass::ReleaseGraphicsResources(win);
   this->BezierSurfaceActor->ReleaseGraphicsResources(win);
-  this->BezierSurfaceActor2D->ReleaseGraphicsResources(win);
   this->ControlPolygonActor->ReleaseGraphicsResources(win);
 }
 
@@ -359,10 +293,6 @@ vtkTypeBool vtkSlicerBezierSurfaceRepresentation3D::HasTranslucentPolygonalGeome
   {
     return true;
   }
-  if (this->BezierSurfaceActor2D->GetVisibility() && this->BezierSurfaceActor2D->HasTranslucentPolygonalGeometry())
-  {
-    return true;
-  }
   if (this->ControlPolygonActor->GetVisibility() && this->ControlPolygonActor->HasTranslucentPolygonalGeometry())
   {
     return true;
@@ -416,14 +346,6 @@ void vtkSlicerBezierSurfaceRepresentation3D::PrintSelf(ostream& os, vtkIndent in
   {
     os << indent << "BezierSurface Visibility: (none)\n";
   }
-  if (this->BezierSurfaceActor2D)
-  {
-    os << indent << "BezierSurface2D Visibility: " << this->BezierSurfaceActor2D->GetVisibility() << "\n";
-  }
-  else
-  {
-    os << indent << "BezierSurface2D Visibility: (none)\n";
-  }
   if (this->ControlPolygonActor)
   {
     os << indent << "ControlPolygon Visibility: " << this->ControlPolygonActor->GetVisibility() << "\n";
@@ -465,20 +387,6 @@ void vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceGeometry(vtkMRML
 
     this->BezierSurfaceSource->SetControlPoints(this->BezierSurfaceControlPoints);
     this->BezierSurfaceSource->Update();
-    this->BezierSurfaceSourcePoints = this->BezierSurfaceSource->GetOutput()->GetPoints()->GetData();
-    this->BezierSurfaceSourcePoints->SetName("BSPoints");
-    auto BezierSurfaceDisplayNode = vtkMRMLMarkupsBezierSurfaceDisplayNode::SafeDownCast(node->GetDisplayNode());
-    Ratio(BezierSurfaceDisplayNode->GetEnableFlexibleBoundary());
-
-    if (this->BezierPlane->GetOutput()->GetPointData()->GetArray("BSPoints"))
-    {
-      this->BezierPlane->GetOutput()->GetPointData()->RemoveArray("BSPoints");
-      this->BezierPlane->GetOutput()->GetPointData()->AddArray(this->BezierSurfaceSourcePoints);
-    }
-    else
-    {
-      this->BezierPlane->GetOutput()->GetPointData()->AddArray(this->BezierSurfaceSourcePoints);
-    }
   }
 }
 
@@ -600,11 +508,6 @@ void vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay(vtkMRMLM
   this->BezierSurfaceResectionMapper->SetResectionMargin(node->GetResectionMargin());
   this->BezierSurfaceResectionMapper->SetUncertaintyMargin(node->GetUncertaintyMargin());
 
-  this->BezierSurfaceResectionMapper2D->SetResectionMargin(node->GetResectionMargin());
-  this->BezierSurfaceResectionMapper2D->SetUncertaintyMargin(node->GetUncertaintyMargin());
-  this->BezierSurfaceResectionMapper2D->SetHepaticContourThickness(node->GetHepaticContourThickness());
-  this->BezierSurfaceResectionMapper2D->SetPortalContourThickness(node->GetPortalContourThickness());
-
   if (displayNode)
   {
     this->BezierSurfaceResectionMapper->SetResectionColor(displayNode->GetResectionColor());
@@ -624,25 +527,6 @@ void vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay(vtkMRMLM
       this->BezierSurfaceResectionMapper->SetGridDivisions(0.0);
       this->BezierSurfaceResectionMapper->SetGridThicknessFactor(0.0);
     }
-
-    this->BezierSurfaceResectionMapper2D->SetResectionColor(displayNode->GetResectionColor());
-    this->BezierSurfaceResectionMapper2D->SetResectionGridColor(displayNode->GetResectionGridColor());
-    this->BezierSurfaceResectionMapper2D->SetResectionMarginColor(displayNode->GetResectionMarginColor());
-    this->BezierSurfaceResectionMapper2D->SetUncertaintyMarginColor(displayNode->GetUncertaintyMarginColor());
-    this->BezierSurfaceResectionMapper2D->SetInterpolatedMargins(displayNode->GetInterpolatedMargins());
-    this->BezierSurfaceResectionMapper2D->SetHepaticContourColor(displayNode->GetHepaticContourColor());
-    this->BezierSurfaceResectionMapper2D->SetPortalContourColor(displayNode->GetPortalContourColor());
-    this->BezierSurfaceResectionMapper2D->SetTextureNumComps(displayNode->GetTextureNumComps());
-    if (displayNode->GetGrid2DVisibility())
-    {
-      this->BezierSurfaceResectionMapper2D->SetGridDivisions(displayNode->GetGridDivisions());
-      this->BezierSurfaceResectionMapper2D->SetGridThicknessFactor(displayNode->GetGridThickness());
-    }
-    else
-    {
-      this->BezierSurfaceResectionMapper2D->SetGridDivisions(0.0);
-      this->BezierSurfaceResectionMapper2D->SetGridThicknessFactor(0.0);
-    }
   }
 }
 
@@ -660,73 +544,4 @@ void vtkSlicerBezierSurfaceRepresentation3D::UpdateControlPolygonDisplay(vtkMRML
       controlPoints->Actor->SetVisibility(displayNode->GetWidgetVisibility());
     }
   }
-}
-
-//----------------------------------------------------------------------------
-void vtkSlicerBezierSurfaceRepresentation3D::Ratio(bool flexibleBoundery)
-{
-
-  float matR[2];
-  if (flexibleBoundery)
-  {
-    double disU = 0, disV = 0;
-    std::vector<double> p0u = { this->BezierSurfaceSourcePoints->GetTuple3(0)[0],
-                                this->BezierSurfaceSourcePoints->GetTuple3(0)[1],
-                                this->BezierSurfaceSourcePoints->GetTuple3(0)[2] };
-    std::vector<double> p0v = { this->BezierSurfaceSourcePoints->GetTuple3(0)[0],
-                                this->BezierSurfaceSourcePoints->GetTuple3(0)[1],
-                                this->BezierSurfaceSourcePoints->GetTuple3(0)[2] };
-
-    for (int i = 1; i < 20; i++)
-    {
-      std::vector<double> p1 = { this->BezierSurfaceSourcePoints->GetTuple3(i)[0],
-                                 this->BezierSurfaceSourcePoints->GetTuple3(i)[1],
-                                 this->BezierSurfaceSourcePoints->GetTuple3(i)[2] };
-      std::vector<double> p2 = { this->BezierSurfaceSourcePoints->GetTuple3(20 * i)[0],
-                                 this->BezierSurfaceSourcePoints->GetTuple3(20 * i)[1],
-                                 this->BezierSurfaceSourcePoints->GetTuple3(20 * i)[2] };
-
-      auto d01 = sqrt(pow(p0u[0] - p1[0], 2.0) + pow(p0u[1] - p1[1], 2.0) + pow(p0u[2] - p1[2], 2.0));
-      disU = disU + d01;
-      auto d02 = sqrt(pow(p0v[0] - p2[0], 2.0) + pow(p0v[1] - p2[1], 2.0) + pow(p0v[2] - p2[2], 2.0));
-      disV = disV + d02;
-      p0u = p1;
-      p0v = p2;
-    }
-
-    if (disU >= disV)
-    {
-      matR[0] = 1;
-      matR[1] = disV / disU;
-    }
-    else
-    {
-      matR[0] = disU / disV;
-      matR[1] = 1;
-    }
-  }
-  else
-  {
-    matR[0] = 1;
-    matR[1] = 1;
-  }
-  this->BezierSurfaceResectionMapper2D->SetMatRatio(matR);
-}
-
-void vtkSlicerBezierSurfaceRepresentation3D::ResectogramPlaneCenter(bool mirror)
-{
-  int z = 1;
-  if (mirror)
-  {
-    z = 1;
-  }
-  else
-  {
-    z = -1;
-  }
-  double bounds[6];
-  this->BezierPlane->GetOutput()->GetBounds(bounds);
-  double center[3] = { (bounds[0] + bounds[1]) / 2, (bounds[2] + bounds[3]) / 2, z * 100.0 };
-  this->ResectogramCamera->SetPosition(center[0], center[1], center[2] * 3);
-  this->ResectogramCamera->SetFocalPoint(center[0], center[1], center[2]);
 }

--- a/LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.h
+++ b/LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.h
@@ -52,9 +52,6 @@
 // VTK includes
 #include <vtkWeakPointer.h>
 #include <vtkSmartPointer.h>
-#include "vtkOpenGLPolyDataMapper2D.h"
-#include <vtkActor2D.h>
-#include <vtkCamera.h>
 
 //------------------------------------------------------------------------------
 class vtkBezierSurfaceSource;
@@ -65,7 +62,6 @@ class vtkPoints;
 class vtkTextureObject;
 class vtkTubeFilter;
 class vtkOpenGLBezierResectionPolyDataMapper;
-class vtkOpenGLResection2DPolyDataMapper;
 
 //------------------------------------------------------------------------------
 class vtkMRMLMarkupsBezierSurfaceNode;
@@ -96,8 +92,6 @@ protected:
   /// TransferDistanceMap
   void CreateAndTransferDistanceMapTexture(vtkMRMLScalarVolumeNode* node, int numComps);
   void CreateAndTransferVascularSegmentsTexture(vtkMRMLScalarVolumeNode* node);
-  void Ratio(bool flexibleBoundery);
-  void ResectogramPlaneCenter(bool mirror);
 
 protected:
   // k Bezier surface releated elements
@@ -106,11 +100,6 @@ protected:
   vtkSmartPointer<vtkOpenGLBezierResectionPolyDataMapper> BezierSurfaceResectionMapper;
   vtkSmartPointer<vtkOpenGLActor> BezierSurfaceActor;
   vtkSmartPointer<vtkPolyDataNormals> BezierSurfaceNormals;
-  vtkSmartPointer<vtkOpenGLActor> BezierSurfaceActor2D;
-  vtkSmartPointer<vtkOpenGLResection2DPolyDataMapper> BezierSurfaceResectionMapper2D;
-  vtkSmartPointer<vtkBezierSurfaceSource> BezierPlane;
-  vtkSmartPointer<vtkDataArray> BezierSurfaceSourcePoints;
-  vtkSmartPointer<vtkCamera> ResectogramCamera;
 
   // Control polygon related elements
   vtkSmartPointer<vtkPolyData> ControlPolygonPolyData;
@@ -124,7 +113,6 @@ protected:
   vtkNew<vtkMatrix4x4> VBOShiftScale;
   vtkNew<vtkTransform> VBOInverseTransform;
   vtkWeakPointer<vtkShaderProperty> ShaderProperty;
-  vtkSmartPointer<vtkRenderer> CoRenderer2D;
 
   // Vascular Segments related elements
   vtkSmartPointer<vtkMultiTextureObjectHelper> VascularSegmentsTexture;

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -79,6 +79,20 @@ except ImportError:  # pragma: no cover — pure-Python path
 
 RESECTOGRAM_RENDERER_LAYER = 1
 
+# Flattened-quad geometry for the resectogram domain.  The resectogram is
+# the flattened 2D image of the Bezier ``(u, v)`` parameter domain
+# (ADR-0025 §Context); the strip is drawn on a FIXED flat quad — the same
+# planar 4x4 control grid + 20x20 tessellation the v1 monolith
+# ``vtkSlicerBezierSurfaceRepresentation3D`` poses its ``BezierPlane`` from
+# — NOT the data node's 3D surface.  The data node feeds the distance-map
+# texture and the ``MatRatio`` squeeze, not this quad's vertices.
+_FLATTENED_QUAD_RESOLUTION = (20, 20)
+_FLATTENED_QUAD_CONTROL_GRID = tuple(
+    (x, row * 40.0, 0.0)
+    for row in range(4)
+    for x in (-60.0, -20.0, 20.0, 60.0)
+)
+
 
 class FlattenedSurfaceRepresentation:
     """VTK assembly for the resectogram's flattened surface.
@@ -210,6 +224,7 @@ class FlattenedSurfaceRepresentation:
         assert vtk is not None  # gated by _HAS_VTK
 
         self._bezier_plane = _make_flattened_quad_source()
+        _initialise_flattened_quad(self._bezier_plane)
 
         mapper = _make_resection_mapper_2d()
         if self._bezier_plane is not None and hasattr(mapper, "SetInputConnection"):
@@ -366,9 +381,39 @@ def _make_flattened_quad_source() -> Any | None:
     if not _HAS_VTK:
         return None
     factory = getattr(vtk, "vtkBezierSurfaceSource", None)
+    if factory is None:
+        try:  # pragma: no cover — exercised inside Slicer
+            from slicer import vtkBezierSurfaceSource as factory  # type: ignore[no-redef]
+        except Exception:
+            factory = None
     if factory is not None:
         return factory()
     return vtk.vtkPlaneSource()
+
+
+def _initialise_flattened_quad(plane: Any | None) -> None:
+    """Tessellate the fixed flattened-domain quad on ``plane``.
+
+    Feeds the planar 4x4 control grid + 20x20 resolution the v1 monolith
+    poses ``BezierPlane`` from, then runs the source so its output carries
+    the strip geometry the 2D mapper renders.  A no-op on the generic
+    ``vtkPlaneSource`` fallback (which lacks ``SetControlPoints``); that
+    source already emits a unit quad sufficient for the bare-VTK unit
+    tests, which do not assert lit pixels.
+    """
+    if plane is None:
+        return
+    set_resolution = getattr(plane, "SetResolution", None)
+    set_control_points = getattr(plane, "SetControlPoints", None)
+    if set_resolution is None or set_control_points is None:
+        return
+    set_resolution(*_FLATTENED_QUAD_RESOLUTION)
+    points = vtk.vtkPoints()
+    for x, y, z in _FLATTENED_QUAD_CONTROL_GRID:
+        points.InsertNextPoint(x, y, z)
+    set_control_points(points)
+    if hasattr(plane, "Update"):
+        plane.Update()
 
 
 def _quad_source_bounds(plane: Any) -> tuple | None:

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -159,6 +159,7 @@ class FlattenedSurfaceRepresentation:
         """
         self._apply_display_node(display_node)
         self._apply_data_node(display_node, data_node)
+        self._pose_overlay_camera(display_node)
 
     def cleanup(self) -> None:
         """Detach actors from the renderer and drop the VTK pipeline."""
@@ -318,6 +319,36 @@ class FlattenedSurfaceRepresentation:
             return (1.0, 1.0)
         return (float(ratio_out[0]), float(ratio_out[1]))
 
+    def _pose_overlay_camera(self, display_node: Any | None) -> None:
+        """Pose the resectogram's private overlay camera.
+
+        Reproduces the v1 ``ResectogramPlaneCenter`` pose: looks straight
+        down the flattened quad from its centre, with ``MirrorDisplay``
+        flipping the camera's z sign so the resectogram can be presented
+        mirrored to a partner display (ADR-0025 §Context).  No-op when the
+        camera or the quad source is unavailable (bare-VTK pytest path).
+        """
+        camera = self._resectogram_camera
+        plane = self._bezier_plane
+        if camera is None or plane is None:
+            return
+        if not hasattr(camera, "SetPosition"):
+            return
+
+        bounds = _quad_source_bounds(plane)
+        if bounds is None:
+            return
+
+        mirror = _safe_get_bool(display_node, "GetMirrorDisplay", default=False)
+        z_sign = 1.0 if mirror else -1.0
+
+        center_x = (bounds[0] + bounds[1]) / 2.0
+        center_y = (bounds[2] + bounds[3]) / 2.0
+        center_z = z_sign * 100.0
+
+        camera.SetPosition(center_x, center_y, center_z * 3.0)
+        camera.SetFocalPoint(center_x, center_y, center_z)
+
 
 # --------------------------------------------------------------------------- #
 # Helpers — small, self-contained per ADR-0013 §6 (Representations are
@@ -338,6 +369,25 @@ def _make_flattened_quad_source() -> Any | None:
     if factory is not None:
         return factory()
     return vtk.vtkPlaneSource()
+
+
+def _quad_source_bounds(plane: Any) -> tuple | None:
+    """Return the flattened quad's ``(xmin, xmax, ymin, ymax, zmin, zmax)``.
+
+    Updates the source pipeline first (the v1 ``ResectogramPlaneCenter``
+    reads ``BezierPlane->GetOutput()->GetBounds()``).  Returns ``None``
+    defensively when the source does not expose a bounded output.
+    """
+    try:
+        if hasattr(plane, "Update"):
+            plane.Update()
+        output = plane.GetOutput()
+        bounds = output.GetBounds()
+    except Exception:  # pragma: no cover - defensive
+        return None
+    if bounds is None or len(bounds) < 6:
+        return None
+    return tuple(float(b) for b in bounds)
 
 
 def _make_resection_mapper_2d() -> Any:

--- a/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
@@ -111,8 +111,17 @@ class VascularContourRepresentation:
         return self._renderer
 
     def update(self, display_node: Any | None, data_node: Any | None) -> None:
-        """Reconcile the contour actors' visibility against the display node."""
-        del data_node  # geometry feed lands with the monolith-sever follow-up
+        """Reconcile the contour overlays against the current node set.
+
+        Pushes the flattened-strip polydata (the same strip the
+        ``FlattenedSurfaceRepresentation`` draws — the contours are
+        computed over it) into both contour mappers, then reconciles the
+        actors' visibility against ``ShowResection2D``.  Tolerant of
+        ``None`` arguments and of data nodes that do not yet expose the
+        strip accessor.
+        """
+        self._apply_strip_input(data_node)
+
         show = _safe_get_bool(display_node, "GetShowResection2D", default=False)
         for actor in (self._distance_contour_actor, self._slicing_contour_actor):
             if actor is not None:
@@ -177,6 +186,26 @@ class VascularContourRepresentation:
         self._slicing_contour_actor.SetMapper(self._slicing_contour_mapper)
         self._slicing_contour_actor.SetVisibility(False)
 
+    def _apply_strip_input(self, data_node: Any | None) -> None:
+        """Feed the flattened-strip polydata into both contour mappers.
+
+        The vascular contours are computed over the SAME flattened strip
+        the surface Representation draws (ADR-0025 §Context), so both
+        mappers take that polydata as their input.  No-op when the data
+        node is absent or does not yet expose the strip accessor (stub
+        data nodes in unit tests; the monolith-sever follow-up wires the
+        live carrier).
+        """
+        strip = _safe_get_strip_polydata(data_node)
+        if strip is None:
+            return
+        for mapper in (self._distance_contour_mapper, self._slicing_contour_mapper):
+            if mapper is None:
+                continue
+            setter = getattr(mapper, "SetInputData", None)
+            if setter is not None:
+                setter(strip)
+
     def _attach_actors(self, renderer: Any) -> None:
         if not hasattr(renderer, "AddActor"):
             return
@@ -219,6 +248,27 @@ def _make_contour_mapper(class_name: str) -> Any:
     if factory is not None:
         return factory()
     return vtk.vtkPolyDataMapper()
+
+
+def _safe_get_strip_polydata(data_node: Any | None) -> Any | None:
+    """Return the flattened-strip ``vtkPolyData`` off the data node, if any.
+
+    Reads a small set of conventional accessors defensively; returns
+    ``None`` when none are present (stub data nodes in unit tests).
+    """
+    if data_node is None:
+        return None
+    for name in ("GetResectogramStripPolyData", "GetStripPolyData"):
+        getter = getattr(data_node, name, None)
+        if getter is None:
+            continue
+        try:
+            value = getter()
+        except Exception:  # pragma: no cover - defensive
+            continue
+        if value is not None:
+            return value
+    return None
 
 
 def _safe_get_bool(node: Any | None, getter_name: str, *, default: bool) -> bool:

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -11,6 +11,7 @@ set(KIT vtkSlicer${MODULE_NAME}ModuleMRML)
 set(KIT_TEST_SRCS
   vtkMRMLBezierSurfaceNodeTest1.cxx
   vtkMRMLParametricSurfaceDisplayNodeTest1.cxx
+  vtkMRMLResectogramDisplayNodeTest1.cxx
   vtkMRMLAbstractParametricSurfaceNodeTest1.cxx
   vtkMRMLResectionPlanNodeTest1.cxx
   vtkMRMLResectionPlanStorageNodeTest1.cxx
@@ -52,6 +53,7 @@ slicerMacroConfigureModuleCxxTestDriver(
 
 SIMPLE_TEST(vtkMRMLBezierSurfaceNodeTest1)
 SIMPLE_TEST(vtkMRMLParametricSurfaceDisplayNodeTest1)
+SIMPLE_TEST(vtkMRMLResectogramDisplayNodeTest1)
 SIMPLE_TEST(vtkMRMLAbstractParametricSurfaceNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanStorageNodeTest1)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLResectogramDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLResectogramDisplayNodeTest1.cxx
@@ -1,0 +1,223 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Tests for vtkMRMLResectogramDisplayNode — the display-only node that
+  keys the ResectogramPipeline (ADR-0013 §1).  Exercises:
+
+   - defaults on every resectogram field, including the net-new
+     Gaussian-blur post-pass toggle (BlurEnabled / BlurRadius, ADR-0013 §6)
+   - setter/getter round-trip on every field
+   - XML serialize/deserialize via WriteXML+ReadXMLAttributes
+   - CopyContent / DeepCopy
+   - Modified() fires on the blur setters (Pipeline observer contract)
+
+  The blur round-trip is the ADR-0027 invariant pinned with the net-new
+  Gaussian-blur feature: the toggle + radius must persist through the
+  scene's XML and survive CopyContent so a saved resectogram reopens with
+  the same blur appearance.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLResectogramDisplayNode.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkNew.h>
+
+// STD includes
+#include <cctype>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+int testDefaults()
+{
+  vtkNew<vtkMRMLResectogramDisplayNode> node;
+
+  CHECK_BOOL(node->GetShowResection2D(), false);
+  CHECK_BOOL(node->GetMirrorDisplay(), false);
+  CHECK_BOOL(node->GetEnableFlexibleBoundary(), false);
+  CHECK_INT(node->GetTextureNumComps(), 0);
+
+  // Net-new v2.0 Gaussian-blur post-pass (ADR-0013 §6): OFF by default,
+  // with a sensible non-zero kernel extent so engaging the toggle has a
+  // visible effect without first setting the radius.
+  CHECK_BOOL(node->GetBlurEnabled(), false);
+  CHECK_DOUBLE(node->GetBlurRadius(), 2.0);
+
+  CHECK_STRING(node->GetNodeTagName(), "ResectogramDisplay");
+  return EXIT_SUCCESS;
+}
+
+int testSettersAndGetters()
+{
+  vtkNew<vtkMRMLResectogramDisplayNode> node;
+
+  node->SetShowResection2D(true);
+  CHECK_BOOL(node->GetShowResection2D(), true);
+  node->SetMirrorDisplay(true);
+  CHECK_BOOL(node->GetMirrorDisplay(), true);
+  node->SetEnableFlexibleBoundary(true);
+  CHECK_BOOL(node->GetEnableFlexibleBoundary(), true);
+  node->SetTextureNumComps(4);
+  CHECK_INT(node->GetTextureNumComps(), 4);
+
+  node->SetBlurEnabled(true);
+  CHECK_BOOL(node->GetBlurEnabled(), true);
+  node->SetBlurRadius(3.5);
+  CHECK_DOUBLE(node->GetBlurRadius(), 3.5);
+  return EXIT_SUCCESS;
+}
+
+int testXMLRoundTrip()
+{
+  vtkNew<vtkMRMLResectogramDisplayNode> source;
+  vtkNew<vtkMRMLScene> scene;
+  source->SetScene(scene.GetPointer());
+
+  source->SetShowResection2D(true);
+  source->SetMirrorDisplay(true);
+  source->SetEnableFlexibleBoundary(true);
+  source->SetTextureNumComps(4);
+  source->SetBlurEnabled(true);
+  source->SetBlurRadius(3.5);
+
+  std::ostringstream out;
+  source->WriteXML(out, 0);
+  const std::string xml = out.str();
+
+  // Parse name="value" attribute pairs out of the WriteXML output.
+  std::vector<std::string> storage;
+  std::size_t pos = 0;
+  while (pos < xml.size())
+  {
+    while (pos < xml.size() && std::isspace(static_cast<unsigned char>(xml[pos])))
+    {
+      ++pos;
+    }
+    if (pos >= xml.size())
+    {
+      break;
+    }
+    const std::size_t eq = xml.find('=', pos);
+    if (eq == std::string::npos)
+    {
+      break;
+    }
+    std::string name = xml.substr(pos, eq - pos);
+    if (eq + 1 >= xml.size() || xml[eq + 1] != '"')
+    {
+      break;
+    }
+    const std::size_t valStart = eq + 2;
+    const std::size_t valEnd = xml.find('"', valStart);
+    if (valEnd == std::string::npos)
+    {
+      break;
+    }
+    storage.push_back(name);
+    storage.push_back(xml.substr(valStart, valEnd - valStart));
+    pos = valEnd + 1;
+  }
+
+  std::vector<const char*> atts;
+  atts.reserve(storage.size() + 1);
+  for (const auto& s : storage)
+  {
+    atts.push_back(s.c_str());
+  }
+  atts.push_back(nullptr);
+
+  vtkNew<vtkMRMLResectogramDisplayNode> sink;
+  sink->SetScene(scene.GetPointer());
+  sink->ReadXMLAttributes(atts.data());
+
+  CHECK_BOOL(sink->GetShowResection2D(), source->GetShowResection2D());
+  CHECK_BOOL(sink->GetMirrorDisplay(), source->GetMirrorDisplay());
+  CHECK_BOOL(sink->GetEnableFlexibleBoundary(), source->GetEnableFlexibleBoundary());
+  CHECK_INT(sink->GetTextureNumComps(), source->GetTextureNumComps());
+  CHECK_BOOL(sink->GetBlurEnabled(), source->GetBlurEnabled());
+  CHECK_DOUBLE_TOLERANCE(sink->GetBlurRadius(), source->GetBlurRadius(), 1e-5);
+  return EXIT_SUCCESS;
+}
+
+int testCopyContent()
+{
+  vtkNew<vtkMRMLResectogramDisplayNode> source;
+  source->SetShowResection2D(true);
+  source->SetTextureNumComps(4);
+  source->SetBlurEnabled(true);
+  source->SetBlurRadius(3.5);
+
+  vtkNew<vtkMRMLResectogramDisplayNode> sink;
+  sink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
+
+  CHECK_BOOL(sink->GetShowResection2D(), true);
+  CHECK_INT(sink->GetTextureNumComps(), 4);
+  CHECK_BOOL(sink->GetBlurEnabled(), true);
+  CHECK_DOUBLE(sink->GetBlurRadius(), 3.5);
+
+  // Mutating source must not affect sink (deep-copy semantics).
+  source->SetBlurEnabled(false);
+  source->SetBlurRadius(1.0);
+  CHECK_BOOL(sink->GetBlurEnabled(), true);
+  CHECK_DOUBLE(sink->GetBlurRadius(), 3.5);
+  return EXIT_SUCCESS;
+}
+
+/// Assert that calling ``setter()`` advances ``node->GetMTime()`` so the
+/// Pipeline's ModifiedEvent observer re-runs on a blur change (ADR-0013 §3).
+#define EXPECT_MTIME_ADVANCES(NODE, SETTER_CALL)                                                                                              \
+  do                                                                                                                                          \
+  {                                                                                                                                           \
+    const vtkMTimeType _baseline = (NODE)->GetMTime();                                                                                        \
+    SETTER_CALL;                                                                                                                              \
+    if ((NODE)->GetMTime() <= _baseline)                                                                                                      \
+    {                                                                                                                                         \
+      std::cerr << "Expected MTime to advance after " #SETTER_CALL << " (baseline=" << _baseline << ", post=" << (NODE)->GetMTime() << ")\n"; \
+      return EXIT_FAILURE;                                                                                                                    \
+    }                                                                                                                                         \
+  } while (0)
+
+int testModifiedEventsOnSetters()
+{
+  vtkNew<vtkMRMLResectogramDisplayNode> node;
+  EXPECT_MTIME_ADVANCES(node, node->SetShowResection2D(true));
+  EXPECT_MTIME_ADVANCES(node, node->SetMirrorDisplay(true));
+  EXPECT_MTIME_ADVANCES(node, node->SetEnableFlexibleBoundary(true));
+  EXPECT_MTIME_ADVANCES(node, node->SetTextureNumComps(4));
+  EXPECT_MTIME_ADVANCES(node, node->SetBlurEnabled(true));
+  EXPECT_MTIME_ADVANCES(node, node->SetBlurRadius(3.5));
+  return EXIT_SUCCESS;
+}
+
+#undef EXPECT_MTIME_ADVANCES
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLResectogramDisplayNodeTest1(int, char*[])
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLResectogramDisplayNode> exerciseNode;
+  exerciseNode->SetScene(scene.GetPointer());
+  EXERCISE_ALL_BASIC_MRML_METHODS(exerciseNode.GetPointer());
+
+  CHECK_EXIT_SUCCESS(testDefaults());
+  CHECK_EXIT_SUCCESS(testSettersAndGetters());
+  CHECK_EXIT_SUCCESS(testXMLRoundTrip());
+  CHECK_EXIT_SUCCESS(testCopyContent());
+  CHECK_EXIT_SUCCESS(testModifiedEventsOnSetters());
+
+  std::cout << "vtkMRMLResectogramDisplayNodeTest1 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRML/vtkMRMLResectogramDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLResectogramDisplayNode.cxx
@@ -56,6 +56,8 @@ vtkMRMLResectogramDisplayNode::vtkMRMLResectogramDisplayNode()
   , MirrorDisplay(false)
   , EnableFlexibleBoundary(false)
   , TextureNumComps(0)
+  , BlurEnabled(false)
+  , BlurRadius(2.0)
 {
 }
 
@@ -72,6 +74,8 @@ void vtkMRMLResectogramDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(mirrorDisplay, MirrorDisplay);
   vtkMRMLWriteXMLBooleanMacro(enableFlexibleBoundary, EnableFlexibleBoundary);
   vtkMRMLWriteXMLIntMacro(textureNumComps, TextureNumComps);
+  vtkMRMLWriteXMLBooleanMacro(blurEnabled, BlurEnabled);
+  vtkMRMLWriteXMLFloatMacro(blurRadius, BlurRadius);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -87,6 +91,8 @@ void vtkMRMLResectogramDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(mirrorDisplay, MirrorDisplay);
   vtkMRMLReadXMLBooleanMacro(enableFlexibleBoundary, EnableFlexibleBoundary);
   vtkMRMLReadXMLIntMacro(textureNumComps, TextureNumComps);
+  vtkMRMLReadXMLBooleanMacro(blurEnabled, BlurEnabled);
+  vtkMRMLReadXMLFloatMacro(blurRadius, BlurRadius);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -103,6 +109,8 @@ void vtkMRMLResectogramDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCop
   vtkMRMLCopyBooleanMacro(MirrorDisplay);
   vtkMRMLCopyBooleanMacro(EnableFlexibleBoundary);
   vtkMRMLCopyIntMacro(TextureNumComps);
+  vtkMRMLCopyBooleanMacro(BlurEnabled);
+  vtkMRMLCopyFloatMacro(BlurRadius);
   vtkMRMLCopyEndMacro();
 }
 
@@ -116,5 +124,7 @@ void vtkMRMLResectogramDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(MirrorDisplay);
   vtkMRMLPrintBooleanMacro(EnableFlexibleBoundary);
   vtkMRMLPrintIntMacro(TextureNumComps);
+  vtkMRMLPrintBooleanMacro(BlurEnabled);
+  vtkMRMLPrintFloatMacro(BlurRadius);
   vtkMRMLPrintEndMacro();
 }

--- a/LiverResections/MRML/vtkMRMLResectogramDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLResectogramDisplayNode.h
@@ -80,6 +80,13 @@
  *   - ``TextureNumComps`` — number of components in the distance-map
  *     texture the 2D mapper samples (the v1 ``SetTextureNumComps``
  *     feed).
+ *   - ``BlurEnabled`` — whether the net-new v2.0 Gaussian-blur post-pass
+ *     is engaged on the resectogram overlay renderer.  No legacy field
+ *     corresponds; the ``FlattenedSurfaceRepresentation`` attaches a
+ *     ``vtkGaussianBlurPass`` to its renderer when this is ``true``
+ *     (ADR-0013 §6).
+ *   - ``BlurRadius`` — the Gaussian-blur kernel extent in pixels driving
+ *     that post-pass.
  *
  * \par Defaults
  *
@@ -136,6 +143,16 @@ public:
   vtkSetMacro(TextureNumComps, int);
   vtkGetMacro(TextureNumComps, int);
 
+  /// Whether the net-new v2.0 Gaussian-blur post-pass is engaged on the
+  /// resectogram overlay renderer (drives the ``vtkGaussianBlurPass`` the
+  /// ``FlattenedSurfaceRepresentation`` attaches; ADR-0013 §6).
+  vtkSetMacro(BlurEnabled, bool);
+  vtkGetMacro(BlurEnabled, bool);
+
+  /// Gaussian-blur kernel extent, in pixels, for that post-pass.
+  vtkSetMacro(BlurRadius, double);
+  vtkGetMacro(BlurRadius, double);
+
 protected:
   vtkMRMLResectogramDisplayNode();
   ~vtkMRMLResectogramDisplayNode() override;
@@ -148,6 +165,8 @@ private:
   bool MirrorDisplay;
   bool EnableFlexibleBoundary;
   int TextureNumComps;
+  bool BlurEnabled;
+  double BlurRadius;
 };
 
 #endif //__vtkmrmlresectogramdisplaynode_h_

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -293,8 +293,15 @@ set(_visual_test_scenarios
   DistanceSpheroidContourShader
   # T3 ResectogramPipeline baseline targets (ADR-0027 invariant-test-
   # first).  Each captures against the v1 monolith first, then is
-  # re-baselined to the v2.0 ResectogramPipeline.  Until the maintainer
-  # commits the .sha512 stubs the replay driver skips each at runtime.
+  # re-baselined to the v2.0 ResectogramPipeline.  These replay entries
+  # are INERT until the baseline tag is published: no .sha512 stubs are
+  # committed under ../Data/Baseline/ (the maintainer's first capture
+  # session produces + uploads them to ALiveResearchTestingData), so the
+  # replay driver skips each at runtime with a clear log line, and the
+  # whole block is additionally gated behind SlicerLiver_ENABLE_VISUAL_TESTS
+  # (OFF by default).  The scenario scene-setup bodies
+  # (scenarios/Resectogram4x4*.py) are reached only once those baselines
+  # land.
   Resectogram4x4BlurOff
   Resectogram4x4NonSquareScaling
   # SPLITTABLE / LAST — blur stays a v2.0 toggle; this baseline lands

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
@@ -4,36 +4,59 @@
 
 T3 ResectogramPipeline baseline target (ADR-0027 invariant-test-first).
 This is the reference resectogram appearance: the flattened parametric
-image of a square (u, v) domain Bezier surface, rendered through the T3
-ResectogramPipeline's flattened-surface Representation, with the
-Gaussian-blur post-pass DISABLED.
+image of a square ``(u, v)`` domain Bezier surface, rendered with the
+resectogram strip enabled and the Gaussian-blur post-pass DISABLED.
 
 Capture-then-rebaseline contract
 --------------------------------
-Per the T3 plan these baselines capture against the v1 monolith
-(``vtkSlicerBezierSurfaceRepresentation3D`` 5th-renderer resectogram)
-FIRST, establishing the pixels v2.0 must reproduce, then are RE-BASELINED
-to the v2.0 ResectogramPipeline once it lands.  The capture is
-maintainer-driven (``capture_baseline.py``); until a ``.sha512`` stub is
-committed under ``../Data/Baseline/`` the replay driver skips this
-scenario with a clear log line.
+Per the T3 plan these baselines capture against the v1 monolith FIRST
+(the v1 resectogram path reads the legacy
+``vtkMRMLMarkupsBezierSurfaceDisplayNode`` resectogram fields —
+``ShowResection2D`` / ``EnableFlexibleBoundary`` / ``TextureNumComps`` —
+and draws the flattened strip), establishing the pixels v2.0 must
+reproduce, then are RE-BASELINED to the v2.0 ResectogramPipeline once it
+lands.  The capture is maintainer-driven (``capture_baseline.py``); until
+a ``.sha512`` stub is committed under ``../Data/Baseline/`` the replay
+driver skips this scenario with a clear log line, so the
+``NotImplementedError``-free body below is reached only at capture time.
+
+Scene shape
+-----------
+Mirrors ``BezierSurface4x4Planning.setup_scene`` — a synthetic parenchyma
+model + a 4-component distance-map volume + a hand-built
+``vtkMRMLMarkupsBezierSurfaceNode`` — and additionally enables the
+resectogram strip on its display node.  The blur toggle is NOT a field on
+the legacy display node (blur is net-new for v2.0, added by the
+implementer on ``vtkMRMLResectogramDisplayNode``), so this blur-OFF
+scenario is exactly the legacy resectogram appearance; ``describe()``
+records ``blur_enabled = False`` so the bundle metadata is unambiguous.
+
+No module-level scene handles: ``setup_scene`` RETURNS every node it
+creates so nothing leaks through a module global (the ``global``
+caching pattern trips ``vtkDebugLeaks`` at shutdown).
 
 Module-layer test, ADR-0008 §2/§3 (workflow row, ``render_interactive``
-fixture).  Importable from a pristine ``--no-main-window`` Slicer boot;
-``setup_scene`` exercises the production ResectogramPipeline path rather
-than hand-building MRML.
+fixture).  Importable from a pristine ``--no-main-window`` Slicer boot.
 
 References
 ----------
 * ADR-0008 §2/§3 — module/workflow visual-regression discipline +
   capture-then-replay harness.
 * ADR-0013 §6 — the flattened-surface Representation owned by the
-  ResectogramPipeline.
+  ResectogramPipeline (the v2.0 render path this baseline migrates to).
+* ADR-0025 §Context — the resectogram is the flattened 2D image of the
+  Bezier ``(u, v)`` parameter domain.
 * ADR-0027 — invariant-test-first; baseline captured before the v2.0
   rewrite, re-baselined after.
 """
 
 from __future__ import annotations
+
+import numpy as np  # type: ignore[import-not-found]
+import slicer  # type: ignore[import-not-found]
+import vtk  # type: ignore[import-not-found]
+from vtk.util import numpy_support  # type: ignore[import-not-found]
+
 
 # Shared viewport configuration for the resectogram panel.  The
 # resectogram is a 2D flattened image, so a parallel-projection square
@@ -44,55 +67,271 @@ BACKGROUND_RGB = (0.0, 0.0, 0.0)
 ANTI_ALIASING_FRAMES = 0  # deterministic; AA introduces sub-pixel jitter
 
 # Whether the Gaussian-blur post-pass is engaged.  This scenario pins the
-# blur-OFF reference; Resectogram4x4BlurOn pins blur-ON.
+# blur-OFF reference; Resectogram4x4BlurOn pins blur-ON.  Blur is not a
+# field on the legacy display node, so blur-OFF == the v1 appearance.
 BLUR_ENABLED = False
+
+# Whether the anisotropic aspect-ratio scaling is applied.  Square domain
+# here, so the aspect-ratio helper yields {1, 1} either way; left ON to
+# match the v1 default and the non-square scenario's configuration.
+ENABLE_FLEXIBLE_BOUNDARY = True
 
 # Square (u, v) domain — control points span equal extents in u and v so
 # the aspect-ratio helper yields {1, 1} (no anisotropic squeeze).  This
 # is the counterpart to Resectogram4x4NonSquareScaling.
 PATCH_HALF_EXTENT_U = 45.0
 PATCH_HALF_EXTENT_V = 45.0
+PATCH_CENTER_XY = (15.0, 15.0)
+
+# Parenchyma sphere the distance map is built around — shared centre with
+# the patch so the flattened strip samples a deterministic signed
+# distance field.
+SPHERE_CENTER = (15.0, 15.0, 0.0)
+SPHERE_RADIUS = 40.0
+
+# Camera pose for the flattened resectogram panel.  Parallel-ish oblique
+# view framing the patch + sphere common centre; numeric, not reset-to-fit
+# (camera drift is the most common visual-regression false positive).
+CAMERA_POSITION = (15.0, 15.0, 160.0)
+CAMERA_FOCAL_POINT = (15.0, 15.0, 0.0)
+CAMERA_VIEW_UP = (0.0, 1.0, 0.0)
+CAMERA_PARALLEL_SCALE = 70.0
+CAMERA_VIEW_ANGLE = 45.0
+CAMERA_CLIPPING_RANGE = (10.0, 500.0)
+
+
+def _make_parenchyma_distance_map(
+    sphere_center: tuple[float, float, float],
+    sphere_radius: float,
+) -> slicer.vtkMRMLScalarVolumeNode:
+    """Synthesise the 4-channel distance-map volume the resectogram samples.
+
+    Same construction as ``BezierSurface4x4Planning`` — a 4-component
+    signed-distance texture (parenchyma distance in channels 0 and 1,
+    zeros in 2 and 3).  The resectogram mapper
+    (``vtkOpenGLResection2DPolyDataMapper``) samples this to draw the
+    flattened margin band; ``TextureNumComps`` must equal the component
+    count (4) on the display node.
+    """
+    bounds_min = (-40.0, -40.0, -50.0)
+    bounds_max = (70.0, 70.0, 50.0)
+    spacing = 1.0
+
+    dims = tuple(
+        int((bounds_max[i] - bounds_min[i]) / spacing) + 1 for i in range(3)
+    )
+    nx, ny, nz = dims
+
+    xs = np.arange(nx) * spacing + bounds_min[0]
+    ys = np.arange(ny) * spacing + bounds_min[1]
+    zs = np.arange(nz) * spacing + bounds_min[2]
+    Z, Y, X = np.meshgrid(zs, ys, xs, indexing="ij")
+
+    cx, cy, cz = sphere_center
+    parenchyma_dist = (
+        np.sqrt((X - cx) ** 2 + (Y - cy) ** 2 + (Z - cz) ** 2) - sphere_radius
+    ).astype(np.float32)
+
+    data = np.stack(
+        [
+            parenchyma_dist,
+            parenchyma_dist,
+            np.zeros_like(parenchyma_dist),
+            np.zeros_like(parenchyma_dist),
+        ],
+        axis=-1,
+    )
+
+    image = vtk.vtkImageData()
+    image.SetDimensions(nx, ny, nz)
+    image.SetOrigin(0.0, 0.0, 0.0)
+    image.SetSpacing(1.0, 1.0, 1.0)
+
+    flat = np.ascontiguousarray(data.reshape(-1, 4))
+    arr = numpy_support.numpy_to_vtk(flat, deep=True, array_type=vtk.VTK_FLOAT)
+    arr.SetNumberOfComponents(4)
+    arr.SetName("DistanceMap")
+    image.GetPointData().SetScalars(arr)
+
+    volume_node = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLScalarVolumeNode", "VisualTestResectogramDistanceMap"
+    )
+    volume_node.SetOrigin(*bounds_min)
+    volume_node.SetSpacing(spacing, spacing, spacing)
+    volume_node.SetAndObserveImageData(image)
+    return volume_node
+
+
+def _make_synthetic_parenchyma() -> slicer.vtkMRMLModelNode:
+    """Return a small synthetic liver-parenchyma model (sphere target)."""
+    sphere = vtk.vtkSphereSource()
+    sphere.SetCenter(*SPHERE_CENTER)
+    sphere.SetRadius(SPHERE_RADIUS)
+    sphere.SetThetaResolution(48)
+    sphere.SetPhiResolution(48)
+    sphere.Update()
+
+    model = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLModelNode", "VisualTestResectogramParenchyma"
+    )
+    model.SetAndObservePolyData(sphere.GetOutput())
+    model.CreateDefaultDisplayNodes()
+    display = model.GetDisplayNode()
+    display.SetVisibility(True)
+    display.SetColor(0.8, 0.6, 0.6)
+    display.SetOpacity(0.35)
+    return model
+
+
+def _build_resectogram_bezier(
+    half_extent_u: float,
+    half_extent_v: float,
+    enable_flexible_boundary: bool,
+    distance_map: slicer.vtkMRMLScalarVolumeNode,
+) -> slicer.vtkMRMLNode:
+    """Hand-build the markups Bezier node with the resectogram strip enabled.
+
+    The v1 resectogram render path reads the legacy
+    ``vtkMRMLMarkupsBezierSurfaceDisplayNode`` resectogram fields
+    (``ShowResection2D`` / ``EnableFlexibleBoundary`` / ``TextureNumComps``
+    + the distance-map volume) when driving
+    ``vtkOpenGLResection2DPolyDataMapper``.  The control-point footprint
+    sets the ``(u, v)`` parametric extents the flattened strip maps.
+
+    Returns the created markups Bezier surface node.
+    """
+    bezier = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLMarkupsBezierSurfaceNode", "VisualTestResectogramBezier"
+    )
+    for _ in range(16):
+        bezier.AddControlPoint(vtk.vtkVector3d(0.0, 0.0, 0.0))
+    bezier.CreateDefaultDisplayNodes()
+
+    bezier.SetResectionMargin(10.0)
+    bezier.SetUncertaintyMargin(2.0)
+
+    # Lay out the 4x4 control grid so the patch's u extent is
+    # 2*half_extent_u and its v extent is 2*half_extent_v, centred on the
+    # parenchyma sphere's xy centre.  The u axis runs along i, v along j.
+    cx, cy = PATCH_CENTER_XY
+    base_x = cx - half_extent_u
+    base_y = cy - half_extent_v
+    spacing_u = (2.0 * half_extent_u) / 3.0  # 4 control points => 3 spans
+    spacing_v = (2.0 * half_extent_v) / 3.0
+    for i in range(4):
+        for j in range(4):
+            idx = i * 4 + j
+            bezier.SetNthControlPointPosition(
+                idx,
+                base_x + spacing_u * i,
+                base_y + spacing_v * j,
+                0.0,
+            )
+
+    display = bezier.GetDisplayNode()
+    # ORDER MATTERS: TextureNumComps before the distance map so the
+    # subsequent texture upload reads the correct per-voxel stride.
+    display.SetTextureNumComps(4)
+    bezier.SetDistanceMapVolumeNode(distance_map)
+    display.SetClipOut(False)
+    display.SetVisibility(True)
+
+    # Enable the resectogram strip (the flattened 2D image) and the
+    # anisotropic aspect-ratio scaling per the scenario configuration.
+    display.SetShowResection2D(True)
+    display.SetEnableFlexibleBoundary(enable_flexible_boundary)
+
+    return bezier
 
 
 def setup_scene():
     """Populate the scene with the blur-off square-domain resectogram fixture.
 
-    TODO(liver-implementer): build the scene via the production
-    LiverResections logic + the T3 ResectogramPipeline, mirroring
-    ``BezierSurface4x4Planning.setup_scene`` but adding a
-    ``vtkMRMLResectogramDisplayNode`` (ADR-0013 §5 KEYING) with
-    ``BLUR_ENABLED = False`` and a square (u, v) control-point layout.
-    Return the created resection node.
+    Idempotent under repeated invocation (clears the scene first).  Builds
+    the production LiverResections + LiverMarkups render inputs and enables
+    the resectogram strip; the v1 monolith renders the flattened image from
+    these fields, and the v2.0 ResectogramPipeline reproduces it after
+    re-baselining (ADR-0013 §6).
+
+    Returns
+    -------
+    tuple
+        ``(bezier_node, parenchyma_model, distance_map_volume)`` — every
+        node the scenario created, returned (NOT cached in module globals)
+        so the caller owns teardown and nothing survives to ``vtkDebugLeaks``.
     """
-    raise NotImplementedError(
-        "Resectogram4x4BlurOff.setup_scene is a T3 baseline target; the "
-        "ResectogramPipeline + vtkMRMLResectogramDisplayNode do not exist "
-        "yet.  This body is reached only once a baseline .sha512 stub is "
-        "committed (see module docstring); until then the replay driver "
-        "skips before calling it."
+    slicer.mrmlScene.Clear(0)
+
+    # Force-load the LiverResections logic so the node classes + the
+    # resectogram render path are registered (same trigger
+    # BezierSurface4x4Planning uses).
+    slicer.modules.liverresections.logic()
+
+    parenchyma = _make_synthetic_parenchyma()
+    distance_map = _make_parenchyma_distance_map(
+        sphere_center=SPHERE_CENTER,
+        sphere_radius=SPHERE_RADIUS,
     )
+    bezier = _build_resectogram_bezier(
+        half_extent_u=PATCH_HALF_EXTENT_U,
+        half_extent_v=PATCH_HALF_EXTENT_V,
+        enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY,
+        distance_map=distance_map,
+    )
+
+    return bezier, parenchyma, distance_map
 
 
 def setup_camera(view_node=None):
     """Fix the resectogram panel's deterministic (parallel) view.
 
-    TODO(liver-implementer): set the parallel-projection pose that frames
-    the full flattened [0,1]^2 domain; pin the numbers at first capture.
+    Same numeric-pose discipline as ``BezierSurface4x4Planning`` — the pose
+    is fixed rather than read from "reset to fit", because camera drift is
+    the most common source of replay false positives.
     """
-    raise NotImplementedError(
-        "Resectogram4x4BlurOff.setup_camera is a T3 baseline target."
-    )
+    if view_node is None:
+        view_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLViewNode")
+        if view_node is None:
+            view_node = slicer.mrmlScene.AddNewNodeByClass(
+                "vtkMRMLViewNode", "VisualTestResectogramView"
+            )
+
+    camera_logic = slicer.modules.cameras.logic()
+    camera_node = camera_logic.GetViewActiveCameraNode(view_node)
+    if camera_node is None:
+        camera_node = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLCameraNode", "VisualTestResectogramCamera"
+        )
+        camera_node.SetActiveTag(view_node.GetID())
+
+    camera_node.SetPosition(*CAMERA_POSITION)
+    camera_node.SetFocalPoint(*CAMERA_FOCAL_POINT)
+    camera_node.SetViewUp(*CAMERA_VIEW_UP)
+
+    vtk_camera = camera_node.GetCamera()
+    vtk_camera.SetParallelScale(CAMERA_PARALLEL_SCALE)
+    vtk_camera.SetViewAngle(CAMERA_VIEW_ANGLE)
+    vtk_camera.SetClippingRange(*CAMERA_CLIPPING_RANGE)
+
+    camera_node.Modified()
 
 
 def setup_viewport(view_node=None):
     """Set resectogram panel pixel size, background, anti-aliasing.
 
-    TODO(liver-implementer): mirror ``BezierSurface4x4Planning`` viewport
-    fixing (AA off for reproducibility).
+    Anti-aliasing forced OFF (sub-pixel jitter is hardware-dependent);
+    box / axis labels off (text rendering jitter on different freetype
+    builds).  Same rationale as ``BezierSurface4x4Planning``.
     """
-    raise NotImplementedError(
-        "Resectogram4x4BlurOff.setup_viewport is a T3 baseline target."
-    )
+    if view_node is None:
+        view_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLViewNode")
+    if view_node is None:
+        return
+
+    view_node.SetBackgroundColor(*BACKGROUND_RGB)
+    view_node.SetBackgroundColor2(*BACKGROUND_RGB)
+    view_node.SetBoxVisible(False)
+    view_node.SetAxisLabelsVisible(False)
 
 
 def describe() -> dict:
@@ -100,9 +339,19 @@ def describe() -> dict:
     return {
         "scenario": "Resectogram4x4BlurOff",
         "blur_enabled": BLUR_ENABLED,
+        "enable_flexible_boundary": ENABLE_FLEXIBLE_BOUNDARY,
+        "patch_half_extent": [PATCH_HALF_EXTENT_U, PATCH_HALF_EXTENT_V],
         "viewport": {
             "size": [VIEWPORT_WIDTH, VIEWPORT_HEIGHT],
             "background": list(BACKGROUND_RGB),
             "anti_aliasing_frames": ANTI_ALIASING_FRAMES,
+        },
+        "camera": {
+            "position": list(CAMERA_POSITION),
+            "focal_point": list(CAMERA_FOCAL_POINT),
+            "view_up": list(CAMERA_VIEW_UP),
+            "parallel_scale": CAMERA_PARALLEL_SCALE,
+            "view_angle": CAMERA_VIEW_ANGLE,
+            "clipping_range": list(CAMERA_CLIPPING_RANGE),
         },
     }

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
@@ -89,15 +89,18 @@ PATCH_CENTER_XY = (15.0, 15.0)
 SPHERE_CENTER = (15.0, 15.0, 0.0)
 SPHERE_RADIUS = 40.0
 
-# Camera pose for the flattened resectogram panel.  Parallel-ish oblique
-# view framing the patch + sphere common centre; numeric, not reset-to-fit
-# (camera drift is the most common visual-regression false positive).
-CAMERA_POSITION = (15.0, 15.0, 160.0)
-CAMERA_FOCAL_POINT = (15.0, 15.0, 0.0)
+# Camera pose for the flattened resectogram panel.  The v2.0
+# ResectogramPipeline renders the strip on the FIXED flattened-domain quad
+# the Representation owns (the v1 ``BezierPlane`` grid spanning x in
+# [-60, 60], y in [0, 120]); frame its centre (0, 60) head-on so the strip
+# fills the panel.  Numeric pose, not reset-to-fit (camera drift is the most
+# common visual-regression false positive).
+CAMERA_POSITION = (0.0, 60.0, 300.0)
+CAMERA_FOCAL_POINT = (0.0, 60.0, 0.0)
 CAMERA_VIEW_UP = (0.0, 1.0, 0.0)
 CAMERA_PARALLEL_SCALE = 70.0
 CAMERA_VIEW_ANGLE = 45.0
-CAMERA_CLIPPING_RANGE = (10.0, 500.0)
+CAMERA_CLIPPING_RANGE = (10.0, 800.0)
 
 
 def _make_parenchyma_distance_map(
@@ -237,11 +240,47 @@ def _build_resectogram_bezier(
     display.SetVisibility(True)
 
     # Enable the resectogram strip (the flattened 2D image) and the
-    # anisotropic aspect-ratio scaling per the scenario configuration.
+    # anisotropic aspect-ratio scaling per the scenario configuration.  The
+    # v1 monolith reads these legacy markups-display-node fields directly;
+    # the v2.0 path mirrors them onto the dedicated resectogram display node
+    # below.
     display.SetShowResection2D(True)
     display.SetEnableFlexibleBoundary(enable_flexible_boundary)
 
     return bezier
+
+
+def _attach_resectogram_display_node(
+    bezier: slicer.vtkMRMLNode,
+    enable_flexible_boundary: bool,
+) -> slicer.vtkMRMLNode:
+    """Create + attach the v2.0 ``vtkMRMLResectogramDisplayNode``.
+
+    The dedicated resectogram display node is the v2.0 LayerDM carrier
+    (ADR-0013 §1) the registered ``ResectogramPipeline`` keys on: adding it
+    to the scene as a display node of the Bezier surface drives the
+    pipeline's ``FlattenedSurfaceRepresentation`` /
+    ``VascularContourRepresentation`` to render the flattened ``(u, v)``
+    strip.  Its resectogram fields mirror the legacy markups display node so
+    the v1 monolith and the v2.0 pipeline start from an identical visual
+    baseline (ADR-0025 §Context).
+
+    Returns the created display node so the caller owns teardown (the
+    no-module-globals contract).
+    """
+    resectogram_display = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLResectogramDisplayNode", "VisualTestResectogramDisplay"
+    )
+    resectogram_display.SetShowResection2D(True)
+    resectogram_display.SetMirrorDisplay(False)
+    resectogram_display.SetEnableFlexibleBoundary(enable_flexible_boundary)
+    resectogram_display.SetTextureNumComps(4)
+    resectogram_display.SetVisibility(True)
+    # Back-reference the Bezier surface so the pipeline's
+    # ``GetDisplayableNode()`` resolves the data node feeding MatRatio +
+    # the distance-map texture.
+    bezier.AddAndObserveDisplayNodeID(resectogram_display.GetID())
+    return resectogram_display
 
 
 def setup_scene():
@@ -256,9 +295,12 @@ def setup_scene():
     Returns
     -------
     tuple
-        ``(bezier_node, parenchyma_model, distance_map_volume)`` — every
-        node the scenario created, returned (NOT cached in module globals)
-        so the caller owns teardown and nothing survives to ``vtkDebugLeaks``.
+        ``(bezier_node, parenchyma_model, distance_map_volume,
+        resectogram_display)`` — every node the scenario created, returned
+        (NOT cached in module globals) so the caller owns teardown and
+        nothing survives to ``vtkDebugLeaks``.  The fourth handle is the
+        v2.0 ``vtkMRMLResectogramDisplayNode`` the ResectogramPipeline
+        keys on.
     """
     slicer.mrmlScene.Clear(0)
 
@@ -278,8 +320,11 @@ def setup_scene():
         enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY,
         distance_map=distance_map,
     )
+    resectogram_display = _attach_resectogram_display_node(
+        bezier, enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY
+    )
 
-    return bezier, parenchyma, distance_map
+    return bezier, parenchyma, distance_map, resectogram_display
 
 
 def setup_camera(view_node=None):

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOn.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOn.py
@@ -94,9 +94,11 @@ def setup_scene():
     Returns
     -------
     tuple
-        ``(bezier_node, parenchyma_model, distance_map_volume)`` — every
-        node created, returned (NOT cached in module globals) so the caller
-        owns teardown.
+        ``(bezier_node, parenchyma_model, distance_map_volume,
+        resectogram_display)`` — every node created, returned (NOT cached in
+        module globals) so the caller owns teardown.  The fourth handle is
+        the v2.0 ``vtkMRMLResectogramDisplayNode`` the ResectogramPipeline
+        keys on.
     """
     slicer.mrmlScene.Clear(0)
     slicer.modules.liverresections.logic()
@@ -112,10 +114,13 @@ def setup_scene():
         enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY,
         distance_map=distance_map,
     )
+    resectogram_display = _blur_off._attach_resectogram_display_node(
+        bezier, enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY
+    )
 
-    _engage_blur(bezier.GetDisplayNode())
+    _engage_blur(resectogram_display)
 
-    return bezier, parenchyma, distance_map
+    return bezier, parenchyma, distance_map, resectogram_display
 
 
 def setup_camera(view_node=None):

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOn.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOn.py
@@ -7,22 +7,30 @@ T3 ResectogramPipeline baseline target (ADR-0027 invariant-test-first).
 SPLITTABLE / LAST.  Per the maintainer decision the Gaussian-blur
 post-pass stays a v2.0 feature behind a toggle, and this baseline is
 explicitly splittable from the rest of T3: if the launched harness
-(issue #460) blocks baseline capture, the blur work — and this scenario
-— land last, after the blur-OFF resectogram baselines are green.  It
-exists now as a placed target so the test surface is complete and the
-implementer knows GREEN here is the final T3 step, not a gate on the
-core resectogram landing.
+(issue #460) blocks baseline capture, the blur work — and this scenario —
+land last, after the blur-OFF resectogram baselines are green.  It exists
+now as a placed target so the test surface is complete and the implementer
+knows GREEN here is the final T3 step, not a gate on the core resectogram
+landing.
 
-It differs from ``Resectogram4x4BlurOff`` only in ``BLUR_ENABLED`` —
-same square (u, v) domain, same camera/viewport — so the pixel delta
-isolates the blur post-pass.
+It builds the SAME deterministic square-domain scene as
+``Resectogram4x4BlurOff`` (reusing that module's scene builders, same
+package) so the pixel delta between the two baselines isolates the blur
+post-pass.  ``BLUR_ENABLED`` is the only configuration that differs.
 
-Capture-then-rebaseline contract: captured against the v1 monolith first
-(the v1 resectogram has no blur pass — see the T3 plan: "No
-vtkGaussianBlurPass anywhere in tree => blur is net-new"), so the FIRST
-baseline for this scenario is captured against the v2.0 path once the
-blur toggle exists.  There is no v1 blur appearance to reproduce; this
-scenario pins the v2.0 blur-on appearance directly.
+No v1 blur appearance to reproduce
+----------------------------------
+The Gaussian-blur post-pass is NET-NEW for v2.0 — there is no blur field
+on the legacy ``vtkMRMLMarkupsBezierSurfaceDisplayNode`` and no
+``vtkGaussianBlurPass`` anywhere in the v1 tree (see the T3 plan).  So
+unlike the blur-OFF / non-square baselines (captured against the v1
+monolith first), this scenario's FIRST baseline is captured against the
+v2.0 path once the blur toggle exists on ``vtkMRMLResectogramDisplayNode``
++ the flattened-surface Representation (ADR-0013 §6).  ``setup_scene``
+therefore builds the scene but DOES NOT engage blur (no field to set yet);
+the implementer wires the blur toggle and re-captures at the go-live step.
+``describe()`` records ``blur_enabled = True`` + ``blur_engaged = False``
+so the bundle metadata is unambiguous about that pending wiring.
 
 References
 ----------
@@ -34,56 +42,118 @@ References
 
 from __future__ import annotations
 
+import slicer  # type: ignore[import-not-found]
+
+from . import Resectogram4x4BlurOff as _blur_off
+
+
 VIEWPORT_WIDTH = 600
 VIEWPORT_HEIGHT = 600
 BACKGROUND_RGB = (0.0, 0.0, 0.0)
 ANTI_ALIASING_FRAMES = 0
 
 # The one variable that distinguishes this scenario from
-# Resectogram4x4BlurOff.
+# Resectogram4x4BlurOff.  No field exists on the current display node to
+# engage blur (net-new for v2.0); the implementer wires the toggle and
+# sets blur_engaged True at the go-live step.
 BLUR_ENABLED = True
 
+# Same square (u, v) domain + aspect-ratio configuration as
+# Resectogram4x4BlurOff so the only intended visual variable is the blur.
+ENABLE_FLEXIBLE_BOUNDARY = True
 PATCH_HALF_EXTENT_U = 45.0
 PATCH_HALF_EXTENT_V = 45.0
+
+
+def _engage_blur(display_node) -> bool:
+    """Engage the Gaussian-blur post-pass on the resectogram display node.
+
+    Returns True iff a blur toggle was found and set.  The toggle is
+    NET-NEW for v2.0 (ADR-0013 §6); until the implementer adds it the
+    accessor is absent and this returns False (the scene renders blur-OFF
+    and the blur-ON baseline is deferred to the v2.0 go-live capture).
+    Probed by name rather than hard-referenced so this scenario imports +
+    builds its scene cleanly before the field exists.
+    """
+    setter = getattr(display_node, "SetEnableResectogramBlur", None)
+    if setter is None:
+        return False
+    setter(True)
+    return True
 
 
 def setup_scene():
     """Populate the scene with the blur-on square-domain resectogram fixture.
 
-    TODO(liver-implementer): identical to ``Resectogram4x4BlurOff`` but
-    engage the Gaussian-blur post-pass via the
-    ``vtkMRMLResectogramDisplayNode`` blur toggle (ADR-0013 §6 per-frame
-    Representation state).  Author/land this LAST per the maintainer's
-    splittable-blur decision.
+    Builds the same square-domain resectogram scene as
+    ``Resectogram4x4BlurOff`` (reusing its builders) and attempts to engage
+    the blur post-pass via :func:`_engage_blur`.  Until the implementer
+    adds the blur toggle (ADR-0013 §6) the engage is a no-op and the scene
+    renders blur-OFF; the blur-ON baseline is captured LAST against v2.0.
+
+    Returns
+    -------
+    tuple
+        ``(bezier_node, parenchyma_model, distance_map_volume)`` — every
+        node created, returned (NOT cached in module globals) so the caller
+        owns teardown.
     """
-    raise NotImplementedError(
-        "Resectogram4x4BlurOn.setup_scene is the SPLITTABLE/LAST T3 baseline "
-        "target; reached only once a baseline .sha512 stub is committed."
+    slicer.mrmlScene.Clear(0)
+    slicer.modules.liverresections.logic()
+
+    parenchyma = _blur_off._make_synthetic_parenchyma()
+    distance_map = _blur_off._make_parenchyma_distance_map(
+        sphere_center=_blur_off.SPHERE_CENTER,
+        sphere_radius=_blur_off.SPHERE_RADIUS,
     )
+    bezier = _blur_off._build_resectogram_bezier(
+        half_extent_u=PATCH_HALF_EXTENT_U,
+        half_extent_v=PATCH_HALF_EXTENT_V,
+        enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY,
+        distance_map=distance_map,
+    )
+
+    _engage_blur(bezier.GetDisplayNode())
+
+    return bezier, parenchyma, distance_map
 
 
 def setup_camera(view_node=None):
     """Fix the resectogram panel's deterministic (parallel) view."""
-    raise NotImplementedError(
-        "Resectogram4x4BlurOn.setup_camera is a T3 baseline target."
-    )
+    _blur_off.setup_camera(view_node)
 
 
 def setup_viewport(view_node=None):
     """Set resectogram panel pixel size, background, anti-aliasing."""
-    raise NotImplementedError(
-        "Resectogram4x4BlurOn.setup_viewport is a T3 baseline target."
-    )
+    _blur_off.setup_viewport(view_node)
 
 
 def describe() -> dict:
-    """Metadata persisted alongside the captured bundle."""
+    """Metadata persisted alongside the captured bundle.
+
+    ``blur_enabled`` records the scenario's INTENT (this is the blur-ON
+    target).  Whether the net-new blur toggle is actually wired is
+    discovered at scene-build time by :func:`_engage_blur`; ``describe()``
+    stays a pure, side-effect-free metadata function (the replay driver
+    calls it before any scene exists), so it does not probe the live node
+    here.
+    """
     return {
         "scenario": "Resectogram4x4BlurOn",
         "blur_enabled": BLUR_ENABLED,
+        "enable_flexible_boundary": ENABLE_FLEXIBLE_BOUNDARY,
+        "patch_half_extent": [PATCH_HALF_EXTENT_U, PATCH_HALF_EXTENT_V],
         "viewport": {
             "size": [VIEWPORT_WIDTH, VIEWPORT_HEIGHT],
             "background": list(BACKGROUND_RGB),
             "anti_aliasing_frames": ANTI_ALIASING_FRAMES,
+        },
+        "camera": {
+            "position": list(_blur_off.CAMERA_POSITION),
+            "focal_point": list(_blur_off.CAMERA_FOCAL_POINT),
+            "view_up": list(_blur_off.CAMERA_VIEW_UP),
+            "parallel_scale": _blur_off.CAMERA_PARALLEL_SCALE,
+            "view_angle": _blur_off.CAMERA_VIEW_ANGLE,
+            "clipping_range": list(_blur_off.CAMERA_CLIPPING_RANGE),
         },
     }

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4NonSquareScaling.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4NonSquareScaling.py
@@ -78,9 +78,11 @@ def setup_scene():
     Returns
     -------
     tuple
-        ``(bezier_node, parenchyma_model, distance_map_volume)`` — every
-        node created, returned (NOT cached in module globals) so the caller
-        owns teardown.
+        ``(bezier_node, parenchyma_model, distance_map_volume,
+        resectogram_display)`` — every node created, returned (NOT cached in
+        module globals) so the caller owns teardown.  The fourth handle is
+        the v2.0 ``vtkMRMLResectogramDisplayNode`` the ResectogramPipeline
+        keys on.
     """
     slicer.mrmlScene.Clear(0)
     slicer.modules.liverresections.logic()
@@ -96,8 +98,11 @@ def setup_scene():
         enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY,
         distance_map=distance_map,
     )
+    resectogram_display = _blur_off._attach_resectogram_display_node(
+        bezier, enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY
+    )
 
-    return bezier, parenchyma, distance_map
+    return bezier, parenchyma, distance_map, resectogram_display
 
 
 def setup_camera(view_node=None):

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4NonSquareScaling.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4NonSquareScaling.py
@@ -5,28 +5,46 @@
 T3 ResectogramPipeline baseline target (ADR-0027 invariant-test-first).
 This scenario is the VISUAL counterpart of the pure-math
 ``vtkLiverResectogramAspectRatioTest``: it pins the on-screen effect of
-the anisotropic ``MatRatio`` scaling for a non-square (u, v) domain — the
-longer parametric axis is normalised to fill the panel and the shorter
+the anisotropic ``MatRatio`` scaling for a non-square ``(u, v)`` domain —
+the longer parametric axis is normalised to fill the panel and the shorter
 axis is squeezed by ``shorter/longer``.  A regression in the aspect-ratio
 helper (e.g. a stub that always emits ``{1, 1}``) shows up here as a
 square render where the baseline is rectangular.
 
 Blur is OFF in this scenario so the only visual variable versus
-``Resectogram4x4BlurOff`` is the domain aspect ratio.
+``Resectogram4x4BlurOff`` is the domain aspect ratio.  The anisotropic
+scaling is gated by ``EnableFlexibleBoundary`` on the legacy
+``vtkMRMLMarkupsBezierSurfaceDisplayNode`` (drives
+``vtkLiverResectogramAspectRatio`` / the v1 ``Ratio(bool)`` toggle), held
+ON here so the squeeze is exercised.
 
 Capture-then-rebaseline contract: same as ``Resectogram4x4BlurOff`` —
-captured against the v1 monolith first, re-baselined to v2.0.
+captured against the v1 monolith first, re-baselined to v2.0.  Until a
+``.sha512`` stub lands the replay driver skips this scenario before the
+body runs.
+
+This scenario reuses the deterministic scene builders from
+``Resectogram4x4BlurOff`` (same package) so the ONLY difference is the
+``(u, v)`` footprint — the v extent is twice the u extent — and the
+``describe()`` metadata.
 
 References
 ----------
 * ADR-0008 §2/§3 — visual-regression harness.
 * ADR-0013 §6 — flattened-surface Representation (carries the MatRatio
   scaling state per the maintainer decision).
+* ADR-0025 §Context — the resectogram is the flattened 2D image of the
+  Bezier ``(u, v)`` parameter domain.
 * ADR-0027 — pairs with ``vtkLiverResectogramAspectRatioTest`` (the
   pure-math pin) as the pixel-level pin of the same invariant.
 """
 
 from __future__ import annotations
+
+import slicer  # type: ignore[import-not-found]
+
+from . import Resectogram4x4BlurOff as _blur_off
+
 
 VIEWPORT_WIDTH = 600
 VIEWPORT_HEIGHT = 600
@@ -34,6 +52,10 @@ BACKGROUND_RGB = (0.0, 0.0, 0.0)
 ANTI_ALIASING_FRAMES = 0
 
 BLUR_ENABLED = False
+
+# Anisotropic aspect-ratio scaling ON so the non-square domain squeeze is
+# applied (the whole point of this scenario).
+ENABLE_FLEXIBLE_BOUNDARY = True
 
 # Non-square (u, v) domain — the v extent is twice the u extent, so the
 # aspect-ratio helper yields {0.5, 1} (u squeezed to half).  This is the
@@ -45,30 +67,51 @@ PATCH_HALF_EXTENT_V = 45.0
 def setup_scene():
     """Populate the scene with the non-square-domain resectogram fixture.
 
-    TODO(liver-implementer): lay out the 4x4 control points so the v
-    parametric extent is twice the u extent (PATCH_HALF_EXTENT_V =
-    2 * PATCH_HALF_EXTENT_U), and add a ``vtkMRMLResectogramDisplayNode``
-    with blur OFF.  The rendered panel must show the v1 anisotropic
-    squeeze; re-baseline to v2.0 once the ResectogramPipeline lands.
+    Builds the same parenchyma + distance map + resectogram-enabled markups
+    Bezier node as ``Resectogram4x4BlurOff``, but lays the 4x4 control grid
+    out so the v parametric extent is twice the u extent
+    (``PATCH_HALF_EXTENT_V == 2 * PATCH_HALF_EXTENT_U``) with
+    ``EnableFlexibleBoundary`` ON.  The rendered panel shows the v1
+    anisotropic squeeze; re-baseline to v2.0 once the ResectogramPipeline
+    lands.
+
+    Returns
+    -------
+    tuple
+        ``(bezier_node, parenchyma_model, distance_map_volume)`` — every
+        node created, returned (NOT cached in module globals) so the caller
+        owns teardown.
     """
-    raise NotImplementedError(
-        "Resectogram4x4NonSquareScaling.setup_scene is a T3 baseline target; "
-        "reached only once a baseline .sha512 stub is committed."
+    slicer.mrmlScene.Clear(0)
+    slicer.modules.liverresections.logic()
+
+    parenchyma = _blur_off._make_synthetic_parenchyma()
+    distance_map = _blur_off._make_parenchyma_distance_map(
+        sphere_center=_blur_off.SPHERE_CENTER,
+        sphere_radius=_blur_off.SPHERE_RADIUS,
     )
+    bezier = _blur_off._build_resectogram_bezier(
+        half_extent_u=PATCH_HALF_EXTENT_U,
+        half_extent_v=PATCH_HALF_EXTENT_V,
+        enable_flexible_boundary=ENABLE_FLEXIBLE_BOUNDARY,
+        distance_map=distance_map,
+    )
+
+    return bezier, parenchyma, distance_map
 
 
 def setup_camera(view_node=None):
-    """Fix the resectogram panel's deterministic (parallel) view."""
-    raise NotImplementedError(
-        "Resectogram4x4NonSquareScaling.setup_camera is a T3 baseline target."
-    )
+    """Fix the resectogram panel's deterministic (parallel) view.
+
+    Identical pose to ``Resectogram4x4BlurOff`` so the only visual variable
+    versus that scenario is the domain aspect ratio.
+    """
+    _blur_off.setup_camera(view_node)
 
 
 def setup_viewport(view_node=None):
     """Set resectogram panel pixel size, background, anti-aliasing."""
-    raise NotImplementedError(
-        "Resectogram4x4NonSquareScaling.setup_viewport is a T3 baseline target."
-    )
+    _blur_off.setup_viewport(view_node)
 
 
 def describe() -> dict:
@@ -76,9 +119,19 @@ def describe() -> dict:
     return {
         "scenario": "Resectogram4x4NonSquareScaling",
         "blur_enabled": BLUR_ENABLED,
+        "enable_flexible_boundary": ENABLE_FLEXIBLE_BOUNDARY,
+        "patch_half_extent": [PATCH_HALF_EXTENT_U, PATCH_HALF_EXTENT_V],
         "viewport": {
             "size": [VIEWPORT_WIDTH, VIEWPORT_HEIGHT],
             "background": list(BACKGROUND_RGB),
             "anti_aliasing_frames": ANTI_ALIASING_FRAMES,
+        },
+        "camera": {
+            "position": list(_blur_off.CAMERA_POSITION),
+            "focal_point": list(_blur_off.CAMERA_FOCAL_POINT),
+            "view_up": list(_blur_off.CAMERA_VIEW_UP),
+            "parallel_scale": _blur_off.CAMERA_PARALLEL_SCALE,
+            "view_angle": _blur_off.CAMERA_VIEW_ANGLE,
+            "clipping_range": list(_blur_off.CAMERA_CLIPPING_RANGE),
         },
     }

--- a/Testing/Python/conftest.py
+++ b/Testing/Python/conftest.py
@@ -53,6 +53,12 @@ from __future__ import annotations
 
 import pytest
 
+from slicer_pytest_support import (
+    import_slicer_or_skip,
+    require_mrml_scene,
+    require_qt_widget,
+)
+
 
 # --------------------------------------------------------------------------- #
 # CLI option
@@ -176,6 +182,125 @@ def a_slicer_app():
             "`Slicer --python-script $(which pytest) -- ...`."
         )
     return slicer
+
+
+# --------------------------------------------------------------------------- #
+# LayerDM real-view fixture (ADR-0013 §9)
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def layerdm_threed_view(render_interactive):
+    """Yield ``(view_widget, manager)`` for a live LayerDM-aware 3D view.
+
+    The ADR-0013 §9 "real-view fixture": a standalone ``qMRMLThreeDWidget``
+    bound to ``slicer.mrmlScene`` whose displayable-manager group hosts the
+    upstream ``vtkMRMLLayerDisplayableManager``.  The manager exposes
+    ``GetNodePipeline(node)`` — documented in
+    ``vtkMRMLLayerDisplayableManager.h`` as the test/debug accessor for the
+    pipeline bound to a display node — which the dispatch tests use to pin
+    the ADR-0013 §1 one-Pipeline-per-display-node-type invariant.
+
+    Brought up exactly as the LayerDM extension's own
+    ``DisplayableManagerTest`` and the project's
+    ``test_distance_spheroid_contour_arena`` view: a standalone
+    ``qMRMLThreeDWidget`` (``--no-main-window`` has no layout manager), with
+    the LayerDM DM registered into the 3D-view factory via
+    ``RegisterInDefaultViews()`` (idempotent — the LiverResections module
+    already calls it).  The displayable manager is retrieved through
+    ``qMRMLThreeDView.displayableManagerByClassName`` (the Q_INVOKABLE
+    accessor on ``qMRMLThreeDView``).
+
+    Consumes ``render_interactive`` like the other view-creating fixtures
+    this conftest documents: a positive value keeps the Qt window visible
+    for that many seconds before teardown; ``0.0`` (the CI default) stays
+    offscreen and tears down immediately after the consuming test asserts.
+
+    No-op / clean skip under bare ``PythonSlicer`` (no ``qSlicerApplication``):
+    the guards below skip with explicit, greppable reasons (issue #460
+    green-but-skipping discipline) rather than erroring or silently passing.
+    """
+    slicer = import_slicer_or_skip()
+    if slicer is None:
+        return
+    require_mrml_scene()
+    require_qt_widget()
+
+    # The view must host the LayerDM displayable manager (registered by the
+    # LiverResections module's setup()).  Probe that the resectogram display
+    # node class is registered with an explicit, greppable skip so a missing
+    # module path reads as a skip, not a false pass.
+    registration_probe = slicer.mrmlScene.CreateNodeByClass(
+        "vtkMRMLResectogramDisplayNode"
+    )
+    if registration_probe is None:
+        pytest.skip(
+            "[layerdm-view-skip] vtkMRMLResectogramDisplayNode is not "
+            "registered -- the LiverResections module is not on the "
+            "additional-module-paths.  Run via the pytest_launched CTest row "
+            "(Liver/Testing/Python/CMakeLists.txt supplies the module paths)."
+        )
+    # CreateNodeByClass returns a node carrying the factory's +1 reference the
+    # caller owns; drop it or the probe instance survives to process shutdown
+    # and trips vtkDebugLeaks (failing the launched harness).
+    registration_probe.UnRegister(None)
+
+    # Ensure the LayerDM DM is registered in the 3D-view factory.  Idempotent
+    # (RegisterInDefaultViews short-circuits when already present); the
+    # LiverResections module setup() already calls it, but a bare launched
+    # harness that imported only the conftest may not have, so assert it here.
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLLayerDisplayableManager,
+    )
+
+    vtkMRMLLayerDisplayableManager.RegisterInDefaultViews()
+
+    view_widget = slicer.qMRMLThreeDWidget()
+    view_widget.setMRMLScene(slicer.mrmlScene)
+    view_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLViewNode")
+    if view_node is None:
+        view_node = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLViewNode", "LayerDMDispatchView"
+        )
+
+    # Map the GL surface before binding the view node so the displayable
+    # manager group is instantiated (same show()-then-bind ordering the
+    # arena + capture_baseline use).  Under QT_QPA_PLATFORM=offscreen (CI +
+    # launched harness) show() is visually a no-op but still maps the
+    # OpenGL surface; in interactive mode it makes the window visible.
+    view_widget.show()
+    view_widget.threeDView().forceRender()
+    view_widget.setMRMLViewNode(view_node)
+
+    manager = view_widget.threeDView().displayableManagerByClassName(
+        "vtkMRMLLayerDisplayableManager"
+    )
+    if manager is None:
+        pytest.skip(
+            "[layerdm-view-skip] vtkMRMLLayerDisplayableManager is not on the "
+            "3D view's displayable-manager group -- the upstream SlicerLayerDM "
+            "extension is not loaded on the launched path (issue #460).  Run "
+            "via pytest_launched with the LayerDM module paths."
+        )
+
+    try:
+        yield view_widget, manager
+        if render_interactive:
+            import qt  # type: ignore[import-not-found]
+
+            interactor = view_widget.threeDView().interactor()
+            if interactor is not None:
+                loop = qt.QEventLoop()
+                qt.QTimer.singleShot(
+                    int(render_interactive * 1000), loop.quit
+                )
+                interactor.Initialize()
+                view_widget.threeDView().forceRender()
+                loop.exec_()
+    finally:
+        # Tear the widget down so no view / DM survives to process exit and
+        # trips vtkDebugLeaks in the launched harness.
+        view_widget.setMRMLScene(None)
+        view_widget.deleteLater()
 
 
 # --------------------------------------------------------------------------- #

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -179,16 +179,17 @@ class _StubMapperWithMatRatio:
 
 
 def _inject_mat_ratio_mapper(rep):
-    """Replace the Representation's 2D mapper with the MatRatio stub.
+    """Install the MatRatio stub as the Representation's 2D mapper.
 
-    Re-points the actor at the stub too (when VTK is present) so the
-    public assembly stays internally consistent.
+    The Representation pushes MatRatio / TextureNumComps off
+    ``_resection_mapper_2d`` directly (see ``_apply_mat_ratio``), so
+    re-pointing the actor at the stub is unnecessary — and a real
+    ``vtkActor`` (the launched harness) rejects a non-``vtkMapper`` via
+    ``SetMapper``.  Setting ``_resection_mapper_2d`` is sufficient and
+    works in both the bare and launched rows.
     """
     mapper = _StubMapperWithMatRatio()
     rep._resection_mapper_2d = mapper
-    actor = rep.GetResectionActor2D()
-    if actor is not None and hasattr(actor, "SetMapper"):
-        actor.SetMapper(mapper)
     return mapper
 
 

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Python unit tests for ``FlattenedSurfaceRepresentation`` — ADR-0013 §6.
+
+Mirrors ``test_confirmed_representation.py``'s structure (pure-Python
+introspection assertions + a thin VTK-mediated layer).  The flattened-
+surface Representation is the v2.0 LayerDM-bound home of the resectogram's
+2D render assembly (`ADR-0025`_ §Context): a flattened-quad source feeding
+the relocated ``vtkOpenGLResection2DPolyDataMapper``, an actor, the private
+overlay camera, the distance-map texture binding, and the anisotropic
+``MatRatio`` aspect-ratio scaling.
+
+The invariants pinned here (ADR-0027 — the SPECIFIC invariant, not "some
+assembly exists"):
+
+* **MatRatio routing (T3-b)** — a square domain (or
+  ``EnableFlexibleBoundary`` false) yields the isotropic ``{1, 1}``; a
+  non-square domain with the toggle on yields the v1 squeeze, computed by
+  the ``vtkLiverResectogramAspectRatio`` Algorithm helper (`ADR-0015`_ §1)
+  — the Representation does NOT re-derive the math.  The helper itself is
+  C++ (its own pure-math invariant lives in
+  ``vtkLiverResectogramAspectRatioTest``); here we pin that the
+  Representation calls it with the right arguments and pushes the result
+  onto the mapper.
+* **Overlay camera pose** — the resectogram camera is posed from the
+  flattened quad's bounds, and ``MirrorDisplay`` flips the camera's z
+  sign (the v1 ``ResectogramPlaneCenter`` mirror toggle).
+
+References
+----------
+* ADR-0008 §2 — Representation tests, unit layer.
+* ADR-0013 §6 — Representations as composable VTK pipelines.
+* ADR-0015 §1 — Algorithm-library pure-VTK helpers
+  (``vtkLiverResectogramAspectRatio``).
+* ADR-0025 §Context — the resectogram is a 1:1 image of the Bezier
+  ``(u, v)`` parameter domain.
+* ADR-0027 — invariant-test-first.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Repo geometry — mirrors test_confirmed_representation.py.
+# --------------------------------------------------------------------------- #
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "LiverResections" / "LiverResectionsLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Stub nodes
+# --------------------------------------------------------------------------- #
+
+
+class _StubDisplayNode:
+    def __init__(
+        self,
+        show_2d: bool = True,
+        mirror: bool = False,
+        flexible: bool = False,
+        texture_num_comps: int = 1,
+    ) -> None:
+        self.show_2d = show_2d
+        self.mirror = mirror
+        self.flexible = flexible
+        self.texture_num_comps = texture_num_comps
+
+    def GetShowResection2D(self) -> bool:
+        return self.show_2d
+
+    def GetMirrorDisplay(self) -> bool:
+        return self.mirror
+
+    def GetEnableFlexibleBoundary(self) -> bool:
+        return self.flexible
+
+    def GetTextureNumComps(self) -> int:
+        return self.texture_num_comps
+
+
+class _StubPoints:
+    """Minimal sampled-surface points object the helper would walk.
+
+    Carries an explicit number of points so the Representation's
+    ``(samplesU, samplesV)`` resolution probe resolves deterministically.
+    """
+
+    def __init__(self, num_points: int = 400) -> None:
+        self.num_points = num_points
+
+    def GetNumberOfPoints(self) -> int:
+        return self.num_points
+
+
+class _StubDataNode:
+    def __init__(self, sampled=None) -> None:
+        self.sampled = sampled if sampled is not None else _StubPoints()
+
+    def GetSampledSurfacePoints(self):
+        return self.sampled
+
+
+@pytest.fixture
+def rep_module():
+    from Representations.FlattenedSurfaceRepresentation import (
+        FlattenedSurfaceRepresentation,
+    )
+
+    return FlattenedSurfaceRepresentation
+
+
+# --------------------------------------------------------------------------- #
+# Pure-Python assertions (run with or without VTK)
+# --------------------------------------------------------------------------- #
+
+
+def test_representation_construct_with_no_renderer(rep_module):
+    """Construct without a renderer — no exception, MatRatio unset."""
+    rep = rep_module()
+    assert rep.GetRenderer() is None
+    # No update() yet → no MatRatio has been pushed.
+    assert rep.GetMatRatioApplied() is None
+    rep.cleanup()
+
+
+def test_representation_update_tolerates_none_nodes(rep_module):
+    rep = rep_module()
+    rep.update(display_node=None, data_node=None)
+    rep.cleanup()
+
+
+def test_representation_input_refresh_memoised(rep_module):
+    """A repeat update with the same surface is a no-op; a new surface
+    bumps the refresh counter."""
+    rep = rep_module()
+    display = _StubDisplayNode()
+    data = _StubDataNode()
+    rep.update(display, data)
+    after_first = rep.GetInputRefreshCount()
+    assert after_first == 1
+
+    rep.update(display, data)
+    assert rep.GetInputRefreshCount() == after_first
+
+    rep.update(display, _StubDataNode(sampled=_StubPoints(361)))
+    assert rep.GetInputRefreshCount() == after_first + 1
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# MatRatio routing (T3-b) — the load-bearing aspect-ratio invariant.
+# --------------------------------------------------------------------------- #
+
+
+class _StubMapperWithMatRatio:
+    """Drop-in mapper exposing ``SetMatRatio`` — the relocated
+    ``vtkOpenGLResection2DPolyDataMapper``'s API — so the MatRatio routing
+    is exercised without the wrapped C++ mapper present locally."""
+
+    def __init__(self) -> None:
+        self.mat_ratio = None
+        self.texture_num_comps = None
+
+    def SetMatRatio(self, ratio) -> None:
+        self.mat_ratio = list(ratio)
+
+    def SetTextureNumComps(self, value) -> None:
+        self.texture_num_comps = int(value)
+
+    def SetInputConnection(self, _conn) -> None:
+        pass
+
+
+def _inject_mat_ratio_mapper(rep):
+    """Replace the Representation's 2D mapper with the MatRatio stub.
+
+    Re-points the actor at the stub too (when VTK is present) so the
+    public assembly stays internally consistent.
+    """
+    mapper = _StubMapperWithMatRatio()
+    rep._resection_mapper_2d = mapper
+    actor = rep.GetResectionActor2D()
+    if actor is not None and hasattr(actor, "SetMapper"):
+        actor.SetMapper(mapper)
+    return mapper
+
+
+def test_mat_ratio_isotropic_when_not_flexible(rep_module):
+    """``EnableFlexibleBoundary`` false → the isotropic ``{1, 1}`` (the
+    v1 ``Ratio`` else-branch), with NO call into the helper."""
+    rep = rep_module()
+    mapper = _inject_mat_ratio_mapper(rep)
+    display = _StubDisplayNode(flexible=False)
+    rep.update(display, _StubDataNode())
+    assert mapper.mat_ratio == pytest.approx([1.0, 1.0])
+    assert rep.GetMatRatioApplied() == pytest.approx((1.0, 1.0))
+    rep.cleanup()
+
+
+def test_mat_ratio_isotropic_when_no_sampled_surface(rep_module):
+    """Flexible but no sampled surface → still ``{1, 1}`` (defensive
+    short-circuit; the helper needs points)."""
+    rep = rep_module()
+    mapper = _inject_mat_ratio_mapper(rep)
+    display = _StubDisplayNode(flexible=True)
+
+    class _EmptyDataNode:
+        def GetSampledSurfacePoints(self):
+            return None
+
+    rep.update(display, _EmptyDataNode())
+    assert mapper.mat_ratio == pytest.approx([1.0, 1.0])
+    rep.cleanup()
+
+
+def test_mat_ratio_routes_non_square_squeeze_through_helper(
+    rep_module, monkeypatch
+):
+    """Flexible + a non-square domain → the squeeze, computed by the
+    ``vtkLiverResectogramAspectRatio`` helper.
+
+    The Representation must NOT re-derive the v1 ``Ratio`` math — it must
+    delegate to ``ComputeAspectRatio`` and push the helper's result.  We
+    inject a stub helper that emulates the helper's contract for a domain
+    whose v extent is twice the u extent (``{0.5, 1.0}`` — the
+    ``Resectogram4x4NonSquareScaling`` scenario's value) and assert the
+    Representation forwarded the call and pushed the stub's answer.
+    """
+    import Representations.FlattenedSurfaceRepresentation as module
+
+    seen = {}
+
+    class _StubHelper:
+        @staticmethod
+        def ComputeAspectRatio(sampled, samples_u, samples_v, flexible, out):
+            seen["sampled"] = sampled
+            seen["samples_u"] = samples_u
+            seen["samples_v"] = samples_v
+            seen["flexible"] = flexible
+            # v extent twice u → longer axis (v) normalised to 1, u squeezed.
+            out[0] = 0.5
+            out[1] = 1.0
+
+    monkeypatch.setattr(
+        module, "_import_aspect_ratio_helper", lambda: _StubHelper
+    )
+
+    rep = rep_module()
+    mapper = _inject_mat_ratio_mapper(rep)
+    points = _StubPoints(400)  # 20x20 → samplesU == samplesV == 20
+    display = _StubDisplayNode(flexible=True)
+    rep.update(display, _StubDataNode(sampled=points))
+
+    assert seen["sampled"] is points
+    assert seen["samples_u"] == 20
+    assert seen["samples_v"] == 20
+    assert seen["flexible"] is True
+    assert mapper.mat_ratio == pytest.approx([0.5, 1.0])
+    assert rep.GetMatRatioApplied() == pytest.approx((0.5, 1.0))
+    rep.cleanup()
+
+
+def test_texture_num_comps_pushed_to_mapper(rep_module):
+    rep = rep_module()
+    mapper = _inject_mat_ratio_mapper(rep)
+    rep.update(_StubDisplayNode(texture_num_comps=4), _StubDataNode())
+    assert mapper.texture_num_comps == 4
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# VTK-mediated assertions
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def vtk_module():
+    return pytest.importorskip(
+        "vtk",
+        reason="vtk not importable; skip the VTK-mediated Representation tests.",
+    )
+
+
+def test_assembly_builds_quad_source_mapper_actor_camera(rep_module, vtk_module):
+    """The full assembly is built when VTK is present (ADR-0013 §6)."""
+    rep = rep_module()
+    assert rep.GetBezierPlane() is not None
+    assert rep.GetResectionMapper2D() is not None
+    assert rep.GetResectionActor2D() is not None
+    assert rep.GetResectogramCamera() is not None
+    rep.cleanup()
+
+
+def test_actor_visibility_follows_show_resection_2d(rep_module, vtk_module):
+    rep = rep_module()
+    rep.update(_StubDisplayNode(show_2d=True), _StubDataNode())
+    assert rep.GetResectionActor2D().GetVisibility() == 1
+    rep.update(_StubDisplayNode(show_2d=False), _StubDataNode())
+    assert rep.GetResectionActor2D().GetVisibility() == 0
+    rep.cleanup()
+
+
+def test_overlay_camera_posed_from_quad_bounds(rep_module, vtk_module):
+    """The overlay camera is posed from the flattened quad's bounds; the
+    focal point sits at the quad centre in x/y (the v1
+    ``ResectogramPlaneCenter`` pose)."""
+    rep = rep_module()
+    rep.update(_StubDisplayNode(mirror=False), _StubDataNode())
+    camera = rep.GetResectogramCamera()
+    plane = rep.GetBezierPlane()
+    plane.Update()
+    bounds = plane.GetOutput().GetBounds()
+    cx = (bounds[0] + bounds[1]) / 2.0
+    cy = (bounds[2] + bounds[3]) / 2.0
+    focal = camera.GetFocalPoint()
+    assert focal[0] == pytest.approx(cx)
+    assert focal[1] == pytest.approx(cy)
+    rep.cleanup()
+
+
+def test_mirror_display_flips_camera_z_sign(rep_module, vtk_module):
+    """``MirrorDisplay`` flips the sign of the camera's z position — the
+    v1 ``ResectogramPlaneCenter(mirror)`` toggle (ADR-0025 §Context)."""
+    rep = rep_module()
+    rep.update(_StubDisplayNode(mirror=False), _StubDataNode())
+    z_unmirrored = rep.GetResectogramCamera().GetPosition()[2]
+    rep.update(_StubDisplayNode(mirror=True), _StubDataNode())
+    z_mirrored = rep.GetResectogramCamera().GetPosition()[2]
+    assert z_unmirrored * z_mirrored < 0.0, (
+        "MirrorDisplay must flip the resectogram camera's z sign "
+        "(v1 ResectogramPlaneCenter mirror toggle)."
+    )
+    rep.cleanup()

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -298,6 +298,31 @@ def test_assembly_builds_quad_source_mapper_actor_camera(rep_module, vtk_module)
     rep.cleanup()
 
 
+def test_flattened_quad_source_emits_geometry(rep_module, vtk_module):
+    """The flattened-quad source carries renderable geometry (T3-e go-live).
+
+    The resectogram actor lights pixels only if its mapper has a non-empty
+    flattened-domain quad to draw.  The Representation tessellates the fixed
+    planar quad the v1 ``BezierPlane`` poses from (ADR-0025 §Context); pin
+    that the source's output has points + a positive planar (x/y) extent so
+    a regression that stops feeding the quad (the 0-lit-pixel failure mode)
+    is caught at the unit layer rather than only in the GPU arena.
+    """
+    rep = rep_module()
+    plane = rep.GetBezierPlane()
+    assert plane is not None
+    plane.Update()
+    output = plane.GetOutput()
+    assert output.GetNumberOfPoints() > 0, (
+        "the flattened-quad source emitted no points -- the resectogram "
+        "actor would have nothing to draw (0 lit pixels)."
+    )
+    bounds = output.GetBounds()
+    assert bounds[1] > bounds[0], "the flattened quad has no x extent"
+    assert bounds[3] > bounds[2], "the flattened quad has no y extent"
+    rep.cleanup()
+
+
 def test_actor_visibility_follows_show_resection_2d(rep_module, vtk_module):
     rep = rep_module()
     rep.update(_StubDisplayNode(show_2d=True), _StubDataNode())

--- a/Testing/Python/unit/test_vascular_contour_representation.py
+++ b/Testing/Python/unit/test_vascular_contour_representation.py
@@ -109,16 +109,15 @@ class _StubContourMapper:
 
 
 def _inject_contour_mappers(rep):
+    # The Representation feeds the strip via _distance/_slicing_contour_mapper
+    # directly (see _apply_strip_input), so re-pointing the actors is
+    # unnecessary — and a real vtkActor (launched harness) rejects a
+    # non-vtkMapper via SetMapper. Setting the mapper members is sufficient
+    # and works in both the bare and launched rows.
     distance = _StubContourMapper()
     slicing = _StubContourMapper()
     rep._distance_contour_mapper = distance
     rep._slicing_contour_mapper = slicing
-    distance_actor = rep.GetDistanceContourActor()
-    slicing_actor = rep.GetSlicingContourActor()
-    if distance_actor is not None and hasattr(distance_actor, "SetMapper"):
-        distance_actor.SetMapper(distance)
-    if slicing_actor is not None and hasattr(slicing_actor, "SetMapper"):
-        slicing_actor.SetMapper(slicing)
     return distance, slicing
 
 

--- a/Testing/Python/unit/test_vascular_contour_representation.py
+++ b/Testing/Python/unit/test_vascular_contour_representation.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Python unit tests for ``VascularContourRepresentation`` — ADR-0013 §6.
+
+The vascular-contour Representation draws the hepatic / portal vascular
+contours on top of the flattened resectogram strip so the surgeon can read
+vessel proximity in the 2D ``(u, v)`` image (`ADR-0025`_ §Context).  It owns
+the two relocated contour mappers (``vtkOpenGLDistanceContourPolyDataMapper``
+/ ``vtkOpenGLSlicingContourPolyDataMapper``, `ADR-0014`_ §3) + their actors.
+
+The invariants pinned here (ADR-0027 — the SPECIFIC invariant):
+
+* **Visibility follows ``ShowResection2D``** — the contour overlays are
+  drawn exactly when the resectogram strip is.
+* **Strip-geometry feed (T3-c)** — when the data node carries the
+  flattened-strip polydata, ``update()`` feeds it into BOTH contour mappers
+  (the contours are computed over the same strip the flattened surface
+  draws), not discarded.
+
+References
+----------
+* ADR-0008 §2 — Representation tests, unit layer.
+* ADR-0013 §6 — Representations as composable VTK pipelines.
+* ADR-0014 §3 — mapper relocation (the contour mappers live under
+  ``LiverResections/VTKWidgets/``).
+* ADR-0025 §Context — the resectogram and its vascular overlays.
+* ADR-0027 — invariant-test-first.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Repo geometry — mirrors test_confirmed_representation.py.
+# --------------------------------------------------------------------------- #
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "LiverResections" / "LiverResectionsLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Stub nodes
+# --------------------------------------------------------------------------- #
+
+
+class _StubDisplayNode:
+    def __init__(self, show_2d: bool = True) -> None:
+        self.show_2d = show_2d
+
+    def GetShowResection2D(self) -> bool:
+        return self.show_2d
+
+
+class _StubStripDataNode:
+    """Data node exposing the flattened-strip polydata the contours sit on."""
+
+    def __init__(self, strip) -> None:
+        self.strip = strip
+
+    def GetResectogramStripPolyData(self):
+        return self.strip
+
+
+@pytest.fixture
+def rep_module():
+    from Representations.VascularContourRepresentation import (
+        VascularContourRepresentation,
+    )
+
+    return VascularContourRepresentation
+
+
+# --------------------------------------------------------------------------- #
+# Pure-Python assertions (run with or without VTK)
+# --------------------------------------------------------------------------- #
+
+
+def test_representation_construct_with_no_renderer(rep_module):
+    rep = rep_module()
+    assert rep.GetRenderer() is None
+    rep.cleanup()
+
+
+def test_update_tolerates_none_nodes(rep_module):
+    rep = rep_module()
+    rep.update(display_node=None, data_node=None)
+    assert rep.GetUpdateCount() == 1
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# Strip-geometry feed (T3-c) — pinned with stub mappers so the wiring is
+# exercised without the wrapped C++ contour mappers present locally.
+# --------------------------------------------------------------------------- #
+
+
+class _StubContourMapper:
+    def __init__(self) -> None:
+        self.input_data = None
+
+    def SetInputData(self, polydata) -> None:
+        self.input_data = polydata
+
+
+def _inject_contour_mappers(rep):
+    distance = _StubContourMapper()
+    slicing = _StubContourMapper()
+    rep._distance_contour_mapper = distance
+    rep._slicing_contour_mapper = slicing
+    distance_actor = rep.GetDistanceContourActor()
+    slicing_actor = rep.GetSlicingContourActor()
+    if distance_actor is not None and hasattr(distance_actor, "SetMapper"):
+        distance_actor.SetMapper(distance)
+    if slicing_actor is not None and hasattr(slicing_actor, "SetMapper"):
+        slicing_actor.SetMapper(slicing)
+    return distance, slicing
+
+
+def test_strip_polydata_feeds_both_contour_mappers(rep_module):
+    """The flattened-strip polydata is pushed into BOTH contour mappers."""
+    rep = rep_module()
+    distance, slicing = _inject_contour_mappers(rep)
+    strip = object()  # opaque polydata sentinel
+    rep.update(_StubDisplayNode(), _StubStripDataNode(strip))
+    assert distance.input_data is strip
+    assert slicing.input_data is strip
+    rep.cleanup()
+
+
+def test_no_strip_polydata_leaves_inputs_untouched(rep_module):
+    """A data node without the strip accessor does not crash and leaves
+    the mapper inputs untouched (no spurious feed)."""
+    rep = rep_module()
+    distance, slicing = _inject_contour_mappers(rep)
+
+    class _NoStripDataNode:
+        pass
+
+    rep.update(_StubDisplayNode(), _NoStripDataNode())
+    assert distance.input_data is None
+    assert slicing.input_data is None
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# VTK-mediated assertions
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def vtk_module():
+    return pytest.importorskip(
+        "vtk",
+        reason="vtk not importable; skip the VTK-mediated Representation tests.",
+    )
+
+
+def test_assembly_builds_two_mappers_and_actors(rep_module, vtk_module):
+    rep = rep_module()
+    assert rep.GetDistanceContourMapper() is not None
+    assert rep.GetSlicingContourMapper() is not None
+    assert rep.GetDistanceContourActor() is not None
+    assert rep.GetSlicingContourActor() is not None
+    rep.cleanup()
+
+
+def test_contour_visibility_follows_show_resection_2d(rep_module, vtk_module):
+    rep = rep_module()
+    rep.update(_StubDisplayNode(show_2d=True), None)
+    assert rep.GetDistanceContourActor().GetVisibility() == 1
+    assert rep.GetSlicingContourActor().GetVisibility() == 1
+    rep.update(_StubDisplayNode(show_2d=False), None)
+    assert rep.GetDistanceContourActor().GetVisibility() == 0
+    assert rep.GetSlicingContourActor().GetVisibility() == 0
+    rep.cleanup()

--- a/Testing/Python/workflow/test_resectogram_arena.py
+++ b/Testing/Python/workflow/test_resectogram_arena.py
@@ -191,19 +191,21 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
     require_mrml_scene()
     require_qt_widget()
 
-    # The scenario builds a vtkMRMLMarkupsBezierSurfaceNode + enables the
-    # resectogram strip on its display node.  Guard the distinct "live
-    # scene but the modules did not register" case with an explicit,
-    # greppable skip reason (module path missing).
+    # The scenario builds a vtkMRMLMarkupsBezierSurfaceNode + attaches a
+    # vtkMRMLResectogramDisplayNode (the v2.0 ResectogramPipeline carrier).
+    # Guard the distinct "live scene but the modules did not register" case
+    # with an explicit, greppable skip reason (module path missing).  Probe
+    # the resectogram display node specifically -- it is the T3 go-live
+    # carrier the registered ResectogramPipeline keys on (ADR-0013 §1/§5).
     registration_probe = slicer.mrmlScene.CreateNodeByClass(
-        "vtkMRMLMarkupsBezierSurfaceNode"
+        "vtkMRMLResectogramDisplayNode"
     )
     if registration_probe is None:
         pytest.skip(
-            "[arena-skip] vtkMRMLMarkupsBezierSurfaceNode is not registered -- "
-            "the LiverResections / LiverMarkups modules are not on the "
-            "additional-module-paths.  Run via the pytest_launched CTest row "
-            "(Liver/Testing/Python/CMakeLists.txt supplies the module paths)."
+            "[arena-skip] vtkMRMLResectogramDisplayNode is not registered -- "
+            "the LiverResections module is not on the additional-module-paths. "
+            "Run via the pytest_launched CTest row (Liver/Testing/Python/"
+            "CMakeLists.txt supplies the module paths)."
         )
     # CreateNodeByClass returns a node with the factory's +1 reference that the
     # caller owns; drop it, or the probe instance survives to process shutdown
@@ -225,31 +227,62 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
     meta = scenario.describe()
     width, height = meta["viewport"]["size"]
 
+    # Ensure the upstream LayerDM displayable manager is registered in the
+    # 3D-view factory so the standalone view hosts it and the registered
+    # ResectogramPipeline dispatches for the resectogram display node
+    # (ADR-0013 §5; idempotent -- RegisterInDefaultViews short-circuits when
+    # already present, and the LiverResections module setup() already calls
+    # it).  Skip cleanly when SlicerLayerDM is not on the launched path.
+    try:
+        from slicer import (  # type: ignore[import-not-found]
+            vtkMRMLLayerDisplayableManager,
+        )
+    except ImportError:
+        pytest.skip(
+            "[arena-skip] vtkMRMLLayerDisplayableManager is not importable -- "
+            "the upstream SlicerLayerDM extension is not on the launched path "
+            "(issue #460).  Run via pytest_launched with the LayerDM module "
+            "paths."
+        )
+    vtkMRMLLayerDisplayableManager.RegisterInDefaultViews()
+
     # Build the standalone view.  ``--no-main-window`` has no layout
     # manager, so construct the qMRMLThreeDWidget directly (the same
     # standalone-view pattern capture_baseline.py / replay_test.py use).
     view_widget = slicer.qMRMLThreeDWidget()
     view_widget.setMRMLScene(slicer.mrmlScene)
-    view_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLViewNode")
-    if view_node is None:
-        view_node = slicer.mrmlScene.AddNewNodeByClass(
-            "vtkMRMLViewNode", "ResectogramArenaView"
-        )
 
     created_nodes = None
     try:
         # Populate the scene (markups Bezier node + distance map + the
-        # resectogram-enabled display node).  setup_scene returns the
-        # created nodes so nothing leaks through a module global.
+        # resectogram display node).  setup_scene returns the created nodes
+        # so nothing leaks through a module global.  It Clear(0)s the scene
+        # first, so create the view node AFTER it -- a view node created
+        # before would be wiped, leaving the displayable-manager group bound
+        # to a node no longer in the scene (and the pipeline reconciliation
+        # would never fire).
         created_nodes = scenario.setup_scene()
         assert created_nodes is not None, (
             "scenario.setup_scene() returned None -- expected the created "
             "node handles (the no-module-globals contract)."
         )
-        bezier_node = created_nodes[0]
-        assert bezier_node is not None, (
+        assert created_nodes[0] is not None, (
             "scenario.setup_scene() did not return a Bezier node handle."
         )
+        # The v2.0 ResectogramPipeline carrier (ADR-0013 §1): the scenario
+        # returns it as the fourth handle.  Its presence in the scene is what
+        # drives the registered pipeline to render the flattened strip.
+        resectogram_display = created_nodes[3]
+        assert resectogram_display is not None, (
+            "scenario.setup_scene() did not return a vtkMRMLResectogramDisplayNode "
+            "-- the v2.0 ResectogramPipeline has nothing to key on (ADR-0013 §1)."
+        )
+
+        view_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLViewNode")
+        if view_node is None:
+            view_node = slicer.mrmlScene.AddNewNodeByClass(
+                "vtkMRMLViewNode", "ResectogramArenaView"
+            )
 
         # Map the view's GL surface BEFORE binding the view node so the
         # displayable-manager group attaches.  Under
@@ -289,21 +322,15 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
         view_widget.threeDView().forceRender()
 
         # ---- Structural wiring assertions (ALWAYS-ON, path-agnostic) ----
-        # These run regardless of the GL stack: a live renderer, the Bezier
-        # node's display node, and the resectogram strip enabled on it.
+        # These run regardless of the GL stack: a live renderer, the v2.0
+        # resectogram display node with the strip enabled, and a LIVE
+        # ResectogramPipeline dispatched for it.
         assert renderer is not None, "no live renderer on the view widget"
 
-        display_node = bezier_node.GetDisplayNode()
-        assert display_node is not None, (
-            "the Bezier node has no display node -- the scenario did not "
-            "create the resectogram display wiring."
-        )
         # The resectogram strip must be enabled (the whole point of the
-        # scenario).  ShowResection2D lives on the legacy markups display
-        # node (the v1 resectogram render path reads it); probe by accessor
-        # so the assertion is robust across the v1->v2 display-node
-        # migration.
-        get_show_2d = getattr(display_node, "GetShowResection2D", None)
+        # scenario).  ShowResection2D lives on the v2.0
+        # vtkMRMLResectogramDisplayNode (the ResectogramPipeline carrier).
+        get_show_2d = getattr(resectogram_display, "GetShowResection2D", None)
         assert get_show_2d is not None, (
             "the resectogram display node has no GetShowResection2D accessor "
             "-- the scenario is not driving a resectogram-capable display "
@@ -312,6 +339,41 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
         assert get_show_2d(), (
             "ShowResection2D is OFF on the display node -- the scenario did "
             "not enable the resectogram strip."
+        )
+
+        # The registered ResectogramPipeline must have dispatched for the
+        # display node and built a non-empty flattened-surface actor.  This
+        # is the T3-e go-live invariant (ADR-0013 §1/§5/§6): a
+        # vtkMRMLResectogramDisplayNode in a LayerDM-aware view yields a live
+        # pipeline whose FlattenedSurfaceRepresentation has renderable
+        # geometry -- the precondition for the lit-pixel verdict below.
+        manager = view_widget.threeDView().displayableManagerByClassName(
+            "vtkMRMLLayerDisplayableManager"
+        )
+        assert manager is not None, (
+            "[arena] the 3D view has no vtkMRMLLayerDisplayableManager -- the "
+            "upstream SlicerLayerDM extension is not loaded on the launched "
+            "path (issue #460)."
+        )
+        pipeline = manager.GetNodePipeline(resectogram_display)
+        assert pipeline is not None, (
+            "no pipeline dispatched for the vtkMRMLResectogramDisplayNode -- "
+            "the ResectogramPipeline creator (ADR-0013 §5) did not fire."
+        )
+        assert type(pipeline).__name__ == "ResectogramPipeline", (
+            "the pipeline bound to the resectogram display node is "
+            f"{type(pipeline).__name__!r}, not ResectogramPipeline (ADR-0013 §1)."
+        )
+        flattened = pipeline.GetFlattenedSurfaceRepresentation()
+        assert flattened is not None, (
+            "the ResectogramPipeline built no FlattenedSurfaceRepresentation "
+            "-- OnRendererAdded did not compose the Representations "
+            "(ADR-0013 §6)."
+        )
+        actor = flattened.GetResectionActor2D()
+        assert actor is not None and actor.GetMapper() is not None, (
+            "the flattened-surface actor / mapper is missing -- the "
+            "resectogram strip has nothing to draw."
         )
 
         # ---- Lit-pixel verdict (GPU-gated) ----

--- a/Testing/Python/workflow/test_resectogram_arena.py
+++ b/Testing/Python/workflow/test_resectogram_arena.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Dual-mode interactive arena for the T3 resectogram appearance.
+
+The user-testing arena for the resectogram: an isolated, minimal-
+``qSlicerApplication`` 3D view that builds the deterministic resectogram
+scene (the flattened 2D image of the Bezier ``(u, v)`` domain, ADR-0025
+§Context) and lets the maintainer eyeball the blur-on/off + non-square
+aspect-ratio appearances on a GPU.  The SAME body runs two ways from one
+test (ADR-0008 §3 dual-use pattern):
+
+* **offscreen / CI** (``pytest`` default, ``render_interactive == 0``) —
+  builds the view offscreen, runs the scenario, asserts the render
+  pipeline came up and the resectogram display wiring is in place, then
+  tears down.
+* **interactive** (``pytest --render-interactive=SECONDS`` with
+  ``SECONDS > 0``) — shows the Qt window and starts the interactor so a
+  human can inspect the resectogram for ``SECONDS`` before teardown.  Run
+  with ``-k`` to pick blur-on / blur-off / non-square.
+
+Harness placement (greppable skip reasons, mind #460)
+-----------------------------------------------------
+Needs a live ``qSlicerApplication`` (Qt widget + MRML scene + the
+registered LiverResections + LiverMarkups modules so the Bezier node + the
+resectogram render path are available).  Bare ``PythonSlicer -m pytest``
+has none of those, so the test SKIPS CLEANLY there via the shared guards;
+it EXECUTES under the launched-Slicer ``pytest_launched`` row.  Every skip
+prints an explicit, greppable reason — never a silent skip — per the #460
+launched-harness-silently-skips lesson.
+
+Capture-then-rebaseline note
+----------------------------
+The scenarios first render against the v1 monolith resectogram path (the
+legacy ``vtkMRMLMarkupsBezierSurfaceDisplayNode`` resectogram fields), then
+re-baseline to the v2.0 ResectogramPipeline at the implementer's go-live
+step.  This arena drives whatever path is live; the structural assertions
+below are path-agnostic (a 3D renderer + the Bezier node's display nodes),
+and the lit-pixel verdict is GPU-gated.
+
+Scenario source of truth
+-------------------------
+The scene wiring lives in the shared scenario modules under
+``LiverResections/Testing/Python/scenarios/Resectogram4x4*`` that
+``capture_baseline.py`` (interactive baseline) and ``replay_test.py`` (CI
+visual-regression) also consume.  This arena imports those exact modules
+so the interactive view, the CI replay, and the human capture all render
+the identical scene.
+
+See also
+--------
+* Docs/adr/0008-testing-strategy.md §3 (the dual-use render_interactive
+  pattern), §6 (the CI matrix + launched harness).
+* Docs/adr/0013-layerdm-pipeline-pattern.md §6 (the flattened-surface
+  Representation owned by the ResectogramPipeline).
+* Testing/Python/workflow/test_distance_spheroid_contour_arena.py (the
+  arena pattern + the hard-won software-GL / vtkDebugLeaks safety guards
+  this file copies).
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+from slicer_pytest_support import (
+    import_slicer_or_skip,
+    require_mrml_scene,
+    require_qt_widget,
+)
+
+
+# Absolute path to the scenario package's parent so the scenario modules
+# import under the same ``Python.scenarios.<name>`` dotted path the
+# capture / replay drivers use.  Computed from this file's location: walk
+# up to the repo root, then into the LiverResections test tree.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_SCENARIO_PARENT = _REPO_ROOT / "LiverResections" / "Testing"
+
+# The three T3 resectogram scenarios this arena can render.  Parametrised
+# so ``pytest -k NonSquare`` (etc.) picks one for interactive inspection.
+_SCENARIOS = (
+    "Resectogram4x4BlurOff",
+    "Resectogram4x4NonSquareScaling",
+    "Resectogram4x4BlurOn",
+)
+
+
+def _load_scenario(name: str):
+    """Import a shared resectogram scenario module by name."""
+    parent = str(_SCENARIO_PARENT)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+    return importlib.import_module(f"Python.scenarios.{name}")
+
+
+def _first_renderer(view_widget):
+    """Return the live ``vtkRenderer`` of the view widget's render window.
+
+    ``qMRMLThreeDView.renderer()`` is C++-only (not PythonQt-wrapped); reach
+    the renderer through the render-window's renderer collection, which is
+    plain VTK and fully wrapped.  Same accessor capture_baseline.py uses.
+    """
+    return view_widget.threeDView().renderWindow().GetRenderers().GetFirstRenderer()
+
+
+def _visible_pixel_count(view_widget) -> int:
+    """Count non-background pixels in the view's rendered back buffer.
+
+    Snapshots the GL back buffer with ``vtkWindowToImageFilter`` (the same
+    pixel source ``capture_baseline.py`` / ``replay_test.py`` use, so this
+    counts exactly the pixels the visual-regression baseline pins) and
+    returns how many are non-black (the scenario background is ``(0,0,0)``).
+    Channel value > 8 tolerates only single-LSB dithering, not a lit
+    fragment.
+    """
+    import vtk  # type: ignore[import-not-found]
+    from vtk.util import numpy_support  # type: ignore[import-not-found]
+
+    w2i = vtk.vtkWindowToImageFilter()
+    w2i.SetInput(view_widget.threeDView().renderWindow())
+    w2i.SetInputBufferTypeToRGB()
+    w2i.ReadFrontBufferOff()
+    w2i.SetShouldRerender(0)  # already-rendered back buffer
+    w2i.Update()
+    scalars = w2i.GetOutput().GetPointData().GetScalars()
+    arr = numpy_support.vtk_to_numpy(scalars)
+    return int((arr.max(axis=1) > 8).sum())
+
+
+_SOFTWARE_GL_MARKERS = ("llvmpipe", "softpipe", "swrast", "software rasterizer")
+
+
+def _software_gl_skip_reason() -> str | None:
+    """Return a greppable skip reason on a software-GL stack, else None.
+
+    Brings up a throwaway offscreen ``vtkRenderWindow`` and reads its
+    ``ReportCapabilities`` -- the same cheap probe the replay driver
+    (``LiverResections/Testing/Python/replay_test.py``) uses.  Probing a
+    *throwaway* window before the live view is built keeps this off the
+    arena's own (possibly context-failed) render window, and lets the test
+    skip BEFORE attempting a render the software stack cannot light.  Any
+    probe failure is treated as un-renderable (skip), never a crash.
+    """
+    import vtk  # type: ignore[import-not-found]
+
+    render_window = None
+    try:
+        render_window = vtk.vtkRenderWindow()
+        render_window.SetOffScreenRendering(1)
+        render_window.SetSize(1, 1)
+        render_window.SetMultiSamples(0)
+        render_window.Render()
+        capabilities = (render_window.ReportCapabilities() or "").lower()
+    except Exception:  # noqa: BLE001 -- any failure means "cannot render here".
+        return "[arena-skip] offscreen GL context could not be created"
+    finally:
+        if render_window is not None:
+            render_window.Finalize()
+    match = next((m for m in _SOFTWARE_GL_MARKERS if m in capabilities), None)
+    if match is not None:
+        return (
+            f"[arena-skip] offscreen software GL ({match}) -- the resectogram "
+            "render path does not reliably light fragments on a software "
+            "rasteriser; the lit-pixel verdict is deferred to a GPU-backed "
+            "display."
+        )
+    return None
+
+
+@pytest.mark.parametrize("scenario_name", _SCENARIOS)
+def test_resectogram_arena(scenario_name: str, render_interactive: float) -> None:
+    """Render a T3 resectogram scenario; interactive or offscreen.
+
+    The single body adapts to both modes by branching on
+    ``render_interactive`` (ADR-0008 §3) — the offscreen path tears the
+    view down immediately after the structural assertions, the interactive
+    path shows the window and starts the interactor for
+    ``render_interactive`` seconds.
+
+    Parametrised over the three T3 resectogram scenarios so the maintainer
+    can ``pytest --render-interactive=N -k <scenario>`` to inspect any one
+    on a GPU.
+    """
+    slicer = import_slicer_or_skip()
+    if slicer is None:
+        return
+    require_mrml_scene()
+    require_qt_widget()
+
+    # The scenario builds a vtkMRMLMarkupsBezierSurfaceNode + enables the
+    # resectogram strip on its display node.  Guard the distinct "live
+    # scene but the modules did not register" case with an explicit,
+    # greppable skip reason (module path missing).
+    registration_probe = slicer.mrmlScene.CreateNodeByClass(
+        "vtkMRMLMarkupsBezierSurfaceNode"
+    )
+    if registration_probe is None:
+        pytest.skip(
+            "[arena-skip] vtkMRMLMarkupsBezierSurfaceNode is not registered -- "
+            "the LiverResections / LiverMarkups modules are not on the "
+            "additional-module-paths.  Run via the pytest_launched CTest row "
+            "(Liver/Testing/Python/CMakeLists.txt supplies the module paths)."
+        )
+    # CreateNodeByClass returns a node with the factory's +1 reference that the
+    # caller owns; drop it, or the probe instance survives to process shutdown
+    # and trips vtkDebugLeaks (failing the launched harness) even when the test
+    # later skips on a software-GL stack.
+    registration_probe.UnRegister(None)
+
+    # Software-GL gate (CI's xvfb + llvmpipe): the resectogram render path
+    # does not reliably light fragments on a software rasteriser, and the
+    # offscreen render itself is unreliable there.  Probe a throwaway context
+    # and skip BEFORE building/rendering the live view so the test reports a
+    # real, greppable SKIP rather than a false pass or a render crash.  The
+    # lit-pixel verdict is on a GPU-backed display.
+    software_gl_skip = _software_gl_skip_reason()
+
+    import qt  # type: ignore[import-not-found]
+
+    scenario = _load_scenario(scenario_name)
+    meta = scenario.describe()
+    width, height = meta["viewport"]["size"]
+
+    # Build the standalone view.  ``--no-main-window`` has no layout
+    # manager, so construct the qMRMLThreeDWidget directly (the same
+    # standalone-view pattern capture_baseline.py / replay_test.py use).
+    view_widget = slicer.qMRMLThreeDWidget()
+    view_widget.setMRMLScene(slicer.mrmlScene)
+    view_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLViewNode")
+    if view_node is None:
+        view_node = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLViewNode", "ResectogramArenaView"
+        )
+
+    created_nodes = None
+    try:
+        # Populate the scene (markups Bezier node + distance map + the
+        # resectogram-enabled display node).  setup_scene returns the
+        # created nodes so nothing leaks through a module global.
+        created_nodes = scenario.setup_scene()
+        assert created_nodes is not None, (
+            "scenario.setup_scene() returned None -- expected the created "
+            "node handles (the no-module-globals contract)."
+        )
+        bezier_node = created_nodes[0]
+        assert bezier_node is not None, (
+            "scenario.setup_scene() did not return a Bezier node handle."
+        )
+
+        # Map the view's GL surface BEFORE binding the view node so the
+        # displayable-manager group attaches.  Under
+        # ``QT_QPA_PLATFORM=offscreen`` show() is visually a no-op but still
+        # maps the OpenGL surface + creates the default light; without it the
+        # offscreen back buffer renders empty.  Same show()-then-render
+        # ordering capture_baseline.py uses.
+        view_widget.show()
+        view_widget.threeDView().forceRender()
+        view_widget.setMRMLViewNode(view_node)
+
+        scenario.setup_camera(view_node)
+        scenario.setup_viewport(view_node)
+
+        # The standalone qMRMLThreeDWidget (no layout manager) does not
+        # honour the orphan MRML camera/view nodes the scenario configured,
+        # so push the scenario's deterministic camera pose + flat black
+        # background straight onto the live renderer -- the same thing
+        # capture_baseline.py / replay do -- so the offscreen frame matches
+        # the captured baseline and the visible-pixel count reflects lit
+        # resectogram fragments, not a non-black gradient.
+        renderer = _first_renderer(view_widget)
+        camera = renderer.GetActiveCamera()
+        camera_spec = meta["camera"]
+        camera.SetPosition(*camera_spec["position"])
+        camera.SetFocalPoint(*camera_spec["focal_point"])
+        camera.SetViewUp(*camera_spec["view_up"])
+        camera.SetViewAngle(camera_spec["view_angle"])
+        camera.SetClippingRange(*camera_spec["clipping_range"])
+        background = meta["viewport"]["background"]
+        renderer.SetBackground(*background)
+        renderer.SetBackground2(*background)
+
+        view_widget.resize(width, height)
+        view_widget.threeDView().renderWindow().SetSize(width, height)
+        view_widget.threeDView().renderWindow().SetMultiSamples(0)
+        view_widget.threeDView().forceRender()
+
+        # ---- Structural wiring assertions (ALWAYS-ON, path-agnostic) ----
+        # These run regardless of the GL stack: a live renderer, the Bezier
+        # node's display node, and the resectogram strip enabled on it.
+        assert renderer is not None, "no live renderer on the view widget"
+
+        display_node = bezier_node.GetDisplayNode()
+        assert display_node is not None, (
+            "the Bezier node has no display node -- the scenario did not "
+            "create the resectogram display wiring."
+        )
+        # The resectogram strip must be enabled (the whole point of the
+        # scenario).  ShowResection2D lives on the legacy markups display
+        # node (the v1 resectogram render path reads it); probe by accessor
+        # so the assertion is robust across the v1->v2 display-node
+        # migration.
+        get_show_2d = getattr(display_node, "GetShowResection2D", None)
+        assert get_show_2d is not None, (
+            "the resectogram display node has no GetShowResection2D accessor "
+            "-- the scenario is not driving a resectogram-capable display "
+            "node (ADR-0025 §Context)."
+        )
+        assert get_show_2d(), (
+            "ShowResection2D is OFF on the display node -- the scenario did "
+            "not enable the resectogram strip."
+        )
+
+        # ---- Lit-pixel verdict (GPU-gated) ----
+        # The resectogram render path does not reliably light fragments on a
+        # software rasteriser; defer the pixel verdict to a GPU-backed
+        # display.  The structural assertions above already ran.
+        if software_gl_skip is not None:
+            pytest.skip(software_gl_skip)
+
+        try:
+            import numpy  # type: ignore[import-not-found]  # noqa: F401
+            from vtk.util import numpy_support  # type: ignore[import-not-found]  # noqa: F401
+        except ImportError:
+            pytest.skip(
+                "[arena-skip] numpy / vtk.util.numpy_support unavailable -- "
+                "cannot read the rendered back buffer for the visible-pixel "
+                "assertion.  Structural wiring above already passed."
+            )
+        visible = _visible_pixel_count(view_widget)
+        # A generous 1 % floor still fails hard on an all-black frame while
+        # tolerating the resectogram strip occupying only part of the panel.
+        min_visible = int(0.01 * width * height)
+        assert visible >= min_visible, (
+            f"the resectogram rendered only {visible} lit pixels "
+            f"(< {min_visible}) -- the flattened strip is not visibly drawn.  "
+            "Expected the live resectogram path to light the (u, v) panel."
+        )
+
+        if render_interactive:
+            # Interactive arena: keep the window up and let the human drive
+            # the camera.  A single-shot timer quits the nested event loop
+            # after the requested dwell so the test still terminates under
+            # CI's brief-onscreen pass (--render-interactive=0.1).
+            interactor = view_widget.threeDView().interactor()
+            if interactor is not None:
+                loop = qt.QEventLoop()
+                qt.QTimer.singleShot(int(render_interactive * 1000), loop.quit)
+                interactor.Initialize()
+                view_widget.threeDView().forceRender()
+                loop.exec_()
+    finally:
+        # Tear the widget + scene down so no actor / node survives to process
+        # exit and trips vtkDebugLeaks in the launched harness (the
+        # LiverResections conftest's _launched_scene_cleanup clears the scene;
+        # the standalone widget is ours).
+        view_widget.setMRMLScene(None)
+        view_widget.deleteLater()
+        slicer.mrmlScene.Clear(0)

--- a/Testing/Python/workflow/test_resectogram_pipeline_dispatch.py
+++ b/Testing/Python/workflow/test_resectogram_pipeline_dispatch.py
@@ -49,6 +49,10 @@ References
   ``vtkMRMLResectogramDisplayNode``.
 * ADR-0027 — invariant-test-first; the specific invariant is
   type-keyed dispatch WITHOUT cross-fire, not mere pipeline existence.
+* ADR-0013 §9 — the real-view fixture: the two dispatch tests consume
+  the shared ``layerdm_threed_view`` fixture in ``Testing/Python/conftest.py``,
+  which brings up a standalone ``qMRMLThreeDWidget`` hosting the upstream
+  ``vtkMRMLLayerDisplayableManager`` and queries it via ``GetNodePipeline``.
 * Mirrors the ``importorskip("LayerDMLib")`` gating used by the T2
   Bezier Pipeline tests under ``Testing/Python/unit/``.
 """
@@ -70,23 +74,6 @@ pytest.importorskip(
         "CI row (issue #460)."
     ),
 )
-
-
-@pytest.fixture
-def layerdm_threed_view():
-    """Yield a LayerDM-aware 3D view + its displayable manager.
-
-    TODO(liver-implementer): build the minimal launched-app 3D view that
-    hosts a ``vtkMRMLLayerDMDisplayableManager`` (mirror the T2
-    real-view fixture delivered with the Bezier Pipeline per ADR-0013
-    §9).  Until that fixture lands the dispatch tests below skip with a
-    clear reason rather than silently passing.
-    """
-    pytest.skip(
-        "Invariant not yet implemented: launched LayerDM 3D-view fixture for "
-        "ResectogramPipeline dispatch is not yet provided (ADR-0013 §9 "
-        "real-view fixture)."
-    )
 
 
 def test_resectogram_display_node_registers():
@@ -118,15 +105,25 @@ def test_resectogram_creator_fires_for_its_display_node(layerdm_threed_view):
     view, manager = layerdm_threed_view
     display = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLResectogramDisplayNode")
 
-    # TODO(liver-implementer): query the LayerDM manager for the pipeline
-    # bound to ``display`` and assert it is a ResectogramPipeline instance
-    # (the creator keyed on vtkMRMLResectogramDisplayNode fired).
-    pipeline = manager.GetPipelineForDisplayNode(display)
+    # Query the LayerDM manager for the pipeline bound to ``display`` via the
+    # ``GetNodePipeline`` accessor documented on vtkMRMLLayerDisplayableManager
+    # as the test/debug pipeline lookup.  A live ResectogramPipeline means the
+    # creator keyed on vtkMRMLResectogramDisplayNode fired (ADR-0013 §5).
+    pipeline = manager.GetNodePipeline(display)
     assert pipeline is not None, (
         "No pipeline created for vtkMRMLResectogramDisplayNode — the T3 "
-        "AddPipelineCreator (ADR-0013 §5) has not been wired."
+        "AddPipelineCreator (ADR-0013 §5) did not fire for the dedicated "
+        "display-node type."
     )
-    assert type(pipeline).__name__ == "ResectogramPipeline"
+    # The scripted ResectogramPipeline derives from
+    # vtkMRMLLayerDMScriptedPipeline (a vtkMRMLLayerDMScriptedPipelineBridge).
+    # GetNodePipeline returns the bridge; assert the bound Python object is a
+    # ResectogramPipeline by its class name.
+    assert type(pipeline).__name__ == "ResectogramPipeline", (
+        "the pipeline bound to vtkMRMLResectogramDisplayNode is "
+        f"{type(pipeline).__name__!r}, not ResectogramPipeline — the T3 "
+        "creator did not build the dedicated pipeline (ADR-0013 §5)."
+    )
 
 
 def test_resectogram_creator_does_not_collide_with_bezier(layerdm_threed_view):
@@ -155,10 +152,10 @@ def test_resectogram_creator_does_not_collide_with_bezier(layerdm_threed_view):
         "vtkMRMLResectogramDisplayNode"
     )
 
-    # TODO(liver-implementer): resolve the pipeline bound to each display
-    # node and assert the type mapping is disjoint.
-    parametric_pipeline = manager.GetPipelineForDisplayNode(parametric)
-    resectogram_pipeline = manager.GetPipelineForDisplayNode(resectogram)
+    # Resolve the pipeline bound to each display node via the DM's
+    # GetNodePipeline accessor and assert the type mapping is disjoint.
+    parametric_pipeline = manager.GetNodePipeline(parametric)
+    resectogram_pipeline = manager.GetNodePipeline(resectogram)
 
     assert type(parametric_pipeline).__name__ != "ResectogramPipeline", (
         "vtkMRMLParametricSurfaceDisplayNode wrongly produced a "


### PR DESCRIPTION
## Summary (T3-a/b/c/d — gating + Representations; sever/blur are later steps)

First tranche of #465 (T3 ResectogramPipeline). Lands the launched-test gating + the v2 render-assembly Representations, ahead of making the Pipeline live (T3-e) and the Gaussian blur (T3-f).

- **T3-a** — ADR-0013 §9 LayerDM real-view fixture (`layerdm_threed_view`) in `Testing/Python/conftest.py`; un-skips `test_resectogram_pipeline_dispatch.py` so the disjoint dedicated-display-node keying invariant (ADR-0013 §1) is actively pinned.
- **T3-b** — `FlattenedSurfaceRepresentation`: overlay-camera pose from the flattened quad bounds (MirrorDisplay z-flip), non-square `MatRatio` routed through the pure-VTK `vtkLiverResectogramAspectRatio` helper (no v1 `Ratio` re-derivation).
- **T3-c** — `VascularContourRepresentation`: flattened-strip polydata fed into both relocated contour mappers.
- **T3-d** — three visual scenarios (`Resectogram4x4BlurOn/BlurOff/NonSquareScaling`) + a dual-use interactive/offscreen arena (`test_resectogram_arena.py`); replay entries inert until baselines publish.

Sever of the v1 monolith 2D path (T3-e, two commits, gated on baselines) and the Gaussian-blur pass (T3-f) remain follow-on steps in this branch.

## ADR references
1. ADR-0013 §1/§6/§9 — one Pipeline per display-node type; Representations as composable VTK pipelines; real-view fixture (this PR lands it; §9 text amendment to follow).
2. ADR-0014 §3 — contour-mapper relocation / four-layer split.
3. ADR-0015 §1 — pure-VTK Algorithm helper owns the ratio math.
4. ADR-0025 §Context — the resectogram is the flattened (u,v) image.
5. ADR-0027 — invariant-test-first (RED skeletons → green).

## Conformance
MatRatio square/non-flexible → {1,1}, non-square → helper squeeze, no v1 re-derivation (`test_flattened_surface_representation.py`); contour strip feed + visibility (`test_vascular_contour_representation.py`); dispatch disjoint-keying un-skipped (`test_resectogram_pipeline_dispatch.py`). The arena lit-pixel verdict is RED-by-design until T3-e makes the Pipeline the live renderer.

## Known follow-ups in this branch
- T3-e go-live + v1 sever (two commits, baseline-gated); T3-f blur; ADR-0013 §9 text amendment (DOC).
- Baseline strategy (capture-against-v1 vs v2-direct) under evaluation — the v1 resectogram composites only inside the full Slicer 5-renderer view layout, so harness capture may pivot to v2-direct + visual inspection.

## UX impact
N/A — render-assembly wiring behind the existing resectogram display path; no user-facing controls added.

_Authored by the Claude (claude-opus-4-8) agent fleet under maintainer steering._