### PR TITLE
ENH: Python-wrappable per-point control-grid setter on the parametric surface

### DIFF
--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLAbstractParametricSurfaceNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLAbstractParametricSurfaceNodeTest1.cxx
@@ -447,6 +447,38 @@ int testGetInitModeAsStringInvalidDefault()
   return EXIT_SUCCESS;
 }
 
+//------------------------------------------------------------------------------
+// Per-point control-grid setter -- the Python-wrappable seam a scenario /
+// interaction uses to position the grid (the flat ``SetControlGrid(const
+// double*)`` cannot cross the Python wrap).  ``SetControlPoint(row, col, x,
+// y, z)`` writes the (row, col) triple into the row-major flat grid at
+// ``(row * Cols + col) * 3``; out-of-range (row >= Rows or col >= Cols)
+// returns false and leaves the grid untouched.  Exercised via the
+// abstract-base pointer so the v2.1 NURBS sibling shares the seam.
+int testSetControlPointWritesGrid()
+{
+  vtkNew<vtkMRMLBezierSurfaceNode> bezier;
+  vtkMRMLAbstractParametricSurfaceNode* surface = bezier.GetPointer();
+  CHECK_NOT_NULL(surface);
+
+  // Default 4x4 grid.  Write the (1, 2) control point.
+  const unsigned int cols = surface->GetCols();
+  CHECK_BOOL(surface->SetControlPoint(1, 2, 1.5, -2.5, 3.0), true);
+
+  const double* grid = surface->GetControlGrid();
+  const unsigned int base = (1u * cols + 2u) * 3u;
+  CHECK_DOUBLE(grid[base + 0], 1.5);
+  CHECK_DOUBLE(grid[base + 1], -2.5);
+  CHECK_DOUBLE(grid[base + 2], 3.0);
+
+  // Out-of-range row / col are rejected and leave the grid unchanged.
+  CHECK_BOOL(surface->SetControlPoint(surface->GetRows(), 0, 9.0, 9.0, 9.0), false);
+  CHECK_BOOL(surface->SetControlPoint(0, surface->GetCols(), 9.0, 9.0, 9.0), false);
+  CHECK_DOUBLE(surface->GetControlGrid()[base + 0], 1.5);
+
+  return EXIT_SUCCESS;
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -469,6 +501,9 @@ int vtkMRMLAbstractParametricSurfaceNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testSetRowsNonSquareRejectedViaBase());
   CHECK_EXIT_SUCCESS(testGetInitModeFromStringNullPtr());
   CHECK_EXIT_SUCCESS(testGetInitModeAsStringInvalidDefault());
+
+  // Per-point control-grid setter (the Python-wrappable grid seam).
+  CHECK_EXIT_SUCCESS(testSetControlPointWritesGrid());
 
   std::cout << "vtkMRMLAbstractParametricSurfaceNodeTest1 completed successfully" << std::endl;
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/vtkMRMLAbstractParametricSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLAbstractParametricSurfaceNode.cxx
@@ -181,6 +181,21 @@ bool vtkMRMLAbstractParametricSurfaceNode::SetControlGrid(const double* values)
 }
 
 //------------------------------------------------------------------------------
+bool vtkMRMLAbstractParametricSurfaceNode::SetControlPoint(unsigned int row, unsigned int col, double x, double y, double z)
+{
+  if (row >= this->Rows || col >= this->Cols)
+  {
+    return false;
+  }
+  const size_t base = static_cast<size_t>(row * this->Cols + col) * 3u;
+  this->ControlGrid[base + 0] = x;
+  this->ControlGrid[base + 1] = y;
+  this->ControlGrid[base + 2] = z;
+  this->Modified();
+  return true;
+}
+
+//------------------------------------------------------------------------------
 bool vtkMRMLAbstractParametricSurfaceNode::SetSlicingPlaneInitPoint(int index, const double point[3])
 {
   if (index < 0 || index > 1 || point == nullptr)

--- a/LiverResections/MRML/vtkMRMLAbstractParametricSurfaceNode.h
+++ b/LiverResections/MRML/vtkMRMLAbstractParametricSurfaceNode.h
@@ -231,6 +231,17 @@ public:
   /// doubles.  Returns true on success; false on null pointer.
   virtual bool SetControlGrid(const double* values);
 
+  /// Set a single control point at grid position ``(row, col)`` to
+  /// ``(x, y, z)``.  Writes into the row-major flat grid at
+  /// ``(row * Cols + col) * 3``.  Returns false (leaving the grid
+  /// untouched) when ``row >= Rows`` or ``col >= Cols``.
+  ///
+  /// This is the Python-wrappable grid seam: the scalar-argument form
+  /// crosses the Python wrap, whereas ``SetControlGrid(const double*)``
+  /// (a bare pointer) does not — so scenarios and interaction code
+  /// position the grid through this.
+  virtual bool SetControlPoint(unsigned int row, unsigned int col, double x, double y, double z);
+
   /// Read the control grid as a flat row-major array.
   const double* GetControlGrid() const { return this->ControlGrid.data(); }
 

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -136,6 +136,24 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;ring-extraction"
     )
 
+    # Per-point control-grid setter is Python-wrappable -- vtkMRMLBezierSurfaceNode
+    # SetControlPoint(row, col, x, y, z) is reachable from Python (the flat
+    # SetControlGrid(const double*) is not) and round-trips via
+    # GetControlGridVector.  The grid seam a re-baseline scenario / interaction
+    # code uses to position the v2 surface.  Needs the wrapped node, so it runs
+    # green under the launched-Slicer `pytest_launched` row and SKIPS CLEANLY
+    # here under bare pytest (no slicer.mrmlScene).
+    add_test(
+      NAME LiverResections_parametric_surface_setcontrolpoint
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_parametric_surface_setcontrolpoint.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_parametric_surface_setcontrolpoint PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;parametric-surface"
+    )
+
     # T2-mapper-wiring -- BezierPlanningRepresentation drives the real,
     # relocated vtkOpenGLBezierResectionPolyDataMapper (ADR-0014 §3) rendering
     # the tessellated Bezier patch (vtkBezierSurfaceSource + vtkPolyDataNormals

--- a/LiverResections/Testing/Python/test_parametric_surface_setcontrolpoint.py
+++ b/LiverResections/Testing/Python/test_parametric_surface_setcontrolpoint.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""The per-point control-grid setter is callable from Python and round-trips.
+
+Slice 1d exists to give the v2 ``vtkMRMLBezierSurfaceNode`` a Python-settable
+control grid: ``SetControlGrid(const double*)`` cannot cross the VTK Python wrap
+(a bare ``double*`` surfaces as an opaque pointer), so a scenario / interaction
+code cannot position the grid through it.  ``SetControlPoint(row, col, x, y, z)``
+takes only scalars and IS wrappable -- this pins that it is reachable from
+Python and writes the row-major flat grid read back by ``GetControlGridVector``.
+
+Launched-Slicer pytest (needs the wrapped node); skips cleanly under bare
+``PythonSlicer -m pytest``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def test_set_control_point_callable_from_python_and_round_trips():
+    slicer = _slicer_or_skip()
+    node = slicer.mrmlScene.AddNewNodeByClass(BEZIER_NODE_CLASS)
+    if node is None:
+        pytest.skip(f"{BEZIER_NODE_CLASS} not registered in this build.")
+    if not hasattr(node, "SetControlPoint"):
+        pytest.skip(
+            "vtkMRMLBezierSurfaceNode has no SetControlPoint -- the Python "
+            "grid seam (slice 1d) has not landed."
+        )
+
+    cols = int(node.GetCols())
+    assert node.SetControlPoint(1, 2, 1.5, -2.5, 3.0) is True
+
+    grid = node.GetControlGridVector()
+    base = (1 * cols + 2) * 3
+    assert abs(grid[base + 0] - 1.5) < 1e-9
+    assert abs(grid[base + 1] - -2.5) < 1e-9
+    assert abs(grid[base + 2] - 3.0) < 1e-9
+
+    # Out-of-range is rejected from Python too.
+    assert node.SetControlPoint(int(node.GetRows()), 0, 9.0, 9.0, 9.0) is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Python-wrappable per-point control-grid setter on the parametric surface

A small node-API enabler for the render-cutover re-baseline (#493).

### Why
`vtkMRMLAbstractParametricSurfaceNode::SetControlGrid` takes a bare `const double*`, which VTK cannot wrap for Python (it surfaces as an opaque pointer string — the same wall as `GetControlGrid`). So a Python scenario or interaction code has **no way to position the v2 surface's control grid**. That blocks the re-baseline: every existing visual-regression scenario still hand-builds the **v1 markups** node because no v2 grid setter is reachable from Python.

### What
`SetControlPoint(row, col, x, y, z)` — scalar arguments cross the Python wrap cleanly. Writes the `(row, col)` triple into the row-major flat grid at `(row * Cols + col) * 3`; returns `false` (grid untouched) for out-of-range `row`/`col`. Declared on the abstract base so the v2.1 NURBS sibling shares the seam.

### Tests
- C++ invariant (`vtkMRMLAbstractParametricSurfaceNodeTest1`): round-trips a control point through the flat grid + out-of-range rejection, via the abstract-base pointer.
- Launched-Slicer test (`test_parametric_surface_setcontrolpoint.py`): pins that `SetControlPoint` is callable **from Python** and round-trips via `GetControlGridVector` — the actual contract this slice provides.

Both pass locally; the Python test skips cleanly under bare `PythonSlicer -m pytest`.

### Context
Independent of #496 (the distance-map render path); together they unblock porting the `BezierSurface4x4*` visual-regression scenarios to drive the v2 surface for re-baselining. References: ADR-0018 §1 (grid-size invariants), ADR-0014 §"Fourth layer", #493 (the cutover).

---
_Authored with assistance from Claude (Anthropic Claude Opus 4.8). Reviewed by the maintainer before merge._
