### PR TITLE
BUG: Init-mode ring extraction silent no-op — resolve extractors from Algorithm wrapping

### DIFF
--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -726,31 +726,28 @@ def _identity_matrix() -> Any:
 
 
 def _require_vtk_class(name: str) -> Any:
-    """Resolve a wrapped-C++ class by name from ``slicer`` then ``vtk``, or raise.
+    """Resolve a wrapped-C++ VTKWidgets class by name from ``slicer``, or raise.
 
     The relocated mapper + the Bezier surface source are wrapped into Slicer's
-    ``slicer`` namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the
-    plain ``vtk`` module is the fallback for a non-Slicer VTK build.  Raises
-    ``RuntimeError`` when neither namespace exposes the class — a real
-    misconfiguration in production (ADR-0014 §3) must fail loudly rather than
+    ``slicer`` namespace (ADR-0014 §3).  Raises ``RuntimeError`` when a class is
+    absent — a real misconfiguration in production must fail loudly rather than
     degrade to a shader-less generic mapper.  Bare-VTK unit tests (ADR-0008 §2)
     avoid this path by injecting a mapper instance instead.
     """
-    for module_name in ("slicer", "vtk"):
-        try:
-            module = __import__(module_name)
-        except ImportError:
-            continue
-        cls = getattr(module, name, None)
-        if cls is not None:
-            return cls
-    raise RuntimeError(
-        f"{name} is not reachable from the 'slicer' or 'vtk' namespace. "
-        "It is a wrapped-C++ class relocated to LiverResections/VTKWidgets/ "
-        "(ADR-0014 §3) and available only inside a launched Slicer with the "
-        "module loaded.  Inject a mapper instance for bare-VTK unit tests "
-        "(ADR-0008 §2)."
-    )
+    try:
+        import slicer
+    except ImportError:
+        slicer = None
+    cls = getattr(slicer, name, None) if slicer is not None else None
+    if cls is None:
+        raise RuntimeError(
+            f"{name} is not reachable from the 'slicer' namespace. "
+            "It is a wrapped-C++ class relocated to LiverResections/VTKWidgets/ "
+            "(ADR-0014 §3) and available only inside a launched Slicer with the "
+            "module loaded.  Inject a mapper instance for bare-VTK unit tests "
+            "(ADR-0008 §2)."
+        )
+    return cls
 
 
 def _push_color3(mapper: Any, setter_name: str, getter: Any | None) -> None:

--- a/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/DistanceSpheroidInitRepresentation.py
@@ -635,53 +635,45 @@ def _as_xyz_tuple(raw: Any) -> tuple[float, float, float]:
 
 
 def _resolve_extractor_class(name: str) -> Any | None:
-    """Resolve a VTK-wrapped ring-extractor class by name.
+    """Resolve a wrapped-C++ ring-extractor class by name, or ``None``.
 
-    The Algorithm-library classes are wrapped into Slicer's ``slicer``
-    namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the
-    plain ``vtk`` module is the fallback for non-Slicer VTK builds.
-    Returns ``None`` when neither namespace exposes the class — the
-    on-commit ring extraction degrades to a no-op when the extractor is
-    unreachable, so this stays resolve-or-``None`` (unlike the mapper
-    resolution, which is resolve-or-raise).
+    The ring extractors live in ``LiverResections/Algorithm/`` and are exposed
+    only on the module's Algorithm Python wrapping (ADR-0014 §3) — NOT on the
+    ``slicer`` or ``vtk`` namespaces.  Lazily imported so this module stays
+    importable where the wrapping is off the path (the bare-VTK unit layer);
+    the on-commit ring extraction then degrades to a no-op when the extractor
+    is unreachable (resolve-or-``None``, unlike the mapper resolve-or-raise).
     """
-    for module_name in ("slicer", "vtk"):
-        try:
-            module = __import__(module_name)
-        except ImportError:
-            continue
-        cls = getattr(module, name, None)
-        if cls is not None:
-            return cls
-    return None
+    try:
+        import vtkSlicerLiverResectionsModuleAlgorithmPython as algorithm
+    except ImportError:
+        return None
+    return getattr(algorithm, name, None)
 
 
 def _require_vtk_class(name: str) -> Any:
-    """Resolve a wrapped-C++ class by name from ``slicer`` then ``vtk``, or raise.
+    """Resolve a wrapped-C++ VTKWidgets class by name from ``slicer``, or raise.
 
-    The relocated custom mapper is wrapped into Slicer's ``slicer``
-    namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the plain
-    ``vtk`` module is the fallback for a non-Slicer VTK build.  Raises
-    ``RuntimeError`` when neither namespace exposes the class — a real
-    misconfiguration in production (ADR-0014 §3) must fail loudly rather
-    than degrade to a shader-less generic mapper.  Bare-VTK unit tests
-    (ADR-0008 §2) avoid this path by injecting a mapper instance instead.
+    The relocated custom mapper is wrapped into Slicer's ``slicer`` namespace
+    (ADR-0014 §3).  Raises ``RuntimeError`` when it is absent — a real
+    misconfiguration in production must fail loudly rather than degrade to a
+    shader-less generic mapper.  Bare-VTK unit tests (ADR-0008 §2) avoid this
+    path by injecting a mapper instance instead.
     """
-    for module_name in ("slicer", "vtk"):
-        try:
-            module = __import__(module_name)
-        except ImportError:
-            continue
-        cls = getattr(module, name, None)
-        if cls is not None:
-            return cls
-    raise RuntimeError(
-        f"{name} is not reachable from the 'slicer' or 'vtk' namespace. "
-        "It is a wrapped-C++ class relocated to LiverResections/VTKWidgets/ "
-        "(ADR-0014 §3) and available only inside a launched Slicer with the "
-        "module loaded.  Inject a mapper instance for bare-VTK unit tests "
-        "(ADR-0008 §2)."
-    )
+    try:
+        import slicer
+    except ImportError:
+        slicer = None
+    cls = getattr(slicer, name, None) if slicer is not None else None
+    if cls is None:
+        raise RuntimeError(
+            f"{name} is not reachable from the 'slicer' namespace. "
+            "It is a wrapped-C++ class relocated to LiverResections/VTKWidgets/ "
+            "(ADR-0014 §3) and available only inside a launched Slicer with the "
+            "module loaded.  Inject a mapper instance for bare-VTK unit tests "
+            "(ADR-0008 §2)."
+        )
+    return cls
 
 
 def _model_polydata(target_model: Any | None) -> Any | None:

--- a/LiverResections/LiverResectionsLib/Representations/SlicingPlaneInitRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/SlicingPlaneInitRepresentation.py
@@ -599,23 +599,19 @@ def _distance(
 
 
 def _resolve_extractor_class(name: str) -> Any | None:
-    """Resolve a VTK-wrapped ring-extractor class by name.
+    """Resolve a wrapped-C++ ring-extractor class by name, or ``None``.
 
-    The Algorithm-library classes are wrapped into Slicer's ``slicer``
-    namespace (``SlicerMacroBuildModuleLogic`` Python wrapping); the
-    plain ``vtk`` module is the fallback for non-Slicer VTK builds.
-    Returns ``None`` when neither namespace exposes the class — the
-    caller then declines to extract rather than raising.
+    The ring extractors live in ``LiverResections/Algorithm/`` and are exposed
+    only on the module's Algorithm Python wrapping (ADR-0014 §3) — NOT on the
+    ``slicer`` or ``vtk`` namespaces.  Lazily imported so this module stays
+    importable where the wrapping is off the path (the bare-VTK unit layer);
+    the caller then declines to extract rather than raising.
     """
-    for module_name in ("slicer", "vtk"):
-        try:
-            module = __import__(module_name)
-        except ImportError:
-            continue
-        cls = getattr(module, name, None)
-        if cls is not None:
-            return cls
-    return None
+    try:
+        import vtkSlicerLiverResectionsModuleAlgorithmPython as algorithm
+    except ImportError:
+        return None
+    return getattr(algorithm, name, None)
 
 
 def _model_polydata(target_model: Any | None) -> Any | None:

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -136,6 +136,27 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;ring-extraction"
     )
 
+    # Ring-extractor CLASS RESOLUTION -- the Init-mode ring extractors
+    # (vtkLiverPlaneRingExtractor / vtkLiverSpheroidRingExtractor) are
+    # Algorithm-library classes (ADR-0014 §3), exposed inside a launched Slicer
+    # ONLY on vtkSlicerLiverResectionsModuleAlgorithmPython -- NOT on the slicer
+    # or vtk namespaces.  Pins that _resolve_extractor_class returns a real class
+    # (not None) so run_ring_extraction is not a silent no-op, plus a behavioral
+    # smoke: a plane through a sphere centre yields a non-empty ring.  Needs the
+    # wrapped Algorithm classes, so it runs under the launched-Slicer
+    # `pytest_launched` row and SKIPS CLEANLY here under bare pytest (the
+    # Algorithm wrapping is off the path).  GL free -- no render window.
+    add_test(
+      NAME LiverResections_ring_extractor_resolution
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_resections_ring_extractor_resolution.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_ring_extractor_resolution PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;ring-extraction"
+    )
+
     # Per-point control-grid setter is Python-wrappable -- vtkMRMLBezierSurfaceNode
     # SetControlPoint(row, col, x, y, z) is reachable from Python (the flat
     # SetControlGrid(const double*) is not) and round-trips via

--- a/LiverResections/Testing/Python/test_resections_ring_extractor_resolution.py
+++ b/LiverResections/Testing/Python/test_resections_ring_extractor_resolution.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Init-mode ring extractors must resolve their wrapped Algorithm classes.
+
+Regression pin for the namespace mismatch that made ``run_ring_extraction`` a
+silent no-op.  ``vtkLiverPlaneRingExtractor`` and ``vtkLiverSpheroidRingExtractor``
+are **Algorithm-library** classes (``LiverResections/Algorithm/``); in a
+launched Slicer they are exposed ONLY on
+``vtkSlicerLiverResectionsModuleAlgorithmPython`` -- not on the ``slicer`` or
+``vtk`` namespaces.  The Init Representations resolved them over
+``("slicer", "vtk")``, so ``_resolve_extractor_class`` returned ``None`` on
+every call and the plane/spheroid intersection rings were never extracted.
+
+This is the same namespace gap caught in the locator producer
+(``vtkLiverResectogramPixelMapping`` is Algorithm-library too).
+
+-- WHY THIS IS A LAUNCHED-SLICER PYTEST --
+
+The wrapped Algorithm classes are reachable only inside a launched Slicer with
+the module loaded; under bare ``PythonSlicer -m pytest`` the
+``vtkSlicerLiverResectionsModuleAlgorithmPython`` module is off the path, so
+every test here SKIPS CLEANLY.  GL free -- no render window (the extractors are
+pure CPU filters; the Representations are built with no renderer).
+
+-- WHY THIS IS RED NOW (a true regression, not skip-pending) --
+
+Under a launched Slicer these assertions FAIL today: the resolver looks in the
+wrong namespaces, returns ``None``, and ``run_ring_extraction`` returns
+``None``.  They go GREEN once the resolvers point at the Algorithm wrapping.
+
+See also:
+  * Docs/adr/0014-*.md §3  (wrapped-class relocation / namespaces)
+  * Docs/adr/0019-resection-state-machine.md  (Init->Planning ring extraction)
+  * LiverResections/Algorithm/vtkLiverPlaneRingExtractor.h
+  * LiverResections/Algorithm/vtkLiverSpheroidRingExtractor.h
+"""
+
+from __future__ import annotations
+
+import pytest
+
+PLANE_EXTRACTOR_CLASS = "vtkLiverPlaneRingExtractor"
+SPHEROID_EXTRACTOR_CLASS = "vtkLiverSpheroidRingExtractor"
+ALGORITHM_PYTHON_MODULE = "vtkSlicerLiverResectionsModuleAlgorithmPython"
+
+
+def _algorithm_module_or_skip():
+    """Import the Algorithm Python wrapping or skip (bare pytest has it off path)."""
+    try:
+        return __import__(ALGORITHM_PYTHON_MODULE)
+    except ImportError:
+        pytest.skip(
+            f"{ALGORITHM_PYTHON_MODULE} not importable -- the wrapped Algorithm "
+            "classes are only reachable inside a launched Slicer with the module "
+            "loaded.  Runs under the launched-Slicer `pytest_launched` row."
+        )
+
+
+def _vtk_or_skip():
+    """Import ``vtk`` (for the target mesh source) or skip cleanly."""
+    try:
+        import vtk
+
+        return vtk
+    except ImportError:
+        pytest.skip("vtk not importable in this environment.")
+
+
+def _plane_representation_or_skip():
+    try:
+        from LiverResectionsLib.Representations.SlicingPlaneInitRepresentation import (
+            SlicingPlaneInitRepresentation,
+            _resolve_extractor_class,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"SlicingPlaneInitRepresentation not importable ({exc!r}).")
+    return SlicingPlaneInitRepresentation, _resolve_extractor_class
+
+
+def _spheroid_representation_or_skip():
+    try:
+        from LiverResectionsLib.Representations.DistanceSpheroidInitRepresentation import (
+            DistanceSpheroidInitRepresentation,
+            _resolve_extractor_class,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"DistanceSpheroidInitRepresentation not importable ({exc!r}).")
+    return DistanceSpheroidInitRepresentation, _resolve_extractor_class
+
+
+class _FakePlaneDataNode:
+    """Duck-typed stand-in exposing the SlicingPlane vec3 accessors."""
+
+    def __init__(self, origin, normal):
+        self._origin = origin
+        self._normal = normal
+
+    def GetSlicingPlaneOrigin(self):
+        return self._origin
+
+    def GetSlicingPlaneNormal(self):
+        return self._normal
+
+
+class _FakeSpheroidDataNode:
+    """Duck-typed stand-in exposing the DistanceSpheroid center + radii accessors."""
+
+    def __init__(self, center, radii):
+        self._center = center
+        self._rx, self._ry, self._rz = radii
+
+    def GetDistanceSpheroidCenter(self):
+        return self._center
+
+    def GetDistanceSpheroidRadiusX(self):
+        return self._rx
+
+    def GetDistanceSpheroidRadiusY(self):
+        return self._ry
+
+    def GetDistanceSpheroidRadiusZ(self):
+        return self._rz
+
+
+def _target_sphere(vtk, radius=50.0):
+    """A closed triangulated sphere mesh the extractors intersect."""
+    source = vtk.vtkSphereSource()
+    source.SetRadius(radius)
+    source.SetThetaResolution(48)
+    source.SetPhiResolution(48)
+    source.Update()
+    return source.GetOutput()
+
+
+# --------------------------------------------------------------------------
+# Resolution invariant -- the direct pin on the namespace bug.
+# --------------------------------------------------------------------------
+
+
+def test_plane_extractor_class_resolves_to_the_algorithm_wrapping():
+    """The plane ring extractor resolves to a real class, not None."""
+    algorithm = _algorithm_module_or_skip()
+    _, resolve = _plane_representation_or_skip()
+
+    expected = getattr(algorithm, PLANE_EXTRACTOR_CLASS, None)
+    assert expected is not None, (
+        f"{PLANE_EXTRACTOR_CLASS} is missing from {ALGORITHM_PYTHON_MODULE} -- "
+        "test premise broken."
+    )
+    resolved = resolve(PLANE_EXTRACTOR_CLASS)
+    assert resolved is not None, (
+        f"_resolve_extractor_class returned None for {PLANE_EXTRACTOR_CLASS}; the "
+        "Algorithm-library class is not reachable from the namespaces the resolver "
+        "checks -- ring extraction silently no-ops (ADR-0014 §3)."
+    )
+    assert resolved is expected
+
+
+def test_spheroid_extractor_class_resolves_to_the_algorithm_wrapping():
+    """The spheroid ring extractor resolves to a real class, not None."""
+    algorithm = _algorithm_module_or_skip()
+    _, resolve = _spheroid_representation_or_skip()
+
+    expected = getattr(algorithm, SPHEROID_EXTRACTOR_CLASS, None)
+    assert expected is not None, (
+        f"{SPHEROID_EXTRACTOR_CLASS} is missing from {ALGORITHM_PYTHON_MODULE} -- "
+        "test premise broken."
+    )
+    resolved = resolve(SPHEROID_EXTRACTOR_CLASS)
+    assert resolved is not None, (
+        f"_resolve_extractor_class returned None for {SPHEROID_EXTRACTOR_CLASS}; the "
+        "Algorithm-library class is not reachable from the namespaces the resolver "
+        "checks -- ring extraction silently no-ops (ADR-0014 §3)."
+    )
+    assert resolved is expected
+
+
+# --------------------------------------------------------------------------
+# Behavioral invariant -- the plane through a sphere yields a non-empty ring.
+# --------------------------------------------------------------------------
+
+
+def test_plane_ring_extraction_produces_a_non_empty_ring():
+    """run_ring_extraction returns a ring with points for a plane through a sphere."""
+    _algorithm_module_or_skip()
+    vtk = _vtk_or_skip()
+    representation_cls, _ = _plane_representation_or_skip()
+
+    representation = representation_cls()
+    representation._data_node = _FakePlaneDataNode(
+        origin=(0.0, 0.0, 0.0), normal=(0.0, 0.0, 1.0)
+    )
+    mesh = _target_sphere(vtk)
+
+    ring = representation.run_ring_extraction(mesh)
+    assert ring is not None, (
+        "run_ring_extraction returned None for a plane through the sphere centre -- "
+        "the extractor class did not resolve (silent no-op)."
+    )
+    assert ring.GetNumberOfPoints() > 0, (
+        "The equatorial intersection ring is empty; the extractor resolved but "
+        "produced no geometry."
+    )


### PR DESCRIPTION
## Summary

Fixes a **silent no-op** in the SlicingPlane and DistanceSpheroid init-mode
ring extraction. `_resolve_extractor_class` looked up
`vtkLiverPlaneRingExtractor` / `vtkLiverSpheroidRingExtractor` over the
`(slicer, vtk)` namespaces, but those are **Algorithm-library** classes
(ADR-0014 §3) exposed inside a launched Slicer **only** on
`vtkSlicerLiverResectionsModuleAlgorithmPython`. The resolver returned `None`
on every call, so `run_ring_extraction` never computed an intersection ring —
the overlays were permanently absent, and the unit tests passed only because
they asserted the graceful-`None` degradation path.

This is the same namespace mismatch caught in the locator producer
(`vtkLiverResectogramPixelMapping` is Algorithm-library too).

Fixes #517.

## Fix

Point the extractor resolvers at the Algorithm Python wrapping, lazily
imported so the module stays importable where the wrapping is off the path
(the bare-VTK unit layer).

## Simplification

The same launched-Slicer namespace probe confirmed **no** Liver class is
reachable from the plain upstream `vtk` module (VTKWidgets classes are on
`slicer`, Algorithm classes on `AlgorithmPython`). All three resolvers
therefore collapse from the `for module_name in ("slicer", "vtk")` +
`__import__` loop to a single-namespace lazy import — the `vtk` fallback was
dead code. The VTKWidgets mapper/source resolvers (`_require_vtk_class`) keep
their resolve-or-raise contract, now via `slicer` only (−77/+62 lines).

Verified namespace map (launched Slicer):

```
vtkLiverPlaneRingExtractor              -> AlgorithmPython
vtkLiverSpheroidRingExtractor           -> AlgorithmPython
vtkOpenGLBezierResectionPolyDataMapper  -> slicer + VTKWidgetsPython
vtkOpenGLDistanceContourPolyDataMapper  -> slicer + VTKWidgetsPython
vtkBezierSurfaceSource                  -> slicer
```

## Test-first (ADR-0027)

Landed RED-then-green. The new invariant test asserts the extractor classes
resolve to a real class (not `None`) and that a plane through a sphere centre
yields a non-empty ring — it **fails** under the launched-Slicer row before
the fix and passes after. It skips cleanly under bare `pytest` (the Algorithm
wrapping is off that path).

Verified launched: 14/14 pass in the ring-extraction + mapper-wiring set
(1 pre-existing unrelated skip); the three new assertions flipped RED→GREEN,
and the Bezier / DistanceSpheroid / Vascular / Flattened mapper-wiring tests
confirm the `_require_vtk_class` change did not regress VTKWidgets resolution.

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
