### PR TITLE
STYLE: Resectogram locator seam review follow-ups

### DIFF
--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -268,6 +268,13 @@ class ResectogramPipeline(_PipelineBase):
         click anywhere it has a data node.  ``distance2`` is 0: the strip owns
         its standalone embedded view, so no other interactive Pipeline competes
         for focus (`ADR-0025`_ §Click-to-reslice).
+
+        The constant-zero ``distance2`` is sound ONLY while the resectogram
+        singleton view hosts a single interactive Pipeline: a zero distance
+        unconditionally wins the LayerDM focus arbitration, so a second
+        interactive Pipeline registered into this view (e.g. the v2.1
+        cross-module producers `ADR-0025`_ anticipates) would be starved.  If
+        that day comes, arbitrate by real display distance here.
         """
         import sys
 
@@ -322,6 +329,9 @@ class ResectogramPipeline(_PipelineBase):
         render_window = renderer.GetRenderWindow() if renderer is not None else None
         if render_window is None:
             return None
+        # The render-window size is the pixel-mapping viewport because the strip
+        # owns a standalone single-renderer embedded view (window == viewport);
+        # this equivalence would break only under a sub-unit renderer viewport.
         viewport_size = render_window.GetSize()
 
         from LiverResectionsLib.ResectogramLocatorProducer import (

--- a/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
+++ b/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
@@ -69,8 +69,8 @@ green-but-skipping prone).
 See also:
   * Docs/adr/0025-locator-architecture.md §Producer, §Consumer, §Context,
     §Click-to-reslice, §Conformance
-  * Docs/adr/0032-... (the resectogram interaction seam)
-  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * Docs/adr/0032-v2-interaction-via-layerdm-pipeline-seam.md  (the seam)
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md  (RED / skip-pending)
   * Docs/adr/0004-python-cpp-boundary.md   (the seam is Python)
   * Docs/adr/0013-layerdm-pipeline-pattern.md §5, §6
   * LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -538,6 +538,37 @@ def test_can_process_interaction_event_gated_on_data_node():
         "displayed (the strip maps every in-view pixel)."
     )
     assert distance2 == pytest.approx(0.0)
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 5 -- the locator resolver's no-scene guard
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_locator_node_none_when_surface_has_no_scene():
+    """``_resolve_locator_node`` returns None when the surface has no scene.
+
+    A displayed carrier always has a scene in production, so this is the
+    defensive guard: a surface whose ``GetScene()`` yields None must resolve to
+    no locator, returning before touching the scene API.  Exercises only the
+    staticmethod's None-guard -- no ``slicer.mrmlScene``, no wrapped classes --
+    but needs ``ResectogramPipeline`` importable (LayerDMLib), so it skips
+    cleanly under bare pytest.
+    """
+    try:
+        module = __import__(PIPELINE_MODULE, fromlist=[PIPELINE_CLASS])
+        pipeline_cls = getattr(module, PIPELINE_CLASS)
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"{PIPELINE_CLASS} not importable ({exc!r}) -- LayerDMLib is off the "
+            "path in this environment."
+        )
+
+    class _SurfaceWithoutScene:
+        def GetScene(self):  # noqa: N802 - VTK verb
+            return None
+
+    assert pipeline_cls._resolve_locator_node(_SurfaceWithoutScene()) is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to the resectogram locator interaction seam, addressing the
low-severity items from its `/slicer-review` (no blockers were found; the seam
merged as-is). No behaviour change.

- **Focus-arbitration invariant** — document that `CanProcessInteractionEvent`
  returning `distance2 = 0.0` is sound *only* while the resectogram singleton
  view hosts a single interactive Pipeline: a zero distance unconditionally
  wins the LayerDM focus arbitration, so a second interactive Pipeline in that
  view (e.g. the v2.1 cross-module producers ADR-0025 anticipates) would be
  starved. If that day comes, arbitrate by real display distance.
- **Viewport assumption** — note that render-window size == pixel-mapping
  viewport holds only for the standalone single-renderer embedded view.
- **Coverage** — add a GL-free (and slicer-free) test for
  `_resolve_locator_node`'s no-scene guard (the surface-without-scene
  `None`-path), the one branch the seam tests had left uncovered.
- **Docstring paths** — fix two dead ADR references in the test docstring
  (`0027` / `0032` full filenames).

Deliberately **not** done: wrapping the `produce(...)` call in a broad
try/except. The seam's documented no-op contract enumerates *state* conditions
(no surface / no locator / unresolved MatRatio / non-positive viewport), all of
which are guarded; catching malformed-type inputs that real VTK event data
never produces would be speculative defensiveness.

## Verification

Launched: 8/8 seam tests pass, 0 skipped (the new no-scene test runs and
asserts). Skips cleanly under bare `pytest`.

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
