### PR TITLE
ENH: Stage-1 Case Setup UI — load volumes + tag LiverRole (shared vocabulary + tagging seam)

### DIFF
--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -220,6 +220,12 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self._shellHost = None
     self._injectedStageCompletion = None
 
+    # Stage-1 Case Setup widgets (built in ``_buildStage1Page``); ``None``
+    # here so a pre-build ``_refreshCaseSetupTable`` short-circuits.
+    self._caseSetupVolumeCombo = None
+    self._caseSetupRoleCombo = None
+    self._caseSetupTable = None
+
   def setup(self):
     """Build the six-stage navigation shell.
 
@@ -247,6 +253,8 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def _onSceneChanged(self, caller=None, event=None):
     """Refresh per-stage indicators in response to scene events."""
     self._refreshStageIndicators()
+    # Newly loaded/removed volumes should appear in the Case Setup role table.
+    self._refreshCaseSetupTable()
 
   # ------------------------------------------------------------------ #
   # Liver-shell sidebar — composition + navigation (ADR-0023 Option H)
@@ -377,18 +385,125 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       return self._buildUnavailablePage(self._STAGE_NAMES[index]), False
     return rep, True
 
-  def _buildStage1Page(self):
-    """Shell-owned Case Setup placeholder (ADR-0023 §Stage 1 / ADR-0029).
+  #: Human-facing dropdown labels for the machine-stable LiverRole values that
+  #: aren't already presentable (the stored value is decoupled from the label).
+  _CASE_SETUP_ROLE_LABELS = {"PortalVenous": "Portal venous"}
 
-    The functional UI for Stage 1 lands in a follow-up task (planner
-    §"Stage 1"); for T5.2-d the shell only reserves the page so the
-    sidebar contract is satisfied.
+  def _buildStage1Page(self):
+    """Shell-owned Case Setup UI (ADR-0023 §Stage 1 / ADR-0029; ADR-0004 Python).
+
+    Load volume(s) via Slicer's Add Data, then tag each with its
+    acquisition-phase role.  A scalar-volume selector + a role dropdown whose
+    "Assign role" writes the shared ``LiverRole`` attribute via
+    ``LiverSegmentationLib.roles.set_volume_role`` — the SAME vocabulary Stage 2
+    reads to pick its working volume — plus a table of tagged volumes.  Tagging
+    flips the Stage-1 completion indicator (``_stage1IsComplete`` reads the
+    attribute).  Degrades to a hint label when the shared roles module is
+    unreachable (a build without ``LiverSegmentationLib``).
     """
+    try:
+      from LiverSegmentationLib import roles
+    except Exception:  # pragma: no cover — surfaces only when the lib is absent
+      page = qt.QWidget()
+      layout = qt.QVBoxLayout(page)
+      layout.addWidget(qt.QLabel(
+        "Case Setup — volume-role tagging unavailable in this build."))
+      layout.addStretch(1)
+      return page
+
     page = qt.QWidget()
     layout = qt.QVBoxLayout(page)
-    layout.addWidget(qt.QLabel("Case Setup — load volumes and tag roles (Stage 1)."))
-    layout.addStretch(1)
+    layout.addWidget(qt.QLabel(
+      "Case Setup — load volume(s) via Add Data, then tag each with its "
+      "acquisition-phase role."))
+
+    row = qt.QHBoxLayout()
+    row.addWidget(qt.QLabel("Volume:"))
+    volumeCombo = slicer.qMRMLNodeComboBox()
+    volumeCombo.setObjectName("CaseSetupVolumeComboBox")
+    volumeCombo.nodeTypes = ["vtkMRMLScalarVolumeNode"]
+    volumeCombo.addEnabled = False
+    volumeCombo.removeEnabled = False
+    volumeCombo.noneEnabled = True
+    volumeCombo.setMRMLScene(slicer.mrmlScene)
+    volumeCombo.connect("currentNodeChanged(vtkMRMLNode*)", self._onCaseSetupVolumeChanged)
+    row.addWidget(volumeCombo, 1)
+
+    row.addWidget(qt.QLabel("Role:"))
+    roleCombo = qt.QComboBox()
+    roleCombo.setObjectName("CaseSetupRoleComboBox")
+    for value in roles.LIVER_ROLES:
+      roleCombo.addItem(self._caseSetupRoleLabel(value), value)
+    row.addWidget(roleCombo)
+
+    assignButton = qt.QPushButton("Assign role")
+    assignButton.setObjectName("CaseSetupAssignButton")
+    assignButton.connect("clicked()", self._onCaseSetupAssignRole)
+    row.addWidget(assignButton)
+    layout.addLayout(row)
+
+    table = qt.QTableWidget()
+    table.setObjectName("CaseSetupRoleTable")
+    table.setColumnCount(2)
+    table.setHorizontalHeaderLabels(["Volume", "Role"])
+    table.horizontalHeader().setStretchLastSection(True)
+    table.editTriggers = qt.QAbstractItemView.NoEditTriggers
+    table.selectionBehavior = qt.QAbstractItemView.SelectRows
+    layout.addWidget(table, 1)
+
+    self._caseSetupVolumeCombo = volumeCombo
+    self._caseSetupRoleCombo = roleCombo
+    self._caseSetupTable = table
+
+    self._refreshCaseSetupTable()
     return page
+
+  def _caseSetupRoleLabel(self, value):
+    """Human dropdown/table label for a stored ``LiverRole`` value."""
+    return self._CASE_SETUP_ROLE_LABELS.get(value, value)
+
+  def _onCaseSetupVolumeChanged(self, node):
+    """Reflect the selected volume's current role in the dropdown, if tagged."""
+    combo = self._caseSetupRoleCombo
+    if combo is None or node is None:
+      return
+    current = node.GetAttribute("LiverRole")
+    if current is None:
+      return
+    index = combo.findData(current)
+    if index >= 0:
+      combo.setCurrentIndex(index)
+
+  def _onCaseSetupAssignRole(self):
+    """Tag the selected volume with the chosen role, then refresh state."""
+    try:
+      from LiverSegmentationLib import roles
+    except Exception:  # pragma: no cover — surfaces only when the lib is absent
+      return
+    volumeCombo = self._caseSetupVolumeCombo
+    roleCombo = self._caseSetupRoleCombo
+    if volumeCombo is None or roleCombo is None:
+      return
+    volume = volumeCombo.currentNode()
+    if volume is None:
+      return
+    role = roleCombo.itemData(roleCombo.currentIndex)
+    roles.set_volume_role(volume, role)
+    self._refreshCaseSetupTable()
+    self._refreshStageIndicators()
+
+  def _refreshCaseSetupTable(self):
+    """Rebuild the volumes x role table from the scene's scalar volumes."""
+    table = self._caseSetupTable
+    if table is None:
+      return
+    volumes = list(slicer.util.getNodesByClass("vtkMRMLScalarVolumeNode"))
+    table.setRowCount(len(volumes))
+    for row, volume in enumerate(volumes):
+      role = volume.GetAttribute("LiverRole") or ""
+      table.setItem(row, 0, qt.QTableWidgetItem(volume.GetName()))
+      table.setItem(row, 1, qt.QTableWidgetItem(
+        self._caseSetupRoleLabel(role) if role else ""))
 
   def _buildResectionPlanningPage(self):
     """Return ``(page_widget, is_available)`` for the Stage-4 Python widget.

--- a/Liver/Testing/Python/CMakeLists.txt
+++ b/Liver/Testing/Python/CMakeLists.txt
@@ -78,6 +78,37 @@ foreach(_pytest_file IN LISTS _liver_shell_pytest_files)
   )
 endforeach()
 
+# Stage-1 Case-Setup volume-role vocabulary + tagging seam (ADR-0029 §Stage 1;
+# ADR-0023 §"Stage 1"; ADR-0004 §"Python/C++ boundary" -- the Qt panel vs the
+# pure-Python role seam).  Pins a NEW shared role module
+# ``SlicerLiverCommonLib.roles`` importable by BOTH the Liver shell (Case Setup,
+# the role WRITER) and LiverSegmentation (Stage 2, the role READER): the fixed
+# ``LiverRole`` scene-attribute key + the five machine-stable CamelCase values
+# (Native / Arterial / PortalVenous / Delayed / Other, NO spaces) + a
+# ``set_volume_role(volume, role) -> bool`` tagging seam (validates the role,
+# writes the attribute, no-op-False on an unknown role or a None volume).
+# Collapses the vocabulary drift between LiverSegmentation.py's ad-hoc constants
+# and the arch doc's spaced labels into one shared module.  Invariant 1 (the
+# vocabulary) needs no scene and runs everywhere the module imports; invariants
+# 2--3 (tagging + the Stage-1 completion predicate) mint a
+# vtkMRMLScalarVolumeNode on the live scene, so they run green under the
+# launched-Slicer `pytest_launched` row and SKIP CLEANLY here under bare pytest
+# (no slicer.mrmlScene).  GL-free -- only node attributes + a scene-level
+# predicate (the body of LiverWidget._stage1IsComplete) are asserted, no view /
+# render window.  RED / skip-pending (guards on the SlicerLiverCommonLib.roles
+# import + the set_volume_role seam) until the implementer lands the shared
+# module (ADR-0027 §Conformance: the skip lifts at the implementation commit).
+add_test(
+  NAME LiverCaseSetupVolumeRoles
+  COMMAND "${Python3_EXECUTABLE}" -m pytest
+    -q
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_case_setup_volume_roles.py"
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+)
+set_tests_properties(LiverCaseSetupVolumeRoles PROPERTIES
+  LABELS "pytest;module-layer;Liver;case-setup"
+)
+
 # --------------------------------------------------------------------------- #
 # pytest_launched — same test roots as pytest_scaffold, inside a launched
 # Slicer.

--- a/Liver/Testing/Python/conftest.py
+++ b/Liver/Testing/Python/conftest.py
@@ -36,8 +36,56 @@ continue to run and exercise the real invariants (ADR-0008 §1, §6).
 
 from __future__ import annotations
 
+import sys
+
+import pytest
+
 from slicer_pytest_support import (  # noqa: F401  (re-exported for `from conftest import ...`)
     import_slicer_or_skip as _import_slicer_or_skip,
     require_mrml_scene as _require_mrml_scene,
     require_qt_widget as _require_qt_widget,
 )
+
+
+def _looks_like_real_slicer(module) -> bool:
+    """True iff ``module`` is the genuine launched-Slicer ``slicer`` module."""
+    return module is not None and getattr(module, "mrmlScene", None) is not None
+
+
+def _live_mrml_scene():
+    """Return the launched-Slicer ``mrmlScene`` or ``None`` under bare pytest."""
+    slicer = sys.modules.get("slicer")
+    if not _looks_like_real_slicer(slicer):
+        return None
+    return slicer.mrmlScene
+
+
+@pytest.fixture(autouse=True)
+def _launched_scene_cleanup():
+    """Clear the MRML scene after each launched test; assert it stays clean.
+
+    Active only under a launched Slicer (``slicer.mrmlScene`` present); a no-op
+    under bare ``PythonSlicer -m pytest``.  Mirrors the LiverResections /
+    LiverSegmentation conftest fixture: no scene node the Case-Setup role tests
+    mint (scalar volumes) may survive to process shutdown and trip
+    ``vtkDebugLeaks`` in the launched harness (ADR-0008 §6).  The role tests also
+    tear down their own volumes in a ``finally``; this fixture is the backstop.
+    """
+    scene = _live_mrml_scene()
+    if scene is None:
+        yield
+        return
+
+    baseline = scene.GetNumberOfNodes()
+
+    yield
+
+    scene.Clear(0)
+    remaining = scene.GetNumberOfNodes()
+    assert remaining <= baseline, (
+        "MRML scene GREW past its pre-test baseline even after Clear(): "
+        f"{remaining} node(s) remain vs {baseline} at test start.  A node "
+        "Clear() cannot reclaim survives to process shutdown and trips "
+        "vtkDebugLeaks, failing the launched harness.  Tear down every node "
+        "the test created."
+    )

--- a/Liver/Testing/Python/test_case_setup_volume_roles.py
+++ b/Liver/Testing/Python/test_case_setup_volume_roles.py
@@ -1,0 +1,365 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Stage-1 Case-Setup volume-role vocabulary + tagging seam (ADR-0029 §Stage 1).
+
+Pins the *logic seam* behind Stage 1's role-tagging job -- the GL-free,
+Qt-free half of Case Setup (ADR-0004 §"Python/C++ boundary": the Case Setup
+panel is a ``Liver``-shell Qt widget, but the vocabulary + the write-side
+tagging kernel it drives are a separate, testable pure-Python seam).
+
+WHAT IS PINNED -- a NEW shared role-vocabulary + tagging module (to be
+implemented later) importable by BOTH the ``Liver`` shell (Case Setup, the
+role WRITER) and ``LiverSegmentation`` (Stage 2, the role READER):
+
+    LiverSegmentationLib.roles
+
+    LIVER_ROLE_ATTRIBUTE = "LiverRole"
+    LIVER_ROLES = ("Native", "Arterial", "PortalVenous", "Delayed", "Other")
+    LIVER_ROLE_PORTAL_VENOUS = "PortalVenous"        # convenience constant
+
+    set_volume_role(volume_node, role) -> bool
+        Validate ``role`` is in ``LIVER_ROLES`` and write
+        ``volume_node.SetAttribute(LIVER_ROLE_ATTRIBUTE, role)``; return True.
+        Return False (no-op) on an unknown role or a None volume, never raising.
+
+-- WHY A SHARED MODULE --
+Today the vocabulary is DRIFTED across three places: ``LiverSegmentation.py``
+carries ad-hoc constants (``LIVER_ROLE_ATTRIBUTE`` / ``LIVER_ROLE_PORTAL_VENOUS``),
+``Docs/architecture/ui-stage-1-case-setup.md`` lists the five values WITH spaces
+("Portal venous", "Delayed/venous"), and ``Liver.py:_stage1IsComplete`` reads the
+raw ``"LiverRole"`` string.  ADR-0029 §"Decision" makes Stage 1 the role WRITER
+and Stage 2 the role READER of the SAME tag; the single shared module collapses
+that drift to one machine-stable vocabulary (CamelCase, NO spaces -- human
+labels are decoupled and live in the Qt panel).  The maintainer fixed the key
+as ``"LiverRole"`` (the shipped scene-attribute key; the closed-vocab
+Liver-prefix guardrail covers new MRML CLASSES, not scene-attribute keys) and
+the five values as ``Native / Arterial / PortalVenous / Delayed / Other``.  No
+SCT codes: phase roles are not ADR-0011 anatomy structures.
+
+SCOPE: this file pins the WRITE side + the vocabulary.  The READ side --
+``selectInputVolume`` (the ``PortalVenous`` reader in ``LiverSegmentation``, the
+Stage-1 -> Stage-2 hand-off) -- is a separate deliverable and is exercised by
+``LiverSegmentation/Testing/Python/test_liversegmentation_segment_input_selection.py``;
+it is NOT re-exercised here.
+
+-- WHY LAUNCHED-SLICER (invariant 2 + 3) --
+The tagging + Stage-1-predicate invariants mint a ``vtkMRMLScalarVolumeNode`` on
+the live ``slicer.mrmlScene``, so they run under the launched-Slicer harness and
+SKIP CLEANLY under bare ``PythonSlicer -m pytest`` via the shared
+``slicer_pytest_support`` guards.  GL-free: only node attributes + a scene-level
+predicate are asserted -- no view / render window.  The vocabulary invariant
+(1) needs no scene and runs everywhere the shared module imports.
+
+-- WHY RED NOW --
+``LiverSegmentationLib.roles`` does not exist yet, so every test skips-pending on
+its import (``_roles_or_skip_pending``).  The skip lifts at the implementation
+commit, at which point the tests ASSERT (ADR-0027 §Conformance -- the skip lifts
+at the implementation commit).
+
+See also:
+  * Docs/adr/0029-stage1-case-setup-contract.md §Decision, §Conformance
+  * Docs/adr/0023-unified-gui-stage-workflow.md §"Stage 1"
+  * Docs/adr/0004-python-cpp-boundary.md  (the Qt panel vs the pure-Python seam)
+  * Docs/adr/0027-invariant-test-first-v2-implementation.md  (RED / skip-pending)
+  * Docs/architecture/ui-stage-1-case-setup.md §"Role tagging"
+  * Liver/Liver.py  (LiverWidget._stage1IsComplete -- the shell predicate)
+  * LiverSegmentation/LiverSegmentation.py  (the ad-hoc constants this collapses)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# The scene-attribute key + the machine-stable role vocabulary the shared module
+# MUST expose.  Duplicated here as the assertion oracle (the test pins the
+# contract; the module must match these EXACTLY).
+EXPECTED_ROLE_ATTRIBUTE = "LiverRole"
+EXPECTED_ROLES = ("Native", "Arterial", "PortalVenous", "Delayed", "Other")
+PORTAL_VENOUS = "PortalVenous"
+
+SCALAR_VOLUME_CLASS = "vtkMRMLScalarVolumeNode"
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror LiverResections/Testing/Python/test_ensure_locator_node.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    """Return the launched-Slicer ``slicer`` module, or skip under bare pytest."""
+    from conftest import (  # type: ignore[import-not-found]
+        _import_slicer_or_skip,
+        _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _roles_or_skip_pending():
+    """Import the shared role module or SKIP-PENDING (ADR-0027).
+
+    RED == ``LiverSegmentationLib.roles`` is not built yet; the skip lifts at
+    the implementation commit, at which point the tests ASSERT.
+    """
+    try:
+        from LiverSegmentationLib import roles
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"LiverSegmentationLib.roles not importable ({exc!r}) -- the "
+            "ADR-0029 §Stage 1 shared role vocabulary + tagging seam has not "
+            "landed.  Skip lifts at the implementation commit (ADR-0027)."
+        )
+    return roles
+
+
+def _set_volume_role_or_skip_pending(roles):
+    """Return the ``set_volume_role`` seam or SKIP-PENDING (ADR-0027)."""
+    seam = getattr(roles, "set_volume_role", None)
+    if not callable(seam):
+        pytest.skip(
+            "LiverSegmentationLib.roles.set_volume_role not present -- the "
+            "ADR-0029 §Stage 1 tagging seam has not landed.  Skip lifts at the "
+            "implementation commit (ADR-0027)."
+        )
+    return seam
+
+
+def _add_scalar_volume(slicer):
+    """Mint a scalar volume on the live scene (caller tears it down)."""
+    node = slicer.mrmlScene.AddNewNodeByClass(SCALAR_VOLUME_CLASS)
+    if node is None:
+        pytest.skip(f"{SCALAR_VOLUME_CLASS} not registered in this build.")
+    return node
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 1 -- the vocabulary contract (no scene needed)
+# --------------------------------------------------------------------------- #
+
+
+def test_role_vocabulary_contract():
+    """Invariant 1: the shared module exposes the exact key + ordered values.
+
+    ADR-0029 §Decision fixes Stage 1 as the role writer of the ``LiverRole``
+    scene attribute; the maintainer fixed the key (``"LiverRole"``, the shipped
+    key) and the five machine-stable CamelCase values in order
+    (``Native / Arterial / PortalVenous / Delayed / Other``).  Human labels are
+    decoupled (they live in the Qt panel); the stored values carry NO spaces.
+    ``PortalVenous`` -- the Stage-1 -> Stage-2 hand-off value (ADR-0024
+    §"Per-structure micro-workflows") -- must be among them.
+    """
+    roles = _roles_or_skip_pending()
+
+    assert getattr(roles, "LIVER_ROLE_ATTRIBUTE", None) == EXPECTED_ROLE_ATTRIBUTE, (
+        "the shared module's LIVER_ROLE_ATTRIBUTE must be the shipped scene key "
+        f"{EXPECTED_ROLE_ATTRIBUTE!r} (ADR-0029 §Decision); got "
+        f"{getattr(roles, 'LIVER_ROLE_ATTRIBUTE', None)!r}."
+    )
+
+    values = tuple(getattr(roles, "LIVER_ROLES", ()))
+    assert values == EXPECTED_ROLES, (
+        "LIVER_ROLES must be the five machine-stable CamelCase values IN ORDER "
+        f"{EXPECTED_ROLES!r} (ADR-0029 §Decision); got {values!r}."
+    )
+
+    assert PORTAL_VENOUS in values, (
+        f"{PORTAL_VENOUS!r} must be in LIVER_ROLES -- it is the Stage-1 -> "
+        "Stage-2 hand-off value (ADR-0024 §'Per-structure micro-workflows')."
+    )
+
+    assert getattr(roles, "LIVER_ROLE_PORTAL_VENOUS", None) == PORTAL_VENOUS, (
+        "LIVER_ROLE_PORTAL_VENOUS convenience constant must equal "
+        f"{PORTAL_VENOUS!r} (the value LiverSegmentation reads); got "
+        f"{getattr(roles, 'LIVER_ROLE_PORTAL_VENOUS', None)!r}."
+    )
+
+    for value in values:
+        assert " " not in value, (
+            f"role value {value!r} must contain NO space -- stored values are "
+            "machine-stable; human labels with spaces live in the Qt panel "
+            "(ADR-0029 §Decision)."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 2 -- the tagging seam (write side)
+# --------------------------------------------------------------------------- #
+
+
+def test_set_volume_role_tags_portal_venous():
+    """Invariant 2a: ``set_volume_role(vol, "PortalVenous")`` writes the tag.
+
+    The seam validates the role is in the vocabulary and writes it to the
+    ``LiverRole`` attribute, returning True (ADR-0029 §Decision -- Stage 1 is
+    the role writer).
+    """
+    slicer = _slicer_or_skip()
+    roles = _roles_or_skip_pending()
+    set_volume_role = _set_volume_role_or_skip_pending(roles)
+    scene = slicer.mrmlScene
+
+    volume = _add_scalar_volume(slicer)
+    try:
+        result = set_volume_role(volume, PORTAL_VENOUS)
+        assert result is True, (
+            "set_volume_role(vol, 'PortalVenous') must return True on a valid "
+            f"role; got {result!r}."
+        )
+        assert volume.GetAttribute(EXPECTED_ROLE_ATTRIBUTE) == PORTAL_VENOUS, (
+            "set_volume_role must write the role to the 'LiverRole' attribute; "
+            f"got {volume.GetAttribute(EXPECTED_ROLE_ATTRIBUTE)!r}."
+        )
+    finally:
+        scene.RemoveNode(volume)
+
+
+def test_set_volume_role_round_trips_every_role():
+    """Invariant 2b: each of the five roles round-trips through the seam.
+
+    Every value in ``LIVER_ROLES`` is a valid write; the attribute reads back
+    exactly the value written (ADR-0029 §Decision -- machine-stable values).
+    """
+    slicer = _slicer_or_skip()
+    roles = _roles_or_skip_pending()
+    set_volume_role = _set_volume_role_or_skip_pending(roles)
+    scene = slicer.mrmlScene
+
+    volume = _add_scalar_volume(slicer)
+    try:
+        for role in EXPECTED_ROLES:
+            result = set_volume_role(volume, role)
+            assert result is True, (
+                f"set_volume_role(vol, {role!r}) must return True for a "
+                f"vocabulary value; got {result!r}."
+            )
+            assert volume.GetAttribute(EXPECTED_ROLE_ATTRIBUTE) == role, (
+                f"role {role!r} must round-trip through the 'LiverRole' "
+                f"attribute; got {volume.GetAttribute(EXPECTED_ROLE_ATTRIBUTE)!r}."
+            )
+    finally:
+        scene.RemoveNode(volume)
+
+
+def test_set_volume_role_rejects_unknown_role_as_noop():
+    """Invariant 2c: an unknown role is a no-op returning False.
+
+    An off-vocabulary role must NOT be written; the seam returns False and
+    leaves any prior attribute value untouched (ADR-0029 §Decision -- the
+    vocabulary is closed; the panel only offers the five values).
+    """
+    slicer = _slicer_or_skip()
+    roles = _roles_or_skip_pending()
+    set_volume_role = _set_volume_role_or_skip_pending(roles)
+    scene = slicer.mrmlScene
+
+    volume = _add_scalar_volume(slicer)
+    try:
+        # Seed a known-good prior tag so we can prove the bad write is a no-op.
+        assert set_volume_role(volume, PORTAL_VENOUS) is True
+        result = set_volume_role(volume, "bogus")
+        assert result is False, (
+            "set_volume_role(vol, 'bogus') must return False for an "
+            f"off-vocabulary role; got {result!r}."
+        )
+        assert volume.GetAttribute(EXPECTED_ROLE_ATTRIBUTE) == PORTAL_VENOUS, (
+            "an unknown-role write must leave the prior 'LiverRole' value "
+            f"untouched; got {volume.GetAttribute(EXPECTED_ROLE_ATTRIBUTE)!r}."
+        )
+    finally:
+        scene.RemoveNode(volume)
+
+
+def test_set_volume_role_none_volume_returns_false():
+    """Invariant 2d: a None volume returns False without raising.
+
+    The seam guards its inputs -- a None volume is a no-op returning False, not
+    an exception (defensive; the Case Setup panel may call it before a volume is
+    selected).
+    """
+    roles = _roles_or_skip_pending()
+    set_volume_role = _set_volume_role_or_skip_pending(roles)
+
+    # No scene needed: the None-guard must short-circuit before touching MRML,
+    # so this branch runs even under bare pytest (once the seam exists).
+    result = set_volume_role(None, PORTAL_VENOUS)
+    assert result is False, (
+        "set_volume_role(None, ...) must return False without raising; got "
+        f"{result!r}."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 3 -- Stage-1 completion predicate
+# --------------------------------------------------------------------------- #
+#
+# The Liver shell's Stage-1 predicate is ``LiverWidget._stage1IsComplete``
+# (Liver.py) -- "done iff at least one scalar volume carries a ``LiverRole``
+# attribute" (ADR-0029 §"Stage 1 functional contract"; the shell reads it via
+# ``slicer.util.getNodesByClass('vtkMRMLScalarVolumeNode')`` + ``GetAttribute``).
+#
+# REACHABILITY DECISION (per the docstring mandate): the SHELL-WIDGET path is
+# pinned by the sibling ``test_liver_shell_isstagecomplete.py`` (it instantiates
+# ``LiverWidget`` behind ``_require_qt_widget`` and asserts the predicate flips).
+# Here we pin the EQUIVALENT SCENE-LEVEL predicate the shell body evaluates -- a
+# scalar volume carrying the ``LiverRole`` attribute is discoverable via
+# ``getNodesByClass`` + ``GetAttribute`` -- because it is the robust GL-free /
+# Qt-free path and it closes the loop from the tagging seam (invariant 2) to the
+# completion signal without depending on the shell widget being instantiable in
+# this dir's harness.  The shell-widget coupling is intentional: this predicate
+# IS the body of ``_stage1IsComplete``, so tagging via ``set_volume_role`` and
+# the shell reporting complete are the same fact asserted at two layers.
+
+
+def _scene_reports_any_liver_role(slicer):
+    """Mirror ``LiverWidget._stage1IsComplete``'s body at the scene level.
+
+    Returns True iff at least one scalar volume in the live scene carries a
+    ``LiverRole`` attribute (ADR-0029 §"Stage 1 functional contract").  Uses
+    ``slicer.util.getNodesByClass`` -- the same helper the shell uses -- which
+    unregisters the returned collection so the launched leak discipline holds.
+    """
+    for node in slicer.util.getNodesByClass(SCALAR_VOLUME_CLASS):
+        if node.GetAttribute(EXPECTED_ROLE_ATTRIBUTE):
+            return True
+    return False
+
+
+def test_stage1_complete_after_tagging_any_role():
+    """Invariant 3: tagging any role makes the Stage-1 predicate report complete.
+
+    After ``set_volume_role`` tags a scalar volume with ANY of the five roles,
+    the scene-level Stage-1 predicate (the body of
+    ``LiverWidget._stage1IsComplete``, ADR-0029 §"Stage 1 functional contract")
+    must report complete -- and an otherwise-untagged scene must NOT.  This
+    closes the loop from the tagging seam (invariant 2) to Stage 1's commit
+    signal.
+    """
+    slicer = _slicer_or_skip()
+    roles = _roles_or_skip_pending()
+    set_volume_role = _set_volume_role_or_skip_pending(roles)
+    scene = slicer.mrmlScene
+
+    volume = _add_scalar_volume(slicer)
+    try:
+        # A freshly-minted, untagged volume must NOT satisfy Stage 1.
+        assert _scene_reports_any_liver_role(slicer) is False, (
+            "an untagged scalar volume must NOT satisfy the Stage-1 predicate "
+            "(ADR-0029 §'Stage 1 functional contract' -- attribute presence is "
+            "the gate)."
+        )
+
+        assert set_volume_role(volume, "Native") is True
+        assert _scene_reports_any_liver_role(slicer) is True, (
+            "after tagging a scalar volume with a LiverRole, the Stage-1 "
+            "predicate must report complete (the body of "
+            "LiverWidget._stage1IsComplete, ADR-0029 §'Stage 1 functional "
+            "contract')."
+        )
+    finally:
+        scene.RemoveNode(volume)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverSegmentation/CMakeLists.txt
+++ b/LiverSegmentation/CMakeLists.txt
@@ -51,6 +51,7 @@ slicerMacroBuildScriptedModule(
 # at qt-scripted-modules/LiverSegmentationLib/ToolWrappers/... unchanged.
 set(LiverSegmentationLib_PYTHON_SCRIPTS
   __init__.py
+  roles.py
   ToolWrappers/__init__.py
   ToolWrappers/TotalSegmentator.py
   )

--- a/LiverSegmentation/LiverSegmentationLib/roles.py
+++ b/LiverSegmentation/LiverSegmentationLib/roles.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Shared volume-role vocabulary for the Stage-1 -> Stage-2 hand-off (ADR-0023).
+
+Case Setup (Stage 1, the Liver shell) tags each loaded volume with its
+acquisition-phase ROLE; Anatomy Definition (Stage 2, LiverSegmentation) reads
+that role to pick its working volume (``LiverRole == 'PortalVenous'``).  The
+vocabulary lives here -- one shared module both sides import -- so the stored
+attribute key + values cannot drift (the value is machine-stable; the
+human-facing dropdown label is decoupled).
+
+Roles are acquisition PHASES, not anatomical structures, so they carry NO SCT
+code (ADR-0011's canonical-dispatch-key decision covers segmented anatomy, not
+contrast phases).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Scene-attribute key a volume's role is stored under (the shipped key).
+LIVER_ROLE_ATTRIBUTE = "LiverRole"
+
+#: The v2.0 role vocabulary, ordered; CamelCase, no spaces (machine-stable
+#: stored values -- human labels are decoupled at the UI).  Only
+#: ``PortalVenous`` is consumed downstream in v2.0 (Stage-2 input selection);
+#: the others are informational phase tags.
+LIVER_ROLES = ("Native", "Arterial", "PortalVenous", "Delayed", "Other")
+
+#: Convenience: the phase Stage-2 selects as its working volume.
+LIVER_ROLE_PORTAL_VENOUS = "PortalVenous"
+
+
+def set_volume_role(volume_node: Any, role: str) -> bool:
+    """Tag ``volume_node`` with ``role`` (writes the ``LiverRole`` attribute).
+
+    Returns ``True`` when the tag is written; ``False`` (a no-op, never raising)
+    when ``volume_node`` is ``None`` or ``role`` is not one of ``LIVER_ROLES``
+    -- an invalid role must not silently corrupt the Stage-1 -> Stage-2 contract.
+    """
+    if volume_node is None or role not in LIVER_ROLES:
+        return False
+    setter = getattr(volume_node, "SetAttribute", None)
+    if setter is None:
+        return False
+    setter(LIVER_ROLE_ATTRIBUTE, role)
+    return True


### PR DESCRIPTION
## Summary

Builds the **Stage-1 Case Setup** UI, replacing the placeholder label
(`Liver.py:380`) with a functional shell-owned panel — the first of the
end-to-end blockers for a fully-usable v2.0. A surgeon loads volume(s) via
Slicer's Add Data, then tags each with its acquisition-phase role; Stage 2
reads that role to pick its working volume.

Closes #523.

## What landed

- **Shared role vocabulary** — `LiverSegmentationLib.roles`: the `LiverRole`
  attribute key, the ordered v2.0 vocabulary (`Native`, `Arterial`,
  `PortalVenous`, `Delayed`, `Other` — CamelCase machine-stable values, human
  labels decoupled at the UI), and `set_volume_role(volume, role)` which
  validates against the vocabulary and writes the attribute (no-op-returning-
  `False` on an unknown role or `None` volume). One shared module both the
  Liver shell (writer) and LiverSegmentation (reader) use, so the key + values
  can't drift. Roles are acquisition phases, not anatomy structures, so they
  carry no SCT code (ADR-0011).
- **Case Setup panel** (ADR-0004 Python, ADR-0023 §Stage 1, ADR-0029): a
  `vtkMRMLScalarVolumeNode` selector + a role dropdown whose "Assign role"
  writes via `set_volume_role`, plus a volumes×role table. Tagging refreshes
  the table and re-runs the stage indicators, so Stage 1 flips to complete once
  a volume carries a role (`_stage1IsComplete`). Degrades to a hint label when
  `LiverSegmentationLib` is absent.

## Test-first (ADR-0027)

Six GL-free invariants (launched; skip cleanly bare), landed RED-then-green:
the vocabulary contract (key, the five ordered CamelCase values, no spaces),
`set_volume_role` tagging / round-trip / unknown-role no-op / None-volume
no-op, and Stage-1 completion flipping true after tagging. **6/6 pass launched.**

## Scope / verification

- The Qt panel itself is verified interactively (confirmed to build on a live
  display: selector + role + assign + table, tagging populates the table and
  flips the Stage-1 indicator); the tagging *logic* is pinned by the GL-free
  seam tests above.
- Deliberately deferred to the Stage-2 work (#527): collapsing
  `LiverSegmentation.py`'s duplicate `LiverRole` constants onto the shared
  module and aligning the arch doc's spaced role labels — no functional drift
  today (values already match).

Build note: incremental CMake reconfigure is safe in the warm tree (the
Qt6Multimedia wall is fresh-clone-only), so staging the new `roles.py` needed
no special handling.

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
