### PR TITLE
ENH: #501 slice 1 — logic CreateResectionPlan (v2 resection triad create-API)

### DIFF
--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -126,6 +126,40 @@ bool vtkSlicerLiverResectionsLogic::IsStageComplete()
 }
 
 //---------------------------------------------------------------------------
+vtkMRMLResectionPlanNode* vtkSlicerLiverResectionsLogic::CreateResectionPlan(const char* name)
+{
+  // Mint the v2 carrier + plan + display triad the interactive workflow
+  // needs (ADR-0032; ADR-0014 §"Fourth layer"), mirroring the file loaders'
+  // resolve-or-create discipline (vtkMRMLResectionPlanStorageNode::ReadFcsv).
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (scene == nullptr)
+  {
+    vtkErrorMacro("CreateResectionPlan: no MRML scene is bound");
+    return nullptr;
+  }
+
+  auto* plan = vtkMRMLResectionPlanNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLResectionPlanNode", (name ? name : "Resection")));
+  auto* carrier = vtkMRMLBezierSurfaceNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLBezierSurfaceNode"));
+  if (plan == nullptr || carrier == nullptr)
+  {
+    vtkErrorMacro("CreateResectionPlan: failed to instantiate the resection node graph");
+    return nullptr;
+  }
+
+  // The parametric-surface display node (which the LayerDM Pipeline creator
+  // matches on, ADR-0013 §5) is minted + observed on the carrier here.
+  carrier->CreateDefaultDisplayNodes();
+
+  // Wire the wrapper to the carrier via the typed geometry reference; the
+  // Pipeline reverse-resolves the plan from this back-reference (ADR-0031).
+  plan->SetAndObserveGeometryNode(carrier);
+
+  // The plan starts in Init (ADR-0019); the control grid is seeded by the
+  // placement step, not here.
+  return plan;
+}
+
+//---------------------------------------------------------------------------
 void vtkSlicerLiverResectionsLogic::RegisterNodes()
 {
   assert(this->GetMRMLScene() != nullptr);

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.h
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.h
@@ -57,6 +57,8 @@
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <itkImage.h>
 
+class vtkMRMLResectionPlanNode;
+
 //------------------------------------------------------------------------------
 class VTK_SLICER_LIVERRESECTIONS_MODULE_LOGIC_EXPORT vtkSlicerLiverResectionsLogic : public vtkSlicerModuleLogic
 {
@@ -89,6 +91,19 @@ public:
   virtual bool IsStageComplete();
 
   char* LoadLiverResection(const std::string& fileName, const std::string& nodeName /*=nullptr*/, vtkMRMLMessageCollection* userMessages /*=nullptr*/);
+
+  /// Create a new v2 resection node graph and return the plan wrapper.
+  ///
+  /// Mints the carrier + plan + display triad the interactive workflow
+  /// needs (ADR-0014 §"Fourth layer"; ADR-0032), identically to the file
+  /// loaders: a ``vtkMRMLResectionPlanNode`` wrapper whose typed
+  /// ``geometry`` reference resolves a freshly-created
+  /// ``vtkMRMLBezierSurfaceNode`` carrier carrying a default
+  /// ``vtkMRMLParametricSurfaceDisplayNode`` (which the LayerDM Pipeline
+  /// creator matches on).  The plan starts in ``Init`` (ADR-0019); the
+  /// control grid is seeded by the placement step, not here.  Returns
+  /// nullptr when no MRML scene is bound or node instantiation fails.
+  vtkMRMLResectionPlanNode* CreateResectionPlan(const char* name = nullptr);
 
 protected:
   vtkSlicerLiverResectionsLogic();

--- a/LiverResections/Testing/Cxx/vtkSlicerLiverResectionsLogicTest1.cxx
+++ b/LiverResections/Testing/Cxx/vtkSlicerLiverResectionsLogicTest1.cxx
@@ -46,6 +46,11 @@
 // VTKSlicer includes
 #include "vtkSlicerLiverResectionsLogic.h"
 
+// Module MRML includes (create-API triad)
+#include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLParametricSurfaceDisplayNode.h"
+#include "vtkMRMLResectionPlanNode.h"
+
 // VTK includes
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
@@ -98,6 +103,24 @@ int vtkSlicerLiverResectionsLogicTest1(int, char*[])
   // ``pythonManager()->executeString``.  Coverage for both calls
   // lives in the manual-launch probe + the workflow-layer pytest
   // under ``Testing/Python/workflow/`` (ADR-0008 §3).
+
+  // #501 slice 1 — the logic create-API mints the v2 carrier + plan +
+  // display triad interactively, identically to the file loaders (ADR-0032
+  // interaction model; ADR-0014 §"Fourth layer" wrapper/carrier; ADR-0031).
+  // Pins the structural invariant: a resection-plan wrapper whose geometry
+  // reference resolves a Bezier carrier that carries a parametric-surface
+  // display node (the LayerDM Pipeline creator matches on that display node),
+  // with the plan in the Init state (ADR-0019).
+  {
+    vtkMRMLResectionPlanNode* plan = logic1->CreateResectionPlan("Resection_CreateApiTest");
+    CHECK_NOT_NULL(plan);
+    CHECK_NOT_NULL(scene->GetNodeByID(plan->GetID()));
+
+    vtkMRMLBezierSurfaceNode* carrier = vtkMRMLBezierSurfaceNode::SafeDownCast(plan->GetGeometryNode());
+    CHECK_NOT_NULL(carrier);
+    CHECK_NOT_NULL(vtkMRMLParametricSurfaceDisplayNode::SafeDownCast(carrier->GetDisplayNode()));
+    CHECK_INT(plan->GetState(), vtkMRMLResectionPlanNode::Init);
+  }
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## #501 slice 1 — logic create-API for the v2 resection triad

First slice of the interactive v1→v2 workflow migration (#501), per **ADR-0032**. Decision-independent (doesn't touch the interaction seam), so it lands first.

### What
`vtkSlicerLiverResectionsLogic::CreateResectionPlan(name)` mints the v2 node graph the interactive workflow needs — which today only the file loaders build:
- a `vtkMRMLResectionPlanNode` wrapper,
- a `vtkMRMLBezierSurfaceNode` carrier with its `vtkMRMLParametricSurfaceDisplayNode` (`CreateDefaultDisplayNodes` — the node the LayerDM Pipeline creator matches on, ADR-0013 §5),
- the typed `geometry` reference wrapper→carrier (the Pipeline reverse-resolves the plan from it, ADR-0031).

The plan starts in `Init` (ADR-0019); the control grid is seeded by the **placement** step (a later #501 slice), not here. Mirrors the loaders' resolve-or-create triad (`vtkMRMLResectionPlanStorageNode`). The Python "Place resection" action (a later slice) will call this.

### Test
C++ invariant (`vtkSlicerLiverResectionsLogicTest1`): the returned plan's `geometry` ref resolves a `vtkMRMLBezierSurfaceNode` carrying a `vtkMRMLParametricSurfaceDisplayNode`, plan in `Init`. All module C++ tests green (7/7, incl. the integration test).

### Next slices (#501)
2. Pipeline `ProcessInteractionEvent` edit path (⚠️ first verify the seam fires under the live LayerDM manager on `:0`); 3. placement; 4. `ResectionPlanningWidget` re-point + Place button; 5. resectogram re-source; 6. round-trip; then #493 v1 retirement.

References: ADR-0032, ADR-0014 §"Fourth layer", ADR-0013 §5, ADR-0031, ADR-0019. Part of #501.

---
_Authored with assistance from Claude (Anthropic Claude Opus 4.8). Reviewed by the maintainer before merge._
