### PR TITLE
ENH: Re-point the Stage-4 resection-planning widget to the v2 plan graph

### DIFF
--- a/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
+++ b/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
@@ -10,13 +10,16 @@ its wrapped C++ nodes/logic directly -- no ``executeString`` string bridge.
 The behaviour mirrors the retired C++ ``qSlicerLiverResectionsModuleWidget``
 faithfully:
 
-* AUTO-POPULATE.  Selecting a ``vtkMRMLMarkupsBezierSurfaceNode`` that carries
-  a distance map ensures EXACTLY ONE ``vtkMRMLResectogramDisplayNode`` on it,
-  runs ``ResectogramViewManager.configureView``, embeds a single
-  ``qMRMLThreeDWidget`` bound to the singleton view node, and hides the hint.
-  Otherwise the hint is shown with the appropriate explanatory text.
-  Edge-triggered on ``(surface identity, hasDistanceMap)`` to avoid the
-  render-storm re-populate.
+* AUTO-POPULATE.  Selecting a ``vtkMRMLResectionPlanNode`` WRAPPER whose
+  distance map is set (``GetDistanceMapVolumeNode``, on the wrapper per
+  `ADR-0031`_) ensures EXACTLY ONE ``vtkMRMLResectogramDisplayNode`` on the
+  wrapper's CARRIER (``GetGeometryNode()``, a ``vtkMRMLBezierSurfaceNode``,
+  `ADR-0014`_ §"Fourth layer"), runs ``ResectogramViewManager.configureView``,
+  embeds a single ``qMRMLThreeDWidget`` bound to the singleton view node, and
+  hides the hint.  Otherwise the hint is shown with the appropriate explanatory
+  text.  Edge-triggered on ``(plan identity, hasDistanceMap)`` to avoid the
+  render-storm re-populate.  A "Place resection" button mints a fresh plan
+  graph via the logic create-API (`ADR-0032`_) and selects it.
 * EMBED.  ONE ``qMRMLThreeDWidget`` (objectName "ResectogramThreeDWidget");
   realize-then-bind so the distance-map 3D texture uploads into a realized GL
   context.
@@ -27,9 +30,12 @@ faithfully:
   remapped to ``WidgetEventNone`` so the flat panel cannot be orbited
   (``lockEmbeddedViewInteraction``) -- no custom DisplayableManager
   (`ADR-0013`_ §5).
-* REACTIVITY.  The active surface is observed for ``PointModifiedEvent`` ONLY
-  (the storm fix) to force a render of the embedded view; a deferred
-  initial-render kick shows the strip on auto-populate without an edit.
+* REACTIVITY.  The carrier is observed for ``ModifiedEvent`` (its only
+  control-point-edit signal -- it is not a markups node) to force a render of
+  the embedded view; a deferred initial-render kick shows the strip on
+  auto-populate without an edit.  The v1 storm-free variant (markups
+  ``PointModifiedEvent``) has no carrier equivalent; the storm-free guard is a
+  GL-coupled concern verified on the interactive ``:0`` probe (`ADR-0032`_).
 * CUSTOM ENLARGE.  A left double-click on the embedded view reparents the ONE
   widget into the layout manager's central viewport and back -- Slicer's
   built-in maximize is suppressed (it realises a blank second widget on the
@@ -42,11 +48,17 @@ References
 * `ADR-0023`_ §Stage-4 -- the dedicated resectogram view + auto-populate.
 * `ADR-0013`_ §5 -- no custom DisplayableManager; config only.
 * `ADR-0009`_ -- explainable state (the hint).
+* `ADR-0014`_ §"Fourth layer" -- the wrapper/carrier split.
+* `ADR-0031`_ -- the distance map lives on the resection-plan wrapper.
+* `ADR-0032`_ -- v2 interaction + the logic create-API for placement.
 
 .. _ADR-0004: ../../Docs/adr/0004-python-cpp-boundary.md
 .. _ADR-0009: ../../Docs/adr/0009-ux-and-design-discipline.md
 .. _ADR-0013: ../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0014: ../../Docs/adr/0014-livermarkups-dissolution.md
 .. _ADR-0023: ../../Docs/adr/0023-unified-gui-stage-workflow.md
+.. _ADR-0031: ../../Docs/adr/0031-distance-map-input-on-resection-plan.md
+.. _ADR-0032: ../../Docs/adr/0032-v2-interaction-via-layerdm-pipeline-seam.md
 """
 
 from __future__ import annotations
@@ -87,9 +99,18 @@ _RESECTOGRAM_CAMERA_FILL_ZOOM = 1.35
 # ResectogramViewManager pushes onto the MRML view node.
 _RESECTOGRAM_BACKGROUND_RGB = (1.0, 1.0, 1.0)
 
-_BEZIER_SURFACE_CLASS = "vtkMRMLMarkupsBezierSurfaceNode"
+# The Stage-4 combo selects the v2 resection-plan WRAPPER (ADR-0014 §"Fourth
+# layer").  The distance map is read off the wrapper (ADR-0031); the resectogram
+# display node + the render observation land on the wrapper's CARRIER
+# (``GetGeometryNode()``, a ``vtkMRMLBezierSurfaceNode``).
+_RESECTION_PLAN_CLASS = "vtkMRMLResectionPlanNode"
+_BEZIER_CARRIER_CLASS = "vtkMRMLBezierSurfaceNode"
 _RESECTOGRAM_DISPLAY_CLASS = "vtkMRMLResectogramDisplayNode"
 _VIEW_NODE_CLASS = "vtkMRMLViewNode"
+# The logic module whose create-API (``CreateResectionPlan``) the Place button
+# calls to mint a fresh plan + carrier + display triad (ADR-0032).
+_LOGIC_MODULE_NAME = "liverresections"
+_DEFAULT_RESECTION_NAME = "Resection"
 
 # Minimum embedded-view height so it reads as a square-ish strip panel rather
 # than a letterboxed sliver (ADR-0023 §Stage-4 layout).
@@ -159,7 +180,7 @@ class ResectionPlanningWidget(qt.QWidget):
 
         comboBox = slicer.qMRMLNodeComboBox()
         comboBox.setObjectName("ResectionSurfaceComboBox")
-        comboBox.nodeTypes = [_BEZIER_SURFACE_CLASS]
+        comboBox.nodeTypes = [_RESECTION_PLAN_CLASS]
         comboBox.noneEnabled = True
         comboBox.addEnabled = False
         comboBox.removeEnabled = False
@@ -167,10 +188,19 @@ class ResectionPlanningWidget(qt.QWidget):
         planningLayout.addWidget(comboBox, 0, 1)
         self._comboBox = comboBox
 
+        # "Place resection" mints a fresh v2 plan graph (wrapper + carrier +
+        # display) via the logic create-API and selects it (ADR-0032; ADR-0019
+        # starts the plan in Init so the placement step seeds the grid).
+        placeButton = qt.QPushButton("Place resection")
+        placeButton.setObjectName("PlaceResectionButton")
+        planningLayout.addWidget(placeButton, 1, 0, 1, 2)
+        self._placeButton = placeButton
+        placeButton.connect("clicked()", self.onPlaceResection)
+
         drawer = ctk.ctkCollapsibleButton()
         drawer.setObjectName("ResectogramDrawer")
         drawer.text = "Resectogram"
-        planningLayout.addWidget(drawer, 1, 0, 1, 2)
+        planningLayout.addWidget(drawer, 2, 0, 1, 2)
         self._drawer = drawer
 
         drawerLayout = qt.QGridLayout(drawer)
@@ -209,25 +239,52 @@ class ResectionPlanningWidget(qt.QWidget):
     def resectogramHintLabel(self):  # noqa: N802 - Slicer/Qt verb convention
         return self._hintLabel
 
+    def placeResectionButton(self):  # noqa: N802 - Slicer/Qt verb convention
+        return self._placeButton
+
     def setActiveResectionNode(self, node):  # noqa: N802 - Slicer/Qt verb convention
         self._comboBox.setCurrentNode(node)
+
+    def onPlaceResection(self):  # noqa: N802 - Slicer/Qt verb convention
+        """Mint a fresh v2 resection plan graph and select it.
+
+        Delegates to the logic create-API (``CreateResectionPlan``), which mints
+        the wrapper + carrier + carrier display triad and wires the geometry
+        reference (ADR-0032; ADR-0014 §"Fourth layer").  The fresh plan starts in
+        Init (ADR-0019); the placement step seeds the control grid.  Selecting it
+        drives the combo -> ``onActiveResectionChanged`` -> drawer path.
+        """
+        logic = self._resectionLogic()
+        if logic is None or not hasattr(logic, "CreateResectionPlan"):
+            return
+        plan = logic.CreateResectionPlan(_DEFAULT_RESECTION_NAME)
+        if plan is not None:
+            self.setActiveResectionNode(plan)
+
+    @staticmethod
+    def _resectionLogic():
+        """Return the LiverResections module logic singleton, or ``None``."""
+        module = getattr(slicer.modules, _LOGIC_MODULE_NAME, None)
+        if module is None:
+            return None
+        return module.logic()
 
     # ----------------------------------------------------------------------- #
     # Selection -> drawer state.
     # ----------------------------------------------------------------------- #
 
     def onActiveResectionChanged(self, node):  # noqa: N802 - Slicer/Qt verb convention
-        surface = self._asBezierSurface(node)
+        plan = self._asResectionPlan(node)
 
-        # Re-observe the active surface so computing a distance map (which
-        # mutates the surface node) re-evaluates the drawer state live -- this
-        # is the auto-populate path.
+        # Re-observe the active plan WRAPPER so attaching a distance map (which
+        # mutates the wrapper, ADR-0031) re-evaluates the drawer state live --
+        # this is the auto-populate path.
         if self._activeResectionNode is not None and self._activeNodeObservationTag is not None:
             self._activeResectionNode.RemoveObserver(self._activeNodeObservationTag)
         self._activeNodeObservationTag = None
-        self._activeResectionNode = surface
-        if surface is not None:
-            self._activeNodeObservationTag = surface.AddObserver(
+        self._activeResectionNode = plan
+        if plan is not None:
+            self._activeNodeObservationTag = plan.AddObserver(
                 vtk.vtkCommand.ModifiedEvent, self._onActiveResectionModified
             )
 
@@ -240,58 +297,63 @@ class ResectionPlanningWidget(qt.QWidget):
         self.scheduleResectogramRender()
 
     def refreshResectogramDrawer(self):  # noqa: N802 - Slicer/Qt verb convention
-        surface = self._asBezierSurface(self._comboBox.currentNode())
+        plan = self._asResectionPlan(self._comboBox.currentNode())
+        # The strip actors, the resectogram display node, and the render
+        # observation all live on the plan's CARRIER (ADR-0014 §"Fourth layer");
+        # the distance map is read off the WRAPPER (ADR-0031).
+        carrier = plan.GetGeometryNode() if plan is not None else None
 
         # ADR-0023 §Stage-4 auto-populate predicate: a resectogram is available
-        # iff a Bezier surface is selected AND it carries a distance map.
-        # State-orthogonal: the predicate does NOT consult the ADR-0019
-        # ResectionState.
-        hasSurface = surface is not None
+        # iff a resection PLAN is selected AND its WRAPPER carries a distance map
+        # (ADR-0031).  State-orthogonal: the predicate does NOT consult the
+        # ADR-0019 ResectionState.
+        hasPlan = plan is not None
         hasDistanceMap = bool(
-            hasSurface and surface.GetDistanceMapVolumeNode() is not None
+            hasPlan and carrier is not None and plan.GetDistanceMapVolumeNode() is not None
         )
         scene = self._mrmlScene
 
-        # Edge-trigger on the populate-relevant state only.  The active-surface
-        # ModifiedEvent observer fires this on EVERY surface modification --
+        # Edge-trigger on the populate-relevant state only.  The active-plan
+        # ModifiedEvent observer fires this on EVERY wrapper modification --
         # including the per-frame re-Modified() a maximize triggers -- but the
-        # populate depends only on the selected surface identity + its
-        # distance-map presence.  When neither changed, skip the work (a leg of
-        # the maximize render storm).  Only short-circuit once a scene is
-        # present: a null scene is a transient pre-attach state.
+        # populate depends only on the selected plan identity + its distance-map
+        # presence.  When neither changed, skip the work (a leg of the maximize
+        # render storm).  Only short-circuit once a scene is present: a null
+        # scene is a transient pre-attach state.
         if (
             scene is not None
             and self._refreshValid
-            and surface is self._refreshedSurface
+            and plan is self._refreshedSurface
             and hasDistanceMap == self._refreshedHasDistanceMap
         ):
             return
         if scene is not None:
             self._refreshValid = True
-            self._refreshedSurface = surface
+            self._refreshedSurface = plan
             self._refreshedHasDistanceMap = hasDistanceMap
 
         if not hasDistanceMap or scene is None:
             # ADR-0009 §"explainable state": show a hint INSTEAD of an edge-on /
-            # blank view, and stop observing any stale surface for render.
+            # blank view, and stop observing any stale carrier for render.
             if self._resectogramWidget is not None:
                 self._resectogramWidget.hide()
             self.observeSurfaceForRender(None)
             self._hintLabel.text = (
                 "Select a resection with a computed distance map."
-                if not hasSurface
+                if not hasPlan
                 else "Compute the distance map for this resection first."
             )
             self._hintLabel.show()
             return
 
-        # Ensure EXACTLY ONE resectogram display node on the surface
-        # (idempotent): reuse an existing one, create one only when absent.
-        displayNode = self._existingResectogramDisplayNode(surface)
+        # Ensure EXACTLY ONE resectogram display node on the CARRIER
+        # (idempotent, ADR-0014 §"Fourth layer"): reuse an existing one, create
+        # one only when absent.
+        displayNode = self._existingResectogramDisplayNode(carrier)
         if displayNode is None:
             displayNode = scene.AddNewNodeByClass(_RESECTOGRAM_DISPLAY_CLASS)
             if displayNode is not None:
-                surface.AddAndObserveDisplayNodeID(displayNode.GetID())
+                carrier.AddAndObserveDisplayNodeID(displayNode.GetID())
 
         # Ensure the singleton resectogram view node AND present the flattened
         # strip alone in it (display-node + view-node + camera configuration;
@@ -299,7 +361,7 @@ class ResectionPlanningWidget(qt.QWidget):
         # view-manager class is Python and is imported + called DIRECTLY here.
         manager = ResectogramViewManager()
         view = manager.ensureViewNode()
-        manager.configureView(view, displayNode, surface)
+        manager.configureView(view, displayNode, carrier)
 
         # Resolve the just-ensured singleton view node back from the scene by
         # its tag and embed a single qMRMLThreeDWidget bound to it.
@@ -316,9 +378,8 @@ class ResectionPlanningWidget(qt.QWidget):
         self._hintLabel.hide()
         self.showResectogramWidget(viewNode)
 
-        # Repaint the embedded strip whenever the selected surface's control
-        # points move.
-        self.observeSurfaceForRender(surface)
+        # Repaint the embedded strip whenever the carrier's control points move.
+        self.observeSurfaceForRender(carrier)
 
         # Replay the working reactivity path on auto-populate so the strip is
         # visible with NO manual edit.  Defer to the next event-loop turn, once
@@ -523,23 +584,23 @@ class ResectionPlanningWidget(qt.QWidget):
             return
 
         # Symmetric removal of the prior observer before re-targeting, so a
-        # stale surface never repaints the strip.
+        # stale carrier never repaints the strip.
         if self._renderObservedNode is not None and self._renderObservationTag is not None:
             self._renderObservedNode.RemoveObserver(self._renderObservationTag)
         self._renderObservationTag = None
 
         self._renderObservedNode = surface
         if surface is not None:
-            # Render on the control-point-edit signal ONLY
-            # (PointModifiedEvent), NOT the generic ModifiedEvent.  A maximize
-            # binds the resectogram view node to two live qMRMLThreeDViews
-            # whose renders re-Modified() the surface every frame; a
-            # generic-ModifiedEvent->forceRender observer would re-fire a render
-            # on each of those render-induced Modifies -- a feedback loop (the
-            # maximize render storm).  PointModifiedEvent is the real
-            # control-point-edit signal a render does not raise.
+            # The v2 carrier (vtkMRMLBezierSurfaceNode) is not a markups node and
+            # fires only the generic ModifiedEvent on a control-point edit, so
+            # observe that.  The v1 storm-free path hooked the markups
+            # PointModifiedEvent to dodge the maximize feedback loop (a render
+            # re-Modified() the surface every frame); the equivalent storm-free
+            # guard on the carrier's ModifiedEvent is a GL-coupled concern
+            # verified on the interactive :0 probe (ADR-0032 §Conformance), not
+            # this headless path.
             self._renderObservationTag = surface.AddObserver(
-                slicer.vtkMRMLMarkupsNode.PointModifiedEvent,
+                vtk.vtkCommand.ModifiedEvent,
                 self._onObservedSurfacePointModified,
             )
 
@@ -694,17 +755,19 @@ class ResectionPlanningWidget(qt.QWidget):
     # ----------------------------------------------------------------------- #
 
     @staticmethod
-    def _asBezierSurface(node):
-        """Return ``node`` if it is a Bezier surface node, else ``None``."""
-        if node is not None and node.IsA(_BEZIER_SURFACE_CLASS):
+    def _asResectionPlan(node):
+        """Return ``node`` if it is a resection-plan wrapper node, else ``None``."""
+        if node is not None and node.IsA(_RESECTION_PLAN_CLASS):
             return node
         return None
 
     @staticmethod
-    def _existingResectogramDisplayNode(surface):
-        """Return the surface's resectogram display node, or ``None``."""
-        for index in range(surface.GetNumberOfDisplayNodes()):
-            candidate = surface.GetNthDisplayNode(index)
+    def _existingResectogramDisplayNode(carrier):
+        """Return the carrier's resectogram display node, or ``None``."""
+        if carrier is None:
+            return None
+        for index in range(carrier.GetNumberOfDisplayNodes()):
+            candidate = carrier.GetNthDisplayNode(index)
             if candidate is not None and candidate.IsA(_RESECTOGRAM_DISPLAY_CLASS):
                 return candidate
         return None

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -330,6 +330,41 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;resectogram;stage4"
     )
 
+    # #501 slice 4 -- re-point the Stage-4 ResectionPlanningWidget (the Python
+    # widget, ADR-0004; ADR-0023 §Stage-4) from the v1 markups surface to the v2
+    # resection-plan node graph (ADR-0014 §"Fourth layer" wrapper/carrier).
+    # Three GPU-free invariants: (1) the active-resection combo offers a
+    # vtkMRMLResectionPlanNode WRAPPER and NOT the v1
+    # vtkMRMLMarkupsBezierSurfaceNode (nodeTypes re-point); (2) the auto-populate
+    # predicate reads the distance map off the WRAPPER
+    # (plan.GetDistanceMapVolumeNode(), ADR-0031) -- none selected -> "select"
+    # hint, plan without distance map -> "compute" hint, plan WITH distance map
+    # -> hint hidden AND exactly one vtkMRMLResectogramDisplayNode ensured on the
+    # CARRIER (plan.GetGeometryNode(), a vtkMRMLBezierSurfaceNode), idempotent on
+    # repeated refresh; (3) a "Place resection" affordance
+    # (placeResectionButton() + onPlaceResection()) mints a plan via the merged
+    # logic create-API (CreateResectionPlan, slice 1), adds it to the scene, and
+    # selects it in the combo (scene gains a plan + a Bezier carrier).  Builds
+    # LiverResectionsLib.ResectionPlanningWidget directly under a launched
+    # qSlicerApplication, so it runs green under the launched-Slicer
+    # `pytest_launched` row (Liver/Testing/Python; this dir is already on its
+    # test roots) and SKIPS CLEANLY here under bare pytest (no qt.QWidget /
+    # no widget / no create-API).  Each invariant is additionally guarded on the
+    # NEW state's presence (nodeTypes inspection / place-button accessor), so it
+    # lands RED-as-skip on the still-v1 build and turns GREEN once slice 4
+    # re-points the widget (ADR-0027 §Conformance: the skip lifts at the
+    # implementation commit).
+    add_test(
+      NAME LiverResections_resection_planning_widget_v2_repoint
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_resection_planning_widget_v2_repoint.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_resection_planning_widget_v2_repoint PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;resectogram;stage4"
+    )
+
     # T3 -- ResectogramPipeline memo-key invariant (ADR-0013 §3 idempotency;
     # the render-storm fix).  The Pipeline keys UpdatePipeline on the
     # control-point geometry digest ALONE, so a render-induced Modified() at

--- a/LiverResections/Testing/Python/test_resection_planning_widget_v2_repoint.py
+++ b/LiverResections/Testing/Python/test_resection_planning_widget_v2_repoint.py
@@ -1,0 +1,721 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""#501 slice 4 -- re-point the Stage-4 ResectionPlanningWidget to the v2 node graph.
+
+Until slice 4 the ResectionPlanningWidget selected a v1
+``vtkMRMLMarkupsBezierSurfaceNode`` and read the distance map off THAT node
+(``GetDistanceMapVolumeNode``).  Slice 4 re-points the widget onto the v2
+resection-plan node graph (ADR-0014 §"Fourth layer" wrapper/carrier split):
+
+  * the active-resection combo box selects the ``vtkMRMLResectionPlanNode``
+    WRAPPER (not the v1 markups surface);
+  * "resectogram available" reads the distance map off the WRAPPER
+    (``plan.GetDistanceMapVolumeNode()`` -- ADR-0031: the distance map lives on
+    the wrapper, not the carrier);
+  * the ``vtkMRMLResectogramDisplayNode`` is ensured on the CARRIER
+    (``plan.GetGeometryNode()``, a ``vtkMRMLBezierSurfaceNode``), not the
+    wrapper;
+  * a "Place resection" affordance mints a fresh plan via the logic create-API
+    (``vtkSlicerLiverResectionsLogic::CreateResectionPlan``, #501 slice 1) and
+    selects it in the combo.
+
+This pins the re-point in three invariants, all MRML/widget-state and GPU-free
+(they run under the ``--no-main-window`` launched harness -- no realized GL
+context needed; the embed itself self-gates on a main window):
+
+  1. COMBO RE-POINT.  After ``setMRMLScene``, a scene holding a
+     ``vtkMRMLResectionPlanNode`` OFFERS it as selectable; a scene holding a v1
+     ``vtkMRMLMarkupsBezierSurfaceNode`` does NOT offer it (the v1 surface is no
+     longer directly selectable -- the combo ``nodeTypes`` is
+     ``["vtkMRMLResectionPlanNode"]``).
+
+  2. AUTO-POPULATE PREDICATE RE-POINTED.  "resectogram available" iff a plan is
+     selected AND ``plan.GetDistanceMapVolumeNode() is not None`` (ADR-0031,
+     read off the WRAPPER).  Three hint states: (a) none selected -> "select"
+     hint; (b) plan without distance map -> "compute the distance map" hint;
+     (c) plan WITH distance map -> hint hidden AND exactly one
+     ``vtkMRMLResectogramDisplayNode`` ensured on the CARRIER
+     (``plan.GetGeometryNode()``), idempotent across repeated refreshes.
+
+  3. PLACE BUTTON.  The widget exposes a "Place resection" affordance
+     (``placeResectionButton()`` accessor + an ``onPlaceResection()`` slot);
+     invoking the slot calls ``logic.CreateResectionPlan(...)``, adds the plan
+     to the scene, and selects it in the combo -- afterwards the combo's current
+     node ``IsA vtkMRMLResectionPlanNode`` and the scene gained a plan + a
+     ``vtkMRMLBezierSurfaceNode`` carrier.
+
+-- WHY LAUNCHED-SLICER + SKIP-PENDING --
+
+The widget imports ``LiverResectionsLib.ResectionPlanningWidget`` (ADR-0004
+Python GUI) and needs the wrapped ``vtkMRMLResectionPlanNode`` /
+``vtkMRMLBezierSurfaceNode`` + the logic create-API, all reachable only inside a
+launched Slicer with the module loaded.  A bare ``PythonSlicer -m pytest`` has
+``slicer.mrmlScene is None`` / no ``qt.QWidget`` / no create-API, so every test
+here SKIPS CLEANLY via the shared ``slicer_pytest_support`` guards -- it never
+errors.
+
+Each invariant is additionally GUARDED on the NEW state's PRESENCE
+(``nodeTypes`` inspection / ``hasattr`` on the place-button accessor + the
+create-API), so this lands RED-as-skip on the current (still-v1) build and
+turns GREEN once slice 4 re-points the widget -- the ADR-0027 §Conformance
+"the skip lifts at the implementation commit" shape.  Verify run-vs-skip in the
+CI log; never trust overall green (the launched harness is green-but-skipping
+prone).
+
+-- NOT PINNED HERE (interactive :0 eyeball follow-ups) --
+
+The GL-coupled reactivity / render path is deliberately NOT committed here.  In
+v1 the storm-free strip-repaint hooked the markups ``PointModifiedEvent`` (a
+signal a render does not raise); the v2 carrier fires only generic
+``Modified()`` on control-point edits, so a control-point edit repainting the
+embedded strip WITHOUT a feedback-storm is a GL-coupled invariant that belongs
+on the interactive ``:0`` eyeball probe (ADR-0032 §Conformance), not a committed
+headless test.
+
+-- IMPLEMENTER CONTRACT (assumed accessors + entry points) --
+
+  * ``LiverResectionsLib.ResectionPlanningWidget`` -- the Python Stage-4 widget
+    (ADR-0004); composed by ``Liver/Liver.py`` for stage 3.
+  * combo box objectName ``"ResectionSurfaceComboBox"`` with
+    ``nodeTypes == ["vtkMRMLResectionPlanNode"]`` (the re-point).
+  * ``widget.placeResectionButton()`` -> the "Place resection" affordance
+    (a ``QPushButton`` / ``QAbstractButton``); ``widget.onPlaceResection()`` ->
+    the slot that mints + selects a fresh plan.
+  * ``widget.resectogramHintLabel()`` -- the drawer hint (ADR-0009 §explainable
+    state), non-empty text, VISIBLE iff the drawer is not populated.
+
+See also:
+  * Docs/adr/0014-livermarkups-dissolution.md §"Fourth layer"  (wrapper/carrier)
+  * Docs/adr/0031-distance-map-on-resection-plan-wrapper.md  (distance map on
+    the WRAPPER; the auto-populate predicate reads it there)
+  * Docs/adr/0019-resection-state-machine.md  (plan state; predicate is
+    state-orthogonal)
+  * Docs/adr/0023-unified-gui-stage-workflow.md §Stage-4  (the GUI surface)
+  * Docs/adr/0004-python-cpp-boundary.md  (the widget is Python)
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md  (RED / skip-pending)
+  * LiverResections/LiverResectionsLib/ResectionPlanningWidget.py  (the widget)
+  * LiverResections/Testing/Python/test_resectogram_open_view_action.py  (the
+    v1-surface auto-populate invariants this re-points from)
+  * LiverResections/Testing/Python/conftest.py  (the cleanup fixtures)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+MODULE_NAME = "liverresections"
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+BEZIER_CARRIER_CLASS = "vtkMRMLBezierSurfaceNode"
+V1_MARKUPS_SURFACE_CLASS = "vtkMRMLMarkupsBezierSurfaceNode"
+RESECTOGRAM_DISPLAY_CLASS = "vtkMRMLResectogramDisplayNode"
+
+COMBO_BOX_OBJECT_NAME = "ResectionSurfaceComboBox"
+HINT_LABEL_OBJECT_NAME = "ResectogramHintLabel"
+VIEW_NODE_CLASS = "vtkMRMLViewNode"
+
+
+# --------------------------------------------------------------------------- #
+# Test isolation -- reclaim the resectogram singleton view node after each test.
+# --------------------------------------------------------------------------- #
+
+
+def _purge_resectogram_singleton_view():
+    """Remove the resectogram singleton view node AND its auto-created camera.
+
+    The positive auto-populate branch runs ``ResectogramViewManager`` which
+    mints a ``vtkMRMLViewNode`` carrying a MRML ``SingletonTag`` (and, via the
+    cameras logic, a paired ``vtkMRMLCameraNode``).  Both SURVIVE
+    ``vtkMRMLScene.Clear(0)`` by design, so they trip this directory's
+    ``_launched_scene_cleanup`` leak-check (``remaining <= baseline``) unless
+    reclaimed here.  Reclaim the paired camera BEFORE the view it points at, so
+    the cameras logic does not re-pair an orphan camera with the surviving
+    singleton.  No-op under bare pytest / before the manager is importable.
+    Mirrors ``test_resectogram_open_view_action._purge_resectogram_singleton_view``.
+    """
+    try:
+        import slicer  # type: ignore[import-not-found]
+        from LiverResectionsLib.ResectogramViewManager import (  # type: ignore[import-not-found]
+            RESECTOGRAM_VIEW_SINGLETON_TAG,
+        )
+    except Exception:  # pragma: no cover - bare-pytest / import-env dependent
+        return
+    scene = getattr(slicer, "mrmlScene", None)
+    if scene is None:
+        return
+
+    stale_views = []
+    stale_view_ids = set()
+    for index in range(scene.GetNumberOfNodesByClass(VIEW_NODE_CLASS)):
+        node = scene.GetNthNodeByClass(index, VIEW_NODE_CLASS)
+        if node is not None and node.GetSingletonTag() == RESECTOGRAM_VIEW_SINGLETON_TAG:
+            stale_views.append(node)
+            stale_view_ids.add(node.GetID())
+
+    stale_cameras = []
+    for index in range(scene.GetNumberOfNodesByClass("vtkMRMLCameraNode")):
+        camera = scene.GetNthNodeByClass(index, "vtkMRMLCameraNode")
+        if camera is not None and camera.GetActiveTag() in stale_view_ids:
+            stale_cameras.append(camera)
+    for camera in stale_cameras:
+        scene.RemoveNode(camera)
+    for node in stale_views:
+        scene.RemoveNode(node)
+
+
+@pytest.fixture(autouse=True)
+def _drop_resectogram_singleton_view():
+    """Reclaim the resectogram singleton view node around each test.
+
+    Function-scoped + module-local so it brackets each test INSIDE the broader
+    conftest cleanup: purge BOTH before (defend the precondition against a
+    sibling-file leak) and after (so this file never leaks onward).  No-op under
+    bare pytest.
+    """
+    _purge_resectogram_singleton_view()
+    yield
+    _purge_resectogram_singleton_view()
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards -- every path prints an explicit, greppable reason (#460 lesson).
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    """Resolve a launched ``slicer`` with a scene, or skip cleanly.
+
+    Imports the guards from ``slicer_pytest_support`` directly (NOT
+    ``from conftest import``): the launched harness passes several test roots,
+    so ``conftest`` resolves to whichever sibling is first on the path.  The
+    sibling LiverResections tests import the canonical bodies the same way.
+    """
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()
+
+
+def _module_or_skip(slicer):
+    """Skip unless the LiverResections loadable module is registered."""
+    module = getattr(slicer.modules, MODULE_NAME, None)
+    if module is None:
+        pytest.skip(
+            f"'{MODULE_NAME}' module not registered -- the Stage-4 widget "
+            "(ADR-0023 §Stage-4) is unreachable in this environment."
+        )
+    return module
+
+
+def _widget_or_skip(slicer):
+    """Construct the Python ResectionPlanningWidget, or skip cleanly.
+
+    Per ADR-0004 the Stage-4 GUI is Python: build the widget directly and call
+    ``setMRMLScene(slicer.mrmlScene)``.  Registers it for deterministic teardown
+    (parentless widgets crash the launched harness at shutdown; the conftest
+    autouse fixture drains + cleans them while the scene is still alive).
+    """
+    from slicer_pytest_support import require_qt_widget, register_widget_for_teardown
+
+    require_qt_widget()
+    _module_or_skip(slicer)
+    try:
+        from LiverResectionsLib.ResectionPlanningWidget import (  # type: ignore[import-not-found]
+            ResectionPlanningWidget,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            "LiverResectionsLib.ResectionPlanningWidget not importable "
+            f"({exc!r}) -- the ADR-0004 Python Stage-4 widget is unreachable in "
+            "this environment; the skip lifts when the lib is on the path."
+        )
+    widget = ResectionPlanningWidget()
+    widget.setMRMLScene(slicer.mrmlScene)
+    return register_widget_for_teardown(widget)
+
+
+def _combo_box(widget):
+    """Return the active-resection combo box by objectName or getter, or None."""
+    import qt  # type: ignore[import-not-found]
+
+    combo = widget.findChild(qt.QWidget, COMBO_BOX_OBJECT_NAME)
+    if combo is not None:
+        return combo
+    getter = getattr(widget, "resectionSurfaceComboBox", None)
+    if callable(getter):
+        return getter()
+    return getattr(widget, "ResectionSurfaceComboBox", None)
+
+
+def _hint_label(widget):
+    """Return the resectogram drawer's hint label by objectName or getter."""
+    import qt  # type: ignore[import-not-found]
+
+    label = widget.findChild(qt.QLabel, HINT_LABEL_OBJECT_NAME)
+    if label is not None:
+        return label
+    getter = getattr(widget, "resectogramHintLabel", None)
+    if callable(getter):
+        return getter()
+    return getattr(widget, "ResectogramHintLabel", None)
+
+
+def _combo_or_skip(widget):
+    """Return the combo box, or skip with implementer guidance."""
+    combo = _combo_box(widget)
+    if combo is None:
+        pytest.skip(
+            "active-resection combo box not found: expected a qMRMLNodeComboBox "
+            f"objectName={COMBO_BOX_OBJECT_NAME!r} (or the "
+            "resectionSurfaceComboBox() getter).  Skip lifts when the "
+            "implementer wires the control (ADR-0023 §Stage-4)."
+        )
+    return combo
+
+
+def _combo_node_types(combo):
+    """Return the combo's nodeTypes as a Python list of str (or None)."""
+    node_types = getattr(combo, "nodeTypes", None)
+    if node_types is None:
+        return None
+    return [str(t) for t in node_types]
+
+
+def _require_combo_repointed_or_skip(combo):
+    """Skip-pending unless the combo has been re-pointed to the plan wrapper.
+
+    RED == the combo still lists the v1 ``vtkMRMLMarkupsBezierSurfaceNode``; the
+    skip lifts at the slice-4 implementation commit (ADR-0027).  Guarded on the
+    NEW state's presence (``nodeTypes`` inspection) rather than a bare assert, so
+    the test skips (not errors) on the still-v1 build.
+    """
+    node_types = _combo_node_types(combo)
+    if node_types is None:
+        pytest.skip(
+            "combo box exposes no inspectable nodeTypes -- cannot verify the "
+            "#501 slice-4 re-point to vtkMRMLResectionPlanNode."
+        )
+    if PLAN_NODE_CLASS not in node_types:
+        pytest.skip(
+            f"combo box nodeTypes {node_types} does not list {PLAN_NODE_CLASS!r} "
+            "-- the #501 slice-4 re-point to the v2 resection-plan wrapper "
+            "(ADR-0014 §'Fourth layer') has not landed.  Skip lifts at the "
+            "implementation commit (ADR-0027)."
+        )
+
+
+def _resection_logic_or_skip(slicer):
+    """Return the resection logic with the create-API, or skip cleanly.
+
+    The plan/carrier/display triad is minted via the merged
+    ``CreateResectionPlan`` (#501 slice 1); skip cleanly if the module / logic /
+    create-API is not reachable in this build.
+    """
+    module = _module_or_skip(slicer)
+    logic = module.logic()
+    if logic is None:
+        pytest.skip("liverresections module has no logic singleton.")
+    if not hasattr(logic, "CreateResectionPlan"):
+        pytest.skip(
+            "vtkSlicerLiverResectionsLogic has no CreateResectionPlan -- the "
+            "create-API (#501 slice 1) is not in this build."
+        )
+    return logic
+
+
+def _make_plan_or_skip(slicer, name, with_distance_map):
+    """Mint a v2 resection plan via the logic create-API.
+
+    Returns the ``vtkMRMLResectionPlanNode`` wrapper.  When
+    ``with_distance_map`` is True, attaches a scalar volume as the distance map
+    on the WRAPPER (ADR-0031); otherwise leaves ``GetDistanceMapVolumeNode()``
+    null so the negative branch of the auto-populate predicate is exercised.
+    """
+    logic = _resection_logic_or_skip(slicer)
+    plan = logic.CreateResectionPlan(name)
+    if plan is None or not plan.IsA(PLAN_NODE_CLASS):
+        pytest.skip(
+            "CreateResectionPlan did not return a vtkMRMLResectionPlanNode -- "
+            "cannot exercise the slice-4 re-point."
+        )
+    for method in ("GetGeometryNode", "GetDistanceMapVolumeNode"):
+        if not hasattr(plan, method):
+            pytest.skip(
+                f"{PLAN_NODE_CLASS} exposes no {method}() in this build -- the "
+                "ADR-0031 distance-map-on-wrapper API is not wrapped."
+            )
+    if with_distance_map:
+        if not hasattr(plan, "SetAndObserveDistanceMapVolumeNode"):
+            pytest.skip(
+                f"{PLAN_NODE_CLASS} has no SetAndObserveDistanceMapVolumeNode -- "
+                "cannot attach the distance map on the wrapper (ADR-0031)."
+            )
+        volume = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLScalarVolumeNode", f"{name}DistanceMap"
+        )
+        if volume is None:
+            pytest.skip(
+                "vtkMRMLScalarVolumeNode not registered -- cannot attach a "
+                "distance map on the wrapper."
+            )
+        plan.SetAndObserveDistanceMapVolumeNode(volume)
+        if plan.GetDistanceMapVolumeNode() is None:
+            pytest.skip(
+                "distance map did not attach to the wrapper -- cannot exercise "
+                "the positive auto-populate branch (ADR-0031)."
+            )
+    return plan
+
+
+def _select(widget, combo, node):
+    """Select ``node`` as the active resection; returns True on success."""
+    setter = getattr(widget, "setActiveResectionNode", None)
+    if callable(setter):
+        setter(node)
+        return True
+    if hasattr(combo, "setCurrentNode"):
+        combo.setCurrentNode(node)
+        return True
+    return False
+
+
+def _count_carrier_resectogram_display_nodes(plan):
+    """Count ``vtkMRMLResectogramDisplayNode``s on the plan's CARRIER.
+
+    Slice 4 attaches the resectogram display node to the carrier
+    (``plan.GetGeometryNode()``), NOT the wrapper (ADR-0014 §'Fourth layer').
+    """
+    carrier = plan.GetGeometryNode()
+    if carrier is None:
+        return 0
+    count = 0
+    for index in range(carrier.GetNumberOfDisplayNodes()):
+        display = carrier.GetNthDisplayNode(index)
+        if display is not None and display.IsA(RESECTOGRAM_DISPLAY_CLASS):
+            count += 1
+    return count
+
+
+def _refresh(widget):
+    """Re-run the drawer's auto-populate predicate (idempotency probe)."""
+    refresh = getattr(widget, "refreshResectogramDrawer", None)
+    if callable(refresh):
+        refresh()
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 1 -- combo re-point (offers plan wrapper, not the v1 surface).
+# --------------------------------------------------------------------------- #
+
+
+def test_combo_offers_resection_plan_node():
+    """The combo lists (and offers) a ``vtkMRMLResectionPlanNode``.
+
+    #501 slice 4 re-points the active-resection combo to the v2 wrapper
+    (ADR-0014 §'Fourth layer').  A scene holding a plan node makes it the
+    combo's current node after selection.  Skip-pending on the still-v1 combo
+    (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    widget = _widget_or_skip(slicer)
+    combo = _combo_or_skip(widget)
+    _require_combo_repointed_or_skip(combo)
+
+    plan = _make_plan_or_skip(slicer, "RepointComboTest", with_distance_map=False)
+    if not _select(widget, combo, plan):
+        pytest.skip("cannot select the active resection (implementer contract).")
+
+    current = combo.currentNode()
+    assert current is not None and current.IsA(PLAN_NODE_CLASS), (
+        "the active-resection combo must offer + select a "
+        f"{PLAN_NODE_CLASS} (ADR-0014 §'Fourth layer'); its current node is "
+        f"{current.GetClassName() if current is not None else None!r}."
+    )
+
+
+def test_combo_does_not_offer_v1_markups_surface():
+    """The combo does NOT directly offer a v1 ``vtkMRMLMarkupsBezierSurfaceNode``.
+
+    #501 slice 4 behaviour change: the v1 markups surface is no longer directly
+    selectable in the Stage-4 combo -- selection is on the plan wrapper.  A
+    scene holding ONLY a v1 surface leaves the combo with no plan to select.
+    Skip-pending on the still-v1 combo (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    widget = _widget_or_skip(slicer)
+    combo = _combo_or_skip(widget)
+    _require_combo_repointed_or_skip(combo)
+
+    v1 = slicer.mrmlScene.AddNewNodeByClass(V1_MARKUPS_SURFACE_CLASS, "V1Surface")
+    if v1 is None:
+        pytest.skip(
+            f"{V1_MARKUPS_SURFACE_CLASS} not registered -- cannot verify it is "
+            "excluded from the re-pointed combo."
+        )
+
+    node_types = _combo_node_types(combo)
+    assert V1_MARKUPS_SURFACE_CLASS not in node_types, (
+        "the re-pointed combo must NOT list the v1 "
+        f"{V1_MARKUPS_SURFACE_CLASS} (it selects the "
+        f"{PLAN_NODE_CLASS} wrapper); nodeTypes is {node_types}."
+    )
+    # Selecting the v1 surface must not make it the combo's current node.
+    if hasattr(combo, "setCurrentNode"):
+        combo.setCurrentNode(v1)
+        current = combo.currentNode()
+        assert current is not v1, (
+            "the v1 markups surface must not be directly selectable in the "
+            f"re-pointed combo (ADR-0014 §'Fourth layer'); got {current!r}."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 2 -- auto-populate predicate reads the distance map off the WRAPPER
+# (ADR-0031); display node ensured on the CARRIER.
+# --------------------------------------------------------------------------- #
+
+
+def test_hint_shown_when_no_plan_selected():
+    """No plan selected => the drawer shows the hint.
+
+    ADR-0023 §Stage-4 auto-populate predicate (negative branch): with no plan
+    selected the drawer cannot populate, so it shows a non-empty, visible hint
+    (ADR-0009 §explainable state).  Checked via ``isHidden()`` not ``visible``:
+    under ``--no-main-window`` the unshown tree reports ``visible==False``
+    regardless.
+    """
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    widget = _widget_or_skip(slicer)
+    combo = _combo_or_skip(widget)
+    _require_combo_repointed_or_skip(combo)
+
+    hint = _hint_label(widget)
+    if hint is None:
+        pytest.skip(
+            f"resectogram hint label not found (objectName "
+            f"{HINT_LABEL_OBJECT_NAME!r} or resectogramHintLabel())."
+        )
+
+    if not _select(widget, combo, None):
+        pytest.skip("cannot clear the selection (implementer contract).")
+
+    assert not hint.isHidden(), (
+        "the resectogram drawer hint must be SHOWN when no plan is selected "
+        "(ADR-0023 §Stage-4 auto-populate predicate; ADR-0009 §explainable "
+        "state)."
+    )
+    assert hint.text, (
+        "the hint must carry non-empty text explaining what to select "
+        "(ADR-0009 §explainable state)."
+    )
+
+
+def test_hint_shown_when_plan_has_no_distance_map():
+    """Plan selected but wrapper has no distance map => the drawer shows the hint.
+
+    ADR-0031: the auto-populate predicate reads
+    ``plan.GetDistanceMapVolumeNode()`` off the WRAPPER.  A plan without a
+    distance map keeps the hint up (the resectogram stack has nothing to
+    sample).  Skip-pending on the still-v1 combo (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    widget = _widget_or_skip(slicer)
+    combo = _combo_or_skip(widget)
+    _require_combo_repointed_or_skip(combo)
+
+    hint = _hint_label(widget)
+    if hint is None:
+        pytest.skip("resectogram hint label not found (implementer contract).")
+
+    plan = _make_plan_or_skip(slicer, "NoDistanceMapPlan", with_distance_map=False)
+    assert plan.GetDistanceMapVolumeNode() is None  # fixture sanity
+    if not _select(widget, combo, plan):
+        pytest.skip("cannot select the active resection (implementer contract).")
+
+    assert not hint.isHidden(), (
+        "the drawer hint must be SHOWN when the selected plan's WRAPPER has no "
+        "distance map (plan.GetDistanceMapVolumeNode() is None) -- ADR-0031, "
+        "ADR-0023 §Stage-4, ADR-0009 §explainable state."
+    )
+    assert hint.text, (
+        "the hint must carry non-empty text explaining the unpopulated reason "
+        "(ADR-0009 §explainable state) -- e.g. 'compute the distance map'."
+    )
+
+
+def test_hint_hidden_and_display_node_on_carrier_when_plan_has_distance_map():
+    """Plan WITH a distance map => hint hidden AND one display node on the carrier.
+
+    ADR-0031 (positive branch): the wrapper carries a distance map, so the
+    predicate is satisfied -- the hint hides and EXACTLY ONE
+    ``vtkMRMLResectogramDisplayNode`` is ensured on the CARRIER
+    (``plan.GetGeometryNode()``, ADR-0014 §'Fourth layer'), never on the
+    wrapper.  GPU-free: pins hint visibility + carrier display-node presence,
+    not the GL render.  Skip-pending on the still-v1 combo (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    widget = _widget_or_skip(slicer)
+    combo = _combo_or_skip(widget)
+    _require_combo_repointed_or_skip(combo)
+
+    hint = _hint_label(widget)
+    if hint is None:
+        pytest.skip("resectogram hint label not found (implementer contract).")
+
+    plan = _make_plan_or_skip(slicer, "DistanceMapPlan", with_distance_map=True)
+    assert plan.GetDistanceMapVolumeNode() is not None  # fixture sanity
+    assert _count_carrier_resectogram_display_nodes(plan) == 0  # fixture sanity
+    if not _select(widget, combo, plan):
+        pytest.skip("cannot select the active resection (implementer contract).")
+
+    assert hint.isHidden(), (
+        "the drawer hint must be HIDDEN when the selected plan's WRAPPER carries "
+        "a distance map -- the drawer auto-populates (ADR-0031, ADR-0023 "
+        "§Stage-4 positive branch).  Checked via isHidden(): the ensure + "
+        "hint-hide run headless; the GL embed self-gates on a main window."
+    )
+    assert _count_carrier_resectogram_display_nodes(plan) == 1, (
+        "populating must ensure EXACTLY ONE "
+        f"{RESECTOGRAM_DISPLAY_CLASS} on the CARRIER (plan.GetGeometryNode(), a "
+        f"{BEZIER_CARRIER_CLASS}), not on the wrapper -- ADR-0014 §'Fourth "
+        "layer'."
+    )
+
+
+def test_repeated_refresh_is_idempotent_on_carrier_display_node():
+    """Repeated refreshes reuse the carrier's resectogram display node.
+
+    ADR-0023 §Stage-4 idempotent ensure: re-running the auto-populate predicate
+    (``refreshResectogramDrawer``) against the same distance-mapped plan REUSES
+    the carrier's ``vtkMRMLResectogramDisplayNode`` rather than minting a second
+    one.  Skip-pending on the still-v1 combo (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    widget = _widget_or_skip(slicer)
+    combo = _combo_or_skip(widget)
+    _require_combo_repointed_or_skip(combo)
+
+    plan = _make_plan_or_skip(slicer, "IdempotentPlan", with_distance_map=True)
+    if not _select(widget, combo, plan):
+        pytest.skip("cannot select the active resection (implementer contract).")
+
+    if _count_carrier_resectogram_display_nodes(plan) != 1:
+        pytest.skip(
+            "drawer did not ensure a carrier display node on selection -- the "
+            "positive auto-populate branch is not yet wired (covered by "
+            "test_hint_hidden_and_display_node_on_carrier_when_plan_has_"
+            "distance_map)."
+        )
+
+    # Re-run the predicate several times: re-select + explicit refresh.
+    _refresh(widget)
+    _select(widget, combo, None)
+    _select(widget, combo, plan)
+    _refresh(widget)
+
+    assert _count_carrier_resectogram_display_nodes(plan) == 1, (
+        "repeated refreshes must REUSE the carrier's resectogram display node, "
+        f"not create a second ({_count_carrier_resectogram_display_nodes(plan)} "
+        "present) -- ADR-0023 §Stage-4 idempotent ensure, ADR-0014 §'Fourth "
+        "layer'."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 3 -- "Place resection" affordance mints + selects a fresh plan.
+# --------------------------------------------------------------------------- #
+
+
+def _place_button_and_slot_or_skip(widget):
+    """Return (button, slot) for the Place-resection affordance, or skip.
+
+    RED == the widget exposes neither the ``placeResectionButton()`` accessor
+    nor the ``onPlaceResection()`` slot; the skip lifts at the slice-4
+    implementation commit (ADR-0027).
+    """
+    button_getter = getattr(widget, "placeResectionButton", None)
+    slot = getattr(widget, "onPlaceResection", None)
+    if not callable(slot):
+        pytest.skip(
+            "widget has no onPlaceResection() slot -- the #501 slice-4 "
+            "'Place resection' affordance (ADR-0023 §Stage-4) has not landed.  "
+            "Skip lifts at the implementation commit (ADR-0027)."
+        )
+    button = button_getter() if callable(button_getter) else None
+    return button, slot
+
+
+def test_place_resection_button_exists():
+    """The widget exposes a "Place resection" affordance.
+
+    ADR-0023 §Stage-4: the panel offers an explicit "Place resection" button
+    (accessor ``placeResectionButton()``).  Cheap structural pin; skip-pending
+    until the affordance lands (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    widget = _widget_or_skip(slicer)
+
+    button, _slot = _place_button_and_slot_or_skip(widget)
+    assert button is not None, (
+        "the widget must expose a 'Place resection' affordance via "
+        "placeResectionButton() -- ADR-0023 §Stage-4."
+    )
+
+
+def test_place_resection_mints_and_selects_plan():
+    """Invoking the place slot mints a plan (+ carrier) and selects it.
+
+    ADR-0023 §Stage-4 + #501 slice 1: ``onPlaceResection()`` calls
+    ``logic.CreateResectionPlan(...)``, adds the plan to the scene, and selects
+    it in the combo.  Afterwards the combo's current node ``IsA
+    vtkMRMLResectionPlanNode`` and the scene gained a plan + a
+    ``vtkMRMLBezierSurfaceNode`` carrier (ADR-0014 §'Fourth layer').
+    Skip-pending on the missing slot / create-API (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    # Require the create-API up front so a build without slice 1 skips cleanly
+    # rather than the slot failing.
+    _resection_logic_or_skip(slicer)
+    widget = _widget_or_skip(slicer)
+    combo = _combo_or_skip(widget)
+    _require_combo_repointed_or_skip(combo)
+
+    _button, slot = _place_button_and_slot_or_skip(widget)
+
+    plans_before = slicer.mrmlScene.GetNumberOfNodesByClass(PLAN_NODE_CLASS)
+    carriers_before = slicer.mrmlScene.GetNumberOfNodesByClass(BEZIER_CARRIER_CLASS)
+
+    slot()
+    slicer.app.processEvents()
+
+    plans_after = slicer.mrmlScene.GetNumberOfNodesByClass(PLAN_NODE_CLASS)
+    carriers_after = slicer.mrmlScene.GetNumberOfNodesByClass(BEZIER_CARRIER_CLASS)
+
+    assert plans_after == plans_before + 1, (
+        "onPlaceResection() must add exactly one vtkMRMLResectionPlanNode to "
+        f"the scene (before {plans_before}, after {plans_after}) via "
+        "logic.CreateResectionPlan(...) -- ADR-0023 §Stage-4, #501 slice 1."
+    )
+    assert carriers_after == carriers_before + 1, (
+        "onPlaceResection() must add exactly one vtkMRMLBezierSurfaceNode "
+        f"carrier (before {carriers_before}, after {carriers_after}) -- the "
+        "plan's geometry node (ADR-0014 §'Fourth layer')."
+    )
+
+    current = combo.currentNode()
+    assert current is not None and current.IsA(PLAN_NODE_CLASS), (
+        "onPlaceResection() must SELECT the freshly-minted plan in the combo; "
+        f"the current node is {current.GetClassName() if current is not None else None!r}."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverResections/Testing/Python/test_resectogram_enlarge_toggle.py
+++ b/LiverResections/Testing/Python/test_resectogram_enlarge_toggle.py
@@ -31,9 +31,13 @@ exercised on the interactive ``:0`` eyeball pass (#460 explicit-skip lesson).
 
 See also:
   * Docs/adr/0023-unified-gui-stage-workflow.md §Stage-4
+  * Docs/adr/0014-livermarkups-dissolution.md §"Fourth layer" (wrapper/carrier)
+  * Docs/adr/0031-distance-map-on-resection-plan-wrapper.md (distance map on the
+    WRAPPER; the fixture attaches it there)
   * Docs/adr/0013-layerdm-pipeline-pattern.md §5 (no custom DM)
   * test_resectogram_open_view_action.py (the auto-populate invariants reused
-    here via the shared scenario builder)
+    here via the shared v2-plan fixture builder)
+  * test_resection_planning_widget_v2_repoint.py (the v2 re-point idioms)
 """
 
 from __future__ import annotations
@@ -41,7 +45,10 @@ from __future__ import annotations
 import pytest
 
 MODULE_NAME = "liverresections"
-BEZIER_SURFACE_CLASS = "vtkMRMLMarkupsBezierSurfaceNode"
+# #501 slice 4: the enlarge/restore invariants are node-model-agnostic (they
+# assert on the embedded qMRMLThreeDWidget reparenting); only the fixture the
+# combo selects changes -- the v2 plan WRAPPER (ADR-0014 §"Fourth layer").
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
 VIEW_NODE_CLASS = "vtkMRMLViewNode"
 COMBO_BOX_OBJECT_NAME = "ResectionSurfaceComboBox"
 
@@ -153,34 +160,66 @@ def _enlarge_api_or_skip(widget):
         )
 
 
-def _select(widget, slicer, bezier):
+def _select(widget, slicer, plan):
     setter = getattr(widget, "setActiveResectionNode", None)
     if callable(setter):
-        setter(bezier)
+        setter(plan)
         return True
     import qt  # type: ignore[import-not-found]
 
     combo = widget.findChild(qt.QWidget, COMBO_BOX_OBJECT_NAME)
     if combo is not None and hasattr(combo, "setCurrentNode"):
-        combo.setCurrentNode(bezier)
+        combo.setCurrentNode(plan)
         return True
     return False
 
 
 def _make_surface_with_distance_map(slicer):
-    from scenarios import Resectogram4x4BlurOff as scn  # type: ignore[import-not-found]
+    """Mint a v2 resection plan WITH a distance map on the WRAPPER (ADR-0031).
 
-    slicer.modules.liverresections.logic()
-    distance_map = scn._make_parenchyma_distance_map(
-        sphere_center=scn.SPHERE_CENTER,
-        sphere_radius=scn.SPHERE_RADIUS,
+    #501 slice 4: builds the wrapper via the logic create-API
+    (``CreateResectionPlan``, #501 slice 1) and attaches the distance map on the
+    WRAPPER; skips cleanly (never fails) when the create-API / node API is
+    absent, mirroring ``test_resection_planning_widget_v2_repoint._make_plan_or_skip``.
+    Returns the ``vtkMRMLResectionPlanNode`` wrapper.
+    """
+    module = getattr(slicer.modules, MODULE_NAME, None)
+    if module is None:
+        pytest.skip(f"'{MODULE_NAME}' module not registered.")
+    logic = module.logic()
+    if logic is None or not hasattr(logic, "CreateResectionPlan"):
+        pytest.skip(
+            "vtkSlicerLiverResectionsLogic has no CreateResectionPlan -- the "
+            "create-API (#501 slice 1) is not in this build."
+        )
+    plan = logic.CreateResectionPlan("EnlargeTogglePlan")
+    if plan is None or not plan.IsA(PLAN_NODE_CLASS):
+        pytest.skip(
+            "CreateResectionPlan did not return a vtkMRMLResectionPlanNode -- "
+            "cannot exercise the #501 slice-4 re-point."
+        )
+    if not hasattr(plan, "SetAndObserveDistanceMapVolumeNode") or not hasattr(
+        plan, "GetDistanceMapVolumeNode"
+    ):
+        pytest.skip(
+            f"{PLAN_NODE_CLASS} has no distance-map-on-wrapper API (ADR-0031) -- "
+            "cannot make the plan populate-ready."
+        )
+    volume = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLScalarVolumeNode", "EnlargeTogglePlanDistanceMap"
     )
-    return scn._build_resectogram_bezier(
-        half_extent_u=scn.PATCH_HALF_EXTENT_U,
-        half_extent_v=scn.PATCH_HALF_EXTENT_V,
-        enable_flexible_boundary=scn.ENABLE_FLEXIBLE_BOUNDARY,
-        distance_map=distance_map,
-    )
+    if volume is None:
+        pytest.skip(
+            "vtkMRMLScalarVolumeNode not registered -- cannot attach a distance "
+            "map on the wrapper."
+        )
+    plan.SetAndObserveDistanceMapVolumeNode(volume)
+    if plan.GetDistanceMapVolumeNode() is None:
+        pytest.skip(
+            "distance map did not attach to the wrapper -- cannot exercise the "
+            "positive auto-populate branch (ADR-0031)."
+        )
+    return plan
 
 
 def _embedded_three_d_widgets(slicer, widget):
@@ -211,8 +250,8 @@ def _setup_populated(slicer):
     rep = widget
     self = rep.self() if hasattr(rep, "self") else rep
     _enlarge_api_or_skip(self)
-    bezier = _make_surface_with_distance_map(slicer)
-    if not _select(self, slicer, bezier):
+    plan = _make_surface_with_distance_map(slicer)
+    if not _select(self, slicer, plan):
         pytest.skip("cannot select the active resection (implementer contract).")
     # Drawer must have populated the embedded widget.
     embedded = _embedded_three_d_widgets(slicer, rep)

--- a/LiverResections/Testing/Python/test_resectogram_open_view_action.py
+++ b/LiverResections/Testing/Python/test_resectogram_open_view_action.py
@@ -1,47 +1,48 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
 
-"""T3-g3 -- auto-populated resectogram drawer on the LiverResections widget.
+"""T3-g3 / #501 slice 4 -- auto-populated resectogram drawer, v2 node graph.
 
 LiverResections is a loadable (C++) module that, until T3-g3, shipped NO widget
 representation (``qSlicerLiverResectionsModule::createWidgetRepresentation()``
 returned ``nullptr``).  T3-g3 adds the module's FIRST GUI -- the ADR-0023
 §Stage-4 "Resection Planning" surface that ``Liver/Liver.py`` composes via
-``LiverResections.widgetRepresentation()`` -- carrying:
+``LiverResections.widgetRepresentation()``.  #501 slice 4 re-points that surface
+off the v1 markups node onto the v2 resection-plan node graph (ADR-0014 §"Fourth
+layer" wrapper/carrier split), so this file's fixtures build + select the v2
+wrapper.  The widget carries:
 
-  * a ``qMRMLNodeComboBox`` of ``vtkMRMLMarkupsBezierSurfaceNode`` (the node
-    the merged resectogram render stack reads -- NOT the
-    ``vtkMRMLBezierSurfaceNode`` carrier) that selects the *active* resection,
-    and
+  * a ``qMRMLNodeComboBox`` of ``vtkMRMLResectionPlanNode`` (the v2 WRAPPER, NOT
+    the v1 ``vtkMRMLMarkupsBezierSurfaceNode``) that selects the *active*
+    resection, and
   * a collapsible "Resectogram" drawer that AUTO-POPULATES (no click) when the
-    selected surface carries a distance map, and shows an explanatory HINT
-    otherwise.
+    selected plan's WRAPPER carries a distance map, and shows an explanatory
+    HINT otherwise.
 
-The TRIGGER is the SELECTION: setting the combo box to a valid surface (no
+The TRIGGER is the SELECTION: setting the combo box to a valid plan (no
 explicit [Open] button; the maintainer removed it -- the drawer auto-populates
-on selection AND when a distance map appears on the already-selected surface).
+on selection AND when a distance map appears on the already-selected plan).
 
 Three pinned invariants (all MRML/widget-state -- GPU-free, runnable in a
 minimal ``qSlicerApplication`` without a GL view; the strip RENDERING is out
 of g3 scope and is the orchestrator's eyeball pass, not asserted here):
 
   1. AUTO-POPULATE PREDICATE (the load-bearing invariant).  The drawer
-     populates iff a Bezier surface is selected AND
-     ``selectedNode->GetDistanceMapVolumeNode() != nullptr``
-     (vtkMRMLMarkupsBezierSurfaceNode.h line 91).  Otherwise the drawer shows a
+     populates iff a plan is selected AND
+     ``plan->GetDistanceMapVolumeNode() != nullptr`` -- the distance map lives
+     on the WRAPPER (ADR-0031), not the carrier.  Otherwise the drawer shows a
      non-empty HINT instead of the view (ADR-0009 §explainable state).
      STATE-ORTHOGONAL: the predicate does NOT read the ADR-0019 ResectionState
-     -- a Planning *or* Confirmed surface with a distance map populates.
+     -- a Planning *or* Confirmed plan with a distance map populates.
 
-  2. SINGLE DISPLAY NODE ON SELECTION.  Selecting a valid surface ensures
-     EXACTLY ONE ``vtkMRMLResectogramDisplayNode`` on it
-     (``AddAndObserveDisplayNodeID`` when none present); re-selecting reuses it
-     (idempotent -- no second display node).  This is net-new production
-     behaviour: today only the ``Resectogram4x4BlurOff`` scenario builder
-     attaches the display node
-     (scenarios/Resectogram4x4BlurOff.py ``_attach_resectogram_display_node``).
+  2. SINGLE DISPLAY NODE ON SELECTION.  Selecting a valid plan ensures
+     EXACTLY ONE ``vtkMRMLResectogramDisplayNode`` on the plan's CARRIER
+     (``plan.GetGeometryNode()``, a ``vtkMRMLBezierSurfaceNode``; ADR-0014
+     §"Fourth layer"), NOT on the wrapper (``AddAndObserveDisplayNodeID`` when
+     none present); re-selecting reuses it (idempotent -- no second display
+     node).
 
-  3. VIEW-NODE IDEMPOTENCY.  Selecting a valid surface ensures the singleton
+  3. VIEW-NODE IDEMPOTENCY.  Selecting a valid plan ensures the singleton
      resectogram view node via ``ResectogramViewManager.ensureViewNode()``
      (LiverResectionsLib/ResectogramViewManager.py); re-selecting reuses it
      -- no second ``vtkMRMLViewNode`` carrying RESECTOGRAM_VIEW_SINGLETON_TAG.
@@ -83,16 +84,16 @@ down minted nodes so the launched harness does not trip ``vtkDebugLeaks``.
   * ``LiverResectionsLib.ResectionPlanningWidget`` -- the Python Stage-4 widget
     (ADR-0004); composed by ``Liver/Liver.py`` for stage 3.
   * objectName ``"ResectionSurfaceComboBox"`` -- the
-    ``qMRMLNodeComboBox`` of ``vtkMRMLMarkupsBezierSurfaceNode`` selecting the
-    active resection.
+    ``qMRMLNodeComboBox`` of ``vtkMRMLResectionPlanNode`` (the v2 wrapper)
+    selecting the active resection.
   * objectName ``"ResectogramDrawer"`` -- the collapsible "Resectogram" drawer
     that auto-populates with the embedded view (or shows the hint).
   * objectName ``"ResectogramHintLabel"`` -- the hint shown in the drawer when
     no valid resectogram is available (ADR-0009 §"explainable state").  Its
     text is non-empty and it is VISIBLE iff the drawer is NOT populated.
-  * Selecting a valid surface (combo ``setCurrentNode``) is the TRIGGER: it
-    keys the display-node-ensure entry point on the selected
-    ``vtkMRMLMarkupsBezierSurfaceNode`` and calls
+  * Selecting a valid plan (combo ``setCurrentNode``) is the TRIGGER: it keys
+    the display-node-ensure entry point on the selected plan's CARRIER
+    (``plan.GetGeometryNode()``) and calls
     ``ResectogramViewManager.ensureViewNode()`` once.
 
 If the implementer cannot expose stable objectNames, a thin Python-accessible
@@ -106,12 +107,15 @@ See also:
   * Docs/adr/0023-unified-gui-stage-workflow.md §Stage-4 (the GUI surface)
   * Docs/adr/0013-layerdm-pipeline-pattern.md §5 (no custom DM)
   * Docs/adr/0009-ux-and-design-discipline.md (explainable state)
-  * LiverMarkups/MRML/vtkMRMLMarkupsBezierSurfaceNode.h line 91
-    (GetDistanceMapVolumeNode)
+  * Docs/adr/0014-livermarkups-dissolution.md §"Fourth layer" (wrapper/carrier)
+  * Docs/adr/0031-distance-map-on-resection-plan-wrapper.md (distance map on the
+    WRAPPER; the auto-populate predicate reads it there)
+  * Docs/adr/0019-resection-state-machine.md (plan state; predicate is
+    state-orthogonal)
   * LiverResections/LiverResectionsLib/ResectogramViewManager.py
     (ensureViewNode singleton-by-tag)
-  * LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
-    (surface-with-distance-map fixture builders reused below)
+  * LiverResections/Testing/Python/test_resection_planning_widget_v2_repoint.py
+    (the v2 re-point invariants; the fixture idioms reused below)
 """
 
 from __future__ import annotations
@@ -119,7 +123,10 @@ from __future__ import annotations
 import pytest
 
 MODULE_NAME = "liverresections"
-BEZIER_SURFACE_CLASS = "vtkMRMLMarkupsBezierSurfaceNode"
+# #501 slice 4: the combo + fixtures now build/select the v2 plan WRAPPER; the
+# resectogram display node lands on its CARRIER (ADR-0014 §"Fourth layer").
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+BEZIER_CARRIER_CLASS = "vtkMRMLBezierSurfaceNode"
 RESECTOGRAM_DISPLAY_CLASS = "vtkMRMLResectogramDisplayNode"
 VIEW_NODE_CLASS = "vtkMRMLViewNode"
 
@@ -282,17 +289,18 @@ def _widget_or_skip(slicer):
     return register_widget_for_teardown(widget)
 
 
-def _accessor_or_skip(bezier):
-    """Skip unless the Bezier surface exposes ``GetDistanceMapVolumeNode``.
+def _accessor_or_skip(plan):
+    """Skip unless the plan WRAPPER exposes ``GetDistanceMapVolumeNode``.
 
-    The gate reads this accessor (vtkMRMLMarkupsBezierSurfaceNode.h line 91);
-    if the Python wrapping does not surface it, the gate cannot be exercised.
+    #501 slice 4: the gate reads the distance map off the WRAPPER (ADR-0031),
+    not off the carrier surface.  If the Python wrapping does not surface the
+    accessor, the gate cannot be exercised -- skip cleanly.
     """
-    if not hasattr(bezier, "GetDistanceMapVolumeNode"):
+    if not hasattr(plan, "GetDistanceMapVolumeNode"):
         pytest.skip(
-            f"{BEZIER_SURFACE_CLASS} exposes no GetDistanceMapVolumeNode() in "
-            "this build -- the T3-g3 gating predicate (ADR-0023 §Stage-4) "
-            "cannot be evaluated."
+            f"{PLAN_NODE_CLASS} exposes no GetDistanceMapVolumeNode() in this "
+            "build -- the ADR-0031 distance-map-on-wrapper gating predicate "
+            "(ADR-0023 §Stage-4) cannot be evaluated."
         )
 
 
@@ -397,11 +405,19 @@ def _require_populated_or_skip(hint):
         )
 
 
-def _count_resectogram_display_nodes(slicer, bezier):
-    """Count ``vtkMRMLResectogramDisplayNode``s referenced by ``bezier``."""
+def _count_resectogram_display_nodes(slicer, plan):
+    """Count ``vtkMRMLResectogramDisplayNode``s on the plan's CARRIER.
+
+    #501 slice 4: the resectogram display node attaches to the carrier
+    (``plan.GetGeometryNode()``, a ``vtkMRMLBezierSurfaceNode``), NOT the
+    wrapper (ADR-0014 §"Fourth layer").
+    """
+    carrier = plan.GetGeometryNode()
+    if carrier is None:
+        return 0
     count = 0
-    for index in range(bezier.GetNumberOfDisplayNodes()):
-        display = bezier.GetNthDisplayNode(index)
+    for index in range(carrier.GetNumberOfDisplayNodes()):
+        display = carrier.GetNthDisplayNode(index)
         if display is not None and display.IsA(RESECTOGRAM_DISPLAY_CLASS):
             count += 1
     return count
@@ -430,58 +446,96 @@ def _count_singleton_view_nodes(slicer):
 
 
 # --------------------------------------------------------------------------- #
-# Fixture builders -- reuse the Resectogram4x4BlurOff scenario, plus a
-# no-distance-map variant for the disabled-gate case.
+# Fixture builders -- mint a v2 resection plan via the logic create-API
+# (#501 slice 1), with / without a distance map on the WRAPPER (ADR-0031).
+# Mirrors ``test_resection_planning_widget_v2_repoint._make_plan_or_skip``.
 # --------------------------------------------------------------------------- #
 
 
-def _make_surface_with_distance_map(slicer):
-    """Build a Bezier surface WITH a distance map (gate-satisfied fixture).
+def _resection_logic_or_skip(slicer):
+    """Return the resection logic with the create-API, or skip cleanly.
 
-    Reuses the ``Resectogram4x4BlurOff`` scenario builders so the fixture
-    matches the production render inputs.  Returns the markups Bezier node;
-    the distance map is attached via ``SetDistanceMapVolumeNode`` inside the
-    builder so ``GetDistanceMapVolumeNode()`` is non-null.
+    The plan/carrier/display triad is minted via the merged
+    ``CreateResectionPlan`` (#501 slice 1); skip cleanly if the module / logic /
+    create-API is not reachable in this build (never fail).
     """
-    from scenarios import Resectogram4x4BlurOff as scn  # type: ignore[import-not-found]
+    module = _module_or_skip(slicer)
+    logic = module.logic()
+    if logic is None:
+        pytest.skip("liverresections module has no logic singleton.")
+    if not hasattr(logic, "CreateResectionPlan"):
+        pytest.skip(
+            "vtkSlicerLiverResectionsLogic has no CreateResectionPlan -- the "
+            "create-API (#501 slice 1) is not in this build."
+        )
+    return logic
 
-    slicer.modules.liverresections.logic()
-    distance_map = scn._make_parenchyma_distance_map(
-        sphere_center=scn.SPHERE_CENTER,
-        sphere_radius=scn.SPHERE_RADIUS,
-    )
-    bezier = scn._build_resectogram_bezier(
-        half_extent_u=scn.PATCH_HALF_EXTENT_U,
-        half_extent_v=scn.PATCH_HALF_EXTENT_V,
-        enable_flexible_boundary=scn.ENABLE_FLEXIBLE_BOUNDARY,
-        distance_map=distance_map,
-    )
-    return bezier
+
+def _make_plan_or_skip(slicer, name, with_distance_map):
+    """Mint a v2 resection plan (``vtkMRMLResectionPlanNode`` wrapper).
+
+    When ``with_distance_map`` is True, attaches a scalar volume as the distance
+    map on the WRAPPER (ADR-0031); otherwise leaves
+    ``GetDistanceMapVolumeNode()`` null so the negative auto-populate branch is
+    exercised.  Skips cleanly (never fails) when the create-API / node API is
+    absent, mirroring the v2 re-point reference test.
+    """
+    logic = _resection_logic_or_skip(slicer)
+    plan = logic.CreateResectionPlan(name)
+    if plan is None or not plan.IsA(PLAN_NODE_CLASS):
+        pytest.skip(
+            "CreateResectionPlan did not return a vtkMRMLResectionPlanNode -- "
+            "cannot exercise the #501 slice-4 re-point."
+        )
+    for method in ("GetGeometryNode", "GetDistanceMapVolumeNode"):
+        if not hasattr(plan, method):
+            pytest.skip(
+                f"{PLAN_NODE_CLASS} exposes no {method}() in this build -- the "
+                "ADR-0031 distance-map-on-wrapper API is not wrapped."
+            )
+    if with_distance_map:
+        if not hasattr(plan, "SetAndObserveDistanceMapVolumeNode"):
+            pytest.skip(
+                f"{PLAN_NODE_CLASS} has no SetAndObserveDistanceMapVolumeNode -- "
+                "cannot attach the distance map on the wrapper (ADR-0031)."
+            )
+        volume = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLScalarVolumeNode", f"{name}DistanceMap"
+        )
+        if volume is None:
+            pytest.skip(
+                "vtkMRMLScalarVolumeNode not registered -- cannot attach a "
+                "distance map on the wrapper."
+            )
+        plan.SetAndObserveDistanceMapVolumeNode(volume)
+        if plan.GetDistanceMapVolumeNode() is None:
+            pytest.skip(
+                "distance map did not attach to the wrapper -- cannot exercise "
+                "the positive auto-populate branch (ADR-0031)."
+            )
+    return plan
+
+
+def _make_surface_with_distance_map(slicer):
+    """Mint a plan WITH a distance map on the WRAPPER (gate-satisfied fixture).
+
+    #501 slice 4: builds the v2 wrapper via ``CreateResectionPlan`` and attaches
+    the distance map on the wrapper (ADR-0031) so
+    ``plan.GetDistanceMapVolumeNode()`` is non-null.  Returns the plan wrapper.
+    """
+    return _make_plan_or_skip(slicer, "GateTestPlanDistanceMap", with_distance_map=True)
 
 
 def _make_surface_without_distance_map(slicer):
-    """Build a Bezier surface with NO distance map (gate-disabled fixture).
+    """Mint a plan with NO distance map on the WRAPPER (gate-disabled fixture).
 
-    Same control-point footprint as the gate-satisfied fixture but
-    ``SetDistanceMapVolumeNode`` is never called, so
-    ``GetDistanceMapVolumeNode()`` is null and the gate must DISABLE the
-    action (ADR-0023 §Stage-4 gating predicate).
+    #501 slice 4: the wrapper's ``GetDistanceMapVolumeNode()`` is left null, so
+    the gate must DISABLE the action (ADR-0031, ADR-0023 §Stage-4 gating
+    predicate).  Returns the plan wrapper.
     """
-    import vtk  # type: ignore[import-not-found]
-
-    slicer.modules.liverresections.logic()
-    bezier = slicer.mrmlScene.AddNewNodeByClass(
-        BEZIER_SURFACE_CLASS, "GateTestBezierNoDistanceMap"
+    return _make_plan_or_skip(
+        slicer, "GateTestPlanNoDistanceMap", with_distance_map=False
     )
-    if bezier is None:
-        pytest.skip(
-            f"{BEZIER_SURFACE_CLASS} not registered in this build -- "
-            "cannot exercise the T3-g3 gate."
-        )
-    for _ in range(16):
-        bezier.AddControlPoint(vtk.vtkVector3d(0.0, 0.0, 0.0))
-    bezier.CreateDefaultDisplayNodes()
-    return bezier
 
 
 # --------------------------------------------------------------------------- #
@@ -544,34 +598,33 @@ def test_hint_shown_when_no_surface_selected():
 
 
 def test_hint_shown_when_surface_has_no_distance_map():
-    """Surface selected but no distance map => the drawer shows the hint.
+    """Plan selected but WRAPPER has no distance map => the drawer shows the hint.
 
-    ADR-0023 §Stage-4 auto-populate predicate: populates iff a surface is
-    selected AND ``GetDistanceMapVolumeNode() != nullptr``
-    (vtkMRMLMarkupsBezierSurfaceNode.h line 91).  A surface without a distance
-    map keeps the hint up -- the merged resectogram stack has nothing to
-    sample.
+    ADR-0023 §Stage-4 auto-populate predicate: populates iff a plan is selected
+    AND ``plan.GetDistanceMapVolumeNode() != nullptr`` -- read off the WRAPPER
+    (ADR-0031).  A plan without a distance map keeps the hint up -- the merged
+    resectogram stack has nothing to sample.
     """
     slicer = _slicer_or_skip()
     slicer.mrmlScene.Clear(0)
     widget = _widget_or_skip(slicer)
     combo, hint = _require_widget_chrome_or_skip(widget)
 
-    bezier = _make_surface_without_distance_map(slicer)
-    _accessor_or_skip(bezier)
-    assert bezier.GetDistanceMapVolumeNode() is None  # fixture sanity
+    plan = _make_surface_without_distance_map(slicer)
+    _accessor_or_skip(plan)
+    assert plan.GetDistanceMapVolumeNode() is None  # fixture sanity
 
-    if not _select_active_resection(widget, combo, bezier):
+    if not _select_active_resection(widget, combo, plan):
         pytest.skip(
             "cannot select the active resection (implementer contract: "
             "setActiveResectionNode / combo.setCurrentNode)."
         )
 
     assert not hint.isHidden(), (
-        "the resectogram drawer hint must be SHOWN when the selected surface "
-        "has no distance map (GetDistanceMapVolumeNode() is None) -- "
-        "ADR-0023 §Stage-4, ADR-0009 §explainable state.  Checked via "
-        "isHidden() not visible (see test_hint_shown_when_no_surface_selected)."
+        "the resectogram drawer hint must be SHOWN when the selected plan's "
+        "WRAPPER has no distance map (plan.GetDistanceMapVolumeNode() is None) "
+        "-- ADR-0031, ADR-0023 §Stage-4, ADR-0009 §explainable state.  Checked "
+        "via isHidden() not visible (see test_hint_shown_when_no_surface_selected)."
     )
     assert hint.text, (
         "the resectogram drawer hint must carry non-empty text explaining the "
@@ -580,35 +633,36 @@ def test_hint_shown_when_surface_has_no_distance_map():
 
 
 def test_hint_hidden_when_surface_has_distance_map():
-    """Surface with a distance map selected => the drawer hint is HIDDEN.
+    """Plan whose WRAPPER carries a distance map => the drawer hint is HIDDEN.
 
     ADR-0023 §Stage-4 auto-populate predicate: the positive branch -- the
-    drawer populates (shows the view), so the hint is hidden.  State-ORTHOGONAL
-    -- the predicate does NOT read ADR-0019 ResectionState, so a distance-mapped
-    surface populates regardless of Planning/Confirmed state.  GPU-free: pins
-    the hint visibility, not the GL render.
+    drawer populates (shows the view), so the hint is hidden.  The distance map
+    is read off the WRAPPER (ADR-0031).  State-ORTHOGONAL -- the predicate does
+    NOT read ADR-0019 ResectionState, so a distance-mapped plan populates
+    regardless of Planning/Confirmed state.  GPU-free: pins the hint visibility,
+    not the GL render.
     """
     slicer = _slicer_or_skip()
     slicer.mrmlScene.Clear(0)
     widget = _widget_or_skip(slicer)
     combo, hint = _require_widget_chrome_or_skip(widget)
 
-    bezier = _make_surface_with_distance_map(slicer)
-    _accessor_or_skip(bezier)
-    assert bezier.GetDistanceMapVolumeNode() is not None  # fixture sanity
+    plan = _make_surface_with_distance_map(slicer)
+    _accessor_or_skip(plan)
+    assert plan.GetDistanceMapVolumeNode() is not None  # fixture sanity
 
-    if not _select_active_resection(widget, combo, bezier):
+    if not _select_active_resection(widget, combo, plan):
         pytest.skip(
             "cannot select the active resection (implementer contract: "
             "setActiveResectionNode / combo.setCurrentNode)."
         )
 
     assert hint.isHidden(), (
-        "the resectogram drawer hint must be HIDDEN when a Bezier surface WITH "
-        "a distance map is selected -- the drawer auto-populates the view in "
-        "its place (ADR-0023 §Stage-4 auto-populate predicate, positive "
-        "branch).  Checked via isHidden(): the ensure + hint-hide run headless; "
-        "the GL embed itself is gated to the main-window eyeball pass."
+        "the resectogram drawer hint must be HIDDEN when the selected plan's "
+        "WRAPPER carries a distance map -- the drawer auto-populates the view "
+        "in its place (ADR-0031, ADR-0023 §Stage-4 auto-populate predicate, "
+        "positive branch).  Checked via isHidden(): the ensure + hint-hide run "
+        "headless; the GL embed itself is gated to the main-window eyeball pass."
     )
 
 
@@ -618,61 +672,63 @@ def test_hint_hidden_when_surface_has_distance_map():
 
 
 def test_trigger_ensures_exactly_one_resectogram_display_node():
-    """Triggering ensures EXACTLY ONE resectogram display node on the surface.
+    """Triggering ensures EXACTLY ONE resectogram display node on the CARRIER.
 
     ADR-0023 §Stage-4 click action: ensure a ``vtkMRMLResectogramDisplayNode``
-    on the selected surface (``AddAndObserveDisplayNodeID`` if none present).
-    The surface starts with no resectogram display node; one trigger creates
-    exactly one.  Net-new production behaviour (today only the
-    Resectogram4x4BlurOff scenario attaches it).
+    on the selected plan's CARRIER (``plan.GetGeometryNode()``; ADR-0014
+    §"Fourth layer") -- ``AddAndObserveDisplayNodeID`` if none present.  The
+    carrier starts with no resectogram display node; one trigger creates
+    exactly one.
     """
     slicer = _slicer_or_skip()
     slicer.mrmlScene.Clear(0)
     widget = _widget_or_skip(slicer)
     combo, hint = _require_widget_chrome_or_skip(widget)
 
-    bezier = _make_surface_with_distance_map(slicer)
-    _accessor_or_skip(bezier)
-    assert _count_resectogram_display_nodes(slicer, bezier) == 0  # fixture sanity
+    plan = _make_surface_with_distance_map(slicer)
+    _accessor_or_skip(plan)
+    assert _count_resectogram_display_nodes(slicer, plan) == 0  # fixture sanity
 
-    if not _select_active_resection(widget, combo, bezier):
+    if not _select_active_resection(widget, combo, plan):
         pytest.skip(
             "cannot select the active resection (implementer contract)."
         )
     _require_populated_or_skip(hint)
 
-    assert _count_resectogram_display_nodes(slicer, bezier) == 1, (
-        "selecting a distance-mapped surface must ensure EXACTLY ONE "
-        f"{RESECTOGRAM_DISPLAY_CLASS} on it "
-        "(AddAndObserveDisplayNodeID when none present) -- ADR-0023 §Stage-4."
+    assert _count_resectogram_display_nodes(slicer, plan) == 1, (
+        "selecting a distance-mapped plan must ensure EXACTLY ONE "
+        f"{RESECTOGRAM_DISPLAY_CLASS} on its CARRIER (plan.GetGeometryNode(), a "
+        f"{BEZIER_CARRIER_CLASS}) -- AddAndObserveDisplayNodeID when none "
+        "present; ADR-0023 §Stage-4, ADR-0014 §\"Fourth layer\"."
     )
 
 
 def test_reselect_reuses_display_node_no_duplicate():
     """Re-selecting does NOT create a second resectogram display node.
 
-    ADR-0023 §Stage-4: the ensure step is idempotent -- a surface that already
-    carries a ``vtkMRMLResectogramDisplayNode`` is reused, not duplicated.
+    ADR-0023 §Stage-4: the ensure step is idempotent -- a carrier that already
+    carries a ``vtkMRMLResectogramDisplayNode`` is reused, not duplicated
+    (ADR-0014 §"Fourth layer").
     """
     slicer = _slicer_or_skip()
     slicer.mrmlScene.Clear(0)
     widget = _widget_or_skip(slicer)
     combo, hint = _require_widget_chrome_or_skip(widget)
 
-    bezier = _make_surface_with_distance_map(slicer)
-    _accessor_or_skip(bezier)
-    if not _select_active_resection(widget, combo, bezier):
+    plan = _make_surface_with_distance_map(slicer)
+    _accessor_or_skip(plan)
+    if not _select_active_resection(widget, combo, plan):
         pytest.skip(
             "cannot select the active resection (implementer contract)."
         )
     _require_populated_or_skip(hint)
-    first_count = _count_resectogram_display_nodes(slicer, bezier)
+    first_count = _count_resectogram_display_nodes(slicer, plan)
 
-    # Re-select the SAME surface (clear then re-select) to re-run the ensure
-    # path and prove idempotency.
+    # Re-select the SAME plan (clear then re-select) to re-run the ensure path
+    # and prove idempotency.
     _select_active_resection(widget, combo, None)
-    _select_active_resection(widget, combo, bezier)
-    second_count = _count_resectogram_display_nodes(slicer, bezier)
+    _select_active_resection(widget, combo, plan)
+    second_count = _count_resectogram_display_nodes(slicer, plan)
 
     assert first_count == 1, (
         "first selection must leave exactly one resectogram display node "
@@ -703,18 +759,18 @@ def test_selection_ensures_singleton_resectogram_view_node():
     widget = _widget_or_skip(slicer)
     combo, hint = _require_widget_chrome_or_skip(widget)
 
-    bezier = _make_surface_with_distance_map(slicer)
-    _accessor_or_skip(bezier)
+    plan = _make_surface_with_distance_map(slicer)
+    _accessor_or_skip(plan)
     assert _count_singleton_view_nodes(slicer) == 0  # fixture sanity
 
-    if not _select_active_resection(widget, combo, bezier):
+    if not _select_active_resection(widget, combo, plan):
         pytest.skip(
             "cannot select the active resection (implementer contract)."
         )
     _require_populated_or_skip(hint)
 
     assert _count_singleton_view_nodes(slicer) == 1, (
-        "selecting a distance-mapped surface must ensure exactly one "
+        "selecting a distance-mapped plan must ensure exactly one "
         "resectogram-tagged vtkMRMLViewNode via "
         "ResectogramViewManager.ensureViewNode() -- ADR-0023 §Stage-4."
     )
@@ -732,9 +788,9 @@ def test_reselect_reuses_view_node_no_duplicate():
     widget = _widget_or_skip(slicer)
     combo, hint = _require_widget_chrome_or_skip(widget)
 
-    bezier = _make_surface_with_distance_map(slicer)
-    _accessor_or_skip(bezier)
-    if not _select_active_resection(widget, combo, bezier):
+    plan = _make_surface_with_distance_map(slicer)
+    _accessor_or_skip(plan)
+    if not _select_active_resection(widget, combo, plan):
         pytest.skip(
             "cannot select the active resection (implementer contract)."
         )
@@ -742,7 +798,7 @@ def test_reselect_reuses_view_node_no_duplicate():
     first_count = _count_singleton_view_nodes(slicer)
 
     _select_active_resection(widget, combo, None)
-    _select_active_resection(widget, combo, bezier)
+    _select_active_resection(widget, combo, plan)
     second_count = _count_singleton_view_nodes(slicer)
 
     assert first_count == 1, (
@@ -820,9 +876,9 @@ def test_selection_embeds_three_d_widget_bound_to_singleton_view_node():
     widget = _widget_or_skip(slicer)
     combo, hint = _require_widget_chrome_or_skip(widget)
 
-    bezier = _make_surface_with_distance_map(slicer)
-    _accessor_or_skip(bezier)
-    if not _select_active_resection(widget, combo, bezier):
+    plan = _make_surface_with_distance_map(slicer)
+    _accessor_or_skip(plan)
+    if not _select_active_resection(widget, combo, plan):
         pytest.skip("cannot select the active resection (implementer contract).")
     _require_populated_or_skip(hint)
 
@@ -862,15 +918,15 @@ def test_reselect_reuses_three_d_widget_no_duplicate():
     widget = _widget_or_skip(slicer)
     combo, hint = _require_widget_chrome_or_skip(widget)
 
-    bezier = _make_surface_with_distance_map(slicer)
-    _accessor_or_skip(bezier)
-    if not _select_active_resection(widget, combo, bezier):
+    plan = _make_surface_with_distance_map(slicer)
+    _accessor_or_skip(plan)
+    if not _select_active_resection(widget, combo, plan):
         pytest.skip("cannot select the active resection (implementer contract).")
     _require_populated_or_skip(hint)
     first_count = len(_resectogram_three_d_widgets(slicer, widget))
 
     _select_active_resection(widget, combo, None)
-    _select_active_resection(widget, combo, bezier)
+    _select_active_resection(widget, combo, plan)
     second_count = len(_resectogram_three_d_widgets(slicer, widget))
 
     assert first_count == 1, (

--- a/LiverResections/Testing/Python/test_resectogram_open_view_presentation.py
+++ b/LiverResections/Testing/Python/test_resectogram_open_view_presentation.py
@@ -204,25 +204,40 @@ def _resectogram_view_node(slicer):
     return view
 
 
-def _resectogram_display_nodes(bezier):
-    """Return the ``vtkMRMLResectogramDisplayNode``s referenced by ``bezier``."""
+def _display_host(plan):
+    """Return the node that carries the display nodes for ``plan``.
+
+    In the v2 node graph the display nodes (resectogram + parametric-surface
+    anatomy) live on the plan's CARRIER (``GetGeometryNode()``, ADR-0014
+    §"Fourth layer"), not the plan wrapper.  Fall back to the node itself if it
+    exposes no geometry node (defensive).
+    """
+    carrier = plan.GetGeometryNode() if hasattr(plan, "GetGeometryNode") else None
+    return carrier if carrier is not None else plan
+
+
+def _resectogram_display_nodes(plan):
+    """Return the ``vtkMRMLResectogramDisplayNode``s on the plan's carrier."""
+    host = _display_host(plan)
     nodes = []
-    for index in range(bezier.GetNumberOfDisplayNodes()):
-        display = bezier.GetNthDisplayNode(index)
+    for index in range(host.GetNumberOfDisplayNodes()):
+        display = host.GetNthDisplayNode(index)
         if display is not None and display.IsA(RESECTOGRAM_DISPLAY_CLASS):
             nodes.append(display)
     return nodes
 
 
-def _surface_anatomy_display_nodes(bezier):
-    """Return the surface's NON-resectogram display node(s).
+def _surface_anatomy_display_nodes(plan):
+    """Return the carrier's NON-resectogram display node(s).
 
-    These are the surface's own 3D-anatomy display nodes (the markups display
-    node etc.) that invariant B restricts AWAY from the resectogram view.
+    These are the carrier's own 3D-anatomy display nodes (the parametric-surface
+    display node) that invariant B restricts AWAY from the resectogram view
+    (ADR-0014 §"Fourth layer").
     """
+    host = _display_host(plan)
     nodes = []
-    for index in range(bezier.GetNumberOfDisplayNodes()):
-        display = bezier.GetNthDisplayNode(index)
+    for index in range(host.GetNumberOfDisplayNodes()):
+        display = host.GetNthDisplayNode(index)
         if display is not None and not display.IsA(RESECTOGRAM_DISPLAY_CLASS):
             nodes.append(display)
     return nodes


### PR DESCRIPTION
## Summary

Re-points the Stage-4 `ResectionPlanningWidget` from the v1 markups surface
(`vtkMRMLMarkupsBezierSurfaceNode`) onto the v2 resection-plan node graph
(#501 slice 4; ADR-0014 §"Fourth layer"; ADR-0032). This is the GUI-wiring
step that moves the interactive resection workflow onto the v2 graph, a
prerequisite for retiring the v1 Bézier render (#493).

## What changed

- The active-resection combo selects the `vtkMRMLResectionPlanNode` **wrapper**;
  the v1 markups surface is no longer directly selectable.
- The auto-populate predicate reads the distance map off the **wrapper**
  (`GetDistanceMapVolumeNode`, ADR-0031).
- The `vtkMRMLResectogramDisplayNode` and the render observation now live on the
  wrapper's **carrier** (`GetGeometryNode()`, a `vtkMRMLBezierSurfaceNode`). The
  carrier is not a markups node, so the strip repaints on its generic
  `ModifiedEvent`; the v1 storm-free `PointModifiedEvent` has no carrier
  equivalent, so the storm-free guard is a GL-coupled concern verified on the
  interactive eyeball pass (ADR-0032).
- Adds a **"Place resection"** button (`placeResectionButton()` /
  `onPlaceResection()`) that mints a fresh plan graph via the logic create-API
  (`vtkSlicerLiverResectionsLogic::CreateResectionPlan`) and selects it.

## Tests

- New GPU-free invariant test `test_resection_planning_widget_v2_repoint.py`
  (8 invariants: combo re-point, auto-populate predicate off the wrapper,
  display-node-on-carrier idempotency, Place-button create+select), authored
  RED-as-skip then turned green by the implementation (ADR-0027).
- Migrates the three existing GPU-free widget test files
  (`test_resectogram_open_view_action`, `test_resectogram_open_view_presentation`,
  `test_resectogram_enlarge_toggle`) onto the v2 create+select fixtures and the
  carrier display-node lookup; invariants are unchanged.
- Full LiverResections launched suite: 76 passed / 11 skipped / 1 xfailed.

## Follow-ups (not in this PR)

- GL-coupled `:0` eyeball of storm-free reactivity + the real embed against v2
  nodes (ADR-0032 §Conformance).
- Remaining #501 slices: DistanceSpheroid placement, resectogram re-source,
  round-trip; then the #493 v1 render retirement.
