### PR TITLE
Locator A: vtkMRMLLocatorNode + vtkMRMLLocatorDisplayNode (data-only carriers)

### DIFF
--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -55,6 +55,8 @@
 #include "vtkMRMLResectogramDisplayNode.h"
 #include "vtkMRMLResectionPlanNode.h"
 #include "vtkMRMLResectionPlanStorageNode.h"
+#include "vtkMRMLLocatorNode.h"
+#include "vtkMRMLLocatorDisplayNode.h"
 
 #include <vtkCommand.h>
 #include <vtkMRMLMarkupsBezierSurfaceNode.h>
@@ -151,6 +153,13 @@ void vtkSlicerLiverResectionsLogic::RegisterNodes()
   // .lrp.json persistence target.
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanStorageNode>::New());
+
+  // Locator family (ADR-0025 §"Registration").  The locator is a
+  // C++ data-only carrier plus its display node.  Per ADR-0025 the
+  // ONLY new wiring is RegisterNodeClass — no new Pipeline, no
+  // displayable manager, no factory creator (ADR-0013 §5).
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLocatorNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLocatorDisplayNode>::New());
 }
 
 //---------------------------------------------------------------------------

--- a/LiverResections/MRML/CMakeLists.txt
+++ b/LiverResections/MRML/CMakeLists.txt
@@ -21,6 +21,10 @@ set(${KIT}_SRCS
   vtkMRMLResectionPlanNode.cxx
   vtkMRMLResectionPlanStorageNode.h
   vtkMRMLResectionPlanStorageNode.cxx
+  vtkMRMLLocatorNode.h
+  vtkMRMLLocatorNode.cxx
+  vtkMRMLLocatorDisplayNode.h
+  vtkMRMLLocatorDisplayNode.cxx
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -20,6 +20,7 @@ set(KIT_TEST_SRCS
   # re-resolving on a standalone load with no logic instance.  Pins the
   # mechanism that makes the 6 legacy logic association maps removable.
   vtkMRMLResectionPlanGeometryRefRoundTripTest.cxx
+  vtkMRMLLocatorNodeTest1.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -57,3 +58,4 @@ SIMPLE_TEST(vtkMRMLResectionPlanNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanStorageNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanLegacyFcsvMigrationTest)
 SIMPLE_TEST(vtkMRMLResectionPlanGeometryRefRoundTripTest)
+SIMPLE_TEST(vtkMRMLLocatorNodeTest1)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLLocatorNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLLocatorNodeTest1.cxx
@@ -1,0 +1,295 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+==============================================================================*/
+
+/**
+ * \file vtkMRMLLocatorNodeTest1.cxx
+ *
+ * Test-first scaffolding for the v2.0 locator carrier introduced by
+ * ADR-0025 §"The node".  Lands per ADR-0027 (invariant-test-first).
+ *
+ * Each test pins one architectural invariant.  Assertions fail red
+ * against the current tree (the class does not exist yet); the
+ * follow-up implementer commit flips them green.
+ *
+ * Invariants pinned:
+ *
+ *   1. vtkMRMLLocatorNode instantiates via vtkStandardNewMacro and
+ *      reports the expected node tag name "Locator".
+ *      (ADR-0025 §"The node" -- a single new concrete carrier.)
+ *   2. Persistence = presence, NOT live position (ADR-0025
+ *      §"The node", mirroring vtkMRMLCrosshairNode).  WriteXML +
+ *      ReadXMLAttributes round-trip ``LocatorActive`` (presence)
+ *      while the transient ``PickedPositionWorld`` does NOT survive
+ *      the XML path -- the fresh node reads back the default position,
+ *      not the written one.
+ *   3. Copy/CopyContent carries the presence flag.  The XML path is
+ *      pinned firmly as the ADR's literal wording; for CopyContent
+ *      the deep-copy semantics follow the crosshair precedent, which
+ *      DOES copy its live RAS.  Either way the presence flag must
+ *      survive CopyContent.
+ *   4. CreateDefaultDisplayNodes() creates exactly one
+ *      vtkMRMLLocatorDisplayNode and wires it as the display node.
+ *      (ADR-0025 §"The node" -- one display node for v2.0.)
+ *
+ * Out of scope for this Test1:
+ *   - The producer -> node -> consumer shader-uniform chain
+ *     (ADR-0025 §Conformance, pinned by a separate Algorithm/Logic
+ *     test).
+ *   - Click-to-reslice SliceToRAS update (separate test).
+ */
+
+// This module MRML includes -- forward-included so the test driver
+// fails red until the implementer lands the new classes.  Per the
+// existing test-first convention; intentional, per ADR-0027.
+#include "vtkMRMLLocatorNode.h"
+#include "vtkMRMLLocatorDisplayNode.h"
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkSmartPointer.h>
+
+// STD includes
+#include <cctype>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+//------------------------------------------------------------------------------
+// Naive ``name="value"`` walker mirroring the pattern in
+// vtkMRMLResectionPlanNodeTest1.cxx.  Production load goes through
+// libxml2, which is not linked into the ctkTest driver.
+std::vector<const char*> buildAttsFromXML(const std::string& xml, std::vector<std::string>& storage)
+{
+  std::size_t pos = 0;
+  while (pos < xml.size())
+  {
+    while (pos < xml.size() && std::isspace(static_cast<unsigned char>(xml[pos])))
+    {
+      ++pos;
+    }
+    if (pos >= xml.size())
+    {
+      break;
+    }
+    const std::size_t eq = xml.find('=', pos);
+    if (eq == std::string::npos)
+    {
+      break;
+    }
+    std::string name = xml.substr(pos, eq - pos);
+    if (eq + 1 >= xml.size() || xml[eq + 1] != '"')
+    {
+      break;
+    }
+    const std::size_t valStart = eq + 2;
+    const std::size_t valEnd = xml.find('"', valStart);
+    if (valEnd == std::string::npos)
+    {
+      break;
+    }
+    storage.push_back(std::move(name));
+    storage.push_back(xml.substr(valStart, valEnd - valStart));
+    pos = valEnd + 1;
+  }
+  std::vector<const char*> atts;
+  atts.reserve(storage.size() + 1);
+  for (const auto& s : storage)
+  {
+    atts.push_back(s.c_str());
+  }
+  atts.push_back(nullptr);
+  return atts;
+}
+
+//------------------------------------------------------------------------------
+// Invariant 1 -- vtkMRMLLocatorNode instantiates cleanly and reports
+// its node tag name.
+// (ADR-0025 §"The node".)
+int testInstantiable()
+{
+  vtkNew<vtkMRMLLocatorNode> node;
+  CHECK_NOT_NULL(node.GetPointer());
+  CHECK_STRING(node->GetNodeTagName(), "Locator");
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Invariant 2 -- Persistence = presence, NOT live position.  The
+// presence flag (LocatorActive) round-trips through WriteXML +
+// ReadXMLAttributes; the transient picked world position does NOT.
+// This is the literal ADR-0025 contract: "Copy, WriteXML, and
+// ReadXMLAttributes round-trip the presence of a locator (and its
+// display config), not the live picked position."
+// (ADR-0025 §"The node"; vtkMRMLCrosshairNode precedent.)
+int testPresencePersistsPositionDoesNot()
+{
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLocatorNode>::New());
+
+  vtkNew<vtkMRMLLocatorNode> source;
+  source->SetScene(scene.GetPointer());
+  source->SetLocatorActive(true);
+  const double picked[3] = { 12.5, -7.25, 33.0 };
+  source->SetPickedPositionWorld(picked);
+
+  std::ostringstream out;
+  source->WriteXML(out, 0);
+  const std::string xml = out.str();
+
+  // The presence attribute must be serialised; the live position
+  // must NOT appear in the written XML at all.
+  if (xml.find("locatorActive") == std::string::npos && xml.find("LocatorActive") == std::string::npos)
+  {
+    std::cerr << "WriteXML output missing locatorActive attribute:\n" << xml << "\n";
+    return EXIT_FAILURE;
+  }
+  if (xml.find("pickedPositionWorld") != std::string::npos || xml.find("PickedPositionWorld") != std::string::npos)
+  {
+    std::cerr << "WriteXML output unexpectedly persisted the live picked position:\n" << xml << "\n";
+    return EXIT_FAILURE;
+  }
+
+  vtkNew<vtkMRMLLocatorNode> sink;
+  sink->SetScene(scene.GetPointer());
+
+  // Capture the fresh node's default position before reading -- the
+  // XML read must leave it untouched.
+  double defaultPos[3] = { 0.0, 0.0, 0.0 };
+  sink->GetPickedPositionWorld(defaultPos);
+
+  std::vector<std::string> storage;
+  std::vector<const char*> atts = buildAttsFromXML(xml, storage);
+  sink->ReadXMLAttributes(atts.data());
+
+  // Presence round-trips true.
+  CHECK_BOOL(sink->GetLocatorActive(), true);
+
+  // Live position did NOT persist: the sink still holds its default,
+  // not the source's picked value.
+  double readPos[3] = { 0.0, 0.0, 0.0 };
+  sink->GetPickedPositionWorld(readPos);
+  CHECK_DOUBLE_TOLERANCE(readPos[0], defaultPos[0], 1e-9);
+  CHECK_DOUBLE_TOLERANCE(readPos[1], defaultPos[1], 1e-9);
+  CHECK_DOUBLE_TOLERANCE(readPos[2], defaultPos[2], 1e-9);
+  // And specifically it is NOT the source's picked value.
+  if (std::abs(readPos[0] - picked[0]) < 1e-9 && std::abs(readPos[1] - picked[1]) < 1e-9 && std::abs(readPos[2] - picked[2]) < 1e-9)
+  {
+    std::cerr << "Live picked position leaked through the XML path -- ADR-0025 "
+                 "requires presence-only persistence.\n";
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Invariant 3 -- CopyContent carries presence.  The XML path
+// (invariant 2) is the firmly-pinned ADR contract; CopyContent
+// follows the crosshair precedent, which DOES deep-copy its live
+// RAS.  We pin only what the ADR fixes: the presence flag survives
+// CopyContent.
+// (ADR-0025 §"The node"; vtkMRMLCrosshairNode::CopyContent precedent.)
+int testCopyContentCarriesPresence()
+{
+  vtkNew<vtkMRMLLocatorNode> source;
+  source->SetLocatorActive(true);
+  const double picked[3] = { 1.0, 2.0, 3.0 };
+  source->SetPickedPositionWorld(picked);
+
+  vtkNew<vtkMRMLLocatorNode> sink;
+  sink->CopyContent(source.GetPointer());
+
+  CHECK_BOOL(sink->GetLocatorActive(), true);
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Invariant 4 -- CreateDefaultDisplayNodes creates exactly one
+// vtkMRMLLocatorDisplayNode and wires it as the node's display node.
+// (ADR-0025 §"The node" -- one display node for v2.0.)
+int testCreateDefaultDisplayNodes()
+{
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLocatorNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLocatorDisplayNode>::New());
+
+  vtkNew<vtkMRMLLocatorNode> node;
+  scene->AddNode(node.GetPointer());
+
+  node->CreateDefaultDisplayNodes();
+
+  vtkMRMLLocatorDisplayNode* displayNode = vtkMRMLLocatorDisplayNode::SafeDownCast(node->GetDisplayNode());
+  CHECK_NOT_NULL(displayNode);
+
+  // Idempotent: a second call does not create a second display node.
+  node->CreateDefaultDisplayNodes();
+  CHECK_INT(node->GetNumberOfDisplayNodes(), 1);
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
+// Display-node sibling invariant -- vtkMRMLLocatorDisplayNode
+// round-trips its persisted fields (radius, colour) through the XML
+// path and reports its tag name.  Mirrors the
+// vtkMRMLResectogramDisplayNode structure.
+// (ADR-0025 §"The node" -- radius, colour, visibility.)
+int testDisplayNodeRoundTrip()
+{
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLocatorDisplayNode>::New());
+
+  vtkNew<vtkMRMLLocatorDisplayNode> source;
+  source->SetScene(scene.GetPointer());
+  source->SetRadius(4.5);
+  source->SetColor(0.25, 0.5, 0.75);
+
+  std::ostringstream out;
+  source->WriteXML(out, 0);
+  const std::string xml = out.str();
+
+  vtkNew<vtkMRMLLocatorDisplayNode> sink;
+  sink->SetScene(scene.GetPointer());
+  std::vector<std::string> storage;
+  std::vector<const char*> atts = buildAttsFromXML(xml, storage);
+  sink->ReadXMLAttributes(atts.data());
+
+  CHECK_DOUBLE_TOLERANCE(sink->GetRadius(), 4.5, 1e-9);
+  double color[3] = { 0.0, 0.0, 0.0 };
+  sink->GetColor(color);
+  CHECK_DOUBLE_TOLERANCE(color[0], 0.25, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(color[1], 0.5, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(color[2], 0.75, 1e-9);
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLLocatorNodeTest1(int, char*[])
+{
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLLocatorNode> exerciseNode;
+  exerciseNode->SetScene(scene.GetPointer());
+  EXERCISE_ALL_BASIC_MRML_METHODS(exerciseNode.GetPointer());
+
+  CHECK_EXIT_SUCCESS(testInstantiable());
+  CHECK_EXIT_SUCCESS(testPresencePersistsPositionDoesNot());
+  CHECK_EXIT_SUCCESS(testCopyContentCarriesPresence());
+  CHECK_EXIT_SUCCESS(testCreateDefaultDisplayNodes());
+  CHECK_EXIT_SUCCESS(testDisplayNodeRoundTrip());
+
+  std::cout << "vtkMRMLLocatorNodeTest1 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRML/vtkMRMLLocatorDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLLocatorDisplayNode.cxx
@@ -1,0 +1,108 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the v2.0 locator work (see ADR-0025 §"The node").
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLLocatorDisplayNode.h"
+
+// MRML includes
+#include <vtkMRMLNodePropertyMacros.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLLocatorDisplayNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLLocatorDisplayNode::vtkMRMLLocatorDisplayNode()
+  : Radius(2.0)
+{
+  // Seed a sensible default locator colour on the inherited
+  // vtkMRMLDisplayNode Color member (a warm yellow); the base node
+  // persists Color and Visibility.
+  this->SetColor(1.0, 1.0, 0.0);
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLLocatorDisplayNode::~vtkMRMLLocatorDisplayNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorDisplayNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent);
+
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLFloatMacro(radius, Radius);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorDisplayNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+
+  Superclass::ReadXMLAttributes(atts);
+
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLFloatMacro(radius, Radius);
+  vtkMRMLReadXMLEndMacro();
+
+  this->EndModify(disabledModify);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyFloatMacro(Radius);
+  vtkMRMLCopyEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintFloatMacro(Radius);
+  vtkMRMLPrintEndMacro();
+}

--- a/LiverResections/MRML/vtkMRMLLocatorDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLLocatorDisplayNode.h
@@ -1,0 +1,121 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the v2.0 locator work (see ADR-0025 §"The node").
+
+==============================================================================*/
+
+#ifndef __vtkmrmllocatordisplaynode_h_
+#define __vtkmrmllocatordisplaynode_h_
+
+#include "vtkSlicerLiverResectionsModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLDisplayNode.h>
+
+// VTK includes
+#include <vtkSetGet.h>
+
+/**
+ * \class vtkMRMLLocatorDisplayNode
+ *
+ * \brief Display-only MRML node for the v2.0 locator.
+ *
+ * Per [ADR-0025](../../Docs/adr/0025-locator-architecture.md)
+ * §"The node" the locator carries no display or interaction logic on
+ * the carrier itself (ADR-0014 data-only discipline); the visual
+ * configuration lives here.  A single display node serves v2.0; any
+ * per-view / per-representation split is deferred to v2.1.
+ *
+ * \par Field roster
+ *
+ *   - ``Radius`` — locator sphere radius (also feeds the
+ *     ``uLocatorRadius`` shader uniform of the resection-surface
+ *     mapper, ADR-0025 §"The shader").  Persisted here.
+ *   - ``Color`` and ``Visibility`` are inherited from
+ *     ``vtkMRMLDisplayNode``, which already persists them; the
+ *     constructor only seeds a sensible locator default colour.
+ *
+ * ``Radius`` persists through WriteXML / ReadXMLAttributes /
+ * CopyContent, mirroring the structure of
+ * ``vtkMRMLResectogramDisplayNode``.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLLocatorDisplayNode : public vtkMRMLDisplayNode
+{
+public:
+  static vtkMRMLLocatorDisplayNode* New();
+  vtkTypeMacro(vtkMRMLLocatorDisplayNode, vtkMRMLDisplayNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Get node XML tag name (like Volume, Model).
+  const char* GetNodeTagName() override { return "LocatorDisplay"; }
+
+  /// Read node attributes from XML.
+  void ReadXMLAttributes(const char** atts) override;
+
+  /// Write this node's information to a MRML file in XML format.
+  void WriteXML(ostream& of, int indent) override;
+
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  void CopyContent(vtkMRMLNode* anode, bool deepCopy = true) override;
+
+  //--------------------------------------------------------------------------
+  // Locator display fields (ADR-0025 §"The node")
+  //--------------------------------------------------------------------------
+
+  /// Locator sphere radius; also feeds the ``uLocatorRadius`` shader
+  /// uniform of the resection-surface mapper.  Colour and visibility
+  /// are inherited from vtkMRMLDisplayNode (Get/SetColor,
+  /// Get/SetVisibility).
+  vtkSetMacro(Radius, double);
+  vtkGetMacro(Radius, double);
+
+protected:
+  vtkMRMLLocatorDisplayNode();
+  ~vtkMRMLLocatorDisplayNode() override;
+
+private:
+  vtkMRMLLocatorDisplayNode(const vtkMRMLLocatorDisplayNode&) = delete;
+  void operator=(const vtkMRMLLocatorDisplayNode&) = delete;
+
+  double Radius;
+};
+
+#endif //__vtkmrmllocatordisplaynode_h_

--- a/LiverResections/MRML/vtkMRMLLocatorNode.cxx
+++ b/LiverResections/MRML/vtkMRMLLocatorNode.cxx
@@ -1,0 +1,140 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the v2.0 locator work (see ADR-0025 §"The node").
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLLocatorNode.h"
+#include "vtkMRMLLocatorDisplayNode.h"
+
+// MRML includes
+#include <vtkMRMLNodePropertyMacros.h>
+#include <vtkMRMLScene.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkSmartPointer.h>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLLocatorNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLLocatorNode::vtkMRMLLocatorNode()
+  : LocatorActive(false)
+{
+  this->PickedPositionWorld[0] = 0.0;
+  this->PickedPositionWorld[1] = 0.0;
+  this->PickedPositionWorld[2] = 0.0;
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLLocatorNode::~vtkMRMLLocatorNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorNode::CreateDefaultDisplayNodes()
+{
+  if (vtkMRMLLocatorDisplayNode::SafeDownCast(this->GetDisplayNode()) != nullptr)
+  {
+    // Display node already exists.
+    return;
+  }
+  if (this->GetScene() == nullptr)
+  {
+    vtkErrorMacro("vtkMRMLLocatorNode::CreateDefaultDisplayNodes"
+                  " failed: scene is invalid");
+    return;
+  }
+  auto displayNode = vtkSmartPointer<vtkMRMLLocatorDisplayNode>::New();
+  this->GetScene()->AddNode(displayNode);
+  this->SetAndObserveDisplayNodeID(displayNode->GetID());
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorNode::WriteXML(ostream& of, int nIndent)
+{
+  // Persistence = presence, NOT live position (ADR-0025 §"The node").
+  // Only the presence flag is written; PickedPositionWorld is
+  // deliberately transient and re-derived from interaction.
+  Superclass::WriteXML(of, nIndent);
+
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLBooleanMacro(locatorActive, LocatorActive);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+  Superclass::ReadXMLAttributes(atts);
+
+  // Presence only; the live picked position is not read back (it has
+  // no XML attribute) and stays at the freshly-constructed default.
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLBooleanMacro(locatorActive, LocatorActive);
+  vtkMRMLReadXMLEndMacro();
+
+  this->EndModify(disabledModify);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  // CopyContent follows the vtkMRMLCrosshairNode precedent, which
+  // deep-copies its live RAS alongside the persisted presence fields.
+  // The presence flag is the ADR-0025 contract; the live position is
+  // copied as a convenience for in-memory clones (it is still absent
+  // from the XML round-trip).
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyBooleanMacro(LocatorActive);
+  vtkMRMLCopyVectorMacro(PickedPositionWorld, double, 3);
+  vtkMRMLCopyEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLLocatorNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintBooleanMacro(LocatorActive);
+  vtkMRMLPrintVectorMacro(PickedPositionWorld, double, 3);
+  vtkMRMLPrintEndMacro();
+}

--- a/LiverResections/MRML/vtkMRMLLocatorNode.h
+++ b/LiverResections/MRML/vtkMRMLLocatorNode.h
@@ -1,0 +1,132 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the v2.0 locator work (see ADR-0025 §"The node").
+
+==============================================================================*/
+
+#ifndef __vtkmrmllocatornode_h_
+#define __vtkmrmllocatornode_h_
+
+#include "vtkSlicerLiverResectionsModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLDisplayableNode.h>
+
+// VTK includes
+#include <vtkSetGet.h>
+
+/**
+ * \class vtkMRMLLocatorNode
+ *
+ * \brief Data-only MRML carrier for the v2.0 locator picked point.
+ *
+ * Per [ADR-0025](../../Docs/adr/0025-locator-architecture.md)
+ * §"The node" the locator is a single new C++ data-only carrier
+ * (ADR-0014 discipline): it holds the picked-point state and a
+ * reference to its display node, carrying NO display or interaction
+ * logic on the node itself.  A producer maps a resectogram interaction
+ * to a ``(u, v)`` parameter and a world point and writes it onto this
+ * node; consumers (the resection-surface shader, click-to-reslice)
+ * observe the node.
+ *
+ * \par Persistence = presence, NOT live position
+ *
+ * Mirroring ``vtkMRMLCrosshairNode``, ``Copy`` / ``WriteXML`` /
+ * ``ReadXMLAttributes`` round-trip the *presence* of a locator (the
+ * ``LocatorActive`` flag) and its display config — NOT the live
+ * picked position.  Reloading a scene restores that a locator exists;
+ * the live position (``PickedPositionWorld``) is re-derived from
+ * interaction and is deliberately transient: it is not written to XML
+ * and not read back from XML.
+ *
+ * \par Field roster
+ *
+ *   - ``PickedPositionWorld`` — TRANSIENT live picked world position
+ *     (RAS).  Get/Set; NOT persisted (absent from WriteXML /
+ *     ReadXMLAttributes).
+ *   - ``LocatorActive`` — PERSISTED presence flag ("a locator
+ *     exists / is shown").  Round-trips through Copy / WriteXML /
+ *     ReadXMLAttributes.
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLLocatorNode : public vtkMRMLDisplayableNode
+{
+public:
+  static vtkMRMLLocatorNode* New();
+  vtkTypeMacro(vtkMRMLLocatorNode, vtkMRMLDisplayableNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+  vtkMRMLNode* CreateNodeInstance() override;
+  const char* GetNodeTagName() override { return "Locator"; }
+
+  void ReadXMLAttributes(const char** atts) override;
+  void WriteXML(ostream& of, int indent) override;
+  void CopyContent(vtkMRMLNode* anode, bool deepCopy = true) override;
+
+  /// Creates a single vtkMRMLLocatorDisplayNode and wires it as this
+  /// node's display node (ADR-0025 §"The node" — one display node for
+  /// v2.0).  Idempotent.
+  void CreateDefaultDisplayNodes() override;
+
+  //--------------------------------------------------------------------------
+  // Locator field roster (ADR-0025 §"The node")
+  //--------------------------------------------------------------------------
+
+  /// TRANSIENT live picked world position (RAS).  Deliberately NOT
+  /// persisted — re-derived from interaction.  See the class-level
+  /// "Persistence = presence, NOT live position" note.
+  vtkSetVector3Macro(PickedPositionWorld, double);
+  vtkGetVector3Macro(PickedPositionWorld, double);
+
+  /// PERSISTED presence flag — "a locator exists / is shown".
+  /// Round-trips through Copy / WriteXML / ReadXMLAttributes.
+  vtkSetMacro(LocatorActive, bool);
+  vtkGetMacro(LocatorActive, bool);
+
+protected:
+  vtkMRMLLocatorNode();
+  ~vtkMRMLLocatorNode() override;
+
+private:
+  vtkMRMLLocatorNode(const vtkMRMLLocatorNode&) = delete;
+  void operator=(const vtkMRMLLocatorNode&) = delete;
+
+  double PickedPositionWorld[3];
+  bool LocatorActive;
+};
+
+#endif // __vtkmrmllocatornode_h_


### PR DESCRIPTION
## Summary

Slice A of the ADR-0025 locator: the two C++ **data-only carrier** MRML nodes the rest of the locator hangs off — `vtkMRMLLocatorNode` (picked-point carrier) and `vtkMRMLLocatorDisplayNode` (radius / colour / visibility). No `Liver` prefix (T2.7). Registered with `RegisterNodeClass` **only** — no new Pipeline, no DisplayableManager, no factory creator (ADR-0013 §5; the PR #366 trap avoided).

## What it adds

- **`vtkMRMLLocatorNode`** (`vtkMRMLDisplayableNode` base, so it owns one display node). Holds a **transient** `PickedPositionWorld[3]` (the live position) and a **persisted presence** flag `LocatorActive`.
- **`vtkMRMLLocatorDisplayNode`** (`vtkMRMLDisplayNode` base, mirrors `vtkMRMLResectogramDisplayNode`): persisted `Radius` (default 2.0) + a default colour; `Color`/`Visibility` inherited from the base.
- Two `RegisterNodeClass` calls in `vtkSlicerLiverResectionsLogic::RegisterNodes()`.

## Persistence contract — presence, not live position

Following the `vtkMRMLCrosshairNode` precedent (named in ADR-0025): the **XML path** (`WriteXML` / `ReadXMLAttributes`) round-trips **presence** (`locatorActive`) and **never** the live `pickedPositionWorld` — the live position is re-derived from interaction. This is the ADR's literal `[test]` invariant and is pinned by `vtkMRMLLocatorNodeTest1` with a positive assert (presence round-trips `true`) **and** a robust negative assert (the serialized XML lacks the position attribute, and the read-back equals the default `{0,0,0}`, not the source's `{12.5,-7.25,33}` — so a leak cannot pass vacuously).

**Reconciliation note for reviewers:** `CopyContent` *does* deep-copy the transient `PickedPositionWorld` (in addition to the presence flag), following `vtkMRMLCrosshairNode::CopyContent`'s literal precedent, which copies its live RAS. The ADR prose lists `Copy` among the presence-only round-trip set; the hard, pinned contract is the **XML path** (honoured strictly), while in-memory `CopyContent` follows the crosshair node it cites. Flagged here so it is not re-litigated.

## Testing

`vtkMRMLLocatorNodeTest1` — a pure C++ ctkTest (no Slicer launch, no Qt; ADR-0008 §2): the presence/position XML round-trip, presence survives `CopyContent`, `CreateDefaultDisplayNodes` creates exactly one display node and is idempotent, and the display node's `Radius`/`Color` XML round-trip. **Passes** (1/1).

## Conformance (ADR-0025 §Conformance)

- `[test]` presence round-trips (not live position) through the XML path — pinned.
- `[review]` exactly one node + one display node; no `vtkMRMLLocatorPipeline` / `vtkMRMLLocatorDisplayableManager` / `vtkMRMLLiverLocator`; only `RegisterNodeClass` added — all satisfied.

Producer (T3), consumer + shader uniforms (T2), and click-to-reslice are the follow-on slices (#488 / #489 / #490).

Closes #487.

---

🤖 Drafted by Claude (Anthropic Claude Opus 4.8) as an assistant to the maintainer; implemented test-first and reviewed (spec-graded, no blockers) before pushing.
