### PR TITLE
ENH: Wire the cross-view locator live — create the node + own the reslice consumer (ADR-0025)

### DIFF
--- a/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
+++ b/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
@@ -156,6 +156,11 @@ class ResectionPlanningWidget(qt.QWidget):
         # The qvtk observer connections, tracked for symmetric removal.
         self._activeNodeObservationTag = None
         self._renderObservationTag = None
+        # The click-to-reslice consumer (ADR-0025 §Click-to-reslice): a plain
+        # Python observer (ADR-0013 §5 -- not a Pipeline/DM) that watches the
+        # scene's single vtkMRMLLocatorNode and reslices the orthogonal slice to
+        # the picked point.  This widget owns its lifetime.
+        self._locatorReslicer = None
 
         self._setupUi()
         self.refreshResectogramDrawer()
@@ -225,7 +230,27 @@ class ResectionPlanningWidget(qt.QWidget):
     def setMRMLScene(self, scene):  # noqa: N802 - Slicer/Qt verb convention
         self._mrmlScene = scene
         self._comboBox.setMRMLScene(scene)
+        self._updateLocatorReslicer(scene)
         self.refreshResectogramDrawer()
+
+    def _updateLocatorReslicer(self, scene):  # noqa: N802 - internal
+        """Own the click-to-reslice consumer's lifetime (ADR-0025 §Click-to-reslice).
+
+        Rebuilds the ``LocatorReslicer`` against the current scene (tearing down
+        any prior one) and drops it on a null scene.  The reslicer resolves the
+        single locator at construction; ``refreshResectogramDrawer`` re-resolves
+        it later so a locator created after the widget still gets observed.
+        """
+        if self._locatorReslicer is not None:
+            self._locatorReslicer.cleanup()
+            self._locatorReslicer = None
+        if scene is None:
+            return
+        try:
+            from LiverResectionsLib.LocatorReslicer import LocatorReslicer
+        except Exception:  # pragma: no cover - surfaces only when the lib is absent
+            return
+        self._locatorReslicer = LocatorReslicer(scene)
 
     def mrmlScene(self):  # noqa: N802 - Slicer/Qt verb convention
         return self._mrmlScene
@@ -297,6 +322,13 @@ class ResectionPlanningWidget(qt.QWidget):
         self.scheduleResectogramRender()
 
     def refreshResectogramDrawer(self):  # noqa: N802 - Slicer/Qt verb convention
+        # Re-resolve the locator the click-to-reslice consumer observes BEFORE
+        # the distance-map guards below (a locator minted after the widget --
+        # e.g. by CreateResectionPlan on Place -- must get observed regardless of
+        # whether the resectogram is drawable yet).
+        if self._locatorReslicer is not None:
+            self._locatorReslicer.refresh()
+
         plan = self._asResectionPlan(self._comboBox.currentNode())
         # The strip actors, the resectogram display node, and the render
         # observation all live on the plan's CARRIER (ADR-0014 §"Fourth layer");
@@ -734,6 +766,11 @@ class ResectionPlanningWidget(qt.QWidget):
         """
         if self._comboBox is not None:
             self._comboBox.setMRMLScene(None)
+        # The click-to-reslice consumer's locator observer (on a scene node that
+        # outlives this panel) -- detach symmetrically.
+        if self._locatorReslicer is not None:
+            self._locatorReslicer.cleanup()
+            self._locatorReslicer = None
         # VTK node observers (on scene nodes that outlive this panel).
         if self._activeResectionNode is not None and self._activeNodeObservationTag is not None:
             self._activeResectionNode.RemoveObserver(self._activeNodeObservationTag)

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -153,9 +153,45 @@ vtkMRMLResectionPlanNode* vtkSlicerLiverResectionsLogic::CreateResectionPlan(con
   // Pipeline reverse-resolves the plan from this back-reference (ADR-0031).
   plan->SetAndObserveGeometryNode(carrier);
 
+  // Ensure the cross-view locator node exists so a resectogram click has a
+  // node to write and the consumers (shader marker, click-to-reslice) have one
+  // to read (ADR-0025 §Consumer: exactly one in v2.0).
+  this->EnsureLocatorNode();
+
   // The plan starts in Init (ADR-0019); the control grid is seeded by the
   // placement step, not here.
   return plan;
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLLocatorNode* vtkSlicerLiverResectionsLogic::EnsureLocatorNode()
+{
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (scene == nullptr)
+  {
+    vtkErrorMacro("EnsureLocatorNode: no MRML scene is bound");
+    return nullptr;
+  }
+
+  // Resolve-or-create: reuse the single existing locator (ADR-0025 §Consumer:
+  // v2.0 has exactly one) rather than minting a second.
+  auto* locator = vtkMRMLLocatorNode::SafeDownCast(scene->GetFirstNodeByClass("vtkMRMLLocatorNode"));
+  if (locator == nullptr)
+  {
+    locator = vtkMRMLLocatorNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLLocatorNode"));
+  }
+  if (locator == nullptr)
+  {
+    vtkErrorMacro("EnsureLocatorNode: failed to instantiate the locator node");
+    return nullptr;
+  }
+
+  // The display node carries the marker radius (default > 0) + feeds the
+  // uLocatorRadius shader uniform; mark the locator active (persisted presence
+  // flag, ADR-0025 §"The node").
+  locator->CreateDefaultDisplayNodes();
+  locator->SetLocatorActive(true);
+  return locator;
 }
 
 //---------------------------------------------------------------------------

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.h
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.h
@@ -58,6 +58,7 @@
 #include <itkImage.h>
 
 class vtkMRMLResectionPlanNode;
+class vtkMRMLLocatorNode;
 
 //------------------------------------------------------------------------------
 class VTK_SLICER_LIVERRESECTIONS_MODULE_LOGIC_EXPORT vtkSlicerLiverResectionsLogic : public vtkSlicerModuleLogic
@@ -104,6 +105,18 @@ public:
   /// control grid is seeded by the placement step, not here.  Returns
   /// nullptr when no MRML scene is bound or node instantiation fails.
   vtkMRMLResectionPlanNode* CreateResectionPlan(const char* name = nullptr);
+
+  /// Ensure the scene has exactly one cross-view locator node.
+  ///
+  /// Resolve-or-create the single ``vtkMRMLLocatorNode`` the ADR-0025
+  /// cross-view locator coordinates through (§Consumer: v2.0 has exactly
+  /// one): returns the existing node if present, otherwise mints one with
+  /// its default ``vtkMRMLLocatorDisplayNode`` (radius > 0, so the marker
+  /// is visible) and marks it active (the persisted presence flag,
+  /// ADR-0025 §"The node").  Idempotent — never mints a second.  Called
+  /// from ``CreateResectionPlan`` so the producer/consumer chain has a
+  /// node to write/read.  Returns nullptr when no MRML scene is bound.
+  vtkMRMLLocatorNode* EnsureLocatorNode();
 
 protected:
   vtkSlicerLiverResectionsLogic();

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -392,6 +392,37 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;locator"
     )
 
+    # Locator SINGLETON on the logic (GL-free), ADR-0025 §Consumer -- the
+    # resolve-or-create half that guarantees "v2.0 has exactly one"
+    # vtkMRMLLocatorNode.  Pins a NEW vtkSlicerLiverResectionsLogic method
+    # EnsureLocatorNode() (ADR-0014 the logic layer, ADR-0004 C++/Python
+    # boundary) that resolves via GetFirstNodeByClass else mints via
+    # AddNewNodeByClass, wires a vtkMRMLLocatorDisplayNode (default Radius 2.0)
+    # through CreateDefaultDisplayNodes(), sets LocatorActive = true, and returns
+    # the node.  Invariant 1: the call leaves exactly one locator, wired +
+    # active; invariant 2: a second call returns the SAME node (same GetID) and
+    # mints no second one (idempotent); invariant 3: CreateResectionPlan calls it
+    # so opening a plan ensures the locator and a second plan does not add
+    # another (still exactly one).  Needs the registered logic singleton + the
+    # wrapped vtkMRMLLocatorNode / vtkMRMLLocatorDisplayNode, so it runs green
+    # under the launched-Slicer `pytest_launched` row and SKIPS CLEANLY here
+    # under bare pytest (no slicer.mrmlScene / no logic).  GL free -- no view /
+    # render window; only node + display state is asserted.  The shared launched
+    # scene is not assumed empty: each test clears pre-existing locators up front
+    # and tears down what it created.  RED / skip-pending (guards on
+    # hasattr(logic, "EnsureLocatorNode")) until the implementer lands the method
+    # (ADR-0027 §Conformance: the skip lifts at the implementation commit).
+    add_test(
+      NAME LiverResections_ensure_locator_node
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_ensure_locator_node.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_ensure_locator_node PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;locator"
+    )
+
     # #501 slice 2 -- the v2 resection control-point edit path on the LayerDM
     # Pipeline (ADR-0032: interaction routes through the Pipeline interaction
     # seam, no standalone vtkAbstractWidget).  Pins the GL-free edit kernel

--- a/LiverResections/Testing/Python/test_ensure_locator_node.py
+++ b/LiverResections/Testing/Python/test_ensure_locator_node.py
@@ -1,0 +1,309 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Logic-side locator SINGLETON invariant -- ``EnsureLocatorNode`` (ADR-0025 §Consumer).
+
+Pins a NEW C++ method on ``vtkSlicerLiverResectionsLogic`` (to be implemented
+later; ADR-0014 the wrapper/carrier + logic layer, ADR-0004 the C++/Python
+boundary) --
+
+    vtkMRMLLocatorNode* EnsureLocatorNode();
+
+It resolve-or-creates the ONE cross-view ``vtkMRMLLocatorNode`` the v2.0
+architecture allows (ADR-0025 §Consumer: "v2.0 has exactly one"), so every
+consumer that reverse-resolves via ``GetFirstNodeByClass("vtkMRMLLocatorNode")``
+sees a single, deterministic node.  The method is idempotent -- resolve via
+``GetFirstNodeByClass`` else mint via ``AddNewNodeByClass`` -- mints + wires a
+``vtkMRMLLocatorDisplayNode`` (default ``Radius`` = 2.0) through
+``CreateDefaultDisplayNodes()``, sets ``LocatorActive`` = true, and returns the
+node (``nullptr`` when the logic has no scene).  ``CreateResectionPlan`` calls it
+too, so opening a plan guarantees the locator exists.
+
+Three invariants:
+
+  1. ``EnsureLocatorNode`` creates EXACTLY ONE locator: after the call the scene
+     has a single ``vtkMRMLLocatorNode``, it carries a
+     ``vtkMRMLLocatorDisplayNode`` with ``Radius`` > 0, and ``LocatorActive`` is
+     true (ADR-0025 §Consumer, §"The node").
+  2. Idempotent: a SECOND call returns the SAME node (same ``GetID()``) and mints
+     no second node -- the singleton invariant holds under repeat calls
+     (ADR-0025 §Consumer).
+  3. ``CreateResectionPlan`` ensures the locator: opening a plan from a
+     locator-free state leaves >= 1 locator; a second plan does not add another
+     (still exactly one).
+
+-- WHY LAUNCHED-SLICER --
+Needs the registered ``liverresections`` module + its logic singleton (bound to
+``slicer.mrmlScene``) and the wrapped ``vtkMRMLLocatorNode`` /
+``vtkMRMLLocatorDisplayNode``, reachable only inside a launched Slicer with the
+module loaded.  Skips cleanly under bare ``PythonSlicer -m pytest`` via the
+shared ``slicer_pytest_support`` guards.  GL-free: no view / render window is
+realised -- only node + display-node state is asserted.
+
+-- WHY RED NOW --
+``EnsureLocatorNode`` is not yet on the logic, so every test skips-pending on
+``hasattr(logic, "EnsureLocatorNode")``.  The skip lifts at the implementation
+commit, at which point the tests ASSERT (ADR-0027 §Conformance).
+
+-- SHARED-SCENE DETERMINISM --
+All launched tests share ONE process + scene, so the scene does NOT start empty.
+Each test removes any pre-existing ``vtkMRMLLocatorNode`` (+ its display node) up
+front so "exactly one" is deterministic, tracks the nodes it caused to be
+created, and tears them down at the end so the launched leak discipline holds
+(``conftest._launched_scene_cleanup``) and later tests are unaffected.
+
+See also:
+  * Docs/adr/0025-locator-architecture.md §Consumer, §"The node"
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md  (RED / skip-pending)
+  * Docs/adr/0014-mrml-node-architecture.md
+  * Docs/adr/0004-python-cpp-boundary.md
+  * LiverResections/MRML/vtkMRMLLocatorNode.h
+  * LiverResections/MRML/vtkMRMLLocatorDisplayNode.h
+  * LiverResections/Logic/vtkSlicerLiverResectionsLogic.h
+  * LiverResections/Testing/Python/test_pipeline_resolves_locator.py
+  * LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+LOCATOR_NODE_CLASS = "vtkMRMLLocatorNode"
+LOCATOR_DISPLAY_NODE_CLASS = "vtkMRMLLocatorDisplayNode"
+
+# The NEW logic method under test.  Every test skips-pending on its absence.
+ENSURE_METHOD = "EnsureLocatorNode"
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror test_resectogram_locator_pipeline_seam.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _resection_logic_or_skip(slicer):
+    """Return the ``vtkSlicerLiverResectionsLogic`` singleton, or skip cleanly."""
+    module = getattr(slicer.modules, "liverresections", None)
+    if module is None:
+        pytest.skip("liverresections module not registered in this build.")
+    logic = module.logic()
+    if logic is None:
+        pytest.skip("liverresections module has no logic singleton.")
+    return logic
+
+
+def _ensure_method_or_skip_pending(logic):
+    """Return the bound ``EnsureLocatorNode`` method or SKIP-PENDING (ADR-0027).
+
+    RED == the method is absent (not built yet); the skip lifts at the
+    implementation commit, at which point the tests ASSERT.
+    """
+    method = getattr(logic, ENSURE_METHOD, None)
+    if not callable(method):
+        pytest.skip(
+            f"vtkSlicerLiverResectionsLogic.{ENSURE_METHOD} not present -- the "
+            "ADR-0025 §Consumer locator-singleton method has not landed.  Skip "
+            "lifts at the implementation commit (ADR-0027)."
+        )
+    return method
+
+
+def _clear_existing_locators(slicer):
+    """Remove every pre-existing ``vtkMRMLLocatorNode`` (+ its display node).
+
+    The launched harness shares one scene across tests, so a prior test may
+    have left a locator; strip them so "exactly one" is deterministic for this
+    test.  Display nodes are removed alongside so a leaked display node cannot
+    survive to the ``_launched_scene_cleanup`` baseline check either.
+    """
+    scene = slicer.mrmlScene
+    locators = [
+        scene.GetNthNodeByClass(i, LOCATOR_NODE_CLASS)
+        for i in range(scene.GetNumberOfNodesByClass(LOCATOR_NODE_CLASS))
+    ]
+    for locator in locators:
+        _remove_locator(scene, locator)
+
+
+def _remove_locator(scene, locator):
+    """Remove a locator node and its display node(s) from the scene."""
+    if locator is None:
+        return
+    for i in range(locator.GetNumberOfDisplayNodes()):
+        display = locator.GetNthDisplayNode(i)
+        if display is not None:
+            scene.RemoveNode(display)
+    scene.RemoveNode(locator)
+
+
+def _remove_plan(scene, plan):
+    """Remove a resection-plan wrapper + its Bezier carrier from the scene."""
+    if plan is None:
+        return
+    if hasattr(plan, "GetGeometryNode"):
+        carrier = plan.GetGeometryNode()
+        if carrier is not None:
+            scene.RemoveNode(carrier)
+    scene.RemoveNode(plan)
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 1 -- EnsureLocatorNode mints exactly one, wired + active
+# --------------------------------------------------------------------------- #
+
+
+def test_ensure_locator_node_creates_exactly_one_wired_active():
+    """Invariant 1: ``EnsureLocatorNode`` yields exactly one wired, active node.
+
+    From a locator-free scene, the call must return a non-None
+    ``vtkMRMLLocatorNode``, leave EXACTLY ONE in the scene, give it a
+    ``vtkMRMLLocatorDisplayNode`` with ``Radius`` > 0 (default 2.0 via
+    ``CreateDefaultDisplayNodes()``), and set ``LocatorActive`` = true
+    (ADR-0025 §Consumer, §"The node").
+    """
+    slicer = _slicer_or_skip()
+    logic = _resection_logic_or_skip(slicer)
+    ensure = _ensure_method_or_skip_pending(logic)
+    scene = slicer.mrmlScene
+
+    _clear_existing_locators(slicer)
+    locator = None
+    try:
+        locator = ensure()
+
+        assert locator is not None, (
+            "EnsureLocatorNode() must return the locator node, not None, when "
+            "the logic has a scene (ADR-0025 §Consumer)."
+        )
+        count = scene.GetNumberOfNodesByClass(LOCATOR_NODE_CLASS)
+        assert count == 1, (
+            "EnsureLocatorNode() must leave EXACTLY ONE vtkMRMLLocatorNode in "
+            f"the scene (v2.0 has exactly one, ADR-0025 §Consumer); got {count}."
+        )
+        display = locator.GetDisplayNode()
+        assert display is not None, (
+            "EnsureLocatorNode() must mint + wire a display node via "
+            "CreateDefaultDisplayNodes() (ADR-0025 §'The node')."
+        )
+        assert display.IsA(LOCATOR_DISPLAY_NODE_CLASS), (
+            "the wired display node must be a vtkMRMLLocatorDisplayNode; got "
+            f"{display.GetClassName()!r}."
+        )
+        assert display.GetRadius() > 0.0, (
+            "the locator display node must carry a positive Radius (default 2.0, "
+            f"ADR-0025 §'The node'); got {display.GetRadius()}."
+        )
+        assert bool(locator.GetLocatorActive()), (
+            "EnsureLocatorNode() must set LocatorActive = true (the persisted "
+            "presence flag, ADR-0025 §'The node')."
+        )
+    finally:
+        _remove_locator(scene, locator)
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 2 -- idempotent: the second call returns the same singleton
+# --------------------------------------------------------------------------- #
+
+
+def test_ensure_locator_node_is_idempotent():
+    """Invariant 2: a second ``EnsureLocatorNode`` returns the SAME node.
+
+    The method resolve-or-creates (``GetFirstNodeByClass`` else
+    ``AddNewNodeByClass``), so a second call must return the same node
+    (``GetID()`` unchanged) and mint NO second node -- the singleton invariant
+    holds under repeat calls (ADR-0025 §Consumer).
+    """
+    slicer = _slicer_or_skip()
+    logic = _resection_logic_or_skip(slicer)
+    ensure = _ensure_method_or_skip_pending(logic)
+    scene = slicer.mrmlScene
+
+    _clear_existing_locators(slicer)
+    first = None
+    try:
+        first = ensure()
+        assert first is not None, "first EnsureLocatorNode() returned None."
+        count_after_first = scene.GetNumberOfNodesByClass(LOCATOR_NODE_CLASS)
+        assert count_after_first == 1, (
+            "the first EnsureLocatorNode() must leave exactly one locator; got "
+            f"{count_after_first}."
+        )
+
+        second = ensure()
+        assert second is not None, "second EnsureLocatorNode() returned None."
+        assert second.GetID() == first.GetID(), (
+            "a second EnsureLocatorNode() must RESOLVE the existing node (same "
+            f"GetID()); got {second.GetID()!r} vs {first.GetID()!r}."
+        )
+        count_after_second = scene.GetNumberOfNodesByClass(LOCATOR_NODE_CLASS)
+        assert count_after_second == 1, (
+            "a second EnsureLocatorNode() must NOT mint a second locator (the "
+            f"singleton invariant, ADR-0025 §Consumer); got {count_after_second}."
+        )
+    finally:
+        _remove_locator(scene, first)
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 3 -- CreateResectionPlan ensures the locator singleton
+# --------------------------------------------------------------------------- #
+
+
+def test_create_resection_plan_ensures_single_locator():
+    """Invariant 3: opening a plan ensures the locator singleton.
+
+    ``CreateResectionPlan`` calls ``EnsureLocatorNode`` internally, so opening a
+    plan from a locator-free state leaves >= 1 ``vtkMRMLLocatorNode``, and a
+    SECOND plan does not increase the locator count (still exactly one) -- the
+    singleton invariant survives multiple plans (ADR-0025 §Consumer).
+    """
+    slicer = _slicer_or_skip()
+    logic = _resection_logic_or_skip(slicer)
+    _ensure_method_or_skip_pending(logic)
+    if not hasattr(logic, "CreateResectionPlan"):
+        pytest.skip(
+            "vtkSlicerLiverResectionsLogic has no CreateResectionPlan -- the "
+            "resection-plan create-API is not in this build."
+        )
+    scene = slicer.mrmlScene
+
+    _clear_existing_locators(slicer)
+    plans = []
+    try:
+        first_plan = logic.CreateResectionPlan("EnsureViaPlan")
+        if first_plan is None:
+            pytest.skip("CreateResectionPlan returned None -- plan not minted.")
+        plans.append(first_plan)
+        count_after_first = scene.GetNumberOfNodesByClass(LOCATOR_NODE_CLASS)
+        assert count_after_first >= 1, (
+            "CreateResectionPlan must ensure at least one vtkMRMLLocatorNode "
+            f"(it calls EnsureLocatorNode); got {count_after_first}."
+        )
+
+        second_plan = logic.CreateResectionPlan("EnsureViaPlanTwo")
+        if second_plan is not None:
+            plans.append(second_plan)
+        count_after_second = scene.GetNumberOfNodesByClass(LOCATOR_NODE_CLASS)
+        assert count_after_second == count_after_first, (
+            "a second CreateResectionPlan must NOT mint another locator (the "
+            f"singleton invariant, ADR-0025 §Consumer); count went from "
+            f"{count_after_first} to {count_after_second}."
+        )
+    finally:
+        for plan in plans:
+            _remove_plan(scene, plan)
+        _clear_existing_locators(slicer)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
+++ b/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
@@ -321,9 +321,7 @@ def test_seam_produces_picked_position_from_display_position():
     """
     slicer = _slicer_or_skip()
     carrier = _make_affine_carrier_or_skip(slicer, "SeamComposePos")
-    locator = slicer.mrmlScene.AddNewNodeByClass(LOCATOR_NODE_CLASS)
-    if locator is None:
-        pytest.skip(f"{LOCATOR_NODE_CLASS} not registered in this build.")
+    locator = _single_locator_or_skip(slicer)
 
     pipeline = _pipeline_or_skip(slicer)
     _inject_state(pipeline, carrier, mat_ratio=(1.0, 1.0), viewport_size=(256, 256))
@@ -355,6 +353,36 @@ def test_seam_produces_picked_position_from_display_position():
 # --------------------------------------------------------------------------- #
 
 
+def _single_locator_or_skip(slicer):
+    """The scene's single locator -- resolved, not minted-anew.
+
+    ``CreateResectionPlan`` now ensures exactly one ``vtkMRMLLocatorNode``
+    (ADR-0025 §Consumer), and the seam resolves THAT one via
+    ``GetFirstNodeByClass``.  Resolve the same node here (creating one only if
+    absent) rather than adding a second the seam would ignore.
+    """
+    scene = slicer.mrmlScene
+    node = scene.GetFirstNodeByClass(LOCATOR_NODE_CLASS)
+    if node is None:
+        node = scene.AddNewNodeByClass(LOCATOR_NODE_CLASS)
+    if node is None:
+        pytest.skip(f"{LOCATOR_NODE_CLASS} not registered in this build.")
+    return node
+
+
+def _clear_locators(slicer):
+    """Remove every locator node so the 'no locator in scene' path is genuine.
+
+    ``CreateResectionPlan`` ensures one, so a test that needs zero must strip it.
+    """
+    scene = slicer.mrmlScene
+    for _ in range(scene.GetNumberOfNodesByClass(LOCATOR_NODE_CLASS)):
+        node = scene.GetFirstNodeByClass(LOCATOR_NODE_CLASS)
+        if node is None:
+            break
+        scene.RemoveNode(node)
+
+
 def _degenerate_pipeline(slicer, *, with_locator, carrier, mat_ratio, viewport_size):
     """Build the Pipeline + inject the (possibly degenerate) state, plus a
     sentinel-seeded locator (when ``with_locator``) so a leak past the guard is
@@ -366,10 +394,10 @@ def _degenerate_pipeline(slicer, *, with_locator, carrier, mat_ratio, viewport_s
     locator = None
     sentinel = (11.0, 22.0, 33.0)
     if with_locator:
-        locator = slicer.mrmlScene.AddNewNodeByClass(LOCATOR_NODE_CLASS)
-        if locator is None:
-            pytest.skip(f"{LOCATOR_NODE_CLASS} not registered in this build.")
+        locator = _single_locator_or_skip(slicer)
         locator.SetPickedPositionWorld(*sentinel)
+    else:
+        _clear_locators(slicer)
     return seam, locator, sentinel
 
 
@@ -480,9 +508,7 @@ def test_process_interaction_event_drives_the_pick_from_display_position():
     """
     slicer = _slicer_or_skip()
     carrier = _make_affine_carrier_or_skip(slicer, "SeamProcessEvent")
-    locator = slicer.mrmlScene.AddNewNodeByClass(LOCATOR_NODE_CLASS)
-    if locator is None:
-        pytest.skip(f"{LOCATOR_NODE_CLASS} not registered in this build.")
+    locator = _single_locator_or_skip(slicer)
 
     pipeline = _pipeline_or_skip(slicer)
     _inject_state(pipeline, carrier, mat_ratio=(1.0, 1.0), viewport_size=(256, 256))


### PR DESCRIPTION
## Summary

Wires the ADR-0025 cross-view locator **live** — the final integration step. The
locator slices are all merged but were inert because nothing created the node
they coordinate through and nothing owned the click-to-reslice consumer. This
closes both gaps.

- **`vtkSlicerLiverResectionsLogic::EnsureLocatorNode()`** — resolves-or-creates
  the scene's single `vtkMRMLLocatorNode` (ADR-0025 §Consumer: v2.0 has exactly
  one), mints its `vtkMRMLLocatorDisplayNode` (default radius 2.0, so the marker
  is visible), and sets `LocatorActive` (the persisted presence flag). Idempotent
  — never mints a second. `CreateResectionPlan` calls it, so a resectogram click
  has a node to write and both consumers (shader marker, click-to-reslice) have
  one to read.
- **`ResectionPlanningWidget` owns a `LocatorReslicer`** for its scene: built in
  `setMRMLScene`, `refresh()`ed at the top of `refreshResectogramDrawer` (so a
  locator minted after the widget — e.g. by `CreateResectionPlan` on Place — gets
  observed), and `cleanup()`ed symmetrically on teardown.

Ownership rationale (per ADR-0004): node *creation* stays in the C++ logic
(alongside the plan/carrier/display triad `CreateResectionPlan` already mints);
the reslice consumer *lifecycle* stays Python (interaction glue). No new
Pipeline or displayable manager (ADR-0013 §5); the node stays data-only
(ADR-0014).

Closes #525. Completes the ADR-0025 locator (tracker #305).

## Test-first (ADR-0027)

Landed RED-then-green. `test_ensure_locator_node.py` pins: (1) ensure creates
exactly one locator wired to a display node with radius > 0 and `LocatorActive`
true; (2) idempotence (second call → same node, none added); (3)
`CreateResectionPlan` ensures a single locator (a second plan adds none).
GL-free, launched; skips cleanly bare.

Because `CreateResectionPlan` now ensures the locator, the resectogram-seam
tests (which mint a carrier via the create-API and previously added their own
locator) were updated to resolve the single ensured locator via
`GetFirstNodeByClass` rather than mint a second the seam would ignore; the
no-locator case strips it explicitly.

Verified: **full LiverResections launched suite green — 132 tests, 0 failures**
(16 env-gated skips). C++ built incrementally in the warm tree.

## Scope / remaining verification

The click→marker (3D Bézier surface) and click→reslice (Red slice) **end-to-end**
is the interactive `:0` confirmation — now genuinely exercisable unaided (place a
resection → click the strip), where before it required a manually minted locator.
Drives the **Red** slice for v2.0; a Red/Yellow/Green sweep is a v2.1 enhancement.

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
