### PR TITLE
ENH: Resectogram dedicated view + Pipeline-dispatch tightening (#483, T3-g1)

### DIFF
--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   DistanceMaps.py
   LiverBezierSurfacePipeline.py
   ResectogramPipeline.py
+  ResectogramViewManager.py
   Representations/__init__.py
   Representations/BezierPlanningRepresentation.py
   Representations/ConfirmedRepresentation.py

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -23,15 +23,14 @@ ADR-0013 §6 (Representations are composable VTK pipelines).  It owns:
   ``vtkLiverResectogramAspectRatio`` helper (Algorithm library,
   ADR-0015 §1) rather than re-deriving the v1 ``Ratio(bool)`` math.
 
-Scope of this skeleton
-----------------------
-Per the T3 bounded slice this skeleton COMPOSES the assembly and wires
-the display-node fields it consumes, but it does NOT yet sever the
-assembly out of the v1 monolith (that is a separate follow-up; until
-then the monolith remains the live 2D renderer) and it does NOT add the
-Gaussian-blur pass (a later v2.0 toggle).  The aspect-ratio math is
-routed through the extracted Algorithm helper; the Gaussian-blur hook
-is intentionally absent.
+Scope
+-----
+This Representation COMPOSES the assembly, wires the display-node fields
+it consumes, and binds the distance-map 3D texture + ras/ijk matrices on
+the 2D mapper so the flattened ``(u, v)`` quad samples the distance field
+and paints the projected margin band (ADR-0025 §Context).  The
+aspect-ratio math is routed through the extracted Algorithm helper.  The
+Gaussian-blur post-pass (a later v2.0 toggle) is intentionally absent.
 
 The VTK objects are soft dependencies — same pattern as
 ``ConfirmedRepresentation``: a pure-Python pytest run skips the VTK-only
@@ -134,6 +133,16 @@ class FlattenedSurfaceRepresentation:
         self._resection_actor_2d: Any | None = None
         self._resectogram_camera: Any | None = None
 
+        # The distance-map volume node the bound texture was built from.
+        # ``None`` until the first ``update()`` with a distance map binds
+        # one; used purely as the idempotency key so the texture is rebuilt
+        # only when the volume changes.  The texture OBJECT itself is owned
+        # SOLELY by the 2D mapper's ``vtkSmartPointer`` (C++) — this
+        # Representation deliberately keeps NO Python reference to it, so it
+        # dies with the mapper at view teardown rather than outliving the
+        # C++ pipeline on the Python heap (a vtkDebugLeaks trip).
+        self._distance_map_volume: Any | None = None
+
         # Last MatRatio pushed onto the 2D mapper.  ``None`` until the
         # first ``update()`` runs OR the mapper does not expose
         # ``SetMatRatio`` (generic-mapper fallback path).
@@ -177,6 +186,19 @@ class FlattenedSurfaceRepresentation:
 
     def cleanup(self) -> None:
         """Detach actors from the renderer and drop the VTK pipeline."""
+        # Drop the distance-map texture off the mapper so the mapper's
+        # vtkSmartPointer (the texture's sole owner) releases it (the v1
+        # clear-on-teardown discipline; avoids a stale sampler3D bind).
+        mapper = self._resection_mapper_2d
+        if mapper is not None:
+            unbind = getattr(mapper, "SetDistanceMapTextureObject", None)
+            if unbind is not None:
+                try:
+                    unbind(None)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+        self._distance_map_volume = None
+
         if self._renderer is not None:
             self._detach_actors(self._renderer)
             self._renderer = None
@@ -286,6 +308,7 @@ class FlattenedSurfaceRepresentation:
             self._input_refresh_count += 1
 
         self._apply_mat_ratio(sampled, flexible)
+        self._apply_distance_map_texture(display_node, data_node)
 
     def _apply_mat_ratio(self, sampled: Any | None, flexible: bool) -> None:
         """Compute + push the resectogram aspect-ratio scaling.
@@ -309,6 +332,175 @@ class FlattenedSurfaceRepresentation:
             return
         setter(list(ratio))
         self._mat_ratio_applied = (float(ratio[0]), float(ratio[1]))
+
+    def _apply_distance_map_texture(
+        self, display_node: Any | None, data_node: Any | None
+    ) -> None:
+        """Bind the distance-map 3D texture + ras/ijk matrices on the mapper.
+
+        Ports the v1 monolith
+        ``vtkSlicerBezierSurfaceRepresentation3D::CreateAndTransferDistanceMapTexture``
+        and the ras/ijk matrix feed (severed by the T3-e rewrite): the
+        flattened ``(u, v)`` quad samples the distance field through the
+        mapper's ``sampler3D`` to paint the projected margin band
+        (ADR-0025 §Context).  Without this only the wireframe grid +
+        coloured border draw.
+
+        Re-binds only when the distance-map volume changes (idempotent
+        per ADR-0013 §3) and degrades safely: no distance map, no mapper
+        ``SetDistanceMapTextureObject``, no renderer/GL context, or no
+        ``TextureObject`` helper all leave the grid/border render intact
+        and drop any stale texture from the mapper rather than sampling a
+        volume that is gone.
+        """
+        mapper = self._resection_mapper_2d
+        if mapper is None:
+            return
+        bind = getattr(mapper, "SetDistanceMapTextureObject", None)
+        if bind is None:
+            return  # generic-mapper fallback (bare-VTK path) — no sampler3D
+
+        already_bound = self._mapper_has_distance_map_texture(mapper)
+        volume = _safe_call_getter(data_node, "GetDistanceMapVolumeNode")
+        if volume is self._distance_map_volume and already_bound:
+            return  # unchanged + already bound — idempotent (ADR-0013 §3)
+
+        image_data = _safe_call_getter(volume, "GetImageData")
+        if image_data is None:
+            # No distance map (or no image data): drop any stale texture so
+            # the mapper falls back to its no-distance-map path instead of
+            # sampling a volume that is gone (the v1 warning branch).
+            bind(None)
+            self._distance_map_volume = volume
+            return
+
+        num_comps = _safe_get_int(display_node, "GetTextureNumComps", default=0)
+        texture = self._create_distance_map_texture(image_data, num_comps)
+        if texture is None:
+            # The GL render window is not live yet (texture build deferred):
+            # leave the volume unrecorded so a later update — once the
+            # window exists — retries the bind rather than short-circuiting.
+            bind(None)
+            self._distance_map_volume = None
+            return
+
+        # Hand the texture to the mapper's vtkSmartPointer and drop the
+        # local reference: the mapper is now its sole owner (no Python
+        # attribute survives to outlive the C++ teardown).
+        self._distance_map_volume = volume
+        bind(texture)
+        self._apply_distance_map_matrices(volume, image_data)
+        del texture
+
+    def _mapper_has_distance_map_texture(self, mapper: Any) -> bool:
+        """Whether the mapper currently holds a distance-map texture object.
+
+        The idempotency probe: the texture object is owned solely by the
+        mapper, so "already bound" is read off the mapper rather than a
+        Python attribute (which is deliberately not retained).  Tolerant of
+        the generic-mapper fallback that lacks the accessor.
+        """
+        getter = getattr(mapper, "GetDistanceMapTextureObject", None)
+        if getter is None:
+            return False
+        try:
+            return getter() is not None
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+    def _create_distance_map_texture(
+        self, image_data: Any, num_comps: int
+    ) -> Any | None:
+        """Build the 3D distance-map texture object from ``image_data``.
+
+        Mirrors the v1 ``CreateAndTransferDistanceMapTexture`` body: a
+        ``vtkMultiTextureObjectHelper`` contexted on the renderer's
+        OpenGL render window, clamp-to-border wrapping, linear filtering,
+        and ``CreateSeq3DFromRaw`` from the volume's scalar pointer with
+        the display node's ``TextureNumComps`` component count.  Returns
+        ``None`` (caller drops the texture) when the helper class or the
+        render window is unavailable.
+        """
+        helper_factory = _import_texture_object_helper()
+        if helper_factory is None:
+            return None
+        render_window = self._render_window()
+        if render_window is None:
+            return None
+        try:
+            texture = helper_factory()
+            texture.SetContext(render_window)
+            clamp = getattr(texture, "ClampToBorder", None)
+            linear = getattr(texture, "Linear", None)
+            if clamp is not None:
+                texture.SetWrapS(clamp)
+                texture.SetWrapT(clamp)
+                texture.SetWrapR(clamp)
+            if linear is not None:
+                texture.SetMinificationFilter(linear)
+                texture.SetMagnificationFilter(linear)
+            texture.SetBorderColor(1000.0, 1000.0, 0.0, 0.0)
+            dimensions = image_data.GetDimensions()
+            texture.CreateSeq3DFromRaw(
+                dimensions[0],
+                dimensions[1],
+                dimensions[2],
+                int(num_comps),
+                vtk.VTK_FLOAT,
+                image_data.GetScalarPointer(),
+                0,
+            )
+        except Exception:  # pragma: no cover - defensive
+            return None
+        return texture
+
+    def _apply_distance_map_matrices(self, volume: Any, image_data: Any) -> None:
+        """Push the ras→ijk + ijk→texture transposed matrices on the mapper.
+
+        The v1 feed: the volume's RAS→IJK matrix (transposed for the
+        shader's column-major uniform) maps the flattened quad's RAS
+        position into the distance-map voxel grid, and a per-dimension
+        ``1/N`` scale (transposed) normalises voxel indices into the
+        ``[0, 1]`` texture domain the ``sampler3D`` reads.  No-op when the
+        mapper lacks the transposed-matrix setters.
+        """
+        mapper = self._resection_mapper_2d
+        set_ras = getattr(mapper, "SetRasToIjkMatrixT", None)
+        set_ijk = getattr(mapper, "SetIjkToTextureMatrixT", None)
+        if set_ras is None or set_ijk is None:
+            return
+        try:
+            ras_to_ijk_t = vtk.vtkMatrix4x4()
+            volume.GetRASToIJKMatrix(ras_to_ijk_t)
+            ras_to_ijk_t.Transpose()
+
+            dimensions = image_data.GetDimensions()
+            scaling = vtk.vtkTransform()
+            scaling.Scale(
+                1.0 / dimensions[0], 1.0 / dimensions[1], 1.0 / dimensions[2]
+            )
+            ijk_to_texture_t = vtk.vtkMatrix4x4()
+            scaling.GetTranspose(ijk_to_texture_t)
+        except Exception:  # pragma: no cover - defensive
+            return
+        set_ras(ras_to_ijk_t)
+        set_ijk(ijk_to_texture_t)
+
+    def _render_window(self) -> Any | None:
+        """Return the renderer's OpenGL render window, or ``None``.
+
+        The ``vtkMultiTextureObjectHelper`` must be contexted on a live
+        GL render window before ``CreateSeq3DFromRaw`` allocates the GPU
+        texture.  Returns ``None`` (no renderer, or the renderer has no
+        window yet) so the texture build is skipped until a window exists.
+        """
+        renderer = self._renderer
+        if renderer is None or not hasattr(renderer, "GetRenderWindow"):
+            return None
+        try:
+            return renderer.GetRenderWindow()
+        except Exception:  # pragma: no cover - defensive
+            return None
 
     def _compute_aspect_ratio(
         self, sampled: Any | None, flexible: bool
@@ -454,22 +646,62 @@ def _make_resection_mapper_2d() -> Any:
     return vtk.vtkPolyDataMapper()
 
 
-def _import_aspect_ratio_helper() -> Any | None:
-    """Return the ``vtkLiverResectogramAspectRatio`` helper class.
+def _import_wrapped_class(name: str) -> Any | None:
+    """Return a wrapped VTK/Slicer class by name, or ``None``.
 
-    Reachable from a Slicer process via the ``slicer`` namespace or the
-    wrapped Algorithm module.  Returns ``None`` in a bare-VTK pytest run
-    where the wrapped class is not importable.
+    Reachable from a Slicer process via the ``vtk`` or ``slicer``
+    namespace; returns ``None`` in a bare-VTK pytest run where the wrapped
+    class is not importable, so the calling branch degrades gracefully.
     """
     if _HAS_VTK:
-        factory = getattr(vtk, "vtkLiverResectogramAspectRatio", None)
+        factory = getattr(vtk, name, None)
         if factory is not None:
             return factory
     try:  # pragma: no cover — exercised inside Slicer
-        from slicer import vtkLiverResectogramAspectRatio  # type: ignore[import-not-found]
+        import slicer  # type: ignore[import-not-found]
 
-        return vtkLiverResectogramAspectRatio
+        return getattr(slicer, name, None)
     except Exception:
+        return None
+
+
+def _import_aspect_ratio_helper() -> Any | None:
+    """Return the ``vtkLiverResectogramAspectRatio`` helper class, or ``None``.
+
+    Named seam (unit tests monkeypatch it to inject a stub helper) over
+    the generic ``_import_wrapped_class``.
+    """
+    return _import_wrapped_class("vtkLiverResectogramAspectRatio")
+
+
+def _import_texture_object_helper() -> Any | None:
+    """Return the ``vtkMultiTextureObjectHelper`` class, or ``None``.
+
+    The helper (``LiverMarkups/VTKWidgets/``) wraps ``vtkTextureObject``
+    with the ``CreateSeq3DFromRaw`` upload the resectogram distance map
+    needs.  A named seam over ``_import_wrapped_class`` for symmetry with
+    the aspect-ratio helper.
+    """
+    return _import_wrapped_class("vtkMultiTextureObjectHelper")
+
+
+def _safe_call_getter(node: Any | None, getter_name: str) -> Any | None:
+    """Return ``node.<getter_name>()`` defensively, or ``None``.
+
+    Tolerant of a missing node, a missing accessor (stub nodes in unit
+    tests), or a raising getter.  Used to read the distance-map volume off
+    the data node (``GetDistanceMapVolumeNode`` — the same source the
+    scenario sets via ``SetDistanceMapVolumeNode``) and the volume's
+    ``GetImageData``.
+    """
+    if node is None:
+        return None
+    getter = getattr(node, getter_name, None)
+    if getter is None:
+        return None
+    try:
+        return getter()
+    except Exception:  # pragma: no cover - defensive
         return None
 
 

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -32,6 +32,20 @@ and paints the projected margin band (ADR-0025 §Context).  The
 aspect-ratio math is routed through the extracted Algorithm helper.  The
 Gaussian-blur post-pass (a later v2.0 toggle) is intentionally absent.
 
+The flattened quad fed to the 2D mapper as its INPUT geometry is the
+fixed planar ``(u, v)`` domain — that defines the OUTPUT rectangle.  The
+real surface enters as the mapper's ``"BSPoints"`` point-data array (the
+``vertexMCBS`` shader attribute): the data node's evaluated Bezier
+surface ``S(u, v)`` positions, sampled at the quad's resolution so the
+arrays align vertex-for-vertex.  The mapper transforms ``BSPoints``
+through ras→ijk→texture to sample the distance field at the REAL surface
+position, so the flattened image is coherent with the 3D surface and
+re-renders when the control points move (ADR-0025 §Context; the v1
+``BezierPlane->GetPointData()->AddArray(BezierSurfaceSourcePoints)``
+feed).  Without ``BSPoints`` the mapper falls back to the flat quad's own
+vertices and paints the distance field on a fixed plane — the
+non-coherent / non-reactive fixed-quad failure mode.
+
 The VTK objects are soft dependencies — same pattern as
 ``ConfirmedRepresentation``: a pure-Python pytest run skips the VTK-only
 branches, while a Slicer process (or any environment with VTK on
@@ -289,8 +303,16 @@ class FlattenedSurfaceRepresentation:
     def _apply_data_node(
         self, display_node: Any | None, data_node: Any | None
     ) -> None:
-        """Push the sampled surface onto the quad source, then recompute
-        the anisotropic ``MatRatio`` via the Algorithm helper.
+        """Push the real surface onto the 2D mapper, then recompute the
+        anisotropic ``MatRatio`` via the Algorithm helper.
+
+        The data node's evaluated Bezier surface ``S(u, v)`` is pushed onto
+        the 2D mapper's input as the ``"BSPoints"`` point-data array (the
+        ``vertexMCBS`` shader attribute), so the flattened image samples the
+        distance field at the REAL surface position — coherent with the 3D
+        view and reactive to control-point edits (ADR-0025 §Context).  When
+        the data node exposes only an explicit sampled-surface points object
+        (the unit-test stub path), that is used directly.
 
         The ``MatRatio`` math is NOT re-derived here — it is routed
         through the extracted pure-VTK ``vtkLiverResectogramAspectRatio``
@@ -301,14 +323,92 @@ class FlattenedSurfaceRepresentation:
             display_node, "GetEnableFlexibleBoundary", default=False
         )
 
+        # Prefer an explicit sampled-surface points object (unit-test stub);
+        # otherwise evaluate S(u, v) from the data node's Bezier control
+        # points (the real markups-node path inside Slicer).
         sampled = _safe_get_sampled_surface(data_node)
-        signature = (id(sampled) if sampled is not None else None, bool(flexible))
+        if sampled is None:
+            sampled = self._evaluate_surface_points(data_node)
+
+        signature = _surface_signature(sampled, flexible)
         if signature != self._last_surface_signature:
             self._last_surface_signature = signature
             self._input_refresh_count += 1
 
+        self._push_surface_onto_mapper_input(sampled)
         self._apply_mat_ratio(sampled, flexible)
         self._apply_distance_map_texture(display_node, data_node)
+
+    def _evaluate_surface_points(self, data_node: Any | None) -> Any | None:
+        """Return the data node's evaluated Bezier surface ``S(u, v)`` points.
+
+        Reads the markups node's 16 control points and feeds a
+        ``vtkBezierSurfaceSource`` at the flattened quad's resolution so the
+        evaluated grid aligns vertex-for-vertex with the quad the 2D mapper
+        renders (the v1 ``BezierSurfaceSource`` feed).  Returns ``None`` when
+        VTK / the source is unavailable, the data node carries no control
+        points, or the legacy 16-point grid is not yet complete — the caller
+        then degrades to the prior fixed-quad fallback (no crash).
+        """
+        if not _HAS_VTK or data_node is None:
+            return None
+
+        control_points = _read_control_points(data_node)
+        if control_points is None:
+            return None
+
+        source = _make_flattened_quad_source()
+        set_resolution = getattr(source, "SetResolution", None)
+        set_control_points = getattr(source, "SetControlPoints", None)
+        if set_resolution is None or set_control_points is None:
+            return None  # generic vtkPlaneSource fallback — no Bezier eval
+        try:
+            set_resolution(*_FLATTENED_QUAD_RESOLUTION)
+            set_control_points(control_points)
+            source.Update()
+            output = source.GetOutput()
+            points = output.GetPoints()
+        except Exception:  # pragma: no cover - defensive
+            return None
+        if points is None or points.GetNumberOfPoints() == 0:
+            return None
+        return points
+
+    def _push_surface_onto_mapper_input(self, sampled: Any | None) -> None:
+        """Push ``sampled`` onto the 2D mapper input as the ``"BSPoints"`` array.
+
+        Adds (or replaces) the ``"BSPoints"`` point-data array on the
+        flattened quad's output — the mapper's optional ``vertexMCBS``
+        attribute (the REAL surface ``S(u, v)`` positions).  The mapper
+        transforms these through ras→ijk→texture to sample the distance
+        field at the real surface, making the flattened image coherent with
+        the 3D surface (the v1
+        ``BezierPlane->GetPointData()->AddArray(BezierSurfaceSourcePoints)``
+        feed).  No-op when the quad source, the sampled surface, or the
+        point-data array (the bare-VTK stub-points path) is unavailable — the
+        mapper then falls back to the flat quad's own vertices.
+        """
+        plane = self._bezier_plane
+        if plane is None or sampled is None:
+            return
+        get_data = getattr(sampled, "GetData", None)
+        if get_data is None:
+            return  # stub points object (unit tests) — no vtkPoints array
+        try:
+            if hasattr(plane, "Update"):
+                plane.Update()
+            output = plane.GetOutput()
+            point_data = output.GetPointData()
+            surface_array = get_data()
+        except Exception:  # pragma: no cover - defensive
+            return
+        if point_data is None or surface_array is None:
+            return
+        # ``AddArray`` replaces an existing same-named array, so naming the
+        # surface array "BSPoints" and adding it both installs and refreshes
+        # the mapper's optional vertexMCBS attribute on every update.
+        surface_array.SetName("BSPoints")
+        point_data.AddArray(surface_array)
 
     def _apply_mat_ratio(self, sampled: Any | None, flexible: bool) -> None:
         """Compute + push the resectogram aspect-ratio scaling.
@@ -722,6 +822,68 @@ def _sampled_surface_resolution(sampled: Any) -> tuple[int, int]:
     if side * side == n:
         return (side, side)
     return (default, default)
+
+
+def _read_control_points(data_node: Any | None) -> Any | None:
+    """Return the data node's Bezier control points as a ``vtkPoints``.
+
+    Mirrors the v1 ``UpdateBezierSurfaceGeometry`` read: the legacy markups
+    Bezier node carries the 16-point ``(4, 4)`` control grid (ADR-0018 §1)
+    via ``GetNumberOfControlPoints`` / ``GetNthControlPointPosition``.
+    Returns ``None`` defensively when the accessors are absent (stub data
+    nodes), the grid is incomplete (< 16 defined points, mid-placement), or
+    a read raises — the caller then keeps the fixed-quad fallback.
+    """
+    if not _HAS_VTK or data_node is None:
+        return None
+    count_getter = getattr(data_node, "GetNumberOfControlPoints", None)
+    position_getter = getattr(data_node, "GetNthControlPointPosition", None)
+    if count_getter is None or position_getter is None:
+        return None
+    try:
+        count = int(count_getter())
+    except Exception:  # pragma: no cover - defensive
+        return None
+    if count != 16:  # the legacy 16-point invariant (the only fed grid)
+        return None
+    points = vtk.vtkPoints()
+    position = [0.0, 0.0, 0.0]
+    try:
+        for index in range(count):
+            position_getter(index, position)
+            points.InsertNextPoint(
+                float(position[0]), float(position[1]), float(position[2])
+            )
+    except Exception:  # pragma: no cover - defensive
+        return None
+    return points
+
+
+def _surface_signature(sampled: Any | None, flexible: bool) -> tuple:
+    """Return an idempotency signature for ``sampled`` + ``flexible``.
+
+    For a ``vtkPoints`` surface the signature folds in the point count and
+    the coordinate ``MTime`` (a stub points object that lacks ``GetMTime``
+    falls back to ``id``), so a control-point edit that re-evaluates the
+    surface bumps the signature and the refresh counter — the reactivity the
+    pipeline-level ``Modified`` observer triggers a re-``update()`` for.
+    """
+    if sampled is None:
+        return (None, bool(flexible))
+    count_getter = getattr(sampled, "GetNumberOfPoints", None)
+    mtime_getter = getattr(sampled, "GetMTime", None)
+    count = None
+    if count_getter is not None:
+        try:
+            count = int(count_getter())
+        except Exception:  # pragma: no cover - defensive
+            count = None
+    if mtime_getter is not None:
+        try:
+            return (count, int(mtime_getter()), bool(flexible))
+        except Exception:  # pragma: no cover - defensive
+            pass
+    return (id(sampled), count, bool(flexible))
 
 
 def _safe_get_sampled_surface(data_node: Any | None) -> Any | None:

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -23,14 +23,30 @@ ADR-0013 §6 (Representations are composable VTK pipelines).  It owns:
   ``vtkLiverResectogramAspectRatio`` helper (Algorithm library,
   ADR-0015 §1) rather than re-deriving the v1 ``Ratio(bool)`` math.
 
+Gaussian-blur post-pass (net-new, v2.0)
+---------------------------------------
+The resectogram display node carries a ``BlurEnabled`` on/off flag (no
+legacy counterpart).  When it is true this Representation moves the
+resectogram actor onto a PRIVATE overlay ``vtkRenderer`` it owns and sets
+a ``vtkGaussianBlurPass`` on that renderer; when false it detaches the
+pass and overlay, leaving the non-blur path byte-identical to the
+pre-blur appearance.  The overlay renderer (rather than the dedicated
+resectogram view's main renderer) carries the pass because
+``qMRMLThreeDView`` resets ``SetPass(nullptr)`` on every view-node
+ModifiedEvent and would clobber a pass set on the main renderer.  The
+blur is a GPU render-pass on a renderer the Representation owns — NOT
+pure-VTK math — so it lives here and not in the ADR-0015 §1 Algorithm
+library.  The toggle is live: it reconciles on every ``update()`` (the
+Pipeline's display-node MTime path), so a ``BlurEnabled`` change engages
+or disengages the pass without rebuilding the assembly (ADR-0013 §6).
+
 Scope
 -----
 This Representation COMPOSES the assembly, wires the display-node fields
 it consumes, and binds the distance-map 3D texture + ras/ijk matrices on
 the 2D mapper so the flattened ``(u, v)`` quad samples the distance field
 and paints the projected margin band (ADR-0025 §Context).  The
-aspect-ratio math is routed through the extracted Algorithm helper.  The
-Gaussian-blur post-pass (a later v2.0 toggle) is intentionally absent.
+aspect-ratio math is routed through the extracted Algorithm helper.
 
 The flattened quad fed to the 2D mapper as its INPUT geometry is the
 fixed planar ``(u, v)`` domain — that defines the OUTPUT rectangle.  The
@@ -122,10 +138,11 @@ class FlattenedSurfaceRepresentation:
     --------------
     * ``update(display_node, data_node)`` — reads decoration from the
       display node (``ShowResection2D`` / ``MirrorDisplay`` /
-      ``EnableFlexibleBoundary`` / ``TextureNumComps``), geometry from
-      the data node, recomputes ``MatRatio`` through the Algorithm
-      helper, and reconciles the resectogram actor.  Tolerant of
-      ``None`` arguments.
+      ``EnableFlexibleBoundary`` / ``TextureNumComps`` / ``BlurEnabled``),
+      geometry from the data node, recomputes ``MatRatio`` through the
+      Algorithm helper, reconciles the resectogram actor, and engages /
+      disengages the Gaussian-blur post-pass.  Tolerant of ``None``
+      arguments.
     * ``cleanup()`` — detaches the actor from the renderer and releases
       the VTK pipeline.
 
@@ -137,6 +154,9 @@ class FlattenedSurfaceRepresentation:
     * ``GetMatRatioApplied()`` — last ``MatRatio`` pushed onto the 2D
       mapper, or ``None`` before the first ``update()`` / when the
       mapper does not expose ``SetMatRatio``.
+    * ``GetBlurPass()`` / ``GetBlurOverlayRenderer()`` /
+      ``IsBlurPassAttached()`` — the Gaussian-blur post-pass, the private
+      overlay renderer hosting it, and whether blur is currently engaged.
     """
 
     def __init__(self, renderer: Any | None = None) -> None:
@@ -146,6 +166,22 @@ class FlattenedSurfaceRepresentation:
         self._resection_mapper_2d: Any | None = None
         self._resection_actor_2d: Any | None = None
         self._resectogram_camera: Any | None = None
+
+        # Gaussian-blur post-pass (net-new v2.0, on/off toggle, ADR-0013 §6).
+        # The blur is a GPU render-pass set DIRECTLY on the resectogram view's
+        # renderer (the one this Representation drew the strip into) — it blurs
+        # the already-correct flattened image.  An earlier private-overlay-
+        # renderer variant (to dodge ``qMRMLThreeDView`` resetting
+        # ``SetPass(nullptr)`` on view-node ModifiedEvent) mis-rendered: the 2D
+        # mapper's distance-map texture + shader did not survive being
+        # relocated onto a second renderer, so only the grid/border drew.  The
+        # dedicated resectogram view has a FIXED camera (no orbit), so its view
+        # node is not modified during steady-state display; ``_reconcile_blur_pass``
+        # re-sets the pass on every ``update()`` (data/display edit) right
+        # before the render, so the clobber does not bite in practice.  Blur-off
+        # clears the pass, leaving the non-blur appearance unchanged.
+        self._blur_pass: Any | None = None
+        self._blur_attached: bool = False
 
         # The distance-map volume node the bound texture was built from.
         # ``None`` until the first ``update()`` with a distance map binds
@@ -180,6 +216,7 @@ class FlattenedSurfaceRepresentation:
     def SetRenderer(self, renderer: Any | None) -> None:
         """Attach the resectogram actor to ``renderer``."""
         if self._renderer is not None and self._renderer is not renderer:
+            self._detach_blur_pass(self._renderer)
             self._detach_actors(self._renderer)
         self._renderer = renderer
         if renderer is not None:
@@ -197,6 +234,7 @@ class FlattenedSurfaceRepresentation:
         self._apply_display_node(display_node)
         self._apply_data_node(display_node, data_node)
         self._pose_overlay_camera(display_node)
+        self._reconcile_blur_pass(display_node)
 
     def cleanup(self) -> None:
         """Detach actors from the renderer and drop the VTK pipeline."""
@@ -214,12 +252,18 @@ class FlattenedSurfaceRepresentation:
         self._distance_map_volume = None
 
         if self._renderer is not None:
+            self._detach_blur_pass(self._renderer)
             self._detach_actors(self._renderer)
             self._renderer = None
         self._bezier_plane = None
         self._resection_mapper_2d = None
         self._resection_actor_2d = None
         self._resectogram_camera = None
+
+        # ``_detach_blur_pass`` above already cleared the pass off the renderer
+        # when blur was engaged; drop the pass object too.
+        self._blur_pass = None
+        self._blur_attached = False
 
     # ------------------------------------------------------------------ #
     # Introspection — used by the unit-layer tests
@@ -242,6 +286,18 @@ class FlattenedSurfaceRepresentation:
 
     def GetInputRefreshCount(self) -> int:
         return self._input_refresh_count
+
+    def GetBlurPass(self) -> Any | None:
+        """The ``vtkGaussianBlurPass``, or ``None`` before it is built."""
+        return self._blur_pass
+
+    def IsBlurPassAttached(self) -> bool:
+        """Whether the blur pass is currently set on the renderer.
+
+        The blur invariant the arena + unit layers pin: blur is engaged when
+        ``BlurEnabled`` is true and disengaged when false.
+        """
+        return self._blur_attached
 
     # ------------------------------------------------------------------ #
     # Internal helpers
@@ -656,6 +712,74 @@ class FlattenedSurfaceRepresentation:
         camera.SetPosition(center_x, center_y, center_z * 3.0)
         camera.SetFocalPoint(center_x, center_y, center_z)
 
+    # ------------------------------------------------------------------ #
+    # Gaussian-blur post-pass (ADR-0013 §6 — net-new v2.0 on/off toggle).
+    # ------------------------------------------------------------------ #
+
+    def _reconcile_blur_pass(self, display_node: Any | None) -> None:
+        """Engage / disengage the Gaussian-blur post-pass per ``BlurEnabled``.
+
+        The blur is a GPU render-pass on a renderer the Representation owns
+        (ADR-0013 §6) — NOT pure-VTK math, so it stays here rather than in the
+        Algorithm library (ADR-0015 §1, which has no GL context).  Live
+        toggle: this runs on every ``update()`` so a ``BlurEnabled`` flip
+        reconciles the pass without rebuilding the assembly — the
+        ``vtkSetMacro(BlurEnabled, bool)`` ``Modified()`` advances the display
+        node's MTime, which ``ResectogramPipeline.UpdatePipeline`` already
+        keys on, so no new observer is needed.  No-op when VTK or the renderer
+        is unavailable (bare-VTK pytest path).
+        """
+        renderer = self._renderer
+        if renderer is None or not _HAS_VTK:
+            return
+        if not hasattr(renderer, "SetPass"):
+            return
+
+        enabled = _safe_get_bool(display_node, "GetBlurEnabled", default=False)
+        radius = _safe_get_float(display_node, "GetBlurRadius", default=2.0)
+
+        if enabled:
+            self._attach_blur_pass(renderer, radius)
+        else:
+            self._detach_blur_pass(renderer)
+
+    def _attach_blur_pass(self, renderer: Any, radius: float) -> None:
+        """Set the ``vtkGaussianBlurPass`` on the resectogram view's renderer.
+
+        The pass (wrapping a ``vtkRenderStepsPass`` delegate) blurs the strip
+        the Representation already drew into ``renderer`` — no actor is moved,
+        so the textured distance-map band + grid + border all blur together
+        (relocating the actor onto a second renderer dropped the mapper's
+        distance-map texture, leaving only the grid).  Idempotent: re-engaging
+        reuses the same pass object and just re-sets it (cheap, and re-asserts
+        the pass should ``qMRMLThreeDView`` have cleared it on a view edit).
+        """
+        if self._blur_pass is None:
+            self._blur_pass = _make_gaussian_blur_pass()
+            if self._blur_pass is None:
+                return
+        _apply_blur_radius(self._blur_pass, radius)
+        try:
+            renderer.SetPass(self._blur_pass)
+        except Exception:  # pragma: no cover - defensive
+            return
+        self._blur_attached = True
+
+    def _detach_blur_pass(self, renderer: Any) -> None:
+        """Clear the blur pass off the renderer (restore the forward path).
+
+        Leaves the non-blur appearance identical to a path that never engaged
+        blur.  A no-op when blur was never engaged.
+        """
+        if not self._blur_attached:
+            return
+        if renderer is not None and hasattr(renderer, "SetPass"):
+            try:
+                renderer.SetPass(None)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        self._blur_attached = False
+
 
 # --------------------------------------------------------------------------- #
 # Helpers — small, self-contained per ADR-0013 §6 (Representations are
@@ -744,6 +868,50 @@ def _make_resection_mapper_2d() -> Any:
     if factory is not None:
         return factory()
     return vtk.vtkPolyDataMapper()
+
+
+def _make_gaussian_blur_pass() -> Any | None:
+    """Return a ``vtkGaussianBlurPass`` wrapping the default forward pass.
+
+    The standard VTK render-pass composition: a ``vtkRenderStepsPass`` (the
+    default sequence a renderer runs) becomes the blur pass's delegate, so the
+    resectogram strip is rendered first and the Gaussian blur is applied to
+    the result.  Returns ``None`` when either render-pass class is unavailable
+    (older VTK / bare environment), leaving the renderer on its default
+    forward pass.
+    """
+    if not _HAS_VTK:
+        return None
+    blur_factory = getattr(vtk, "vtkGaussianBlurPass", None)
+    steps_factory = getattr(vtk, "vtkRenderStepsPass", None)
+    if blur_factory is None or steps_factory is None:
+        return None
+    blur_pass = blur_factory()
+    delegate = steps_factory()
+    if hasattr(blur_pass, "SetDelegatePass"):
+        blur_pass.SetDelegatePass(delegate)
+    return blur_pass
+
+
+def _apply_blur_radius(blur_pass: Any, radius: float) -> None:
+    """Push the kernel extent onto the blur pass, if it is configurable.
+
+    ``vtkGaussianBlurPass`` derives its kernel from the framebuffer it renders
+    into and does not expose a public radius setter on every VTK version; the
+    radius is consumed where the API allows it (best-effort) and otherwise
+    ignored.  The load-bearing visible difference is the on/off toggle, not
+    the radius — ``BlurRadius`` stays a dormant display-node field.
+    """
+    if blur_pass is None:
+        return
+    setter = getattr(blur_pass, "SetKernelRadius", None) or getattr(
+        blur_pass, "SetRadius", None
+    )
+    if setter is not None:
+        try:
+            setter(float(radius))
+        except Exception:  # pragma: no cover - defensive
+            pass
 
 
 def _import_wrapped_class(name: str) -> Any | None:
@@ -927,5 +1095,17 @@ def _safe_get_int(node: Any | None, getter_name: str, *, default: int) -> int:
         return default
     try:
         return int(getter())
+    except Exception:  # pragma: no cover - defensive
+        return default
+
+
+def _safe_get_float(node: Any | None, getter_name: str, *, default: float) -> float:
+    if node is None:
+        return default
+    getter = getattr(node, getter_name, None)
+    if getter is None:
+        return default
+    try:
+        return float(getter())
     except Exception:  # pragma: no cover - defensive
         return default

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -159,15 +159,21 @@ class ResectogramPipeline(_PipelineBase):
         """Reconcile both Representations against the current node set.
 
         Idempotent: a second call with no intervening node mutation is a
-        no-op observationally — the memoised ``(dataMTime, displayMTime)``
-        key short-circuits the work (`ADR-0013`_ §3).
+        no-op observationally — the memoised key short-circuits the work
+        (`ADR-0013`_ §3).  The key folds in the data node's control-point
+        MTime alongside its ``GetMTime``, because a markups control-point
+        DRAG advances the control-point MTime but NOT the node ``GetMTime``
+        — keying on ``GetMTime`` alone would leave the resectogram
+        non-reactive to surface edits (the dragging-changes-nothing failure
+        mode).
         """
         self._ensure_representations()
 
         data_mtime = _safe_get_mtime(self._data_node)
+        control_points_digest = _safe_get_control_points_digest(self._data_node)
         display_mtime = _safe_get_mtime(self._display_node)
 
-        key = (data_mtime, display_mtime)
+        key = (data_mtime, control_points_digest, display_mtime)
         if key == self._last_update_key:
             return  # idempotent short-circuit
         self._last_update_key = key
@@ -298,17 +304,26 @@ class ResectogramPipeline(_PipelineBase):
             return None
 
     def _attach_observer(self, node: Any) -> None:
-        """Add a ``vtkCommand::ModifiedEvent`` observer to ``node``.
+        """Observe the node's modification events, routed to ``UpdatePipeline()``.
 
-        Routes the callback into ``UpdatePipeline()``.  Stores the
-        observer tag so ``cleanup()`` / ``_detach_observer`` can detach
-        precisely.
+        Observes ``ModifiedEvent`` AND the markups control-point edit events
+        (``PointModifiedEvent`` / ``PointPositionDefinedEvent``).  A
+        markups control-point DRAG does NOT advance the node's ``GetMTime``
+        and fires ``PointModifiedEvent`` rather than ``ModifiedEvent``, so a
+        ``ModifiedEvent``-only observer would leave the resectogram
+        non-reactive to surface edits (the dragging-changes-nothing failure
+        mode).  Stores every observer tag so ``cleanup()`` /
+        ``_detach_observer`` can detach precisely.
         """
         if node is None or not hasattr(node, "AddObserver"):
             return
 
-        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
-        self._observer_tags.setdefault(id(node), []).append(tag)
+        tags = self._observer_tags.setdefault(id(node), [])
+        tags.append(node.AddObserver("ModifiedEvent", self._on_node_modified))
+        for event_name in ("PointModifiedEvent", "PointPositionDefinedEvent"):
+            event = getattr(node, event_name, None)
+            if event is not None:
+                tags.append(node.AddObserver(event, self._on_node_modified))
         if node not in self._observed_node_refs:
             self._observed_node_refs.append(node)
 
@@ -327,8 +342,16 @@ class ResectogramPipeline(_PipelineBase):
             pass
 
     def _on_node_modified(self, caller: Any, event: str) -> None:
-        """VTK observer callback — re-runs ``UpdatePipeline()``."""
+        """VTK observer callback — re-runs ``UpdatePipeline()``.
+
+        Invalidates the memoised update key first: the firing of an observed
+        event IS the change signal, but a markups control-point edit does
+        not advance the node ``GetMTime`` the key is built from, so without
+        the invalidation ``UpdatePipeline`` would short-circuit and the
+        flattened surface would not re-feed (the non-reactive failure mode).
+        """
         del caller, event  # observers route uniformly into UpdatePipeline()
+        self._last_update_key = None
         self.UpdatePipeline()
 
 
@@ -348,6 +371,35 @@ def _safe_get_mtime(node: Any) -> int:
         return int(getter())
     except Exception:  # pragma: no cover - defensive
         return 0
+
+
+def _safe_get_control_points_digest(node: Any) -> tuple:
+    """Return a digest of the data node's markups control-point positions.
+
+    A markups control-point DRAG does not advance the node's ``GetMTime``
+    (the positions live in a separately-timed control-point structure), so
+    the memoisation key folds in a cheap digest of the control-point
+    positions to stay reactive to surface edits.  Returns an empty tuple
+    when the node is missing the markups control-point accessors (stub nodes
+    in unit tests) or a read raises — the key then degrades to ``GetMTime``
+    alone, which is the correct behaviour for a non-markups data node.
+    """
+    if node is None:
+        return ()
+    count_getter = getattr(node, "GetNumberOfControlPoints", None)
+    position_getter = getattr(node, "GetNthControlPointPosition", None)
+    if count_getter is None or position_getter is None:
+        return ()
+    try:
+        count = int(count_getter())
+        position = [0.0, 0.0, 0.0]
+        digest = []
+        for index in range(count):
+            position_getter(index, position)
+            digest.append((position[0], position[1], position[2]))
+        return tuple(digest)
+    except Exception:  # pragma: no cover - defensive
+        return ()
 
 
 # --------------------------------------------------------------------------- #

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -375,11 +375,15 @@ def registerResectogramPipelineCreator() -> None:
     Slicer restart in embedded contexts) would append a duplicate.
 
     The creator returns a fresh ``ResectogramPipeline`` only when the
-    ``(viewNode, node)`` pair matches
-    ``(vtkMRMLViewNode, vtkMRMLResectogramDisplayNode)``.  Other
-    combinations short-circuit to ``None`` so the Bezier creator (and any
-    other registered creator) gets a chance to handle them — no
-    cross-fire (`ADR-0013`_ §1).
+    ``node`` is a ``vtkMRMLResectogramDisplayNode`` AND the ``viewNode`` is
+    the DEDICATED resectogram view — the one carrying
+    ``SetSingletonTag(RESECTOGRAM_VIEW_SINGLETON_TAG)`` (`ADR-0023`_
+    §Stage-4).  Every other ``(viewNode, node)`` combination — slice views,
+    the shared 3D anatomy view, the Bezier parametric-surface display node —
+    short-circuits to ``None`` so the Bezier creator (and any other
+    registered creator) gets a chance to handle them, and the flattened
+    strip never bleeds into the shared anatomy renderer (`ADR-0013`_ §1
+    disjoint keying; `ADR-0023`_ §Stage-4).
     """
     global _REGISTERED
     if _REGISTERED:
@@ -396,13 +400,27 @@ def registerResectogramPipelineCreator() -> None:
         vtkMRMLViewNode,
     )
 
+    # Imported here (not at module top) because the tag constant lives in a
+    # sibling module that itself defers its ``slicer`` import; the local
+    # import keeps this module importable in plain Python.
+    try:  # pragma: no cover - exercised once per import path
+        from .ResectogramViewManager import RESECTOGRAM_VIEW_SINGLETON_TAG
+    except ImportError:
+        from ResectogramViewManager import (  # type: ignore[no-redef]
+            RESECTOGRAM_VIEW_SINGLETON_TAG,
+        )
+
     def tryCreate(viewNode, node):
-        # 3D-only gating: the resectogram renders into an overlay
-        # renderer of a 3D view.  ``RegisterInDefaultViews`` registers the
-        # generic LayerDM DM in both 3D and slice factories, so this
-        # creator is invoked for slice-view nodes too — short-circuit to
-        # None there so other creators (or none) handle the slice path.
+        # Dedicated-view gating (ADR-0023 §Stage-4): the resectogram renders
+        # ONLY into its dedicated view — the one carrying the resectogram
+        # singleton tag.  ``RegisterInDefaultViews`` registers the generic
+        # LayerDM DM in every 3D and slice factory, so this creator is
+        # invoked for the shared anatomy view and slice views too; gating on
+        # the singleton tag keeps the flattened strip out of the shared
+        # anatomy renderer (ADR-0013 §1 disjoint keying).
         if not isinstance(viewNode, vtkMRMLViewNode):
+            return None
+        if viewNode.GetSingletonTag() != RESECTOGRAM_VIEW_SINGLETON_TAG:
             return None
         if not isinstance(node, vtkMRMLResectogramDisplayNode):
             return None

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -136,22 +136,10 @@ class ResectogramPipeline(_PipelineBase):
         the Pipeline.  Re-entrant: replacing an already-attached display
         node detaches the old observers and re-derives the data node.
         """
-        if self._display_node is not None:
-            self._detach_observer(self._display_node)
-        if self._data_node is not None:
-            self._detach_observer(self._data_node)
-
         super().SetDisplayNode(displayNode)
 
         self._display_node = displayNode
-        self._data_node = None
-        if displayNode is not None:
-            getter = getattr(displayNode, "GetDisplayableNode", None)
-            if getter is not None:
-                self._data_node = getter()
-            self._attach_observer(displayNode)
-            if self._data_node is not None:
-                self._attach_observer(self._data_node)
+        self._reattach_node_observers()
 
         self._last_update_key = None
 
@@ -194,6 +182,16 @@ class ResectogramPipeline(_PipelineBase):
         """
         del renderer  # accessed via self.GetRenderer() inside the helper
         self._ensure_representations()
+        # ``OnRendererRemoved`` -> ``cleanup()`` detaches the node observers
+        # (they are bundled with the renderer-scoped Representation teardown),
+        # so re-establish them here.  Without this the observed set is empty
+        # after the manager's initial renderer churn (SetDisplayNode attaches,
+        # OnRendererRemoved detaches, OnRendererAdded historically did NOT
+        # re-attach) and a control-point DRAG never reaches ``UpdatePipeline``
+        # — the dragging-changes-nothing failure mode.  Also re-derives the
+        # data node, covering the lifecycle where ``GetDisplayableNode()`` is
+        # not yet resolvable at ``SetDisplayNode`` time.
+        self._reattach_node_observers()
         # Re-emit a dispatch so the Representations re-attach their actors
         # against the new renderer.
         self._last_update_key = None
@@ -303,6 +301,36 @@ class ResectogramPipeline(_PipelineBase):
         except Exception:  # pragma: no cover - defensive
             return None
 
+    def _reattach_node_observers(self) -> None:
+        """(Re-)wire the display + data node observers, idempotently.
+
+        The observed set is logically tied to the display/data node, NOT the
+        renderer — but ``OnRendererRemoved`` -> ``cleanup()`` detaches every
+        observer to release the renderer-scoped Representations, so the
+        observers must be re-established whenever the display node is set or a
+        renderer is (re-)attached, or the resectogram silently stops tracking
+        control-point edits (the dragging-changes-nothing failure mode).
+
+        Detaches any stale observers first so repeated calls never stack
+        duplicate observers.  Re-derives ``self._data_node`` from the display
+        node's ``GetDisplayableNode()`` each time, which also covers the
+        lifecycle where the back-reference is not yet resolvable at
+        ``SetDisplayNode`` time but is by ``OnRendererAdded``.
+        """
+        for node in list(self._observed_node_refs):
+            self._detach_observer(node)
+
+        self._data_node = None
+        if self._display_node is None:
+            return
+
+        getter = getattr(self._display_node, "GetDisplayableNode", None)
+        if getter is not None:
+            self._data_node = getter()
+        self._attach_observer(self._display_node)
+        if self._data_node is not None:
+            self._attach_observer(self._data_node)
+
     def _attach_observer(self, node: Any) -> None:
         """Observe the node's modification events, routed to ``UpdatePipeline()``.
 
@@ -353,6 +381,20 @@ class ResectogramPipeline(_PipelineBase):
         del caller, event  # observers route uniformly into UpdatePipeline()
         self._last_update_key = None
         self.UpdatePipeline()
+        # UpdatePipeline only refreshes the Representations' VTK objects; the
+        # dedicated resectogram view's render window must still be told to
+        # repaint, or a control-point DRAG updates the flattened geometry
+        # without the panel visibly changing.  The framework renders after its
+        # own display-node event path, but this direct data-node observer
+        # bypasses it, so request a (coalesced) render through the base
+        # Pipeline's ``RequestRender`` (delegates to
+        # ``vtkMRMLLayerDMPipelineManager::RequestRender``).
+        request_render = getattr(self, "RequestRender", None)
+        if request_render is not None:
+            try:
+                request_render()
+            except Exception:  # pragma: no cover - defensive (stub bases)
+                pass
 
 
 # --------------------------------------------------------------------------- #

--- a/LiverResections/LiverResectionsLib/ResectogramViewManager.py
+++ b/LiverResections/LiverResectionsLib/ResectogramViewManager.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Dedicated-view manager for the resectogram concept (`ADR-0023`_ §Stage-4).
+
+The resectogram is the flattened 2D image of the Bezier ``(u, v)``
+parameter domain (`ADR-0025`_ §Context).  `ADR-0023`_ §Stage-4 names it
+as the ONE custom Slicer layout v2.0 ships: it renders in a dedicated 3D
+view, NOT as a sub-viewport of the shared anatomy 3D view (the retired v1
+``CoRenderer2D`` path).
+
+``ResectogramViewManager`` owns the dedicated ``vtkMRMLViewNode`` that
+carries the resectogram singleton tag.  The view node is a **singleton**:
+re-running ``setup()`` (module reload, second open) re-targets the
+existing node rather than multiplying view nodes — the singleton-tag
+mechanism the Slicer view machinery already enforces.  This mirrors the
+SlicerHyperProbe ``HyperprobeViewManager._create_view_node`` precedent:
+a private view node with a custom ``LayoutName`` / ``LayoutLabel`` and box
++ axis labels off, so the flattened panel reads as a clean 2D image.
+
+No custom DisplayableManager (`ADR-0013`_ §5; the
+``feedback_layerdm_no_custom_dm`` lesson): the dedicated view gets the
+upstream LayerDM displayable manager for free via
+``RegisterInDefaultViews()``, and the registered ``ResectogramPipeline``
+creator — tightened to fire ONLY for the view carrying
+``RESECTOGRAM_VIEW_SINGLETON_TAG`` — dispatches the flattened strip into
+this view's renderer alone.
+
+References
+----------
+* `ADR-0013`_ §1, §5 — one Pipeline per display-node type; the three
+  registration calls; no custom DisplayableManager.
+* `ADR-0023`_ §Stage-4 — the dedicated resectogram view as the one custom
+  Slicer layout v2.0 ships.
+* `ADR-0025`_ §Context — the resectogram as the flattened ``(u, v)`` image.
+
+.. _ADR-0013: ../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0023: ../../Docs/adr/0023-resection-plan-architecture.md
+.. _ADR-0025: ../../Docs/adr/0025-locator-architecture.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The singleton tag the dedicated resectogram view carries.  The tightened
+# ``registerResectogramPipelineCreator().tryCreate`` discriminates the
+# dedicated view from every shared 3D anatomy view by this exact value.
+# Human-readable, prefix-free (the Hyperprobe custom-view convention,
+# ADR-0023 §Stage-4).  The dispatch tests pin the same literal in
+# ``Testing/Python/conftest.py`` as RESECTOGRAM_VIEW_SINGLETON_TAG.
+RESECTOGRAM_VIEW_SINGLETON_TAG = "LiverResectogram"
+
+# Human-facing layout name / label for the dedicated view.  Reused as the
+# Slicer view-node ``LayoutName`` / ``LayoutLabel`` (the Hyperprobe
+# precedent uses the bare concept name for both).
+_RESECTOGRAM_VIEW_LAYOUT_NAME = "LiverResectogram"
+_RESECTOGRAM_VIEW_LAYOUT_LABEL = "Resectogram"
+
+
+class ResectogramViewManager:
+    """Owns the dedicated ``vtkMRMLViewNode`` for the resectogram display.
+
+    Singleton-by-tag: ``ensureViewNode()`` returns the existing tagged view
+    node when one is already in the scene, creating it only on first call.
+    Constructing the manager is side-effect-free; the view node is created
+    lazily on the first ``ensureViewNode()`` so a bare import (e.g. in a
+    unit test that only reads the tag constant) does not mutate the scene.
+    """
+
+    def __init__(self) -> None:
+        self._view_node: Any | None = None
+
+    def ensureViewNode(self) -> Any:  # noqa: N802 - Slicer/Qt verb convention
+        """Return the dedicated resectogram view node, creating it once.
+
+        Singleton (re-target, don't multiply) per the dedicated-view
+        decision: a second call returns the SAME node.  Resolves an
+        already-present tagged node first (e.g. after a scene reload that
+        kept the singleton), so the manager never appends a duplicate.
+        """
+        import slicer  # type: ignore[import-not-found]
+
+        if self._view_node is not None:
+            return self._view_node
+
+        existing = self._find_tagged_view_node(slicer)
+        if existing is not None:
+            self._view_node = existing
+            return existing
+
+        view = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLViewNode")
+        view.SetName(_RESECTOGRAM_VIEW_LAYOUT_NAME)
+        view.SetSingletonTag(RESECTOGRAM_VIEW_SINGLETON_TAG)
+        view.SetLayoutName(_RESECTOGRAM_VIEW_LAYOUT_NAME)
+        view.SetLayoutLabel(_RESECTOGRAM_VIEW_LAYOUT_LABEL)
+        # The flattened panel reads as a clean 2D image: drop the 3D box
+        # and axis labels (the Hyperprobe precedent does the same).
+        view.SetBoxVisible(False)
+        view.SetAxisLabelsVisible(False)
+        self._view_node = view
+        return view
+
+    def getViewNode(self) -> Any | None:  # noqa: N802 - Slicer/Qt verb convention
+        """Return the owned view node, or ``None`` if not yet created."""
+        return self._view_node
+
+    @staticmethod
+    def _find_tagged_view_node(slicer: Any) -> Any | None:
+        """Return the scene's resectogram-tagged view node, if any."""
+        scene = slicer.mrmlScene
+        count = scene.GetNumberOfNodesByClass("vtkMRMLViewNode")
+        for index in range(count):
+            node = scene.GetNthNodeByClass(index, "vtkMRMLViewNode")
+            if (
+                node is not None
+                and node.GetSingletonTag() == RESECTOGRAM_VIEW_SINGLETON_TAG
+            ):
+                return node
+        return None

--- a/LiverResections/LiverResectionsLib/__init__.py
+++ b/LiverResections/LiverResectionsLib/__init__.py
@@ -24,10 +24,16 @@ from .ResectogramPipeline import (
     ResectogramPipeline,
     registerResectogramPipelineCreator,
 )
+from .ResectogramViewManager import (
+    RESECTOGRAM_VIEW_SINGLETON_TAG,
+    ResectogramViewManager,
+)
 
 __all__ = [
     "LiverBezierSurfacePipeline",
     "registerPipelineCreator",
     "ResectogramPipeline",
     "registerResectogramPipelineCreator",
+    "ResectogramViewManager",
+    "RESECTOGRAM_VIEW_SINGLETON_TAG",
 ]

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
@@ -378,6 +378,17 @@ def setup_viewport(view_node=None):
     view_node.SetBoxVisible(False)
     view_node.SetAxisLabelsVisible(False)
 
+    # Tag the panel's view as the dedicated resectogram view so the
+    # tightened ResectogramPipeline creator (ADR-0023 §Stage-4) dispatches
+    # the flattened strip into it -- the tightened creator no longer fires
+    # for an untagged view.  Reuse the production tag so the scenario, the
+    # arena, and the live module agree on a single value.
+    from LiverResectionsLib.ResectogramViewManager import (  # type: ignore[import-not-found]
+        RESECTOGRAM_VIEW_SINGLETON_TAG,
+    )
+
+    view_node.SetSingletonTag(RESECTOGRAM_VIEW_SINGLETON_TAG)
+
 
 def describe() -> dict:
     """Metadata persisted alongside the captured bundle."""

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOn.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOn.py
@@ -4,40 +4,33 @@
 
 T3 ResectogramPipeline baseline target (ADR-0027 invariant-test-first).
 
-SPLITTABLE / LAST.  Per the maintainer decision the Gaussian-blur
-post-pass stays a v2.0 feature behind a toggle, and this baseline is
-explicitly splittable from the rest of T3: if the launched harness
-(issue #460) blocks baseline capture, the blur work — and this scenario —
-land last, after the blur-OFF resectogram baselines are green.  It exists
-now as a placed target so the test surface is complete and the implementer
-knows GREEN here is the final T3 step, not a gate on the core resectogram
-landing.
-
 It builds the SAME deterministic square-domain scene as
 ``Resectogram4x4BlurOff`` (reusing that module's scene builders, same
 package) so the pixel delta between the two baselines isolates the blur
-post-pass.  ``BLUR_ENABLED`` is the only configuration that differs.
+post-pass.  ``BLUR_ENABLED`` is the only configuration that differs — the
+blur kernel extent (``BlurRadius``) is left at the display node's default,
+matching ``Resectogram4x4BlurOff``, so blur on/off is the single visual
+variable.
 
 No v1 blur appearance to reproduce
 ----------------------------------
 The Gaussian-blur post-pass is NET-NEW for v2.0 — there is no blur field
 on the legacy ``vtkMRMLMarkupsBezierSurfaceDisplayNode`` and no
-``vtkGaussianBlurPass`` anywhere in the v1 tree (see the T3 plan).  So
-unlike the blur-OFF / non-square baselines (captured against the v1
-monolith first), this scenario's FIRST baseline is captured against the
-v2.0 path once the blur toggle exists on ``vtkMRMLResectogramDisplayNode``
-+ the flattened-surface Representation (ADR-0013 §6).  ``setup_scene``
-therefore builds the scene but DOES NOT engage blur (no field to set yet);
-the implementer wires the blur toggle and re-captures at the go-live step.
-``describe()`` records ``blur_enabled = True`` + ``blur_engaged = False``
-so the bundle metadata is unambiguous about that pending wiring.
+``vtkGaussianBlurPass`` anywhere in the v1 tree.  So unlike the blur-OFF /
+non-square baselines (captured against the v1 monolith first), this
+scenario's baseline is captured against the v2.0 path: the blur toggle
+lives on ``vtkMRMLResectogramDisplayNode`` (``BlurEnabled``) and the
+flattened-surface Representation attaches a ``vtkGaussianBlurPass`` to a
+private overlay renderer when engaged (ADR-0013 §6).  ``setup_scene``
+engages blur on the resectogram display node so the rendered strip differs
+visibly (softer band) from ``Resectogram4x4BlurOff``.
 
 References
 ----------
 * ADR-0008 §2/§3 — visual-regression harness.
 * ADR-0013 §6 — the blur is a per-frame state on the flattened-surface
   Representation owned by the ResectogramPipeline.
-* ADR-0027 — invariant-test-first; this target is splittable/last.
+* ADR-0027 — invariant-test-first.
 """
 
 from __future__ import annotations
@@ -53,9 +46,10 @@ BACKGROUND_RGB = (0.0, 0.0, 0.0)
 ANTI_ALIASING_FRAMES = 0
 
 # The one variable that distinguishes this scenario from
-# Resectogram4x4BlurOff.  No field exists on the current display node to
-# engage blur (net-new for v2.0); the implementer wires the toggle and
-# sets blur_engaged True at the go-live step.
+# Resectogram4x4BlurOff: the net-new v2.0 Gaussian-blur post-pass is
+# engaged on the resectogram display node (ADR-0013 §6).  BlurRadius is
+# left at the display node's default (matching Resectogram4x4BlurOff) so
+# blur on/off is the single visual variable.
 BLUR_ENABLED = True
 
 # Same square (u, v) domain + aspect-ratio configuration as
@@ -65,31 +59,26 @@ PATCH_HALF_EXTENT_U = 45.0
 PATCH_HALF_EXTENT_V = 45.0
 
 
-def _engage_blur(display_node) -> bool:
+def _engage_blur(display_node) -> None:
     """Engage the Gaussian-blur post-pass on the resectogram display node.
 
-    Returns True iff a blur toggle was found and set.  The toggle is
-    NET-NEW for v2.0 (ADR-0013 §6); until the implementer adds it the
-    accessor is absent and this returns False (the scene renders blur-OFF
-    and the blur-ON baseline is deferred to the v2.0 go-live capture).
-    Probed by name rather than hard-referenced so this scenario imports +
-    builds its scene cleanly before the field exists.
+    Sets ``BlurEnabled`` on the v2.0 ``vtkMRMLResectogramDisplayNode``
+    (ADR-0013 §6); the flattened-surface Representation moves the
+    resectogram actor onto a private overlay renderer carrying a
+    ``vtkGaussianBlurPass`` in response, softening the strip relative to
+    ``Resectogram4x4BlurOff``.  ``BlurRadius`` is left at the display node's
+    default so blur on/off is the only visual variable.
     """
-    setter = getattr(display_node, "SetEnableResectogramBlur", None)
-    if setter is None:
-        return False
-    setter(True)
-    return True
+    display_node.SetBlurEnabled(True)
 
 
 def setup_scene():
     """Populate the scene with the blur-on square-domain resectogram fixture.
 
     Builds the same square-domain resectogram scene as
-    ``Resectogram4x4BlurOff`` (reusing its builders) and attempts to engage
-    the blur post-pass via :func:`_engage_blur`.  Until the implementer
-    adds the blur toggle (ADR-0013 §6) the engage is a no-op and the scene
-    renders blur-OFF; the blur-ON baseline is captured LAST against v2.0.
+    ``Resectogram4x4BlurOff`` (reusing its builders) and engages the
+    Gaussian-blur post-pass via :func:`_engage_blur` (ADR-0013 §6) so the
+    rendered strip differs visibly (softer band) from the blur-OFF baseline.
 
     Returns
     -------
@@ -136,15 +125,13 @@ def setup_viewport(view_node=None):
 def describe() -> dict:
     """Metadata persisted alongside the captured bundle.
 
-    ``blur_enabled`` records the scenario's INTENT (this is the blur-ON
-    target).  Whether the net-new blur toggle is actually wired is
-    discovered at scene-build time by :func:`_engage_blur`; ``describe()``
-    stays a pure, side-effect-free metadata function (the replay driver
-    calls it before any scene exists), so it does not probe the live node
-    here.
+    ``blur`` / ``blur_enabled`` record the scenario's blur-ON configuration;
+    ``describe()`` stays a pure, side-effect-free metadata function (the
+    replay driver calls it before any scene exists).
     """
     return {
         "scenario": "Resectogram4x4BlurOn",
+        "blur": BLUR_ENABLED,
         "blur_enabled": BLUR_ENABLED,
         "enable_flexible_boundary": ENABLE_FLEXIBLE_BOUNDARY,
         "patch_half_extent": [PATCH_HALF_EXTENT_U, PATCH_HALF_EXTENT_V],

--- a/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp
+++ b/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp
@@ -496,11 +496,11 @@ void vtkOpenGLResection2DPolyDataMapper::SetDistanceMapTextureObject(vtkTextureO
     return;
   }
 
+  // The smart-pointer member already holds the managed reference; an extra
+  // manual Register() here would never be balanced by an UnRegister() on the
+  // SetDistanceMapTextureObject(nullptr) clear path, leaking the texture
+  // object past the mapper's own destruction (vtkDebugLeaks).
   this->Impl->DistanceMapTextureObject = object;
-  if (object)
-  {
-    object->Register(this);
-  }
 
   this->Modified();
 }
@@ -519,11 +519,9 @@ void vtkOpenGLResection2DPolyDataMapper::SetVascularSegmentsTextureObject(vtkTex
     return;
   }
 
+  // See SetDistanceMapTextureObject: the smart-pointer member owns the
+  // reference; the manual Register() was unbalanced and leaked the object.
   this->Impl->VascularSegmentsTextureObject = object;
-  if (object)
-  {
-    object->Register(this);
-  }
 
   this->Modified();
 }

--- a/Testing/Python/conftest.py
+++ b/Testing/Python/conftest.py
@@ -304,6 +304,165 @@ def layerdm_threed_view(render_interactive):
 
 
 # --------------------------------------------------------------------------- #
+# Dedicated resectogram view fixture (ADR-0023 §Stage-4 — the one custom
+# layout v2.0 ships; ADR-0013 §1 disjoint keying)
+# --------------------------------------------------------------------------- #
+
+# Contract: the singleton tag the dedicated resectogram view carries.  The
+# T3-g1 view-manager adopts THIS exact value when it creates the dedicated
+# ``vtkMRMLViewNode`` (Hyperprobe pattern — a custom ``LayoutName`` /
+# ``LayoutLabel`` plus ``SetSingletonTag(RESECTOGRAM_VIEW_SINGLETON_TAG)``),
+# and the tightened ``registerResectogramPipelineCreator().tryCreate``
+# discriminates the dedicated view from every shared 3D anatomy view by this
+# tag.  Prefix-free + human-readable per the Hyperprobe custom-view
+# convention (ADR-0023 §Stage-4: "the one custom Slicer layout in v2.0").
+RESECTOGRAM_VIEW_SINGLETON_TAG = "LiverResectogram"
+
+
+def _bring_up_layerdm_threed_view(slicer, view_node):
+    """Build a standalone LayerDM-aware ``qMRMLThreeDWidget`` bound to ``view_node``.
+
+    Factored out of ``layerdm_threed_view`` so both the single-view fixture
+    and the two-view ``layerdm_resectogram_view`` fixture share the exact
+    show()-then-bind ordering (ADR-0013 §9 real-view fixture).  Returns
+    ``(view_widget, manager)`` or ``(view_widget, None)`` when the upstream
+    LayerDM displayable manager is not on the launched path.
+    """
+    view_widget = slicer.qMRMLThreeDWidget()
+    view_widget.setMRMLScene(slicer.mrmlScene)
+
+    # Map the GL surface before binding the view node so the displayable
+    # manager group is instantiated (same show()-then-bind ordering the arena
+    # + capture_baseline use).
+    view_widget.show()
+    view_widget.threeDView().forceRender()
+    view_widget.setMRMLViewNode(view_node)
+
+    manager = view_widget.threeDView().displayableManagerByClassName(
+        "vtkMRMLLayerDisplayableManager"
+    )
+    return view_widget, manager
+
+
+@pytest.fixture
+def layerdm_resectogram_view(render_interactive):
+    """Yield two LayerDM-aware 3D views: a shared anatomy view + the dedicated one.
+
+    The T3-g1 keystone fixture.  It stands up TWO standalone
+    ``qMRMLThreeDWidget``s, each hosting the upstream
+    ``vtkMRMLLayerDisplayableManager`` (ADR-0013 §9 real-view shape):
+
+    * a **shared anatomy view** — a plain ``vtkMRMLViewNode`` with NO
+      resectogram singleton tag (the v2.0 default 3D anatomy view), and
+    * the **dedicated resectogram view** — a ``vtkMRMLViewNode`` carrying
+      ``SetSingletonTag(RESECTOGRAM_VIEW_SINGLETON_TAG)`` (the Hyperprobe
+      custom-layout pattern; ADR-0023 §Stage-4 names the resectogram view as
+      the one custom Slicer layout v2.0 ships).
+
+    Yields a mapping so the keystone tests can address each view + its DM by
+    role::
+
+        {
+            "shared": (shared_view_widget, shared_manager),
+            "dedicated": (dedicated_view_widget, dedicated_manager),
+            "tag": RESECTOGRAM_VIEW_SINGLETON_TAG,
+        }
+
+    This fixture creates the dedicated view node + tag itself ONLY as the
+    test arena (the production view-manager does not exist yet — that is the
+    implementer's T3-g1).  It does NOT register or tighten any pipeline
+    creator: the creator-tightening is the implementation under test, and
+    the keystone dispatch tests are RED-by-design until it lands (ADR-0027).
+
+    Consumes ``render_interactive`` like the sibling ``layerdm_threed_view``;
+    skips cleanly under bare ``PythonSlicer`` (no ``qSlicerApplication``) with
+    explicit, greppable reasons (issue #460 green-but-skipping discipline).
+    """
+    slicer = import_slicer_or_skip()
+    if slicer is None:
+        return
+    require_mrml_scene()
+    require_qt_widget()
+
+    # Same registration probe the single-view fixture uses: a missing module
+    # path must read as a skip, not a false pass.
+    registration_probe = slicer.mrmlScene.CreateNodeByClass(
+        "vtkMRMLResectogramDisplayNode"
+    )
+    if registration_probe is None:
+        pytest.skip(
+            "[layerdm-view-skip] vtkMRMLResectogramDisplayNode is not "
+            "registered -- the LiverResections module is not on the "
+            "additional-module-paths.  Run via the pytest_launched CTest row "
+            "(Liver/Testing/Python/CMakeLists.txt supplies the module paths)."
+        )
+    # Drop the factory's +1 reference the caller owns (vtkDebugLeaks guard).
+    registration_probe.UnRegister(None)
+
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLLayerDisplayableManager,
+    )
+
+    vtkMRMLLayerDisplayableManager.RegisterInDefaultViews()
+
+    # The shared anatomy view: a plain view node, NO resectogram tag.
+    shared_view_node = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLViewNode", "LiverAnatomyView"
+    )
+
+    # The dedicated resectogram view: the Hyperprobe custom-layout pattern --
+    # a distinct view node carrying the resectogram singleton tag.  This is
+    # the arena standing in for the implementer's T3-g1 view-manager.
+    dedicated_view_node = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLViewNode", "LiverResectogramView"
+    )
+    dedicated_view_node.SetSingletonTag(RESECTOGRAM_VIEW_SINGLETON_TAG)
+
+    shared_widget, shared_manager = _bring_up_layerdm_threed_view(
+        slicer, shared_view_node
+    )
+    dedicated_widget, dedicated_manager = _bring_up_layerdm_threed_view(
+        slicer, dedicated_view_node
+    )
+
+    if shared_manager is None or dedicated_manager is None:
+        # Tear the partial widgets down before skipping (vtkDebugLeaks guard).
+        for widget in (shared_widget, dedicated_widget):
+            widget.setMRMLScene(None)
+            widget.deleteLater()
+        pytest.skip(
+            "[layerdm-view-skip] vtkMRMLLayerDisplayableManager is not on the "
+            "3D view's displayable-manager group -- the upstream SlicerLayerDM "
+            "extension is not loaded on the launched path (issue #460).  Run "
+            "via pytest_launched with the LayerDM module paths."
+        )
+
+    try:
+        yield {
+            "shared": (shared_widget, shared_manager),
+            "dedicated": (dedicated_widget, dedicated_manager),
+            "tag": RESECTOGRAM_VIEW_SINGLETON_TAG,
+        }
+        if render_interactive:
+            import qt  # type: ignore[import-not-found]
+
+            loop = qt.QEventLoop()
+            qt.QTimer.singleShot(int(render_interactive * 1000), loop.quit)
+            for widget in (shared_widget, dedicated_widget):
+                interactor = widget.threeDView().interactor()
+                if interactor is not None:
+                    interactor.Initialize()
+                    widget.threeDView().forceRender()
+            loop.exec_()
+    finally:
+        # Tear both widgets down so no view / DM survives to process exit and
+        # trips vtkDebugLeaks in the launched harness.
+        for widget in (shared_widget, dedicated_widget):
+            widget.setMRMLScene(None)
+            widget.deleteLater()
+
+
+# --------------------------------------------------------------------------- #
 # TODO (follow-up PRs) — fixture set to come
 # --------------------------------------------------------------------------- #
 #

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -66,11 +66,15 @@ class _StubDisplayNode:
         mirror: bool = False,
         flexible: bool = False,
         texture_num_comps: int = 1,
+        blur_enabled: bool = False,
+        blur_radius: float = 2.0,
     ) -> None:
         self.show_2d = show_2d
         self.mirror = mirror
         self.flexible = flexible
         self.texture_num_comps = texture_num_comps
+        self.blur_enabled = blur_enabled
+        self.blur_radius = blur_radius
 
     def GetShowResection2D(self) -> bool:
         return self.show_2d
@@ -83,6 +87,12 @@ class _StubDisplayNode:
 
     def GetTextureNumComps(self) -> int:
         return self.texture_num_comps
+
+    def GetBlurEnabled(self) -> bool:
+        return self.blur_enabled
+
+    def GetBlurRadius(self) -> float:
+        return self.blur_radius
 
 
 class _StubPoints:
@@ -363,4 +373,119 @@ def test_mirror_display_flips_camera_z_sign(rep_module, vtk_module):
         "MirrorDisplay must flip the resectogram camera's z sign "
         "(v1 ResectogramPlaneCenter mirror toggle)."
     )
+    rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# Gaussian-blur post-pass (T3-g2) — the net-new v2.0 on/off blur invariant.
+#
+# qMRMLThreeDView owns the shared renderer's render-pass chain (it resets
+# SetPass(nullptr) on every view-node ModifiedEvent), so the Representation
+# hosts the blur on a PRIVATE overlay renderer it adds to the render window
+# when BlurEnabled is true (ADR-0013 §6 — the Representation owns the pass).
+# These pin: the overlay renderer is created + added to the window with the
+# vtkGaussianBlurPass set on IT when blur engages; the toggle is live
+# (true->false->true reuses the same objects); teardown removes the overlay
+# from the window; a no-renderer reconcile is a no-op.  They need a real
+# renderer + render window (SetPass / AddRenderer), so they skip when the
+# render-pass classes are unavailable.
+#
+# The OVERLAY renderer carries the pass — NOT the main renderer (whose
+# GetPass() is not None inside a live qMRMLThreeDView, so asserting it is
+# None there would be wrong).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def render_pass_or_skip(vtk_module):
+    if getattr(vtk_module, "vtkGaussianBlurPass", None) is None:
+        pytest.skip("vtkGaussianBlurPass unavailable in this VTK build.")
+    if getattr(vtk_module, "vtkRenderStepsPass", None) is None:
+        pytest.skip("vtkRenderStepsPass unavailable in this VTK build.")
+    return vtk_module
+
+
+def _renderer_in_window(vtk):
+    """Return a renderer wired into an offscreen render window.
+
+    The blur pass is set directly on this renderer; a window is not strictly
+    required for ``SetPass``, but an offscreen window keeps the fixture close
+    to the live path without lighting real pixels.
+    """
+    renderer = vtk.vtkRenderer()
+    window = vtk.vtkRenderWindow()
+    window.SetOffScreenRendering(1)
+    window.AddRenderer(renderer)
+    return renderer, window
+
+
+def test_blur_pass_attached_when_enabled(rep_module, render_pass_or_skip):
+    """``BlurEnabled`` true → a vtkGaussianBlurPass is set on the renderer."""
+    vtk = render_pass_or_skip
+    renderer, _window = _renderer_in_window(vtk)
+    rep = rep_module(renderer=renderer)
+    assert not rep.IsBlurPassAttached()
+    assert renderer.GetPass() is None
+
+    rep.update(_StubDisplayNode(blur_enabled=True), _StubDataNode())
+
+    assert rep.IsBlurPassAttached(), "blur not engaged with BlurEnabled true"
+    assert renderer.GetPass() is rep.GetBlurPass() is not None, (
+        "the blur pass is not set on the renderer"
+    )
+    assert rep.GetBlurPass().IsA("vtkGaussianBlurPass")
+    rep.cleanup()
+
+
+def test_blur_pass_absent_when_disabled(rep_module, render_pass_or_skip):
+    """``BlurEnabled`` false → no pass on the renderer; blur is off."""
+    vtk = render_pass_or_skip
+    renderer, _window = _renderer_in_window(vtk)
+    rep = rep_module(renderer=renderer)
+    rep.update(_StubDisplayNode(blur_enabled=False), _StubDataNode())
+    assert not rep.IsBlurPassAttached()
+    assert renderer.GetPass() is None
+    rep.cleanup()
+
+
+def test_blur_toggles_live(rep_module, render_pass_or_skip):
+    """Toggling ``BlurEnabled`` across successive ``update()`` calls engages
+    then disengages blur without rebuilding the assembly — the live-toggle
+    invariant (ADR-0013 §6).  The SAME pass object is reused on re-engage (no
+    rebuild / leak)."""
+    vtk = render_pass_or_skip
+    renderer, _window = _renderer_in_window(vtk)
+    rep = rep_module(renderer=renderer)
+
+    rep.update(_StubDisplayNode(blur_enabled=True), _StubDataNode())
+    assert renderer.GetPass() is rep.GetBlurPass() is not None
+    blur_pass = rep.GetBlurPass()
+
+    rep.update(_StubDisplayNode(blur_enabled=False), _StubDataNode())
+    assert not rep.IsBlurPassAttached()
+    assert renderer.GetPass() is None
+
+    rep.update(_StubDisplayNode(blur_enabled=True), _StubDataNode())
+    assert renderer.GetPass() is blur_pass, "blur pass was rebuilt on re-engage"
+    rep.cleanup()
+
+
+def test_blur_detached_on_cleanup(rep_module, render_pass_or_skip):
+    """``cleanup()`` clears the blur pass off the renderer (forward path
+    restored)."""
+    vtk = render_pass_or_skip
+    renderer, _window = _renderer_in_window(vtk)
+    rep = rep_module(renderer=renderer)
+    rep.update(_StubDisplayNode(blur_enabled=True), _StubDataNode())
+    assert renderer.GetPass() is not None
+    rep.cleanup()
+    assert renderer.GetPass() is None, "blur pass survived cleanup on the renderer"
+
+
+def test_blur_reconcile_tolerates_no_renderer(rep_module):
+    """Blur reconcile is a no-op without a renderer (bare-VTK / unit path) —
+    no exception, blur never engages."""
+    rep = rep_module()
+    rep.update(_StubDisplayNode(blur_enabled=True), _StubDataNode())
+    assert not rep.IsBlurPassAttached()
     rep.cleanup()

--- a/Testing/Python/workflow/test_resectogram_arena.py
+++ b/Testing/Python/workflow/test_resectogram_arena.py
@@ -963,3 +963,127 @@ def test_resectogram_is_coherent_with_surface() -> None:
             resectogram_widget.setMRMLScene(None)
             resectogram_widget.deleteLater()
         slicer.mrmlScene.Clear(0)
+
+
+def test_resectogram_reacts_to_control_point_edit() -> None:
+    """A control-point edit MUST drive the pipeline WITHOUT a manual re-drive.
+
+    The reactivity invariant (ADR-0027; ADR-0023 §Stage-4): editing the
+    Bezier surface's control points must propagate to the flattened
+    resectogram through the Pipeline's OWN observer chain -- the data-node
+    ``PointModifiedEvent`` / ``ModifiedEvent`` observer wired in
+    ``ResectogramPipeline.SetDisplayNode`` -> ``_attach_observer``.
+
+    This is the gap ``test_resectogram_is_coherent_with_surface`` does NOT
+    cover: that test manually calls ``pipeline.UpdatePipeline()`` after
+    bending, so it proves the re-feed renders but says nothing about whether
+    a real (mouse-driven) edit auto-triggers it.  Here we bend the surface
+    and assert ``GetUpdateCount()`` ADVANCES on its own -- RED if the
+    observer never reaches the live pipeline (the dragging-changes-nothing
+    failure mode the maintainer caught), GREEN once the observer is attached
+    to the data node the user actually edits.
+
+    Does not need GPU: the assertion is on the Python-side update counter,
+    not rendered pixels, so it runs even under the software-GL skip.
+    """
+    slicer = import_slicer_or_skip()
+    if slicer is None:
+        return
+    require_mrml_scene()
+    require_qt_widget()
+
+    registration_probe = slicer.mrmlScene.CreateNodeByClass(
+        "vtkMRMLResectogramDisplayNode"
+    )
+    if registration_probe is None:
+        pytest.skip(
+            "[arena-skip] vtkMRMLResectogramDisplayNode is not registered -- "
+            "the LiverResections module is not on the additional-module-paths. "
+            "Run via the pytest_launched CTest row."
+        )
+    registration_probe.UnRegister(None)
+
+    try:
+        from slicer import (  # type: ignore[import-not-found]
+            vtkMRMLLayerDisplayableManager,
+        )
+    except ImportError:
+        pytest.skip(
+            "[arena-skip] vtkMRMLLayerDisplayableManager is not importable -- "
+            "the upstream SlicerLayerDM extension is not on the launched path "
+            "(issue #460)."
+        )
+    vtkMRMLLayerDisplayableManager.RegisterInDefaultViews()
+
+    scenario = _load_scenario("Resectogram4x4BlurOff")
+    meta = scenario.describe()
+    width, height = meta["viewport"]["size"]
+
+    resectogram_widget = None
+    try:
+        created_nodes = scenario.setup_scene()
+        bezier = created_nodes[0]
+        resectogram_display = created_nodes[3]
+
+        from LiverResectionsLib.ResectogramViewManager import (  # type: ignore[import-not-found]
+            ResectogramViewManager,
+        )
+
+        resectogram_view_node = ResectogramViewManager().ensureViewNode()
+        _restrict_display_to_view(resectogram_display, resectogram_view_node)
+
+        resectogram_widget = _build_view_widget(
+            slicer, slicer.mrmlScene, resectogram_view_node
+        )
+        scenario.setup_camera(resectogram_view_node)
+        scenario.setup_viewport(resectogram_view_node)
+        resectogram_widget.resize(width, height)
+        resectogram_widget.threeDView().renderWindow().SetSize(width, height)
+        resectogram_widget.threeDView().renderWindow().SetMultiSamples(0)
+        resectogram_widget.threeDView().forceRender()
+
+        manager = resectogram_widget.threeDView().displayableManagerByClassName(
+            "vtkMRMLLayerDisplayableManager"
+        )
+        assert manager is not None, (
+            "[arena] the resectogram view has no vtkMRMLLayerDisplayableManager "
+            "(SlicerLayerDM not loaded; issue #460)."
+        )
+        pipeline = manager.GetNodePipeline(resectogram_display)
+        assert pipeline is not None, (
+            "no pipeline dispatched for the resectogram display node "
+            "(ADR-0013 §5)."
+        )
+
+        # Sanity: the pipeline must have resolved the SAME Bezier node the
+        # edit targets as its data node, or the observer is on the wrong node
+        # and reactivity cannot work regardless of the render path.
+        data_node = pipeline.GetDataNode()
+        assert data_node is not None, (
+            "the ResectogramPipeline resolved no data node -- "
+            "SetDisplayNode/GetDisplayableNode returned None (the back-reference "
+            "was not established when the pipeline was created)."
+        )
+        assert data_node.GetID() == bezier.GetID(), (
+            f"the ResectogramPipeline's data node is {data_node.GetID()} but the "
+            f"edited Bezier node is {bezier.GetID()} -- the PointModifiedEvent "
+            "observer is attached to the wrong node."
+        )
+
+        before_count = pipeline.GetUpdateCount()
+        _bend_control_points(bezier)
+        # NO manual pipeline.UpdatePipeline() here -- the observer chain wired
+        # in SetDisplayNode / OnRendererAdded must carry the edit on its own.
+        after_count = pipeline.GetUpdateCount()
+
+        assert after_count > before_count, (
+            f"editing the Bezier control points did NOT advance the pipeline "
+            f"update count ({before_count} -> {after_count}) -- the data-node "
+            "modification observer never reached UpdatePipeline.  The "
+            "resectogram is non-reactive to surface edits (ADR-0027)."
+        )
+    finally:
+        if resectogram_widget is not None:
+            resectogram_widget.setMRMLScene(None)
+            resectogram_widget.deleteLater()
+        slicer.mrmlScene.Clear(0)

--- a/Testing/Python/workflow/test_resectogram_arena.py
+++ b/Testing/Python/workflow/test_resectogram_arena.py
@@ -560,6 +560,31 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
             widget.threeDView().renderWindow().SetMultiSamples(0)
             widget.threeDView().forceRender()
 
+        # Frame the scene view on the 3D anatomy.  The standalone
+        # qMRMLThreeDWidget has no layout manager, so nothing resets-to-fit;
+        # without this the default camera sits at the origin and the view
+        # shows only the crosshair + a stray glyph instead of the framed
+        # parenchyma + Bezier surface.  Actors exist after the render above,
+        # so ResetCamera frames them -- but ResetCamera alone leaves the
+        # camera looking straight down +z, framing the z=0 planar Bezier
+        # surface EDGE-ON ("two collinear planes").  Re-pose it to an
+        # elevated 3/4 oblique view AFTER ResetCamera (so the clipping range
+        # ResetCamera computed still fits) by orbiting the camera up and
+        # around its focal point, then re-fitting.  The surface then reads as
+        # a 3D sheet, not a line.  Interactive-only polish: the band metric
+        # reads the resectogram renderer, not this one, so the assertions are
+        # unaffected.
+        scene_renderer.ResetCamera()
+        scene_camera = scene_renderer.GetActiveCamera()
+        scene_camera.Azimuth(45.0)
+        scene_camera.Elevation(35.0)
+        scene_camera.OrthogonalizeViewUp()
+        scene_renderer.ResetCameraClippingRange()
+        _crosshair = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLCrosshairNode")
+        if _crosshair is not None:
+            _crosshair.SetCrosshairMode(0)  # vtkMRMLCrosshairNode.NoCrosshair
+        scene_widget.threeDView().forceRender()
+
         # ---- Structural wiring assertions (ALWAYS-ON, path-agnostic) ----
         # These run regardless of the GL stack: live renderers, the v2.0
         # resectogram display node with the strip enabled, and a LIVE
@@ -736,6 +761,8 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
             # the cameras.  A single-shot timer quits the nested event loop
             # after the requested dwell so the test still terminates under
             # CI's brief-onscreen pass (--render-interactive=0.1).
+            import vtk  # type: ignore[import-not-found]
+
             loop = qt.QEventLoop()
             qt.QTimer.singleShot(int(render_interactive * 1000), loop.quit)
             for widget in (scene_widget, resectogram_widget):
@@ -743,6 +770,17 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
                 if interactor is not None:
                     interactor.Initialize()
                     widget.threeDView().forceRender()
+            # The scene view is the 3D anatomy the maintainer rotates to
+            # confirm coherence.  The standalone qMRMLThreeDView's default
+            # interactor style does not give plain trackball orbit, so install
+            # vtkInteractorStyleTrackballCamera on the scene interactor for the
+            # dwell (the resectogram view is a fixed flattened panel -- no
+            # rotation wanted there).
+            scene_interactor = scene_widget.threeDView().interactor()
+            if scene_interactor is not None:
+                scene_interactor.SetInteractorStyle(
+                    vtk.vtkInteractorStyleTrackballCamera()
+                )
             loop.exec_()
     finally:
         # Tear the widgets + scene down so no actor / node survives to process
@@ -753,4 +791,175 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
             if widget is not None:
                 widget.setMRMLScene(None)
                 widget.deleteLater()
+        slicer.mrmlScene.Clear(0)
+
+
+def _bend_control_points(bezier) -> None:
+    """Push the Bezier surface OUT of its planar pose (a coherence mutation).
+
+    The scenario lays the 16 control points flat at ``z == 0`` (a planar
+    surface).  Lift the interior control points well off that plane so the
+    evaluated ``S(u, v)`` bows into a dome — a large, unambiguous geometry
+    change.  The flattened resectogram samples the distance field at the
+    real ``S(u, v)``, so a coherent (BSPoints-fed) render MUST shift the
+    band; a fixed-quad render (the bug) ignores the surface and stays
+    pixel-identical.
+    """
+    for index in range(bezier.GetNumberOfControlPoints()):
+        position = [0.0, 0.0, 0.0]
+        bezier.GetNthControlPointPosition(index, position)
+        bezier.SetNthControlPointPosition(
+            index, position[0], position[1], position[2] + 35.0
+        )
+
+
+def test_resectogram_is_coherent_with_surface() -> None:
+    """Moving the surface's control points MUST change the flattened render.
+
+    The coherence / reactivity invariant (ADR-0027; ADR-0025 §Context): the
+    resectogram is the flattened image of the ACTUAL Bezier surface, so a
+    control-point edit that re-shapes ``S(u, v)`` must re-shape the flattened
+    distance-map band.  The fixed-quad failure mode (the maintainer-caught
+    bug) paints the distance field on a fixed plane regardless of the
+    surface, so the render is pixel-identical before/after the edit — this
+    test is RED against it and GREEN once the real surface feeds the 2D
+    mapper as the ``"BSPoints"`` attribute.
+
+    Single dedicated resectogram view (the band lives there); the scene view
+    is irrelevant to coherence so it is not built.  GPU-gated like the band
+    metric — the software rasteriser does not reliably light the band.
+    """
+    slicer = import_slicer_or_skip()
+    if slicer is None:
+        return
+    require_mrml_scene()
+    require_qt_widget()
+
+    registration_probe = slicer.mrmlScene.CreateNodeByClass(
+        "vtkMRMLResectogramDisplayNode"
+    )
+    if registration_probe is None:
+        pytest.skip(
+            "[arena-skip] vtkMRMLResectogramDisplayNode is not registered -- "
+            "the LiverResections module is not on the additional-module-paths. "
+            "Run via the pytest_launched CTest row."
+        )
+    registration_probe.UnRegister(None)
+
+    software_gl_skip = _software_gl_skip_reason()
+    if software_gl_skip is not None:
+        pytest.skip(software_gl_skip)
+
+    try:
+        from slicer import (  # type: ignore[import-not-found]
+            vtkMRMLLayerDisplayableManager,
+        )
+    except ImportError:
+        pytest.skip(
+            "[arena-skip] vtkMRMLLayerDisplayableManager is not importable -- "
+            "the upstream SlicerLayerDM extension is not on the launched path "
+            "(issue #460).  Run via pytest_launched with the LayerDM module "
+            "paths."
+        )
+    vtkMRMLLayerDisplayableManager.RegisterInDefaultViews()
+
+    try:
+        import numpy  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        pytest.skip(
+            "[arena-skip] numpy unavailable -- cannot read the rendered back "
+            "buffer for the coherence assertion."
+        )
+
+    scenario = _load_scenario("Resectogram4x4BlurOff")
+    meta = scenario.describe()
+    width, height = meta["viewport"]["size"]
+
+    resectogram_widget = None
+    try:
+        created_nodes = scenario.setup_scene()
+        bezier = created_nodes[0]
+        parenchyma = created_nodes[1]
+        resectogram_display = created_nodes[3]
+
+        from LiverResectionsLib.ResectogramViewManager import (  # type: ignore[import-not-found]
+            ResectogramViewManager,
+        )
+
+        # Restrict the resectogram strip to its dedicated view, and ALL
+        # anatomy display nodes (the Bezier surface + markers + parenchyma)
+        # to a separate scene view.  Without the anatomy restriction the
+        # Bezier surface actor renders into the resectogram view too and
+        # MOVES with the control points -- which would let a fixed-quad
+        # resectogram (the bug) appear to "change" via the leaked surface
+        # actor and mask the non-coherence.  Isolating the resectogram
+        # renderer to the strip alone makes the pixel delta attributable to
+        # the flattened image only (ADR-0023 §Stage-4).
+        scene_view_node = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLViewNode", "CoherenceSceneView"
+        )
+        resectogram_view_node = ResectogramViewManager().ensureViewNode()
+        for display in _collect_anatomy_display_nodes(bezier, parenchyma):
+            _restrict_display_to_view(display, scene_view_node)
+        _restrict_display_to_view(resectogram_display, resectogram_view_node)
+
+        resectogram_widget = _build_view_widget(
+            slicer, slicer.mrmlScene, resectogram_view_node
+        )
+        scenario.setup_camera(resectogram_view_node)
+        scenario.setup_viewport(resectogram_view_node)
+        resectogram_renderer = _first_renderer(resectogram_widget)
+        _apply_camera_and_background(resectogram_renderer, meta)
+        resectogram_widget.resize(width, height)
+        resectogram_widget.threeDView().renderWindow().SetSize(width, height)
+        resectogram_widget.threeDView().renderWindow().SetMultiSamples(0)
+        resectogram_widget.threeDView().forceRender()
+
+        # Interior-only mask: the band lives in the panel interior, so an
+        # interior signature isolates the distance-map fill from the fixed
+        # grid + border (which do not move when the surface bends).
+        before = _lit_mask(resectogram_widget)
+        rows, cols = before.shape
+        mr, mc = int(0.18 * rows), int(0.18 * cols)
+        before_interior = before[mr : rows - mr, mc : cols - mc].copy()
+
+        # Re-shape the surface, then drive the pipeline so the
+        # FlattenedSurfaceRepresentation re-feeds BSPoints + re-renders.
+        _bend_control_points(bezier)
+        manager = resectogram_widget.threeDView().displayableManagerByClassName(
+            "vtkMRMLLayerDisplayableManager"
+        )
+        assert manager is not None, (
+            "[arena] the resectogram view has no vtkMRMLLayerDisplayableManager "
+            "(SlicerLayerDM not loaded; issue #460)."
+        )
+        pipeline = manager.GetNodePipeline(resectogram_display)
+        assert pipeline is not None, (
+            "no pipeline dispatched for the resectogram display node "
+            "(ADR-0013 §5)."
+        )
+        pipeline.UpdatePipeline()
+        resectogram_widget.threeDView().forceRender()
+
+        after = _lit_mask(resectogram_widget)
+        after_interior = after[mr : rows - mr, mc : cols - mc]
+
+        changed = int(numpy.count_nonzero(before_interior != after_interior))
+        # A real coherent render bends the band substantially when the
+        # surface domes 35 mm off the plane; require a non-trivial fraction
+        # of interior pixels to flip so single-pixel dithering cannot pass.
+        min_changed = int(0.01 * before_interior.size)
+        assert changed >= min_changed, (
+            f"the flattened resectogram changed by only {changed} interior "
+            f"pixels (< {min_changed}) when the surface's control points "
+            "moved 35 mm off-plane -- the flattened image is NOT tracking the "
+            "real surface.  This is the fixed-quad bug: the 2D mapper is "
+            "painting the distance field on a fixed plane instead of the real "
+            "S(u, v) (feed the surface as the mapper's BSPoints attribute; "
+            "ADR-0025 §Context)."
+        )
+    finally:
+        if resectogram_widget is not None:
+            resectogram_widget.setMRMLScene(None)
+            resectogram_widget.deleteLater()
         slicer.mrmlScene.Clear(0)

--- a/Testing/Python/workflow/test_resectogram_arena.py
+++ b/Testing/Python/workflow/test_resectogram_arena.py
@@ -813,6 +813,133 @@ def _bend_control_points(bezier) -> None:
         )
 
 
+
+def test_resectogram_blur_engages_pass() -> None:
+    """Engaging ``BlurEnabled`` MUST set a Gaussian-blur pass on the pipeline.
+
+    The on/off Gaussian-blur invariant (ADR-0027; ADR-0013 §6): rendering a
+    blur-ON resectogram through the real dedicated view + ResectogramPipeline
+    must leave a ``vtkGaussianBlurPass`` engaged on the FlattenedSurface
+    Representation (its reconcile sets the pass on the view's renderer).
+
+    This asserts the WIRING -- the pass object + that the reconcile engaged it
+    -- not rendered pixels.  The pixel-level softening is confirmed by the
+    maintainer's eyeball + the captured baseline; a cross-render pixel delta is
+    unreliable here because the dedicated resectogram view is a SINGLETON
+    shared across launched tests, so a prior widget's render can leak into a
+    pixel measurement.  The object wiring reflects THIS pipeline only, so it is
+    immune to that contamination.
+
+    GPU-gated: needs a real GL context + the registered LiverResections +
+    SlicerLayerDM modules, so it carries the software-GL + registration /
+    SlicerLayerDM (#460) skips; it SKIPS CLEANLY otherwise.
+    """
+    slicer = import_slicer_or_skip()
+    if slicer is None:
+        return
+    require_mrml_scene()
+    require_qt_widget()
+
+    registration_probe = slicer.mrmlScene.CreateNodeByClass(
+        "vtkMRMLResectogramDisplayNode"
+    )
+    if registration_probe is None:
+        pytest.skip(
+            "[arena-skip] vtkMRMLResectogramDisplayNode is not registered -- "
+            "the LiverResections module is not on the additional-module-paths. "
+            "Run via the pytest_launched CTest row."
+        )
+    registration_probe.UnRegister(None)
+
+    software_gl_skip = _software_gl_skip_reason()
+    if software_gl_skip is not None:
+        pytest.skip(software_gl_skip)
+
+    try:
+        from slicer import (  # type: ignore[import-not-found]
+            vtkMRMLLayerDisplayableManager,
+        )
+    except ImportError:
+        pytest.skip(
+            "[arena-skip] vtkMRMLLayerDisplayableManager is not importable -- "
+            "the upstream SlicerLayerDM extension is not on the launched path "
+            "(issue #460).  Run via pytest_launched with the LayerDM module "
+            "paths."
+        )
+    vtkMRMLLayerDisplayableManager.RegisterInDefaultViews()
+
+    scenario = _load_scenario("Resectogram4x4BlurOn")  # blur ON
+    meta = scenario.describe()
+    width, height = meta["viewport"]["size"]
+
+    resectogram_widget = None
+    try:
+        created_nodes = scenario.setup_scene()
+        bezier = created_nodes[0]
+        parenchyma = created_nodes[1]
+        resectogram_display = created_nodes[3]
+
+        from LiverResectionsLib.ResectogramViewManager import (  # type: ignore[import-not-found]
+            ResectogramViewManager,
+        )
+
+        scene_view_node = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLViewNode", "BlurSceneView"
+        )
+        resectogram_view_node = ResectogramViewManager().ensureViewNode()
+        for display in _collect_anatomy_display_nodes(bezier, parenchyma):
+            _restrict_display_to_view(display, scene_view_node)
+        _restrict_display_to_view(resectogram_display, resectogram_view_node)
+
+        resectogram_widget = _build_view_widget(
+            slicer, slicer.mrmlScene, resectogram_view_node
+        )
+        scenario.setup_camera(resectogram_view_node)
+        scenario.setup_viewport(resectogram_view_node)
+        _apply_camera_and_background(_first_renderer(resectogram_widget), meta)
+        resectogram_widget.resize(width, height)
+        resectogram_widget.threeDView().renderWindow().SetSize(width, height)
+        resectogram_widget.threeDView().renderWindow().SetMultiSamples(0)
+        resectogram_widget.threeDView().forceRender()
+
+        manager = resectogram_widget.threeDView().displayableManagerByClassName(
+            "vtkMRMLLayerDisplayableManager"
+        )
+        assert manager is not None, (
+            "[arena] the resectogram view has no vtkMRMLLayerDisplayableManager "
+            "(SlicerLayerDM not loaded; issue #460)."
+        )
+        pipeline = manager.GetNodePipeline(resectogram_display)
+        assert pipeline is not None, (
+            "no pipeline dispatched for the resectogram display node "
+            "(ADR-0013 §5)."
+        )
+
+        # The scenario enabled blur; the pipeline must have reconciled a
+        # Gaussian-blur pass onto the flattened-surface Representation.
+        assert resectogram_display.GetBlurEnabled(), (
+            "the Resectogram4x4BlurOn scenario did not set BlurEnabled."
+        )
+        flattened = pipeline.GetFlattenedSurfaceRepresentation()
+        assert flattened is not None, (
+            "the ResectogramPipeline built no FlattenedSurfaceRepresentation "
+            "(ADR-0013 §6)."
+        )
+        assert flattened.IsBlurPassAttached(), (
+            "BlurEnabled is true but the FlattenedSurfaceRepresentation did not "
+            "engage the blur pass (ADR-0013 §6)."
+        )
+        blur_pass = flattened.GetBlurPass()
+        assert blur_pass is not None and blur_pass.IsA("vtkGaussianBlurPass"), (
+            "the engaged blur pass is not a vtkGaussianBlurPass."
+        )
+    finally:
+        if resectogram_widget is not None:
+            resectogram_widget.setMRMLScene(None)
+            resectogram_widget.deleteLater()
+        slicer.mrmlScene.Clear(0)
+
+
 def test_resectogram_is_coherent_with_surface() -> None:
     """Moving the surface's control points MUST change the flattened render.
 

--- a/Testing/Python/workflow/test_resectogram_arena.py
+++ b/Testing/Python/workflow/test_resectogram_arena.py
@@ -1,23 +1,61 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
 
-"""Dual-mode interactive arena for the T3 resectogram appearance.
+"""Two-view interactive arena for the T3 resectogram appearance + content.
 
-The user-testing arena for the resectogram: an isolated, minimal-
-``qSlicerApplication`` 3D view that builds the deterministic resectogram
-scene (the flattened 2D image of the Bezier ``(u, v)`` domain, ADR-0025
-§Context) and lets the maintainer eyeball the blur-on/off + non-square
-aspect-ratio appearances on a GPU.  The SAME body runs two ways from one
-test (ADR-0008 §3 dual-use pattern):
+The user-testing arena for the resectogram.  It builds the deterministic
+resectogram scene (the flattened 2D image of the Bezier ``(u, v)`` domain,
+ADR-0025 §Context) into TWO isolated, minimal-``qSlicerApplication`` 3D
+views and lets the maintainer eyeball the blur-on/off + non-square
+aspect-ratio appearances on a GPU:
+
+* a **scene view** — a normal ``vtkMRMLViewNode`` showing the 3D anatomy
+  (the parenchyma sphere + the Bezier surface + its markers), and
+* the **resectogram view** — the dedicated ``"LiverResectogram"``-tagged
+  view (the Hyperprobe custom-layout pattern, ADR-0023 §Stage-4) showing
+  ONLY the flattened resectogram strip.
+
+The maintainer chose two physically separate ``qMRMLThreeDWidget`` views
+(rather than one shared view) so the 3D anatomy and the flattened strip
+never co-mingle in one renderer: per-display-node ``ViewNodeIDs``
+restriction binds each display node to exactly one view, and the arena
+asserts the renderer-level separation (no anatomy actor in the resectogram
+renderer; no strip actor in the scene renderer).
+
+The SAME body runs two ways from one test (ADR-0008 §3 dual-use pattern):
 
 * **offscreen / CI** (``pytest`` default, ``render_interactive == 0``) —
-  builds the view offscreen, runs the scenario, asserts the render
-  pipeline came up and the resectogram display wiring is in place, then
-  tears down.
+  builds both views offscreen, runs the scenario, asserts the render
+  pipeline came up, the resectogram display wiring is in place, the two
+  views are separated, and the resectogram view draws the actual margin
+  BAND (not just the wireframe grid + border), then tears down.
 * **interactive** (``pytest --render-interactive=SECONDS`` with
-  ``SECONDS > 0``) — shows the Qt window and starts the interactor so a
+  ``SECONDS > 0``) — shows both Qt windows and starts the interactors so a
   human can inspect the resectogram for ``SECONDS`` before teardown.  Run
   with ``-k`` to pick blur-on / blur-off / non-square.
+
+The band-content gate (RED-by-design, ADR-0027)
+------------------------------------------------
+Beyond "any lit pixels", the arena pins a CONTENT invariant: the
+resectogram view must render the projected distance-map margin BAND, not
+merely the flattened wireframe grid + coloured borders.  The earlier "≥1 %
+lit pixels" floor was too lenient — the grid + border alone clear it even
+when no texture is bound.  The new metric (``_interior_lit_fraction``)
+counts lit pixels in the strip INTERIOR (a margin around the panel edge is
+excluded), where a bare grid + border leaves the interior essentially
+empty but a textured margin band fills a contiguous interior region.  The
+scenario's deterministic 4-component distance map yields a deterministic
+band, so the interior-lit fraction is a stable discriminator.
+
+This gate is RED TODAY: ``FlattenedSurfaceRepresentation`` does not bind
+the distance-map texture (no ``SetDistanceMapTextureObject`` / ras-ijk
+matrices; the T3-e rewrite severed v1's texture path), so the strip
+interior is empty (grid + border only).  It goes GREEN once the implementer
+binds the distance-map texture so the projected margin band fills the
+``(u, v)`` panel interior (ADR-0025 §Context).  The verdict is GPU-gated —
+the software-GL rasteriser does not reliably light the band — so it carries
+the same software-GL skip the lit-pixel verdict always did; it needs
+launched/GPU verification.
 
 Harness placement (greppable skip reasons, mind #460)
 -----------------------------------------------------
@@ -28,15 +66,6 @@ has none of those, so the test SKIPS CLEANLY there via the shared guards;
 it EXECUTES under the launched-Slicer ``pytest_launched`` row.  Every skip
 prints an explicit, greppable reason — never a silent skip — per the #460
 launched-harness-silently-skips lesson.
-
-Capture-then-rebaseline note
-----------------------------
-The scenarios first render against the v1 monolith resectogram path (the
-legacy ``vtkMRMLMarkupsBezierSurfaceDisplayNode`` resectogram fields), then
-re-baseline to the v2.0 ResectogramPipeline at the implementer's go-live
-step.  This arena drives whatever path is live; the structural assertions
-below are path-agnostic (a 3D renderer + the Bezier node's display nodes),
-and the lit-pixel verdict is GPU-gated.
 
 Scenario source of truth
 -------------------------
@@ -53,9 +82,13 @@ See also
   pattern), §6 (the CI matrix + launched harness).
 * Docs/adr/0013-layerdm-pipeline-pattern.md §6 (the flattened-surface
   Representation owned by the ResectogramPipeline).
-* Testing/Python/workflow/test_distance_spheroid_contour_arena.py (the
-  arena pattern + the hard-won software-GL / vtkDebugLeaks safety guards
-  this file copies).
+* Docs/adr/0023-resection-plan-architecture.md §Stage-4 (the dedicated
+  resectogram view as the one custom Slicer layout v2.0 ships).
+* Docs/adr/0025-locator-architecture.md §Context (the resectogram is the
+  flattened ``(u, v)`` distance-map image).
+* Testing/Python/workflow/test_resectogram_pipeline_dispatch.py (the
+  ``_first_renderer`` / ``GetAddressAsString`` renderer-ownership identity
+  pattern this file reuses for the two-view separation).
 """
 
 from __future__ import annotations
@@ -102,20 +135,64 @@ def _first_renderer(view_widget):
 
     ``qMRMLThreeDView.renderer()`` is C++-only (not PythonQt-wrapped); reach
     the renderer through the render-window's renderer collection, which is
-    plain VTK and fully wrapped.  Same accessor capture_baseline.py uses.
+    plain VTK and fully wrapped.  Same accessor capture_baseline.py and the
+    dispatch tests (``test_resectogram_pipeline_dispatch.py``) use.
     """
     return view_widget.threeDView().renderWindow().GetRenderers().GetFirstRenderer()
 
 
-def _visible_pixel_count(view_widget) -> int:
-    """Count non-background pixels in the view's rendered back buffer.
+def _renderer_owns_actor(renderer, actor) -> bool:
+    """Whether ``actor`` is in ``renderer``'s actor collection.
+
+    Walks ``GetActors()`` by VTK-object identity (the C++ pointer the
+    wrapper reports via ``GetAddressAsString("")``) rather than Python
+    ``is`` — PythonQt/VTK can hand back distinct Python wrappers around the
+    same C++ ``vtkProp``, so identity must be compared at the C++ level.
+    Same identity pattern as ``test_resectogram_pipeline_dispatch.py``.
+    """
+    if renderer is None or actor is None:
+        return False
+    target = actor.GetAddressAsString("")
+    actors = renderer.GetActors()
+    actors.InitTraversal()
+    for _ in range(actors.GetNumberOfItems()):
+        candidate = actors.GetNextActor()
+        if candidate is not None and candidate.GetAddressAsString("") == target:
+            return True
+    return False
+
+
+def _renderer_actor_addresses(renderer) -> set[str]:
+    """Return the set of C++ actor addresses in ``renderer``.
+
+    The renderer-level companion to ``_renderer_owns_actor`` for the
+    two-view separation assertions: snapshots one renderer's actor identity
+    set so the other view's actors can be tested for absence by address
+    (ADR-0023 §Stage-4 — anatomy and the flattened strip must not co-mingle
+    in one renderer).
+    """
+    addresses: set[str] = set()
+    if renderer is None:
+        return addresses
+    actors = renderer.GetActors()
+    actors.InitTraversal()
+    for _ in range(actors.GetNumberOfItems()):
+        candidate = actors.GetNextActor()
+        if candidate is not None:
+            addresses.add(candidate.GetAddressAsString(""))
+    return addresses
+
+
+def _lit_mask(view_widget):
+    """Return a boolean H×W numpy mask of non-background pixels.
 
     Snapshots the GL back buffer with ``vtkWindowToImageFilter`` (the same
     pixel source ``capture_baseline.py`` / ``replay_test.py`` use, so this
-    counts exactly the pixels the visual-regression baseline pins) and
-    returns how many are non-black (the scenario background is ``(0,0,0)``).
-    Channel value > 8 tolerates only single-LSB dithering, not a lit
-    fragment.
+    reads exactly the pixels the visual-regression baseline pins) and marks
+    each pixel whose brightest channel exceeds 8 (the scenario background is
+    ``(0,0,0)``; the >8 threshold tolerates only single-LSB dithering, not a
+    lit fragment).  Shaped ``(height, width)`` so the band metric can carve
+    out an interior region.
     """
     import vtk  # type: ignore[import-not-found]
     from vtk.util import numpy_support  # type: ignore[import-not-found]
@@ -126,9 +203,62 @@ def _visible_pixel_count(view_widget) -> int:
     w2i.ReadFrontBufferOff()
     w2i.SetShouldRerender(0)  # already-rendered back buffer
     w2i.Update()
-    scalars = w2i.GetOutput().GetPointData().GetScalars()
-    arr = numpy_support.vtk_to_numpy(scalars)
-    return int((arr.max(axis=1) > 8).sum())
+    image = w2i.GetOutput()
+    cols, rows, _ = image.GetDimensions()
+    scalars = image.GetPointData().GetScalars()
+    arr = numpy_support.vtk_to_numpy(scalars).reshape(rows, cols, -1)
+    return arr.max(axis=2) > 8
+
+
+def _visible_pixel_count(view_widget) -> int:
+    """Count non-background pixels in the view's rendered back buffer.
+
+    The structural lit-pixel floor (any visible fragment).  Distinct from
+    the band-content metric below: this only proves the strip drew SOMETHING
+    (grid + border qualify); the band metric proves it drew the margin BAND.
+    """
+    return int(_lit_mask(view_widget).sum())
+
+
+def _interior_lit_fraction(view_widget, border_frac: float = 0.18) -> float:
+    """Return the lit fraction of the panel INTERIOR (the band-content metric).
+
+    The content gate that distinguishes a textured margin band from a bare
+    flattened grid + coloured border (ADR-0025 §Context — the resectogram is
+    the flattened ``(u, v)`` distance-map image; the band IS the projected
+    distance map, not the wireframe).
+
+    Why interior-only discriminates band-from-grid
+    -----------------------------------------------
+    The flattened-surface Representation always draws the ``(u, v)`` quad
+    GRID (a sparse wireframe) and the coloured resection BORDERS (the panel
+    edges).  Those clear a whole-frame "≥1 % lit" floor on their own — the
+    earlier, too-lenient gate.  But they are confined to the panel PERIMETER
+    and the thin grid lines: the panel INTERIOR (everything inside a
+    ``border_frac`` margin from each edge) stays dark when no distance-map
+    texture is bound.  A bound distance-map texture, by contrast, paints the
+    projected margin band as a CONTIGUOUS fill across that interior.  So the
+    interior-lit fraction separates the two regimes:
+
+    * grid + border only  → interior fraction ≈ 0 (a few stray grid pixels),
+    * textured margin band → interior fraction well above the floor.
+
+    ``border_frac`` (default 0.18) excludes the outer 18 % of the panel on
+    every side, leaving a centred interior window safely clear of the
+    coloured borders + the outermost grid lines for the scenario's fixed
+    camera pose.  The band fills a deterministic region because the
+    scenario's 4-component distance map is deterministic.
+
+    Returns the fraction in ``[0, 1]`` of interior pixels that are lit.
+    """
+    mask = _lit_mask(view_widget)
+    rows, cols = mask.shape
+    margin_r = int(border_frac * rows)
+    margin_c = int(border_frac * cols)
+    interior = mask[margin_r : rows - margin_r, margin_c : cols - margin_c]
+    if interior.size == 0:
+        return 0.0
+    return float(interior.sum()) / float(interior.size)
 
 
 _SOFTWARE_GL_MARKERS = ("llvmpipe", "softpipe", "swrast", "software rasterizer")
@@ -140,8 +270,8 @@ def _software_gl_skip_reason() -> str | None:
     Brings up a throwaway offscreen ``vtkRenderWindow`` and reads its
     ``ReportCapabilities`` -- the same cheap probe the replay driver
     (``LiverResections/Testing/Python/replay_test.py``) uses.  Probing a
-    *throwaway* window before the live view is built keeps this off the
-    arena's own (possibly context-failed) render window, and lets the test
+    *throwaway* window before the live views are built keeps this off the
+    arena's own (possibly context-failed) render windows, and lets the test
     skip BEFORE attempting a render the software stack cannot light.  Any
     probe failure is treated as un-renderable (skip), never a crash.
     """
@@ -165,21 +295,123 @@ def _software_gl_skip_reason() -> str | None:
         return (
             f"[arena-skip] offscreen software GL ({match}) -- the resectogram "
             "render path does not reliably light fragments on a software "
-            "rasteriser; the lit-pixel verdict is deferred to a GPU-backed "
+            "rasteriser; the band-content verdict is deferred to a GPU-backed "
             "display."
         )
     return None
 
 
+def _build_view_widget(slicer, scene, view_node):
+    """Build + map a standalone ``qMRMLThreeDWidget`` bound to ``view_node``.
+
+    ``--no-main-window`` has no layout manager, so construct the
+    ``qMRMLThreeDWidget`` directly (the same standalone-view pattern
+    capture_baseline.py / replay_test.py and the dispatch fixtures use).
+    Maps the GL surface (``show()`` + ``forceRender()``) BEFORE binding the
+    view node so the LayerDM displayable-manager group attaches.  Under
+    ``QT_QPA_PLATFORM=offscreen`` show() is visually a no-op but still maps
+    the OpenGL surface; without it the offscreen back buffer renders empty.
+    """
+    widget = slicer.qMRMLThreeDWidget()
+    widget.setMRMLScene(scene)
+    widget.show()
+    widget.threeDView().forceRender()
+    widget.setMRMLViewNode(view_node)
+    return widget
+
+
+def _apply_camera_and_background(renderer, meta) -> None:
+    """Push the scenario's deterministic camera pose + flat background.
+
+    The standalone ``qMRMLThreeDWidget`` (no layout manager) does not honour
+    the orphan MRML camera/view nodes the scenario configured, so push the
+    scenario's deterministic camera pose + flat black background straight
+    onto the live renderer -- the same thing capture_baseline.py / replay do
+    -- so the offscreen frame matches the captured baseline and the
+    interior-lit fraction reflects lit resectogram fragments, not a
+    non-black gradient.
+    """
+    camera = renderer.GetActiveCamera()
+    camera_spec = meta["camera"]
+    camera.SetPosition(*camera_spec["position"])
+    camera.SetFocalPoint(*camera_spec["focal_point"])
+    camera.SetViewUp(*camera_spec["view_up"])
+    camera.SetViewAngle(camera_spec["view_angle"])
+    camera.SetClippingRange(*camera_spec["clipping_range"])
+    background = meta["viewport"]["background"]
+    renderer.SetBackground(*background)
+    renderer.SetBackground2(*background)
+
+
+def _restrict_display_to_view(display_node, view_node) -> None:
+    """Bind ``display_node`` to render in ``view_node`` ONLY.
+
+    Clears any existing view restriction then adds the single target view,
+    so the display node's actor is hosted by exactly one view's renderer.
+    This is the per-display-node half of the no-overlap contract (ADR-0023
+    §Stage-4): anatomy display nodes restricted to the scene view, the
+    resectogram display node restricted to the resectogram view.
+    """
+    if display_node is None or view_node is None:
+        return
+    display_node.RemoveAllViewNodeIDs()
+    display_node.AddViewNodeID(view_node.GetID())
+
+
+def _collect_anatomy_display_nodes(bezier, parenchyma):
+    """Return every anatomy (non-resectogram) display node in the scene.
+
+    The 3D anatomy is the parenchyma sphere model + the Bezier surface +
+    its markers; each carries one or more display nodes.  Gather them so the
+    arena can restrict ALL of them to the scene view (and, by exclusion,
+    keep them out of the resectogram renderer).  The resectogram display
+    node (``vtkMRMLResectogramDisplayNode``) is explicitly excluded -- it is
+    bound to the resectogram view instead.
+    """
+    nodes = []
+    for owner in (parenchyma, bezier):
+        if owner is None:
+            continue
+        for index in range(owner.GetNumberOfDisplayNodes()):
+            display = owner.GetNthDisplayNode(index)
+            if display is None:
+                continue
+            if display.IsA("vtkMRMLResectogramDisplayNode"):
+                continue
+            nodes.append(display)
+    return nodes
+
+
 @pytest.mark.parametrize("scenario_name", _SCENARIOS)
 def test_resectogram_arena(scenario_name: str, render_interactive: float) -> None:
-    """Render a T3 resectogram scenario; interactive or offscreen.
+    """Render a T3 resectogram scenario into TWO separated views.
 
     The single body adapts to both modes by branching on
     ``render_interactive`` (ADR-0008 §3) — the offscreen path tears the
-    view down immediately after the structural assertions, the interactive
-    path shows the window and starts the interactor for
-    ``render_interactive`` seconds.
+    views down immediately after the structural + separation + band-content
+    assertions, the interactive path shows both windows and starts the
+    interactors for ``render_interactive`` seconds.
+
+    Two views, no overlap (ADR-0023 §Stage-4)
+    -----------------------------------------
+    * a **scene view** (plain ``vtkMRMLViewNode``) hosting the 3D anatomy,
+      its display nodes restricted to that view, and
+    * the dedicated **resectogram view** (the ``"LiverResectogram"`` tagged
+      view via ``ResectogramViewManager``) hosting ONLY the flattened strip.
+
+    The arena asserts the renderer-level separation: the resectogram strip
+    actor is in the resectogram renderer and ABSENT from the scene renderer,
+    and the anatomy actors are absent from the resectogram renderer.
+
+    Band-content gate (RED-by-design, ADR-0027)
+    -------------------------------------------
+    Beyond "any lit pixels", the resectogram view must draw the projected
+    distance-map margin BAND (ADR-0025 §Context), measured as a non-trivial
+    interior-lit fraction.  RED TODAY because
+    ``FlattenedSurfaceRepresentation`` does not bind the distance-map texture
+    (the T3-e rewrite severed v1's texture path), so the strip interior is
+    grid-only; GREEN once the implementer binds the texture.  The verdict is
+    GPU-gated and needs launched/GPU verification.
 
     Parametrised over the three T3 resectogram scenarios so the maintainer
     can ``pytest --render-interactive=N -k <scenario>`` to inspect any one
@@ -216,9 +448,9 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
     # Software-GL gate (CI's xvfb + llvmpipe): the resectogram render path
     # does not reliably light fragments on a software rasteriser, and the
     # offscreen render itself is unreliable there.  Probe a throwaway context
-    # and skip BEFORE building/rendering the live view so the test reports a
+    # and skip BEFORE building/rendering the live views so the test reports a
     # real, greppable SKIP rather than a false pass or a render crash.  The
-    # lit-pixel verdict is on a GPU-backed display.
+    # band-content verdict is on a GPU-backed display.
     software_gl_skip = _software_gl_skip_reason()
 
     import qt  # type: ignore[import-not-found]
@@ -228,7 +460,7 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
     width, height = meta["viewport"]["size"]
 
     # Ensure the upstream LayerDM displayable manager is registered in the
-    # 3D-view factory so the standalone view hosts it and the registered
+    # 3D-view factory so the standalone views host it and the registered
     # ResectogramPipeline dispatches for the resectogram display node
     # (ADR-0013 §5; idempotent -- RegisterInDefaultViews short-circuits when
     # already present, and the LiverResections module setup() already calls
@@ -246,27 +478,23 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
         )
     vtkMRMLLayerDisplayableManager.RegisterInDefaultViews()
 
-    # Build the standalone view.  ``--no-main-window`` has no layout
-    # manager, so construct the qMRMLThreeDWidget directly (the same
-    # standalone-view pattern capture_baseline.py / replay_test.py use).
-    view_widget = slicer.qMRMLThreeDWidget()
-    view_widget.setMRMLScene(slicer.mrmlScene)
-
-    created_nodes = None
+    scene_widget = None
+    resectogram_widget = None
     try:
-        # Populate the scene (markups Bezier node + distance map + the
-        # resectogram display node).  setup_scene returns the created nodes
-        # so nothing leaks through a module global.  It Clear(0)s the scene
-        # first, so create the view node AFTER it -- a view node created
-        # before would be wiped, leaving the displayable-manager group bound
-        # to a node no longer in the scene (and the pipeline reconciliation
-        # would never fire).
+        # Populate the scene (markups Bezier node + parenchyma + distance map
+        # + the resectogram display node).  setup_scene returns the created
+        # nodes so nothing leaks through a module global.  It Clear(0)s the
+        # scene first, so create the view nodes AFTER it -- a view node
+        # created before would be wiped, leaving the displayable-manager
+        # group bound to a node no longer in the scene.
         created_nodes = scenario.setup_scene()
         assert created_nodes is not None, (
             "scenario.setup_scene() returned None -- expected the created "
             "node handles (the no-module-globals contract)."
         )
-        assert created_nodes[0] is not None, (
+        bezier = created_nodes[0]
+        parenchyma = created_nodes[1]
+        assert bezier is not None, (
             "scenario.setup_scene() did not return a Bezier node handle."
         )
         # The v2.0 ResectogramPipeline carrier (ADR-0013 §1): the scenario
@@ -278,59 +506,68 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
             "-- the v2.0 ResectogramPipeline has nothing to key on (ADR-0013 §1)."
         )
 
-        # The view must carry the resectogram singleton tag so the tightened
-        # ResectogramPipeline creator (ADR-0023 §Stage-4) fires for it -- an
-        # untagged view no longer gets a pipeline dispatched.  Reuse the
-        # production view-manager so the arena and the live module agree on
-        # the tag + layout name.
+        # ---- Two view nodes ----
+        # The scene view: a normal vtkMRMLViewNode hosting the 3D anatomy.
+        # NO resectogram singleton tag, so the tightened ResectogramPipeline
+        # creator never fires for it (ADR-0023 §Stage-4).
+        scene_view_node = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLViewNode", "ArenaSceneView"
+        )
+
+        # The dedicated resectogram view: the production view-manager owns
+        # the "LiverResectogram"-tagged singleton view node so the arena and
+        # the live module agree on the tag + layout name (ADR-0023 §Stage-4).
         from LiverResectionsLib.ResectogramViewManager import (  # type: ignore[import-not-found]
             ResectogramViewManager,
         )
 
-        view_node = ResectogramViewManager().ensureViewNode()
+        resectogram_view_node = ResectogramViewManager().ensureViewNode()
 
-        # Map the view's GL surface BEFORE binding the view node so the
-        # displayable-manager group attaches.  Under
-        # ``QT_QPA_PLATFORM=offscreen`` show() is visually a no-op but still
-        # maps the OpenGL surface + creates the default light; without it the
-        # offscreen back buffer renders empty.  Same show()-then-render
-        # ordering capture_baseline.py uses.
-        view_widget.show()
-        view_widget.threeDView().forceRender()
-        view_widget.setMRMLViewNode(view_node)
+        # ---- No-overlap: restrict each display node to its one view ----
+        # Anatomy display nodes (parenchyma + Bezier + markers) render in the
+        # scene view ONLY; the resectogram display node renders in the
+        # resectogram view ONLY.  ViewNodeIDs is the per-display-node half of
+        # the no-overlap contract (ADR-0023 §Stage-4); the renderer-level
+        # assertions below verify the consequence.
+        anatomy_display_nodes = _collect_anatomy_display_nodes(bezier, parenchyma)
+        for display in anatomy_display_nodes:
+            _restrict_display_to_view(display, scene_view_node)
+        _restrict_display_to_view(resectogram_display, resectogram_view_node)
 
-        scenario.setup_camera(view_node)
-        scenario.setup_viewport(view_node)
+        # ---- Build + map both standalone views ----
+        scene_widget = _build_view_widget(
+            slicer, slicer.mrmlScene, scene_view_node
+        )
+        resectogram_widget = _build_view_widget(
+            slicer, slicer.mrmlScene, resectogram_view_node
+        )
 
-        # The standalone qMRMLThreeDWidget (no layout manager) does not
-        # honour the orphan MRML camera/view nodes the scenario configured,
-        # so push the scenario's deterministic camera pose + flat black
-        # background straight onto the live renderer -- the same thing
-        # capture_baseline.py / replay do -- so the offscreen frame matches
-        # the captured baseline and the visible-pixel count reflects lit
-        # resectogram fragments, not a non-black gradient.
-        renderer = _first_renderer(view_widget)
-        camera = renderer.GetActiveCamera()
-        camera_spec = meta["camera"]
-        camera.SetPosition(*camera_spec["position"])
-        camera.SetFocalPoint(*camera_spec["focal_point"])
-        camera.SetViewUp(*camera_spec["view_up"])
-        camera.SetViewAngle(camera_spec["view_angle"])
-        camera.SetClippingRange(*camera_spec["clipping_range"])
-        background = meta["viewport"]["background"]
-        renderer.SetBackground(*background)
-        renderer.SetBackground2(*background)
+        scenario.setup_camera(resectogram_view_node)
+        scenario.setup_viewport(resectogram_view_node)
 
-        view_widget.resize(width, height)
-        view_widget.threeDView().renderWindow().SetSize(width, height)
-        view_widget.threeDView().renderWindow().SetMultiSamples(0)
-        view_widget.threeDView().forceRender()
+        # Push the scenario's deterministic camera + flat background onto the
+        # resectogram renderer (the panel the band metric reads).  The scene
+        # renderer keeps Slicer's default 3D camera -- the arena does not pin
+        # its pixels, only that anatomy actors live there and the strip does
+        # not.
+        scene_renderer = _first_renderer(scene_widget)
+        resectogram_renderer = _first_renderer(resectogram_widget)
+        _apply_camera_and_background(resectogram_renderer, meta)
+
+        for widget in (scene_widget, resectogram_widget):
+            widget.resize(width, height)
+            widget.threeDView().renderWindow().SetSize(width, height)
+            widget.threeDView().renderWindow().SetMultiSamples(0)
+            widget.threeDView().forceRender()
 
         # ---- Structural wiring assertions (ALWAYS-ON, path-agnostic) ----
-        # These run regardless of the GL stack: a live renderer, the v2.0
+        # These run regardless of the GL stack: live renderers, the v2.0
         # resectogram display node with the strip enabled, and a LIVE
-        # ResectogramPipeline dispatched for it.
-        assert renderer is not None, "no live renderer on the view widget"
+        # ResectogramPipeline dispatched for it on the dedicated view.
+        assert scene_renderer is not None, "no live renderer on the scene view"
+        assert resectogram_renderer is not None, (
+            "no live renderer on the resectogram view"
+        )
 
         # The resectogram strip must be enabled (the whole point of the
         # scenario).  ShowResection2D lives on the v2.0
@@ -347,18 +584,19 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
         )
 
         # The registered ResectogramPipeline must have dispatched for the
-        # display node and built a non-empty flattened-surface actor.  This
-        # is the T3-e go-live invariant (ADR-0013 §1/§5/§6): a
-        # vtkMRMLResectogramDisplayNode in a LayerDM-aware view yields a live
-        # pipeline whose FlattenedSurfaceRepresentation has renderable
-        # geometry -- the precondition for the lit-pixel verdict below.
-        manager = view_widget.threeDView().displayableManagerByClassName(
+        # display node ON THE DEDICATED VIEW and built a non-empty
+        # flattened-surface actor.  This is the T3-e go-live invariant
+        # (ADR-0013 §1/§5/§6): a vtkMRMLResectogramDisplayNode in a
+        # LayerDM-aware dedicated view yields a live pipeline whose
+        # FlattenedSurfaceRepresentation has renderable geometry -- the
+        # precondition for the band-content verdict below.
+        manager = resectogram_widget.threeDView().displayableManagerByClassName(
             "vtkMRMLLayerDisplayableManager"
         )
         assert manager is not None, (
-            "[arena] the 3D view has no vtkMRMLLayerDisplayableManager -- the "
-            "upstream SlicerLayerDM extension is not loaded on the launched "
-            "path (issue #460)."
+            "[arena] the resectogram 3D view has no "
+            "vtkMRMLLayerDisplayableManager -- the upstream SlicerLayerDM "
+            "extension is not loaded on the launched path (issue #460)."
         )
         pipeline = manager.GetNodePipeline(resectogram_display)
         assert pipeline is not None, (
@@ -375,16 +613,74 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
             "-- OnRendererAdded did not compose the Representations "
             "(ADR-0013 §6)."
         )
-        actor = flattened.GetResectionActor2D()
-        assert actor is not None and actor.GetMapper() is not None, (
+        strip_actor = flattened.GetResectionActor2D()
+        assert strip_actor is not None and strip_actor.GetMapper() is not None, (
             "the flattened-surface actor / mapper is missing -- the "
             "resectogram strip has nothing to draw."
         )
 
-        # ---- Lit-pixel verdict (GPU-gated) ----
+        # The flattened-surface mapper carries the (u, v) aspect-ratio
+        # mapping (MatRatio) the non-square scenario exercises.  Keep the
+        # structural reachability check: the mapper must expose the MatRatio
+        # accessor so the aspect-ratio path is wired (ADR-0013 §6).  Probe by
+        # attribute so the check reads as a wiring assertion, not a value
+        # assertion (the value is pinned by the visual-regression baseline).
+        mapper = strip_actor.GetMapper()
+        assert hasattr(mapper, "GetMatRatio"), (
+            "the flattened-surface mapper exposes no GetMatRatio accessor -- "
+            "the (u, v) aspect-ratio mapping the non-square scenario pins is "
+            "not wired on the resectogram mapper (ADR-0013 §6)."
+        )
+
+        # ---- Two-view separation (ALWAYS-ON, renderer identity) ----
+        # No overlap: the strip actor lives in the resectogram renderer and
+        # NOT in the scene renderer; the anatomy actors live in the scene
+        # renderer and NOT in the resectogram renderer (ADR-0023 §Stage-4 --
+        # the flattened strip must not bleed into the 3D anatomy view, and
+        # the anatomy must not bleed into the flattened panel).
+        assert _renderer_owns_actor(resectogram_renderer, strip_actor), (
+            "the resectogram strip actor is NOT in the resectogram view's "
+            "renderer -- the dedicated Pipeline did not attach it "
+            "(ADR-0023 §Stage-4)."
+        )
+        assert not _renderer_owns_actor(scene_renderer, strip_actor), (
+            "the resectogram strip actor is present in the SCENE (anatomy) "
+            "renderer -- the flattened strip is bleeding into the 3D anatomy "
+            "view (the overlap bug).  Restrict the resectogram display node to "
+            "the dedicated view (ADR-0023 §Stage-4)."
+        )
+
+        # We have no direct handle to the anatomy vtkActors (they live inside
+        # the upstream model / markups displayable managers), so assert the
+        # separation by renderer actor-identity SETS: the scene renderer
+        # carries the anatomy actors (everything but the strip), and NONE of
+        # those identities may appear in the resectogram renderer.
+        resectogram_addresses = _renderer_actor_addresses(resectogram_renderer)
+        scene_addresses = _renderer_actor_addresses(scene_renderer)
+        strip_address = strip_actor.GetAddressAsString("")
+        # The scene renderer must carry anatomy actors (the parenchyma sphere
+        # at minimum) and none of them may be the strip actor; the
+        # resectogram renderer must NOT share any actor identity with the
+        # scene renderer's anatomy actors (overlap = a shared address).
+        anatomy_addresses = scene_addresses - {strip_address}
+        assert anatomy_addresses, (
+            "the scene (anatomy) renderer carries no anatomy actors -- the "
+            "parenchyma / Bezier surface did not render into the scene view "
+            "(restriction bound them to the wrong view?)."
+        )
+        leaked = anatomy_addresses & resectogram_addresses
+        assert not leaked, (
+            "anatomy actor(s) leaked into the resectogram renderer "
+            f"(shared addresses: {sorted(leaked)}) -- the anatomy and the "
+            "flattened strip are co-mingling in one view (the overlap bug).  "
+            "Restrict the anatomy display nodes to the scene view "
+            "(ADR-0023 §Stage-4)."
+        )
+
+        # ---- Band-content verdict (GPU-gated, RED-by-design) ----
         # The resectogram render path does not reliably light fragments on a
-        # software rasteriser; defer the pixel verdict to a GPU-backed
-        # display.  The structural assertions above already ran.
+        # software rasteriser; defer the pixel verdicts to a GPU-backed
+        # display.  The structural + separation assertions above already ran.
         if software_gl_skip is not None:
             pytest.skip(software_gl_skip)
 
@@ -394,36 +690,67 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
         except ImportError:
             pytest.skip(
                 "[arena-skip] numpy / vtk.util.numpy_support unavailable -- "
-                "cannot read the rendered back buffer for the visible-pixel "
-                "assertion.  Structural wiring above already passed."
+                "cannot read the rendered back buffer for the band-content "
+                "assertion.  Structural wiring + separation above already "
+                "passed."
             )
-        visible = _visible_pixel_count(view_widget)
-        # A generous 1 % floor still fails hard on an all-black frame while
-        # tolerating the resectogram strip occupying only part of the panel.
+
+        # Structural lit-pixel floor: the strip drew SOMETHING (grid + border
+        # qualify).  Kept as the cheap precondition for the band metric.
+        visible = _visible_pixel_count(resectogram_widget)
         min_visible = int(0.01 * width * height)
         assert visible >= min_visible, (
             f"the resectogram rendered only {visible} lit pixels "
-            f"(< {min_visible}) -- the flattened strip is not visibly drawn.  "
-            "Expected the live resectogram path to light the (u, v) panel."
+            f"(< {min_visible}) -- the flattened strip is not visibly drawn at "
+            "all.  Expected the live resectogram path to light the (u, v) panel."
+        )
+
+        # Band-content gate (the RED pin, ADR-0027): the projected
+        # distance-map margin BAND must fill a non-trivial CONTIGUOUS region
+        # of the panel INTERIOR, distinguishing it from the bare flattened
+        # grid + coloured border (which leave the interior dark).  The
+        # scenario's deterministic 4-component distance map yields a
+        # deterministic band, so a stable interior-lit-fraction floor
+        # separates band-from-grid (ADR-0025 §Context).
+        #
+        # RED TODAY: FlattenedSurfaceRepresentation does not bind the
+        # distance-map texture (no SetDistanceMapTextureObject / ras-ijk
+        # matrices; the T3-e rewrite severed v1's texture path), so the
+        # interior is grid-only and this fraction is ~0.  GREEN once the
+        # implementer binds the distance-map texture so the margin band
+        # fills the (u, v) panel interior.  Needs launched/GPU verification.
+        interior_fraction = _interior_lit_fraction(resectogram_widget)
+        min_interior_fraction = 0.10
+        assert interior_fraction >= min_interior_fraction, (
+            f"the resectogram panel interior is only {interior_fraction:.3f} "
+            f"lit (< {min_interior_fraction}) -- the flattened strip is drawing "
+            "the (u, v) GRID + coloured BORDER but NOT the projected "
+            "distance-map margin BAND.  The band fills a contiguous interior "
+            "region only once FlattenedSurfaceRepresentation binds the "
+            "distance-map texture (RED-by-design until that lands; "
+            "ADR-0025 §Context)."
         )
 
         if render_interactive:
-            # Interactive arena: keep the window up and let the human drive
-            # the camera.  A single-shot timer quits the nested event loop
+            # Interactive arena: keep both windows up and let the human drive
+            # the cameras.  A single-shot timer quits the nested event loop
             # after the requested dwell so the test still terminates under
             # CI's brief-onscreen pass (--render-interactive=0.1).
-            interactor = view_widget.threeDView().interactor()
-            if interactor is not None:
-                loop = qt.QEventLoop()
-                qt.QTimer.singleShot(int(render_interactive * 1000), loop.quit)
-                interactor.Initialize()
-                view_widget.threeDView().forceRender()
-                loop.exec_()
+            loop = qt.QEventLoop()
+            qt.QTimer.singleShot(int(render_interactive * 1000), loop.quit)
+            for widget in (scene_widget, resectogram_widget):
+                interactor = widget.threeDView().interactor()
+                if interactor is not None:
+                    interactor.Initialize()
+                    widget.threeDView().forceRender()
+            loop.exec_()
     finally:
-        # Tear the widget + scene down so no actor / node survives to process
+        # Tear the widgets + scene down so no actor / node survives to process
         # exit and trips vtkDebugLeaks in the launched harness (the
         # LiverResections conftest's _launched_scene_cleanup clears the scene;
-        # the standalone widget is ours).
-        view_widget.setMRMLScene(None)
-        view_widget.deleteLater()
+        # the standalone widgets are ours).
+        for widget in (scene_widget, resectogram_widget):
+            if widget is not None:
+                widget.setMRMLScene(None)
+                widget.deleteLater()
         slicer.mrmlScene.Clear(0)

--- a/Testing/Python/workflow/test_resectogram_arena.py
+++ b/Testing/Python/workflow/test_resectogram_arena.py
@@ -278,11 +278,16 @@ def test_resectogram_arena(scenario_name: str, render_interactive: float) -> Non
             "-- the v2.0 ResectogramPipeline has nothing to key on (ADR-0013 §1)."
         )
 
-        view_node = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLViewNode")
-        if view_node is None:
-            view_node = slicer.mrmlScene.AddNewNodeByClass(
-                "vtkMRMLViewNode", "ResectogramArenaView"
-            )
+        # The view must carry the resectogram singleton tag so the tightened
+        # ResectogramPipeline creator (ADR-0023 §Stage-4) fires for it -- an
+        # untagged view no longer gets a pipeline dispatched.  Reuse the
+        # production view-manager so the arena and the live module agree on
+        # the tag + layout name.
+        from LiverResectionsLib.ResectogramViewManager import (  # type: ignore[import-not-found]
+            ResectogramViewManager,
+        )
+
+        view_node = ResectogramViewManager().ensureViewNode()
 
         # Map the view's GL surface BEFORE binding the view node so the
         # displayable-manager group attaches.  Under

--- a/Testing/Python/workflow/test_resectogram_pipeline_dispatch.py
+++ b/Testing/Python/workflow/test_resectogram_pipeline_dispatch.py
@@ -166,3 +166,152 @@ def test_resectogram_creator_does_not_collide_with_bezier(layerdm_threed_view):
         "vtkMRMLResectogramDisplayNode wrongly produced a Bezier-surface "
         "Pipeline — the creators cross-fire (ADR-0013 §1 violation)."
     )
+
+
+# --------------------------------------------------------------------------- #
+# T3-g1 keystone invariants — the dedicated resectogram view (ADR-0023
+# §Stage-4) is the ONLY view the ResectogramPipeline fires into; the shared
+# anatomy 3D view stays clear (ADR-0013 §1 disjoint keying).
+#
+# RED-by-design (ADR-0027): both tests fail today because
+# ``registerResectogramPipelineCreator().tryCreate`` gates only on
+# ``isinstance(viewNode, vtkMRMLViewNode)`` (ResectogramPipeline.py
+# ~L399-409) — so the creator fires for EVERY 3D view, dispatching the
+# flattened strip into the shared anatomy renderer.  They go GREEN once the
+# T3-g1 implementer (a) lands the dedicated singleton view (Hyperprobe
+# pattern, ``SetSingletonTag(RESECTOGRAM_VIEW_SINGLETON_TAG)``) and (b)
+# tightens ``tryCreate`` to fire ONLY for the view carrying that tag.
+# --------------------------------------------------------------------------- #
+
+
+def _first_renderer(view_widget):
+    """Return the live ``vtkRenderer`` of the view widget's render window.
+
+    ``qMRMLThreeDView.renderer()`` is C++-only (not PythonQt-wrapped); reach
+    the renderer through the render-window's renderer collection, which is
+    plain VTK and fully wrapped.  Same accessor the resectogram arena
+    (``test_resectogram_arena.py``) and ``capture_baseline.py`` use.
+    """
+    return view_widget.threeDView().renderWindow().GetRenderers().GetFirstRenderer()
+
+
+def _renderer_owns_actor(renderer, actor) -> bool:
+    """Whether ``actor`` is in ``renderer``'s actor collection.
+
+    Walks ``GetActors()`` by VTK-object identity (``IsSameObject``) rather
+    than Python ``is`` — PythonQt/VTK can hand back distinct Python wrappers
+    around the same C++ ``vtkActor``.
+    """
+    if renderer is None or actor is None:
+        return False
+    actors = renderer.GetActors()
+    actors.InitTraversal()
+    for _ in range(actors.GetNumberOfItems()):
+        candidate = actors.GetNextActor()
+        if candidate is not None and candidate.IsSameObject(actor):
+            return True
+    return False
+
+
+def test_creator_fires_only_in_dedicated_view(layerdm_resectogram_view):
+    """The ResectogramPipeline dispatches into the dedicated view, NOT the shared one.
+
+    Pins ADR-0013 §1 (disjoint keying — one Pipeline per renderable target)
+    and ADR-0023 §Stage-4 (the resectogram is the one custom Slicer layout
+    v2.0 ships; it must not bleed into the shared 3D anatomy view).  With a
+    single ``vtkMRMLResectogramDisplayNode`` in the scene and TWO views
+    present — a shared anatomy ``vtkMRMLViewNode`` (no resectogram tag) and a
+    dedicated view carrying ``RESECTOGRAM_VIEW_SINGLETON_TAG`` — the LayerDM
+    DM yields a ``ResectogramPipeline`` ON THE DEDICATED VIEW and yields none
+    (or anything but a ResectogramPipeline) on the shared anatomy view.
+
+    RED-by-design (ADR-0027): the current ``tryCreate`` fires for every
+    ``vtkMRMLViewNode``, so the shared anatomy view ALSO gets a
+    ResectogramPipeline.  GREEN once T3-g1 tightens the creator to gate on
+    the dedicated view's singleton tag.
+    """
+    import slicer
+
+    shared_widget, shared_manager = layerdm_resectogram_view["shared"]
+    dedicated_widget, dedicated_manager = layerdm_resectogram_view["dedicated"]
+
+    display = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLResectogramDisplayNode")
+    shared_widget.threeDView().forceRender()
+    dedicated_widget.threeDView().forceRender()
+
+    dedicated_pipeline = dedicated_manager.GetNodePipeline(display)
+    shared_pipeline = shared_manager.GetNodePipeline(display)
+
+    assert (
+        dedicated_pipeline is not None
+        and type(dedicated_pipeline).__name__ == "ResectogramPipeline"
+    ), (
+        "the dedicated resectogram view (singleton tag "
+        f"{layerdm_resectogram_view['tag']!r}) did not get a "
+        "ResectogramPipeline — T3-g1's creator must fire for the dedicated "
+        "view (ADR-0023 §Stage-4)."
+    )
+    assert type(shared_pipeline).__name__ != "ResectogramPipeline", (
+        "the SHARED anatomy view wrongly got a ResectogramPipeline — the "
+        "creator still fires for every 3D view (ResectogramPipeline.py "
+        "tryCreate gates only on vtkMRMLViewNode).  T3-g1 must tighten it to "
+        "the dedicated view's singleton tag (ADR-0013 §1 disjoint keying)."
+    )
+
+
+def test_strip_actor_absent_from_shared_renderer(layerdm_resectogram_view):
+    """The flattened-surface strip actor lives in the dedicated renderer ONLY.
+
+    Pins ADR-0023 §Stage-4 at the renderer level: the
+    ``FlattenedSurfaceRepresentation``'s strip actor
+    (``GetResectionActor2D``) must be present in the dedicated view's
+    renderer and ABSENT from the shared anatomy view's renderer collection.
+    This is the visible consequence of the dispatch invariant — the strip
+    rendering into the shared anatomy renderer is the bug T3-g1 fixes.
+
+    RED-by-design (ADR-0027): today the creator fires for the shared view too,
+    so its ResectogramPipeline attaches the strip actor to the shared
+    renderer.  GREEN once T3-g1 tightens the creator.
+    """
+    import slicer
+
+    shared_widget, shared_manager = layerdm_resectogram_view["shared"]
+    dedicated_widget, dedicated_manager = layerdm_resectogram_view["dedicated"]
+
+    display = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLResectogramDisplayNode")
+    shared_widget.threeDView().forceRender()
+    dedicated_widget.threeDView().forceRender()
+
+    dedicated_pipeline = dedicated_manager.GetNodePipeline(display)
+    assert (
+        dedicated_pipeline is not None
+        and type(dedicated_pipeline).__name__ == "ResectogramPipeline"
+    ), (
+        "no ResectogramPipeline on the dedicated view — cannot locate the "
+        "strip actor (precondition for the renderer-ownership invariant)."
+    )
+
+    flattened = dedicated_pipeline.GetFlattenedSurfaceRepresentation()
+    assert flattened is not None, (
+        "the dedicated ResectogramPipeline has no FlattenedSurfaceRepresentation "
+        "— the strip assembly (ADR-0013 §6) is not built."
+    )
+    strip_actor = flattened.GetResectionActor2D()
+    assert strip_actor is not None, (
+        "the FlattenedSurfaceRepresentation exposes no 2D strip actor "
+        "(GetResectionActor2D) — nothing to locate in a renderer."
+    )
+
+    dedicated_renderer = _first_renderer(dedicated_widget)
+    shared_renderer = _first_renderer(shared_widget)
+
+    assert _renderer_owns_actor(dedicated_renderer, strip_actor), (
+        "the resectogram strip actor is NOT in the dedicated view's renderer "
+        "— the dedicated Pipeline did not attach it (ADR-0023 §Stage-4)."
+    )
+    assert not _renderer_owns_actor(shared_renderer, strip_actor), (
+        "the resectogram strip actor is present in the SHARED anatomy "
+        "renderer — the flattened strip is bleeding into the shared 3D view "
+        "(the T3-g1 bug).  T3-g1 must tighten tryCreate so the creator never "
+        "fires for the shared view (ADR-0013 §1; ADR-0023 §Stage-4)."
+    )

--- a/Testing/Python/workflow/test_resectogram_pipeline_dispatch.py
+++ b/Testing/Python/workflow/test_resectogram_pipeline_dispatch.py
@@ -198,17 +198,19 @@ def _first_renderer(view_widget):
 def _renderer_owns_actor(renderer, actor) -> bool:
     """Whether ``actor`` is in ``renderer``'s actor collection.
 
-    Walks ``GetActors()`` by VTK-object identity (``IsSameObject``) rather
-    than Python ``is`` — PythonQt/VTK can hand back distinct Python wrappers
-    around the same C++ ``vtkActor``.
+    Walks ``GetActors()`` by VTK-object identity (the C++ pointer the
+    wrapper reports via ``GetAddressAsString("")``) rather than Python
+    ``is`` — PythonQt/VTK can hand back distinct Python wrappers around the
+    same C++ ``vtkActor``, so identity must be compared at the C++ level.
     """
     if renderer is None or actor is None:
         return False
+    target = actor.GetAddressAsString("")
     actors = renderer.GetActors()
     actors.InitTraversal()
     for _ in range(actors.GetNumberOfItems()):
         candidate = actors.GetNextActor()
-        if candidate is not None and candidate.IsSameObject(actor):
+        if candidate is not None and candidate.GetAddressAsString("") == target:
             return True
     return False
 


### PR DESCRIPTION
## #483 — Side-panel resectogram view (accumulating; T3-g1 keystone landed)

First sub-task of #483 (the dedicated resectogram render home + blur + placement + locator + baselines). This is the **keystone**: the resectogram now renders into its own dedicated view, not the shared 3D-view renderer.

### T3-g1 — dedicated singleton view + creator tightening
- **Root cause fixed:** `ResectogramPipeline.tryCreate` gated only on `isinstance(viewNode, vtkMRMLViewNode)`, so it fired for **every** 3D view (incl. the shared anatomy view) — that's why the flattened strip was rendering into the shared renderer.
- New `ResectogramViewManager` — a **singleton** dedicated `vtkMRMLViewNode` (`SetSingletonTag("LiverResectogram")` + custom layout name/label, box/axis off), SlicerHyperProbe pattern. **No custom DisplayableManager** (reuses the upstream LayerDM DM).
- `tryCreate` now also gates on `GetSingletonTag() == "LiverResectogram"` → the Pipeline dispatches **only** into the dedicated view.
- Arena + scenarios updated to tag their view so the tightened creator still fires.

### Tests (RED→GREEN, ADR-0027)
- `test_creator_fires_only_in_dedicated_view` — Pipeline on the dedicated view, NOT the shared anatomy view.
- `test_strip_actor_absent_from_shared_renderer` — strip actor in the dedicated renderer, absent from the shared.
- Verified GREEN on GPU (8 passed dispatch+arena; arena lit-pixel ran, not skipped); full unit suite 108 passed.

### Still to come on this branch (#483)
T3-g2 blur render pass on the dedicated window · T3-g3 `[Open resectogram view ▶]` Stage-4 action (gated on active resection + distance-map availability) · T3-g5 locator/hover (pixel→(u,v)→3D, ADR-0025) · T3-g4 v2-direct baselines.

## ADR references
ADR-0013 §1/§5/§6 (one Pipeline per display-node type; no custom DM), ADR-0023 §Stage-4 (dedicated resectogram view).

## UX impact
N/A this tranche — render-target plumbing; the user-facing [Open resectogram view] action + side-panel placement land in T3-g3.

_Authored by the Claude (claude-opus-4-8) agent fleet under maintainer steering._