### PR TITLE
ENH: Port the Bezier visual-regression scenarios to the v2 LayerDM render path

### DIFF
--- a/LiverResections/Testing/Python/scenarios/BezierSurface4x4Confirmed.py
+++ b/LiverResections/Testing/Python/scenarios/BezierSurface4x4Confirmed.py
@@ -8,14 +8,18 @@ Bezier surface remains visible after the fragment shader's discard
 runs.
 
 In the ``qMRMLThreeDWidget`` replay harness the visible pixels come
-from the legacy Markups render path
-(``vtkMRMLMarkupsBezierSurfaceNode`` → upstream Markups displayable
-manager → ``vtkSlicerBezierSurfaceRepresentation3D`` →
-``vtkOpenGLBezierResectionPolyDataMapper``).  In that path the only
-pixel-flipping difference between Planning and Confirmed is the
-``ClipOut`` uniform — driven by the ``ClipOut`` flag on the markups
-display node.  This scenario therefore reuses the Planning fixture and
-flips ``ClipOut`` on that display node.
+from the v2 LayerDM render path (``vtkMRMLBezierSurfaceNode`` +
+``vtkMRMLParametricSurfaceDisplayNode`` + the orchestrating
+``vtkMRMLResectionPlanNode`` → ``LiverBezierSurfacePipeline`` →
+``BezierPlanningRepresentation`` → ``vtkOpenGLBezierResectionPolyDataMapper``).
+The only pixel-flipping difference between Planning and Confirmed is the
+``ClipOut`` uniform — driven by the ``ClipOut`` flag on the parametric-
+surface display node.  This scenario therefore reuses the Planning
+fixture and flips ``ClipOut`` on that display node, staying on the
+Planning representation (the one that threads the distance map),
+mirroring v1's single-representation + uniform model.  Driving the
+Confirmed-state representation off the distance map is a separate
+follow-on (the ConfirmedRepresentation does not yet thread it).
 
 References
 ----------
@@ -50,22 +54,23 @@ CAMERA_VIEW_ANGLE = _planning.CAMERA_VIEW_ANGLE
 CAMERA_CLIPPING_RANGE = _planning.CAMERA_CLIPPING_RANGE
 
 
-def setup_scene() -> slicer.vtkMRMLMarkupsBezierSurfaceNode:
+def setup_scene() -> slicer.vtkMRMLBezierSurfaceNode:
     """Build the Planning fixture, then engage Confirmed-state trim.
 
     In this render path the Confirmed state differs from Planning by a
     single shader uniform — parenchyma trim — driven by ``ClipOut`` on
-    the markups Bezier surface display node.
+    the parametric-surface display node.
 
     Returns
     -------
-    vtkMRMLMarkupsBezierSurfaceNode
-        The same markups Bezier surface node ``BezierSurface4x4Planning``
-        builds, with the Confirmed-state ``ClipOut`` uniform engaged.
+    vtkMRMLBezierSurfaceNode
+        The same data carrier ``BezierSurface4x4Planning`` builds, with
+        the Confirmed-state ``ClipOut`` uniform engaged on its display
+        node.
     """
-    bezier = _planning.setup_scene()
-    bezier.GetDisplayNode().SetClipOut(True)
-    return bezier
+    carrier = _planning.setup_scene()
+    carrier.GetDisplayNode().SetClipOut(True)
+    return carrier
 
 
 def setup_camera(view_node: slicer.vtkMRMLViewNode | None = None) -> None:

--- a/LiverResections/Testing/Python/scenarios/BezierSurface4x4Planning.py
+++ b/LiverResections/Testing/Python/scenarios/BezierSurface4x4Planning.py
@@ -11,8 +11,9 @@ This module exposes three setup functions consumed identically by
 ``replay_test.py`` (the CI replay flow):
 
 * :func:`setup_scene`     — populates the MRML scene with a target
-  parenchyma model and a markups Bezier surface node carrying the
-  shader inputs.  Returns the created markups Bezier surface node so
+  parenchyma model and the v2 resection node graph (data carrier +
+  parametric-surface display node + the orchestrating resection-plan
+  wrapper carrying the shader inputs).  Returns the data carrier so
   callers can drive further per-scenario state.
 * :func:`setup_camera`    — sets the 3D view camera to a deterministic
   pose.  Replay tolerance is tight; camera drift is the most common
@@ -23,8 +24,9 @@ This module exposes three setup functions consumed identically by
 
 Designed to be importable from a pristine Slicer (``--no-main-window``)
 boot; no module GUI bring-up required.  The scene-setup code builds the
-markups Bezier surface node — the same node class the GUI render path
-binds — so the test exercises the production Markups render pipeline.
+v2 node graph the production GUI render path binds — so the test
+exercises the production LayerDM Pipeline render path (ADR-0013 §5,
+ADR-0031), not the retired v1 Markups path.
 
 References
 ----------
@@ -190,35 +192,40 @@ def _make_synthetic_parenchyma() -> slicer.vtkMRMLModelNode:
     return model
 
 
-def setup_scene() -> slicer.vtkMRMLMarkupsBezierSurfaceNode:
-    """Populate ``slicer.mrmlScene`` with the 4x4 Bezier Planning fixture.
+def setup_scene() -> slicer.vtkMRMLBezierSurfaceNode:
+    """Populate ``slicer.mrmlScene`` with the v2 4x4 Bezier Planning fixture.
 
     The function clears the scene first so it is idempotent under
     repeated invocation (e.g. across retries in capture_baseline.py).
 
     The visible pixels in the ``qMRMLThreeDWidget`` replay harness come
-    from the legacy Markups render path:
-    ``vtkMRMLMarkupsBezierSurfaceNode`` (+ its display node) → the
-    upstream Markups displayable manager →
-    ``vtkSlicerBezierSurfaceRepresentation3D`` → the
-    ``vtkOpenGLBezierResectionPolyDataMapper``.  The fixture therefore
-    hand-builds the markups bezier node directly and lands the shader
-    inputs on it; the v2 resection-plan carrier is render-inert in this
-    harness and is intentionally not part of the scene.
+    from the v2 LayerDM render path: the data carrier
+    ``vtkMRMLBezierSurfaceNode`` + its decoration
+    ``vtkMRMLParametricSurfaceDisplayNode`` + the orchestrating
+    ``vtkMRMLResectionPlanNode`` (which carries the distance-map volume +
+    the safety / risk margins per ADR-0031) → ``LiverBezierSurfacePipeline``
+    → ``BezierPlanningRepresentation`` → the real
+    ``vtkOpenGLBezierResectionPolyDataMapper``.  The pipeline's creator
+    matches the parametric-surface display node; the pipeline
+    reverse-resolves the plan from the carrier's ``geometry``
+    back-reference (ADR-0031) and threads the distance map + margins onto
+    the mapper.
 
     Returns
     -------
-    vtkMRMLMarkupsBezierSurfaceNode
-        The created markups Bezier surface node; callers may further
-        mutate its display node.
+    vtkMRMLBezierSurfaceNode
+        The created data carrier; callers reach the display node via
+        ``GetDisplayNode()`` to flip per-state uniforms (e.g. the
+        Confirmed scenario's ``ClipOut``).
     """
     slicer.mrmlScene.Clear(0)
 
     # Force-load the LiverResections logic.  In ``--no-main-window``
     # boots, modules are not auto-instantiated until first reference;
     # going through ``slicer.modules`` triggers module load + logic
-    # singleton construction — which is what registers the Markups
-    # bezier node + its displayable manager on the render path.
+    # singleton construction — which performs the ADR-0013 §5
+    # registration calls (node classes + the LayerDM displayable manager
+    # in default views + the Pipeline creator) the v2 render path needs.
     slicer.modules.liverresections.logic()
 
     _make_synthetic_parenchyma()
@@ -227,54 +234,66 @@ def setup_scene() -> slicer.vtkMRMLMarkupsBezierSurfaceNode:
         sphere_radius=40.0,
     )
 
-    # Hand-build the markups Bezier surface node directly.  The
-    # representation no-ops unless the node carries exactly 16 control
-    # points, so seed 16 (mirroring the 4x4 grid the legacy
-    # ``AddBezierSurface`` laid out) before re-positioning them below.
-    bezier = slicer.mrmlScene.AddNewNodeByClass(
-        "vtkMRMLMarkupsBezierSurfaceNode", "VisualTestBezier"
+    # v2 data carrier + its parametric-surface display node.  The LayerDM
+    # Pipeline creator matches on the display node; the carrier is its
+    # displayable node (``display.GetDisplayableNode()``), from which the
+    # Pipeline derives its data node.
+    carrier = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLBezierSurfaceNode", "VisualTestBezier"
     )
-    for _ in range(16):
-        bezier.AddControlPoint(vtk.vtkVector3d(0.0, 0.0, 0.0))
-    bezier.CreateDefaultDisplayNodes()
+    display = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLParametricSurfaceDisplayNode", "VisualTestBezierDisplay"
+    )
+    carrier.SetAndObserveDisplayNodeID(display.GetID())
 
-    # Shader inputs that live on the markups NODE (see
-    # vtkMRMLMarkupsBezierSurfaceNode.h): resection / uncertainty
-    # margins and the distance-map volume.
-    bezier.SetResectionMargin(10.0)
-    bezier.SetUncertaintyMargin(2.0)
-
-    # Re-position the 16 control points so the patch fully encloses the
-    # parenchyma's z=0 disc.  The legacy layout was a default 0..30
-    # grid; we expand to -30..60 (centred on sphere centre 15,15) so the
-    # bezier-plane / contour-band correspondence is visible.
+    # Position the 4x4 control grid so the patch encloses the parenchyma's
+    # z=0 disc — same layout the v1 fixture used (centred on sphere centre
+    # (15, 15), spanning -30..60).  ``SetControlPoint`` is the
+    # Python-wrappable grid seam; ``(row, col)`` indexes the row-major grid.
     cx, cy = PATCH_CENTER_XY
-    half = PATCH_HALF_EXTENT
-    base_x = cx - half
-    base_y = cy - half
-    for i in range(4):
-        for j in range(4):
-            idx = i * 4 + j
-            bezier.SetNthControlPointPosition(
-                idx,
-                base_x + PATCH_SPACING * i,
-                base_y + PATCH_SPACING * j,
+    base_x = cx - PATCH_HALF_EXTENT
+    base_y = cy - PATCH_HALF_EXTENT
+    for row in range(4):
+        for col in range(4):
+            carrier.SetControlPoint(
+                row,
+                col,
+                base_x + PATCH_SPACING * row,
+                base_y + PATCH_SPACING * col,
                 0.0,
             )
 
-    # Display-node decoration (see
-    # vtkMRMLMarkupsBezierSurfaceDisplayNode.h).  ORDER MATTERS:
-    # ``TextureNumComps`` must be set BEFORE the distance map so the
-    # subsequent texture upload reads the correct per-voxel stride
-    # rather than the default zero-component stride.  Planning state
-    # leaves ``ClipOut`` off — the full surface is visible.
-    display = bezier.GetDisplayNode()
-    display.SetTextureNumComps(4)
-    bezier.SetDistanceMapVolumeNode(distance_map)
+    # Decoration on the display node
+    # (vtkMRMLParametricSurfaceDisplayNode).  Unlike v1 there is no
+    # ``TextureNumComps`` to set — the v2 mapper derives the component
+    # count from the distance-map image itself.  Planning leaves
+    # ``ClipOut`` off — the full surface is visible.
+    display.SetResectionColor(1.0, 1.0, 1.0)
+    display.SetGrid3DVisibility(True)
     display.SetClipOut(False)
     display.SetVisibility(True)
 
-    return bezier
+    # The orchestrating plan wrapper carries the path-specific inputs the
+    # surface shader needs (ADR-0031): the distance-map volume + the
+    # safety / risk margins (the v1 shader inputs that lived on the
+    # markups node).  The ``geometry`` reference to the carrier is what
+    # lets the Pipeline reverse-resolve this plan from the rendered
+    # surface.
+    plan = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLResectionPlanNode", "VisualTestResectionPlan"
+    )
+    plan.SetAndObserveGeometryNode(carrier)
+    plan.SetAndObserveDistanceMapVolumeNode(distance_map)
+    plan.SetSafetyMargin_mm(10.0)
+    plan.SetRiskMargin_mm(2.0)
+
+    # Planning state activates the BezierPlanningRepresentation (the one
+    # that threads the distance map).  Confirmed reuses this fixture and
+    # flips the display node's ClipOut — it stays on this representation,
+    # mirroring v1's single-representation + uniform model.
+    carrier.SetState(1)  # vtkMRMLBezierSurfaceNode::Planning
+
+    return carrier
 
 
 def setup_camera(view_node: slicer.vtkMRMLViewNode | None = None) -> None:


### PR DESCRIPTION
## Port the Bézier visual-regression scenarios to the v2 LayerDM render path

Slice 2 of the #493 render cutover. Builds on the now-merged distance-map render path (#496) and the `SetControlPoint` grid seam (#497).

### What changed
`BezierSurface4x4Planning` / `BezierSurface4x4Confirmed` now build the **v2 node graph** instead of the v1 markups node:
- `vtkMRMLBezierSurfaceNode` carrier — control grid positioned via `SetControlPoint` (the Python-wrappable seam from #497);
- `vtkMRMLParametricSurfaceDisplayNode` — colour / grid / ClipOut;
- `vtkMRMLResectionPlanNode` wrapper — `geometry` ref → carrier, distance-map ref + `SafetyMargin_mm`/`RiskMargin_mm` (ADR-0031).

The LayerDM pipeline's creator matches the display node, reverse-resolves the plan from the carrier's geometry back-reference (ADR-0031 / #496), and threads the distance map + margins onto the real `vtkOpenGLBezierResectionPolyDataMapper`. So the scenarios exercise the **production LayerDM render path**, not the retired v1 Markups path.

The parenchyma + 4-component distance-map fixtures and the camera/viewport are unchanged (inputs). Confirmed reuses the Planning fixture and flips the display node's `ClipOut`, staying on the Planning representation (mirroring v1's single-representation + uniform model); driving the Confirmed-state representation off the distance map is a separate follow-on.

### Verified
On an interactive `:0` render (non-interactive probe): the live LayerDM pipeline renders the surface, the distance map + margins reach the mapper **through the live path** (`GetDistanceMapImageData` set, `GetResectionMargin` == 10), and the framebuffer is non-trivial (grid + margin shading present, ~32% non-background).

### ⚠️ Baselines need re-capture (human-gated) before this is Ready
The captured baselines on ALiveResearchTestingData still reflect the **v1** render. They must be re-captured against this v2 path:
1. On a real-GL `:0`: `Slicer --no-main-window --python-script LiverResections/Testing/Python/capture_baseline.py --test BezierSurface4x4Planning` (then `--test BezierSurface4x4Confirmed`).
2. Visually confirm the v2 render matches the v1 margin/grid/clip-out shading, press `s`.
3. Upload the new bundles + update the in-repo `.sha512` stubs.

Until then the replay gate is **non-blocking** (excluded from the gating ctest + soft-gated step + self-skips on CI's software GL), so this PR does not red CI. Keep as Draft until baselines land.

References: ADR-0031, ADR-0013 §5, ADR-0020 §7 (capture/replay), ADR-0003. #493 (cutover); #496/#497 (prerequisites).

---
_Authored with assistance from Claude (Anthropic Claude Opus 4.8). Reviewed by the maintainer before merge._
