### PR TITLE
Locator C (shader half): uLocatorPosition / uLocatorRadius on the Bezier resection mapper

### DIFF
--- a/LiverResections/VTKWidgets/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/VTKWidgets/Testing/Cxx/CMakeLists.txt
@@ -11,6 +11,7 @@ set(KIT vtkSlicer${MODULE_NAME}ModuleVTKWidgets)
 set(KIT_TEST_SRCS
   vtkLiverBezierWidgetTest1.cxx
   vtkOpenGLLiverResectionMappersRelocationTest1.cxx
+  vtkOpenGLBezierResectionPolyDataMapperLocatorTest1.cxx
   vtkOpenGLDistanceContourMapperSpheroidSSOTTest.cxx
   )
 
@@ -43,6 +44,7 @@ target_link_libraries(${KIT}CxxTests
 
 SIMPLE_TEST(vtkLiverBezierWidgetTest1)
 SIMPLE_TEST(vtkOpenGLLiverResectionMappersRelocationTest1)
+SIMPLE_TEST(vtkOpenGLBezierResectionPolyDataMapperLocatorTest1)
 
 # GPU-path / SSOT consistency pin for the distance-spheroid init contour
 # (ADR-0014 §2 triaxial-ellipsoid contour, ADR-0015 §"Stack 4" render ==

--- a/LiverResections/VTKWidgets/Testing/Cxx/vtkOpenGLBezierResectionPolyDataMapperLocatorTest1.cxx
+++ b/LiverResections/VTKWidgets/Testing/Cxx/vtkOpenGLBezierResectionPolyDataMapperLocatorTest1.cxx
@@ -1,0 +1,118 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2018-2026, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed by Rafael Palomar (Oslo University
+  Hospital and NTNU) and was supported by The Research Council of Norway
+  through the ALive project (grant nr. 311393).
+
+==============================================================================*/
+
+// LiverResections VTKWidgets includes
+#include "vtkOpenGLBezierResectionPolyDataMapper.h"
+
+// MRML includes (ctkTest assertion macros)
+#include "vtkMRMLCoreTestingMacros.h"
+
+// VTK includes
+#include <vtkNew.h>
+
+// STD includes
+#include <iostream>
+
+// ADR-0025 §Conformance — the GL-free half of "the chain delivers the
+// world point to the mapper as uLocatorPosition".  This pins the locator
+// shader-uniform accessor surface on vtkOpenGLBezierResectionPolyDataMapper:
+// the default off state (LocatorRadius == 0, LocatorPosition == origin) and
+// the round-trip of a RAS world point + radius through the public setters.
+//
+// The GLSL marker rendering itself (uLocatorRadius > 0 draws a white
+// sphere at uLocatorPosition) is GPU/visual-regression and is OUT OF SCOPE
+// for this no-GL, no-Slicer unit test.
+
+namespace
+{
+
+int testLocatorUniformAccessorsDefaultOffState()
+{
+  vtkNew<vtkOpenGLBezierResectionPolyDataMapper> mapper;
+  CHECK_NOT_NULL(mapper.GetPointer());
+
+  // Off state: radius 0 means no marker drawn (ADR-0025).
+  CHECK_DOUBLE(mapper->GetLocatorRadius(), 0.0);
+
+  const float* position = mapper->GetLocatorPosition();
+  CHECK_NOT_NULL(position);
+  CHECK_DOUBLE(position[0], 0.0);
+  CHECK_DOUBLE(position[1], 0.0);
+  CHECK_DOUBLE(position[2], 0.0);
+
+  return EXIT_SUCCESS;
+}
+
+int testLocatorUniformAccessorsRoundTrip()
+{
+  vtkNew<vtkOpenGLBezierResectionPolyDataMapper> mapper;
+
+  mapper->SetLocatorPosition(1.5f, -2.5f, 3.0f);
+  mapper->SetLocatorRadius(4.0f);
+
+  const float* position = mapper->GetLocatorPosition();
+  CHECK_NOT_NULL(position);
+  CHECK_DOUBLE(position[0], 1.5);
+  CHECK_DOUBLE(position[1], -2.5);
+  CHECK_DOUBLE(position[2], 3.0);
+
+  CHECK_DOUBLE(mapper->GetLocatorRadius(), 4.0);
+
+  // The array setter overload must agree with the scalar one.
+  float other[3] = { -1.0f, 0.25f, 7.0f };
+  mapper->SetLocatorPosition(other);
+  const float* position2 = mapper->GetLocatorPosition();
+  CHECK_DOUBLE(position2[0], -1.0);
+  CHECK_DOUBLE(position2[1], 0.25);
+  CHECK_DOUBLE(position2[2], 7.0);
+
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkOpenGLBezierResectionPolyDataMapperLocatorTest1(int, char*[])
+{
+  CHECK_EXIT_SUCCESS(testLocatorUniformAccessorsDefaultOffState());
+  CHECK_EXIT_SUCCESS(testLocatorUniformAccessorsRoundTrip());
+
+  std::cout << "vtkOpenGLBezierResectionPolyDataMapperLocatorTest1 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -78,6 +78,8 @@ public:
     , ResectionClipOut(false)
     , GridDivisions(20)
     , GridThicknessFactor(9.5f)
+    , LocatorPosition{ 0.0f, 0.0f, 0.0f }
+    , LocatorRadius(0.0f)
   {
     this->RasToIjkMatrixT = vtkSmartPointer<vtkMatrix4x4>::New();
     this->IjkToTextureMatrixT = vtkSmartPointer<vtkMatrix4x4>::New();
@@ -98,6 +100,8 @@ public:
   bool ResectionClipOut;
   unsigned int GridDivisions;
   float GridThicknessFactor;
+  float LocatorPosition[3];
+  float LocatorRadius;
 };
 
 //------------------------------------------------------------------------------
@@ -144,6 +148,7 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(std::map<vtkSha
                                "//VTK::PositionVC::Dec\n"
                                "out vec4 vertexMCVSOutput;\n"
                                "out vec4 vertexWCVSOutput;\n"
+                               "out vec4 vertexRASVSOutput;\n"
                                "in vec2  uvCoords;\n"
                                "out vec2 uvCoordsOutput;\n"
                                "uniform mat4 uShiftScale;\n"
@@ -155,7 +160,8 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(std::map<vtkSha
                                "//VTK::PositionVC::Impl\n"
                                "vertexMCVSOutput = vertexMC;\n"
                                "uvCoordsOutput = uvCoords;\n"
-                               "vertexWCVSOutput = uIjkToTexture*uRasToIjk*uShiftScale*vertexMC;\n");
+                               "vertexWCVSOutput = uIjkToTexture*uRasToIjk*uShiftScale*vertexMC;\n"
+                               "vertexRASVSOutput = uShiftScale*vertexMC;\n");
 
   vtkShaderProgram::Substitute(FSSource,
                                "//VTK::PositionVC::Dec",
@@ -178,7 +184,10 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(std::map<vtkSha
                                "uniform int uInterpolatedMargins;\n"
                                "uniform int uGridDivisions;\n"
                                "uniform float uGridThickness;\n"
+                               "uniform vec3 uLocatorPosition;\n"
+                               "uniform float uLocatorRadius;\n"
                                "in vec4 vertexWCVSOutput;\n"
+                               "in vec4 vertexRASVSOutput;\n"
                                "in vec2 uvCoordsOutput;\n"
                                "vec4 fragPositionMC = vertexWCVSOutput;\n");
 
@@ -239,6 +248,14 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(std::map<vtkSha
     "    diffuseColor = vec3(0.0);\n"
     "  } else if ((uvCoordsOutput.x > 0.5 && uvCoordsOutput.y < borderSize) || (uvCoordsOutput.x > 1.0 - borderSize && uvCoordsOutput.y < 0.5) ) {\n"
     "    ambientColor = topRightColor;\n"
+    "    diffuseColor = vec3(0.0);\n"
+    "  }\n"
+
+    // Locator marker (ADR-0025): draws on top of the corner markers where
+    // they overlap.  uLocatorRadius == 0 is the off state.  The colour is
+    // a placeholder white; the locator display node will drive it later.
+    "  if (uLocatorRadius > 0.0 && distance(vertexRASVSOutput.xyz, uLocatorPosition) < uLocatorRadius) {\n"
+    "    ambientColor = vec3(1.0, 1.0, 1.0);\n"
     "    diffuseColor = vec3(0.0);\n"
     "  }\n"
     "}\n");
@@ -367,6 +384,16 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetMapperShaderParameters(vtkOpenGL
   if (cellBO.Program->IsUniformUsed("uGridThickness"))
   {
     cellBO.Program->SetUniformf("uGridThickness", this->Impl->GridThicknessFactor);
+  }
+
+  if (cellBO.Program->IsUniformUsed("uLocatorPosition"))
+  {
+    cellBO.Program->SetUniform3f("uLocatorPosition", this->Impl->LocatorPosition);
+  }
+
+  if (cellBO.Program->IsUniformUsed("uLocatorRadius"))
+  {
+    cellBO.Program->SetUniformf("uLocatorRadius", this->Impl->LocatorRadius);
   }
 
   Superclass::SetMapperShaderParameters(cellBO, ren, actor);
@@ -644,5 +671,42 @@ float vtkOpenGLBezierResectionPolyDataMapper::GetGridThicknessFactor() const
 void vtkOpenGLBezierResectionPolyDataMapper::SetGridThicknessFactor(float thickness)
 {
   this->Impl->GridThicknessFactor = thickness;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+const float* vtkOpenGLBezierResectionPolyDataMapper::GetLocatorPosition() const
+{
+  return this->Impl->LocatorPosition;
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLBezierResectionPolyDataMapper::SetLocatorPosition(float position[3])
+{
+  this->Impl->LocatorPosition[0] = position[0];
+  this->Impl->LocatorPosition[1] = position[1];
+  this->Impl->LocatorPosition[2] = position[2];
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLBezierResectionPolyDataMapper::SetLocatorPosition(float x, float y, float z)
+{
+  this->Impl->LocatorPosition[0] = x;
+  this->Impl->LocatorPosition[1] = y;
+  this->Impl->LocatorPosition[2] = z;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+float vtkOpenGLBezierResectionPolyDataMapper::GetLocatorRadius() const
+{
+  return this->Impl->LocatorRadius;
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLBezierResectionPolyDataMapper::SetLocatorRadius(float radius)
+{
+  this->Impl->LocatorRadius = radius;
   this->Modified();
 }

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
@@ -148,6 +148,18 @@ public:
   /// Get the distance-map texture object set by the representation.
   vtkTextureObject* GetDistanceMapTextureObject() const;
 
+  /// Get the locator marker position (RAS world point, ADR-0025)
+  const float* GetLocatorPosition() const;
+  /// Set the locator marker position (RAS world point, ADR-0025)
+  void SetLocatorPosition(float position[3]);
+  /// Set the locator marker position (RAS world point, ADR-0025)
+  void SetLocatorPosition(float x, float y, float z);
+
+  /// Get the locator marker radius (0 disables the marker, ADR-0025)
+  float GetLocatorRadius() const;
+  /// Set the locator marker radius (0 disables the marker, ADR-0025)
+  void SetLocatorRadius(float radius);
+
 protected:
   vtkOpenGLBezierResectionPolyDataMapper();
   ~vtkOpenGLBezierResectionPolyDataMapper();


### PR DESCRIPTION
## Summary

The **C++ shader-uniform half** of Locator C (#489): `vtkOpenGLBezierResectionPolyDataMapper` gains `uLocatorPosition` / `uLocatorRadius` so the resection-surface shader can draw a locator marker at a world point (ADR-0025). Built on the now-merged Locator A node (#487).

## What it adds

- `vtkInternal`: `LocatorPosition[3]` (default `{0,0,0}`) + `LocatorRadius` (default `0` = off).
- Accessors mirroring the existing `Set/GetResectionMargin` family: `Get/SetLocatorPosition` (array + 3-scalar) and `Get/SetLocatorRadius`.
- Vertex shader: exports `vertexRASVSOutput = uShiftScale*vertexMC` (the RAS world position — `uShiftScale*vertexMC` is what `uRasToIjk` consumes downstream, verified against the existing texture-coord path).
- Fragment shader: `uLocatorPosition`/`uLocatorRadius` decls + a marker block that colours fragments within `uLocatorRadius` of `uLocatorPosition`. It is **added after** the existing corner-marker block (they coexist; corner-marker removal is #380/v2.1, per ADR-0025 Consequences).
- `SetMapperShaderParameters`: `IsUniformUsed`-gated binds for both uniforms.

## Testing

`vtkOpenGLBezierResectionPolyDataMapperLocatorTest1` — a GL-free C++ ctkTest pinning the ADR-0025 §Conformance accessor invariant (default off-state + round-trip of position/radius). **Passes** (1/1). The GLSL marker rendering itself is GPU/visual-regression and out of scope for the unit test.

## Deferred (consumer wiring)

The Python **consumer Representation** that would feed these uniforms from a `vtkMRMLLocatorNode` is **blocked on the T2-mapper-relocation** (ADR-0014 §3): `BezierPlanningRepresentation` still uses a placeholder `vtkPolyDataMapper`, not the real one, so the full node → consumer → `uLocatorPosition` chain cannot close yet. This PR lands the shader plumbing; #489 stays open for the consumer wiring once the relocation lands. See #489 for the scope split.

Part of #489 (ADR-0025 Locator).

---

🤖 Drafted by Claude (Anthropic Claude Opus 4.8) as an assistant to the maintainer.
