### PR TITLE
ENH: Distance-map input on the resection-plan wrapper + bind it on the v2 render path (ADR-0031)

### DIFF
--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -287,6 +287,19 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         """
         self._ensure_representations()
 
+        # Reverse-resolve the orchestrating wrapper when no explicit one was
+        # set (ADR-0031).  The LayerDM creator hands the Pipeline only the
+        # display node (it matches on vtkMRMLParametricSurfaceDisplayNode), so
+        # nothing sets _resection_node in the live render path; discover the
+        # vtkMRMLResectionPlanNode whose geometry reference is our data node
+        # and adopt it, so the plan's distance-map + margins reach the mapper
+        # with no external SetResectionNode caller.  Re-attempted while unset
+        # (the plan's geometry ref may be wired after the display node lands).
+        if self._resection_node is None and self._data_node is not None:
+            resolved = self._resolve_resection_node()
+            if resolved is not None:
+                self.SetResectionNode(resolved)
+
         # Build the dispatch key.  Falls back to ``0`` MTime for nodes
         # whose ``GetMTime`` is unavailable (defensive — stub nodes in
         # tests may not implement it).
@@ -413,6 +426,42 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             return getter()
         except Exception:  # pragma: no cover - defensive
             return None
+
+    def _resolve_resection_node(self) -> Any | None:
+        """Reverse-resolve the ``vtkMRMLResectionPlanNode`` wrapper.
+
+        The plan wrapper references the surface carrier via the ``geometry``
+        role (ADR-0014 §"Fourth layer"); the Pipeline reverse-walks that to
+        adopt the wrapper, so it can thread the plan's distance-map + margins
+        (ADR-0031) onto the Representation without an external caller.  Scans
+        the scene for the plan whose ``GetGeometryNode()`` is our data node.
+        Returns ``None`` when no plan owns this data node (a bare surface — the
+        no-distance-map fallback).
+        """
+        data_node = self._data_node
+        if data_node is None:
+            return None
+        scene = getattr(data_node, "GetScene", lambda: None)()
+        if scene is None:
+            return None
+        try:
+            plans = scene.GetNodesByClass("vtkMRMLResectionPlanNode")
+        except Exception:  # pragma: no cover - defensive
+            return None
+        if plans is None:
+            return None
+        plans.InitTraversal()
+        item = plans.GetNextItemAsObject()
+        while item is not None:
+            getter = getattr(item, "GetGeometryNode", None)
+            if getter is not None:
+                try:
+                    if getter() is data_node:
+                        return item
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            item = plans.GetNextItemAsObject()
+        return None
 
     def _run_ring_extraction(self, target_model: Any | None = None) -> None:
         """Run the discrete ring extraction against ``target_model``.

--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -306,6 +306,12 @@ class LiverBezierSurfacePipeline(_PipelineBase):
 
         active = self._representations.get(active_name) if active_name else None
         if active is not None:
+            # Thread the orchestrating wrapper to Representations that consume
+            # its path-specific inputs (the Planning surface reads the
+            # distance-map volume + margins off it, ADR-0031).  Only the
+            # BezierPlanningRepresentation implements this; others ignore it.
+            if hasattr(active, "SetResectionPlanNode"):
+                active.SetResectionPlanNode(self._resection_node)
             active.update(self._display_node, self._data_node)
 
         # Init-mode parameter mutations only MARK extraction pending; the

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -179,6 +179,13 @@ class BezierPlanningRepresentation:
         # bumps this counter.
         self._input_refresh_count: int = 0
 
+        # The orchestrating ``vtkMRMLResectionPlanNode`` wrapper, set by the
+        # Pipeline via ``SetResectionPlanNode`` (ADR-0031).  It carries the
+        # distance-map volume + the resection / uncertainty margins the
+        # surface shader needs — path-specific inputs that live on the
+        # wrapper, not the carrier.  ``None`` until the Pipeline wires it.
+        self._resection_plan_node: Any | None = None
+
         if _HAS_VTK:
             self._build_vtk_pipeline()
 
@@ -203,6 +210,16 @@ class BezierPlanningRepresentation:
     def GetRenderer(self) -> Any | None:
         return self._renderer
 
+    def SetResectionPlanNode(self, plan_node: Any | None) -> None:
+        """Attach the orchestrating ``vtkMRMLResectionPlanNode`` wrapper.
+
+        The Pipeline calls this before ``update()`` so the Representation can
+        read the distance-map volume + the resection / uncertainty margins
+        off the wrapper (ADR-0031) and thread them onto the real mapper.
+        ``None`` clears it (the no-distance-map fallback).
+        """
+        self._resection_plan_node = plan_node
+
     def update(
         self, display_node: Any | None, data_node: Any | None
     ) -> None:
@@ -218,6 +235,10 @@ class BezierPlanningRepresentation:
         # VTK.
         self._apply_display_node(display_node)
         self._apply_data_node(data_node)
+        # Thread the wrapper's distance-map volume + margins onto the real
+        # mapper (ADR-0031).  No-op on the generic fallback mapper / when no
+        # plan node is wired.
+        self._apply_resection_plan(self._resection_plan_node)
 
     def cleanup(self) -> None:
         """Detach actors from the renderer and drop the VTK pipeline."""
@@ -230,6 +251,7 @@ class BezierPlanningRepresentation:
         self._surface_polydata = None
         self._surface_mapper = None
         self._surface_actor = None
+        self._resection_plan_node = None
 
     # ------------------------------------------------------------------ #
     # Introspection — used by the unit-layer tests
@@ -557,6 +579,75 @@ class BezierPlanningRepresentation:
             if set_thickness is not None:
                 set_thickness(0.0)
 
+    def _apply_resection_plan(self, plan_node: Any | None) -> None:
+        """Thread the wrapper's distance map + margins onto the real mapper.
+
+        Per ADR-0031 the distance-map volume + the resection / uncertainty
+        margins are path-specific inputs carried by the
+        ``vtkMRMLResectionPlanNode`` wrapper.  This ports v1's
+        ``UpdateFromMRML`` distance-map block
+        (``vtkSlicerBezierSurfaceRepresentation3D``): set the margins, and
+        when a distance-map volume with image data is present, hand the image
+        to the mapper (which builds + binds the 3D texture in C++ at render
+        time — the ``void*`` upload cannot cross the Python wrap) and compute
+        the RAS->IJK and IJK->texture matrices from the volume geometry.  When
+        no distance map is wired, clear the image and reset the matrices to
+        identity (the graceful no-distance-map fallback the shader supports).
+
+        A no-op on the generic fallback mapper (the getattr guard) and when
+        VTK is unavailable.
+        """
+        if not _HAS_VTK:
+            return
+        mapper = self._surface_mapper
+        if mapper is None or not hasattr(mapper, "SetDistanceMapImageData"):
+            return  # generic fallback mapper — no distance-map shader surface
+
+        # Margins are plan fields, meaningful independent of the distance map
+        # (the shader simply has no band to draw without a bound texture).
+        if plan_node is not None:
+            safety = getattr(plan_node, "GetSafetyMargin_mm", None)
+            risk = getattr(plan_node, "GetRiskMargin_mm", None)
+            if safety is not None:
+                mapper.SetResectionMargin(float(safety()))
+            if risk is not None:
+                mapper.SetUncertaintyMargin(float(risk()))
+
+        volume = None
+        if plan_node is not None:
+            getter = getattr(plan_node, "GetDistanceMapVolumeNode", None)
+            if getter is not None:
+                volume = getter()
+
+        image = volume.GetImageData() if volume is not None else None
+        if image is None:
+            # No distance map: drop the texture source and reset the
+            # transforms so MRML state and GL state cannot diverge.
+            mapper.SetDistanceMapImageData(None)
+            mapper.SetRasToIjkMatrix(_identity_matrix())
+            mapper.SetIjkToTextureMatrix(_identity_matrix())
+            return
+
+        mapper.SetDistanceMapImageData(image)
+
+        # RAS->IJK straight off the volume; the mapper transposes internally.
+        ras_to_ijk = vtk.vtkMatrix4x4()
+        volume.GetRASToIJKMatrix(ras_to_ijk)
+        mapper.SetRasToIjkMatrix(ras_to_ijk)
+
+        # IJK->texture is the 1/dimensions scaling (texture coords are
+        # normalised), matching v1's scaling transform.
+        dimensions = image.GetDimensions()
+        scaling = vtk.vtkTransform()
+        scaling.Scale(
+            1.0 / dimensions[0] if dimensions[0] else 1.0,
+            1.0 / dimensions[1] if dimensions[1] else 1.0,
+            1.0 / dimensions[2] if dimensions[2] else 1.0,
+        )
+        ijk_to_texture = vtk.vtkMatrix4x4()
+        scaling.GetMatrix(ijk_to_texture)
+        mapper.SetIjkToTextureMatrix(ijk_to_texture)
+
     def _refresh_surface_polydata(self, points: Any, rows: int, cols: int) -> None:
         assert vtk is not None
         polydata = self._surface_polydata
@@ -583,6 +674,15 @@ class BezierPlanningRepresentation:
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+
+
+def _identity_matrix() -> Any:
+    """A fresh 4x4 identity ``vtkMatrix4x4`` (reset transform for the
+    no-distance-map fallback)."""
+    assert vtk is not None
+    m = vtk.vtkMatrix4x4()
+    m.Identity()
+    return m
 
 
 def _resolve_vtk_class(name: str) -> Any | None:

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -21,6 +21,11 @@ set(KIT_TEST_SRCS
   # re-resolving on a standalone load with no logic instance.  Pins the
   # mechanism that makes the 6 legacy logic association maps removable.
   vtkMRMLResectionPlanGeometryRefRoundTripTest.cxx
+  # ADR-0031: the distance-map volume is a path-specific input of the
+  # resection plan, named by a typed "distanceMap" node-ref on the plan
+  # wrapper (not the carrier).  Pins the role literal + the in-scene
+  # set/get round-trip + nullptr-clears.
+  vtkMRMLResectionPlanDistanceMapRefTest.cxx
   vtkMRMLLocatorNodeTest1.cxx
   )
 
@@ -60,4 +65,5 @@ SIMPLE_TEST(vtkMRMLResectionPlanNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanStorageNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanLegacyFcsvMigrationTest)
 SIMPLE_TEST(vtkMRMLResectionPlanGeometryRefRoundTripTest)
+SIMPLE_TEST(vtkMRMLResectionPlanDistanceMapRefTest)
 SIMPLE_TEST(vtkMRMLLocatorNodeTest1)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanDistanceMapRefTest.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanDistanceMapRefTest.cxx
@@ -1,0 +1,126 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==============================================================================*/
+
+/**
+ * \file vtkMRMLResectionPlanDistanceMapRefTest.cxx
+ *
+ * Invariant test for ADR-0031: the distance-map volume is a path-specific
+ * input of the resection plan and is named by a typed ``distanceMap``
+ * node-reference role on ``vtkMRMLResectionPlanNode`` -- NOT on the
+ * ``vtkMRMLBezierSurfaceNode`` carrier.
+ *
+ * What it pins
+ * ------------
+ *  - The role literal is ``"distanceMap"`` (``GetDistanceMapReferenceRole()``).
+ *  - ``SetAndObserveDistanceMapVolumeNode()`` /
+ *    ``GetDistanceMapVolumeNode()`` round-trip a ``vtkMRMLScalarVolumeNode``
+ *    in-scene: the typed accessor resolves the volume that was set.
+ *  - Passing ``nullptr`` clears the reference (the graceful no-distance-map
+ *    fallback ADR-0031 preserves).
+ *
+ * It deliberately does NOT assert the carrier lacks the role (that absence
+ * is enforced by the ADR-0031 conformance grep, not a colour-of-the-sky
+ * runtime test).
+ *
+ * ADR-0003 testability: pure MRML-level test, ctkTest driver, no Slicer
+ * launch and no logic library.
+ *
+ * Architectural anchors:
+ *   - ADR-0031 -- distance-map input on the resection-plan wrapper.
+ *   - ADR-0014 §"Fourth layer" -- wrapper carries path-specific inputs.
+ *   - vtkMRMLResectionPlanNode.h §"Node references".
+ */
+
+// Module MRML includes
+#include "vtkMRMLResectionPlanNode.h"
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScalarVolumeNode.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkSmartPointer.h>
+
+// STD includes
+#include <cstring>
+#include <iostream>
+
+namespace
+{
+
+//------------------------------------------------------------------------------
+// The distanceMap reference role round-trips a scalar volume in-scene, and
+// the role literal is the canonical "distanceMap" string. [ADR-0031]
+int testDistanceMapRefRoundTrip()
+{
+  // The role literal is the contract the storage node + Pipeline share.
+  CHECK_STRING(vtkMRMLResectionPlanNode::GetDistanceMapReferenceRole(), "distanceMap");
+
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanNode>::New());
+
+  vtkNew<vtkMRMLResectionPlanNode> plan;
+  scene->AddNode(plan.GetPointer());
+
+  // No distance map yet -- the typed accessor resolves to nullptr (the
+  // graceful fallback ADR-0031 preserves).
+  CHECK_NULL(plan->GetDistanceMapVolumeNode());
+
+  vtkNew<vtkMRMLScalarVolumeNode> distanceMap;
+  scene->AddNode(distanceMap.GetPointer());
+  plan->SetAndObserveDistanceMapVolumeNode(distanceMap.GetPointer());
+
+  // The typed accessor resolves the volume that was set.
+  CHECK_POINTER(plan->GetDistanceMapVolumeNode(), distanceMap.GetPointer());
+
+  // Clearing the reference returns to the no-distance-map state.
+  plan->SetAndObserveDistanceMapVolumeNode(nullptr);
+  CHECK_NULL(plan->GetDistanceMapVolumeNode());
+
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLResectionPlanDistanceMapRefTest(int, char*[])
+{
+  CHECK_EXIT_SUCCESS(testDistanceMapRefRoundTrip());
+
+  std::cout << "vtkMRMLResectionPlanDistanceMapRefTest completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRML/vtkMRMLResectionPlanNode.cxx
+++ b/LiverResections/MRML/vtkMRMLResectionPlanNode.cxx
@@ -15,6 +15,7 @@
 #include "vtkMRMLResectionPlanNode.h"
 #include "vtkMRMLResectionPlanStorageNode.h"
 #include "vtkMRMLAbstractParametricSurfaceNode.h"
+#include "vtkMRMLScalarVolumeNode.h"
 
 // MRML includes
 #include <vtkMRMLNodePropertyMacros.h>
@@ -43,6 +44,13 @@ vtkMRMLResectionPlanNode::vtkMRMLResectionPlanNode()
   // surface bulk data persists through the storage node, not through
   // the .mrml XML.
   this->AddNodeReferenceRole(GetGeometryReferenceRole(), GetGeometryReferenceRole());
+
+  // Typed node-reference role to the distance-map scalar volume the
+  // resection margins are measured against (ADR-0031).  The distance map
+  // is a path-specific input of the plan; per ADR-0014 §"Fourth layer"
+  // inputs live on the wrapper, not the surface carrier.  Like the
+  // geometry role, no content-modified observation is wired here.
+  this->AddNodeReferenceRole(GetDistanceMapReferenceRole(), GetDistanceMapReferenceRole());
 }
 
 //------------------------------------------------------------------------------
@@ -93,6 +101,18 @@ vtkMRMLAbstractParametricSurfaceNode* vtkMRMLResectionPlanNode::GetGeometryNode(
 void vtkMRMLResectionPlanNode::SetAndObserveGeometryNode(vtkMRMLAbstractParametricSurfaceNode* surface)
 {
   this->SetAndObserveNodeReferenceID(GetGeometryReferenceRole(), surface ? surface->GetID() : nullptr);
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLScalarVolumeNode* vtkMRMLResectionPlanNode::GetDistanceMapVolumeNode()
+{
+  return vtkMRMLScalarVolumeNode::SafeDownCast(this->GetNodeReference(GetDistanceMapReferenceRole()));
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLResectionPlanNode::SetAndObserveDistanceMapVolumeNode(vtkMRMLScalarVolumeNode* distanceMap)
+{
+  this->SetAndObserveNodeReferenceID(GetDistanceMapReferenceRole(), distanceMap ? distanceMap->GetID() : nullptr);
 }
 
 //------------------------------------------------------------------------------

--- a/LiverResections/MRML/vtkMRMLResectionPlanNode.h
+++ b/LiverResections/MRML/vtkMRMLResectionPlanNode.h
@@ -50,6 +50,7 @@
 #include <vtkSetGet.h>
 
 class vtkMRMLAbstractParametricSurfaceNode;
+class vtkMRMLScalarVolumeNode;
 
 /**
  * \class vtkMRMLResectionPlanNode
@@ -167,6 +168,23 @@ public:
   /// Reference role name — exposed as a constant so the storage node
   /// + Logic share a single literal.
   static const char* GetGeometryReferenceRole() { return "geometry"; }
+
+  /// Typed accessor for the ``distanceMap`` reference to the scalar
+  /// volume the resection margins are measured against.  Returns
+  /// nullptr when no distance map is wired (ADR-0031).  The distance
+  /// map is a path-specific INPUT of the plan, not a property of the
+  /// surface carrier — per ADR-0014 §"Fourth layer" inputs live on the
+  /// wrapper.
+  vtkMRMLScalarVolumeNode* GetDistanceMapVolumeNode();
+
+  /// Set the ``distanceMap`` reference to the distance-map scalar volume
+  /// (ADR-0031).  Passing nullptr clears it (the graceful
+  /// no-distance-map fallback the render path preserves).
+  void SetAndObserveDistanceMapVolumeNode(vtkMRMLScalarVolumeNode* distanceMap);
+
+  /// Reference role name — exposed as a constant so the storage node,
+  /// the Pipeline, and the render Representation share a single literal.
+  static const char* GetDistanceMapReferenceRole() { return "distanceMap"; }
 
 protected:
   vtkMRMLResectionPlanNode();

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -161,6 +161,24 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;mapper-wiring"
     )
 
+    # T2 render-cutover slice 1c -- the LayerDM Pipeline reverse-resolves its
+    # vtkMRMLResectionPlanNode wrapper from the data node's geometry
+    # back-reference (ADR-0031), so the live render path threads the
+    # distance-map + margins with no external SetResectionNode caller.  Needs
+    # the wrapped plan / carrier / display nodes + the importable Pipeline, so
+    # it runs green under the launched-Slicer `pytest_launched` row and SKIPS
+    # CLEANLY here under bare pytest (no slicer.mrmlScene / LayerDMLib).
+    add_test(
+      NAME LiverResections_pipeline_resolves_resection_plan
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_pipeline_resolves_resection_plan.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_pipeline_resolves_resection_plan PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;mapper-wiring"
+    )
+
     # T3-g3 -- auto-populate of the Stage-4 ResectionPlanningWidget (the Python
     # widget, ADR-0004; ADR-0023 §Stage-4).  Three invariants: (1) the drawer
     # auto-populates iff a vtkMRMLMarkupsBezierSurfaceNode is selected AND

--- a/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
@@ -78,6 +78,8 @@ import pytest
 
 BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
 DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+VOLUME_NODE_CLASS = "vtkMRMLScalarVolumeNode"
 REAL_MAPPER_CLASS = "vtkOpenGLBezierResectionPolyDataMapper"
 
 
@@ -263,6 +265,105 @@ def test_planning_display_fields_plumbed_to_mapper():
         "Grid3DVisibility off must zero the mapper's GridDivisions "
         f"(v1 parity); got {mapper.GetGridDivisions()}."
     )
+
+
+def _require_plan_distance_map_seam_or_skip(rep, slicer):
+    """Skip unless the distance-map threading seam (ADR-0031) has landed.
+
+    RED == ``BezierPlanningRepresentation`` has no ``SetResectionPlanNode`` or
+    the mapper has no ``SetDistanceMapImageData`` / the plan node is not
+    registered.  The skip lifts when slice 1b wires the wrapper's distance-map
+    + margins through to the mapper (ADR-0027 §Conformance).
+    """
+    mapper = rep.GetSurfaceMapper()
+    if not hasattr(rep, "SetResectionPlanNode") or not hasattr(
+        mapper, "SetDistanceMapImageData"
+    ):
+        pytest.skip(
+            "distance-map threading seam absent (no SetResectionPlanNode / "
+            "SetDistanceMapImageData) -- ADR-0031 slice 1b has not landed."
+        )
+    if slicer.mrmlScene.AddNewNodeByClass(PLAN_NODE_CLASS) is None:
+        pytest.skip(
+            f"{PLAN_NODE_CLASS} not registered in this build -- cannot thread "
+            "the distance-map input."
+        )
+
+
+def test_planning_distance_map_threaded_from_plan_to_mapper():
+    """ADR-0031: the wrapper's distance-map volume + margins reach the mapper.
+
+    The Pipeline threads the orchestrating ``vtkMRMLResectionPlanNode`` to the
+    Planning Representation, which pushes the distance-map image data, the
+    RAS/IJK matrices, and the safety / risk margins onto the real mapper.  All
+    GL-free: the image is *stored* on the mapper here (the 3D texture is built
+    at render, exercised on the :0 eyeball), the matrices/margins are CPU
+    setters.  Clearing the distance map returns the mapper to the
+    no-distance-map fallback.
+    """
+    import vtk
+
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    mapper = _require_real_mapper_or_skip(rep)
+    _require_plan_distance_map_seam_or_skip(rep, slicer)
+
+    data = _bezier_node_or_skip(slicer)
+    display = _display_node_or_skip(slicer)
+
+    plan = slicer.mrmlScene.AddNewNodeByClass(PLAN_NODE_CLASS)
+    volume = slicer.mrmlScene.AddNewNodeByClass(VOLUME_NODE_CLASS)
+    assert plan is not None and volume is not None
+
+    # Non-identity geometry so the RAS/IJK matrix is observably non-identity.
+    image = vtk.vtkImageData()
+    image.SetDimensions(4, 4, 4)
+    image.AllocateScalars(vtk.VTK_FLOAT, 1)
+    volume.SetAndObserveImageData(image)
+    volume.SetSpacing(2.0, 2.0, 2.0)
+
+    plan.SetAndObserveDistanceMapVolumeNode(volume)
+    plan.SetSafetyMargin_mm(10.0)
+    plan.SetRiskMargin_mm(2.0)
+
+    rep.SetResectionPlanNode(plan)
+    rep.update(display, data)
+
+    assert mapper.GetDistanceMapImageData() is volume.GetImageData(), (
+        "the wrapper's distance-map image must reach the mapper (the mapper "
+        "builds the 3D texture from it in C++ at render)."
+    )
+    assert abs(mapper.GetResectionMargin() - 10.0) < 1e-5, (
+        "plan SafetyMargin_mm must reach the mapper's ResectionMargin; got "
+        f"{mapper.GetResectionMargin()}."
+    )
+    assert abs(mapper.GetUncertaintyMargin() - 2.0) < 1e-5, (
+        "plan RiskMargin_mm must reach the mapper's UncertaintyMargin; got "
+        f"{mapper.GetUncertaintyMargin()}."
+    )
+    ras_to_ijk_t = mapper.GetRasToIjkMatrixT()
+    assert ras_to_ijk_t is not None and not _is_identity(ras_to_ijk_t), (
+        "the RAS/IJK matrix must be computed from the distance-map volume "
+        "geometry (non-identity for a spacing-2 volume), not left at identity."
+    )
+
+    # Clear the distance map -> mapper returns to the no-distance-map fallback.
+    plan.SetAndObserveDistanceMapVolumeNode(None)
+    rep.update(display, data)
+    assert mapper.GetDistanceMapImageData() is None, (
+        "clearing the wrapper's distance-map reference must drop the image "
+        "from the mapper (MRML state and GL state must not diverge)."
+    )
+
+
+def _is_identity(matrix, tol=1e-9):
+    """True iff a vtkMatrix4x4 is the identity within ``tol``."""
+    for i in range(4):
+        for j in range(4):
+            expected = 1.0 if i == j else 0.0
+            if abs(matrix.GetElement(i, j) - expected) > tol:
+                return False
+    return True
 
 
 if __name__ == "__main__":

--- a/LiverResections/Testing/Python/test_pipeline_resolves_resection_plan.py
+++ b/LiverResections/Testing/Python/test_pipeline_resolves_resection_plan.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""T2 render-cutover slice 1c -- the Pipeline reverse-resolves its plan wrapper.
+
+ADR-0031 puts the distance-map volume (and the resection / uncertainty margins)
+on the ``vtkMRMLResectionPlanNode`` *wrapper*, and slice 1b made
+``BezierPlanningRepresentation`` thread them onto the mapper -- but only when the
+Pipeline's ``_resection_node`` is set.  In the live LayerDM render path the
+displayable manager creates the Pipeline for the surface's *display node*
+(``registerPipelineCreator`` matches ``vtkMRMLParametricSurfaceDisplayNode``),
+so the Pipeline derives its data node but is never handed the wrapper -- nothing
+in production calls ``SetResectionNode``.  Without this slice the live v2
+surface renders with NO margin shading (the distance map never reaches the
+mapper), which would make the render cutover a visible regression.
+
+This pins the fix: the Pipeline reverse-resolves the wrapper from its data node
+via the ``geometry`` back-reference (the plan references the surface carrier, so
+the plan whose ``GetGeometryNode()`` is our data node is our wrapper) and sets
+``_resection_node`` itself -- no external caller required.
+
+-- WHY LAUNCHED-SLICER --
+Needs the wrapped ``vtkMRMLResectionPlanNode`` / ``vtkMRMLBezierSurfaceNode`` /
+``vtkMRMLParametricSurfaceDisplayNode`` + the importable
+``LiverBezierSurfacePipeline`` (LayerDMLib reachable only inside Slicer).  Skips
+cleanly under bare ``PythonSlicer -m pytest``.
+
+-- WHY RED NOW --
+The Pipeline has no reverse-resolution; ``GetResectionNode()`` stays ``None``
+after wiring the graph.  The skip/fail lifts when slice 1c lands (ADR-0027).
+
+See also:
+  * Docs/adr/0031-distance-map-input-on-resection-plan.md
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §5
+  * LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_pipeline_or_skip():
+    try:
+        from LiverResectionsLib.LiverBezierSurfacePipeline import (
+            LiverBezierSurfacePipeline,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"LiverBezierSurfacePipeline not importable ({exc!r}) -- LayerDMLib "
+            "not reachable in this environment."
+        )
+    return LiverBezierSurfacePipeline()
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def _wire_surface_with_display(slicer):
+    """Create a Bezier carrier + its parametric-surface display node, wired so
+    ``display.GetDisplayableNode()`` resolves the carrier (the back-reference
+    the Pipeline derives its data node from)."""
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, DISPLAY_NODE_CLASS)
+    data.SetAndObserveDisplayNodeID(display.GetID())
+    if display.GetDisplayableNode() is not data:
+        pytest.skip(
+            "display.GetDisplayableNode() does not resolve the carrier in this "
+            "build -- cannot exercise the Pipeline's data-node derivation."
+        )
+    return data, display
+
+
+def test_pipeline_reverse_resolves_plan_from_geometry_ref():
+    """The Pipeline resolves its wrapper from the data node's geometry back-ref.
+
+    Wire ``plan --geometry--> data <--displayable-- display``, attach the
+    display node to a fresh Pipeline and dispatch; the Pipeline must discover
+    the plan (``GetResectionNode()``) without anyone calling
+    ``SetResectionNode`` -- the production wiring the live render path needs.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+
+    data, display = _wire_surface_with_display(slicer)
+    plan = _add_or_skip(slicer, PLAN_NODE_CLASS)
+    if not hasattr(plan, "SetAndObserveGeometryNode"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveGeometryNode.")
+    plan.SetAndObserveGeometryNode(data)
+    assert plan.GetGeometryNode() is data
+
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    assert pipeline.GetResectionNode() is plan, (
+        "the Pipeline must reverse-resolve its vtkMRMLResectionPlanNode wrapper "
+        "from the data node's geometry back-reference (ADR-0031) so the live "
+        "LayerDM render path threads the distance-map + margins without an "
+        "external SetResectionNode caller; got "
+        f"{pipeline.GetResectionNode()!r}."
+    )
+
+
+def test_pipeline_resection_node_none_for_unowned_surface():
+    """A bare surface with no owning plan resolves to no wrapper.
+
+    Pins that the reverse-resolution does not false-positive: a Pipeline over a
+    surface that no plan references must leave ``GetResectionNode()`` None
+    (the no-distance-map fallback the shader supports).
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+
+    data, display = _wire_surface_with_display(slicer)
+    # No plan references ``data``.
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    assert pipeline.GetResectionNode() is None, (
+        "a surface no plan owns must resolve to no wrapper; got "
+        f"{pipeline.GetResectionNode()!r}."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverResections/VTKWidgets/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/VTKWidgets/Testing/Cxx/CMakeLists.txt
@@ -12,6 +12,7 @@ set(KIT_TEST_SRCS
   vtkLiverBezierWidgetTest1.cxx
   vtkOpenGLLiverResectionMappersRelocationTest1.cxx
   vtkOpenGLBezierResectionPolyDataMapperLocatorTest1.cxx
+  vtkOpenGLBezierResectionPolyDataMapperDistanceMapTest1.cxx
   vtkOpenGLDistanceContourMapperSpheroidSSOTTest.cxx
   )
 
@@ -45,6 +46,7 @@ target_link_libraries(${KIT}CxxTests
 SIMPLE_TEST(vtkLiverBezierWidgetTest1)
 SIMPLE_TEST(vtkOpenGLLiverResectionMappersRelocationTest1)
 SIMPLE_TEST(vtkOpenGLBezierResectionPolyDataMapperLocatorTest1)
+SIMPLE_TEST(vtkOpenGLBezierResectionPolyDataMapperDistanceMapTest1)
 
 # GPU-path / SSOT consistency pin for the distance-spheroid init contour
 # (ADR-0014 §2 triaxial-ellipsoid contour, ADR-0015 §"Stack 4" render ==

--- a/LiverResections/VTKWidgets/Testing/Cxx/vtkOpenGLBezierResectionPolyDataMapperDistanceMapTest1.cxx
+++ b/LiverResections/VTKWidgets/Testing/Cxx/vtkOpenGLBezierResectionPolyDataMapperDistanceMapTest1.cxx
@@ -1,0 +1,111 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2018-2026, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed by Rafael Palomar (Oslo University
+  Hospital and NTNU) and was supported by The Research Council of Norway
+  through the ALive project (grant nr. 311393).
+
+==============================================================================*/
+
+// LiverResections VTKWidgets includes
+#include "vtkOpenGLBezierResectionPolyDataMapper.h"
+
+// MRML includes (ctkTest assertion macros)
+#include "vtkMRMLCoreTestingMacros.h"
+
+// VTK includes
+#include <vtkImageData.h>
+#include <vtkNew.h>
+
+// STD includes
+#include <iostream>
+
+// ADR-0031 §Conformance — the GL-free half of "the distance-map input reaches
+// the mapper".  Pins the SetDistanceMapImageData / GetDistanceMapImageData
+// accessor surface: the default no-distance-map state, the image round-trip,
+// and that passing nullptr clears both the image and the (lazily built)
+// texture so MRML state and GL state cannot diverge (ADR-0003).
+//
+// The actual GL texture upload (Create3DFromRaw in BuildBufferObjects) needs a
+// live render window and is exercised by the interactive :0 eyeball /
+// launched-GL pass — OUT OF SCOPE for this no-GL, no-Slicer unit test.
+
+namespace
+{
+
+int testDistanceMapImageDefaultState()
+{
+  vtkNew<vtkOpenGLBezierResectionPolyDataMapper> mapper;
+  CHECK_NOT_NULL(mapper.GetPointer());
+
+  // No distance map by default — the sampler falls back to the
+  // no-distance-map path.
+  CHECK_NULL(mapper->GetDistanceMapImageData());
+  CHECK_NULL(mapper->GetDistanceMapTextureObject());
+
+  return EXIT_SUCCESS;
+}
+
+int testDistanceMapImageRoundTripAndClear()
+{
+  vtkNew<vtkOpenGLBezierResectionPolyDataMapper> mapper;
+
+  vtkNew<vtkImageData> image;
+  image->SetDimensions(4, 4, 4);
+  image->AllocateScalars(VTK_FLOAT, 1);
+
+  mapper->SetDistanceMapImageData(image.GetPointer());
+  CHECK_POINTER(mapper->GetDistanceMapImageData(), image.GetPointer());
+  // GL-free: the texture is built only at render, so it stays null here even
+  // though the image is set.
+  CHECK_NULL(mapper->GetDistanceMapTextureObject());
+
+  // Clearing the image drops both the image and any built texture.
+  mapper->SetDistanceMapImageData(nullptr);
+  CHECK_NULL(mapper->GetDistanceMapImageData());
+  CHECK_NULL(mapper->GetDistanceMapTextureObject());
+
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkOpenGLBezierResectionPolyDataMapperDistanceMapTest1(int, char*[])
+{
+  CHECK_EXIT_SUCCESS(testDistanceMapImageDefaultState());
+  CHECK_EXIT_SUCCESS(testDistanceMapImageRoundTripAndClear());
+
+  std::cout << "vtkOpenGLBezierResectionPolyDataMapperDistanceMapTest1 completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -89,6 +89,12 @@ public:
   vtkSmartPointer<vtkMatrix4x4> RasToIjkMatrixT;
   vtkSmartPointer<vtkMatrix4x4> IjkToTextureMatrixT;
   vtkSmartPointer<vtkTextureObject> DistanceMapTexture;
+  // Distance-map source image set from Python (ADR-0031); the texture above
+  // is (re)built from it lazily in BuildBufferObjects once a GL context is
+  // available.  DistanceMapBuiltMTime tracks the image MTime the live
+  // texture was built from, so a changed volume triggers a rebuild.
+  vtkSmartPointer<vtkImageData> DistanceMapImageData;
+  vtkMTimeType DistanceMapBuiltMTime = 0;
   float ResectionMargin;
   float UncertaintyMargin;
   float ResectionMarginColor[3];
@@ -132,6 +138,38 @@ void vtkOpenGLBezierResectionPolyDataMapper::BuildBufferObjects(vtkRenderer* ren
     vtkOpenGLVertexBufferObjectCache* cache = renWin->GetVBOCache();
     auto tcoords = this->CurrentInput->GetPointData()->GetTCoords();
     this->VBOs->CacheDataArray("uvCoords", tcoords, cache, VTK_FLOAT);
+  }
+
+  // Build / refresh the 3D distance-map texture from the image data set via
+  // SetDistanceMapImageData (ADR-0031).  Done here — not in the setter —
+  // because the upload needs a live GL context (the render window), and
+  // realize-then-bind on the live context is the ADR-0003 discipline.  The
+  // texture is rebuilt only when the source image's MTime advances past the
+  // one the current texture was built from, so steady-state renders do not
+  // re-upload.  Mirrors v1 CreateAndTransferDistanceMapTexture, but uses the
+  // base vtkTextureObject (single texture — no multi-texture sequencing).
+  if (this->Impl->DistanceMapImageData)
+  {
+    vtkImageData* image = this->Impl->DistanceMapImageData;
+    if (!this->Impl->DistanceMapTexture || image->GetMTime() > this->Impl->DistanceMapBuiltMTime)
+    {
+      auto renWin = vtkOpenGLRenderWindow::SafeDownCast(ren->GetRenderWindow());
+      int dimensions[3] = { 0, 0, 0 };
+      image->GetDimensions(dimensions);
+
+      vtkNew<vtkTextureObject> texture;
+      texture->SetContext(renWin);
+      texture->SetWrapS(vtkTextureObject::ClampToBorder);
+      texture->SetWrapT(vtkTextureObject::ClampToBorder);
+      texture->SetWrapR(vtkTextureObject::ClampToBorder);
+      texture->SetMinificationFilter(vtkTextureObject::Linear);
+      texture->SetMagnificationFilter(vtkTextureObject::Linear);
+      texture->SetBorderColor(1000.0f, 1000.0f, 0.0f, 0.0f);
+      texture->Create3DFromRaw(dimensions[0], dimensions[1], dimensions[2], image->GetNumberOfScalarComponents(), image->GetScalarType(), image->GetScalarPointer());
+
+      this->Impl->DistanceMapTexture = texture;
+      this->Impl->DistanceMapBuiltMTime = image->GetMTime();
+    }
   }
 
   Superclass::BuildBufferObjects(ren, act);
@@ -424,6 +462,32 @@ void vtkOpenGLBezierResectionPolyDataMapper::SetDistanceMapTextureObject(vtkText
 vtkTextureObject* vtkOpenGLBezierResectionPolyDataMapper::GetDistanceMapTextureObject() const
 {
   return this->Impl->DistanceMapTexture;
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLBezierResectionPolyDataMapper::SetDistanceMapImageData(vtkImageData* imageData)
+{
+  if (this->Impl->DistanceMapImageData == imageData)
+  {
+    return;
+  }
+  this->Impl->DistanceMapImageData = imageData;
+  // Force a texture (re)build on the next BuildBufferObjects, and drop the
+  // current texture when the image is cleared so the sampler falls back to
+  // the no-distance-map path (MRML state and GL state must not diverge —
+  // ADR-0003).
+  this->Impl->DistanceMapBuiltMTime = 0;
+  if (imageData == nullptr)
+  {
+    this->Impl->DistanceMapTexture = nullptr;
+  }
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+vtkImageData* vtkOpenGLBezierResectionPolyDataMapper::GetDistanceMapImageData() const
+{
+  return this->Impl->DistanceMapImageData;
 }
 
 //------------------------------------------------------------------------------

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
@@ -50,6 +50,7 @@
 #include <memory>
 
 class vtkTextureObject;
+class vtkImageData;
 
 //-------------------------------------------------------------------------------
 class VTK_SLICER_LIVERRESECTIONS_MODULE_VTKWIDGETS_EXPORT vtkOpenGLBezierResectionPolyDataMapper : public vtkOpenGLPolyDataMapper
@@ -147,6 +148,22 @@ public:
   void SetDistanceMapTextureObject(vtkTextureObject* texture);
   /// Get the distance-map texture object set by the representation.
   vtkTextureObject* GetDistanceMapTextureObject() const;
+
+  /// Set the distance-map volume's image data; the mapper builds and binds
+  /// the 3D distance texture from it internally at render time (ADR-0031).
+  ///
+  /// The texture upload (``vtkTextureObject::Create3DFromRaw`` with the
+  /// scalar ``void*``) cannot cross the Python wrap, so a Python
+  /// Representation passes the ``vtkImageData`` here and the GL upload lives
+  /// in C++.  The number of components is read from the image itself.  The
+  /// texture is (re)built lazily in ``BuildBufferObjects`` when a live GL
+  /// context is available and the image changed — never eagerly here, so the
+  /// realize-then-bind discipline holds (ADR-0003).  Passing nullptr clears
+  /// the distance map (the graceful no-distance-map fallback).
+  void SetDistanceMapImageData(vtkImageData* imageData);
+  /// Get the distance-map image data set via SetDistanceMapImageData (the
+  /// GL-free introspection point; the texture itself is built at render).
+  vtkImageData* GetDistanceMapImageData() const;
 
   /// Get the locator marker position (RAS world point, ADR-0025)
   const float* GetLocatorPosition() const;


### PR DESCRIPTION
## Distance-map input on the resection-plan wrapper + bind it on the v2 render path

Implements ADR-0031 and closes the prerequisite for the #493 render cutover: the v2 LayerDM Bézier render path now reproduces v1's distance-map margin / uncertainty / clip-out shading, so v1's live Bézier render can be removed without a visual-regression.

Two slices, test-first (ADR-0027):

### 1 — `distanceMap` node reference on `vtkMRMLResectionPlanNode` (commit 1)
The distance-map volume is a path-specific input of the resection plan, so per ADR-0031 it lives on the **wrapper** (typed `distanceMap` ref role: `GetDistanceMapReferenceRole()` / `GetDistanceMapVolumeNode()` / `SetAndObserveDistanceMapVolumeNode()`), alongside the `SafetyMargin_mm` / `RiskMargin_mm` scalars already there — not on the carrier. Mirrors the existing `geometry` role. MRML-level invariant test pins the role literal, the in-scene round-trip, and nullptr-clears.

### 2 — bind the distance map on the render path (commit 2)
- **C++ (mapper):** `SetDistanceMapImageData(vtkImageData*)` stores the image and builds + binds the 3D distance texture lazily in `BuildBufferObjects` on a live GL context, rebuilding only when the image MTime advances (realize-then-bind — ADR-0003). The `void*` `Create3DFromRaw` upload can't cross the Python wrap, so it lives in C++. A single base `vtkTextureObject` suffices — no LiverMarkups multi-texture-helper dependency. `GetDistanceMapImageData()` is the GL-free introspection point.
- **Python (Representation):** `SetResectionPlanNode()`; `update()` reads the wrapper's distance-map volume + margins, hands the image to the mapper, computes the RAS→IJK / IJK→texture matrices from the volume geometry, and pushes the margins. No distance map → clears the image + resets matrices to identity (graceful fallback). The Pipeline threads the wrapper to the Representation before `update()`.

### Tests
- C++ GL-free accessor test (`vtkMRMLResectionPlanDistanceMapRefTest`, `vtkOpenGLBezierResectionPolyDataMapperDistanceMapTest1`).
- Launched-Slicer invariant (`test_planning_distance_map_threaded_from_plan_to_mapper`): the full plan→Representation→mapper thread (image stored, margins set, RAS/IJK matrix non-identity, clearing returns to the fallback).
- Texture build + bind + a two-render **no-ADR-0003-abort** check verified on an interactive `:0` render.

Verified locally: all MRML + VTKWidgets C++ tests pass; the launched LiverResections suite is 57 passed / 9 skipped / 1 xfailed (no failures introduced).

### Scope / conformance
This is the binding prerequisite only. Removing the v1 `vtkSlicerBezierSurfaceWidget` / `vtkSlicerBezierSurfaceRepresentation3D` render and re-baselining the `BezierSurface4x4*` visual-regression scenarios are the follow-on cutover slices tracked under #493. References: ADR-0031, ADR-0014 §"Fourth layer", ADR-0013 §4/§5, ADR-0003, ADR-0027.

---
_Authored with assistance from Claude (Anthropic Claude Opus 4.8). Reviewed by the maintainer before merge._


### 3 — Pipeline reverse-resolves the plan wrapper (commit 3)
The LayerDM displayable manager creates the Pipeline for a surface's `vtkMRMLParametricSurfaceDisplayNode`, so it derived the data node but was never handed the wrapper — nothing in production calls `SetResectionNode`, so the live v2 surface rendered with **no margin shading**. `UpdatePipeline` now reverse-resolves the `vtkMRMLResectionPlanNode` from the data node's `geometry` back-reference and adopts it, so the distance map + margins reach the mapper through the slice-2 path with no external caller. Launched invariant test pins the resolution + the negative (unowned-surface → no wrapper) case. This completes the **live** v2 distance-map render path; without it slices 1+2 have no production driver.
