### PR TITLE
BUG/PERF: Cutover review fixes — distance-map build guard + pipeline scan memoization

### DIFF
--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -189,6 +189,14 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         self._display_node: Any | None = None
         self._resection_node: Any | None = None
 
+        # Scene ``MTime`` the last plan reverse-resolution scan ran against
+        # (ADR-0031).  The scan (``GetNodesByClass``) is gated on this so a
+        # bare surface with no owning plan does not full-scene-scan on every
+        # ``UpdatePipeline`` tick; it re-scans only when the scene structure
+        # changes (a plan added later).  ``None`` forces a scan on the next
+        # dispatch (reset when the display/data node changes).
+        self._last_resection_scan_mtime: int | None = None
+
         # Observer tags so ``cleanup()`` can detach precisely.  Index
         # by ``id(node)`` because ``vtkObject`` subclasses are not
         # universally hashable on identity.
@@ -273,6 +281,8 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         # Invalidate the memoised dispatch key — the next
         # ``UpdatePipeline`` picks up the new node set.
         self._last_update_key = None
+        # Force a fresh plan reverse-resolution for the new data node.
+        self._last_resection_scan_mtime = None
 
     def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
         """Dispatch the active Representation by ``(state, initMode)``.
@@ -295,10 +305,18 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         # and adopt it, so the plan's distance-map + margins reach the mapper
         # with no external SetResectionNode caller.  Re-attempted while unset
         # (the plan's geometry ref may be wired after the display node lands).
+        # Gate the scan on the scene's MTime so a bare surface with no owning
+        # plan does not full-scene-scan every tick (every interaction frame):
+        # re-scan only when the scene structure changed since the last scan
+        # (which is when a plan could have appeared).
         if self._resection_node is None and self._data_node is not None:
-            resolved = self._resolve_resection_node()
-            if resolved is not None:
-                self.SetResectionNode(resolved)
+            scene = self._data_node.GetScene()
+            scene_mtime = scene.GetMTime() if scene is not None else 0
+            if scene_mtime != self._last_resection_scan_mtime:
+                self._last_resection_scan_mtime = scene_mtime
+                resolved = self._resolve_resection_node()
+                if resolved is not None:
+                    self.SetResectionNode(resolved)
 
         # Build the dispatch key.  Falls back to ``0`` MTime for nodes
         # whose ``GetMTime`` is unavailable (defensive — stub nodes in

--- a/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
@@ -8,9 +8,9 @@ Bezier resection surface): the Planning-state Representation must render the
 *tessellated Bezier patch* through the relocated, real
 ``vtkOpenGLBezierResectionPolyDataMapper`` -- NOT the placeholder raw
 control-mesh through a generic ``vtkPolyDataMapper``.  This is the bottleneck
-slice that unblocks the ADR-0025 locator consumer (#489) and Locator B/D: the
-``uLocatorPosition`` / ``uLocatorRadius`` uniforms landed on that mapper have
-no visible effect until a real instance actually renders the surface.
+slice that unblocks the ADR-0025 locator consumer (Slice C) and Locator B/D:
+the ``uLocatorPosition`` / ``uLocatorRadius`` uniforms landed on that mapper
+have no visible effect until a real instance actually renders the surface.
 
 Three pinned invariants (all GL-free -- no render, no window):
 
@@ -31,17 +31,16 @@ Three pinned invariants (all GL-free -- no render, no window):
      ``SetGridDivisions`` / ``SetGridThicknessFactor``), porting the v1 setup
      from ``vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay``.
 
--- SCOPED OUT of this slice (deferred) --
+-- Distance-map binding (now landed, ADR-0031) --
 
 The RAS/IJK transformation matrices and the distance-map 3D texture binding
-(``SetRasToIjkMatrixT`` / ``SetIjkToTextureMatrixT`` /
-``SetDistanceMapTextureObject``) are NOT wired here: the v2
-``vtkMRMLBezierSurfaceNode`` carries no distance-map volume reference (the v1
-``vtkMRMLMarkupsBezierSurfaceNode`` did, via ``GetDistanceMapVolumeNode()``).
-With no node-level distance-map source there is nothing to thread; the mapper's
-fragment shader already degrades gracefully when no ``distanceTexture`` is
-bound (``SetUniformi("distanceTexture", 0)`` fallback).  Those parts wait on a
-follow-on that gives the v2 node a distance-map reference.
+were the follow-on this slice originally deferred.  They have since landed: the
+distance-map volume is a path-specific input on the ``vtkMRMLResectionPlanNode``
+wrapper (ADR-0031), threaded by ``BezierPlanningRepresentation`` onto the mapper
+(``SetDistanceMapImageData`` + the RAS/IJK matrices).
+``test_planning_distance_map_threaded_from_plan_to_mapper`` below pins that
+threading; the mapper still degrades gracefully (no band) when no distance map
+is wired.
 
 -- WHY THIS IS A LAUNCHED-SLICER PYTEST --
 
@@ -53,20 +52,19 @@ widget classes off the path, so this SKIPS CLEANLY via the shared
 ``slicer_pytest_support`` guards.  The Representation is plain Python + VTK;
 the test needs no render window.
 
--- WHY THIS IS RED NOW --
+-- HARNESS BEHAVIOUR --
 
-``BezierPlanningRepresentation._build_vtk_pipeline`` still constructs a generic
-``vtk.vtkPolyDataMapper`` and ``_apply_data_node`` builds the raw control mesh
-(``TODO(T2-mapper-relocation)`` at construction + data-apply).  Each test
-SKIPS pre-implementation on the real-mapper seam (``_require_real_mapper_or_skip``)
-rather than failing noisily, and goes GREEN once the implementer swaps the
-mapper + ports the tessellation -- per ADR-0027 §Conformance ("for skipped
-tests, the skip lifts at the implementation commit").
+The swap + tessellation + distance-map threading have landed, so these tests
+run GREEN under a launched Slicer.  Each still guards on the real-mapper seam
+(``_require_real_mapper_or_skip``) so it SKIPS CLEANLY -- never fails noisily --
+in an environment where the wrapped mapper is off the path (bare pytest), per
+ADR-0027 §Conformance.
 
 See also:
   * Docs/adr/0014-livermarkups-dissolution.md §3   (mapper relocation -- done)
   * Docs/adr/0013-layerdm-pipeline-pattern.md §6     (Representations as pipelines)
-  * Docs/adr/0025-cross-view-locator.md              (#489 consumer this unblocks)
+  * Docs/adr/0031-distance-map-input-on-resection-plan.md  (distance-map input)
+  * Docs/adr/0025-cross-view-locator.md              (the locator consumer this unblocks)
   * Docs/adr/0008-testing-strategy.md §1, §6         (dual-harness strategy)
   * LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx  (v1 source)
   * LiverResections/Testing/Python/conftest.py       (the cleanup fixtures)

--- a/LiverResections/Testing/Python/test_pipeline_resolves_resection_plan.py
+++ b/LiverResections/Testing/Python/test_pipeline_resolves_resection_plan.py
@@ -140,5 +140,42 @@ def test_pipeline_resection_node_none_for_unowned_surface():
     )
 
 
+def test_pipeline_does_not_rescan_for_plan_every_tick():
+    """The reverse-resolution is memoised against scene state, not per-tick.
+
+    For a bare surface with no owning plan, ``_resection_node`` stays None;
+    a naive implementation re-scans the scene (``GetNodesByClass``) on every
+    ``UpdatePipeline`` -- i.e. every interaction/drag frame.  Pin that the scan
+    is gated on the scene's modified time: repeated dispatches with no scene
+    change must resolve at most once.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+
+    data, display = _wire_surface_with_display(slicer)  # no owning plan
+    if not hasattr(pipeline, "_resolve_resection_node"):
+        pytest.skip("Pipeline has no _resolve_resection_node -- slice 1c absent.")
+    pipeline.SetDisplayNode(display)
+
+    calls = {"n": 0}
+    original = pipeline._resolve_resection_node
+
+    def _counting(*args, **kwargs):
+        calls["n"] += 1
+        return original(*args, **kwargs)
+
+    pipeline._resolve_resection_node = _counting
+
+    for _ in range(3):
+        pipeline.UpdatePipeline()
+
+    assert calls["n"] <= 1, (
+        "the Pipeline re-scanned the scene for an owning plan on every "
+        f"UpdatePipeline tick ({calls['n']} scans, no scene change) -- the "
+        "reverse-resolution must be memoised against scene state so idle / "
+        "per-drag dispatches do not full-scene-scan."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -157,18 +157,28 @@ void vtkOpenGLBezierResectionPolyDataMapper::BuildBufferObjects(vtkRenderer* ren
       int dimensions[3] = { 0, 0, 0 };
       image->GetDimensions(dimensions);
 
-      vtkNew<vtkTextureObject> texture;
-      texture->SetContext(renWin);
-      texture->SetWrapS(vtkTextureObject::ClampToBorder);
-      texture->SetWrapT(vtkTextureObject::ClampToBorder);
-      texture->SetWrapR(vtkTextureObject::ClampToBorder);
-      texture->SetMinificationFilter(vtkTextureObject::Linear);
-      texture->SetMagnificationFilter(vtkTextureObject::Linear);
-      texture->SetBorderColor(1000.0f, 1000.0f, 0.0f, 0.0f);
-      texture->Create3DFromRaw(dimensions[0], dimensions[1], dimensions[2], image->GetNumberOfScalarComponents(), image->GetScalarType(), image->GetScalarPointer());
+      // Build only when there is a live GL context, the image is non-empty,
+      // and its scalars are allocated: Create3DFromRaw on a null/short buffer
+      // would upload garbage or abort.  Otherwise leave DistanceMapTexture
+      // untouched and do NOT advance DistanceMapBuiltMTime, so the shader takes
+      // its no-distance-map path and a later render retries once the
+      // image/context is valid (ADR-0003: MRML and GL state must not diverge).
+      const bool canBuild = renWin != nullptr && dimensions[0] > 0 && dimensions[1] > 0 && dimensions[2] > 0 && image->GetScalarPointer() != nullptr;
+      if (canBuild)
+      {
+        vtkNew<vtkTextureObject> texture;
+        texture->SetContext(renWin);
+        texture->SetWrapS(vtkTextureObject::ClampToBorder);
+        texture->SetWrapT(vtkTextureObject::ClampToBorder);
+        texture->SetWrapR(vtkTextureObject::ClampToBorder);
+        texture->SetMinificationFilter(vtkTextureObject::Linear);
+        texture->SetMagnificationFilter(vtkTextureObject::Linear);
+        texture->SetBorderColor(1000.0f, 1000.0f, 0.0f, 0.0f);
+        texture->Create3DFromRaw(dimensions[0], dimensions[1], dimensions[2], image->GetNumberOfScalarComponents(), image->GetScalarType(), image->GetScalarPointer());
 
-      this->Impl->DistanceMapTexture = texture;
-      this->Impl->DistanceMapBuiltMTime = image->GetMTime();
+        this->Impl->DistanceMapTexture = texture;
+        this->Impl->DistanceMapBuiltMTime = image->GetMTime();
+      }
     }
   }
 


### PR DESCRIPTION
## Cutover review fixes — `/slicer-review` follow-ups (fix-forward on merged #496)

Addresses the actionable findings from the architecture-aware review of the T2 render cutover. No blockers were found; these are the two correctness items + the doc nits, all fix-forward on already-merged code.

### BUG — guard the distance-map texture build (`vtkOpenGLBezierResectionPolyDataMapper`)
`BuildBufferObjects` called `Create3DFromRaw` unconditionally once a distance-map image was set. A present-but-unallocated `vtkImageData` (null `GetScalarPointer`), zero dimensions, or a non-OpenGL render window would upload garbage / abort. Now builds only when a live GL context + non-zero dims + allocated scalars are all present; otherwise it leaves the texture untouched and does not advance the built-MTime, so the shader takes its no-distance-map path and a later render retries (ADR-0003: MRML and GL state must not diverge). Happy path (allocated image) re-confirmed on an interactive `:0` render.

### PERF — gate the pipeline plan reverse-resolution on scene MTime (`LiverBezierSurfacePipeline`)
The ADR-0031 reverse-resolution scanned the whole scene (`GetNodesByClass`) on every `UpdatePipeline` for a surface with no owning plan — i.e. every interaction/drag frame, since `_resection_node` stays `None` permanently for a bare surface. Now gated on the scene's `MTime`: re-scan only when the scene structure changed since the last scan (when a plan could have appeared), preserving the wired-after-display ordering robustness. Launched test pins that repeated dispatches with no scene change resolve at most once.

### DOC — refresh the mapper-wiring test docstring
The module docstring still described the pre-implementation RED state ("SCOPED OUT (deferred)" distance-map block + "WHY THIS IS RED NOW"); rewritten to the landed reality, and dropped two bare `(#489)` issue refs in favour of the ADR-0025 path anchor (source-reference convention).

### Verified
Launched LiverResections suite: 61 passed / 9 skipped / 1 xfailed, no failures. The new pipeline scan-memoization test passes; the distance-map happy-path render confirmed on `:0`.

### Not addressed here (tracked / expected)
- `BezierSurface4x4Confirmed` rendering via the Planning representation (planner open Q2 — re-point when `ConfirmedRepresentation` threads the distance map).
- Stale v1 baselines / dormant replay — the human re-capture gate (#499).
- `getattr`/`hasattr` + `_HAS_VTK` speculative defensiveness — scoped in #498.

References: ADR-0003, ADR-0031, ADR-0013 §4. Follow-up to the merged distance-map render path (#496).

---
_Authored with assistance from Claude (Anthropic Claude Opus 4.8). Reviewed by the maintainer before merge._
