### PR TITLE
ENH: Re-source the resectogram strip off the resection-plan wrapper

### DIFF
--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -193,6 +193,13 @@ class FlattenedSurfaceRepresentation:
         # C++ pipeline on the Python heap (a vtkDebugLeaks trip).
         self._distance_map_volume: Any | None = None
 
+        # The orchestrating ``vtkMRMLResectionPlanNode`` wrapper, set by the
+        # ResectogramPipeline via ``SetResectionPlanNode`` (ADR-0031).  It
+        # carries the distance-shading input set the flattened strip reads --
+        # the distance-map volume AND the safety / risk margins -- none of
+        # which live on the carrier (ADR-0014 §"Fourth layer").
+        self._resection_plan_node: Any | None = None
+
         # Last MatRatio pushed onto the 2D mapper.  ``None`` until the
         # first ``update()`` runs OR the mapper does not expose
         # ``SetMatRatio`` (generic-mapper fallback path).
@@ -224,6 +231,17 @@ class FlattenedSurfaceRepresentation:
 
     def GetRenderer(self) -> Any | None:
         return self._renderer
+
+    def SetResectionPlanNode(self, plan_node: Any | None) -> None:  # noqa: N802 - VTK verb
+        """Attach the orchestrating ``vtkMRMLResectionPlanNode`` wrapper.
+
+        The ResectogramPipeline calls this before ``update()`` so the flattened
+        strip can read its distance-shading input set -- the distance-map volume
+        AND the safety / risk margins -- off the wrapper (ADR-0031), mirroring
+        the 3D ``BezierPlanningRepresentation``.  ``None`` clears it (the
+        no-distance-map fallback).
+        """
+        self._resection_plan_node = plan_node
 
     def update(self, display_node: Any | None, data_node: Any | None) -> None:
         """Reconcile the resectogram against the current display + data nodes.
@@ -489,6 +507,29 @@ class FlattenedSurfaceRepresentation:
         setter(list(ratio))
         self._mat_ratio_applied = (float(ratio[0]), float(ratio[1]))
 
+    def _apply_resection_margins(self, mapper: Any) -> None:
+        """Thread the wrapper's resection / uncertainty margins onto the mapper.
+
+        Per ADR-0031 the safety + risk margins are path-specific inputs carried
+        by the ``vtkMRMLResectionPlanNode`` wrapper, alongside the distance-map
+        volume, as one distance-shading input set.  Ports the margin block of
+        the 3D ``BezierPlanningRepresentation._apply_resection_plan``: push
+        ``GetSafetyMargin_mm`` -> ``SetResectionMargin`` and ``GetRiskMargin_mm``
+        -> ``SetUncertaintyMargin``.  A no-op when no plan is wired or on the
+        generic fallback mapper (the getattr guards).
+        """
+        plan = self._resection_plan_node
+        if plan is None:
+            return
+        safety = getattr(plan, "GetSafetyMargin_mm", None)
+        risk = getattr(plan, "GetRiskMargin_mm", None)
+        set_resection = getattr(mapper, "SetResectionMargin", None)
+        set_uncertainty = getattr(mapper, "SetUncertaintyMargin", None)
+        if safety is not None and set_resection is not None:
+            set_resection(float(safety()))
+        if risk is not None and set_uncertainty is not None:
+            set_uncertainty(float(risk()))
+
     def _apply_distance_map_texture(
         self, display_node: Any | None, data_node: Any | None
     ) -> None:
@@ -512,12 +553,23 @@ class FlattenedSurfaceRepresentation:
         mapper = self._resection_mapper_2d
         if mapper is None:
             return
+
+        # Thread the wrapper's resection / uncertainty margins onto the 2D
+        # mapper FIRST (ADR-0031): they are valid plan state independent of the
+        # distance-map texture (the shader simply has no band to draw until a
+        # texture is bound), so they must be set even on the no-distance-map /
+        # deferred-GL paths below.  Mirrors BezierPlanningRepresentation.
+        self._apply_resection_margins(mapper)
+
         bind = getattr(mapper, "SetDistanceMapTextureObject", None)
         if bind is None:
             return  # generic-mapper fallback (bare-VTK path) — no sampler3D
 
         already_bound = self._mapper_has_distance_map_texture(mapper)
-        volume = _safe_call_getter(data_node, "GetDistanceMapVolumeNode")
+        # Source the distance-map volume from the WRAPPER (ADR-0031), NOT the
+        # data node / carrier — the distance map is a wrapper-owned input of
+        # the resection plan (ADR-0014 §"Fourth layer").
+        volume = _safe_call_getter(self._resection_plan_node, "GetDistanceMapVolumeNode")
         if volume is self._distance_map_volume and already_bound:
             return  # unchanged + already bound — idempotent (ADR-0013 §3)
 
@@ -534,10 +586,12 @@ class FlattenedSurfaceRepresentation:
         texture = self._create_distance_map_texture(image_data, num_comps)
         if texture is None:
             # The GL render window is not live yet (texture build deferred):
-            # leave the volume unrecorded so a later update — once the
-            # window exists — retries the bind rather than short-circuiting.
+            # record the SOURCED (wrapper) volume so the sourced layer is
+            # observable, but leave the texture unbound so a later update --
+            # once the window exists -- retries the bind (``already_bound``
+            # stays False, so the idempotency guard above does not short it).
             bind(None)
-            self._distance_map_volume = None
+            self._distance_map_volume = volume
             return
 
         # Hand the texture to the mapper's vtkSmartPointer and drop the

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -125,6 +125,16 @@ class ResectogramPipeline(_PipelineBase):
         self._vascular_contour: Any | None = None
         self._representations_initialised = False
 
+        # The orchestrating ``vtkMRMLResectionPlanNode`` wrapper, reverse-
+        # resolved from the data node's ``geometry`` back-reference (ADR-0031;
+        # ADR-0014 §"Fourth layer"), so the flattened strip reads its distance-
+        # shading input set (distance map + margins) off the wrapper.  Mirrors
+        # LiverBezierSurfacePipeline.  The scan (``GetNodesByClass``) is gated on
+        # the scene MTime so a bare surface (no owning plan) does not re-scan on
+        # every render.
+        self._resection_node: Any | None = None
+        self._last_resection_scan_mtime: int | None = None
+
     # ------------------------------------------------------------------ #
     # LayerDM lifecycle overrides
     # ------------------------------------------------------------------ #
@@ -142,6 +152,9 @@ class ResectogramPipeline(_PipelineBase):
         self._reattach_node_observers()
 
         self._last_update_key = None
+        # Re-resolve the owning plan wrapper for the new data node (ADR-0031).
+        self._resection_node = None
+        self._last_resection_scan_mtime = None
 
     def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
         """Reconcile both Representations against the current node set.
@@ -165,6 +178,20 @@ class ResectogramPipeline(_PipelineBase):
         is the correct reactivity signal on both counts.
         """
         self._ensure_representations()
+
+        # Reverse-resolve the owning plan wrapper (scene-MTime-gated so a bare
+        # surface does not re-scan every render) and thread it into the
+        # flattened strip BEFORE the memo-key short-circuit, so the strip always
+        # holds the current wrapper reference (ADR-0031; mirror
+        # LiverBezierSurfacePipeline).  ``update()`` below then reads the
+        # distance-shading set off it when the geometry digest changes.
+        if self._resection_node is None and self._data_node is not None:
+            scene_mtime = _safe_get_scene_mtime(self._data_node)
+            if scene_mtime != self._last_resection_scan_mtime:
+                self._last_resection_scan_mtime = scene_mtime
+                self._resection_node = self._resolve_resection_node()
+        if self._flattened_surface is not None:
+            self._flattened_surface.SetResectionPlanNode(self._resection_node)
 
         key = _safe_get_control_points_digest(self._data_node)
         if key == self._last_update_key:
@@ -213,6 +240,14 @@ class ResectogramPipeline(_PipelineBase):
 
     def GetDataNode(self) -> Any | None:
         return self._data_node
+
+    def GetResectionNode(self) -> Any | None:  # noqa: N802 - VTK verb
+        """Return the reverse-resolved ``vtkMRMLResectionPlanNode`` wrapper.
+
+        ``None`` for a bare surface with no owning plan (the no-distance-map
+        fallback).  Resolved lazily in ``UpdatePipeline`` (ADR-0031).
+        """
+        return self._resection_node
 
     def GetFlattenedSurfaceRepresentation(self) -> Any | None:
         return self._flattened_surface
@@ -289,6 +324,42 @@ class ResectogramPipeline(_PipelineBase):
         self._vascular_contour = VascularContourRepresentation(renderer=renderer)
 
         self._representations_initialised = True
+
+    def _resolve_resection_node(self) -> Any | None:
+        """Reverse-resolve the ``vtkMRMLResectionPlanNode`` wrapper.
+
+        The plan wrapper references the surface carrier via the ``geometry``
+        role (ADR-0014 §"Fourth layer"); the Pipeline reverse-walks that to
+        adopt the wrapper, so it can thread the plan's distance-map + margins
+        (ADR-0031) onto the flattened strip without an external caller.  Scans
+        the scene for the plan whose ``GetGeometryNode()`` is our data node.
+        Returns ``None`` when no plan owns this data node (a bare surface — the
+        no-distance-map fallback).  Mirrors LiverBezierSurfacePipeline.
+        """
+        data_node = self._data_node
+        if data_node is None:
+            return None
+        scene = getattr(data_node, "GetScene", lambda: None)()
+        if scene is None:
+            return None
+        try:
+            plans = scene.GetNodesByClass("vtkMRMLResectionPlanNode")
+        except Exception:  # pragma: no cover - defensive
+            return None
+        if plans is None:
+            return None
+        plans.InitTraversal()
+        item = plans.GetNextItemAsObject()
+        while item is not None:
+            getter = getattr(item, "GetGeometryNode", None)
+            if getter is not None:
+                try:
+                    if getter() is data_node:
+                        return item
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            item = plans.GetNextItemAsObject()
+        return None
 
     def _safe_get_renderer(self) -> Any | None:
         """Return ``self.GetRenderer()`` if available, else ``None``.
@@ -409,6 +480,25 @@ class ResectogramPipeline(_PipelineBase):
 # --------------------------------------------------------------------------- #
 # Safe accessors — tolerant of stub nodes that omit the markups accessors.
 # --------------------------------------------------------------------------- #
+
+
+def _safe_get_scene_mtime(node: Any) -> int | None:
+    """Return the MTime of ``node``'s scene, or ``None`` if unreachable.
+
+    Gates the plan reverse-resolution scan (``GetNodesByClass``) so a bare
+    surface with no owning plan does not re-scan on every render — the scan
+    re-runs only when the scene has changed since the last miss.
+    """
+    scene = getattr(node, "GetScene", lambda: None)() if node is not None else None
+    if scene is None:
+        return None
+    getter = getattr(scene, "GetMTime", None)
+    if getter is None:
+        return None
+    try:
+        return int(getter())
+    except Exception:  # pragma: no cover - defensive
+        return None
 
 
 def _safe_get_control_points_digest(node: Any) -> tuple:

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -417,6 +417,59 @@ if(DEFINED Python3_EXECUTABLE)
     set_tests_properties(LiverResections_resectogram_pipeline_memo_key PROPERTIES
       LABELS "pytest;module-layer;LiverResections;resectogram;render-storm"
     )
+
+    # #501 slice 5 -- thread the resection-plan WRAPPER into the resectogram
+    # render path (ADR-0031: the distance-map volume + the safety / risk
+    # margins are wrapper-owned inputs on vtkMRMLResectionPlanNode; ADR-0013 §5,
+    # §6).  Ports the 3D path (LiverBezierSurfacePipeline._resolve_resection_node
+    # + BezierPlanningRepresentation.SetResectionPlanNode) into the resectogram
+    # path.  This entry pins the PIPELINE half: ResectogramPipeline
+    # reverse-resolves the vtkMRMLResectionPlanNode whose GetGeometryNode() is
+    # its data node (carrier) and hands it to the FlattenedSurfaceRepresentation
+    # via SetResectionPlanNode -- an unowned carrier resolves to None.  Needs
+    # the wrapped plan / carrier / resectogram-display nodes + the importable
+    # Pipeline (base vtkMRMLLayerDMScriptedPipeline), so it runs green under the
+    # launched-Slicer `pytest_launched` row and SKIPS CLEANLY here under bare
+    # pytest (no slicer.mrmlScene / LayerDMLib).  RED / skip-pending until the
+    # implementer lands the reverse-resolution seam (ADR-0027 §Conformance: the
+    # skip lifts at the implementation commit).
+    add_test(
+      NAME LiverResections_resectogram_pipeline_resolves_resection_plan
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_resectogram_pipeline_resolves_resection_plan.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_resectogram_pipeline_resolves_resection_plan PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;resectogram;mapper-wiring"
+    )
+
+    # #501 slice 5 -- the REPRESENTATION half: FlattenedSurfaceRepresentation
+    # shades off the WRAPPER (ADR-0031), not the carrier.  With a plan wrapper
+    # set, update() threads SetResectionMargin(SafetyMargin_mm) +
+    # SetUncertaintyMargin(RiskMargin_mm) onto the 2D
+    # vtkOpenGLResection2DPolyDataMapper and sources the distance-map volume
+    # from plan.GetDistanceMapVolumeNode() (present -> resolved source; absent ->
+    # source cleared, graceful fallback, margins still set).  GL-free: a FAKE 2D
+    # mapper records the margin scalar-setters + the resolved distance-map source
+    # (same mock-mapper idiom as test_bezier_planning_surface_mapper_wiring.py);
+    # the real GL 3D-texture upload + the strip render are the :0 eyeball
+    # follow-up, NOT asserted here.  Needs the wrapped plan / carrier /
+    # resectogram-display / volume nodes, so it runs green under the
+    # launched-Slicer `pytest_launched` row and SKIPS CLEANLY here under bare
+    # pytest (no slicer.mrmlScene).  RED / skip-pending until the implementer
+    # ports the wrapper-shading path (ADR-0027 §Conformance: the skip lifts at
+    # the implementation commit).
+    add_test(
+      NAME LiverResections_flattened_surface_plan_shading
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_flattened_surface_plan_shading.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_flattened_surface_plan_shading PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;resectogram;mapper-wiring"
+    )
   else()
     message(STATUS
       "Slicer-Liver: pytest not importable from ${Python3_EXECUTABLE}; "

--- a/LiverResections/Testing/Python/test_flattened_surface_plan_shading.py
+++ b/LiverResections/Testing/Python/test_flattened_surface_plan_shading.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""#501 slice 5 -- FlattenedSurfaceRepresentation shades off the WRAPPER.
+
+The resectogram's flattened strip shades from the same distance field the 3D
+Bezier path uses, through the SAME ``vtkOpenGLResection2DPolyDataMapper``.  Its
+band needs the three wrapper-owned inputs ADR-0031 clusters on the
+``vtkMRMLResectionPlanNode`` wrapper: the distance-map volume,
+``SetResectionMargin(SafetyMargin_mm)``, and
+``SetUncertaintyMargin(RiskMargin_mm)``.
+
+The gap this pins: today ``FlattenedSurfaceRepresentation._apply_distance_map_texture``
+reads ``GetDistanceMapVolumeNode`` off the DATA NODE (the carrier) -- the WRONG
+layer (ADR-0031 puts the distance map on the wrapper) -- and threads NO margins.
+Slice 5 ports the 3D path (``BezierPlanningRepresentation.SetResectionPlanNode``
++ ``_apply_resection_plan``): source the distance-map volume from the wrapper
+(``plan.GetDistanceMapVolumeNode()``) and push ``SetResectionMargin`` /
+``SetUncertaintyMargin`` from the wrapper's margins onto the 2D mapper.
+
+-- GL-FREE VIA A FAKE MAPPER --
+
+The real 2D mapper binds the distance map through ``SetDistanceMapTextureObject``
+(a GL 3D texture built on the render window -- needs a live GL context).  These
+tests are GL-free: they inject a FAKE mapper (same idiom as
+``test_bezier_planning_surface_mapper_wiring.py``'s mock-mapper) that RECORDS the
+``SetResectionMargin`` / ``SetUncertaintyMargin`` scalar-setter calls and the
+distance-map volume node the Representation sourced, so the margin values + the
+distance-map SOURCE LAYER are asserted without any render window.  The actual
+3D-texture upload + the strip render stay on the :0 eyeball follow-up (see the
+module note below) -- they are not asserted here.
+
+-- WHY LAUNCHED-SLICER (soft) --
+
+The Representation is plain Python + VTK, but it sources the distance-map volume
+off a wrapped ``vtkMRMLResectionPlanNode``, so a wrapped plan node is needed for
+the positive path.  Skips cleanly under bare pytest via the shared
+``slicer_pytest_support`` guards + the ``SetResectionPlanNode`` seam gate.
+
+-- WHY RED NOW --
+
+``FlattenedSurfaceRepresentation`` has no ``SetResectionPlanNode`` seam and does
+not thread margins, so every test SKIPS cleanly.  The skip lifts when slice 5
+ports the wrapper-shading path (ADR-0027 §Conformance).
+
+:0-EYEBALL FOLLOW-UP (explicitly out of scope here):
+  * the GL 3D distance-map TEXTURE upload (``SetDistanceMapTextureObject`` +
+    ras/ijk matrices on the real mapper); and
+  * the flattened strip actually rendering the projected margin band.
+  Both need a live GL context and are verified on the interactive :0 pass, not
+  in this GL-free module-layer test (ADR-0031; ADR-0032 §Conformance idiom).
+
+See also:
+  * Docs/adr/0031-distance-map-input-on-resection-plan.md
+  * Docs/adr/0025-locator-architecture.md §Context (the resectogram band)
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §3, §6
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md
+  * LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+  * LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+    (SetResectionPlanNode / _apply_resection_plan -- the 3D-path precedent)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+RESECTOGRAM_DISPLAY_NODE_CLASS = "vtkMRMLResectogramDisplayNode"
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+VOLUME_NODE_CLASS = "vtkMRMLScalarVolumeNode"
+
+
+class _FakeResection2DMapper:
+    """GL-free stand-in for ``vtkOpenGLResection2DPolyDataMapper``.
+
+    Records the margin scalar-setters + the distance-map source so the
+    wrapper-shading path is asserted without a GL context.  The real mapper
+    binds the distance map through ``SetDistanceMapTextureObject`` (a GL 3D
+    texture) -- here we record only the volume node the Representation SOURCED,
+    which is the layer-discrimination this slice is about; the texture upload
+    is the :0 follow-up.
+    """
+
+    def __init__(self):
+        self.resection_margin = None
+        self.uncertainty_margin = None
+        # ``sentinel`` distinguishes "never touched" from an explicit clear.
+        self.distance_map_texture = "sentinel"
+        # The volume node the Representation resolved as the distance-map
+        # source (recorded by the injected sourcing hook, below).
+        self.distance_map_source = "sentinel"
+
+    def SetResectionMargin(self, value):  # noqa: N802 - VTK verb
+        self.resection_margin = float(value)
+
+    def SetUncertaintyMargin(self, value):  # noqa: N802 - VTK verb
+        self.uncertainty_margin = float(value)
+
+    def SetDistanceMapTextureObject(self, texture):  # noqa: N802 - VTK verb
+        self.distance_map_texture = texture
+
+    def GetDistanceMapTextureObject(self):  # noqa: N802 - VTK verb
+        return None if self.distance_map_texture == "sentinel" else self.distance_map_texture
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_representation_or_skip():
+    try:
+        from LiverResectionsLib.Representations.FlattenedSurfaceRepresentation import (
+            FlattenedSurfaceRepresentation,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            "FlattenedSurfaceRepresentation not importable "
+            f"({exc!r}) -- not reachable in this environment."
+        )
+    return FlattenedSurfaceRepresentation()
+
+
+def _require_plan_shading_seam_or_skip(rep):
+    """Skip unless the wrapper-shading seam (slice 5) has landed.
+
+    RED == the Representation has no ``SetResectionPlanNode`` -- the seam that
+    sources the distance map + margins off the ``vtkMRMLResectionPlanNode``
+    wrapper (ADR-0031).  The skip lifts when slice 5 ports the 3D path's
+    ``_apply_resection_plan`` (ADR-0027 §Conformance).
+    """
+    if not hasattr(rep, "SetResectionPlanNode"):
+        pytest.skip(
+            "FlattenedSurfaceRepresentation has no SetResectionPlanNode -- "
+            "the #501 slice 5 wrapper-shading seam has not landed."
+        )
+
+
+def _inject_fake_mapper(rep):
+    """Swap the Representation's 2D mapper for the GL-free fake + record the
+    distance-map source layer.
+
+    The Representation's ``_apply_distance_map_texture`` sources the volume via
+    a getter on some node (the carrier today; the WRAPPER after slice 5).  We
+    cannot read the private call directly, so we wrap the mapper's
+    ``SetDistanceMapTextureObject`` and, crucially, record which node the
+    Representation queried by wrapping the sourcing helper if present; falling
+    back to inspecting ``_distance_map_volume`` which the Representation records
+    as the resolved source (see ``_apply_distance_map_texture``).
+    """
+    fake = _FakeResection2DMapper()
+    rep._resection_mapper_2d = fake
+    return fake
+
+
+def _resolved_distance_map_source(rep, fake):
+    """The volume node the Representation recorded as its distance-map source.
+
+    ``_apply_distance_map_texture`` stores the resolved volume on
+    ``rep._distance_map_volume`` -- that is the SOURCE-LAYER discriminator this
+    slice is about (carrier vs wrapper).  Returns it, or ``None`` when unset.
+    """
+    return getattr(rep, "_distance_map_volume", None)
+
+
+def test_flattened_surface_threads_margins_from_wrapper():
+    """Invariant 2: safety + risk margins reach the 2D mapper from the WRAPPER.
+
+    With a plan wrapper carrying ``SafetyMargin_mm`` / ``RiskMargin_mm``, the
+    Representation's ``update`` pushes ``SetResectionMargin(safety)`` +
+    ``SetUncertaintyMargin(risk)`` onto the 2D mapper -- porting
+    ``BezierPlanningRepresentation._apply_resection_plan`` into the resectogram
+    path.  Asserted GL-free via the fake mapper's recorded scalars.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_plan_shading_seam_or_skip(rep)
+
+    fake = _inject_fake_mapper(rep)
+
+    data = slicer.mrmlScene.AddNewNodeByClass(BEZIER_NODE_CLASS)
+    display = slicer.mrmlScene.AddNewNodeByClass(RESECTOGRAM_DISPLAY_NODE_CLASS)
+    plan = slicer.mrmlScene.AddNewNodeByClass(PLAN_NODE_CLASS)
+    if data is None or display is None or plan is None:
+        pytest.skip("wrapper / carrier / display nodes not all registered.")
+    if not (hasattr(plan, "SetSafetyMargin_mm") and hasattr(plan, "SetRiskMargin_mm")):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no Safety/Risk margin setters.")
+
+    plan.SetSafetyMargin_mm(10.0)
+    plan.SetRiskMargin_mm(2.0)
+
+    rep.SetResectionPlanNode(plan)
+    rep.update(display, data)
+
+    assert fake.resection_margin is not None, (
+        "the wrapper's SafetyMargin_mm must reach the 2D mapper's "
+        "SetResectionMargin (ADR-0031) -- no margin was threaded."
+    )
+    assert abs(fake.resection_margin - 10.0) < 1e-5, (
+        "plan SafetyMargin_mm must reach SetResectionMargin; got "
+        f"{fake.resection_margin}."
+    )
+    assert fake.uncertainty_margin is not None and abs(
+        fake.uncertainty_margin - 2.0
+    ) < 1e-5, (
+        "plan RiskMargin_mm must reach the 2D mapper's SetUncertaintyMargin; "
+        f"got {fake.uncertainty_margin}."
+    )
+
+
+def test_flattened_surface_sources_distance_map_from_wrapper_not_carrier():
+    """Invariant 3 (positive): distance map is sourced from the WRAPPER.
+
+    Negative discriminator: a carrier whose data node has NO distance map but
+    whose WRAPPER carries one -- the Representation must resolve the distance-map
+    volume from the WRAPPER (present), NOT the carrier.  This is the layer fix:
+    ADR-0031 puts the distance map on the plan wrapper, not the carrier.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_plan_shading_seam_or_skip(rep)
+
+    _inject_fake_mapper(rep)
+
+    data = slicer.mrmlScene.AddNewNodeByClass(BEZIER_NODE_CLASS)
+    display = slicer.mrmlScene.AddNewNodeByClass(RESECTOGRAM_DISPLAY_NODE_CLASS)
+    plan = slicer.mrmlScene.AddNewNodeByClass(PLAN_NODE_CLASS)
+    volume = slicer.mrmlScene.AddNewNodeByClass(VOLUME_NODE_CLASS)
+    if None in (data, display, plan, volume):
+        pytest.skip("wrapper / carrier / display / volume not all registered.")
+    if not hasattr(plan, "SetAndObserveDistanceMapVolumeNode"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveDistanceMapVolumeNode.")
+    # Carrier deliberately has NO distance map; only the WRAPPER carries one.
+    if hasattr(data, "SetAndObserveDistanceMapVolumeNode"):
+        data.SetAndObserveDistanceMapVolumeNode(None)
+    plan.SetAndObserveDistanceMapVolumeNode(volume)
+
+    rep.SetResectionPlanNode(plan)
+    rep.update(display, data)
+
+    assert _resolved_distance_map_source(rep, None) is volume, (
+        "the distance-map volume must be sourced from the WRAPPER "
+        "(plan.GetDistanceMapVolumeNode(), ADR-0031), NOT the carrier "
+        "data node -- the carrier has none, so a carrier-sourced read would "
+        "leave the source None; got "
+        f"{_resolved_distance_map_source(rep, None)!r}."
+    )
+
+
+def test_flattened_surface_clears_source_when_wrapper_has_no_distance_map():
+    """Invariant 3 (negative): no wrapper distance map -> source cleared.
+
+    A wrapper with no distance map returns the Representation to the graceful
+    no-distance-map fallback: the distance-map source is cleared (so the mapper
+    does not sample a volume that is gone), while the margins are STILL threaded
+    from the wrapper.  MRML state and the mapper's source must not diverge.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_plan_shading_seam_or_skip(rep)
+
+    fake = _inject_fake_mapper(rep)
+
+    data = slicer.mrmlScene.AddNewNodeByClass(BEZIER_NODE_CLASS)
+    display = slicer.mrmlScene.AddNewNodeByClass(RESECTOGRAM_DISPLAY_NODE_CLASS)
+    plan = slicer.mrmlScene.AddNewNodeByClass(PLAN_NODE_CLASS)
+    if None in (data, display, plan):
+        pytest.skip("wrapper / carrier / display not all registered.")
+    if not hasattr(plan, "SetAndObserveDistanceMapVolumeNode"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveDistanceMapVolumeNode.")
+    if not (hasattr(plan, "SetSafetyMargin_mm") and hasattr(plan, "SetRiskMargin_mm")):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no Safety/Risk margin setters.")
+
+    plan.SetAndObserveDistanceMapVolumeNode(None)
+    plan.SetSafetyMargin_mm(5.0)
+    plan.SetRiskMargin_mm(1.0)
+
+    rep.SetResectionPlanNode(plan)
+    rep.update(display, data)
+
+    assert _resolved_distance_map_source(rep, fake) is None, (
+        "a wrapper with no distance map must clear the Representation's "
+        "distance-map source (the graceful fallback); got "
+        f"{_resolved_distance_map_source(rep, fake)!r}."
+    )
+    # Margins are orthogonal to the distance map: they must still be threaded.
+    assert fake.resection_margin is not None and abs(
+        fake.resection_margin - 5.0
+    ) < 1e-5, (
+        "margins must still be threaded from the wrapper even when no "
+        f"distance map is present; got {fake.resection_margin}."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverResections/Testing/Python/test_resectogram_pipeline_resolves_resection_plan.py
+++ b/LiverResections/Testing/Python/test_resectogram_pipeline_resolves_resection_plan.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""#501 slice 5 -- the ResectogramPipeline reverse-resolves its plan wrapper.
+
+The resectogram's flattened strip shades from the SAME distance field the 3D
+Bezier path uses.  ADR-0031 clusters the three wrapper-owned inputs the band
+needs on the ``vtkMRMLResectionPlanNode`` wrapper: the distance-map volume, the
+safety margin, and the risk (uncertainty) margin.  Slice 5 ports the 3D path's
+wrapper-threading (already landed on ``LiverBezierSurfacePipeline`` +
+``BezierPlanningRepresentation``) into the resectogram path.
+
+The gap this pins: ``ResectogramPipeline`` derives its data node (the carrier)
+from the resectogram display node's ``GetDisplayableNode()`` back-reference, but
+never resolves the orchestrating wrapper -- so the flattened strip renders with
+NO margin shading and reads the distance map off the wrong (carrier) layer.  The
+fix mirrors ``LiverBezierSurfacePipeline._resolve_resection_node`` /
+``GetResectionNode``: reverse-walk the ``geometry`` back-reference (the plan whose
+``GetGeometryNode()`` is our data node is our wrapper) and hand it to the
+``FlattenedSurfaceRepresentation`` via ``SetResectionPlanNode`` before / within
+``UpdatePipeline`` -- no external caller required.
+
+-- WHY LAUNCHED-SLICER --
+
+Needs the wrapped ``vtkMRMLResectionPlanNode`` / ``vtkMRMLBezierSurfaceNode`` /
+``vtkMRMLResectogramDisplayNode`` + the importable ``ResectogramPipeline`` whose
+base ``vtkMRMLLayerDMScriptedPipeline`` is constructible only inside a Slicer
+process with SlicerLayerDM loaded.  Skips cleanly under bare
+``PythonSlicer -m pytest``.
+
+-- WHY RED NOW --
+
+The ResectogramPipeline has no reverse-resolution seam yet
+(``GetResectionNode`` / ``_resolve_resection_node`` absent, or the
+``FlattenedSurfaceRepresentation`` has no ``SetResectionPlanNode``), so the
+tests SKIP cleanly.  The skip lifts when slice 5 lands (ADR-0027 §Conformance).
+
+See also:
+  * Docs/adr/0031-distance-map-input-on-resection-plan.md
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §3, §5, §6
+  * Docs/adr/0014-livermarkups-dissolution.md §"Fourth layer" (wrapper/carrier)
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md
+  * LiverResections/LiverResectionsLib/ResectogramPipeline.py
+  * LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+    (_resolve_resection_node -- the 3D-path precedent this ports)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+RESECTOGRAM_DISPLAY_NODE_CLASS = "vtkMRMLResectogramDisplayNode"
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_pipeline_or_skip():
+    """Construct a ``ResectogramPipeline`` or skip if unimportable.
+
+    Skips cleanly when LayerDMLib (the Pipeline base class) is not importable
+    -- i.e. outside a launched Slicer with the SlicerLayerDM extension.
+    """
+    pytest.importorskip(
+        "LayerDMLib",
+        reason="ResectogramPipeline's base vtkMRMLLayerDMScriptedPipeline is "
+        "only constructible inside a Slicer process with SlicerLayerDM loaded "
+        "(the launched pytest_launched row); skipping under bare pytest.",
+    )
+    try:
+        from LiverResectionsLib.ResectogramPipeline import ResectogramPipeline
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"ResectogramPipeline not importable ({exc!r}).")
+    return ResectogramPipeline()
+
+
+def _require_resolve_seam_or_skip(pipeline):
+    """Skip unless the wrapper reverse-resolution seam (slice 5) has landed.
+
+    RED == the ``ResectogramPipeline`` has no ``GetResectionNode`` /
+    ``_resolve_resection_node`` and / or the ``FlattenedSurfaceRepresentation``
+    has no ``SetResectionPlanNode``.  The skip lifts when slice 5 ports the
+    3D path's wrapper-threading (ADR-0027 §Conformance).
+    """
+    try:
+        from LiverResectionsLib.Representations.FlattenedSurfaceRepresentation import (
+            FlattenedSurfaceRepresentation,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"FlattenedSurfaceRepresentation not importable ({exc!r}).")
+    if not hasattr(FlattenedSurfaceRepresentation, "SetResectionPlanNode"):
+        pytest.skip(
+            "FlattenedSurfaceRepresentation has no SetResectionPlanNode -- "
+            "#501 slice 5 (the wrapper-threading seam) has not landed."
+        )
+    if not hasattr(pipeline, "GetResectionNode"):
+        pytest.skip(
+            "ResectogramPipeline has no GetResectionNode -- #501 slice 5 "
+            "(the wrapper reverse-resolution) has not landed."
+        )
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def _wire_surface_with_resectogram_display(slicer):
+    """Create a Bezier carrier + its resectogram display node, wired so
+    ``display.GetDisplayableNode()`` resolves the carrier (the back-reference
+    the Pipeline derives its data node from)."""
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+    data.SetAndObserveDisplayNodeID(display.GetID())
+    if display.GetDisplayableNode() is not data:
+        pytest.skip(
+            "display.GetDisplayableNode() does not resolve the carrier in this "
+            "build -- cannot exercise the Pipeline's data-node derivation."
+        )
+    return data, display
+
+
+def test_resectogram_pipeline_reverse_resolves_plan_from_geometry_ref():
+    """The Pipeline resolves its wrapper from the data node's geometry back-ref.
+
+    Wire ``plan --geometry--> data <--displayable-- resectogram-display``,
+    attach the display node to a fresh Pipeline and dispatch; the Pipeline must
+    discover the plan (``GetResectionNode()``) without anyone calling a setter
+    -- the production wiring the live resectogram render path needs so the
+    distance map + margins reach the 2D mapper (ADR-0031).
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_resolve_seam_or_skip(pipeline)
+
+    data, display = _wire_surface_with_resectogram_display(slicer)
+    plan = _add_or_skip(slicer, PLAN_NODE_CLASS)
+    if not hasattr(plan, "SetAndObserveGeometryNode"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveGeometryNode.")
+    plan.SetAndObserveGeometryNode(data)
+    assert plan.GetGeometryNode() is data
+
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    assert pipeline.GetResectionNode() is plan, (
+        "the ResectogramPipeline must reverse-resolve its "
+        "vtkMRMLResectionPlanNode wrapper from the data node's geometry "
+        "back-reference (ADR-0031) so the flattened strip threads the "
+        "distance-map + margins without an external caller; got "
+        f"{pipeline.GetResectionNode()!r}."
+    )
+
+
+def test_resectogram_pipeline_resection_node_none_for_unowned_surface():
+    """A bare surface with no owning plan resolves to no wrapper.
+
+    Pins that the reverse-resolution does not false-positive: a Pipeline over a
+    surface that no plan references must leave ``GetResectionNode()`` None (the
+    no-distance-map fallback the 2D mapper degrades to gracefully).
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_resolve_seam_or_skip(pipeline)
+
+    data, display = _wire_surface_with_resectogram_display(slicer)
+    # No plan references ``data``.
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    assert pipeline.GetResectionNode() is None, (
+        "a surface no plan owns must resolve to no wrapper; got "
+        f"{pipeline.GetResectionNode()!r}."
+    )
+
+
+def test_resectogram_pipeline_sets_plan_on_flattened_representation():
+    """The resolved wrapper is threaded to the FlattenedSurfaceRepresentation.
+
+    The Pipeline must not merely resolve the plan -- it must hand it to the
+    ``FlattenedSurfaceRepresentation`` (which sources the distance map + margins
+    off the wrapper per ADR-0031) before / within ``UpdatePipeline``, mirroring
+    ``LiverBezierSurfacePipeline``'s ``active.SetResectionPlanNode(...)`` call.
+    Verified by spying the representation's ``SetResectionPlanNode``.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_resolve_seam_or_skip(pipeline)
+
+    data, display = _wire_surface_with_resectogram_display(slicer)
+    plan = _add_or_skip(slicer, PLAN_NODE_CLASS)
+    if not hasattr(plan, "SetAndObserveGeometryNode"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveGeometryNode.")
+    plan.SetAndObserveGeometryNode(data)
+
+    pipeline.SetDisplayNode(display)
+    # Force the Representations to exist so we can spy the setter.  A bare
+    # pipeline builds them lazily on first dispatch; call once, then spy.
+    pipeline.UpdatePipeline()
+    rep = pipeline.GetFlattenedSurfaceRepresentation()
+    if rep is None:
+        pytest.skip(
+            "FlattenedSurfaceRepresentation not constructed (no renderer) -- "
+            "cannot spy SetResectionPlanNode; exercised on the launched path."
+        )
+
+    seen = {"plan": "unset"}
+    original = rep.SetResectionPlanNode
+
+    def _spy(plan_node):
+        seen["plan"] = plan_node
+        return original(plan_node)
+
+    rep.SetResectionPlanNode = _spy
+
+    # Re-dispatch so the Pipeline threads the (already resolved) wrapper.
+    pipeline._last_update_key = None  # force a non-short-circuit dispatch
+    pipeline.UpdatePipeline()
+
+    assert seen["plan"] is plan, (
+        "UpdatePipeline must call SetResectionPlanNode(plan) on the "
+        "FlattenedSurfaceRepresentation with the resolved wrapper (ADR-0031) "
+        "so the distance-map + margins reach the 2D mapper; got "
+        f"{seen['plan']!r}."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Threads the `vtkMRMLResectionPlanNode` wrapper into the resectogram render
path so the flattened strip reads its distance-shading input set off the
wrapper (#501 slice 5; ADR-0031), matching the 3D `BezierPlanningRepresentation`.
Before this, the strip sourced the distance map from the data node (carrier) —
the wrong layer per ADR-0031 — and threaded no margins, so the projected
margin band could not be correct.

## What changed

- **`ResectogramPipeline`** reverse-resolves the plan wrapper from the data
  node's `geometry` back-reference (scene-MTime-gated, mirroring
  `LiverBezierSurfacePipeline`) and calls `SetResectionPlanNode` on the
  `FlattenedSurfaceRepresentation` before `update`; adds `GetResectionNode`.
- **`FlattenedSurfaceRepresentation`** gains `SetResectionPlanNode` and threads
  the wrapper's safety/risk margins (`SetResectionMargin` /
  `SetUncertaintyMargin`) onto the 2D mapper, and sources the distance-map
  volume from the wrapper (`GetDistanceMapVolumeNode`) rather than the carrier
  (ADR-0014 §"Fourth layer"). The sourced volume is recorded even when the GL
  texture build is deferred, so a later update retries the bind.

## Scope note

Per ADR-0031 the distance-map volume and the two margins are one coherent
wrapper-owned "distance-shading input set" (the shared
`vtkOpenGLResection2DPolyDataMapper` draws the band from all three), so this
slice threads the full set, not just the distance map — matching the 3D path.

## Tests

- `test_resectogram_pipeline_resolves_resection_plan.py` (3) + `test_flattened_surface_plan_shading.py` (3): reverse-resolve + wrapper-set;
  margins + wrapper-sourced distance map reach the 2D mapper (GL-free, via a
  fake mapper mirroring the 3D mapper-wiring test); wrapper-vs-carrier source
  discriminator. Authored RED-as-skip, green after implementation (ADR-0027).
- The real `vtkOpenGLResection2DPolyDataMapper` exposes `SetResectionMargin` /
  `SetUncertaintyMargin` / `SetDistanceMapTextureObject`; the GL texture upload
  + strip render is the same path already proven for the embedded view, now
  re-sourced from the wrapper. Full strip-render-with-margin-band is an
  interactive `:0` follow-up (ADR-0032/0023 §Conformance).
