### PR TITLE
ENH: Wire BezierPlanningRepresentation to the real resection mapper (T2-mapper-wiring slice 1)

### DIFF
--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -14,20 +14,26 @@ constructed by ``LiverBezierSurfacePipeline.initialize()`` and
 exercised by direct Python instantiation in unit tests.  Full
 integration with Slicer's LayerDM framework happens at T2.6.
 
-Per ADR-0014 §3 the four custom OpenGL mappers
-(``vtkOpenGLBezierResectionPolyDataMapper``,
-``vtkOpenGLSlicingContourPolyDataMapper``,
-``vtkOpenGLDistanceContourPolyDataMapper``,
-``vtkOpenGLResection2DPolyDataMapper``) **relocate** from
-``LiverMarkups/VTKWidgets/`` to ``LiverResections/VTKWidgets/``.  The
-relocation has not landed yet (it is part of the broader T2 cohort,
-not the T2.2 stack); this Representation uses the generic
-``vtkPolyDataMapper`` + ``vtkActor`` pair until that relocation
-completes, at which point the surface mapper field will flip to
-``vtkOpenGLBezierResectionPolyDataMapper`` *without changing the
-Representation's public API*.  Marked with
-``TODO(T2-mapper-relocation)`` at the construction point so the
-swap is mechanical.
+Surface mapper (T2-mapper-wiring)
+---------------------------------
+Per ADR-0014 §3 the four custom OpenGL mappers relocated from
+``LiverMarkups/VTKWidgets/`` to ``LiverResections/VTKWidgets/``.  Inside a
+launched Slicer this Representation drives the relocated, real
+``vtkOpenGLBezierResectionPolyDataMapper`` over the tessellated Bernstein
+patch built by ``vtkBezierSurfaceSource`` + ``vtkPolyDataNormals`` (the same
+pipeline shape v1's ``vtkSlicerBezierSurfaceRepresentation3D`` assembled),
+including the ``uvCoords`` the mapper's vertex shader reads and the
+display-node colour / grid uniforms.  When the wrapped classes are off the
+path — the bare-VTK unit layer — it falls back to a generic
+``vtkPolyDataMapper`` + ``vtkActor`` pair over the raw control mesh so the
+Representation still constructs (``_resolve_vtk_class`` selects the path).
+
+The RAS/IJK transform matrices and the distance-map 3D texture binding are
+NOT wired here: the v2 ``vtkMRMLBezierSurfaceNode`` carries no distance-map
+reference (the v1 markups node did), so there is no node-level source to
+thread, and the fragment shader degrades gracefully when no ``distanceTexture``
+is bound.  Those wait on a follow-on that gives the v2 node a distance-map
+reference.
 
 Renderer attachment
 -------------------
@@ -87,6 +93,19 @@ except ImportError:  # pragma: no cover — pure-Python path
 DEFAULT_RESECTION_COLOR = (1.0, 1.0, 1.0)
 DEFAULT_RESECTION_OPACITY = 1.0
 
+# The relocated real surface mapper + the Bezier tessellation source (ADR-0014
+# §3).  Both are wrapped-C++ classes reachable only inside a launched Slicer;
+# ``_resolve_vtk_class`` falls back to ``None`` in the bare-VTK unit layer, in
+# which case the Representation builds a generic ``vtkPolyDataMapper`` pipeline
+# so it still constructs (the structural / colour bookkeeping stays testable).
+REAL_SURFACE_MAPPER_CLASS = "vtkOpenGLBezierResectionPolyDataMapper"
+BEZIER_SURFACE_SOURCE_CLASS = "vtkBezierSurfaceSource"
+
+# Tessellation resolution of the Bezier patch, carried forward verbatim from
+# the v1 ``vtkSlicerBezierSurfaceRepresentation3D`` ctor (``SetResolution(20,
+# 20)``) so the rendered surface matches the legacy visual baseline.
+BEZIER_SURFACE_RESOLUTION = 20
+
 
 class BezierPlanningRepresentation:
     """VTK assembly for the Planning-state Bezier surface.
@@ -110,19 +129,15 @@ class BezierPlanningRepresentation:
 
     Grid rendering
     --------------
-    The 4×4 control grid is **not** rendered as a separate actor.  Per
-    ADR-0014 §3 the relocated ``vtkOpenGLBezierResectionPolyDataMapper``
-    overlays the grid as a fragment-shader feature on the *surface*
-    mapper itself — the legacy mapper at
-    ``LiverMarkups/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp:281``
-    draws it procedurally via ``uGridDivisions`` / ``uGridThickness`` /
-    ``uResectionGridColor`` uniforms tested against
-    ``uvCoordsOutput``.  This skeleton therefore renders only the
-    surface actor; the display node's ``GridVisibility`` /
-    ``GridDivisions`` / ``GridThickness`` / ``ResectionGridColor``
-    fields are stored on the node and will be plumbed into the mapper's
-    uniforms when the relocation happens (``TODO(T2-mapper-relocation)``
-    in ``_build_vtk_pipeline``).
+    The control grid is **not** rendered as a separate actor.  Per
+    ADR-0014 §3 the ``vtkOpenGLBezierResectionPolyDataMapper`` overlays the
+    grid as a fragment-shader feature on the *surface* mapper itself, drawing
+    it procedurally via ``uGridDivisions`` / ``uGridThickness`` /
+    ``uResectionGridColor`` uniforms tested against ``uvCoordsOutput``.  The
+    Representation renders only the surface actor and plumbs the display node's
+    ``Grid3DVisibility`` / ``GridDivisions`` / ``GridThickness`` /
+    ``ResectionGridColor`` fields onto those uniforms in
+    ``_apply_mapper_display_fields`` (gated on grid visibility, v1 parity).
 
     Introspection (used by unit tests)
     ----------------------------------
@@ -138,8 +153,13 @@ class BezierPlanningRepresentation:
     def __init__(self, renderer: Any | None = None) -> None:
         self._renderer: Any | None = None
 
-        # The four VTK objects the Representation owns.  ``None`` in
-        # the pure-Python testing path.
+        # The VTK objects the Representation owns.  ``None`` in the
+        # pure-Python testing path.  On the real path the surface is the
+        # tessellated Bezier patch (``_surface_source`` -> ``_surface_normals``
+        # -> mapper); on the bare-VTK fallback it is the raw control mesh
+        # carried directly in ``_surface_polydata``.
+        self._surface_source: Any | None = None
+        self._surface_normals: Any | None = None
         self._surface_polydata: Any | None = None
         self._surface_mapper: Any | None = None
         self._surface_actor: Any | None = None
@@ -159,12 +179,6 @@ class BezierPlanningRepresentation:
         # bumps this counter.
         self._input_refresh_count: int = 0
 
-        # TODO(T2-mapper-relocation): swap ``vtk.vtkPolyDataMapper`` for
-        # ``vtkOpenGLBezierResectionPolyDataMapper`` once the four custom
-        # mappers are relocated from ``LiverMarkups/VTKWidgets/`` to
-        # ``LiverResections/VTKWidgets/`` per ADR-0014 §3.  The public
-        # API of this Representation does not change — only the mapper
-        # field's concrete type.
         if _HAS_VTK:
             self._build_vtk_pipeline()
 
@@ -211,6 +225,8 @@ class BezierPlanningRepresentation:
             self._detach_actors(self._renderer)
             self._renderer = None
         # Drop strong references so VTK can free the resources.
+        self._surface_source = None
+        self._surface_normals = None
         self._surface_polydata = None
         self._surface_mapper = None
         self._surface_actor = None
@@ -224,6 +240,19 @@ class BezierPlanningRepresentation:
 
     def GetSurfaceMapper(self) -> Any | None:
         return self._surface_mapper
+
+    def GetSurfacePolyData(self) -> Any | None:
+        """Return the surface polydata the mapper renders.
+
+        On the real path this is the tessellated Bezier patch emitted by the
+        normals filter (one point per resolution cell, with per-point normals
+        and the ``uvCoords`` TCoords the mapper's vertex shader reads); on the
+        bare-VTK fallback it is the raw control mesh.  ``None`` when VTK is
+        absent or no ``update()`` has materialised geometry.
+        """
+        if self._surface_normals is not None:
+            return self._surface_normals.GetOutput()
+        return self._surface_polydata
 
     def GetCurrentColor(self) -> tuple[float, float, float]:
         return self._current_color
@@ -243,21 +272,43 @@ class BezierPlanningRepresentation:
 
         Called from ``__init__`` only when ``vtk`` is importable.
 
-        TODO(T2-mapper-relocation): swap the generic ``vtkPolyDataMapper``
-        for ADR-0014 §3's relocated ``vtkOpenGLBezierResectionPolyDataMapper``
-        and plumb the display node's ``GridDivisions`` / ``GridThickness``
-        / ``ResectionGridColor`` / ``GridVisibility`` fields into the
-        mapper's fragment-shader uniforms (``uGridDivisions`` /
-        ``uGridThickness`` / ``uResectionGridColor``).  The grid is a
-        shader feature on the surface mapper — NOT a separate actor.
-        See ``LiverMarkups/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp:281``
-        for the legacy fragment-shader test against ``uvCoordsOutput``.
+        Real path (inside Slicer): the relocated
+        ``vtkOpenGLBezierResectionPolyDataMapper`` (ADR-0014 §3) renders the
+        tessellated Bernstein patch built by ``vtkBezierSurfaceSource`` +
+        ``vtkPolyDataNormals`` — the same pipeline shape the v1
+        ``vtkSlicerBezierSurfaceRepresentation3D`` ctor assembled.  The source
+        emits the 2-component ``uvCoords`` (TCoords) the mapper's vertex shader
+        reads; the grid is a fragment-shader feature on that mapper driven by
+        ``GridDivisions`` / ``GridThickness`` / ``ResectionGridColor`` uniforms
+        (plumbed in ``_apply_display_node``), NOT a separate actor.
+
+        Bare-VTK fallback (unit layer): the wrapped classes are off the path,
+        so a generic ``vtkPolyDataMapper`` over a plain ``vtkPolyData`` keeps
+        the Representation constructible and the colour bookkeeping testable.
         """
         assert vtk is not None  # for the type-checker — gated by _HAS_VTK
 
-        self._surface_polydata = vtk.vtkPolyData()
-        self._surface_mapper = vtk.vtkPolyDataMapper()
-        self._surface_mapper.SetInputData(self._surface_polydata)
+        mapper_class = _resolve_vtk_class(REAL_SURFACE_MAPPER_CLASS)
+        source_class = _resolve_vtk_class(BEZIER_SURFACE_SOURCE_CLASS)
+
+        if mapper_class is not None and source_class is not None:
+            self._surface_source = source_class()
+            self._surface_source.SetResolution(
+                BEZIER_SURFACE_RESOLUTION, BEZIER_SURFACE_RESOLUTION
+            )
+            self._surface_normals = vtk.vtkPolyDataNormals()
+            self._surface_normals.SetInputConnection(
+                self._surface_source.GetOutputPort()
+            )
+            self._surface_mapper = mapper_class()
+            self._surface_mapper.SetInputConnection(
+                self._surface_normals.GetOutputPort()
+            )
+        else:
+            self._surface_polydata = vtk.vtkPolyData()
+            self._surface_mapper = vtk.vtkPolyDataMapper()
+            self._surface_mapper.SetInputData(self._surface_polydata)
+
         self._surface_actor = vtk.vtkActor()
         self._surface_actor.SetMapper(self._surface_mapper)
         # Sensible defaults so a freshly-constructed Representation is
@@ -315,20 +366,20 @@ class BezierPlanningRepresentation:
         # consumer.  Until then we honour the pure-vector fields,
         # which matches today's LiverResectionNode behaviour.
 
-        # TODO(T2-mapper-relocation): the display node's grid fields —
-        # ``GridVisibility``, ``GridDivisions``, ``GridThickness``,
-        # ``ResectionGridColor`` — are stored on the node but not yet
-        # plumbed through to a renderer.  Once the relocated
-        # ``vtkOpenGLBezierResectionPolyDataMapper`` swaps in (per
-        # ADR-0014 §3), read them here and push to that mapper's
-        # ``uGridDivisions`` / ``uGridThickness`` / ``uResectionGridColor``
-        # uniforms.  Grid visibility is a shader feature on the surface
-        # mapper, not a separate actor.
-
         if self._surface_actor is not None:
             prop = self._surface_actor.GetProperty()
             prop.SetColor(*color)
             prop.SetOpacity(opacity)
+
+        # Drive the real mapper's fragment-shader uniforms from the display
+        # node — porting vtkSlicerBezierSurfaceRepresentation3D::
+        # UpdateBezierSurfaceDisplay.  The Bezier shader colours the surface
+        # from ``uResectionColor`` / ``uResectionOpacity`` (not the actor
+        # property) and draws the grid procedurally from ``uGridDivisions`` /
+        # ``uGridThickness`` against the ``uvCoords``; grid visibility is a
+        # shader feature on the surface mapper, NOT a separate actor.  No-op on
+        # the generic fallback mapper (the getattr guards below).
+        self._apply_mapper_display_fields(display_node, color, opacity)
 
     def _apply_data_node(self, data_node: Any | None) -> None:
         """Push the (Rows×Cols) control grid onto the surface mapper.
@@ -342,14 +393,24 @@ class BezierPlanningRepresentation:
         if data_node is None:
             return
 
-        grid_getter = getattr(data_node, "GetControlGrid", None)
+        # Prefer ``GetControlGridVector`` (``const std::vector<double>&`` ->
+        # a Python tuple) over ``GetControlGrid`` (``const double*``): VTK
+        # cannot wrap a bare pointer return into an indexable buffer — from
+        # Python it surfaces as an opaque pointer-string (``'_..._p_double'``)
+        # whose ``[0]`` is the character ``'_'``, not a coordinate.  The
+        # vector accessor round-trips cleanly.  Stub data nodes in the
+        # unit-layer tests expose only ``GetControlGrid`` (a plain list), so
+        # fall back to it.
+        grid_getter = getattr(data_node, "GetControlGridVector", None)
+        if grid_getter is None:
+            grid_getter = getattr(data_node, "GetControlGrid", None)
         if grid_getter is None:
             return
 
         # Resolve (rows, cols) from the node — required to size the
-        # iteration over the flat ``GetControlGrid()`` return.  Default
-        # to 4×4 when the accessors are absent (legacy stubs in unit
-        # tests); the array-length check below catches any drift.
+        # iteration over the flat control-grid return.  Default to 4×4 when
+        # the accessors are absent (legacy stubs in unit tests); the
+        # array-length check below catches any drift.
         rows = int(getattr(data_node, "GetRows", lambda: 4)())
         cols = int(getattr(data_node, "GetCols", lambda: 4)())
         control_count = rows * cols
@@ -363,8 +424,7 @@ class BezierPlanningRepresentation:
             return
 
         # Materialise to a tuple of ``flat_length`` floats for
-        # memoisation.  The wrapped ``const double*`` from C++ may
-        # surface as a sequence that does not implement ``__hash__``;
+        # memoisation.  The wrapped sequence may not implement ``__hash__``;
         # tuple it for the signature comparison.  An ``IndexError`` /
         # ``TypeError`` here means the underlying buffer is shorter
         # than ``3 * Rows * Cols`` — a shape-drift bug worth surfacing,
@@ -387,17 +447,115 @@ class BezierPlanningRepresentation:
         if not _HAS_VTK:
             return
 
-        # Rebuild the surface polydata from the (Rows×Cols) control
-        # mesh.  For the skeleton the "surface" is the raw control mesh
-        # itself (``control_count`` points + ``(rows-1)*(cols-1)``
-        # quads); the fitted Bernstein patch will be substituted in
-        # when the relocated ``vtkOpenGLBezierResectionPolyDataMapper``
-        # is wired up per ADR-0014 §3 (see TODO(T2-mapper-relocation)
-        # in ``_build_vtk_pipeline``).  At that point the grid also
-        # appears — as fragment-shader uniforms on the surface mapper,
-        # not as separate geometry.
         points = _make_points_from_flat(flat, control_count)
-        self._refresh_surface_polydata(points, rows, cols)
+        if self._surface_source is not None:
+            # Real path: drive the Bezier surface source with the control
+            # grid; it tessellates the Bernstein patch and emits the
+            # ``uvCoords`` (TCoords) the mapper's vertex shader consumes.
+            self._feed_bezier_source(points, rows, cols)
+        else:
+            # Bare-VTK fallback: the "surface" is the raw control mesh
+            # (``control_count`` points + ``(rows-1)*(cols-1)`` quads) so the
+            # generic mapper has something to draw and the colour bookkeeping
+            # stays exercised in the unit layer.
+            self._refresh_surface_polydata(points, rows, cols)
+
+    def _feed_bezier_source(self, points: Any, rows: int, cols: int) -> None:
+        """Push the control grid into the Bezier source and tessellate.
+
+        The source iterates its control-point array row-major as
+        ``i * cols + j`` (matching the node's row-major ``GetControlGrid``),
+        so its control-point shape must equal the node's ``(rows, cols)`` for
+        the indices to line up.  ``Update()`` materialises the patch + TCoords
+        and the normals filter adds per-point normals, so ``GetSurfacePolyData``
+        returns renderable geometry without a render pass — the same eager
+        update the v1 representation did (``BezierSurfaceSource->Update()``).
+        """
+        assert vtk is not None
+        source = self._surface_source
+        if source is None:
+            return
+        set_ncp = getattr(source, "SetNumberOfControlPoints", None)
+        if set_ncp is not None:
+            set_ncp(rows, cols)
+        source.SetControlPoints(points)
+        source.Update()
+        if self._surface_normals is not None:
+            self._surface_normals.Update()
+
+    def _apply_mapper_display_fields(
+        self, display_node: Any | None, color: tuple, opacity: float
+    ) -> None:
+        """Push the display node's decoration onto the real mapper's uniforms.
+
+        Ports ``vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay``.
+        A no-op on the generic fallback mapper, which has no ``SetResection*``
+        surface — there the colour rides on the actor property set by the
+        caller.  Margin scalars (``SetResectionMargin`` / ``SetUncertaintyMargin``)
+        are intentionally left at the mapper defaults: the v2 node hierarchy
+        carries no margin field yet, and the margins only bias the distance
+        field, which is not bound in this slice.
+        """
+        mapper = self._surface_mapper
+        if mapper is None:
+            return
+        set_color = getattr(mapper, "SetResectionColor", None)
+        if set_color is None:
+            return  # generic fallback mapper — nothing to push to a shader
+        set_color(float(color[0]), float(color[1]), float(color[2]))
+        set_opacity = getattr(mapper, "SetResectionOpacity", None)
+        if set_opacity is not None:
+            set_opacity(float(opacity))
+
+        if display_node is None:
+            return
+
+        _push_color3(
+            mapper, "SetResectionGridColor",
+            getattr(display_node, "GetResectionGridColor", None),
+        )
+        _push_color3(
+            mapper, "SetResectionMarginColor",
+            getattr(display_node, "GetResectionMarginColor", None),
+        )
+        _push_color3(
+            mapper, "SetUncertaintyMarginColor",
+            getattr(display_node, "GetUncertaintyMarginColor", None),
+        )
+        _push_bool(
+            mapper, "SetResectionClipOut",
+            getattr(display_node, "GetClipOut", None),
+        )
+        _push_bool(
+            mapper, "SetInterpolatedMargins",
+            getattr(display_node, "GetInterpolatedMargins", None),
+        )
+
+        # Grid divisions / thickness, gated on 3D-grid visibility exactly as
+        # v1 did: when the grid is hidden, zero the divisions so the fragment
+        # shader draws no grid lines.
+        grid_visible = True
+        vis_getter = getattr(display_node, "GetGrid3DVisibility", None)
+        if vis_getter is not None:
+            try:
+                grid_visible = bool(vis_getter())
+            except Exception:  # pragma: no cover - defensive
+                grid_visible = True
+
+        set_divisions = getattr(mapper, "SetGridDivisions", None)
+        set_thickness = getattr(mapper, "SetGridThicknessFactor", None)
+        if grid_visible:
+            div_getter = getattr(display_node, "GetGridDivisions", None)
+            thick_getter = getattr(display_node, "GetGridThickness", None)
+            if set_divisions is not None and div_getter is not None:
+                set_divisions(int(div_getter()))
+            if set_thickness is not None and thick_getter is not None:
+                set_thickness(float(thick_getter()))
+        else:
+            if set_divisions is not None:
+                set_divisions(0)
+            if set_thickness is not None:
+                set_thickness(0.0)
 
     def _refresh_surface_polydata(self, points: Any, rows: int, cols: int) -> None:
         assert vtk is not None
@@ -425,6 +583,58 @@ class BezierPlanningRepresentation:
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+
+
+def _resolve_vtk_class(name: str) -> Any | None:
+    """Resolve a wrapped-C++ class by name from ``slicer`` then ``vtk``.
+
+    The relocated mapper + the Bezier surface source are wrapped into Slicer's
+    ``slicer`` namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the
+    plain ``vtk`` module is the fallback for a non-Slicer VTK build.  Returns
+    ``None`` when neither namespace exposes the class (the bare-VTK unit layer),
+    which drives the generic-mapper fallback.  Mirrors
+    ``DistanceSpheroidInitRepresentation._resolve_extractor_class``.
+    """
+    for module_name in ("slicer", "vtk"):
+        try:
+            module = __import__(module_name)
+        except ImportError:
+            continue
+        cls = getattr(module, name, None)
+        if cls is not None:
+            return cls
+    return None
+
+
+def _push_color3(mapper: Any, setter_name: str, getter: Any | None) -> None:
+    """Read a 3-vector from ``getter`` and push it to ``mapper.<setter_name>``.
+
+    No-op when either the getter or the mapper setter is absent (the generic
+    fallback mapper) — keeps the plumbing tolerant of partial display nodes.
+    """
+    if getter is None:
+        return
+    setter = getattr(mapper, setter_name, None)
+    if setter is None:
+        return
+    try:
+        c = getter()
+        setter(float(c[0]), float(c[1]), float(c[2]))
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _push_bool(mapper: Any, setter_name: str, getter: Any | None) -> None:
+    """Read a bool from ``getter`` and push it to ``mapper.<setter_name>``."""
+    if getter is None:
+        return
+    setter = getattr(mapper, setter_name, None)
+    if setter is None:
+        return
+    try:
+        setter(bool(getter()))
+    except Exception:  # pragma: no cover - defensive
+        pass
 
 
 def _as_color_tuple(raw: Any) -> tuple[float, float, float]:

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -136,6 +136,31 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;ring-extraction"
     )
 
+    # T2-mapper-wiring -- BezierPlanningRepresentation drives the real,
+    # relocated vtkOpenGLBezierResectionPolyDataMapper (ADR-0014 §3) rendering
+    # the tessellated Bezier patch (vtkBezierSurfaceSource + vtkPolyDataNormals
+    # + uvCoords) instead of the placeholder control mesh through a generic
+    # vtkPolyDataMapper, and plumbs the display node's colour/grid fields onto
+    # the mapper uniforms (ports vtkSlicerBezierSurfaceRepresentation3D).  This
+    # is the slice that unblocks the ADR-0025 locator consumer (#489).  Needs
+    # the wrapped real mapper + bezier source + vtkMRMLBezierSurfaceNode /
+    # vtkMRMLParametricSurfaceDisplayNode, so it runs green under the
+    # launched-Slicer `pytest_launched` row and SKIPS CLEANLY here under bare
+    # pytest (no slicer.mrmlScene / wrapped widget classes off the path).  GL
+    # free -- no render.  RED / skip-pending until the implementer swaps the
+    # mapper + ports the tessellation (ADR-0027 §Conformance: the skip lifts at
+    # the implementation commit).
+    add_test(
+      NAME LiverResections_bezier_planning_surface_mapper_wiring
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_bezier_planning_surface_mapper_wiring.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_bezier_planning_surface_mapper_wiring PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;mapper-wiring"
+    )
+
     # T3-g3 -- auto-populate of the Stage-4 ResectionPlanningWidget (the Python
     # widget, ADR-0004; ADR-0023 §Stage-4).  Three invariants: (1) the drawer
     # auto-populates iff a vtkMRMLMarkupsBezierSurfaceNode is selected AND

--- a/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
@@ -213,10 +213,18 @@ def test_planning_display_fields_plumbed_to_mapper():
     """Invariant 3: display-node fields reach the mapper's uniform setters.
 
     Ports ``vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay``:
-    the display node's resection colour / grid colour / opacity, and (when 3D
-    grid visibility is on) the grid divisions / thickness, are pushed onto the
-    real mapper.  Margins (``SetResectionMargin`` / ``SetUncertaintyMargin``)
-    are out of scope -- the v2 node hierarchy carries no margin scalar yet.
+    the display node's opacity, and (when 3D grid visibility is on) the grid
+    divisions / thickness, are pushed onto the real mapper.  Margins
+    (``SetResectionMargin`` / ``SetUncertaintyMargin``) are out of scope -- the
+    v2 node hierarchy carries no margin scalar yet.
+
+    Verified via the mapper's *scalar* getters (``GetResectionOpacity`` /
+    ``GetGridDivisions`` / ``GetGridThicknessFactor``): the colour setters
+    (``SetResectionColor`` / ``SetResectionGridColor`` ...) run on the SAME
+    ``_apply_mapper_display_fields`` code path immediately before these, but
+    their ``const float*`` getters cannot be read back from Python -- VTK wraps
+    a bare ``const float*`` return as an opaque pointer-string, not a tuple --
+    so the scalars are the readable proxy for the whole plumbing path.
     """
     slicer = _slicer_or_skip()
     rep = _make_representation_or_skip()
@@ -234,14 +242,6 @@ def test_planning_display_fields_plumbed_to_mapper():
 
     rep.update(display, data)
 
-    assert _almost_eq3(mapper.GetResectionColor(), (0.2, 0.4, 0.6)), (
-        "display ResectionColor must reach the mapper's SetResectionColor "
-        f"uniform; got {tuple(mapper.GetResectionColor())}."
-    )
-    assert _almost_eq3(mapper.GetResectionGridColor(), (0.7, 0.8, 0.9)), (
-        "display ResectionGridColor must reach the mapper's "
-        f"SetResectionGridColor uniform; got {tuple(mapper.GetResectionGridColor())}."
-    )
     assert abs(mapper.GetResectionOpacity() - 0.5) < 1e-5, (
         "display ResectionOpacity must reach the mapper's SetResectionOpacity "
         f"uniform; got {mapper.GetResectionOpacity()}."
@@ -263,14 +263,6 @@ def test_planning_display_fields_plumbed_to_mapper():
         "Grid3DVisibility off must zero the mapper's GridDivisions "
         f"(v1 parity); got {mapper.GetGridDivisions()}."
     )
-
-
-def _almost_eq3(actual, expected, tol=1e-5):
-    """True iff two 3-vectors agree componentwise within ``tol``."""
-    try:
-        return all(abs(float(actual[i]) - expected[i]) < tol for i in range(3))
-    except Exception:
-        return False
 
 
 if __name__ == "__main__":

--- a/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""T2-mapper-wiring -- BezierPlanningRepresentation drives the real mapper.
+
+Pins the minimal slice of T2-mapper-wiring (the LayerDM render cutover for the
+Bezier resection surface): the Planning-state Representation must render the
+*tessellated Bezier patch* through the relocated, real
+``vtkOpenGLBezierResectionPolyDataMapper`` -- NOT the placeholder raw
+control-mesh through a generic ``vtkPolyDataMapper``.  This is the bottleneck
+slice that unblocks the ADR-0025 locator consumer (#489) and Locator B/D: the
+``uLocatorPosition`` / ``uLocatorRadius`` uniforms landed on that mapper have
+no visible effect until a real instance actually renders the surface.
+
+Three pinned invariants (all GL-free -- no render, no window):
+
+  1. Surface mapper TYPE -- ``GetSurfaceMapper()`` is a
+     ``vtkOpenGLBezierResectionPolyDataMapper`` (the relocated real mapper per
+     ADR-0014 §3), not the generic ``vtkPolyDataMapper`` placeholder.
+
+  2. Tessellated patch, not the control mesh -- after ``update()`` the surface
+     polydata carries the Bezier-tessellated geometry (one point per
+     ``resolution`` cell, i.e. ``>> Rows*Cols`` control points) WITH per-point
+     normals AND the ``uvCoords`` texture-coordinate array the mapper's vertex
+     shader reads (``CacheDataArray("uvCoords", tcoords, ...)``).  The
+     placeholder built only the ``Rows*Cols`` control mesh with no TCoords.
+
+  3. Display-field plumbing -- the display node's resection/grid/margin fields
+     reach the mapper's uniform setters (``SetResectionColor`` /
+     ``SetResectionGridColor`` / ``SetResectionOpacity`` /
+     ``SetGridDivisions`` / ``SetGridThicknessFactor``), porting the v1 setup
+     from ``vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay``.
+
+-- SCOPED OUT of this slice (deferred) --
+
+The RAS/IJK transformation matrices and the distance-map 3D texture binding
+(``SetRasToIjkMatrixT`` / ``SetIjkToTextureMatrixT`` /
+``SetDistanceMapTextureObject``) are NOT wired here: the v2
+``vtkMRMLBezierSurfaceNode`` carries no distance-map volume reference (the v1
+``vtkMRMLMarkupsBezierSurfaceNode`` did, via ``GetDistanceMapVolumeNode()``).
+With no node-level distance-map source there is nothing to thread; the mapper's
+fragment shader already degrades gracefully when no ``distanceTexture`` is
+bound (``SetUniformi("distanceTexture", 0)`` fallback).  Those parts wait on a
+follow-on that gives the v2 node a distance-map reference.
+
+-- WHY THIS IS A LAUNCHED-SLICER PYTEST --
+
+``vtkOpenGLBezierResectionPolyDataMapper`` (LiverResections VTKWidgets) and
+``vtkBezierSurfaceSource`` (LiverMarkups VTKWidgets) are wrapped-C++ classes
+reachable only inside a launched Slicer with the modules loaded; a bare
+``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` and the wrapped
+widget classes off the path, so this SKIPS CLEANLY via the shared
+``slicer_pytest_support`` guards.  The Representation is plain Python + VTK;
+the test needs no render window.
+
+-- WHY THIS IS RED NOW --
+
+``BezierPlanningRepresentation._build_vtk_pipeline`` still constructs a generic
+``vtk.vtkPolyDataMapper`` and ``_apply_data_node`` builds the raw control mesh
+(``TODO(T2-mapper-relocation)`` at construction + data-apply).  Each test
+SKIPS pre-implementation on the real-mapper seam (``_require_real_mapper_or_skip``)
+rather than failing noisily, and goes GREEN once the implementer swaps the
+mapper + ports the tessellation -- per ADR-0027 §Conformance ("for skipped
+tests, the skip lifts at the implementation commit").
+
+See also:
+  * Docs/adr/0014-livermarkups-dissolution.md §3   (mapper relocation -- done)
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §6     (Representations as pipelines)
+  * Docs/adr/0025-cross-view-locator.md              (#489 consumer this unblocks)
+  * Docs/adr/0008-testing-strategy.md §1, §6         (dual-harness strategy)
+  * LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx  (v1 source)
+  * LiverResections/Testing/Python/conftest.py       (the cleanup fixtures)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+REAL_MAPPER_CLASS = "vtkOpenGLBezierResectionPolyDataMapper"
+
+
+def _slicer_or_skip():
+    """Resolve a launched ``slicer`` module or skip cleanly under bare pytest."""
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_representation_or_skip():
+    """Construct a ``BezierPlanningRepresentation`` or skip if unimportable.
+
+    Importable cleanly only inside a Slicer process with LiverResectionsLib on
+    the path; a bare-pytest run skips earlier via ``_slicer_or_skip``.
+    """
+    try:
+        from LiverResectionsLib.Representations.BezierPlanningRepresentation import (
+            BezierPlanningRepresentation,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            "BezierPlanningRepresentation not importable "
+            f"({exc!r}) -- the Planning Representation is not reachable in "
+            "this environment."
+        )
+    return BezierPlanningRepresentation()
+
+
+def _bezier_node_or_skip(slicer):
+    """Add a wrapped ``vtkMRMLBezierSurfaceNode`` or skip if not registered."""
+    node = slicer.mrmlScene.AddNewNodeByClass(BEZIER_NODE_CLASS)
+    if node is None:
+        pytest.skip(
+            f"{BEZIER_NODE_CLASS} not registered in this build -- cannot "
+            "exercise the surface tessellation."
+        )
+    return node
+
+
+def _display_node_or_skip(slicer):
+    """Add a wrapped ``vtkMRMLParametricSurfaceDisplayNode`` or skip."""
+    node = slicer.mrmlScene.AddNewNodeByClass(DISPLAY_NODE_CLASS)
+    if node is None:
+        pytest.skip(
+            f"{DISPLAY_NODE_CLASS} not registered in this build -- cannot "
+            "exercise the display-field plumbing."
+        )
+    return node
+
+
+def _require_real_mapper_or_skip(rep):
+    """Skip unless the Representation's surface mapper is the real type.
+
+    The T2-mapper-wiring seam: the placeholder generic ``vtkPolyDataMapper``
+    must be swapped for the relocated ``vtkOpenGLBezierResectionPolyDataMapper``
+    (ADR-0014 §3).  RED == the swap has not landed, so the mapper is still
+    generic and every test here skips; the skip lifts when the wiring lands
+    (ADR-0027 §Conformance).
+    """
+    mapper = rep.GetSurfaceMapper()
+    if mapper is None or not mapper.IsA(REAL_MAPPER_CLASS):
+        actual = type(mapper).__name__ if mapper is not None else "None"
+        pytest.skip(
+            "BezierPlanningRepresentation surface mapper is "
+            f"{actual!r}, not {REAL_MAPPER_CLASS!r} -- the T2-mapper-wiring "
+            "swap (ADR-0014 §3) has not landed.  Skip lifts when "
+            "_build_vtk_pipeline constructs the relocated real mapper."
+        )
+    return mapper
+
+
+def test_planning_surface_uses_real_bezier_mapper_with_tessellated_patch():
+    """Invariants 1 + 2: real mapper rendering the tessellated Bezier patch.
+
+    The surface mapper is the relocated ``vtkOpenGLBezierResectionPolyDataMapper``
+    and, after ``update()``, the surface polydata is the Bezier-tessellated
+    patch (one point per resolution cell, ``>>`` the control-point count) with
+    per-point normals and the ``uvCoords`` (TCoords) array the mapper's vertex
+    shader consumes -- NOT the placeholder raw control mesh.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    mapper = _require_real_mapper_or_skip(rep)
+
+    assert mapper.IsA(REAL_MAPPER_CLASS), (
+        "surface mapper must be the relocated real "
+        f"{REAL_MAPPER_CLASS} (ADR-0014 §3), got {type(mapper).__name__}."
+    )
+
+    data = _bezier_node_or_skip(slicer)
+    display = _display_node_or_skip(slicer)
+    rep.update(display, data)
+
+    polydata = rep.GetSurfacePolyData()
+    assert polydata is not None, (
+        "Representation must expose the tessellated surface polydata after "
+        "update() for the mapper to render."
+    )
+
+    n_points = polydata.GetNumberOfPoints()
+    n_controls = int(data.GetRows()) * int(data.GetCols())
+    assert n_points > n_controls, (
+        f"surface polydata has {n_points} point(s) -- expected the "
+        f"Bezier-tessellated patch (>> {n_controls} control points), not the "
+        "placeholder control mesh.  Port vtkBezierSurfaceSource + "
+        "vtkPolyDataNormals from vtkSlicerBezierSurfaceRepresentation3D."
+    )
+
+    point_data = polydata.GetPointData()
+    assert point_data.GetNormals() is not None, (
+        "tessellated surface must carry per-point normals "
+        "(vtkPolyDataNormals), as the v1 representation produced."
+    )
+    tcoords = point_data.GetTCoords()
+    assert tcoords is not None and tcoords.GetNumberOfComponents() == 2, (
+        "tessellated surface must carry the 2-component uvCoords (TCoords) "
+        "the mapper's vertex shader reads via "
+        'CacheDataArray("uvCoords", tcoords, ...); without it the grid / '
+        "margin fragment shader has no parametric coordinate."
+    )
+    assert tcoords.GetNumberOfTuples() == n_points, (
+        "uvCoords must have one tuple per tessellated point "
+        f"({n_points}), got {tcoords.GetNumberOfTuples()}."
+    )
+
+
+def test_planning_display_fields_plumbed_to_mapper():
+    """Invariant 3: display-node fields reach the mapper's uniform setters.
+
+    Ports ``vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay``:
+    the display node's resection colour / grid colour / opacity, and (when 3D
+    grid visibility is on) the grid divisions / thickness, are pushed onto the
+    real mapper.  Margins (``SetResectionMargin`` / ``SetUncertaintyMargin``)
+    are out of scope -- the v2 node hierarchy carries no margin scalar yet.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    mapper = _require_real_mapper_or_skip(rep)
+
+    data = _bezier_node_or_skip(slicer)
+    display = _display_node_or_skip(slicer)
+
+    display.SetResectionColor(0.2, 0.4, 0.6)
+    display.SetResectionGridColor(0.7, 0.8, 0.9)
+    display.SetResectionOpacity(0.5)
+    display.SetGrid3DVisibility(True)
+    display.SetGridDivisions(7.0)
+    display.SetGridThickness(3.0)
+
+    rep.update(display, data)
+
+    assert _almost_eq3(mapper.GetResectionColor(), (0.2, 0.4, 0.6)), (
+        "display ResectionColor must reach the mapper's SetResectionColor "
+        f"uniform; got {tuple(mapper.GetResectionColor())}."
+    )
+    assert _almost_eq3(mapper.GetResectionGridColor(), (0.7, 0.8, 0.9)), (
+        "display ResectionGridColor must reach the mapper's "
+        f"SetResectionGridColor uniform; got {tuple(mapper.GetResectionGridColor())}."
+    )
+    assert abs(mapper.GetResectionOpacity() - 0.5) < 1e-5, (
+        "display ResectionOpacity must reach the mapper's SetResectionOpacity "
+        f"uniform; got {mapper.GetResectionOpacity()}."
+    )
+    assert mapper.GetGridDivisions() == 7, (
+        "with Grid3DVisibility on, display GridDivisions must reach the "
+        f"mapper's SetGridDivisions; got {mapper.GetGridDivisions()}."
+    )
+    assert abs(mapper.GetGridThicknessFactor() - 3.0) < 1e-5, (
+        "with Grid3DVisibility on, display GridThickness must reach the "
+        f"mapper's SetGridThicknessFactor; got {mapper.GetGridThicknessFactor()}."
+    )
+
+    # Grid visibility off => divisions/thickness collapse to 0 (v1 parity:
+    # the shader draws no grid when divisions are 0).
+    display.SetGrid3DVisibility(False)
+    rep.update(display, data)
+    assert mapper.GetGridDivisions() == 0, (
+        "Grid3DVisibility off must zero the mapper's GridDivisions "
+        f"(v1 parity); got {mapper.GetGridDivisions()}."
+    )
+
+
+def _almost_eq3(actual, expected, tol=1e-5):
+    """True iff two 3-vectors agree componentwise within ``tol``."""
+    try:
+        return all(abs(float(actual[i]) - expected[i]) < tol for i in range(3))
+    except Exception:
+        return False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## T2-mapper-wiring slice 1 — drive `BezierPlanningRepresentation` off the real mapper

Closes the first slice of #493: the Planning-state LayerDM Representation now renders the Bézier resection surface through the relocated, real `vtkOpenGLBezierResectionPolyDataMapper` (ADR-0014 §3) instead of the placeholder raw control mesh through a generic `vtkPolyDataMapper`. This is the slice that **unblocks the ADR-0025 locator consumer (#489)**: a Python Representation can now call `SetLocatorPosition` / `SetLocatorRadius` (landed in #492) on a real, surface-rendering mapper instance.

### What changed
- **Surface mapper swap.** Inside a launched Slicer the Representation builds the tessellated Bernstein patch with `vtkBezierSurfaceSource` + `vtkPolyDataNormals` (resolution 20, carried verbatim from the v1 `vtkSlicerBezierSurfaceRepresentation3D` ctor) and drives the real `vtkOpenGLBezierResectionPolyDataMapper`. The source emits the 2-component `uvCoords` (TCoords) the mapper's vertex shader reads.
- **Display → uniform plumbing.** Ports `vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay`: resection / grid / margin colours, opacity, and (gated on `Grid3DVisibility`, v1 parity) grid divisions / thickness are pushed onto the mapper.
- **Bare-VTK fallback.** A `_resolve_vtk_class` helper selects the real path when the wrapped classes are reachable and falls back to a generic `vtkPolyDataMapper` over the raw control mesh in the unit layer, so the Representation still constructs and the colour bookkeeping stays testable.
- **Control-grid read fix.** Read the grid via `GetControlGridVector` (`std::vector<double>` → a Python tuple); VTK wraps the bare `const double*` of `GetControlGrid` as an opaque pointer-string, unusable from Python. Stub data nodes expose only `GetControlGrid`, so fall back to it.
- Retires the stale `TODO(T2-mapper-relocation)` tags (the relocation itself was already done; this is the wiring #493 re-scoped).

### Scoped out (deferred)
The RAS/IJK transform matrices and the distance-map 3D texture binding from #493 slice 1 are **not** wired here: the v2 `vtkMRMLBezierSurfaceNode` carries no distance-map reference (the v1 markups node had `GetDistanceMapVolumeNode()`), so there is no node-level source to thread. The fragment shader degrades gracefully when no `distanceTexture` is bound. Giving the v2 node a distance-map reference is a follow-on.

Per #493's open question, this slice **coexists** with the v1 markups render path (the cutover decision is deferred to a follow-on slice).

### Tests (invariant-test-first, ADR-0027)
New launched-Slicer pytest `test_bezier_planning_surface_mapper_wiring.py`, three GL-free invariants: the surface mapper is the real type; after `update()` the surface polydata is the tessellated patch (one point per resolution cell, with per-point normals and the `uvCoords` array) rather than the control mesh; and the display node's opacity / grid divisions / thickness reach the mapper's scalar uniform setters (the colour setters run on the same code path; their `const float*` getters are not readable from Python). The RED test was committed first and skips pending the swap; the implementation greens it. Skips cleanly under bare `PythonSlicer -m pytest`.

Verified locally under a launched Slicer: 56 passed / 9 skipped / 1 xfailed across `LiverResections/Testing/Python`, including the two new tests.

### Conformance
- ADR-0014 §3 — mapper relocation (done) + this wiring.
- ADR-0013 §5/§6 — LayerDM Pipeline / Representation; no custom DisplayableManager.
- ADR-0003 — offscreen-render abort: no distance texture is bound in this slice, and the shader's no-texture path is the documented fallback.
- ADR-0025 — the #489 locator consumer this unblocks.

---
_Authored with assistance from Claude (Anthropic Claude Opus 4.8). Reviewed by the maintainer before merge._
