### PR TITLE
ENH: Locator consumer — drive the resection shader marker off vtkMRMLLocatorNode (ADR-0025)

### DIFF
--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -197,6 +197,15 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         # dispatch (reset when the display/data node changes).
         self._last_resection_scan_mtime: int | None = None
 
+        # The cross-view locator node (ADR-0025), reverse-resolved from the
+        # scene (v2.0 has exactly one).  Observed so its picked-point changes
+        # re-dispatch; threaded onto the active Representation's consumer seam.
+        # Discovery is gated on the scene ``MTime`` (like the plan scan) so a
+        # position update to an already-resolved locator rides its own observer
+        # rather than a per-tick class scan.
+        self._locator_node: Any | None = None
+        self._last_locator_scan_mtime: int | None = None
+
         # Observer tags so ``cleanup()`` can detach precisely.  Index
         # by ``id(node)`` because ``vtkObject`` subclasses are not
         # universally hashable on identity.
@@ -298,6 +307,8 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         self._last_update_key = None
         # Force a fresh plan reverse-resolution for the new data node.
         self._last_resection_scan_mtime = None
+        # Force a fresh locator re-resolution too (ADR-0025).
+        self._last_locator_scan_mtime = None
         # Restart SlicingPlane init-placement for the new carrier (slice 3a).
         self._slicing_plane_points_placed = 0
         # Restart DistanceSpheroid init-placement for the new carrier (slice 3b).
@@ -337,6 +348,29 @@ class LiverBezierSurfacePipeline(_PipelineBase):
                 if resolved is not None:
                     self.SetResectionNode(resolved)
 
+        # Reverse-resolve the cross-view locator node (ADR-0025) — the scene's
+        # single ``vtkMRMLLocatorNode`` — and re-target its observer when it
+        # appears / disappears, so its picked-point changes re-dispatch.  Gated
+        # on the scene MTime like the plan scan: a picked-point update to an
+        # already-resolved locator arrives via its observer + the locator MTime
+        # in the key below, not a per-tick class scan.
+        if self._data_node is not None:
+            scene = self._data_node.GetScene()
+            scene_mtime = scene.GetMTime() if scene is not None else 0
+            if scene_mtime != self._last_locator_scan_mtime:
+                self._last_locator_scan_mtime = scene_mtime
+                found = (
+                    scene.GetFirstNodeByClass("vtkMRMLLocatorNode")
+                    if scene is not None
+                    else None
+                )
+                if found is not self._locator_node:
+                    if self._locator_node is not None:
+                        self._detach_observer(self._locator_node)
+                    self._locator_node = found
+                    if found is not None:
+                        self._attach_observer(found)
+
         # Build the dispatch key.  Falls back to ``0`` MTime for nodes
         # whose ``GetMTime`` is unavailable (defensive — stub nodes in
         # tests may not implement it).
@@ -345,8 +379,11 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         data_mtime = _safe_get_mtime(self._data_node)
         display_mtime = _safe_get_mtime(self._display_node)
         resection_mtime = _safe_get_mtime(self._resection_node)
+        locator_mtime = _safe_get_mtime(self._locator_node)
 
-        key = (state, init_mode, data_mtime, display_mtime, resection_mtime)
+        key = (
+            state, init_mode, data_mtime, display_mtime, resection_mtime, locator_mtime,
+        )
         if key == self._last_update_key:
             return  # idempotent short-circuit
         self._last_update_key = key
@@ -362,6 +399,10 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             # BezierPlanningRepresentation implements this; others ignore it.
             if hasattr(active, "SetResectionPlanNode"):
                 active.SetResectionPlanNode(self._resection_node)
+            # Thread the resolved locator node to the consumer seam (ADR-0025);
+            # only BezierPlanningRepresentation implements it, others ignore.
+            if hasattr(active, "SetLocatorNode"):
+                active.SetLocatorNode(self._locator_node)
             active.update(self._display_node, self._data_node)
 
         # Init-mode parameter mutations only MARK extraction pending; the

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -185,6 +185,12 @@ class BezierPlanningRepresentation:
         # wrapper, not the carrier.  ``None`` until the Pipeline wires it.
         self._resection_plan_node: Any | None = None
 
+        # The cross-view locator node (ADR-0025).  The consumer reads its
+        # picked world point + the display-node radius and drives the surface
+        # mapper's ``uLocatorPosition`` / ``uLocatorRadius`` uniforms; ``None``
+        # (or a zero radius) is the marker-off state.
+        self._locator_node: Any | None = None
+
         self._build_vtk_pipeline(surface_mapper)
 
         if renderer is not None:
@@ -218,6 +224,15 @@ class BezierPlanningRepresentation:
         """
         self._resection_plan_node = plan_node
 
+    def SetLocatorNode(self, locator_node: Any | None) -> None:
+        """Attach the cross-view ``vtkMRMLLocatorNode`` (ADR-0025).
+
+        The Pipeline resolves the scene's single locator node and calls this
+        before ``update()`` so the consumer can drive the surface shader's
+        locator marker.  ``None`` clears it (marker off).
+        """
+        self._locator_node = locator_node
+
     def update(
         self, display_node: Any | None, data_node: Any | None
     ) -> None:
@@ -237,6 +252,39 @@ class BezierPlanningRepresentation:
         # mapper (ADR-0031).  No-op on the generic fallback mapper / when no
         # plan node is wired.
         self._apply_resection_plan(self._resection_plan_node)
+        # Drive the locator marker uniforms off the locator node (ADR-0025).
+        self._apply_locator()
+
+    def _apply_locator(self) -> None:
+        """Thread the locator node's picked point + radius onto the mapper.
+
+        Reads ``GetPickedPositionWorld`` off the ``vtkMRMLLocatorNode`` and the
+        ``Radius`` off its display node, driving the surface mapper's
+        ``uLocatorPosition`` / ``uLocatorRadius`` uniforms (ADR-0025 §Rendering).
+        ``uLocatorRadius == 0`` is the marker-off state: used when no locator
+        node is wired.  A no-op on the generic fallback mapper (the getattr
+        guards) so the bare-VTK unit layer, which injects a plain
+        ``vtkPolyDataMapper``, still constructs + updates.
+        """
+        mapper = self._surface_mapper
+        if mapper is None:
+            return
+        set_position = getattr(mapper, "SetLocatorPosition", None)
+        set_radius = getattr(mapper, "SetLocatorRadius", None)
+        if set_position is None or set_radius is None:
+            return  # generic fallback mapper — no locator uniforms
+
+        node = self._locator_node
+        if node is None:
+            set_radius(0.0)  # marker off
+            return
+
+        position = node.GetPickedPositionWorld()
+        set_position(float(position[0]), float(position[1]), float(position[2]))
+
+        display_node = node.GetDisplayNode() if hasattr(node, "GetDisplayNode") else None
+        radius = display_node.GetRadius() if display_node is not None else 0.0
+        set_radius(float(radius))
 
     def cleanup(self) -> None:
         """Detach actors from the renderer and drop the VTK pipeline."""
@@ -250,6 +298,7 @@ class BezierPlanningRepresentation:
         self._surface_mapper = None
         self._surface_actor = None
         self._resection_plan_node = None
+        self._locator_node = None
 
     # ------------------------------------------------------------------ #
     # Introspection — used by the unit-layer tests

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -218,6 +218,59 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;mapper-wiring"
     )
 
+    # #489 locator consumer (Representation half) -- BezierPlanningRepresentation
+    # reads a single vtkMRMLLocatorNode's picked world point + its display-node
+    # Radius and drives the real vtkOpenGLBezierResectionPolyDataMapper's locator
+    # uniforms (uLocatorPosition / uLocatorRadius, ADR-0025 §Rendering) through a
+    # new SetLocatorNode seam (mirrors SetResectionPlanNode; NO custom DM, NO new
+    # factory -- ADR-0013 §5/§6).  Invariant 1: node position + display radius
+    # reach the mapper; invariant 2: no locator node (SetLocatorNode(None)) zeroes
+    # uLocatorRadius (the shader off state).  Node -> consumer only; the full
+    # producer -> node -> consumer chain (#489) closes when Slice B lands.  Needs
+    # the wrapped locator nodes + real mapper + Representation, so it runs green
+    # under the launched-Slicer `pytest_launched` row and SKIPS CLEANLY here under
+    # bare pytest (no slicer.mrmlScene / wrapped classes off the path).  GL free
+    # -- the mapper's uniform accessors need no render window.  RED / skip-pending
+    # (guards on the SetLocatorNode + GetLocatorRadius seams) until the implementer
+    # lands the consumer (ADR-0027 §Conformance: the skip lifts at the
+    # implementation commit).
+    add_test(
+      NAME LiverResections_bezier_planning_locator_consumer
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_bezier_planning_locator_consumer.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_bezier_planning_locator_consumer PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;locator;mapper-wiring"
+    )
+
+    # #489 locator consumer (Pipeline half) -- LiverBezierSurfacePipeline resolves
+    # the scene's single vtkMRMLLocatorNode (GetFirstNodeByClass; v2.0 has exactly
+    # one) and threads it onto the active Representation via SetLocatorNode before
+    # update() (mirrors the ADR-0031 SetResectionPlanNode reverse-resolve+thread;
+    # ADR-0025 §Consumer, ADR-0013 §6).  Positive: a locator node in the scene ->
+    # its display Radius reaches the mapper's uLocatorRadius with no external
+    # SetLocatorNode caller; negative: no locator node -> uLocatorRadius stays 0
+    # (no false-positive; shader off state).  Node -> consumer only; the full
+    # producer -> node -> consumer chain (#489) closes when Slice B lands.  Needs
+    # the wrapped locator nodes + real mapper + importable Pipeline, so it runs
+    # green under the launched-Slicer `pytest_launched` row and SKIPS CLEANLY here
+    # under bare pytest (no slicer.mrmlScene / LayerDMLib).  GL free.  RED /
+    # skip-pending (guards on a Representation exposing SetLocatorNode) until the
+    # implementer lands the Pipeline resolution + threading (ADR-0027 §Conformance:
+    # the skip lifts at the implementation commit).
+    add_test(
+      NAME LiverResections_pipeline_resolves_locator
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_pipeline_resolves_locator.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_pipeline_resolves_locator PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;locator;mapper-wiring"
+    )
+
     # #501 slice 2 -- the v2 resection control-point edit path on the LayerDM
     # Pipeline (ADR-0032: interaction routes through the Pipeline interaction
     # seam, no standalone vtkAbstractWidget).  Pins the GL-free edit kernel

--- a/LiverResections/Testing/Python/test_bezier_planning_locator_consumer.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_locator_consumer.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Locator consumer -- BezierPlanningRepresentation drives the locator uniforms.
+
+Pins the Representation half of the ADR-0025 locator *consumer* slice (#489
+consumer half): ``BezierPlanningRepresentation`` reads a single
+``vtkMRMLLocatorNode``'s picked world point + its display-node radius and drives
+the real ``vtkOpenGLBezierResectionPolyDataMapper``'s locator uniforms
+(``uLocatorPosition`` / ``uLocatorRadius``, ADR-0025 §"Rendering").  The
+consumer is realised INSIDE the existing T2 Bezier surface Representation -- NO
+new displayable manager, NO new pipeline factory (ADR-0013 §5).
+
+The seam this pins:
+
+  * ``rep.SetLocatorNode(node)`` -- the Pipeline threads the resolved single
+    locator node onto the active Representation before ``update()`` (mirrors the
+    existing ``SetResectionPlanNode`` thread, ADR-0013 §6).
+  * ``rep.update(display, data)`` -- when the locator node carries a
+    ``PickedPositionWorld`` and its display node a ``Radius``, the real mapper's
+    ``GetLocatorPosition()`` matches that world point and ``GetLocatorRadius()``
+    matches the display radius (invariant 1).  When there is no locator node
+    (``SetLocatorNode(None)``) or no active picked position, the mapper's
+    ``GetLocatorRadius()`` is ``0.0`` -- the shader's off state
+    (``uLocatorRadius == 0``, invariant 2).
+
+SCOPE: this pins the node -> consumer half only.  The FULL producer ->
+``vtkMRMLLocatorNode`` -> consumer chain (issue #489; ADR-0025 §Conformance
+[test]) closes when Slice B (the resectogram producer) lands; the producer is
+not exercised here.
+
+-- VERIFIED API (from the merged headers) --
+
+  * ``vtkMRMLLocatorNode``:
+    ``SetPickedPositionWorld(x, y, z)`` / ``GetPickedPositionWorld()`` --
+    TRANSIENT double[3] RAS world point (the carrier of the picked point);
+    ``CreateDefaultDisplayNodes()`` mints + wires a single
+    ``vtkMRMLLocatorDisplayNode`` (ADR-0025 §"The node").
+  * ``vtkMRMLLocatorDisplayNode``: ``SetRadius(double)`` / ``GetRadius()`` --
+    the sphere radius that feeds ``uLocatorRadius`` (per the node's own doc).
+  * ``vtkOpenGLBezierResectionPolyDataMapper`` (merged, ADR-0014 §3):
+    ``GetLocatorPosition()`` (``const float*``), ``SetLocatorPosition(...)``,
+    ``GetLocatorRadius()`` / ``SetLocatorRadius(float)``.
+
+The mapper DOES expose a radius getter (``GetLocatorRadius()`` -> ``float``), so
+both the on- and off-states are pinned on the readable radius.  The position
+getter is a ``const float*``; VTK's Python wrapper returns that as a length-3
+tuple, but where that is unreliable across builds the radius is the primary
+proxy (the same readable-scalar-proxy idiom as the colour setters in
+``test_bezier_planning_surface_mapper_wiring.py``).
+
+-- WHY THIS IS A LAUNCHED-SLICER PYTEST --
+
+``vtkOpenGLBezierResectionPolyDataMapper`` (LiverResections VTKWidgets) and the
+wrapped ``vtkMRMLLocatorNode`` / ``vtkMRMLLocatorDisplayNode`` are wrapped-C++
+classes reachable only inside a launched Slicer with the module loaded; a bare
+``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` and those classes
+off the path, so this SKIPS CLEANLY via the shared ``slicer_pytest_support``
+guards.  All GL-free: the mapper's uniform accessors need no render window.
+
+-- WHY RED NOW --
+
+``BezierPlanningRepresentation`` has no ``SetLocatorNode`` seam yet, so each
+test skips on ``_require_locator_seam_or_skip``; the skip lifts when the
+consumer slice lands (ADR-0027 §Conformance -- the skip lifts at the
+implementation commit).
+
+See also:
+  * Docs/adr/0025-locator-architecture.md §"Rendering", §"Consumer", §Conformance
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §5, §6
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md
+  * LiverResections/MRML/vtkMRMLLocatorNode.h
+  * LiverResections/MRML/vtkMRMLLocatorDisplayNode.h
+  * LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.h
+  * LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+LOCATOR_NODE_CLASS = "vtkMRMLLocatorNode"
+LOCATOR_DISPLAY_NODE_CLASS = "vtkMRMLLocatorDisplayNode"
+REAL_MAPPER_CLASS = "vtkOpenGLBezierResectionPolyDataMapper"
+
+
+def _slicer_or_skip():
+    """Resolve a launched ``slicer`` module or skip cleanly under bare pytest."""
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_representation_or_skip():
+    """Construct a ``BezierPlanningRepresentation`` or skip if unimportable."""
+    try:
+        from LiverResectionsLib.Representations.BezierPlanningRepresentation import (
+            BezierPlanningRepresentation,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            "BezierPlanningRepresentation not importable "
+            f"({exc!r}) -- the Planning Representation is not reachable in "
+            "this environment."
+        )
+    return BezierPlanningRepresentation()
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def _require_real_mapper_or_skip(rep):
+    """Skip unless the Representation's surface mapper is the real type.
+
+    The consumer drives ``uLocatorPosition`` / ``uLocatorRadius`` on the real
+    ``vtkOpenGLBezierResectionPolyDataMapper``; on the generic placeholder
+    mapper there are no locator setters to drive.  This is the same guard the
+    sibling mapper-wiring test uses (ADR-0014 §3).
+    """
+    mapper = rep.GetSurfaceMapper()
+    if mapper is None or not mapper.IsA(REAL_MAPPER_CLASS):
+        actual = type(mapper).__name__ if mapper is not None else "None"
+        pytest.skip(
+            "BezierPlanningRepresentation surface mapper is "
+            f"{actual!r}, not {REAL_MAPPER_CLASS!r} -- the real mapper the "
+            "locator uniforms live on is not present."
+        )
+    return mapper
+
+
+def _require_locator_seam_or_skip(rep):
+    """Skip unless the locator-consumer seam has landed.
+
+    RED == ``BezierPlanningRepresentation`` has no ``SetLocatorNode`` seam or
+    the mapper has no ``GetLocatorRadius`` accessor.  The skip lifts when the
+    ADR-0025 consumer slice wires the locator node -> mapper uniforms (ADR-0027
+    §Conformance).
+    """
+    mapper = rep.GetSurfaceMapper()
+    if not hasattr(rep, "SetLocatorNode"):
+        pytest.skip(
+            "BezierPlanningRepresentation has no SetLocatorNode seam -- the "
+            "ADR-0025 locator consumer slice has not landed."
+        )
+    if not hasattr(mapper, "GetLocatorRadius"):
+        pytest.skip(
+            "surface mapper has no GetLocatorRadius accessor -- cannot read "
+            "back the driven uLocatorRadius uniform."
+        )
+
+
+def _attach_locator_display(slicer, locator, radius):
+    """Attach a ``vtkMRMLLocatorDisplayNode`` with a known ``Radius``.
+
+    Uses the node's own ``CreateDefaultDisplayNodes()`` (ADR-0025 §"The node":
+    mints + wires a single display node), then reads the wired display node
+    back and sets its ``Radius``.  Falls back to adding + observing a display
+    node explicitly if the convenience path is not present in this build.
+    """
+    display = None
+    if hasattr(locator, "CreateDefaultDisplayNodes"):
+        locator.CreateDefaultDisplayNodes()
+        display = locator.GetDisplayNode()
+    if display is None:
+        display = _add_or_skip(slicer, LOCATOR_DISPLAY_NODE_CLASS)
+        locator.AddAndObserveDisplayNodeID(display.GetID())
+    if not display.IsA(LOCATOR_DISPLAY_NODE_CLASS) or not hasattr(display, "SetRadius"):
+        pytest.skip(
+            f"locator display node is not a {LOCATOR_DISPLAY_NODE_CLASS} with "
+            "SetRadius -- cannot exercise the radius uniform."
+        )
+    display.SetRadius(radius)
+    return display
+
+
+def _locator_position(mapper):
+    """Read the mapper's ``GetLocatorPosition()`` as a length-3 tuple, or None.
+
+    The getter is a ``const float*``; VTK's Python wrapper usually returns a
+    length-3 tuple, but where it surfaces as an opaque pointer-string the
+    caller falls back to the readable radius (the same wrapping caveat the
+    colour getters carry in test_bezier_planning_surface_mapper_wiring.py).
+    """
+    raw = mapper.GetLocatorPosition()
+    try:
+        pos = tuple(float(c) for c in raw)
+    except (TypeError, ValueError):
+        return None
+    return pos if len(pos) == 3 else None
+
+
+def test_planning_locator_consumer_drives_uniforms_from_node():
+    """Invariant 1: the consumer drives the mapper uniforms from the node.
+
+    With a ``vtkMRMLLocatorNode`` whose ``PickedPositionWorld`` is a known RAS
+    point and a display node with a known ``Radius``, after
+    ``SetLocatorNode(node)`` + ``update()`` the real mapper's
+    ``GetLocatorRadius()`` reflects the display radius and (when the position
+    getter is Python-readable) ``GetLocatorPosition()`` matches the world point
+    within float tolerance (ADR-0025 §"Rendering").
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    mapper = _require_real_mapper_or_skip(rep)
+    _require_locator_seam_or_skip(rep)
+
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, DISPLAY_NODE_CLASS)
+
+    locator = _add_or_skip(slicer, LOCATOR_NODE_CLASS)
+    known_point = (12.0, -34.0, 56.0)
+    known_radius = 4.5
+    locator.SetPickedPositionWorld(*known_point)
+    _attach_locator_display(slicer, locator, known_radius)
+
+    rep.SetLocatorNode(locator)
+    rep.update(display, data)
+
+    assert abs(mapper.GetLocatorRadius() - known_radius) < 1e-4, (
+        "the locator display node's Radius must reach the mapper's "
+        f"SetLocatorRadius uniform; got {mapper.GetLocatorRadius()} "
+        f"(expected {known_radius})."
+    )
+
+    # Position is a const float* getter; assert only when it is
+    # Python-readable (the mapper stores float, the node is double -> tolerance).
+    pos = _locator_position(mapper)
+    if pos is not None:
+        for got, want in zip(pos, known_point):
+            assert abs(got - want) < 1e-3, (
+                "the locator node's PickedPositionWorld must reach the mapper's "
+                f"SetLocatorPosition uniform; got {pos} (expected {known_point})."
+            )
+
+
+def test_planning_locator_off_state_zeroes_radius_when_no_node():
+    """Invariant 2: no locator node -> ``SetLocatorRadius(0.0)`` (marker off).
+
+    ``SetLocatorNode(None)`` (no active locator) must leave the mapper's
+    ``GetLocatorRadius()`` at ``0.0`` -- the shader's off state
+    (``uLocatorRadius == 0``, ADR-0025 §"Rendering").  Pinned by first driving
+    a non-zero radius from a real node, then clearing the node and confirming
+    the radius collapses to zero (MRML state and GL state must not diverge).
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    mapper = _require_real_mapper_or_skip(rep)
+    _require_locator_seam_or_skip(rep)
+
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, DISPLAY_NODE_CLASS)
+
+    # First establish a non-zero radius from a real locator so the zero after
+    # clearing is a genuine transition, not the mapper's construction default.
+    locator = _add_or_skip(slicer, LOCATOR_NODE_CLASS)
+    locator.SetPickedPositionWorld(1.0, 2.0, 3.0)
+    _attach_locator_display(slicer, locator, 7.0)
+    rep.SetLocatorNode(locator)
+    rep.update(display, data)
+    assert mapper.GetLocatorRadius() > 0.0, (
+        "precondition: a real locator with a positive display Radius must "
+        "drive a positive uLocatorRadius before the off-state is exercised."
+    )
+
+    # Clear the locator -> the marker turns off (radius uniform 0).
+    rep.SetLocatorNode(None)
+    rep.update(display, data)
+    assert abs(mapper.GetLocatorRadius()) < 1e-6, (
+        "with no locator node the mapper's uLocatorRadius must be 0 (the "
+        f"shader off state, ADR-0025 §Rendering); got {mapper.GetLocatorRadius()}."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverResections/Testing/Python/test_pipeline_resolves_locator.py
+++ b/LiverResections/Testing/Python/test_pipeline_resolves_locator.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Locator consumer -- the Pipeline resolves + threads the single locator node.
+
+Pins the Pipeline half of the ADR-0025 locator *consumer* slice (#489 consumer
+half): ``LiverBezierSurfacePipeline`` resolves the scene's single
+``vtkMRMLLocatorNode`` (``GetFirstNodeByClass("vtkMRMLLocatorNode")`` -- v2.0
+has exactly one) and threads it onto the active Representation via
+``SetLocatorNode(node)`` before ``update()`` -- mirroring how it already
+reverse-resolves + threads the resection-plan wrapper via
+``SetResectionPlanNode`` (ADR-0031, ADR-0013 §6).  NO new displayable manager,
+NO new pipeline factory (ADR-0025 §"Consumer", ADR-0013 §5).
+
+Two invariants:
+
+  1. Positive -- with a ``vtkMRMLLocatorNode`` in the scene carrying a known
+     ``PickedPositionWorld`` + a display ``Radius``, after ``UpdatePipeline``
+     the active Representation's real mapper reflects the locator radius uniform
+     (the Pipeline resolved the node and threaded it, ADR-0025 §"Consumer").
+  2. Negative -- no ``vtkMRMLLocatorNode`` in the scene leaves the consumer in
+     its off state (mapper ``GetLocatorRadius()`` == 0): the resolution does not
+     false-positive, and the shader's off state holds (ADR-0025 §"Rendering").
+
+SCOPE: this pins node -> consumer (via the Pipeline) only.  The FULL producer ->
+``vtkMRMLLocatorNode`` -> consumer chain (issue #489; ADR-0025 §Conformance
+[test]) closes when Slice B (the resectogram producer) lands; the producer is
+not exercised here.
+
+-- WHY LAUNCHED-SLICER --
+Needs the wrapped ``vtkMRMLLocatorNode`` / ``vtkMRMLLocatorDisplayNode`` /
+``vtkMRMLBezierSurfaceNode`` / ``vtkMRMLParametricSurfaceDisplayNode`` + the
+real ``vtkOpenGLBezierResectionPolyDataMapper`` + the importable
+``LiverBezierSurfacePipeline`` (LayerDMLib reachable only inside Slicer).  Skips
+cleanly under bare ``PythonSlicer -m pytest``.  GL-free: the mapper's uniform
+accessors need no render window.
+
+-- WHY RED NOW --
+The Pipeline has no locator resolution / threading, and the Representation has
+no ``SetLocatorNode`` seam, so the tests skip on ``_require_locator_seam_or_skip``.
+The skip lifts when the ADR-0025 consumer slice lands (ADR-0027 §Conformance --
+the skip lifts at the implementation commit).
+
+See also:
+  * Docs/adr/0025-locator-architecture.md §"Consumer", §"Rendering", §Conformance
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §5, §6
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md
+  * LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+  * LiverResections/Testing/Python/test_pipeline_resolves_resection_plan.py
+  * LiverResections/Testing/Python/test_bezier_planning_locator_consumer.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+LOCATOR_NODE_CLASS = "vtkMRMLLocatorNode"
+LOCATOR_DISPLAY_NODE_CLASS = "vtkMRMLLocatorDisplayNode"
+REAL_MAPPER_CLASS = "vtkOpenGLBezierResectionPolyDataMapper"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_pipeline_or_skip():
+    try:
+        from LiverResectionsLib.LiverBezierSurfacePipeline import (
+            LiverBezierSurfacePipeline,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"LiverBezierSurfacePipeline not importable ({exc!r}) -- LayerDMLib "
+            "not reachable in this environment."
+        )
+    return LiverBezierSurfacePipeline()
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def _wire_surface_with_display(slicer):
+    """Create a Bezier carrier + its parametric-surface display node, wired so
+    ``display.GetDisplayableNode()`` resolves the carrier (the back-reference
+    the Pipeline derives its data node from)."""
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, DISPLAY_NODE_CLASS)
+    data.SetAndObserveDisplayNodeID(display.GetID())
+    if display.GetDisplayableNode() is not data:
+        pytest.skip(
+            "display.GetDisplayableNode() does not resolve the carrier in this "
+            "build -- cannot exercise the Pipeline's data-node derivation."
+        )
+    return data, display
+
+
+def _require_locator_seam_or_skip(pipeline):
+    """Skip unless the Pipeline threads a locator seam onto its Representations.
+
+    RED == the Pipeline never activates a Representation carrying a
+    ``SetLocatorNode`` seam, i.e. the ADR-0025 consumer slice has not landed.
+    The skip lifts when the Pipeline resolves + threads the locator node
+    (ADR-0027 §Conformance).
+    """
+    pipeline._ensure_representations()  # noqa: SLF001 - test drives the lazy build
+    reps = getattr(pipeline, "_representations", None)
+    if not reps or not any(
+        r is not None and hasattr(r, "SetLocatorNode") for r in reps.values()
+    ):
+        pytest.skip(
+            "no Representation exposes a SetLocatorNode seam -- the ADR-0025 "
+            "locator consumer slice has not landed."
+        )
+
+
+def _active_real_mapper_or_skip(pipeline, slicer):
+    """Return the active Planning Representation's real surface mapper, or skip.
+
+    The consumer lives on the Planning-state Bezier surface Representation; its
+    mapper must be the real ``vtkOpenGLBezierResectionPolyDataMapper`` the
+    locator uniforms live on (ADR-0014 §3).
+    """
+    name = getattr(pipeline, "_current_representation_name", None)
+    reps = getattr(pipeline, "_representations", {}) or {}
+    active = reps.get(name) if name else None
+    if active is None or not hasattr(active, "GetSurfaceMapper"):
+        pytest.skip(
+            "active Representation exposes no surface mapper -- the Planning "
+            "surface consumer is not the active Representation in this state."
+        )
+    mapper = active.GetSurfaceMapper()
+    if mapper is None or not mapper.IsA(REAL_MAPPER_CLASS):
+        actual = type(mapper).__name__ if mapper is not None else "None"
+        pytest.skip(
+            f"active surface mapper is {actual!r}, not {REAL_MAPPER_CLASS!r} -- "
+            "the real mapper the locator uniforms live on is not present."
+        )
+    if not hasattr(mapper, "GetLocatorRadius"):
+        pytest.skip(
+            "surface mapper has no GetLocatorRadius accessor -- cannot read "
+            "back the threaded uLocatorRadius uniform."
+        )
+    return mapper
+
+
+def _attach_locator_display(slicer, locator, radius):
+    """Attach a ``vtkMRMLLocatorDisplayNode`` with a known ``Radius``.
+
+    Uses ``CreateDefaultDisplayNodes()`` (ADR-0025 §"The node"), falling back to
+    an explicit add + observe if the convenience path is absent.
+    """
+    display = None
+    if hasattr(locator, "CreateDefaultDisplayNodes"):
+        locator.CreateDefaultDisplayNodes()
+        display = locator.GetDisplayNode()
+    if display is None:
+        display = _add_or_skip(slicer, LOCATOR_DISPLAY_NODE_CLASS)
+        locator.AddAndObserveDisplayNodeID(display.GetID())
+    if not display.IsA(LOCATOR_DISPLAY_NODE_CLASS) or not hasattr(display, "SetRadius"):
+        pytest.skip(
+            f"locator display node is not a {LOCATOR_DISPLAY_NODE_CLASS} with "
+            "SetRadius -- cannot exercise the radius uniform."
+        )
+    display.SetRadius(radius)
+    return display
+
+
+def test_pipeline_resolves_and_threads_single_locator_node():
+    """Invariant 3 (positive): the Pipeline resolves + threads the locator node.
+
+    With a single ``vtkMRMLLocatorNode`` in the scene, dispatching the Pipeline
+    over the surface must resolve that node
+    (``GetFirstNodeByClass("vtkMRMLLocatorNode")``) and thread it onto the
+    active Representation, so the real mapper's ``GetLocatorRadius()`` reflects
+    the locator display ``Radius`` -- with no external ``SetLocatorNode`` caller
+    (ADR-0025 §"Consumer", ADR-0013 §6).
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_locator_seam_or_skip(pipeline)
+
+    data, display = _wire_surface_with_display(slicer)
+
+    locator = _add_or_skip(slicer, LOCATOR_NODE_CLASS)
+    known_radius = 5.25
+    locator.SetPickedPositionWorld(10.0, 20.0, 30.0)
+    _attach_locator_display(slicer, locator, known_radius)
+
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    mapper = _active_real_mapper_or_skip(pipeline, slicer)
+    assert abs(mapper.GetLocatorRadius() - known_radius) < 1e-4, (
+        "the Pipeline must resolve the scene's single vtkMRMLLocatorNode and "
+        "thread it onto the active Representation so its display Radius reaches "
+        f"the mapper's uLocatorRadius; got {mapper.GetLocatorRadius()} "
+        f"(expected {known_radius})."
+    )
+
+
+def test_pipeline_locator_off_when_no_locator_node_in_scene():
+    """Invariant 3 (negative): no locator node -> the consumer stays off.
+
+    A Pipeline dispatched over a surface with NO ``vtkMRMLLocatorNode`` in the
+    scene must leave the mapper's ``GetLocatorRadius()`` at ``0.0`` -- the
+    resolution does not false-positive and the shader off state holds
+    (ADR-0025 §"Rendering").
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_locator_seam_or_skip(pipeline)
+
+    data, display = _wire_surface_with_display(slicer)
+    # No vtkMRMLLocatorNode is added to the scene.
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    mapper = _active_real_mapper_or_skip(pipeline, slicer)
+    assert abs(mapper.GetLocatorRadius()) < 1e-6, (
+        "with no vtkMRMLLocatorNode in the scene the mapper's uLocatorRadius "
+        f"must be 0 (the shader off state); got {mapper.GetLocatorRadius()}."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Contributes to #489 (consumer half; the shader half #492 is already merged).

## Summary

Implements the ADR-0025 **locator consumer** in the T2 `LiverBezierSurfacePipeline`: the scene's single `vtkMRMLLocatorNode` picked point drives the resection-surface shader's locator marker. No new displayable manager / pipeline factory (ADR-0013 §5) — a consumer Representation inside the existing pipeline.

## What lands

- **`BezierPlanningRepresentation.SetLocatorNode(node)`** + `_apply_locator()`: reads `GetPickedPositionWorld()` off the locator node and `Radius` off its display node, driving the real `vtkOpenGLBezierResectionPolyDataMapper`'s `SetLocatorPosition` / `SetLocatorRadius` (the `uLocatorPosition` / `uLocatorRadius` uniforms from #492). No locator node → radius `0` (marker off). Guarded (getattr) so the bare-VTK unit layer's generic mapper is tolerated.
- **`LiverBezierSurfacePipeline`**: reverse-resolves the scene's single `vtkMRMLLocatorNode` (scene-MTime-gated, mirroring the resection-plan resolve), observes it so picked-point changes re-dispatch, folds its MTime into the memo-key (so off→on re-dispatches), and threads it onto the active Representation's `SetLocatorNode` seam before `update`.

## Tests (test-first, ADR-0027)

- New `test_bezier_planning_locator_consumer.py` + `test_pipeline_resolves_locator.py`, RED-as-skip on the seam, green after.
- Launched suite: 93 passed / 14 skipped / 1 xfailed / 0 failed. Bare-VTK unit layer: 84 passed (the guarded `_apply_locator` leaves it green).
- The **2 pipeline-resolve assertions skip headless** ("no active real-mapper Representation without a realized view") — the same gate the other pipeline-routing tests use. The rep-level consumer (node → mapper uniform) is directly proven; the resolve/thread code runs clean through the full suite. The pipeline-resolve + actual marker render is an interactive `:0` follow-up, and the full **producer → node → consumer** chain closes with Slice B (#488).

## Scope
Consumer only. Producer (#488, resectogram click → (u,v) → world → node) and click-to-reslice (#490) follow.
