### PR TITLE
ENH: Click-to-reslice consumer (LocatorReslicer) — ADR-0025 Slice D

### DIFF
--- a/LiverResections/LiverResectionsLib/LocatorReslicer.py
+++ b/LiverResections/LiverResectionsLib/LocatorReslicer.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Click-to-reslice consumer — locator picked point drives the slice (ADR-0025).
+
+The cross-view locator's picked RAS world point (carried on the single
+``vtkMRMLLocatorNode``, `ADR-0025`_ §"The node") drives the orthogonal slice so
+its plane passes through that point ("click-to-reslice", `ADR-0025`_
+§Click-to-reslice).  This is the data-flow arrow ``Node -> Slice``, distinct
+from the shader-marker arrow ``Node -> Consumer -> Shader`` the T2 Pipeline
+already carries.
+
+Per `ADR-0013`_ §5 this is **not** a Pipeline or a displayable manager — it is
+a plain Python observer (`ADR-0004`_): it resolves the scene's single locator,
+observes its ``ModifiedEvent``, and on a picked-point change reslices the Red
+slice node via ``vtkMRMLSliceNode.JumpSliceByOffsetting`` (which translates the
+slice ALONG its normal only, so the plane's orientation is preserved and only
+its offset moves onto the point).  Its lifecycle is owned by the caller (the
+Resection Planning widget), which constructs it with the scene and calls
+``cleanup()`` on teardown.  The locator reads/writes stay on the data-only
+carrier (`ADR-0014`_): the reslicer reads ``GetPickedPositionWorld`` and writes
+only the slice node.
+
+Driving a single (Red) slice matches the v2.0 scope; a Red/Yellow/Green sweep
+is a v2.1 enhancement alongside the deferred cross-module locator unification.
+
+References
+----------
+* `ADR-0025`_ §Click-to-reslice.
+* `ADR-0013`_ §5 — no custom displayable manager.
+* `ADR-0004`_ — the consumer is Python.
+
+.. _ADR-0025: ../../Docs/adr/0025-locator-architecture.md
+.. _ADR-0013: ../../Docs/adr/0013-layerdm-pipeline-pattern.md
+.. _ADR-0014: ../../Docs/adr/0014-livermarkups-dissolution.md
+.. _ADR-0004: ../../Docs/adr/0004-python-cpp-boundary.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_LOCATOR_NODE_CLASS = "vtkMRMLLocatorNode"
+#: The orthogonal slice driven by a resectogram click (v2.0 scope: Red only).
+_RED_SLICE_NODE_ID = "vtkMRMLSliceNodeRed"
+
+
+class LocatorReslicer:
+    """Observes the single locator node and reslices the Red slice to its pick."""
+
+    def __init__(self, scene: Any) -> None:
+        self._scene = scene
+        self._locator_node: Any | None = None
+        self._observer_tag: int | None = None
+        self.refresh()
+
+    @staticmethod
+    def reslice_slice_to_world(slice_node: Any, world_xyz: Any) -> bool:
+        """Offset ``slice_node``'s plane onto the RAS point, preserving orientation.
+
+        Uses ``vtkMRMLSliceNode.JumpSliceByOffsetting(r, a, s)`` — a translation
+        along the slice normal, so the plane's normal is invariant and only its
+        offset moves onto ``world_xyz``.  Returns ``True`` when it reslices;
+        ``False`` (a no-op, never raising) on a degenerate input (no slice node,
+        no world point, or a slice node without the jump API).
+        """
+        if slice_node is None or world_xyz is None:
+            return False
+        jump = getattr(slice_node, "JumpSliceByOffsetting", None)
+        if jump is None:
+            return False
+        jump(float(world_xyz[0]), float(world_xyz[1]), float(world_xyz[2]))
+        return True
+
+    def refresh(self) -> None:
+        """Re-resolve the scene's single locator node and (re)attach the observer.
+
+        Idempotent: safe to call when the scene gains/loses its locator node.
+        """
+        found = self._resolve_locator()
+        if found is self._locator_node:
+            return
+        self._detach()
+        self._locator_node = found
+        if found is not None and hasattr(found, "AddObserver"):
+            self._observer_tag = found.AddObserver(
+                "ModifiedEvent", self._on_locator_modified
+            )
+
+    def cleanup(self) -> None:
+        """Detach the observer and drop references (symmetric with ``__init__``)."""
+        self._detach()
+        self._locator_node = None
+        self._scene = None
+
+    # -- internals ------------------------------------------------------- #
+
+    def _resolve_locator(self) -> Any | None:
+        if self._scene is None:
+            return None
+        return self._scene.GetFirstNodeByClass(_LOCATOR_NODE_CLASS)
+
+    def _detach(self) -> None:
+        if self._locator_node is not None and self._observer_tag is not None:
+            try:
+                self._locator_node.RemoveObserver(self._observer_tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        self._observer_tag = None
+
+    def _on_locator_modified(self, caller: Any, event: str) -> None:
+        self._reslice_from_locator(caller)
+
+    def _reslice_from_locator(self, locator: Any) -> None:
+        if locator is None or self._scene is None:
+            return
+        getter = getattr(locator, "GetPickedPositionWorld", None)
+        if getter is None:
+            return
+        red = self._scene.GetNodeByID(_RED_SLICE_NODE_ID)
+        if red is None:
+            return
+        self.reslice_slice_to_world(red, getter())

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -360,6 +360,38 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;locator"
     )
 
+    # Locator D: click-to-reslice CONSUMER kernel (GL-free), ADR-0025
+    # §Click-to-reslice -- the slice-reslice half of the ADR-0025 locator
+    # architecture.  Pins a NEW LiverResectionsLib.LocatorReslicer (ADR-0004
+    # Python, ADR-0013 §5 no custom DM) whose STATIC kernel
+    # reslice_slice_to_world(slice_node, world_xyz) -> bool updates the
+    # vtkMRMLSliceNode's SliceToRAS (via JumpSliceByOffsetting) so the slice
+    # plane passes through the picked RAS world point, preserving orientation.
+    # Invariant 1 (the [test] pin): seed a KNOWN non-axial SliceToRAS, pick a
+    # world point OFF the plane, reslice, assert the point now lies in the plane
+    # (dot(normal, point - origin) == 0) and the normal direction is unchanged.
+    # Invariant 2: degenerate input (slice_node None / world_xyz None) is a
+    # no-op returning False, never raising.  Invariant 3 (secondary,
+    # skip-pending on the constructor/observe API): a LocatorReslicer(scene)
+    # observing the scene's single vtkMRMLLocatorNode reslices the Red slice on
+    # a picked position.  Needs the wrapped vtkMRMLSliceNode / vtkMRMLLocatorNode
+    # + the importable LocatorReslicer, so it runs green under the
+    # launched-Slicer `pytest_launched` row and SKIPS CLEANLY here under bare
+    # pytest (no slicer.mrmlScene / LiverResectionsLib off the path).  GL free --
+    # SliceToRAS lives on the bare node, no view/widget/render window.  RED /
+    # skip-pending until the implementer lands LocatorReslicer (ADR-0027
+    # §Conformance: the skip lifts at the implementation commit).
+    add_test(
+      NAME LiverResections_locator_reslice_consumer
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_locator_reslice_consumer.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_locator_reslice_consumer PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;locator"
+    )
+
     # #501 slice 2 -- the v2 resection control-point edit path on the LayerDM
     # Pipeline (ADR-0032: interaction routes through the Pipeline interaction
     # seam, no standalone vtkAbstractWidget).  Pins the GL-free edit kernel

--- a/LiverResections/Testing/Python/test_locator_reslice_consumer.py
+++ b/LiverResections/Testing/Python/test_locator_reslice_consumer.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Click-to-reslice CONSUMER kernel (GL-free), ADR-0025 §Click-to-reslice.
+
+Pins the slice-reslice half of the ADR-0025 locator architecture: a
+resectogram click carries a picked RAS world point on the single
+``vtkMRMLLocatorNode``, and the consumer side reslices the orthogonal slice
+view so the slice PLANE passes through that world point.  This file pins a NEW
+module/class to be implemented later (ADR-0004 Python, ADR-0013 §5 -- no custom
+displayable manager):
+
+    LiverResectionsLib.LocatorReslicer.LocatorReslicer
+
+The [test] pin (ADR-0025 §Conformance, verbatim): "click-to-reslice updates the
+slice ``SliceToRAS`` so the slice passes through the picked world point."
+
+THE KERNEL (the [test] pin)
+---------------------------
+A STATIC method::
+
+    LocatorReslicer.reslice_slice_to_world(slice_node, world_xyz) -> bool
+
+updates ``slice_node``'s ``SliceToRAS`` so the slice plane passes through the
+RAS point ``world_xyz`` (a 3-sequence of float), PRESERVING orientation.  It is
+implemented via ``vtkMRMLSliceNode.JumpSliceByOffsetting(r, a, s)`` -- which
+translates the slice ALONG its normal only, so the plane's normal direction is
+invariant and only the in-plane offset moves.  Returns True when it reslices;
+False (a no-op) on degenerate input (``slice_node`` None, or ``world_xyz``
+None), and it must not raise on those.
+
+TEST DESIGN -- GL-free, launched-Slicer, no slice VIEW/widget
+-------------------------------------------------------------
+``SliceToRAS`` lives on the bare ``vtkMRMLSliceNode``; no slice view, layout
+manager, or render window is realised.  The point-in-plane invariant is read
+directly off the node's matrix:
+
+  * normal  = the 3rd column of ``GetSliceToRAS()`` (rows 0..2, col 2);
+  * origin  = the translation, the 4th column (rows 0..2, col 3);
+  * a point ``p`` lies in the plane iff ``dot(normal, p - origin) == 0``.
+
+Invariant 1 seeds a KNOWN non-axial orientation (a ~35 deg rotation so the
+normal is not a pure axis -- a trivial axial plane would pass an
+identity-preserving no-op), picks a world point deliberately OFF that plane,
+reslices, and asserts (a) the point now lies in the plane and (b) the
+normalized normal is unchanged (JumpSliceByOffsetting only translates).
+
+WHY LAUNCHED-SLICER / RUN-VS-SKIP
+---------------------------------
+Needs the wrapped ``vtkMRMLSliceNode`` (+ its ``JumpSliceByOffsetting`` /
+``SliceToRAS`` API) and the importable ``LocatorReslicer`` -- reachable only
+inside a launched Slicer with the module on the path; a bare
+``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` and those off the
+path, so every test SKIPS CLEANLY via the shared ``slicer_pytest_support``
+guards.  GL-free: the matrix accessors need no render window.
+
+The kernel tests are SKIP-PENDING on the not-yet-existing ``LocatorReslicer`` /
+``reslice_slice_to_world`` (ADR-0027 -- the skip lifts at the implementation
+commit); ONCE PRESENT they must ASSERT, not skip.  The secondary observer test
+(invariant 3) stays skip-pending on the constructor/observe API.
+
+See also:
+  * Docs/adr/0025-locator-architecture.md §Click-to-reslice, §Conformance
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md  (RED / skip-pending)
+  * Docs/adr/0004-python-cpp-boundary.md   (the consumer is Python)
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §5  (no custom DM)
+  * LiverResections/MRML/Testing/Cxx/vtkMRMLLocatorNodeTest1.cxx
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+SLICE_NODE_CLASS = "vtkMRMLSliceNode"
+LOCATOR_NODE_CLASS = "vtkMRMLLocatorNode"
+
+# The module/class carrying the reslice kernel (ADR-0004 Python, ADR-0013 §5).
+RESLICER_MODULE = "LiverResectionsLib.LocatorReslicer"
+RESLICER_CLASS = "LocatorReslicer"
+
+# Point-in-plane / normal-preservation tolerance.  Loose enough for the double
+# rounding JumpSliceByOffsetting accumulates through the RAS->offset->matrix
+# round trip, tight enough that a wrong translation axis or a rotated normal
+# fails.
+PLANE_TOL = 1e-4
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror test_pipeline_resolves_locator.py /
+# test_resectogram_locator_pipeline_seam.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def _reslicer_class_or_skip_pending():
+    """Return ``LocatorReslicer`` or SKIP-PENDING (ADR-0027).
+
+    RED == the ``LocatorReslicer`` module/class is absent; the skip lifts at the
+    implementation commit, at which point the kernel tests ASSERT.  A bare
+    pytest run cannot import it (LiverResectionsLib is off the path), so this
+    also serves as the bare-run clean skip.
+    """
+    try:
+        module = __import__(RESLICER_MODULE, fromlist=[RESLICER_CLASS])
+        return getattr(module, RESLICER_CLASS)
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"{RESLICER_CLASS} not importable ({exc!r}) -- the ADR-0025 "
+            "click-to-reslice consumer has not landed (or LiverResectionsLib is "
+            "off the path).  Skip lifts at the implementation commit (ADR-0027)."
+        )
+
+
+def _reslice_method_or_skip_pending(reslicer_cls):
+    """Return the bound ``reslice_slice_to_world`` staticmethod or SKIP-PENDING."""
+    method = getattr(reslicer_cls, "reslice_slice_to_world", None)
+    if not callable(method):
+        pytest.skip(
+            f"{RESLICER_CLASS}.reslice_slice_to_world not present -- the ADR-0025 "
+            "click-to-reslice kernel has not landed.  Skip lifts at the "
+            "implementation commit (ADR-0027)."
+        )
+    return method
+
+
+# --------------------------------------------------------------------------- #
+# Matrix helpers -- read the plane off vtkMRMLSliceNode.GetSliceToRAS()
+# --------------------------------------------------------------------------- #
+
+
+def _seed_non_axial_orientation(slice_node, vtk, angle_deg=35.0):
+    """Set a KNOWN non-axial ``SliceToRAS`` so the invariant is non-trivial.
+
+    Rotates the default axial plane ~35 deg about the R axis, so the slice
+    normal is neither a pure axis nor the world point's own axis -- an
+    identity-preserving no-op would then fail invariant 1.  Adopts the
+    externally-built matrix the way the vtkMRMLSliceNode API documents:
+    ``GetSliceToRAS()->DeepCopy(m)`` followed by ``UpdateMatrices()`` (see the
+    header doc-comment on ``GetSliceToRAS``).
+    """
+    theta = math.radians(angle_deg)
+    c, s = math.cos(theta), math.sin(theta)
+    m = vtk.vtkMatrix4x4()
+    m.Identity()
+    # Rotation about R (x): leaves R fixed, tilts the A/S columns.
+    m.SetElement(1, 1, c)
+    m.SetElement(1, 2, -s)
+    m.SetElement(2, 1, s)
+    m.SetElement(2, 2, c)
+    # A non-zero origin so "passes through the point" is not accidentally the
+    # origin already lying on a plane through 0.
+    m.SetElement(0, 3, 5.0)
+    m.SetElement(1, 3, -7.0)
+    m.SetElement(2, 3, 11.0)
+    slice_node.GetSliceToRAS().DeepCopy(m)
+    slice_node.UpdateMatrices()
+
+
+def _plane_normal(slice_to_ras):
+    """Slice normal = the 3rd column (rows 0..2, col 2) of SliceToRAS."""
+    return (
+        slice_to_ras.GetElement(0, 2),
+        slice_to_ras.GetElement(1, 2),
+        slice_to_ras.GetElement(2, 2),
+    )
+
+
+def _plane_origin(slice_to_ras):
+    """Slice origin = the translation, the 4th column (rows 0..2, col 3)."""
+    return (
+        slice_to_ras.GetElement(0, 3),
+        slice_to_ras.GetElement(1, 3),
+        slice_to_ras.GetElement(2, 3),
+    )
+
+
+def _dot(a, b):
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _normalized(v):
+    n = math.sqrt(_dot(v, v))
+    if n == 0.0:
+        return v
+    return (v[0] / n, v[1] / n, v[2] / n)
+
+
+def _signed_distance_to_plane(slice_to_ras, point):
+    """dot(unit_normal, point - origin) -- zero iff ``point`` lies in the plane."""
+    normal = _normalized(_plane_normal(slice_to_ras))
+    origin = _plane_origin(slice_to_ras)
+    diff = (point[0] - origin[0], point[1] - origin[1], point[2] - origin[2])
+    return _dot(normal, diff)
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 1 -- the point-in-plane kernel (the [test] pin)
+# --------------------------------------------------------------------------- #
+
+
+def test_reslice_makes_slice_plane_pass_through_world_point():
+    """The [test] pin: reslice updates SliceToRAS so the plane passes through
+    the picked world point, preserving orientation.
+
+    Seed a KNOWN non-axial orientation, pick a world point deliberately OFF the
+    current plane, call ``reslice_slice_to_world``, then assert:
+      (a) True is returned (a reslice happened);
+      (b) the picked point now lies IN the plane
+          (``dot(normal, point - origin) == 0`` within PLANE_TOL);
+      (c) the plane NORMAL direction is unchanged
+          (JumpSliceByOffsetting only translates along the normal).
+    Once ``LocatorReslicer`` lands this ASSERTS; until then it skips-pending
+    (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    import vtk
+
+    reslicer_cls = _reslicer_class_or_skip_pending()
+    reslice = _reslice_method_or_skip_pending(reslicer_cls)
+
+    slice_node = _add_or_skip(slicer, SLICE_NODE_CLASS)
+    _seed_non_axial_orientation(slice_node, vtk)
+
+    normal_before = _normalized(_plane_normal(slice_node.GetSliceToRAS()))
+
+    # A world point deliberately OFF the current plane: start at the origin and
+    # step ALONG the normal so the signed distance is non-zero.
+    origin = _plane_origin(slice_node.GetSliceToRAS())
+    world = (
+        origin[0] + 40.0 * normal_before[0] + 3.0,
+        origin[1] + 40.0 * normal_before[1] - 2.0,
+        origin[2] + 40.0 * normal_before[2] + 6.0,
+    )
+    assert abs(_signed_distance_to_plane(slice_node.GetSliceToRAS(), world)) > 1.0, (
+        "test setup: the chosen world point must start OFF the seeded plane, "
+        "else the invariant is trivially satisfied before reslicing."
+    )
+
+    result = reslice(slice_node, world)
+
+    assert result is True, (
+        "reslice_slice_to_world must return True when it reslices a valid slice "
+        f"node to a valid world point; got {result!r}."
+    )
+    after = slice_node.GetSliceToRAS()
+    distance = _signed_distance_to_plane(after, world)
+    assert abs(distance) < PLANE_TOL, (
+        "after reslicing, the picked world point must lie in the slice plane "
+        f"(dot(normal, point - origin) == 0); signed distance is {distance} "
+        f"(tol {PLANE_TOL}) -- the SliceToRAS was not offset onto the point "
+        "(ADR-0025 §Click-to-reslice)."
+    )
+    normal_after = _normalized(_plane_normal(after))
+    for axis, (b, a) in enumerate(zip(normal_before, normal_after)):
+        assert abs(a - b) < PLANE_TOL, (
+            "reslice must PRESERVE the slice orientation -- JumpSliceByOffsetting "
+            f"only translates along the normal; normal component {axis} changed "
+            f"from {b} to {a}."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 2 -- degenerate inputs are no-ops returning False (and never raise)
+# --------------------------------------------------------------------------- #
+
+
+def test_reslice_no_op_when_slice_node_none():
+    """A None slice node is a no-op returning False (and must not raise)."""
+    _slicer_or_skip()
+    reslicer_cls = _reslicer_class_or_skip_pending()
+    reslice = _reslice_method_or_skip_pending(reslicer_cls)
+
+    assert reslice(None, (1.0, 2.0, 3.0)) is False, (
+        "reslice_slice_to_world(None, world) must be a no-op returning False, "
+        "not raise -- there is no slice to reslice."
+    )
+
+
+def test_reslice_no_op_when_world_none():
+    """A None world point is a no-op returning False (and must not raise),
+    leaving the slice's SliceToRAS untouched."""
+    slicer = _slicer_or_skip()
+    import vtk
+
+    reslicer_cls = _reslicer_class_or_skip_pending()
+    reslice = _reslice_method_or_skip_pending(reslicer_cls)
+
+    slice_node = _add_or_skip(slicer, SLICE_NODE_CLASS)
+    _seed_non_axial_orientation(slice_node, vtk)
+    before = vtk.vtkMatrix4x4()
+    before.DeepCopy(slice_node.GetSliceToRAS())
+
+    assert reslice(slice_node, None) is False, (
+        "reslice_slice_to_world(slice_node, None) must be a no-op returning "
+        "False, not raise -- there is no world point to reslice onto."
+    )
+    after = slice_node.GetSliceToRAS()
+    for row in range(4):
+        for col in range(4):
+            assert abs(after.GetElement(row, col) - before.GetElement(row, col)) < PLANE_TOL, (
+                "a degenerate (world None) reslice must leave the slice's "
+                f"SliceToRAS untouched; element ({row},{col}) changed."
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 3 (secondary) -- the scene-observing consumer reslices the Red slice
+# --------------------------------------------------------------------------- #
+
+
+def test_locator_observer_reslices_red_slice_on_picked_position():
+    """Secondary: a ``LocatorReslicer(scene)`` observes the scene's single
+    ``vtkMRMLLocatorNode`` and reslices the Red slice so the picked point lies
+    in its plane (ADR-0025 §Click-to-reslice, consumer side).
+
+    Skip-pending on the constructor / observe API (the primary [test] pin is the
+    kernel, invariants 1+2).  Uses the launched-Slicer Red slice node
+    (``vtkMRMLSliceNodeRed``) so no view/widget is realised -- SliceToRAS lives
+    on the bare node.
+    """
+    slicer = _slicer_or_skip()
+    import vtk
+
+    reslicer_cls = _reslicer_class_or_skip_pending()
+    _reslice_method_or_skip_pending(reslicer_cls)
+
+    red = slicer.mrmlScene.GetNodeByID("vtkMRMLSliceNodeRed")
+    if red is None:
+        pytest.skip(
+            "no vtkMRMLSliceNodeRed in the scene -- the launched-Slicer default "
+            "slice nodes are not present in this environment."
+        )
+    _seed_non_axial_orientation(red, vtk)
+
+    locator = _add_or_skip(slicer, LOCATOR_NODE_CLASS)
+    if not hasattr(locator, "SetPickedPositionWorld"):
+        pytest.skip(
+            "vtkMRMLLocatorNode has no SetPickedPositionWorld in this build -- "
+            "cannot drive the observer."
+        )
+
+    # Construct the observing consumer.  Skip-pending on the constructor/observe
+    # API until the consumer lands (ADR-0027).
+    try:
+        reslicer = reslicer_cls(slicer.mrmlScene)
+    except Exception as exc:  # pragma: no cover - constructor-shape dependent
+        pytest.skip(
+            f"{RESLICER_CLASS}(scene) not constructable ({exc!r}) -- the "
+            "scene-observing consumer wiring has not landed (ADR-0027)."
+        )
+    if reslicer is None:
+        pytest.skip(f"{RESLICER_CLASS}(scene) returned None.")
+
+    origin = _plane_origin(red.GetSliceToRAS())
+    normal = _normalized(_plane_normal(red.GetSliceToRAS()))
+    world = (
+        origin[0] + 50.0 * normal[0] + 4.0,
+        origin[1] + 50.0 * normal[1] - 3.0,
+        origin[2] + 50.0 * normal[2] + 8.0,
+    )
+
+    locator.SetPickedPositionWorld(*world)
+    locator.Modified()
+
+    distance = _signed_distance_to_plane(red.GetSliceToRAS(), world)
+    assert abs(distance) < PLANE_TOL, (
+        "setting the locator's PickedPositionWorld + firing Modified must drive "
+        "the observing LocatorReslicer to reslice the Red slice so the picked "
+        f"point lies in its plane; signed distance is {distance} (tol {PLANE_TOL})."
+    )
+
+    # Tear down the observer so it does not survive to process shutdown (launched
+    # leak discipline; the scene-cleanup fixture reclaims the minted nodes).
+    for name in ("cleanup", "RemoveObservers", "removeObservers"):
+        teardown = getattr(reslicer, name, None)
+        if callable(teardown):
+            try:
+                teardown()
+            except Exception:  # pragma: no cover - defensive teardown
+                pass
+            break
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Implements the ADR-0025 **click-to-reslice** consumer (§Click-to-reslice) — the
last data-flow arrow of the cross-view locator, `Node → Slice`, distinct from
the shader-marker path `Node → Consumer → Shader` that already merged.

`LocatorReslicer` is a plain Python observer (ADR-0013 §5 clean — not a Pipeline
or displayable manager; ADR-0004 Python): it resolves the scene's single
`vtkMRMLLocatorNode`, observes its `ModifiedEvent`, and on a picked-point change
reslices the Red slice node so its plane passes through the point.

The pure kernel `reslice_slice_to_world(slice_node, world_xyz)` uses
`vtkMRMLSliceNode.JumpSliceByOffsetting` — a translation along the slice normal
only, so orientation is preserved and only the offset moves onto the point. It
reads the picked point off the data-only locator carrier (ADR-0014) and writes
only the slice node.

Drives the **Red** slice for v2.0; a Red/Yellow/Green sweep is a v2.1
enhancement (alongside the deferred cross-module locator unification, ADR-0012).

Contributes to #490.

## Test-first (ADR-0027)

Landed RED-then-green. The [test] pin (verbatim from #490): *"click-to-reslice
updates the slice SliceToRAS so the slice passes through the picked world
point."* The kernel test seeds a known non-axial `SliceToRAS`, picks a point off
the plane, reslices, and asserts (a) the point now lies in the plane
(`dot(normal, point − origin) ≈ 0`, read off the matrix) and (b) the normal is
unchanged (orientation preserved); plus degenerate no-ops.

Verified launched: **3/3 kernel tests pass**. GL-free — `SliceToRAS` lives on
the bare slice node, no view/widget realised; skips cleanly under bare pytest. A
secondary scene-observer test rides the launched Red slice node and skips
headless (`--no-main-window` has no default slice nodes).

## Scope

Tested consumer unit only. The live wiring — creating the `vtkMRMLLocatorNode`,
having `ResectionPlanningWidget` own the `LocatorReslicer`, and `:0`-verifying
click→reslice + click→marker end-to-end — is a separate integration step (the
locator chain is currently inert because nothing instantiates the node yet).

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
