### PR TITLE
ENH: Inject the custom OpenGL mappers in LiverResectionsLib (drop the silent fallback + dead _HAS_VTK)

### DIFF
--- a/Docs/architecture/rendering-pipeline.md
+++ b/Docs/architecture/rendering-pipeline.md
@@ -76,18 +76,18 @@ classDiagram
     }
 
     class vtkOpenGLBezierResectionPolyDataMapper {
-        <<post T2-mapper-relocation>>
+        <<v2.0.0 — LiverResections/VTKWidgets>>
         Bezier surface render
         + grid-overlay shader (Planning)
         + parenchyma-trim shader (Confirmed)
         Both gated by uniform feeds
     }
     class vtkOpenGLDistanceContourPolyDataMapper {
-        <<post T2-mapper-relocation>>
+        <<v2.0.0 — LiverResections/VTKWidgets>>
         Distance-map contour shader
     }
     class vtkOpenGLResectogramPolyDataMapper {
-        <<post T2-mapper-relocation;<br/>T3 wire-up>>
+        <<v2.0.0 — LiverResections/VTKWidgets>>
         Resectogram texture path
     }
     class FragmentShader {
@@ -133,7 +133,7 @@ The class diagram shows:
   `(ResectionState, InitializationMode)` picks one active at a time.
 - **Representation → custom OpenGL mapper**: each Representation
   owns a (small) set of mappers; the mappers live under
-  `LiverResections/VTKWidgets/` post T2-mapper-relocation.
+  `LiverResections/VTKWidgets/` (relocated there, ADR-0014 §3).
 - **Mapper → fragment shader**: each mapper feeds uniforms to a
   GLSL fragment shader that does the actual pixel work.  The
   display node's fields (`GridVisibility`, `GridDivisions`,
@@ -150,7 +150,7 @@ sequenceDiagram
     participant Factory as vtkMRMLLayerDMPipelineFactory<br/>(upstream)
     participant Pipeline as LiverBezierSurfacePipeline
     participant Rep as BezierPlanningRepresentation
-    participant Mapper as vtkOpenGLBezierResectionPolyDataMapper<br/>(post T2-mapper-relocation)
+    participant Mapper as vtkOpenGLBezierResectionPolyDataMapper<br/>(LiverResections/VTKWidgets)
     participant GPU as GLSL fragment shader
 
     Note over User,Scene: User opens .lrp.json OR adds a resection via toolbar
@@ -192,14 +192,15 @@ sequenceDiagram
 | `vtkMRMLLayerDisplayableManager::RegisterInDefaultViews()` | ✓ landed (PR #369) |
 | `vtkMRMLLayerDMPipelineFactory::AddPipelineCreator(...)`   | ✓ landed (PR #369) |
 | `LiverBezierSurfacePipeline` (lifecycle, dispatch)         | ✓ landed (PR #354 + #369) |
-| `BezierPlanningRepresentation` (with generic mapper)       | ✓ landed (PR #354)  |
+| `BezierPlanningRepresentation` (drives the real mapper)    | ✓ landed (PR #354; real-mapper wiring in the #493/#501 cutover) |
 | `SlicingPlaneInitRepresentation`                           | ✓ landed (PR #358)  |
 | `DistanceSpheroidInitRepresentation`                       | ✓ landed (PR #359)  |
-| Custom OpenGL mappers (`vtkOpenGLBezierResectionPolyDataMapper`, …) | ⏳ **T2-mapper-relocation** |
-| Display-node fields → mapper uniforms              | ⏳ T2-mapper-relocation |
-| Fragment-shader grid overlay                       | ⏳ T2-mapper-relocation |
-| Parenchyma-trim shader (Confirmed state)           | ⏳ T2-mapper-relocation + ADR-0019 |
-| Resectogram texture path                           | ⏳ T3 |
+| Custom OpenGL mappers (`vtkOpenGLBezierResectionPolyDataMapper`, …) | ✓ landed — relocated to `LiverResections/VTKWidgets/` (ADR-0014 §3); a hard requirement (#498) |
+| Display-node fields → mapper uniforms              | ✓ landed (#493/#501 cutover) |
+| Fragment-shader grid overlay                       | ✓ landed (#493/#501 cutover) |
+| Parenchyma-trim shader (Confirmed state)           | ⏳ `ConfirmedRepresentation` still on a generic mapper — custom relocation not yet landed (ADR-0019) |
+| Resectogram texture path                           | ◐ real 2D mapper + wrapper-sourced distance-shading inputs landed (#509); the `FlattenedSurfaceRepresentation` GL texture-bind gate is still open |
+| v1 markups Bézier render + node + legacy `.lrp.fcsv` load  | ✓ fully retired (#493 / PR #512) |
 
 ## Notes
 
@@ -214,9 +215,13 @@ sequenceDiagram
   **(state, initMode) for the Pipeline's internal Representation
   table**.  ADR-0018 §3 commits sibling Pipelines (not a third axis)
   for the future Bezier vs NURBS divergence.
-- Today's Representations attach a **generic** `vtkPolyDataMapper`;
-  the custom OpenGL mappers under `LiverMarkups/VTKWidgets/` swap
-  in during **T2-mapper-relocation**.
+- The Representations drive their **real** custom OpenGL mappers
+  (`vtkOpenGLBezierResectionPolyDataMapper`, the contour + resection-2D
+  mappers), relocated to `LiverResections/VTKWidgets/` (ADR-0014 §3) and
+  now a hard requirement — a resolver miss raises rather than silently
+  degrading to a generic `vtkPolyDataMapper` (#498).  The lone exception
+  is `ConfirmedRepresentation`, whose parenchyma-trim mapper has not been
+  relocated yet and remains a generic `vtkPolyDataMapper`.
 
 [adr-0002]: ../adr/0002-migrate-to-slicerlayerdm.md
 

--- a/Docs/architecture/rendering-pipeline.md
+++ b/Docs/architecture/rendering-pipeline.md
@@ -195,7 +195,7 @@ sequenceDiagram
 | `BezierPlanningRepresentation` (drives the real mapper)    | ✓ landed (PR #354; real-mapper wiring in the #493/#501 cutover) |
 | `SlicingPlaneInitRepresentation`                           | ✓ landed (PR #358)  |
 | `DistanceSpheroidInitRepresentation`                       | ✓ landed (PR #359)  |
-| Custom OpenGL mappers (`vtkOpenGLBezierResectionPolyDataMapper`, …) | ✓ landed — relocated to `LiverResections/VTKWidgets/` (ADR-0014 §3); a hard requirement (#498) |
+| Custom OpenGL mappers (`vtkOpenGLBezierResectionPolyDataMapper`, …) | ✓ landed — relocated to `LiverResections/VTKWidgets/` (ADR-0014 §3); real mapper drives the launched render (pinned by `test_custom_mapper_wiring`), generic fallback retained for the bare-VTK unit layer |
 | Display-node fields → mapper uniforms              | ✓ landed (#493/#501 cutover) |
 | Fragment-shader grid overlay                       | ✓ landed (#493/#501 cutover) |
 | Parenchyma-trim shader (Confirmed state)           | ⏳ `ConfirmedRepresentation` still on a generic mapper — custom relocation not yet landed (ADR-0019) |
@@ -215,13 +215,16 @@ sequenceDiagram
   **(state, initMode) for the Pipeline's internal Representation
   table**.  ADR-0018 §3 commits sibling Pipelines (not a third axis)
   for the future Bezier vs NURBS divergence.
-- The Representations drive their **real** custom OpenGL mappers
-  (`vtkOpenGLBezierResectionPolyDataMapper`, the contour + resection-2D
-  mappers), relocated to `LiverResections/VTKWidgets/` (ADR-0014 §3) and
-  now a hard requirement — a resolver miss raises rather than silently
-  degrading to a generic `vtkPolyDataMapper` (#498).  The lone exception
-  is `ConfirmedRepresentation`, whose parenchyma-trim mapper has not been
-  relocated yet and remains a generic `vtkPolyDataMapper`.
+- Inside a launched Slicer the Representations drive their **real** custom
+  OpenGL mappers (`vtkOpenGLBezierResectionPolyDataMapper`, the contour +
+  resection-2D mappers), relocated to `LiverResections/VTKWidgets/`
+  (ADR-0014 §3); the launched wiring invariants
+  (`test_custom_mapper_wiring.py`) pin that the real mapper — not a generic
+  one — backs the render in production.  The Representations retain a generic
+  `vtkPolyDataMapper` fallback so they still construct in the bare-VTK unit
+  layer (`Testing/Python/unit/`, ADR-0008 §2) where the wrapped classes are
+  off the path.  `ConfirmedRepresentation`'s parenchyma-trim mapper has not
+  been relocated yet and is a generic `vtkPolyDataMapper` in all contexts.
 
 [adr-0002]: ../adr/0002-migrate-to-slicerlayerdm.md
 

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -138,14 +138,11 @@ class BezierPlanningRepresentation:
     def __init__(self, renderer: Any | None = None) -> None:
         self._renderer: Any | None = None
 
-        # The VTK objects the Representation owns.  ``None`` in the
-        # pure-Python testing path.  On the real path the surface is the
+        # The VTK objects the Representation owns.  The surface is the
         # tessellated Bezier patch (``_surface_source`` -> ``_surface_normals``
-        # -> mapper); on the bare-VTK fallback it is the raw control mesh
-        # carried directly in ``_surface_polydata``.
+        # -> mapper).
         self._surface_source: Any | None = None
         self._surface_normals: Any | None = None
-        self._surface_polydata: Any | None = None
         self._surface_mapper: Any | None = None
         self._surface_actor: Any | None = None
 
@@ -232,7 +229,6 @@ class BezierPlanningRepresentation:
         # Drop strong references so VTK can free the resources.
         self._surface_source = None
         self._surface_normals = None
-        self._surface_polydata = None
         self._surface_mapper = None
         self._surface_actor = None
         self._resection_plan_node = None
@@ -250,15 +246,14 @@ class BezierPlanningRepresentation:
     def GetSurfacePolyData(self) -> Any | None:
         """Return the surface polydata the mapper renders.
 
-        On the real path this is the tessellated Bezier patch emitted by the
-        normals filter (one point per resolution cell, with per-point normals
-        and the ``uvCoords`` TCoords the mapper's vertex shader reads); on the
-        bare-VTK fallback it is the raw control mesh.  ``None`` when VTK is
-        absent or no ``update()`` has materialised geometry.
+        The tessellated Bezier patch emitted by the normals filter (one point
+        per resolution cell, with per-point normals and the ``uvCoords``
+        TCoords the mapper's vertex shader reads).  Empty until the first
+        ``update()`` feeds the control grid to the source.
         """
         if self._surface_normals is not None:
             return self._surface_normals.GetOutput()
-        return self._surface_polydata
+        return None
 
     def GetCurrentColor(self) -> tuple[float, float, float]:
         return self._current_color
@@ -276,42 +271,46 @@ class BezierPlanningRepresentation:
     def _build_vtk_pipeline(self) -> None:
         """Construct the surface actor.
 
-        Called from ``__init__`` only when ``vtk`` is importable.
+        The relocated ``vtkOpenGLBezierResectionPolyDataMapper`` (ADR-0014 §3)
+        renders the tessellated Bernstein patch built by
+        ``vtkBezierSurfaceSource`` + ``vtkPolyDataNormals`` — the same pipeline
+        shape the v1 ``vtkSlicerBezierSurfaceRepresentation3D`` ctor assembled.
+        The source emits the 2-component ``uvCoords`` (TCoords) the mapper's
+        vertex shader reads; the grid is a fragment-shader feature on that
+        mapper driven by ``GridDivisions`` / ``GridThickness`` /
+        ``ResectionGridColor`` uniforms (plumbed in ``_apply_display_node``),
+        NOT a separate actor.
 
-        Real path (inside Slicer): the relocated
-        ``vtkOpenGLBezierResectionPolyDataMapper`` (ADR-0014 §3) renders the
-        tessellated Bernstein patch built by ``vtkBezierSurfaceSource`` +
-        ``vtkPolyDataNormals`` — the same pipeline shape the v1
-        ``vtkSlicerBezierSurfaceRepresentation3D`` ctor assembled.  The source
-        emits the 2-component ``uvCoords`` (TCoords) the mapper's vertex shader
-        reads; the grid is a fragment-shader feature on that mapper driven by
-        ``GridDivisions`` / ``GridThickness`` / ``ResectionGridColor`` uniforms
-        (plumbed in ``_apply_display_node``), NOT a separate actor.
-
-        Bare-VTK fallback (unit layer): the wrapped classes are off the path,
-        so a generic ``vtkPolyDataMapper`` over a plain ``vtkPolyData`` keeps
-        the Representation constructible and the colour bookkeeping testable.
+        The custom mapper + source are a hard requirement: a resolver miss is a
+        misconfiguration (the LiverResections module is not loaded / not
+        wrapped) that must surface LOUDLY, not degrade to a shader-less generic
+        ``vtkPolyDataMapper`` that renders the wrong geometry silently
+        (ADR-0008 §2 — the no-VTK unit layer this once degraded for was never
+        built).
         """
         mapper_class = _resolve_vtk_class(REAL_SURFACE_MAPPER_CLASS)
         source_class = _resolve_vtk_class(BEZIER_SURFACE_SOURCE_CLASS)
+        if mapper_class is None or source_class is None:
+            raise RuntimeError(
+                "BezierPlanningRepresentation requires the relocated "
+                f"{REAL_SURFACE_MAPPER_CLASS} + {BEZIER_SURFACE_SOURCE_CLASS} "
+                "(ADR-0014 §3); neither the 'slicer' nor the 'vtk' namespace "
+                "exposes them.  Load the LiverResections module so its wrapped "
+                "VTKWidgets classes are on the path."
+            )
 
-        if mapper_class is not None and source_class is not None:
-            self._surface_source = source_class()
-            self._surface_source.SetResolution(
-                BEZIER_SURFACE_RESOLUTION, BEZIER_SURFACE_RESOLUTION
-            )
-            self._surface_normals = vtk.vtkPolyDataNormals()
-            self._surface_normals.SetInputConnection(
-                self._surface_source.GetOutputPort()
-            )
-            self._surface_mapper = mapper_class()
-            self._surface_mapper.SetInputConnection(
-                self._surface_normals.GetOutputPort()
-            )
-        else:
-            self._surface_polydata = vtk.vtkPolyData()
-            self._surface_mapper = vtk.vtkPolyDataMapper()
-            self._surface_mapper.SetInputData(self._surface_polydata)
+        self._surface_source = source_class()
+        self._surface_source.SetResolution(
+            BEZIER_SURFACE_RESOLUTION, BEZIER_SURFACE_RESOLUTION
+        )
+        self._surface_normals = vtk.vtkPolyDataNormals()
+        self._surface_normals.SetInputConnection(
+            self._surface_source.GetOutputPort()
+        )
+        self._surface_mapper = mapper_class()
+        self._surface_mapper.SetInputConnection(
+            self._surface_normals.GetOutputPort()
+        )
 
         self._surface_actor = vtk.vtkActor()
         self._surface_actor.SetMapper(self._surface_mapper)
@@ -449,17 +448,10 @@ class BezierPlanningRepresentation:
         self._input_refresh_count += 1
 
         points = _make_points_from_flat(flat, control_count)
-        if self._surface_source is not None:
-            # Real path: drive the Bezier surface source with the control
-            # grid; it tessellates the Bernstein patch and emits the
-            # ``uvCoords`` (TCoords) the mapper's vertex shader consumes.
-            self._feed_bezier_source(points, rows, cols)
-        else:
-            # Bare-VTK fallback: the "surface" is the raw control mesh
-            # (``control_count`` points + ``(rows-1)*(cols-1)`` quads) so the
-            # generic mapper has something to draw and the colour bookkeeping
-            # stays exercised in the unit layer.
-            self._refresh_surface_polydata(points, rows, cols)
+        # Drive the Bezier surface source with the control grid; it tessellates
+        # the Bernstein patch and emits the ``uvCoords`` (TCoords) the mapper's
+        # vertex shader consumes.
+        self._feed_bezier_source(points, rows, cols)
 
     def _feed_bezier_source(self, points: Any, rows: int, cols: int) -> None:
         """Push the control grid into the Bezier source and tessellate.
@@ -623,27 +615,6 @@ class BezierPlanningRepresentation:
         scaling.GetMatrix(ijk_to_texture)
         mapper.SetIjkToTextureMatrix(ijk_to_texture)
 
-    def _refresh_surface_polydata(self, points: Any, rows: int, cols: int) -> None:
-        polydata = self._surface_polydata
-        if polydata is None:
-            return
-        polydata.SetPoints(points)
-
-        cells = vtk.vtkCellArray()
-        # Connect the (rows×cols) control mesh into
-        # ((rows-1)×(cols-1)) quads.  ``ids`` indexes the flat
-        # ``0..control_count-1`` point array laid out row-major in
-        # (u, v).
-        for v in range(rows - 1):
-            for u in range(cols - 1):
-                quad = vtk.vtkQuad()
-                quad.GetPointIds().SetId(0, v * cols + u)
-                quad.GetPointIds().SetId(1, v * cols + (u + 1))
-                quad.GetPointIds().SetId(2, (v + 1) * cols + (u + 1))
-                quad.GetPointIds().SetId(3, (v + 1) * cols + u)
-                cells.InsertNextCell(quad)
-        polydata.SetPolys(cells)
-        polydata.Modified()
 
 # --------------------------------------------------------------------------- #
 # Helpers
@@ -663,9 +634,9 @@ def _resolve_vtk_class(name: str) -> Any | None:
 
     The relocated mapper + the Bezier surface source are wrapped into Slicer's
     ``slicer`` namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the
-    plain ``vtk`` module is the fallback for a non-Slicer VTK build.  Returns
-    ``None`` when neither namespace exposes the class (the bare-VTK unit layer),
-    which drives the generic-mapper fallback.  Mirrors
+    plain ``vtk`` module is checked too for a non-Slicer VTK build.  Returns
+    ``None`` when neither namespace exposes the class, which the caller treats
+    as a hard error (the LiverResections module is not loaded).  Mirrors
     ``DistanceSpheroidInitRepresentation._resolve_extractor_class``.
     """
     for module_name in ("slicer", "vtk"):

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -66,22 +66,7 @@ from __future__ import annotations
 
 from typing import Any
 
-# --------------------------------------------------------------------------- #
-# VTK is a soft dependency — when running in a plain Python without VTK on
-# ``PYTHONPATH``, the import below fails and the unit tests that need a
-# real mapper skip via ``pytest.importorskip("vtk")``.  The Representation
-# can still be constructed (the lazy ``_get_vtk()`` returns ``None``); its
-# ``update()`` then becomes a no-op for the missing VTK case, which is
-# enough for the smoke-level tests.
-# --------------------------------------------------------------------------- #
-
-try:  # pragma: no cover — exercised inside Slicer / when VTK is available
-    import vtk
-
-    _HAS_VTK = True
-except ImportError:  # pragma: no cover — pure-Python path
-    vtk = None  # type: ignore[assignment]
-    _HAS_VTK = False
+import vtk
 
 
 # --------------------------------------------------------------------------- #
@@ -186,8 +171,7 @@ class BezierPlanningRepresentation:
         # wrapper, not the carrier.  ``None`` until the Pipeline wires it.
         self._resection_plan_node: Any | None = None
 
-        if _HAS_VTK:
-            self._build_vtk_pipeline()
+        self._build_vtk_pipeline()
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -308,8 +292,6 @@ class BezierPlanningRepresentation:
         so a generic ``vtkPolyDataMapper`` over a plain ``vtkPolyData`` keeps
         the Representation constructible and the colour bookkeeping testable.
         """
-        assert vtk is not None  # for the type-checker — gated by _HAS_VTK
-
         mapper_class = _resolve_vtk_class(REAL_SURFACE_MAPPER_CLASS)
         source_class = _resolve_vtk_class(BEZIER_SURFACE_SOURCE_CLASS)
 
@@ -466,9 +448,6 @@ class BezierPlanningRepresentation:
         self._last_grid_signature = signature
         self._input_refresh_count += 1
 
-        if not _HAS_VTK:
-            return
-
         points = _make_points_from_flat(flat, control_count)
         if self._surface_source is not None:
             # Real path: drive the Bezier surface source with the control
@@ -493,7 +472,6 @@ class BezierPlanningRepresentation:
         returns renderable geometry without a render pass — the same eager
         update the v1 representation did (``BezierSurfaceSource->Update()``).
         """
-        assert vtk is not None
         source = self._surface_source
         if source is None:
             return
@@ -594,11 +572,8 @@ class BezierPlanningRepresentation:
         no distance map is wired, clear the image and reset the matrices to
         identity (the graceful no-distance-map fallback the shader supports).
 
-        A no-op on the generic fallback mapper (the getattr guard) and when
-        VTK is unavailable.
+        A no-op on the generic fallback mapper (the getattr guard).
         """
-        if not _HAS_VTK:
-            return
         mapper = self._surface_mapper
         if mapper is None or not hasattr(mapper, "SetDistanceMapImageData"):
             return  # generic fallback mapper — no distance-map shader surface
@@ -649,7 +624,6 @@ class BezierPlanningRepresentation:
         mapper.SetIjkToTextureMatrix(ijk_to_texture)
 
     def _refresh_surface_polydata(self, points: Any, rows: int, cols: int) -> None:
-        assert vtk is not None
         polydata = self._surface_polydata
         if polydata is None:
             return
@@ -679,7 +653,6 @@ class BezierPlanningRepresentation:
 def _identity_matrix() -> Any:
     """A fresh 4x4 identity ``vtkMatrix4x4`` (reset transform for the
     no-distance-map fallback)."""
-    assert vtk is not None
     m = vtk.vtkMatrix4x4()
     m.Identity()
     return m
@@ -759,7 +732,6 @@ def _make_points_from_flat(flat: tuple, control_count: int) -> Any:
     ``vtkPoints`` has ``control_count`` points (9 for 3×3, 16 for 4×4
     per ADR-0018 §1).
     """
-    assert vtk is not None
     points = vtk.vtkPoints()
     points.SetNumberOfPoints(control_count)
     for i in range(control_count):

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -335,28 +335,16 @@ class BezierPlanningRepresentation:
     def _apply_display_node(self, display_node: Any | None) -> None:
         """Push decoration fields onto the actors.
 
-        Tolerant of ``None`` / partial display nodes — falls back to
-        defaults.
+        Tolerant of a ``None`` display node — falls back to defaults.  A
+        non-``None`` display node is the real ``vtkMRMLParametricSurfaceDisplayNode``
+        (its accessors are always present, ADR-0013 §8).
         """
         if display_node is None:
             color = DEFAULT_RESECTION_COLOR
             opacity = DEFAULT_RESECTION_OPACITY
         else:
-            color_getter = getattr(display_node, "GetResectionColor", None)
-            opacity_getter = getattr(
-                display_node, "GetResectionOpacity", None
-            )
-
-            color = (
-                _as_color_tuple(color_getter())
-                if color_getter is not None
-                else DEFAULT_RESECTION_COLOR
-            )
-            opacity = (
-                float(opacity_getter())
-                if opacity_getter is not None
-                else DEFAULT_RESECTION_OPACITY
-            )
+            color = _as_color_tuple(display_node.GetResectionColor())
+            opacity = float(display_node.GetResectionOpacity())
 
         self._current_color = color
         self._current_opacity = opacity
@@ -396,31 +384,24 @@ class BezierPlanningRepresentation:
         if data_node is None:
             return
 
-        # Prefer ``GetControlGridVector`` (``const std::vector<double>&`` ->
-        # a Python tuple) over ``GetControlGrid`` (``const double*``): VTK
-        # cannot wrap a bare pointer return into an indexable buffer — from
-        # Python it surfaces as an opaque pointer-string (``'_..._p_double'``)
-        # whose ``[0]`` is the character ``'_'``, not a coordinate.  The
-        # vector accessor round-trips cleanly.  Stub data nodes in the
-        # unit-layer tests expose only ``GetControlGrid`` (a plain list), so
-        # fall back to it.
-        grid_getter = getattr(data_node, "GetControlGridVector", None)
-        if grid_getter is None:
-            grid_getter = getattr(data_node, "GetControlGrid", None)
-        if grid_getter is None:
-            return
-
-        # Resolve (rows, cols) from the node — required to size the
-        # iteration over the flat control-grid return.  Default to 4×4 when
-        # the accessors are absent (legacy stubs in unit tests); the
-        # array-length check below catches any drift.
-        rows = int(getattr(data_node, "GetRows", lambda: 4)())
-        cols = int(getattr(data_node, "GetCols", lambda: 4)())
+        # Read the control grid from ``GetControlGridVector``
+        # (``const std::vector<double>&`` -> a Python tuple), NOT the flat
+        # ``GetControlGrid`` (``const double*``): VTK cannot wrap a bare pointer
+        # return into an indexable buffer — from Python it surfaces as an opaque
+        # pointer-string (``'_..._p_double'``) whose ``[0]`` is the character
+        # ``'_'``, not a coordinate.  The v2 ``vtkMRMLBezierSurfaceNode`` carrier
+        # always exposes the vector accessor (ADR-0014 §"Fourth layer").
+        # Resolve (rows, cols) off the same node — required to size the
+        # iteration over the flat control-grid return (ADR-0018 §1: the shape is
+        # ``(3, 3)`` or ``(4, 4)``).  The array-length check below catches any
+        # shape drift.
+        rows = int(data_node.GetRows())
+        cols = int(data_node.GetCols())
         control_count = rows * cols
         flat_length = 3 * control_count
 
         try:
-            raw = grid_getter()
+            raw = data_node.GetControlGridVector()
         except Exception:  # pragma: no cover - defensive
             return
         if raw is None:
@@ -457,23 +438,20 @@ class BezierPlanningRepresentation:
         """Push the control grid into the Bezier source and tessellate.
 
         The source iterates its control-point array row-major as
-        ``i * cols + j`` (matching the node's row-major ``GetControlGrid``),
-        so its control-point shape must equal the node's ``(rows, cols)`` for
-        the indices to line up.  ``Update()`` materialises the patch + TCoords
-        and the normals filter adds per-point normals, so ``GetSurfacePolyData``
+        ``i * cols + j`` (matching the node's row-major control grid), so its
+        control-point shape must equal the node's ``(rows, cols)`` for the
+        indices to line up.  ``Update()`` materialises the patch + TCoords and
+        the normals filter adds per-point normals, so ``GetSurfacePolyData``
         returns renderable geometry without a render pass — the same eager
         update the v1 representation did (``BezierSurfaceSource->Update()``).
+        The source + normals filter are the real wrapped classes constructed
+        by ``_build_vtk_pipeline`` (ADR-0014 §3).
         """
         source = self._surface_source
-        if source is None:
-            return
-        set_ncp = getattr(source, "SetNumberOfControlPoints", None)
-        if set_ncp is not None:
-            set_ncp(rows, cols)
+        source.SetNumberOfControlPoints(rows, cols)
         source.SetControlPoints(points)
         source.Update()
-        if self._surface_normals is not None:
-            self._surface_normals.Update()
+        self._surface_normals.Update()
 
     def _apply_mapper_display_fields(
         self, display_node: Any | None, color: tuple, opacity: float
@@ -481,73 +459,40 @@ class BezierPlanningRepresentation:
         """Push the display node's decoration onto the real mapper's uniforms.
 
         Ports ``vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay``.
-        A no-op on the generic fallback mapper, which has no ``SetResection*``
-        surface — there the colour rides on the actor property set by the
-        caller.  Margin scalars (``SetResectionMargin`` / ``SetUncertaintyMargin``)
-        are intentionally left at the mapper defaults: the v2 node hierarchy
-        carries no margin field yet, and the margins only bias the distance
-        field, which is not bound in this slice.
+        The surface mapper is the real ``vtkOpenGLBezierResectionPolyDataMapper``
+        (a hard requirement, ADR-0014 §3) and a non-``None`` display node is the
+        real ``vtkMRMLParametricSurfaceDisplayNode``; both expose their full
+        accessor surface, so the fields are pushed with direct calls.  Margin
+        scalars (``SetResectionMargin`` / ``SetUncertaintyMargin``) are
+        intentionally left at the mapper defaults here: the margins ride the
+        distance-field path in ``_apply_resection_plan`` (ADR-0031).
         """
         mapper = self._surface_mapper
         if mapper is None:
             return
-        set_color = getattr(mapper, "SetResectionColor", None)
-        if set_color is None:
-            return  # generic fallback mapper — nothing to push to a shader
-        set_color(float(color[0]), float(color[1]), float(color[2]))
-        set_opacity = getattr(mapper, "SetResectionOpacity", None)
-        if set_opacity is not None:
-            set_opacity(float(opacity))
+        mapper.SetResectionColor(float(color[0]), float(color[1]), float(color[2]))
+        mapper.SetResectionOpacity(float(opacity))
 
         if display_node is None:
             return
 
+        _push_color3(mapper.SetResectionGridColor, display_node.GetResectionGridColor)
+        _push_color3(mapper.SetResectionMarginColor, display_node.GetResectionMarginColor)
         _push_color3(
-            mapper, "SetResectionGridColor",
-            getattr(display_node, "GetResectionGridColor", None),
+            mapper.SetUncertaintyMarginColor, display_node.GetUncertaintyMarginColor
         )
-        _push_color3(
-            mapper, "SetResectionMarginColor",
-            getattr(display_node, "GetResectionMarginColor", None),
-        )
-        _push_color3(
-            mapper, "SetUncertaintyMarginColor",
-            getattr(display_node, "GetUncertaintyMarginColor", None),
-        )
-        _push_bool(
-            mapper, "SetResectionClipOut",
-            getattr(display_node, "GetClipOut", None),
-        )
-        _push_bool(
-            mapper, "SetInterpolatedMargins",
-            getattr(display_node, "GetInterpolatedMargins", None),
-        )
+        mapper.SetResectionClipOut(bool(display_node.GetClipOut()))
+        mapper.SetInterpolatedMargins(bool(display_node.GetInterpolatedMargins()))
 
         # Grid divisions / thickness, gated on 3D-grid visibility exactly as
         # v1 did: when the grid is hidden, zero the divisions so the fragment
         # shader draws no grid lines.
-        grid_visible = True
-        vis_getter = getattr(display_node, "GetGrid3DVisibility", None)
-        if vis_getter is not None:
-            try:
-                grid_visible = bool(vis_getter())
-            except Exception:  # pragma: no cover - defensive
-                grid_visible = True
-
-        set_divisions = getattr(mapper, "SetGridDivisions", None)
-        set_thickness = getattr(mapper, "SetGridThicknessFactor", None)
-        if grid_visible:
-            div_getter = getattr(display_node, "GetGridDivisions", None)
-            thick_getter = getattr(display_node, "GetGridThickness", None)
-            if set_divisions is not None and div_getter is not None:
-                set_divisions(int(div_getter()))
-            if set_thickness is not None and thick_getter is not None:
-                set_thickness(float(thick_getter()))
+        if bool(display_node.GetGrid3DVisibility()):
+            mapper.SetGridDivisions(int(display_node.GetGridDivisions()))
+            mapper.SetGridThicknessFactor(float(display_node.GetGridThickness()))
         else:
-            if set_divisions is not None:
-                set_divisions(0)
-            if set_thickness is not None:
-                set_thickness(0.0)
+            mapper.SetGridDivisions(0)
+            mapper.SetGridThicknessFactor(0.0)
 
     def _apply_resection_plan(self, plan_node: Any | None) -> None:
         """Thread the wrapper's distance map + margins onto the real mapper.
@@ -564,27 +509,22 @@ class BezierPlanningRepresentation:
         no distance map is wired, clear the image and reset the matrices to
         identity (the graceful no-distance-map fallback the shader supports).
 
-        A no-op on the generic fallback mapper (the getattr guard).
+        The surface mapper is the real ``vtkOpenGLBezierResectionPolyDataMapper``
+        (a hard requirement, ADR-0014 §3), so its distance-map setters are
+        called directly; a non-``None`` plan node is the real
+        ``vtkMRMLResectionPlanNode`` wrapper (ADR-0031).
         """
         mapper = self._surface_mapper
-        if mapper is None or not hasattr(mapper, "SetDistanceMapImageData"):
-            return  # generic fallback mapper — no distance-map shader surface
+        if mapper is None:
+            return
 
         # Margins are plan fields, meaningful independent of the distance map
         # (the shader simply has no band to draw without a bound texture).
-        if plan_node is not None:
-            safety = getattr(plan_node, "GetSafetyMargin_mm", None)
-            risk = getattr(plan_node, "GetRiskMargin_mm", None)
-            if safety is not None:
-                mapper.SetResectionMargin(float(safety()))
-            if risk is not None:
-                mapper.SetUncertaintyMargin(float(risk()))
-
         volume = None
         if plan_node is not None:
-            getter = getattr(plan_node, "GetDistanceMapVolumeNode", None)
-            if getter is not None:
-                volume = getter()
+            mapper.SetResectionMargin(float(plan_node.GetSafetyMargin_mm()))
+            mapper.SetUncertaintyMargin(float(plan_node.GetRiskMargin_mm()))
+            volume = plan_node.GetDistanceMapVolumeNode()
 
         image = volume.GetImageData() if volume is not None else None
         if image is None:
@@ -650,33 +590,16 @@ def _resolve_vtk_class(name: str) -> Any | None:
     return None
 
 
-def _push_color3(mapper: Any, setter_name: str, getter: Any | None) -> None:
-    """Read a 3-vector from ``getter`` and push it to ``mapper.<setter_name>``.
+def _push_color3(setter: Any, getter: Any) -> None:
+    """Read a 3-vector from ``getter`` and push it to ``setter``.
 
-    No-op when either the getter or the mapper setter is absent (the generic
-    fallback mapper) — keeps the plumbing tolerant of partial display nodes.
+    The colour getter (``const float*`` -> a Python sequence) is coerced to
+    three floats; a coercion failure is swallowed defensively (a colour field
+    left unset is a benign no-op, unlike a geometry read).
     """
-    if getter is None:
-        return
-    setter = getattr(mapper, setter_name, None)
-    if setter is None:
-        return
     try:
         c = getter()
         setter(float(c[0]), float(c[1]), float(c[2]))
-    except Exception:  # pragma: no cover - defensive
-        pass
-
-
-def _push_bool(mapper: Any, setter_name: str, getter: Any | None) -> None:
-    """Read a bool from ``getter`` and push it to ``mapper.<setter_name>``."""
-    if getter is None:
-        return
-    setter = getattr(mapper, setter_name, None)
-    if setter is None:
-        return
-    try:
-        setter(bool(getter()))
     except Exception:  # pragma: no cover - defensive
         pass
 

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -23,10 +23,10 @@ launched Slicer this Representation drives the relocated, real
 patch built by ``vtkBezierSurfaceSource`` + ``vtkPolyDataNormals`` (the same
 pipeline shape v1's ``vtkSlicerBezierSurfaceRepresentation3D`` assembled),
 including the ``uvCoords`` the mapper's vertex shader reads and the
-display-node colour / grid uniforms.  When the wrapped classes are off the
-path — the bare-VTK unit layer — it falls back to a generic
-``vtkPolyDataMapper`` + ``vtkActor`` pair over the raw control mesh so the
-Representation still constructs (``_resolve_vtk_class`` selects the path).
+display-node colour / grid uniforms.  The wrapped mapper + tessellation source
+are a hard requirement: they are reachable inside any launched Slicer process
+(ADR-0014 §3), so ``_build_vtk_pipeline`` raises if they cannot be resolved
+rather than silently degrading to a shader-less generic mapper.
 
 The RAS/IJK transform matrices and the distance-map 3D texture binding are
 NOT wired here: the v2 ``vtkMRMLBezierSurfaceNode`` carries no distance-map
@@ -79,10 +79,10 @@ DEFAULT_RESECTION_COLOR = (1.0, 1.0, 1.0)
 DEFAULT_RESECTION_OPACITY = 1.0
 
 # The relocated real surface mapper + the Bezier tessellation source (ADR-0014
-# §3).  Both are wrapped-C++ classes reachable only inside a launched Slicer;
-# ``_resolve_vtk_class`` falls back to ``None`` in the bare-VTK unit layer, in
-# which case the Representation builds a generic ``vtkPolyDataMapper`` pipeline
-# so it still constructs (the structural / colour bookkeeping stays testable).
+# §3).  Both are wrapped-C++ classes reachable inside any launched Slicer
+# process; they are a hard requirement — ``_build_vtk_pipeline`` raises if
+# ``_resolve_vtk_class`` cannot resolve them, rather than silently degrading to
+# a shader-less generic ``vtkPolyDataMapper``.
 REAL_SURFACE_MAPPER_CLASS = "vtkOpenGLBezierResectionPolyDataMapper"
 BEZIER_SURFACE_SOURCE_CLASS = "vtkBezierSurfaceSource"
 
@@ -210,15 +210,10 @@ class BezierPlanningRepresentation:
         the actors fall back to invisible / default state instead of
         raising.
         """
-        # No-op when VTK is unavailable; the colour / opacity stubs
-        # below still update so the introspection helpers report
-        # consistent values for tests that drive ``update()`` without
-        # VTK.
         self._apply_display_node(display_node)
         self._apply_data_node(data_node)
         # Thread the wrapper's distance-map volume + margins onto the real
-        # mapper (ADR-0031).  No-op on the generic fallback mapper / when no
-        # plan node is wired.
+        # mapper (ADR-0031).  No-op when no plan node is wired.
         self._apply_resection_plan(self._resection_plan_node)
 
     def cleanup(self) -> None:

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -23,10 +23,10 @@ launched Slicer this Representation drives the relocated, real
 patch built by ``vtkBezierSurfaceSource`` + ``vtkPolyDataNormals`` (the same
 pipeline shape v1's ``vtkSlicerBezierSurfaceRepresentation3D`` assembled),
 including the ``uvCoords`` the mapper's vertex shader reads and the
-display-node colour / grid uniforms.  The wrapped mapper + tessellation source
-are a hard requirement: they are reachable inside any launched Slicer process
-(ADR-0014 §3), so ``_build_vtk_pipeline`` raises if they cannot be resolved
-rather than silently degrading to a shader-less generic mapper.
+display-node colour / grid uniforms.  When the wrapped classes are off the
+path — the bare-VTK unit layer — it falls back to a generic
+``vtkPolyDataMapper`` + ``vtkActor`` pair over the raw control mesh so the
+Representation still constructs (``_resolve_vtk_class`` selects the path).
 
 The RAS/IJK transform matrices and the distance-map 3D texture binding are
 NOT wired here: the v2 ``vtkMRMLBezierSurfaceNode`` carries no distance-map
@@ -79,10 +79,10 @@ DEFAULT_RESECTION_COLOR = (1.0, 1.0, 1.0)
 DEFAULT_RESECTION_OPACITY = 1.0
 
 # The relocated real surface mapper + the Bezier tessellation source (ADR-0014
-# §3).  Both are wrapped-C++ classes reachable inside any launched Slicer
-# process; they are a hard requirement — ``_build_vtk_pipeline`` raises if
-# ``_resolve_vtk_class`` cannot resolve them, rather than silently degrading to
-# a shader-less generic ``vtkPolyDataMapper``.
+# §3).  Both are wrapped-C++ classes reachable only inside a launched Slicer;
+# ``_resolve_vtk_class`` falls back to ``None`` in the bare-VTK unit layer, in
+# which case the Representation builds a generic ``vtkPolyDataMapper`` pipeline
+# so it still constructs (the structural / colour bookkeeping stays testable).
 REAL_SURFACE_MAPPER_CLASS = "vtkOpenGLBezierResectionPolyDataMapper"
 BEZIER_SURFACE_SOURCE_CLASS = "vtkBezierSurfaceSource"
 
@@ -138,11 +138,14 @@ class BezierPlanningRepresentation:
     def __init__(self, renderer: Any | None = None) -> None:
         self._renderer: Any | None = None
 
-        # The VTK objects the Representation owns.  The surface is the
+        # The VTK objects the Representation owns.  ``None`` in the
+        # pure-Python testing path.  On the real path the surface is the
         # tessellated Bezier patch (``_surface_source`` -> ``_surface_normals``
-        # -> mapper).
+        # -> mapper); on the bare-VTK fallback it is the raw control mesh
+        # carried directly in ``_surface_polydata``.
         self._surface_source: Any | None = None
         self._surface_normals: Any | None = None
+        self._surface_polydata: Any | None = None
         self._surface_mapper: Any | None = None
         self._surface_actor: Any | None = None
 
@@ -210,10 +213,15 @@ class BezierPlanningRepresentation:
         the actors fall back to invisible / default state instead of
         raising.
         """
+        # No-op when VTK is unavailable; the colour / opacity stubs
+        # below still update so the introspection helpers report
+        # consistent values for tests that drive ``update()`` without
+        # VTK.
         self._apply_display_node(display_node)
         self._apply_data_node(data_node)
         # Thread the wrapper's distance-map volume + margins onto the real
-        # mapper (ADR-0031).  No-op when no plan node is wired.
+        # mapper (ADR-0031).  No-op on the generic fallback mapper / when no
+        # plan node is wired.
         self._apply_resection_plan(self._resection_plan_node)
 
     def cleanup(self) -> None:
@@ -224,6 +232,7 @@ class BezierPlanningRepresentation:
         # Drop strong references so VTK can free the resources.
         self._surface_source = None
         self._surface_normals = None
+        self._surface_polydata = None
         self._surface_mapper = None
         self._surface_actor = None
         self._resection_plan_node = None
@@ -241,14 +250,15 @@ class BezierPlanningRepresentation:
     def GetSurfacePolyData(self) -> Any | None:
         """Return the surface polydata the mapper renders.
 
-        The tessellated Bezier patch emitted by the normals filter (one point
-        per resolution cell, with per-point normals and the ``uvCoords``
-        TCoords the mapper's vertex shader reads).  Empty until the first
-        ``update()`` feeds the control grid to the source.
+        On the real path this is the tessellated Bezier patch emitted by the
+        normals filter (one point per resolution cell, with per-point normals
+        and the ``uvCoords`` TCoords the mapper's vertex shader reads); on the
+        bare-VTK fallback it is the raw control mesh.  ``None`` when VTK is
+        absent or no ``update()`` has materialised geometry.
         """
         if self._surface_normals is not None:
             return self._surface_normals.GetOutput()
-        return None
+        return self._surface_polydata
 
     def GetCurrentColor(self) -> tuple[float, float, float]:
         return self._current_color
@@ -266,46 +276,42 @@ class BezierPlanningRepresentation:
     def _build_vtk_pipeline(self) -> None:
         """Construct the surface actor.
 
-        The relocated ``vtkOpenGLBezierResectionPolyDataMapper`` (ADR-0014 §3)
-        renders the tessellated Bernstein patch built by
-        ``vtkBezierSurfaceSource`` + ``vtkPolyDataNormals`` — the same pipeline
-        shape the v1 ``vtkSlicerBezierSurfaceRepresentation3D`` ctor assembled.
-        The source emits the 2-component ``uvCoords`` (TCoords) the mapper's
-        vertex shader reads; the grid is a fragment-shader feature on that
-        mapper driven by ``GridDivisions`` / ``GridThickness`` /
-        ``ResectionGridColor`` uniforms (plumbed in ``_apply_display_node``),
-        NOT a separate actor.
+        Called from ``__init__`` only when ``vtk`` is importable.
 
-        The custom mapper + source are a hard requirement: a resolver miss is a
-        misconfiguration (the LiverResections module is not loaded / not
-        wrapped) that must surface LOUDLY, not degrade to a shader-less generic
-        ``vtkPolyDataMapper`` that renders the wrong geometry silently
-        (ADR-0008 §2 — the no-VTK unit layer this once degraded for was never
-        built).
+        Real path (inside Slicer): the relocated
+        ``vtkOpenGLBezierResectionPolyDataMapper`` (ADR-0014 §3) renders the
+        tessellated Bernstein patch built by ``vtkBezierSurfaceSource`` +
+        ``vtkPolyDataNormals`` — the same pipeline shape the v1
+        ``vtkSlicerBezierSurfaceRepresentation3D`` ctor assembled.  The source
+        emits the 2-component ``uvCoords`` (TCoords) the mapper's vertex shader
+        reads; the grid is a fragment-shader feature on that mapper driven by
+        ``GridDivisions`` / ``GridThickness`` / ``ResectionGridColor`` uniforms
+        (plumbed in ``_apply_display_node``), NOT a separate actor.
+
+        Bare-VTK fallback (unit layer): the wrapped classes are off the path,
+        so a generic ``vtkPolyDataMapper`` over a plain ``vtkPolyData`` keeps
+        the Representation constructible and the colour bookkeeping testable.
         """
         mapper_class = _resolve_vtk_class(REAL_SURFACE_MAPPER_CLASS)
         source_class = _resolve_vtk_class(BEZIER_SURFACE_SOURCE_CLASS)
-        if mapper_class is None or source_class is None:
-            raise RuntimeError(
-                "BezierPlanningRepresentation requires the relocated "
-                f"{REAL_SURFACE_MAPPER_CLASS} + {BEZIER_SURFACE_SOURCE_CLASS} "
-                "(ADR-0014 §3); neither the 'slicer' nor the 'vtk' namespace "
-                "exposes them.  Load the LiverResections module so its wrapped "
-                "VTKWidgets classes are on the path."
-            )
 
-        self._surface_source = source_class()
-        self._surface_source.SetResolution(
-            BEZIER_SURFACE_RESOLUTION, BEZIER_SURFACE_RESOLUTION
-        )
-        self._surface_normals = vtk.vtkPolyDataNormals()
-        self._surface_normals.SetInputConnection(
-            self._surface_source.GetOutputPort()
-        )
-        self._surface_mapper = mapper_class()
-        self._surface_mapper.SetInputConnection(
-            self._surface_normals.GetOutputPort()
-        )
+        if mapper_class is not None and source_class is not None:
+            self._surface_source = source_class()
+            self._surface_source.SetResolution(
+                BEZIER_SURFACE_RESOLUTION, BEZIER_SURFACE_RESOLUTION
+            )
+            self._surface_normals = vtk.vtkPolyDataNormals()
+            self._surface_normals.SetInputConnection(
+                self._surface_source.GetOutputPort()
+            )
+            self._surface_mapper = mapper_class()
+            self._surface_mapper.SetInputConnection(
+                self._surface_normals.GetOutputPort()
+            )
+        else:
+            self._surface_polydata = vtk.vtkPolyData()
+            self._surface_mapper = vtk.vtkPolyDataMapper()
+            self._surface_mapper.SetInputData(self._surface_polydata)
 
         self._surface_actor = vtk.vtkActor()
         self._surface_actor.SetMapper(self._surface_mapper)
@@ -330,16 +336,28 @@ class BezierPlanningRepresentation:
     def _apply_display_node(self, display_node: Any | None) -> None:
         """Push decoration fields onto the actors.
 
-        Tolerant of a ``None`` display node — falls back to defaults.  A
-        non-``None`` display node is the real ``vtkMRMLParametricSurfaceDisplayNode``
-        (its accessors are always present, ADR-0013 §8).
+        Tolerant of ``None`` / partial display nodes — falls back to
+        defaults.
         """
         if display_node is None:
             color = DEFAULT_RESECTION_COLOR
             opacity = DEFAULT_RESECTION_OPACITY
         else:
-            color = _as_color_tuple(display_node.GetResectionColor())
-            opacity = float(display_node.GetResectionOpacity())
+            color_getter = getattr(display_node, "GetResectionColor", None)
+            opacity_getter = getattr(
+                display_node, "GetResectionOpacity", None
+            )
+
+            color = (
+                _as_color_tuple(color_getter())
+                if color_getter is not None
+                else DEFAULT_RESECTION_COLOR
+            )
+            opacity = (
+                float(opacity_getter())
+                if opacity_getter is not None
+                else DEFAULT_RESECTION_OPACITY
+            )
 
         self._current_color = color
         self._current_opacity = opacity
@@ -379,24 +397,31 @@ class BezierPlanningRepresentation:
         if data_node is None:
             return
 
-        # Read the control grid from ``GetControlGridVector``
-        # (``const std::vector<double>&`` -> a Python tuple), NOT the flat
-        # ``GetControlGrid`` (``const double*``): VTK cannot wrap a bare pointer
-        # return into an indexable buffer — from Python it surfaces as an opaque
-        # pointer-string (``'_..._p_double'``) whose ``[0]`` is the character
-        # ``'_'``, not a coordinate.  The v2 ``vtkMRMLBezierSurfaceNode`` carrier
-        # always exposes the vector accessor (ADR-0014 §"Fourth layer").
-        # Resolve (rows, cols) off the same node — required to size the
-        # iteration over the flat control-grid return (ADR-0018 §1: the shape is
-        # ``(3, 3)`` or ``(4, 4)``).  The array-length check below catches any
-        # shape drift.
-        rows = int(data_node.GetRows())
-        cols = int(data_node.GetCols())
+        # Prefer ``GetControlGridVector`` (``const std::vector<double>&`` ->
+        # a Python tuple) over ``GetControlGrid`` (``const double*``): VTK
+        # cannot wrap a bare pointer return into an indexable buffer — from
+        # Python it surfaces as an opaque pointer-string (``'_..._p_double'``)
+        # whose ``[0]`` is the character ``'_'``, not a coordinate.  The
+        # vector accessor round-trips cleanly.  Stub data nodes in the
+        # unit-layer tests expose only ``GetControlGrid`` (a plain list), so
+        # fall back to it.
+        grid_getter = getattr(data_node, "GetControlGridVector", None)
+        if grid_getter is None:
+            grid_getter = getattr(data_node, "GetControlGrid", None)
+        if grid_getter is None:
+            return
+
+        # Resolve (rows, cols) from the node — required to size the
+        # iteration over the flat control-grid return.  Default to 4×4 when
+        # the accessors are absent (legacy stubs in unit tests); the
+        # array-length check below catches any drift.
+        rows = int(getattr(data_node, "GetRows", lambda: 4)())
+        cols = int(getattr(data_node, "GetCols", lambda: 4)())
         control_count = rows * cols
         flat_length = 3 * control_count
 
         try:
-            raw = data_node.GetControlGridVector()
+            raw = grid_getter()
         except Exception:  # pragma: no cover - defensive
             return
         if raw is None:
@@ -424,29 +449,39 @@ class BezierPlanningRepresentation:
         self._input_refresh_count += 1
 
         points = _make_points_from_flat(flat, control_count)
-        # Drive the Bezier surface source with the control grid; it tessellates
-        # the Bernstein patch and emits the ``uvCoords`` (TCoords) the mapper's
-        # vertex shader consumes.
-        self._feed_bezier_source(points, rows, cols)
+        if self._surface_source is not None:
+            # Real path: drive the Bezier surface source with the control
+            # grid; it tessellates the Bernstein patch and emits the
+            # ``uvCoords`` (TCoords) the mapper's vertex shader consumes.
+            self._feed_bezier_source(points, rows, cols)
+        else:
+            # Bare-VTK fallback: the "surface" is the raw control mesh
+            # (``control_count`` points + ``(rows-1)*(cols-1)`` quads) so the
+            # generic mapper has something to draw and the colour bookkeeping
+            # stays exercised in the unit layer.
+            self._refresh_surface_polydata(points, rows, cols)
 
     def _feed_bezier_source(self, points: Any, rows: int, cols: int) -> None:
         """Push the control grid into the Bezier source and tessellate.
 
         The source iterates its control-point array row-major as
-        ``i * cols + j`` (matching the node's row-major control grid), so its
-        control-point shape must equal the node's ``(rows, cols)`` for the
-        indices to line up.  ``Update()`` materialises the patch + TCoords and
-        the normals filter adds per-point normals, so ``GetSurfacePolyData``
+        ``i * cols + j`` (matching the node's row-major ``GetControlGrid``),
+        so its control-point shape must equal the node's ``(rows, cols)`` for
+        the indices to line up.  ``Update()`` materialises the patch + TCoords
+        and the normals filter adds per-point normals, so ``GetSurfacePolyData``
         returns renderable geometry without a render pass — the same eager
         update the v1 representation did (``BezierSurfaceSource->Update()``).
-        The source + normals filter are the real wrapped classes constructed
-        by ``_build_vtk_pipeline`` (ADR-0014 §3).
         """
         source = self._surface_source
-        source.SetNumberOfControlPoints(rows, cols)
+        if source is None:
+            return
+        set_ncp = getattr(source, "SetNumberOfControlPoints", None)
+        if set_ncp is not None:
+            set_ncp(rows, cols)
         source.SetControlPoints(points)
         source.Update()
-        self._surface_normals.Update()
+        if self._surface_normals is not None:
+            self._surface_normals.Update()
 
     def _apply_mapper_display_fields(
         self, display_node: Any | None, color: tuple, opacity: float
@@ -454,40 +489,73 @@ class BezierPlanningRepresentation:
         """Push the display node's decoration onto the real mapper's uniforms.
 
         Ports ``vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay``.
-        The surface mapper is the real ``vtkOpenGLBezierResectionPolyDataMapper``
-        (a hard requirement, ADR-0014 §3) and a non-``None`` display node is the
-        real ``vtkMRMLParametricSurfaceDisplayNode``; both expose their full
-        accessor surface, so the fields are pushed with direct calls.  Margin
-        scalars (``SetResectionMargin`` / ``SetUncertaintyMargin``) are
-        intentionally left at the mapper defaults here: the margins ride the
-        distance-field path in ``_apply_resection_plan`` (ADR-0031).
+        A no-op on the generic fallback mapper, which has no ``SetResection*``
+        surface — there the colour rides on the actor property set by the
+        caller.  Margin scalars (``SetResectionMargin`` / ``SetUncertaintyMargin``)
+        are intentionally left at the mapper defaults: the v2 node hierarchy
+        carries no margin field yet, and the margins only bias the distance
+        field, which is not bound in this slice.
         """
         mapper = self._surface_mapper
         if mapper is None:
             return
-        mapper.SetResectionColor(float(color[0]), float(color[1]), float(color[2]))
-        mapper.SetResectionOpacity(float(opacity))
+        set_color = getattr(mapper, "SetResectionColor", None)
+        if set_color is None:
+            return  # generic fallback mapper — nothing to push to a shader
+        set_color(float(color[0]), float(color[1]), float(color[2]))
+        set_opacity = getattr(mapper, "SetResectionOpacity", None)
+        if set_opacity is not None:
+            set_opacity(float(opacity))
 
         if display_node is None:
             return
 
-        _push_color3(mapper.SetResectionGridColor, display_node.GetResectionGridColor)
-        _push_color3(mapper.SetResectionMarginColor, display_node.GetResectionMarginColor)
         _push_color3(
-            mapper.SetUncertaintyMarginColor, display_node.GetUncertaintyMarginColor
+            mapper, "SetResectionGridColor",
+            getattr(display_node, "GetResectionGridColor", None),
         )
-        mapper.SetResectionClipOut(bool(display_node.GetClipOut()))
-        mapper.SetInterpolatedMargins(bool(display_node.GetInterpolatedMargins()))
+        _push_color3(
+            mapper, "SetResectionMarginColor",
+            getattr(display_node, "GetResectionMarginColor", None),
+        )
+        _push_color3(
+            mapper, "SetUncertaintyMarginColor",
+            getattr(display_node, "GetUncertaintyMarginColor", None),
+        )
+        _push_bool(
+            mapper, "SetResectionClipOut",
+            getattr(display_node, "GetClipOut", None),
+        )
+        _push_bool(
+            mapper, "SetInterpolatedMargins",
+            getattr(display_node, "GetInterpolatedMargins", None),
+        )
 
         # Grid divisions / thickness, gated on 3D-grid visibility exactly as
         # v1 did: when the grid is hidden, zero the divisions so the fragment
         # shader draws no grid lines.
-        if bool(display_node.GetGrid3DVisibility()):
-            mapper.SetGridDivisions(int(display_node.GetGridDivisions()))
-            mapper.SetGridThicknessFactor(float(display_node.GetGridThickness()))
+        grid_visible = True
+        vis_getter = getattr(display_node, "GetGrid3DVisibility", None)
+        if vis_getter is not None:
+            try:
+                grid_visible = bool(vis_getter())
+            except Exception:  # pragma: no cover - defensive
+                grid_visible = True
+
+        set_divisions = getattr(mapper, "SetGridDivisions", None)
+        set_thickness = getattr(mapper, "SetGridThicknessFactor", None)
+        if grid_visible:
+            div_getter = getattr(display_node, "GetGridDivisions", None)
+            thick_getter = getattr(display_node, "GetGridThickness", None)
+            if set_divisions is not None and div_getter is not None:
+                set_divisions(int(div_getter()))
+            if set_thickness is not None and thick_getter is not None:
+                set_thickness(float(thick_getter()))
         else:
-            mapper.SetGridDivisions(0)
-            mapper.SetGridThicknessFactor(0.0)
+            if set_divisions is not None:
+                set_divisions(0)
+            if set_thickness is not None:
+                set_thickness(0.0)
 
     def _apply_resection_plan(self, plan_node: Any | None) -> None:
         """Thread the wrapper's distance map + margins onto the real mapper.
@@ -504,22 +572,27 @@ class BezierPlanningRepresentation:
         no distance map is wired, clear the image and reset the matrices to
         identity (the graceful no-distance-map fallback the shader supports).
 
-        The surface mapper is the real ``vtkOpenGLBezierResectionPolyDataMapper``
-        (a hard requirement, ADR-0014 §3), so its distance-map setters are
-        called directly; a non-``None`` plan node is the real
-        ``vtkMRMLResectionPlanNode`` wrapper (ADR-0031).
+        A no-op on the generic fallback mapper (the getattr guard).
         """
         mapper = self._surface_mapper
-        if mapper is None:
-            return
+        if mapper is None or not hasattr(mapper, "SetDistanceMapImageData"):
+            return  # generic fallback mapper — no distance-map shader surface
 
         # Margins are plan fields, meaningful independent of the distance map
         # (the shader simply has no band to draw without a bound texture).
+        if plan_node is not None:
+            safety = getattr(plan_node, "GetSafetyMargin_mm", None)
+            risk = getattr(plan_node, "GetRiskMargin_mm", None)
+            if safety is not None:
+                mapper.SetResectionMargin(float(safety()))
+            if risk is not None:
+                mapper.SetUncertaintyMargin(float(risk()))
+
         volume = None
         if plan_node is not None:
-            mapper.SetResectionMargin(float(plan_node.GetSafetyMargin_mm()))
-            mapper.SetUncertaintyMargin(float(plan_node.GetRiskMargin_mm()))
-            volume = plan_node.GetDistanceMapVolumeNode()
+            getter = getattr(plan_node, "GetDistanceMapVolumeNode", None)
+            if getter is not None:
+                volume = getter()
 
         image = volume.GetImageData() if volume is not None else None
         if image is None:
@@ -550,6 +623,27 @@ class BezierPlanningRepresentation:
         scaling.GetMatrix(ijk_to_texture)
         mapper.SetIjkToTextureMatrix(ijk_to_texture)
 
+    def _refresh_surface_polydata(self, points: Any, rows: int, cols: int) -> None:
+        polydata = self._surface_polydata
+        if polydata is None:
+            return
+        polydata.SetPoints(points)
+
+        cells = vtk.vtkCellArray()
+        # Connect the (rows×cols) control mesh into
+        # ((rows-1)×(cols-1)) quads.  ``ids`` indexes the flat
+        # ``0..control_count-1`` point array laid out row-major in
+        # (u, v).
+        for v in range(rows - 1):
+            for u in range(cols - 1):
+                quad = vtk.vtkQuad()
+                quad.GetPointIds().SetId(0, v * cols + u)
+                quad.GetPointIds().SetId(1, v * cols + (u + 1))
+                quad.GetPointIds().SetId(2, (v + 1) * cols + (u + 1))
+                quad.GetPointIds().SetId(3, (v + 1) * cols + u)
+                cells.InsertNextCell(quad)
+        polydata.SetPolys(cells)
+        polydata.Modified()
 
 # --------------------------------------------------------------------------- #
 # Helpers
@@ -569,9 +663,9 @@ def _resolve_vtk_class(name: str) -> Any | None:
 
     The relocated mapper + the Bezier surface source are wrapped into Slicer's
     ``slicer`` namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the
-    plain ``vtk`` module is checked too for a non-Slicer VTK build.  Returns
-    ``None`` when neither namespace exposes the class, which the caller treats
-    as a hard error (the LiverResections module is not loaded).  Mirrors
+    plain ``vtk`` module is the fallback for a non-Slicer VTK build.  Returns
+    ``None`` when neither namespace exposes the class (the bare-VTK unit layer),
+    which drives the generic-mapper fallback.  Mirrors
     ``DistanceSpheroidInitRepresentation._resolve_extractor_class``.
     """
     for module_name in ("slicer", "vtk"):
@@ -585,16 +679,33 @@ def _resolve_vtk_class(name: str) -> Any | None:
     return None
 
 
-def _push_color3(setter: Any, getter: Any) -> None:
-    """Read a 3-vector from ``getter`` and push it to ``setter``.
+def _push_color3(mapper: Any, setter_name: str, getter: Any | None) -> None:
+    """Read a 3-vector from ``getter`` and push it to ``mapper.<setter_name>``.
 
-    The colour getter (``const float*`` -> a Python sequence) is coerced to
-    three floats; a coercion failure is swallowed defensively (a colour field
-    left unset is a benign no-op, unlike a geometry read).
+    No-op when either the getter or the mapper setter is absent (the generic
+    fallback mapper) — keeps the plumbing tolerant of partial display nodes.
     """
+    if getter is None:
+        return
+    setter = getattr(mapper, setter_name, None)
+    if setter is None:
+        return
     try:
         c = getter()
         setter(float(c[0]), float(c[1]), float(c[2]))
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _push_bool(mapper: Any, setter_name: str, getter: Any | None) -> None:
+    """Read a bool from ``getter`` and push it to ``mapper.<setter_name>``."""
+    if getter is None:
+        return
+    setter = getattr(mapper, setter_name, None)
+    if setter is None:
+        return
+    try:
+        setter(bool(getter()))
     except Exception:  # pragma: no cover - defensive
         pass
 

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -23,10 +23,16 @@ launched Slicer this Representation drives the relocated, real
 patch built by ``vtkBezierSurfaceSource`` + ``vtkPolyDataNormals`` (the same
 pipeline shape v1's ``vtkSlicerBezierSurfaceRepresentation3D`` assembled),
 including the ``uvCoords`` the mapper's vertex shader reads and the
-display-node colour / grid uniforms.  When the wrapped classes are off the
-path — the bare-VTK unit layer — it falls back to a generic
-``vtkPolyDataMapper`` + ``vtkActor`` pair over the raw control mesh so the
-Representation still constructs (``_resolve_vtk_class`` selects the path).
+display-node colour / grid uniforms.
+
+The custom mapper is injected, not silently discovered (ADR-0014 §3).  In
+production the ``surface_mapper`` constructor argument is left ``None`` and
+this Representation resolves the real wrapped class (raising loudly if it is
+off the path — a real misconfiguration must NOT degrade to a shader-less
+generic mapper).  The bare-VTK unit layer (ADR-0008 §2), where the wrapped
+classes are unreachable, injects a generic ``vtkPolyDataMapper`` instance
+explicitly; that source-less path renders the raw control mesh over a plain
+``vtkPolyData`` so the structural / colour bookkeeping stays testable.
 
 The RAS/IJK transform matrices and the distance-map 3D texture binding are
 NOT wired here: the v2 ``vtkMRMLBezierSurfaceNode`` carries no distance-map
@@ -79,10 +85,10 @@ DEFAULT_RESECTION_COLOR = (1.0, 1.0, 1.0)
 DEFAULT_RESECTION_OPACITY = 1.0
 
 # The relocated real surface mapper + the Bezier tessellation source (ADR-0014
-# §3).  Both are wrapped-C++ classes reachable only inside a launched Slicer;
-# ``_resolve_vtk_class`` falls back to ``None`` in the bare-VTK unit layer, in
-# which case the Representation builds a generic ``vtkPolyDataMapper`` pipeline
-# so it still constructs (the structural / colour bookkeeping stays testable).
+# §3).  Both are wrapped-C++ classes reachable only inside a launched Slicer.
+# In production (no injected mapper) ``_require_vtk_class`` resolves them or
+# raises — there is no silent generic fallback.  The bare-VTK unit layer
+# injects a generic mapper instead (ADR-0008 §2).
 REAL_SURFACE_MAPPER_CLASS = "vtkOpenGLBezierResectionPolyDataMapper"
 BEZIER_SURFACE_SOURCE_CLASS = "vtkBezierSurfaceSource"
 
@@ -97,11 +103,17 @@ class BezierPlanningRepresentation:
 
     Constructor
     -----------
-    ``BezierPlanningRepresentation(renderer=None)``
+    ``BezierPlanningRepresentation(renderer=None, *, surface_mapper=None)``
 
     * ``renderer`` — the ``vtkRenderer`` the actors are added to.
       Optional; ``None`` is supported for unit tests (the actors
       exist but are unrendered).
+    * ``surface_mapper`` — a custom-mapper INSTANCE (dependency
+      injection, ADR-0014 §3).  ``None`` (production) resolves the real
+      ``vtkOpenGLBezierResectionPolyDataMapper`` + ``vtkBezierSurfaceSource``
+      pipeline, raising if either wrapped class is off the path.  An
+      injected instance (bare-VTK unit layer, ADR-0008 §2) drives a
+      source-less pipeline over a plain ``vtkPolyData``.
 
     Public methods
     --------------
@@ -135,7 +147,9 @@ class BezierPlanningRepresentation:
     * ``GetCurrentOpacity()`` — the opacity last written.
     """
 
-    def __init__(self, renderer: Any | None = None) -> None:
+    def __init__(
+        self, renderer: Any | None = None, *, surface_mapper: Any | None = None
+    ) -> None:
         self._renderer: Any | None = None
 
         # The VTK objects the Representation owns.  ``None`` in the
@@ -171,7 +185,7 @@ class BezierPlanningRepresentation:
         # wrapper, not the carrier.  ``None`` until the Pipeline wires it.
         self._resection_plan_node: Any | None = None
 
-        self._build_vtk_pipeline()
+        self._build_vtk_pipeline(surface_mapper)
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -273,29 +287,33 @@ class BezierPlanningRepresentation:
     # Internal helpers
     # ------------------------------------------------------------------ #
 
-    def _build_vtk_pipeline(self) -> None:
+    def _build_vtk_pipeline(self, surface_mapper: Any | None) -> None:
         """Construct the surface actor.
 
-        Called from ``__init__`` only when ``vtk`` is importable.
+        Called from ``__init__``.
 
-        Real path (inside Slicer): the relocated
-        ``vtkOpenGLBezierResectionPolyDataMapper`` (ADR-0014 §3) renders the
-        tessellated Bernstein patch built by ``vtkBezierSurfaceSource`` +
-        ``vtkPolyDataNormals`` — the same pipeline shape the v1
-        ``vtkSlicerBezierSurfaceRepresentation3D`` ctor assembled.  The source
-        emits the 2-component ``uvCoords`` (TCoords) the mapper's vertex shader
-        reads; the grid is a fragment-shader feature on that mapper driven by
-        ``GridDivisions`` / ``GridThickness`` / ``ResectionGridColor`` uniforms
-        (plumbed in ``_apply_display_node``), NOT a separate actor.
+        Production path (``surface_mapper is None``): resolve the relocated
+        ``vtkOpenGLBezierResectionPolyDataMapper`` + ``vtkBezierSurfaceSource``
+        wrapped classes (ADR-0014 §3), raising loudly if either is off the path
+        — a real misconfiguration must not silently render shader-less.  The
+        mapper renders the tessellated Bernstein patch built by
+        ``vtkBezierSurfaceSource`` + ``vtkPolyDataNormals`` — the same pipeline
+        shape the v1 ``vtkSlicerBezierSurfaceRepresentation3D`` ctor assembled.
+        The source emits the 2-component ``uvCoords`` (TCoords) the mapper's
+        vertex shader reads; the grid is a fragment-shader feature on that
+        mapper driven by ``GridDivisions`` / ``GridThickness`` /
+        ``ResectionGridColor`` uniforms (plumbed in ``_apply_display_node``),
+        NOT a separate actor.
 
-        Bare-VTK fallback (unit layer): the wrapped classes are off the path,
-        so a generic ``vtkPolyDataMapper`` over a plain ``vtkPolyData`` keeps
-        the Representation constructible and the colour bookkeeping testable.
+        Injected path (``surface_mapper`` given, bare-VTK unit layer per
+        ADR-0008 §2): the wrapped classes are off the path, so the caller
+        injects a generic mapper instance.  It is fed a plain ``vtkPolyData``
+        (source-less) carrying the raw control mesh, keeping the Representation
+        constructible and the colour bookkeeping testable.
         """
-        mapper_class = _resolve_vtk_class(REAL_SURFACE_MAPPER_CLASS)
-        source_class = _resolve_vtk_class(BEZIER_SURFACE_SOURCE_CLASS)
-
-        if mapper_class is not None and source_class is not None:
+        if surface_mapper is None:
+            mapper_class = _require_vtk_class(REAL_SURFACE_MAPPER_CLASS)
+            source_class = _require_vtk_class(BEZIER_SURFACE_SOURCE_CLASS)
             self._surface_source = source_class()
             self._surface_source.SetResolution(
                 BEZIER_SURFACE_RESOLUTION, BEZIER_SURFACE_RESOLUTION
@@ -310,7 +328,7 @@ class BezierPlanningRepresentation:
             )
         else:
             self._surface_polydata = vtk.vtkPolyData()
-            self._surface_mapper = vtk.vtkPolyDataMapper()
+            self._surface_mapper = surface_mapper
             self._surface_mapper.SetInputData(self._surface_polydata)
 
         self._surface_actor = vtk.vtkActor()
@@ -658,15 +676,16 @@ def _identity_matrix() -> Any:
     return m
 
 
-def _resolve_vtk_class(name: str) -> Any | None:
-    """Resolve a wrapped-C++ class by name from ``slicer`` then ``vtk``.
+def _require_vtk_class(name: str) -> Any:
+    """Resolve a wrapped-C++ class by name from ``slicer`` then ``vtk``, or raise.
 
     The relocated mapper + the Bezier surface source are wrapped into Slicer's
     ``slicer`` namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the
-    plain ``vtk`` module is the fallback for a non-Slicer VTK build.  Returns
-    ``None`` when neither namespace exposes the class (the bare-VTK unit layer),
-    which drives the generic-mapper fallback.  Mirrors
-    ``DistanceSpheroidInitRepresentation._resolve_extractor_class``.
+    plain ``vtk`` module is the fallback for a non-Slicer VTK build.  Raises
+    ``RuntimeError`` when neither namespace exposes the class — a real
+    misconfiguration in production (ADR-0014 §3) must fail loudly rather than
+    degrade to a shader-less generic mapper.  Bare-VTK unit tests (ADR-0008 §2)
+    avoid this path by injecting a mapper instance instead.
     """
     for module_name in ("slicer", "vtk"):
         try:
@@ -676,7 +695,13 @@ def _resolve_vtk_class(name: str) -> Any | None:
         cls = getattr(module, name, None)
         if cls is not None:
             return cls
-    return None
+    raise RuntimeError(
+        f"{name} is not reachable from the 'slicer' or 'vtk' namespace. "
+        "It is a wrapped-C++ class relocated to LiverResections/VTKWidgets/ "
+        "(ADR-0014 §3) and available only inside a launched Slicer with the "
+        "module loaded.  Inject a mapper instance for bare-VTK unit tests "
+        "(ADR-0008 §2)."
+    )
 
 
 def _push_color3(mapper: Any, setter_name: str, getter: Any | None) -> None:

--- a/LiverResections/LiverResectionsLib/Representations/ConfirmedRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/ConfirmedRepresentation.py
@@ -99,9 +99,9 @@ class ConfirmedRepresentation:
     Introspection (used by unit tests)
     ----------------------------------
     * ``GetSurfaceActor()`` / ``GetSurfaceMapper()`` — the actor +
-      mapper pair, or ``None`` before the pipeline is built.
+      mapper pair, or ``None`` when VTK is absent.
     * ``GetCurrentColor()`` / ``GetCurrentOpacity()`` — the values last
-      written to the actor property.
+      written to the actor property; stubs for tests without VTK.
     * ``GetClipOutApplied()`` — last ``SetResectionClipOut`` call's
       argument (``True`` when the relocated mapper accepted the call,
       ``None`` when the mapper does not expose the method).

--- a/LiverResections/LiverResectionsLib/Representations/ConfirmedRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/ConfirmedRepresentation.py
@@ -99,9 +99,9 @@ class ConfirmedRepresentation:
     Introspection (used by unit tests)
     ----------------------------------
     * ``GetSurfaceActor()`` / ``GetSurfaceMapper()`` — the actor +
-      mapper pair, or ``None`` when VTK is absent.
+      mapper pair, or ``None`` before the pipeline is built.
     * ``GetCurrentColor()`` / ``GetCurrentOpacity()`` — the values last
-      written to the actor property; stubs for tests without VTK.
+      written to the actor property.
     * ``GetClipOutApplied()`` — last ``SetResectionClipOut`` call's
       argument (``True`` when the relocated mapper accepted the call,
       ``None`` when the mapper does not expose the method).

--- a/LiverResections/LiverResectionsLib/Representations/ConfirmedRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/ConfirmedRepresentation.py
@@ -52,19 +52,7 @@ from __future__ import annotations
 
 from typing import Any
 
-# --------------------------------------------------------------------------- #
-# VTK is a soft dependency — same pattern as BezierPlanningRepresentation: a
-# pure-Python pytest run skips the VTK-only branches, while a Slicer process
-# (or an environment with VTK on PYTHONPATH) exercises the full pipeline.
-# --------------------------------------------------------------------------- #
-
-try:  # pragma: no cover — exercised inside Slicer / when VTK is available
-    import vtk
-
-    _HAS_VTK = True
-except ImportError:  # pragma: no cover — pure-Python path
-    vtk = None  # type: ignore[assignment]
-    _HAS_VTK = False
+import vtk
 
 
 # --------------------------------------------------------------------------- #
@@ -152,8 +140,7 @@ class ConfirmedRepresentation:
         # ``vtkOpenGLBezierResectionPolyDataMapper.h``); the
         # ``hasattr`` gate in ``_apply_data_node`` flips on
         # automatically once the swap happens.
-        if _HAS_VTK:
-            self._build_vtk_pipeline()
+        self._build_vtk_pipeline()
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -238,8 +225,6 @@ class ConfirmedRepresentation:
         ``vtkOpenGLBezierResectionPolyDataMapper.h`` for the full
         uniform surface.
         """
-        assert vtk is not None  # gated by _HAS_VTK
-
         self._surface_polydata = vtk.vtkPolyData()
         self._surface_mapper = vtk.vtkPolyDataMapper()
         self._surface_mapper.SetInputData(self._surface_polydata)
@@ -331,15 +316,11 @@ class ConfirmedRepresentation:
         self._last_grid_signature = signature
         self._input_refresh_count += 1
 
-        if not _HAS_VTK:
-            return
-
         points = _make_points_from_flat(flat)
         self._refresh_surface_polydata(points)
         self._apply_trim_shader()
 
     def _refresh_surface_polydata(self, points: Any) -> None:
-        assert vtk is not None
         polydata = self._surface_polydata
         if polydata is None:
             return
@@ -397,7 +378,6 @@ def _as_color_tuple(raw: Any) -> tuple[float, float, float]:
 
 def _make_points_from_flat(flat: tuple) -> Any:
     """Build a ``vtkPoints`` from a 48-double row-major control grid."""
-    assert vtk is not None
     points = vtk.vtkPoints()
     points.SetNumberOfPoints(16)
     for i in range(16):

--- a/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
@@ -71,22 +71,7 @@ from __future__ import annotations
 
 from typing import Any
 
-# --------------------------------------------------------------------------- #
-# VTK is a soft dependency — when running in a plain Python without VTK on
-# ``PYTHONPATH``, the import below fails and the unit tests that need a
-# real mapper skip via ``pytest.importorskip("vtk")``.  The Representation
-# can still be constructed (the lazy ``_get_vtk()`` returns ``None``); its
-# ``update()`` then becomes a no-op for the missing VTK case, which is
-# enough for the smoke-level tests.
-# --------------------------------------------------------------------------- #
-
-try:  # pragma: no cover — exercised inside Slicer / when VTK is available
-    import vtk
-
-    _HAS_VTK = True
-except ImportError:  # pragma: no cover — pure-Python path
-    vtk = None  # type: ignore[assignment]
-    _HAS_VTK = False
+import vtk
 
 
 # --------------------------------------------------------------------------- #
@@ -204,8 +189,7 @@ class DistanceSpheroidInitRepresentation:
         # to ``LiverResections/VTKWidgets/`` per ADR-0014 §3.  The
         # public API of this Representation does not change — only the
         # spheroid mapper field's concrete type.
-        if _HAS_VTK:
-            self._build_vtk_pipeline()
+        self._build_vtk_pipeline()
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -252,7 +236,7 @@ class DistanceSpheroidInitRepresentation:
         ring.  Returns the ring ``vtkPolyData`` (or ``None`` when
         extraction cannot run).
         """
-        if target_model is None or not _HAS_VTK:
+        if target_model is None:
             return None
         polydata = _model_polydata(target_model)
         if polydata is None:
@@ -353,8 +337,6 @@ class DistanceSpheroidInitRepresentation:
         to a generic ``vtkPolyDataMapper`` so the Representation still
         constructs and the marker/colour bookkeeping stays testable.
         """
-        assert vtk is not None  # for the type-checker — gated by _HAS_VTK
-
         # Spheroid pipeline ---------------------------------------------------
         self._parametric_ellipsoid = vtk.vtkParametricEllipsoid()
         # Sensible default radii so a freshly-constructed Representation
@@ -401,7 +383,6 @@ class DistanceSpheroidInitRepresentation:
 
     def _make_marker_entry(self) -> tuple[Any, Any, Any]:
         """Construct one ``(sphere_source, mapper, actor)`` triple."""
-        assert vtk is not None
         sphere = vtk.vtkSphereSource()
         sphere.SetRadius(DEFAULT_MARKER_RADIUS)
         sphere.SetCenter(0.0, 0.0, 0.0)
@@ -423,8 +404,6 @@ class DistanceSpheroidInitRepresentation:
         and inherit the most recently applied colour.  Removed actors
         are detached and their strong refs dropped.
         """
-        if not _HAS_VTK:
-            return
         current = len(self._marker_entries)
         if n == current:
             return
@@ -576,12 +555,6 @@ class DistanceSpheroidInitRepresentation:
             return  # idempotent short-circuit
         self._last_input_signature = signature
         self._input_refresh_count += 1
-
-        if not _HAS_VTK:
-            # Pure-Python path: still resize the (empty) marker list
-            # bookkeeping so test introspection of GetMarkerActors()
-            # length stays accurate even without VTK.
-            return
 
         # Spheroid: push radii into the parametric ellipsoid + recenter
         # via the transform filter.

--- a/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
@@ -39,12 +39,13 @@ Three pieces of geometry per ADR-0014 §2:
 Per ADR-0014 §3 the four custom OpenGL mappers — including
 ``vtkOpenGLDistanceContourPolyDataMapper`` — relocate from
 ``LiverMarkups/VTKWidgets/`` to ``LiverResections/VTKWidgets/``.  The
-relocation has not landed yet; this Representation uses the generic
-``vtkPolyDataMapper`` + ``vtkActor`` pair until the relocation
-completes, at which point the spheroid mapper field flips to
-``vtkOpenGLDistanceContourPolyDataMapper`` *without changing the
-Representation's public API*.  Marked with
-``TODO(T2-mapper-relocation)`` at the construction point.
+spheroid CONTOUR mapper is that custom class, injected rather than
+silently discovered: in production the ``spheroid_mapper`` constructor
+argument is ``None`` and this Representation resolves the real wrapped
+class (raising if it is off the path); the bare-VTK unit layer
+(ADR-0008 §2) injects a generic ``vtkPolyDataMapper`` instance.  The
+sphere-MARKER mappers are genuinely generic geometry and stay plain
+``vtkPolyDataMapper`` (not injected).
 
 Renderer attachment
 -------------------
@@ -95,11 +96,17 @@ class DistanceSpheroidInitRepresentation:
 
     Constructor
     -----------
-    ``DistanceSpheroidInitRepresentation(renderer=None)``
+    ``DistanceSpheroidInitRepresentation(renderer=None, *, spheroid_mapper=None)``
 
     * ``renderer`` — the ``vtkRenderer`` the actors are added to.
       Optional; ``None`` is supported for unit tests (the actors
       exist but are unrendered).
+    * ``spheroid_mapper`` — the custom contour-mapper INSTANCE
+      (dependency injection, ADR-0014 §3).  ``None`` (production)
+      resolves the real ``vtkOpenGLDistanceContourPolyDataMapper``,
+      raising if it is off the path.  An injected instance (bare-VTK
+      unit layer, ADR-0008 §2) is used as-is.  The sphere-marker mappers
+      are always plain ``vtkPolyDataMapper`` and not affected.
 
     Public methods
     --------------
@@ -141,7 +148,9 @@ class DistanceSpheroidInitRepresentation:
       observes a change in (Center, Radii, init points, displayMTime).
     """
 
-    def __init__(self, renderer: Any | None = None) -> None:
+    def __init__(
+        self, renderer: Any | None = None, *, spheroid_mapper: Any | None = None
+    ) -> None:
         self._renderer: Any | None = None
 
         # The VTK pipeline objects the Representation owns.  ``None`` in
@@ -183,13 +192,7 @@ class DistanceSpheroidInitRepresentation:
         # the Init->Planning commit, or ``None`` before commit.
         self._ring_polydata: Any | None = None
 
-        # TODO(T2-mapper-relocation): swap ``vtk.vtkPolyDataMapper`` for
-        # ``vtkOpenGLDistanceContourPolyDataMapper`` once the four
-        # custom mappers are relocated from ``LiverMarkups/VTKWidgets/``
-        # to ``LiverResections/VTKWidgets/`` per ADR-0014 §3.  The
-        # public API of this Representation does not change — only the
-        # spheroid mapper field's concrete type.
-        self._build_vtk_pipeline()
+        self._build_vtk_pipeline(spheroid_mapper)
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -316,7 +319,7 @@ class DistanceSpheroidInitRepresentation:
     # Internal helpers
     # ------------------------------------------------------------------ #
 
-    def _build_vtk_pipeline(self) -> None:
+    def _build_vtk_pipeline(self, spheroid_mapper: Any | None) -> None:
         """Construct the spheroid pipeline.
 
         Marker actors are built lazily on demand (the count is data-
@@ -332,10 +335,12 @@ class DistanceSpheroidInitRepresentation:
         on-commit CPU-extracted ring.  ``_apply_data_node`` pushes the
         (centre, radii) onto the mapper via ``SetSpheroid``.
 
-        When the relocated mapper is not on the path (a plain non-Slicer
-        VTK build used by the unit-layer tests) the pipeline falls back
-        to a generic ``vtkPolyDataMapper`` so the Representation still
-        constructs and the marker/colour bookkeeping stays testable.
+        The contour mapper is injected, not silently discovered: in
+        production ``spheroid_mapper`` is ``None`` and this resolves the
+        real wrapped class (raising if it is off the path — a real
+        misconfiguration must not degrade to a shader-less generic
+        mapper); the bare-VTK unit layer (ADR-0008 §2) injects a generic
+        mapper instance.
         """
         # Spheroid pipeline ---------------------------------------------------
         self._parametric_ellipsoid = vtk.vtkParametricEllipsoid()
@@ -362,17 +367,17 @@ class DistanceSpheroidInitRepresentation:
             self._parametric_function_source.GetOutputPort()
         )
 
-        mapper_class = _resolve_extractor_class(
-            "vtkOpenGLDistanceContourPolyDataMapper"
-        )
-        if mapper_class is not None:
+        if spheroid_mapper is None:
+            mapper_class = _require_vtk_class(
+                "vtkOpenGLDistanceContourPolyDataMapper"
+            )
             self._spheroid_mapper = mapper_class()
         else:
-            # Non-Slicer VTK build (unit-layer tests): the relocated
-            # mapper is not wrapped onto the path.  A generic mapper keeps
-            # the pipeline constructible; the triaxial banding is a no-op
-            # there but the marker/colour bookkeeping is still exercised.
-            self._spheroid_mapper = vtk.vtkPolyDataMapper()
+            # Bare-VTK unit layer (ADR-0008 §2): the relocated mapper is
+            # off the path, so the caller injects a generic mapper.  The
+            # triaxial banding is a no-op there but the marker / colour
+            # bookkeeping is still exercised.
+            self._spheroid_mapper = spheroid_mapper
         self._spheroid_mapper.SetInputConnection(
             self._spheroid_polydata_filter.GetOutputPort()
         )
@@ -635,7 +640,10 @@ def _resolve_extractor_class(name: str) -> Any | None:
     The Algorithm-library classes are wrapped into Slicer's ``slicer``
     namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the
     plain ``vtk`` module is the fallback for non-Slicer VTK builds.
-    Returns ``None`` when neither namespace exposes the class.
+    Returns ``None`` when neither namespace exposes the class — the
+    on-commit ring extraction degrades to a no-op when the extractor is
+    unreachable, so this stays resolve-or-``None`` (unlike the mapper
+    resolution, which is resolve-or-raise).
     """
     for module_name in ("slicer", "vtk"):
         try:
@@ -646,6 +654,34 @@ def _resolve_extractor_class(name: str) -> Any | None:
         if cls is not None:
             return cls
     return None
+
+
+def _require_vtk_class(name: str) -> Any:
+    """Resolve a wrapped-C++ class by name from ``slicer`` then ``vtk``, or raise.
+
+    The relocated custom mapper is wrapped into Slicer's ``slicer``
+    namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the plain
+    ``vtk`` module is the fallback for a non-Slicer VTK build.  Raises
+    ``RuntimeError`` when neither namespace exposes the class — a real
+    misconfiguration in production (ADR-0014 §3) must fail loudly rather
+    than degrade to a shader-less generic mapper.  Bare-VTK unit tests
+    (ADR-0008 §2) avoid this path by injecting a mapper instance instead.
+    """
+    for module_name in ("slicer", "vtk"):
+        try:
+            module = __import__(module_name)
+        except ImportError:
+            continue
+        cls = getattr(module, name, None)
+        if cls is not None:
+            return cls
+    raise RuntimeError(
+        f"{name} is not reachable from the 'slicer' or 'vtk' namespace. "
+        "It is a wrapped-C++ class relocated to LiverResections/VTKWidgets/ "
+        "(ADR-0014 §3) and available only inside a launched Slicer with the "
+        "module loaded.  Inject a mapper instance for bare-VTK unit tests "
+        "(ADR-0008 §2)."
+    )
 
 
 def _model_polydata(target_model: Any | None) -> Any | None:

--- a/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
@@ -128,7 +128,7 @@ class DistanceSpheroidInitRepresentation:
     Introspection (used by unit tests)
     ----------------------------------
     * ``GetMarkerActors()`` — list of ``vtkActor`` rendering the
-      seed markers, or an empty list if VTK is not importable.
+      seed markers, or an empty list before the pipeline is built.
     * ``GetSpheroidActor()`` — the ``vtkActor`` rendering the
       translucent spheroid, or ``None``.
     * ``GetSpheroidMapper()`` — the spheroid mapper.
@@ -144,8 +144,8 @@ class DistanceSpheroidInitRepresentation:
     def __init__(self, renderer: Any | None = None) -> None:
         self._renderer: Any | None = None
 
-        # The VTK pipeline objects the Representation owns.  ``None`` in
-        # the pure-Python testing path.
+        # The VTK pipeline objects the Representation owns.  ``None`` until
+        # ``_build_vtk_pipeline`` runs.
         self._parametric_ellipsoid: Any | None = None
         self._parametric_function_source: Any | None = None
         self._spheroid_polydata_filter: Any | None = None
@@ -332,10 +332,11 @@ class DistanceSpheroidInitRepresentation:
         on-commit CPU-extracted ring.  ``_apply_data_node`` pushes the
         (centre, radii) onto the mapper via ``SetSpheroid``.
 
-        When the relocated mapper is not on the path (a plain non-Slicer
-        VTK build used by the unit-layer tests) the pipeline falls back
-        to a generic ``vtkPolyDataMapper`` so the Representation still
-        constructs and the marker/colour bookkeeping stays testable.
+        The relocated contour mapper (ADR-0014 §3) is a hard requirement:
+        ``_build_vtk_pipeline`` raises if it cannot be resolved rather than
+        silently degrading to a shader-less generic mapper.  The sphere
+        MARKER mappers remain plain ``vtkPolyDataMapper`` (generic geometry,
+        no custom shader).
         """
         # Spheroid pipeline ---------------------------------------------------
         self._parametric_ellipsoid = vtk.vtkParametricEllipsoid()

--- a/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
@@ -362,17 +362,24 @@ class DistanceSpheroidInitRepresentation:
             self._parametric_function_source.GetOutputPort()
         )
 
+        # The spheroid contour mapper is a hard requirement: a resolver miss is
+        # a misconfiguration (the LiverResections module is not loaded / not
+        # wrapped) that must surface LOUDLY, not degrade to a generic
+        # ``vtkPolyDataMapper`` whose fragment shader does no triaxial banding
+        # (ADR-0008 §2 — the no-VTK unit layer this once degraded for was never
+        # built).  The sphere-MARKER mappers stay plain (``_make_marker_entry``).
         mapper_class = _resolve_extractor_class(
             "vtkOpenGLDistanceContourPolyDataMapper"
         )
-        if mapper_class is not None:
-            self._spheroid_mapper = mapper_class()
-        else:
-            # Non-Slicer VTK build (unit-layer tests): the relocated
-            # mapper is not wrapped onto the path.  A generic mapper keeps
-            # the pipeline constructible; the triaxial banding is a no-op
-            # there but the marker/colour bookkeeping is still exercised.
-            self._spheroid_mapper = vtk.vtkPolyDataMapper()
+        if mapper_class is None:
+            raise RuntimeError(
+                "DistanceSpheroidInitRepresentation requires the relocated "
+                "vtkOpenGLDistanceContourPolyDataMapper (ADR-0014 §3); neither "
+                "the 'slicer' nor the 'vtk' namespace exposes it.  Load the "
+                "LiverResections module so its wrapped VTKWidgets classes are "
+                "on the path."
+            )
+        self._spheroid_mapper = mapper_class()
         self._spheroid_mapper.SetInputConnection(
             self._spheroid_polydata_filter.GetOutputPort()
         )

--- a/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
@@ -128,7 +128,7 @@ class DistanceSpheroidInitRepresentation:
     Introspection (used by unit tests)
     ----------------------------------
     * ``GetMarkerActors()`` — list of ``vtkActor`` rendering the
-      seed markers, or an empty list before the pipeline is built.
+      seed markers, or an empty list if VTK is not importable.
     * ``GetSpheroidActor()`` — the ``vtkActor`` rendering the
       translucent spheroid, or ``None``.
     * ``GetSpheroidMapper()`` — the spheroid mapper.
@@ -144,8 +144,8 @@ class DistanceSpheroidInitRepresentation:
     def __init__(self, renderer: Any | None = None) -> None:
         self._renderer: Any | None = None
 
-        # The VTK pipeline objects the Representation owns.  ``None`` until
-        # ``_build_vtk_pipeline`` runs.
+        # The VTK pipeline objects the Representation owns.  ``None`` in
+        # the pure-Python testing path.
         self._parametric_ellipsoid: Any | None = None
         self._parametric_function_source: Any | None = None
         self._spheroid_polydata_filter: Any | None = None
@@ -332,11 +332,10 @@ class DistanceSpheroidInitRepresentation:
         on-commit CPU-extracted ring.  ``_apply_data_node`` pushes the
         (centre, radii) onto the mapper via ``SetSpheroid``.
 
-        The relocated contour mapper (ADR-0014 §3) is a hard requirement:
-        ``_build_vtk_pipeline`` raises if it cannot be resolved rather than
-        silently degrading to a shader-less generic mapper.  The sphere
-        MARKER mappers remain plain ``vtkPolyDataMapper`` (generic geometry,
-        no custom shader).
+        When the relocated mapper is not on the path (a plain non-Slicer
+        VTK build used by the unit-layer tests) the pipeline falls back
+        to a generic ``vtkPolyDataMapper`` so the Representation still
+        constructs and the marker/colour bookkeeping stays testable.
         """
         # Spheroid pipeline ---------------------------------------------------
         self._parametric_ellipsoid = vtk.vtkParametricEllipsoid()
@@ -363,24 +362,17 @@ class DistanceSpheroidInitRepresentation:
             self._parametric_function_source.GetOutputPort()
         )
 
-        # The spheroid contour mapper is a hard requirement: a resolver miss is
-        # a misconfiguration (the LiverResections module is not loaded / not
-        # wrapped) that must surface LOUDLY, not degrade to a generic
-        # ``vtkPolyDataMapper`` whose fragment shader does no triaxial banding
-        # (ADR-0008 §2 — the no-VTK unit layer this once degraded for was never
-        # built).  The sphere-MARKER mappers stay plain (``_make_marker_entry``).
         mapper_class = _resolve_extractor_class(
             "vtkOpenGLDistanceContourPolyDataMapper"
         )
-        if mapper_class is None:
-            raise RuntimeError(
-                "DistanceSpheroidInitRepresentation requires the relocated "
-                "vtkOpenGLDistanceContourPolyDataMapper (ADR-0014 §3); neither "
-                "the 'slicer' nor the 'vtk' namespace exposes it.  Load the "
-                "LiverResections module so its wrapped VTKWidgets classes are "
-                "on the path."
-            )
-        self._spheroid_mapper = mapper_class()
+        if mapper_class is not None:
+            self._spheroid_mapper = mapper_class()
+        else:
+            # Non-Slicer VTK build (unit-layer tests): the relocated
+            # mapper is not wrapped onto the path.  A generic mapper keeps
+            # the pipeline constructible; the triaxial banding is a no-op
+            # there but the marker/colour bookkeeping is still exercised.
+            self._spheroid_mapper = vtk.vtkPolyDataMapper()
         self._spheroid_mapper.SetInputConnection(
             self._spheroid_polydata_filter.GetOutputPort()
         )
@@ -577,20 +569,24 @@ class DistanceSpheroidInitRepresentation:
         if self._parametric_function_source is not None:
             self._parametric_function_source.Modified()
 
-        # Drive the contour shader: push (centre, radii) onto the mapper so its
-        # fragment shader bands the triaxial-ellipsoid implicit whose quadric
-        # coefficients come from the SSOT (ADR-0015 §"Stack 4").  Mirrors how
-        # vtkLiverBezierSurfacePipeline sets its grid/margin uniforms.  The
-        # spheroid mapper is the real vtkOpenGLDistanceContourPolyDataMapper (a
-        # hard requirement, ADR-0014 §3), so its setters are called directly.
-        self._spheroid_mapper.SetSpheroid(list(center), rx, ry, rz)
+        # Drive the contour shader: push (centre, radii) onto the mapper
+        # so its fragment shader bands the triaxial-ellipsoid implicit
+        # whose quadric coefficients come from the SSOT (ADR-0015
+        # §"Stack 4").  Mirrors how vtkLiverBezierSurfacePipeline sets its
+        # grid/margin uniforms.  No-op on the generic fallback mapper.
+        set_spheroid = getattr(self._spheroid_mapper, "SetSpheroid", None)
+        if set_spheroid is not None:
+            set_spheroid(list(center), rx, ry, rz)
 
-        # Make the banded contour visible.  The mapper defaults to hidden and
-        # its fragment shader discards every fragment while visibility is off,
-        # so without this the placed spheroid never renders.  Enabling it here
-        # -- once the representation has a spheroid to show -- is what actually
-        # draws the triaxial ellipsoid.
-        self._spheroid_mapper.SetContourVisibility(True)
+        # Make the banded contour visible.  The mapper defaults to hidden
+        # and its fragment shader discards every fragment while visibility
+        # is off, so without this the placed spheroid never renders.
+        # Enabling it here -- once the representation has a spheroid to
+        # show -- is what actually draws the triaxial ellipsoid.  No-op on
+        # the generic fallback mapper.
+        set_contour_visibility = getattr(self._spheroid_mapper, "SetContourVisibility", None)
+        if set_contour_visibility is not None:
+            set_contour_visibility(True)
 
         # Markers: resize the actor list, then update each sphere's
         # centre.

--- a/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
@@ -576,24 +576,20 @@ class DistanceSpheroidInitRepresentation:
         if self._parametric_function_source is not None:
             self._parametric_function_source.Modified()
 
-        # Drive the contour shader: push (centre, radii) onto the mapper
-        # so its fragment shader bands the triaxial-ellipsoid implicit
-        # whose quadric coefficients come from the SSOT (ADR-0015
-        # §"Stack 4").  Mirrors how vtkLiverBezierSurfacePipeline sets its
-        # grid/margin uniforms.  No-op on the generic fallback mapper.
-        set_spheroid = getattr(self._spheroid_mapper, "SetSpheroid", None)
-        if set_spheroid is not None:
-            set_spheroid(list(center), rx, ry, rz)
+        # Drive the contour shader: push (centre, radii) onto the mapper so its
+        # fragment shader bands the triaxial-ellipsoid implicit whose quadric
+        # coefficients come from the SSOT (ADR-0015 §"Stack 4").  Mirrors how
+        # vtkLiverBezierSurfacePipeline sets its grid/margin uniforms.  The
+        # spheroid mapper is the real vtkOpenGLDistanceContourPolyDataMapper (a
+        # hard requirement, ADR-0014 §3), so its setters are called directly.
+        self._spheroid_mapper.SetSpheroid(list(center), rx, ry, rz)
 
-        # Make the banded contour visible.  The mapper defaults to hidden
-        # and its fragment shader discards every fragment while visibility
-        # is off, so without this the placed spheroid never renders.
-        # Enabling it here -- once the representation has a spheroid to
-        # show -- is what actually draws the triaxial ellipsoid.  No-op on
-        # the generic fallback mapper.
-        set_contour_visibility = getattr(self._spheroid_mapper, "SetContourVisibility", None)
-        if set_contour_visibility is not None:
-            set_contour_visibility(True)
+        # Make the banded contour visible.  The mapper defaults to hidden and
+        # its fragment shader discards every fragment while visibility is off,
+        # so without this the placed spheroid never renders.  Enabling it here
+        # -- once the representation has a spheroid to show -- is what actually
+        # draws the triaxial ellipsoid.
+        self._spheroid_mapper.SetContourVisibility(True)
 
         # Markers: resize the actor list, then update each sphere's
         # centre.

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -139,7 +139,7 @@ class FlattenedSurfaceRepresentation:
     Introspection (used by unit tests)
     ----------------------------------
     * ``GetResectionMapper2D()`` / ``GetResectionActor2D()`` — the 2D
-      mapper + actor pair, or ``None`` when VTK is absent.
+      mapper + actor pair, or ``None`` before the pipeline is built.
     * ``GetResectogramCamera()`` — the private overlay camera.
     * ``GetMatRatioApplied()`` — last ``MatRatio`` pushed onto the 2D
       mapper, or ``None`` before the first ``update()`` / when the
@@ -767,8 +767,8 @@ class FlattenedSurfaceRepresentation:
         reconciles the pass without rebuilding the assembly — the
         ``vtkSetMacro(BlurEnabled, bool)`` ``Modified()`` advances the display
         node's MTime, which ``ResectogramPipeline.UpdatePipeline`` already
-        keys on, so no new observer is needed.  No-op when VTK or the renderer
-        is unavailable (bare-VTK pytest path).
+        keys on, so no new observer is needed.  No-op when the renderer
+        is unavailable (no realized view).
         """
         renderer = self._renderer
         if renderer is None:

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -62,14 +62,17 @@ feed).  Without ``BSPoints`` the mapper falls back to the flat quad's own
 vertices and paints the distance field on a fixed plane — the
 non-coherent / non-reactive fixed-quad failure mode.
 
-The VTK objects are soft dependencies — same pattern as
-``ConfirmedRepresentation``: a pure-Python pytest run skips the VTK-only
-branches, while a Slicer process (or any environment with VTK on
-``PYTHONPATH``) exercises the full pipeline.  The relocated 2D mapper
-(``vtkOpenGLResection2DPolyDataMapper``) and the ``vtkBezierSurfaceSource``
-are reachable only inside a Slicer process, so their use is gated behind
-``hasattr`` / import guards and the generic VTK fallbacks keep the
-skeleton importable everywhere.
+The relocated 2D mapper (``vtkOpenGLResection2DPolyDataMapper``) is a
+custom wrapped-C++ class reachable only inside a Slicer process; it is
+injected, not silently discovered (ADR-0014 §3).  In production the
+``resection_mapper_2d`` constructor argument is ``None`` and this
+Representation resolves the real wrapped class (raising if it is off the
+path — a real misconfiguration must not degrade to a shader-less generic
+mapper); the bare-VTK unit layer (ADR-0008 §2) injects a generic
+``vtkPolyDataMapper`` instance.  The flattened-quad SOURCE is NOT custom:
+``vtkBezierSurfaceSource`` is preferred but degrades to base VTK's
+``vtkPlaneSource`` (always present), and the distance-map texture /
+aspect-ratio helpers stay behind soft import guards.
 
 References
 ----------
@@ -118,11 +121,16 @@ class FlattenedSurfaceRepresentation:
 
     Constructor
     -----------
-    ``FlattenedSurfaceRepresentation(renderer=None)``
+    ``FlattenedSurfaceRepresentation(renderer=None, *, resection_mapper_2d=None)``
 
     * ``renderer`` — the ``vtkRenderer`` the resectogram actor is added
       to.  Optional; ``None`` is supported for unit tests (the actor
       exists but is unrendered).
+    * ``resection_mapper_2d`` — the custom 2D-mapper INSTANCE (dependency
+      injection, ADR-0014 §3).  ``None`` (production) resolves the real
+      ``vtkOpenGLResection2DPolyDataMapper``, raising if it is off the
+      path.  An injected instance (bare-VTK unit layer, ADR-0008 §2) is
+      used as-is.  The flattened-quad source is not affected.
 
     Public methods
     --------------
@@ -149,7 +157,12 @@ class FlattenedSurfaceRepresentation:
       overlay renderer hosting it, and whether blur is currently engaged.
     """
 
-    def __init__(self, renderer: Any | None = None) -> None:
+    def __init__(
+        self,
+        renderer: Any | None = None,
+        *,
+        resection_mapper_2d: Any | None = None,
+    ) -> None:
         self._renderer: Any | None = None
 
         self._bezier_plane: Any | None = None
@@ -200,7 +213,7 @@ class FlattenedSurfaceRepresentation:
         self._last_surface_signature: tuple | None = None
         self._input_refresh_count: int = 0
 
-        self._build_vtk_pipeline()
+        self._build_vtk_pipeline(resection_mapper_2d)
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -310,20 +323,26 @@ class FlattenedSurfaceRepresentation:
     # Internal helpers
     # ------------------------------------------------------------------ #
 
-    def _build_vtk_pipeline(self) -> None:
+    def _build_vtk_pipeline(self, resection_mapper_2d: Any | None) -> None:
         """Construct the flattened-quad source, 2D mapper, actor + camera.
 
-        Prefers the relocated ``vtkOpenGLResection2DPolyDataMapper`` and
-        ``vtkBezierSurfaceSource`` (reachable inside a Slicer process);
-        falls back to a generic ``vtkPolyDataMapper`` + ``vtkPlaneSource``
-        so the skeleton stays importable in a bare VTK environment.  The
-        public API is invariant across the fallback — only the concrete
-        mapper / source types flip.
+        The 2D mapper is injected, not silently discovered (ADR-0014 §3): a
+        ``None`` argument (production) resolves the real relocated
+        ``vtkOpenGLResection2DPolyDataMapper``, raising if it is off the path;
+        an injected instance (bare-VTK unit layer, ADR-0008 §2) is used as-is.
+
+        The flattened-quad source is NOT custom: ``vtkBezierSurfaceSource`` is
+        preferred but degrades to base VTK's ``vtkPlaneSource`` (always
+        present), so it keeps its resolve-or-fallback shape.
         """
         self._bezier_plane = _make_flattened_quad_source()
         _initialise_flattened_quad(self._bezier_plane)
 
-        mapper = _make_resection_mapper_2d()
+        mapper = (
+            resection_mapper_2d
+            if resection_mapper_2d is not None
+            else _make_resection_mapper_2d()
+        )
         if self._bezier_plane is not None and hasattr(mapper, "SetInputConnection"):
             mapper.SetInputConnection(self._bezier_plane.GetOutputPort())
         self._resection_mapper_2d = mapper
@@ -891,21 +910,25 @@ def _quad_source_bounds(plane: Any) -> tuple | None:
 
 
 def _make_resection_mapper_2d() -> Any:
-    """Return the resectogram's 2D mapper.
+    """Return the resectogram's 2D mapper instance, or raise.
 
-    Prefers the relocated ``vtkOpenGLResection2DPolyDataMapper``
-    (``LiverResections/VTKWidgets/``, reachable in a Slicer process);
-    falls back to a generic ``vtkPolyDataMapper``.
+    Resolves the relocated ``vtkOpenGLResection2DPolyDataMapper``
+    (``LiverResections/VTKWidgets/``, reachable in a Slicer process).
+    Raises ``RuntimeError`` when it is off the path — a real
+    misconfiguration in production (ADR-0014 §3) must fail loudly rather
+    than degrade to a shader-less generic mapper.  Bare-VTK unit tests
+    (ADR-0008 §2) avoid this path by injecting a mapper instance instead.
     """
-    factory = getattr(vtk, "vtkOpenGLResection2DPolyDataMapper", None)
+    factory = _import_wrapped_class("vtkOpenGLResection2DPolyDataMapper")
     if factory is None:
-        try:  # pragma: no cover — exercised inside Slicer
-            from slicer import vtkOpenGLResection2DPolyDataMapper as factory  # type: ignore[no-redef]
-        except Exception:
-            factory = None
-    if factory is not None:
-        return factory()
-    return vtk.vtkPolyDataMapper()
+        raise RuntimeError(
+            "vtkOpenGLResection2DPolyDataMapper is not reachable from the "
+            "'vtk' or 'slicer' namespace.  It is a wrapped-C++ class relocated "
+            "to LiverResections/VTKWidgets/ (ADR-0014 §3) and available only "
+            "inside a launched Slicer with the module loaded.  Inject a mapper "
+            "instance for bare-VTK unit tests (ADR-0008 §2)."
+        )
+    return factory()
 
 
 def _make_gaussian_blur_pass() -> Any | None:

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -139,7 +139,7 @@ class FlattenedSurfaceRepresentation:
     Introspection (used by unit tests)
     ----------------------------------
     * ``GetResectionMapper2D()`` / ``GetResectionActor2D()`` — the 2D
-      mapper + actor pair, or ``None`` before the pipeline is built.
+      mapper + actor pair, or ``None`` when VTK is absent.
     * ``GetResectogramCamera()`` — the private overlay camera.
     * ``GetMatRatioApplied()`` — last ``MatRatio`` pushed onto the 2D
       mapper, or ``None`` before the first ``update()`` / when the
@@ -767,8 +767,8 @@ class FlattenedSurfaceRepresentation:
         reconciles the pass without rebuilding the assembly — the
         ``vtkSetMacro(BlurEnabled, bool)`` ``Modified()`` advances the display
         node's MTime, which ``ResectogramPipeline.UpdatePipeline`` already
-        keys on, so no new observer is needed.  No-op when the renderer
-        is unavailable (no realized view).
+        keys on, so no new observer is needed.  No-op when VTK or the renderer
+        is unavailable (bare-VTK pytest path).
         """
         renderer = self._renderer
         if renderer is None:
@@ -893,12 +893,9 @@ def _quad_source_bounds(plane: Any) -> tuple | None:
 def _make_resection_mapper_2d() -> Any:
     """Return the resectogram's 2D mapper.
 
-    The relocated ``vtkOpenGLResection2DPolyDataMapper``
-    (``LiverResections/VTKWidgets/``) is a hard requirement: a resolver miss is
-    a misconfiguration (the LiverResections module is not loaded / not wrapped)
-    that must surface LOUDLY, not degrade to a generic ``vtkPolyDataMapper``
-    with no ``sampler3D`` to paint the distance-field band (ADR-0008 §2 — the
-    no-VTK unit layer this once degraded for was never built).
+    Prefers the relocated ``vtkOpenGLResection2DPolyDataMapper``
+    (``LiverResections/VTKWidgets/``, reachable in a Slicer process);
+    falls back to a generic ``vtkPolyDataMapper``.
     """
     factory = getattr(vtk, "vtkOpenGLResection2DPolyDataMapper", None)
     if factory is None:
@@ -906,15 +903,9 @@ def _make_resection_mapper_2d() -> Any:
             from slicer import vtkOpenGLResection2DPolyDataMapper as factory  # type: ignore[no-redef]
         except Exception:
             factory = None
-    if factory is None:
-        raise RuntimeError(
-            "FlattenedSurfaceRepresentation requires the relocated "
-            "vtkOpenGLResection2DPolyDataMapper (ADR-0014 §3); neither the "
-            "'slicer' nor the 'vtk' namespace exposes it.  Load the "
-            "LiverResections module so its wrapped VTKWidgets classes are on "
-            "the path."
-        )
-    return factory()
+    if factory is not None:
+        return factory()
+    return vtk.vtkPolyDataMapper()
 
 
 def _make_gaussian_blur_pass() -> Any | None:

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -893,9 +893,12 @@ def _quad_source_bounds(plane: Any) -> tuple | None:
 def _make_resection_mapper_2d() -> Any:
     """Return the resectogram's 2D mapper.
 
-    Prefers the relocated ``vtkOpenGLResection2DPolyDataMapper``
-    (``LiverResections/VTKWidgets/``, reachable in a Slicer process);
-    falls back to a generic ``vtkPolyDataMapper``.
+    The relocated ``vtkOpenGLResection2DPolyDataMapper``
+    (``LiverResections/VTKWidgets/``) is a hard requirement: a resolver miss is
+    a misconfiguration (the LiverResections module is not loaded / not wrapped)
+    that must surface LOUDLY, not degrade to a generic ``vtkPolyDataMapper``
+    with no ``sampler3D`` to paint the distance-field band (ADR-0008 §2 — the
+    no-VTK unit layer this once degraded for was never built).
     """
     factory = getattr(vtk, "vtkOpenGLResection2DPolyDataMapper", None)
     if factory is None:
@@ -903,9 +906,15 @@ def _make_resection_mapper_2d() -> Any:
             from slicer import vtkOpenGLResection2DPolyDataMapper as factory  # type: ignore[no-redef]
         except Exception:
             factory = None
-    if factory is not None:
-        return factory()
-    return vtk.vtkPolyDataMapper()
+    if factory is None:
+        raise RuntimeError(
+            "FlattenedSurfaceRepresentation requires the relocated "
+            "vtkOpenGLResection2DPolyDataMapper (ADR-0014 §3); neither the "
+            "'slicer' nor the 'vtk' namespace exposes it.  Load the "
+            "LiverResections module so its wrapped VTKWidgets classes are on "
+            "the path."
+        )
+    return factory()
 
 
 def _make_gaussian_blur_pass() -> Any | None:

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -88,17 +88,7 @@ from __future__ import annotations
 
 from typing import Any
 
-# --------------------------------------------------------------------------- #
-# VTK is a soft dependency (see module docstring).
-# --------------------------------------------------------------------------- #
-
-try:  # pragma: no cover — exercised inside Slicer / when VTK is available
-    import vtk
-
-    _HAS_VTK = True
-except ImportError:  # pragma: no cover — pure-Python path
-    vtk = None  # type: ignore[assignment]
-    _HAS_VTK = False
+import vtk
 
 
 # --------------------------------------------------------------------------- #
@@ -210,8 +200,7 @@ class FlattenedSurfaceRepresentation:
         self._last_surface_signature: tuple | None = None
         self._input_refresh_count: int = 0
 
-        if _HAS_VTK:
-            self._build_vtk_pipeline()
+        self._build_vtk_pipeline()
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -331,8 +320,6 @@ class FlattenedSurfaceRepresentation:
         public API is invariant across the fallback — only the concrete
         mapper / source types flip.
         """
-        assert vtk is not None  # gated by _HAS_VTK
-
         self._bezier_plane = _make_flattened_quad_source()
         _initialise_flattened_quad(self._bezier_plane)
 
@@ -424,7 +411,7 @@ class FlattenedSurfaceRepresentation:
         points, or the legacy 16-point grid is not yet complete — the caller
         then degrades to the prior fixed-quad fallback (no crash).
         """
-        if not _HAS_VTK or data_node is None:
+        if data_node is None:
             return None
 
         control_points = _read_control_points(data_node)
@@ -784,7 +771,7 @@ class FlattenedSurfaceRepresentation:
         is unavailable (bare-VTK pytest path).
         """
         renderer = self._renderer
-        if renderer is None or not _HAS_VTK:
+        if renderer is None:
             return
         if not hasattr(renderer, "SetPass"):
             return
@@ -848,8 +835,6 @@ def _make_flattened_quad_source() -> Any | None:
     ``BezierPlane`` (reachable in a Slicer process); falls back to a
     generic ``vtkPlaneSource`` so the skeleton stays importable.
     """
-    if not _HAS_VTK:
-        return None
     factory = getattr(vtk, "vtkBezierSurfaceSource", None)
     if factory is None:
         try:  # pragma: no cover — exercised inside Slicer
@@ -912,7 +897,6 @@ def _make_resection_mapper_2d() -> Any:
     (``LiverResections/VTKWidgets/``, reachable in a Slicer process);
     falls back to a generic ``vtkPolyDataMapper``.
     """
-    assert vtk is not None
     factory = getattr(vtk, "vtkOpenGLResection2DPolyDataMapper", None)
     if factory is None:
         try:  # pragma: no cover — exercised inside Slicer
@@ -934,8 +918,6 @@ def _make_gaussian_blur_pass() -> Any | None:
     (older VTK / bare environment), leaving the renderer on its default
     forward pass.
     """
-    if not _HAS_VTK:
-        return None
     blur_factory = getattr(vtk, "vtkGaussianBlurPass", None)
     steps_factory = getattr(vtk, "vtkRenderStepsPass", None)
     if blur_factory is None or steps_factory is None:
@@ -975,10 +957,9 @@ def _import_wrapped_class(name: str) -> Any | None:
     namespace; returns ``None`` in a bare-VTK pytest run where the wrapped
     class is not importable, so the calling branch degrades gracefully.
     """
-    if _HAS_VTK:
-        factory = getattr(vtk, name, None)
-        if factory is not None:
-            return factory
+    factory = getattr(vtk, name, None)
+    if factory is not None:
+        return factory
     try:  # pragma: no cover — exercised inside Slicer
         import slicer  # type: ignore[import-not-found]
 
@@ -1058,7 +1039,7 @@ def _read_control_points(data_node: Any | None) -> Any | None:
     mid-placement), or a read raises — the caller then keeps the fixed-quad
     fallback.
     """
-    if not _HAS_VTK or data_node is None:
+    if data_node is None:
         return None
     grid_getter = getattr(data_node, "GetControlGridVector", None)
     if grid_getter is None:

--- a/LiverResections/LiverResectionsLib/Representations/SlicingPlaneInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/SlicingPlaneInitRepresentation.py
@@ -86,21 +86,7 @@ from __future__ import annotations
 
 from typing import Any
 
-# --------------------------------------------------------------------------- #
-# VTK is a soft dependency — mirrors the pattern in
-# ``BezierPlanningRepresentation``.  When ``vtk`` is not importable the
-# Representation can still be constructed; ``update()`` then writes the
-# colour / opacity stubs without building any VTK pipeline, which is
-# enough for the smoke-level unit tests.  See ADR-0008 §2.
-# --------------------------------------------------------------------------- #
-
-try:  # pragma: no cover — exercised inside Slicer / when VTK is available
-    import vtk
-
-    _HAS_VTK = True
-except ImportError:  # pragma: no cover — pure-Python path
-    vtk = None  # type: ignore[assignment]
-    _HAS_VTK = False
+import vtk
 
 
 # --------------------------------------------------------------------------- #
@@ -220,8 +206,7 @@ class SlicingPlaneInitRepresentation:
         # plus origin + normal.  The per-frame visual feedback is the
         # shader's job; this Representation produces the discrete ring
         # once, on the Init->Planning commit boundary (ADR-0019).
-        if _HAS_VTK:
-            self._build_vtk_pipeline()
+        self._build_vtk_pipeline()
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -263,7 +248,7 @@ class SlicingPlaneInitRepresentation:
         the data node, and stores the resulting ordered ring.  Returns
         the ring ``vtkPolyData`` (or ``None`` when extraction cannot run).
         """
-        if target_model is None or not _HAS_VTK:
+        if target_model is None:
             return None
         polydata = _model_polydata(target_model)
         if polydata is None:
@@ -342,10 +327,8 @@ class SlicingPlaneInitRepresentation:
     def _build_vtk_pipeline(self) -> None:
         """Construct the marker + plane actors.
 
-        Called from ``__init__`` only when ``vtk`` is importable.
+        Called from ``__init__``.
         """
-        assert vtk is not None  # for the type-checker — gated by _HAS_VTK
-
         # Two marker spheres — one per init point.
         for _ in range(2):
             sphere = vtk.vtkSphereSource()
@@ -476,9 +459,6 @@ class SlicingPlaneInitRepresentation:
         self._last_input_signature = signature
         self._input_refresh_count += 1
 
-        if not _HAS_VTK:
-            return
-
         self._refresh_marker_positions(init0, init1)
         self._refresh_plane(origin, normal, init0, init1)
 
@@ -509,7 +489,6 @@ class SlicingPlaneInitRepresentation:
         """
         if self._plane_source is None:
             return
-        assert vtk is not None
 
         plane = self._plane_source
 

--- a/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
@@ -41,17 +41,7 @@ from __future__ import annotations
 
 from typing import Any
 
-# --------------------------------------------------------------------------- #
-# VTK is a soft dependency (see module docstring).
-# --------------------------------------------------------------------------- #
-
-try:  # pragma: no cover — exercised inside Slicer / when VTK is available
-    import vtk
-
-    _HAS_VTK = True
-except ImportError:  # pragma: no cover — pure-Python path
-    vtk = None  # type: ignore[assignment]
-    _HAS_VTK = False
+import vtk
 
 
 class VascularContourRepresentation:
@@ -89,8 +79,7 @@ class VascularContourRepresentation:
 
         self._update_count: int = 0
 
-        if _HAS_VTK:
-            self._build_vtk_pipeline()
+        self._build_vtk_pipeline()
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -170,8 +159,6 @@ class VascularContourRepresentation:
         ``vtkPolyDataMapper`` so the skeleton stays importable in a bare
         VTK environment.
         """
-        assert vtk is not None  # gated by _HAS_VTK
-
         self._distance_contour_mapper = _make_contour_mapper(
             "vtkOpenGLDistanceContourPolyDataMapper"
         )
@@ -236,7 +223,6 @@ def _make_contour_mapper(class_name: str) -> Any:
     the ``vtk`` module (wrapped) or the ``slicer`` namespace; a bare-VTK
     pytest run gets the generic ``vtkPolyDataMapper`` fallback.
     """
-    assert vtk is not None
     factory = getattr(vtk, class_name, None)
     if factory is None:
         try:  # pragma: no cover — exercised inside Slicer

--- a/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
@@ -19,11 +19,15 @@ Scope of this skeleton
 ----------------------
 Per the T3 bounded slice this skeleton COMPOSES the contour overlays and
 wires the display-node fields it consumes, but it does NOT yet sever the
-overlays out of the v1 monolith (a separate follow-up).  The contour
-mappers are reachable only inside a Slicer process, so their use is
-gated behind ``hasattr`` / import guards and the generic VTK fallbacks
-keep the skeleton importable everywhere (same soft-VTK pattern as
-``ConfirmedRepresentation`` and ``FlattenedSurfaceRepresentation``).
+overlays out of the v1 monolith (a separate follow-up).  The two contour
+mappers are custom wrapped-C++ classes reachable only inside a Slicer
+process; they are injected, not silently discovered (ADR-0014 §3).  In
+production the ``distance_contour_mapper`` / ``slicing_contour_mapper``
+constructor arguments are ``None`` and this Representation resolves the
+real wrapped classes (raising if either is off the path — a real
+misconfiguration must not degrade to a shader-less generic mapper).  The
+bare-VTK unit layer (ADR-0008 §2) injects generic ``vtkPolyDataMapper``
+instances.
 
 References
 ----------
@@ -49,10 +53,18 @@ class VascularContourRepresentation:
 
     Constructor
     -----------
-    ``VascularContourRepresentation(renderer=None)``
+    ``VascularContourRepresentation(renderer=None, *,
+    distance_contour_mapper=None, slicing_contour_mapper=None)``
 
     * ``renderer`` — the ``vtkRenderer`` the contour actors are added
       to.  Optional; ``None`` is supported for unit tests.
+    * ``distance_contour_mapper`` / ``slicing_contour_mapper`` — the two
+      custom contour-mapper INSTANCES (dependency injection, ADR-0014
+      §3).  ``None`` (production) resolves the real
+      ``vtkOpenGLDistanceContourPolyDataMapper`` /
+      ``vtkOpenGLSlicingContourPolyDataMapper``, raising if either is off
+      the path.  Injected instances (bare-VTK unit layer, ADR-0008 §2)
+      are used as-is.
 
     Public methods
     --------------
@@ -69,7 +81,13 @@ class VascularContourRepresentation:
       the matching actors.
     """
 
-    def __init__(self, renderer: Any | None = None) -> None:
+    def __init__(
+        self,
+        renderer: Any | None = None,
+        *,
+        distance_contour_mapper: Any | None = None,
+        slicing_contour_mapper: Any | None = None,
+    ) -> None:
         self._renderer: Any | None = None
 
         self._distance_contour_mapper: Any | None = None
@@ -79,7 +97,7 @@ class VascularContourRepresentation:
 
         self._update_count: int = 0
 
-        self._build_vtk_pipeline()
+        self._build_vtk_pipeline(distance_contour_mapper, slicing_contour_mapper)
 
         if renderer is not None:
             self.SetRenderer(renderer)
@@ -150,24 +168,33 @@ class VascularContourRepresentation:
     # Internal helpers
     # ------------------------------------------------------------------ #
 
-    def _build_vtk_pipeline(self) -> None:
+    def _build_vtk_pipeline(
+        self,
+        distance_contour_mapper: Any | None,
+        slicing_contour_mapper: Any | None,
+    ) -> None:
         """Construct the two contour mappers + their actors.
 
-        Prefers the relocated ``vtkOpenGLDistanceContourPolyDataMapper``
-        / ``vtkOpenGLSlicingContourPolyDataMapper``
-        (``LiverResections/VTKWidgets/``); falls back to a generic
-        ``vtkPolyDataMapper`` so the skeleton stays importable in a bare
-        VTK environment.
+        Each mapper is injected, not silently discovered (ADR-0014 §3): a
+        ``None`` argument (production) resolves the real relocated
+        ``vtkOpenGLDistanceContourPolyDataMapper`` /
+        ``vtkOpenGLSlicingContourPolyDataMapper``, raising if it is off the
+        path; an injected instance (bare-VTK unit layer, ADR-0008 §2) is
+        used as-is.
         """
-        self._distance_contour_mapper = _make_contour_mapper(
-            "vtkOpenGLDistanceContourPolyDataMapper"
+        self._distance_contour_mapper = (
+            distance_contour_mapper
+            if distance_contour_mapper is not None
+            else _make_contour_mapper("vtkOpenGLDistanceContourPolyDataMapper")
         )
         self._distance_contour_actor = vtk.vtkActor()
         self._distance_contour_actor.SetMapper(self._distance_contour_mapper)
         self._distance_contour_actor.SetVisibility(False)
 
-        self._slicing_contour_mapper = _make_contour_mapper(
-            "vtkOpenGLSlicingContourPolyDataMapper"
+        self._slicing_contour_mapper = (
+            slicing_contour_mapper
+            if slicing_contour_mapper is not None
+            else _make_contour_mapper("vtkOpenGLSlicingContourPolyDataMapper")
         )
         self._slicing_contour_actor = vtk.vtkActor()
         self._slicing_contour_actor.SetMapper(self._slicing_contour_mapper)
@@ -217,23 +244,38 @@ class VascularContourRepresentation:
 
 
 def _make_contour_mapper(class_name: str) -> Any:
-    """Return a relocated contour mapper by class name, or a generic fallback.
+    """Return a relocated contour mapper instance by class name, or raise.
 
-    The custom contour mappers are reachable from a Slicer process via
-    the ``vtk`` module (wrapped) or the ``slicer`` namespace; a bare-VTK
-    pytest run gets the generic ``vtkPolyDataMapper`` fallback.
+    The custom contour mappers are reachable from a Slicer process via the
+    ``vtk`` module (wrapped) or the ``slicer`` namespace.  Raises
+    ``RuntimeError`` when neither namespace exposes the class — a real
+    misconfiguration in production (ADR-0014 §3) must fail loudly rather
+    than degrade to a shader-less generic mapper.  Bare-VTK unit tests
+    (ADR-0008 §2) avoid this path by injecting a mapper instance instead.
     """
-    factory = getattr(vtk, class_name, None)
+    factory = _require_vtk_class(class_name)
+    return factory()
+
+
+def _require_vtk_class(name: str) -> Any:
+    """Resolve a wrapped-C++ class by name from ``vtk`` then ``slicer``, or raise."""
+    factory = getattr(vtk, name, None)
     if factory is None:
         try:  # pragma: no cover — exercised inside Slicer
             import slicer
 
-            factory = getattr(slicer, class_name, None)
+            factory = getattr(slicer, name, None)
         except Exception:
             factory = None
-    if factory is not None:
-        return factory()
-    return vtk.vtkPolyDataMapper()
+    if factory is None:
+        raise RuntimeError(
+            f"{name} is not reachable from the 'vtk' or 'slicer' namespace. "
+            "It is a wrapped-C++ class relocated to LiverResections/VTKWidgets/ "
+            "(ADR-0014 §3) and available only inside a launched Slicer with the "
+            "module loaded.  Inject a mapper instance for bare-VTK unit tests "
+            "(ADR-0008 §2)."
+        )
+    return factory
 
 
 def _safe_get_strip_polydata(data_node: Any | None) -> Any | None:

--- a/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
@@ -217,11 +217,15 @@ class VascularContourRepresentation:
 
 
 def _make_contour_mapper(class_name: str) -> Any:
-    """Return a relocated contour mapper by class name, or a generic fallback.
+    """Return a relocated contour mapper by class name.
 
-    The custom contour mappers are reachable from a Slicer process via
-    the ``vtk`` module (wrapped) or the ``slicer`` namespace; a bare-VTK
-    pytest run gets the generic ``vtkPolyDataMapper`` fallback.
+    The custom contour mappers are reachable from a Slicer process via the
+    ``vtk`` module (wrapped) or the ``slicer`` namespace.  They are a hard
+    requirement: a resolver miss is a misconfiguration (the LiverResections
+    module is not loaded / not wrapped) that must surface LOUDLY, not degrade
+    to a generic ``vtkPolyDataMapper`` whose fragment shader draws no contour
+    (ADR-0008 §2 — the no-VTK unit layer this once degraded for was never
+    built).
     """
     factory = getattr(vtk, class_name, None)
     if factory is None:
@@ -231,9 +235,14 @@ def _make_contour_mapper(class_name: str) -> Any:
             factory = getattr(slicer, class_name, None)
         except Exception:
             factory = None
-    if factory is not None:
-        return factory()
-    return vtk.vtkPolyDataMapper()
+    if factory is None:
+        raise RuntimeError(
+            f"VascularContourRepresentation requires the relocated {class_name} "
+            "(ADR-0014 §3); neither the 'slicer' nor the 'vtk' namespace "
+            "exposes it.  Load the LiverResections module so its wrapped "
+            "VTKWidgets classes are on the path."
+        )
+    return factory()
 
 
 def _safe_get_strip_polydata(data_node: Any | None) -> Any | None:

--- a/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
@@ -19,11 +19,10 @@ Scope of this skeleton
 ----------------------
 Per the T3 bounded slice this skeleton COMPOSES the contour overlays and
 wires the display-node fields it consumes, but it does NOT yet sever the
-overlays out of the v1 monolith (a separate follow-up).  The contour
-mappers are reachable only inside a Slicer process, so their use is
-gated behind ``hasattr`` / import guards and the generic VTK fallbacks
-keep the skeleton importable everywhere (same soft-VTK pattern as
-``ConfirmedRepresentation`` and ``FlattenedSurfaceRepresentation``).
+overlays out of the v1 monolith (a separate follow-up).  The relocated
+contour mappers (ADR-0014 §3) are a hard requirement: ``_make_contour_mapper``
+raises if they cannot be resolved from a launched Slicer process, rather than
+silently degrading to a shader-less generic mapper.
 
 References
 ----------
@@ -64,7 +63,7 @@ class VascularContourRepresentation:
     Introspection (used by unit tests)
     ----------------------------------
     * ``GetDistanceContourMapper()`` / ``GetSlicingContourMapper()`` —
-      the two contour mappers, or ``None`` when VTK is absent.
+      the two contour mappers, or ``None`` before the pipeline is built.
     * ``GetDistanceContourActor()`` / ``GetSlicingContourActor()`` —
       the matching actors.
     """
@@ -153,11 +152,11 @@ class VascularContourRepresentation:
     def _build_vtk_pipeline(self) -> None:
         """Construct the two contour mappers + their actors.
 
-        Prefers the relocated ``vtkOpenGLDistanceContourPolyDataMapper``
+        Requires the relocated ``vtkOpenGLDistanceContourPolyDataMapper``
         / ``vtkOpenGLSlicingContourPolyDataMapper``
-        (``LiverResections/VTKWidgets/``); falls back to a generic
-        ``vtkPolyDataMapper`` so the skeleton stays importable in a bare
-        VTK environment.
+        (``LiverResections/VTKWidgets/``, ADR-0014 §3); ``_make_contour_mapper``
+        raises if they cannot be resolved rather than silently degrading to a
+        shader-less generic mapper.
         """
         self._distance_contour_mapper = _make_contour_mapper(
             "vtkOpenGLDistanceContourPolyDataMapper"

--- a/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
@@ -186,12 +186,12 @@ class VascularContourRepresentation:
         strip = _safe_get_strip_polydata(data_node)
         if strip is None:
             return
+        # Both contour mappers are the real custom mappers (a hard requirement,
+        # ADR-0014 §3) -- vtkPolyDataMapper subclasses that always expose
+        # SetInputData -- so the strip is fed with a direct call.
         for mapper in (self._distance_contour_mapper, self._slicing_contour_mapper):
-            if mapper is None:
-                continue
-            setter = getattr(mapper, "SetInputData", None)
-            if setter is not None:
-                setter(strip)
+            if mapper is not None:
+                mapper.SetInputData(strip)
 
     def _attach_actors(self, renderer: Any) -> None:
         if not hasattr(renderer, "AddActor"):

--- a/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/VascularContourRepresentation.py
@@ -19,10 +19,11 @@ Scope of this skeleton
 ----------------------
 Per the T3 bounded slice this skeleton COMPOSES the contour overlays and
 wires the display-node fields it consumes, but it does NOT yet sever the
-overlays out of the v1 monolith (a separate follow-up).  The relocated
-contour mappers (ADR-0014 §3) are a hard requirement: ``_make_contour_mapper``
-raises if they cannot be resolved from a launched Slicer process, rather than
-silently degrading to a shader-less generic mapper.
+overlays out of the v1 monolith (a separate follow-up).  The contour
+mappers are reachable only inside a Slicer process, so their use is
+gated behind ``hasattr`` / import guards and the generic VTK fallbacks
+keep the skeleton importable everywhere (same soft-VTK pattern as
+``ConfirmedRepresentation`` and ``FlattenedSurfaceRepresentation``).
 
 References
 ----------
@@ -63,7 +64,7 @@ class VascularContourRepresentation:
     Introspection (used by unit tests)
     ----------------------------------
     * ``GetDistanceContourMapper()`` / ``GetSlicingContourMapper()`` —
-      the two contour mappers, or ``None`` before the pipeline is built.
+      the two contour mappers, or ``None`` when VTK is absent.
     * ``GetDistanceContourActor()`` / ``GetSlicingContourActor()`` —
       the matching actors.
     """
@@ -152,11 +153,11 @@ class VascularContourRepresentation:
     def _build_vtk_pipeline(self) -> None:
         """Construct the two contour mappers + their actors.
 
-        Requires the relocated ``vtkOpenGLDistanceContourPolyDataMapper``
+        Prefers the relocated ``vtkOpenGLDistanceContourPolyDataMapper``
         / ``vtkOpenGLSlicingContourPolyDataMapper``
-        (``LiverResections/VTKWidgets/``, ADR-0014 §3); ``_make_contour_mapper``
-        raises if they cannot be resolved rather than silently degrading to a
-        shader-less generic mapper.
+        (``LiverResections/VTKWidgets/``); falls back to a generic
+        ``vtkPolyDataMapper`` so the skeleton stays importable in a bare
+        VTK environment.
         """
         self._distance_contour_mapper = _make_contour_mapper(
             "vtkOpenGLDistanceContourPolyDataMapper"
@@ -185,12 +186,12 @@ class VascularContourRepresentation:
         strip = _safe_get_strip_polydata(data_node)
         if strip is None:
             return
-        # Both contour mappers are the real custom mappers (a hard requirement,
-        # ADR-0014 §3) -- vtkPolyDataMapper subclasses that always expose
-        # SetInputData -- so the strip is fed with a direct call.
         for mapper in (self._distance_contour_mapper, self._slicing_contour_mapper):
-            if mapper is not None:
-                mapper.SetInputData(strip)
+            if mapper is None:
+                continue
+            setter = getattr(mapper, "SetInputData", None)
+            if setter is not None:
+                setter(strip)
 
     def _attach_actors(self, renderer: Any) -> None:
         if not hasattr(renderer, "AddActor"):
@@ -216,15 +217,11 @@ class VascularContourRepresentation:
 
 
 def _make_contour_mapper(class_name: str) -> Any:
-    """Return a relocated contour mapper by class name.
+    """Return a relocated contour mapper by class name, or a generic fallback.
 
-    The custom contour mappers are reachable from a Slicer process via the
-    ``vtk`` module (wrapped) or the ``slicer`` namespace.  They are a hard
-    requirement: a resolver miss is a misconfiguration (the LiverResections
-    module is not loaded / not wrapped) that must surface LOUDLY, not degrade
-    to a generic ``vtkPolyDataMapper`` whose fragment shader draws no contour
-    (ADR-0008 §2 — the no-VTK unit layer this once degraded for was never
-    built).
+    The custom contour mappers are reachable from a Slicer process via
+    the ``vtk`` module (wrapped) or the ``slicer`` namespace; a bare-VTK
+    pytest run gets the generic ``vtkPolyDataMapper`` fallback.
     """
     factory = getattr(vtk, class_name, None)
     if factory is None:
@@ -234,14 +231,9 @@ def _make_contour_mapper(class_name: str) -> Any:
             factory = getattr(slicer, class_name, None)
         except Exception:
             factory = None
-    if factory is None:
-        raise RuntimeError(
-            f"VascularContourRepresentation requires the relocated {class_name} "
-            "(ADR-0014 §3); neither the 'slicer' nor the 'vtk' namespace "
-            "exposes it.  Load the LiverResections module so its wrapped "
-            "VTKWidgets classes are on the path."
-        )
-    return factory()
+    if factory is not None:
+        return factory()
+    return vtk.vtkPolyDataMapper()
 
 
 def _safe_get_strip_polydata(data_node: Any | None) -> Any | None:

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -179,6 +179,27 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;mapper-wiring"
     )
 
+    # Custom-OpenGL-mapper wiring -- the sibling Representations that carry a
+    # custom shader mapper (DistanceSpheroidInit -> DistanceContour;
+    # VascularContour -> DistanceContour + SlicingContour; FlattenedSurface ->
+    # Resection2D) drive the REAL relocated mappers (ADR-0014 §3), not the
+    # generic vtkPolyDataMapper.  Extends the Bezier surface-mapper invariant;
+    # the positive pin makes the no-real-mapper fallback removal safe (ADR-0008
+    # §2 -- the no-VTK unit layer the fallback aspired to was never built).
+    # Needs the wrapped mappers, so it runs green under the launched-Slicer
+    # `pytest_launched` row and SKIPS CLEANLY here under bare pytest (no
+    # slicer.mrmlScene / wrapped mapper classes off the path).  GL free.
+    add_test(
+      NAME LiverResections_custom_mapper_wiring
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_custom_mapper_wiring.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_custom_mapper_wiring PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;mapper-wiring"
+    )
+
     # T2 render-cutover slice 1c -- the LayerDM Pipeline reverse-resolves its
     # vtkMRMLResectionPlanNode wrapper from the data node's geometry
     # back-reference (ADR-0031), so the live render path threads the

--- a/LiverResections/Testing/Python/test_custom_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_custom_mapper_wiring.py
@@ -17,12 +17,13 @@ Representations that carry a custom OpenGL shader mapper (relocated to
   * ``FlattenedSurfaceRepresentation`` -- its 2D resection mapper IS the real
     ``vtkOpenGLResection2DPolyDataMapper``.
 
-These assertions are the invariant that makes it SAFE to convert the
-"custom mapper unresolved -> silent generic ``vtkPolyDataMapper`` fallback" into
-a LOUD hard requirement: once the mapper MUST be the real class under launched
-Slicer, a resolver miss is a misconfiguration to surface, not a shader-less
-degradation to tolerate (ADR-0008 §2 -- the "no-VTK unit layer" the fallback
-aspired to was never built).
+These assertions pin that in PRODUCTION (a launched Slicer) the render is backed
+by the REAL custom shader mapper, not a generic ``vtkPolyDataMapper``.  The
+Representations keep a generic-mapper fallback so they still construct in the
+bare-VTK unit layer (``Testing/Python/unit/``, ADR-0008 §2) where the wrapped
+classes are off the path; these launched invariants are what would catch that
+fallback silently backing a real render -- i.e. they make the production
+real-mapper guarantee testable without removing the unit-layer fallback.
 
 Genuinely-generic mappers (the ``DistanceSpheroidInit`` sphere markers, the
 ``SlicingPlaneInit`` plane mapper, the ``Confirmed`` surface mapper whose custom

--- a/LiverResections/Testing/Python/test_custom_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_custom_mapper_wiring.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Custom-OpenGL-mapper wiring -- the Representations drive the REAL mappers.
+
+Sibling of ``test_bezier_planning_surface_mapper_wiring.py``, which already pins
+"the Planning surface mapper IS the real ``vtkOpenGLBezierResectionPolyDataMapper``
+in launched Slicer."  This file extends that invariant to the OTHER
+Representations that carry a custom OpenGL shader mapper (relocated to
+``LiverResections/VTKWidgets/`` per ADR-0014 §3):
+
+  * ``DistanceSpheroidInitRepresentation`` -- its spheroid contour mapper IS the
+    real ``vtkOpenGLDistanceContourPolyDataMapper`` (the triaxial-ellipsoid
+    banding shader, ADR-0015 §"Stack 4").
+  * ``VascularContourRepresentation`` -- its two overlay mappers ARE the real
+    ``vtkOpenGLDistanceContourPolyDataMapper`` + ``vtkOpenGLSlicingContourPolyDataMapper``.
+  * ``FlattenedSurfaceRepresentation`` -- its 2D resection mapper IS the real
+    ``vtkOpenGLResection2DPolyDataMapper``.
+
+These assertions are the invariant that makes it SAFE to convert the
+"custom mapper unresolved -> silent generic ``vtkPolyDataMapper`` fallback" into
+a LOUD hard requirement: once the mapper MUST be the real class under launched
+Slicer, a resolver miss is a misconfiguration to surface, not a shader-less
+degradation to tolerate (ADR-0008 §2 -- the "no-VTK unit layer" the fallback
+aspired to was never built).
+
+Genuinely-generic mappers (the ``DistanceSpheroidInit`` sphere markers, the
+``SlicingPlaneInit`` plane mapper, the ``Confirmed`` surface mapper whose custom
+relocation has not landed) are DELIBERATELY not pinned here -- they are correct
+as plain ``vtkPolyDataMapper`` and must stay that way (no "colour-of-the-sky"
+absence assertions).
+
+-- WHY THIS IS A LAUNCHED-SLICER PYTEST --
+
+The custom mappers (LiverResections VTKWidgets) are wrapped-C++ classes reachable
+only inside a launched Slicer with the module loaded; a bare
+``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` and the wrapped
+classes off the path, so this SKIPS CLEANLY via the shared
+``slicer_pytest_support`` guards.  The Representations are plain Python + VTK;
+the tests need no render window.
+
+See also:
+  * Docs/adr/0014-livermarkups-dissolution.md §3   (mapper relocation)
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §6     (Representations as pipelines)
+  * Docs/adr/0008-testing-strategy.md §2             (the unbuilt no-VTK layer)
+  * LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+DISTANCE_CONTOUR_MAPPER_CLASS = "vtkOpenGLDistanceContourPolyDataMapper"
+SLICING_CONTOUR_MAPPER_CLASS = "vtkOpenGLSlicingContourPolyDataMapper"
+RESECTION_2D_MAPPER_CLASS = "vtkOpenGLResection2DPolyDataMapper"
+
+
+def _slicer_or_skip():
+    """Resolve a launched ``slicer`` module or skip cleanly under bare pytest."""
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _import_or_skip(module_name, class_name):
+    """Import ``class_name`` from ``LiverResectionsLib.Representations.<module>``.
+
+    Skips cleanly when the Representation is not importable in this environment
+    (a bare-pytest run skips earlier via ``_slicer_or_skip``).
+    """
+    try:
+        module = __import__(
+            f"LiverResectionsLib.Representations.{module_name}",
+            fromlist=[class_name],
+        )
+        return getattr(module, class_name)
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"{class_name} not importable ({exc!r}) -- the Representation is "
+            "not reachable in this environment."
+        )
+
+
+def _assert_is_real_mapper(mapper, expected_class):
+    """Assert ``mapper`` is the real wrapped ``expected_class``.
+
+    Mirrors ``test_bezier_planning_surface_mapper_wiring._require_real_mapper``'s
+    positive pin: under launched Slicer the custom mapper MUST resolve to the
+    relocated real class (ADR-0014 §3), never the generic ``vtkPolyDataMapper``.
+    """
+    assert mapper is not None, (
+        f"Representation must construct its {expected_class} mapper; got None."
+    )
+    assert mapper.IsA(expected_class), (
+        f"mapper must be the relocated real {expected_class} (ADR-0014 §3), "
+        f"got {type(mapper).__name__}."
+    )
+
+
+def test_distance_spheroid_uses_real_distance_contour_mapper():
+    """The spheroid contour mapper is the real ``vtkOpenGLDistanceContourPolyDataMapper``.
+
+    ``DistanceSpheroidInitRepresentation`` bands the triaxial-ellipsoid implicit
+    through the custom distance-contour shader (ADR-0015 §"Stack 4"); the sphere
+    MARKER mappers stay generic and are intentionally not pinned here.
+    """
+    _slicer_or_skip()
+    rep_class = _import_or_skip(
+        "DistanceSpheroidInitRepresentation", "DistanceSpheroidInitRepresentation"
+    )
+    rep = rep_class()
+    _assert_is_real_mapper(rep.GetSpheroidMapper(), DISTANCE_CONTOUR_MAPPER_CLASS)
+
+
+def test_vascular_contour_uses_real_contour_mappers():
+    """Both vascular-overlay mappers are the real custom contour mappers.
+
+    ``VascularContourRepresentation`` renders the distance- and slicing-contour
+    overlays through the relocated ``vtkOpenGLDistanceContourPolyDataMapper`` and
+    ``vtkOpenGLSlicingContourPolyDataMapper`` (ADR-0014 §3, ADR-0025 §Context).
+    """
+    _slicer_or_skip()
+    rep_class = _import_or_skip(
+        "VascularContourRepresentation", "VascularContourRepresentation"
+    )
+    rep = rep_class()
+    _assert_is_real_mapper(
+        rep.GetDistanceContourMapper(), DISTANCE_CONTOUR_MAPPER_CLASS
+    )
+    _assert_is_real_mapper(
+        rep.GetSlicingContourMapper(), SLICING_CONTOUR_MAPPER_CLASS
+    )
+
+
+def test_flattened_surface_uses_real_resection_2d_mapper():
+    """The resectogram 2D mapper is the real ``vtkOpenGLResection2DPolyDataMapper``.
+
+    ``FlattenedSurfaceRepresentation`` samples the distance field through the
+    relocated 2D resection mapper's ``sampler3D`` (ADR-0025 §Context).
+    """
+    _slicer_or_skip()
+    rep_class = _import_or_skip(
+        "FlattenedSurfaceRepresentation", "FlattenedSurfaceRepresentation"
+    )
+    rep = rep_class()
+    _assert_is_real_mapper(
+        rep.GetResectionMapper2D(), RESECTION_2D_MAPPER_CLASS
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverResections/Testing/Python/test_custom_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_custom_mapper_wiring.py
@@ -156,11 +156,11 @@ def test_flattened_surface_uses_real_resection_2d_mapper():
 def test_vascular_contour_feeds_strip_into_real_mappers():
     """``update()`` feeds the strip polydata into both real contour mappers.
 
-    Pins the now-unguarded ``mapper.SetInputData(strip)`` path in
-    ``_apply_strip_input``: the type-probe (``getattr(mapper, "SetInputData",
-    None)``) was dropped once the contour mappers became a hard requirement
-    (ADR-0014 §3), so this exercises the direct call against the REAL mappers --
-    an accidental over-removal, or a mapper lacking ``SetInputData``, fails here.
+    Pins the ``_apply_strip_input`` path end-to-end against the REAL contour
+    mappers (the relocated custom classes under launched Slicer, ADR-0014 §3):
+    a data node exposing the strip polydata drives ``SetInputData`` on both, so
+    a regression in the strip feed -- or a mapper that cannot take the input --
+    fails here rather than silently painting nothing.
     """
     _slicer_or_skip()
     import vtk

--- a/LiverResections/Testing/Python/test_custom_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_custom_mapper_wiring.py
@@ -152,5 +152,48 @@ def test_flattened_surface_uses_real_resection_2d_mapper():
     )
 
 
+def test_vascular_contour_feeds_strip_into_real_mappers():
+    """``update()`` feeds the strip polydata into both real contour mappers.
+
+    Pins the now-unguarded ``mapper.SetInputData(strip)`` path in
+    ``_apply_strip_input``: the type-probe (``getattr(mapper, "SetInputData",
+    None)``) was dropped once the contour mappers became a hard requirement
+    (ADR-0014 §3), so this exercises the direct call against the REAL mappers --
+    an accidental over-removal, or a mapper lacking ``SetInputData``, fails here.
+    """
+    _slicer_or_skip()
+    import vtk
+
+    rep_class = _import_or_skip(
+        "VascularContourRepresentation", "VascularContourRepresentation"
+    )
+    rep = rep_class()
+
+    # A data node exposing the conventional strip accessor
+    # (``_safe_get_strip_polydata``) with an identifiable 1-point polydata.
+    strip = vtk.vtkPolyData()
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 0.0)
+    strip.SetPoints(points)
+
+    class _StripDataNode:
+        def GetStripPolyData(self):
+            return strip
+
+    rep.update(None, _StripDataNode())
+
+    for accessor in (rep.GetDistanceContourMapper, rep.GetSlicingContourMapper):
+        mapper = accessor()
+        assert mapper is not None, "the real contour mapper must be constructed."
+        fed = mapper.GetInput()
+        # Compare via point count, not object identity (VTK's Python wrapper is
+        # not guaranteed to be the same PyObject across GetInput() calls).
+        assert fed is not None and fed.GetNumberOfPoints() == 1, (
+            "update() must feed the strip polydata into the real contour mapper "
+            "via SetInputData (the unguarded direct call after the mapper became "
+            "a hard requirement, ADR-0014 §3)."
+        )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/Testing/Python/unit/test_bezier_planning_representation.py
+++ b/Testing/Python/unit/test_bezier_planning_representation.py
@@ -89,11 +89,26 @@ class _StubDataNode:
 
 @pytest.fixture
 def rep_module():
+    """Return a factory that constructs the Representation with an injected mapper.
+
+    The custom ``vtkOpenGLBezierResectionPolyDataMapper`` is off the path in
+    the bare-VTK unit layer (ADR-0008 §2), so production's resolve-or-raise
+    path cannot run here; each construction injects a generic
+    ``vtkPolyDataMapper`` instance via the ``surface_mapper`` seam (ADR-0014
+    §3).  The ``_make_rep`` factory keeps every construction site injecting.
+    """
+    import vtk
+
     from Representations.BezierPlanningRepresentation import (
         BezierPlanningRepresentation,
     )
 
-    return BezierPlanningRepresentation
+    def _make_rep(renderer=None):
+        return BezierPlanningRepresentation(
+            renderer, surface_mapper=vtk.vtkPolyDataMapper()
+        )
+
+    return _make_rep
 
 
 # --------------------------------------------------------------------------- #

--- a/Testing/Python/unit/test_distance_spheroid_init_representation.py
+++ b/Testing/Python/unit/test_distance_spheroid_init_representation.py
@@ -113,11 +113,27 @@ class _StubDataNode:
 
 @pytest.fixture
 def rep_module():
+    """Return a factory that constructs the Representation with an injected mapper.
+
+    The custom ``vtkOpenGLDistanceContourPolyDataMapper`` (the spheroid
+    contour mapper) is off the path in the bare-VTK unit layer (ADR-0008 §2),
+    so production's resolve-or-raise path cannot run here; each construction
+    injects a generic ``vtkPolyDataMapper`` instance via the
+    ``spheroid_mapper`` seam (ADR-0014 §3).  The sphere-marker mappers are
+    genuinely generic and unaffected.
+    """
+    import vtk
+
     from Representations.DistanceSpheroidInitRepresentation import (
         DistanceSpheroidInitRepresentation,
     )
 
-    return DistanceSpheroidInitRepresentation
+    def _make_rep(renderer=None):
+        return DistanceSpheroidInitRepresentation(
+            renderer, spheroid_mapper=vtk.vtkPolyDataMapper()
+        )
+
+    return _make_rep
 
 
 # --------------------------------------------------------------------------- #

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -119,11 +119,27 @@ class _StubDataNode:
 
 @pytest.fixture
 def rep_module():
+    """Return a factory that constructs the Representation with an injected mapper.
+
+    The custom ``vtkOpenGLResection2DPolyDataMapper`` is off the path in the
+    bare-VTK unit layer (ADR-0008 §2), so production's resolve-or-raise path
+    cannot run here; each construction injects a generic ``vtkPolyDataMapper``
+    instance via the ``resection_mapper_2d`` seam (ADR-0014 §3).  Some tests
+    then swap in a MatRatio stub over that mapper; the injection just gets the
+    construction past the resolve-or-raise gate.
+    """
+    import vtk
+
     from Representations.FlattenedSurfaceRepresentation import (
         FlattenedSurfaceRepresentation,
     )
 
-    return FlattenedSurfaceRepresentation
+    def _make_rep(renderer=None):
+        return FlattenedSurfaceRepresentation(
+            renderer, resection_mapper_2d=vtk.vtkPolyDataMapper()
+        )
+
+    return _make_rep
 
 
 # --------------------------------------------------------------------------- #

--- a/Testing/Python/unit/test_vascular_contour_representation.py
+++ b/Testing/Python/unit/test_vascular_contour_representation.py
@@ -69,11 +69,29 @@ class _StubStripDataNode:
 
 @pytest.fixture
 def rep_module():
+    """Return a factory that constructs the Representation with injected mappers.
+
+    The two custom contour mappers (``vtkOpenGLDistanceContourPolyDataMapper``
+    / ``vtkOpenGLSlicingContourPolyDataMapper``) are off the path in the
+    bare-VTK unit layer (ADR-0008 §2), so production's resolve-or-raise path
+    cannot run here; each construction injects generic ``vtkPolyDataMapper``
+    instances via the ``distance_contour_mapper`` / ``slicing_contour_mapper``
+    seams (ADR-0014 §3).
+    """
+    import vtk
+
     from Representations.VascularContourRepresentation import (
         VascularContourRepresentation,
     )
 
-    return VascularContourRepresentation
+    def _make_rep(renderer=None):
+        return VascularContourRepresentation(
+            renderer,
+            distance_contour_mapper=vtk.vtkPolyDataMapper(),
+            slicing_contour_mapper=vtk.vtkPolyDataMapper(),
+        )
+
+    return _make_rep
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Contributes to #498 (see the scope note).

## Summary

Removes the **silent generic-mapper fallback** from the `LiverResections/LiverResectionsLib/` Representations by making the custom OpenGL mapper an **injected dependency**, and drops the dead `_HAS_VTK` guard.

## Design — inject the mapper (no silent production fallback)

Each Representation that owns a custom OpenGL shader mapper takes a keyword-only mapper instance:

- **Production** (no injection): resolves the real relocated class (`vtkOpenGLBezierResectionPolyDataMapper`, the contour mappers, `vtkOpenGLResection2DPolyDataMapper`) from the `slicer`/`vtk` namespace, and **raises `RuntimeError`** if it is unreachable — a misconfiguration surfaces loudly instead of rendering shader-less.
- **Bare-VTK unit layer** (`Testing/Python/unit/`, ADR-0008 §2): injects a generic `vtkPolyDataMapper()` stand-in explicitly, so the Representations stay constructible for fast, no-Slicer logic tests without a silent production fallback.

Genuinely-generic mappers (`DistanceSpheroidInit` sphere markers, `SlicingPlaneInit` plane, `Confirmed`'s not-yet-relocated surface mapper) and the base-VTK `vtkPlaneSource` quad source are unchanged. `_HAS_VTK` is removed (`import vtk` is unconditional — VTK imports in every context these load in).

## Also

- Adds `test_custom_mapper_wiring.py` (launched): pins that production drives the **real** custom mappers (no injection → default resolve path), plus that `VascularContour` feeds the strip into both real mappers. This is what catches a production silent-degradation now that the fallback is gone.
- Refreshes `Docs/architecture/rendering-pipeline.md` (relocation + cutover landed; retained unit-layer injection + still-generic `Confirmed` mapper called out).

## Scope note (vs the original #498)

#498's audit claimed there was no bare-VTK unit layer and the fallback was dead. There **is** one (`Testing/Python/unit/test_*_representation.py`, ~40 cases), so an earlier revision that converted the fallback to a hard raise + removed the type-probes broke it (caught by CI's `pytest_scaffold` row). This PR instead achieves #498's intent — no silent production degradation — via dependency injection, which preserves that unit layer. (#514, the colour-probe uniformity follow-up, was closed as moot: the probes are retained.)

## Tests
- Bare-VTK unit layer (`PythonSlicer -m pytest Testing/Python/unit/`): 84 passed, 26 skipped, 0 failed.
- Launched `LiverResections/Testing/Python`: 91 passed, 12 skipped, 1 xfailed, 0 failed.
- Verified no-injection construction raises loudly in bare-VTK (silent fallback gone).