### PR TITLE
ENH: Stage-2 completion routing + silent hand-off guard (#527 Slice A)

### DIFF
--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -627,11 +627,17 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     shellPredicate = {
       0: self._stage1IsComplete,
-      1: self._stage2IsComplete,  # Stage 2 stub — used when LiverSegmentation is absent.
       5: self._stage6IsComplete,
     }.get(row)
     if shellPredicate is not None:
       return shellPredicate()
+
+    # Stage 2 (row 1) routes to the LiverSegmentation module's own
+    # isStageComplete via the module-logic lookup below when the module is
+    # present; when it is absent the lookup returns False (the graceful-
+    # degradation semantics _stage2IsComplete documents).  It is NOT pinned to
+    # the always-False shell stub here, or a completed anatomy stage would never
+    # flip its indicator (ADR-0023 §Stage 2).
 
     moduleName = self._STAGE_MODULE.get(row)
     if moduleName is None:
@@ -639,22 +645,32 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     module = getattr(slicer.modules, moduleName, None)
     if module is None:
       return False
+
+    # C++ stage logics expose their predicate on the wrapped module logic
+    # (``IsStageComplete`` VTK convention / ``isStageComplete`` Python).
     try:
       logic = module.logic()
     except Exception:  # pragma: no cover — defensive
-      return False
-    if logic is None:
-      return False
-
-    # C++ logic exposes ``IsStageComplete`` (VTK convention);
-    # Python logic exposes ``isStageComplete`` (Python convention).
+      logic = None
     for attr in ("IsStageComplete", "isStageComplete"):
-      query = getattr(logic, attr, None)
+      query = getattr(logic, attr, None) if logic is not None else None
       if callable(query):
         try:
           return bool(query())
         except Exception:  # pragma: no cover — defensive
           return False
+
+    # LiverSegmentation is a SCRIPTED module: its ``isStageComplete`` lives on
+    # the Python ``LiverSegmentationLogic``, not the wrapped module logic that
+    # ``module.logic()`` returns.  Resolve a fresh instance — it reads the same
+    # scene, so no module widget need be built — so a completed anatomy stage
+    # flips its indicator instead of being pinned False (ADR-0023 §Stage 2).
+    if moduleName == "liversegmentation":
+      try:
+        import LiverSegmentation
+        return bool(LiverSegmentation.LiverSegmentationLogic().isStageComplete())
+      except Exception:  # pragma: no cover — defensive
+        return False
     return False
 
   def _stageIndicatorState(self, row):

--- a/Liver/Testing/Python/test_liver_shell_isstagecomplete.py
+++ b/Liver/Testing/Python/test_liver_shell_isstagecomplete.py
@@ -130,6 +130,26 @@ def _liver_widget():
     return widget
 
 
+def _liver_widget_no_setup():
+    """A ``LiverWidget`` WITHOUT ``setup()`` — for tests that only exercise the
+    completion predicates.
+
+    ``_stageIsComplete`` reads scene + module state and needs no sidebar/layout,
+    so skipping ``setup()`` keeps these tests verifiable headless
+    (``--no-main-window``), where ``setup()``'s ``self.layout`` is ``None``.
+    """
+    from conftest import _require_qt_widget  # type: ignore[import-not-found]
+    _require_qt_widget()
+
+    _import_slicer_or_skip()
+    try:
+        import qt  # type: ignore[import-not-found]
+        import Liver  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(f"Liver scripted module not importable ({exc}).")
+    return Liver.LiverWidget(qt.QWidget())
+
+
 # =========================================================================== #
 # T2 — Symbol existence per stage
 # =========================================================================== #
@@ -380,3 +400,152 @@ def test_t3_stage4_semantics_confirmed_state_returns_true():
     plan = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLResectionPlanNode")
     plan.SetState(2)  # Confirmed
     assert logic.IsStageComplete() is True
+
+
+# =========================================================================== #
+# Stage-2 completion ROUTING — the shell delegates row 1 to the module logic
+# =========================================================================== #
+#
+# Contract: ``_stageIsComplete(1)`` must route to the LiverSegmentation module
+# logic's ``isStageComplete()`` (true iff a canonical segmentation holds >=1
+# SCT-tagged segment), NOT to the always-False ``_stage2IsComplete`` shell
+# stub.  The stub survives only as the graceful-degradation answer when the
+# module is ABSENT (pinned by ``test_t2_stage2_predicate_degrades_gracefully``
+# above, which exercises ``_stage2IsComplete`` directly).
+#
+# ``_STAGE_MODULE[1] == "liversegmentation"`` already maps row 1 to the module;
+# the fix removes the ``1:`` entry from ``_stageIsComplete``'s ``shellPredicate``
+# dict so row 1 falls through to the module-logic path.  These tests therefore
+# need the ``liversegmentation`` module registered (launched Slicer); they skip
+# cleanly bare and when the module is absent.
+#
+# ADR-0023 §"Per-stage state-indicator semantics" (Stage 2 soft-done);
+# ADR-0024 §"Output contract" (single canonical node); test-first per ADR-0027.
+
+
+def _liversegmentation_logic_or_skip():
+    """Resolve the Python ``LiverSegmentationLogic``, or skip.
+
+    Mirrors the sibling module suite's ``_logic_or_skip`` resolution: the
+    module must be registered (so the shell's module-logic path can find it)
+    AND the Python module importable (so we can drive its own accept/tag seams
+    to make ``isStageComplete()`` true).
+    """
+    slicer = _import_slicer_or_skip()
+    module = getattr(slicer.modules, "liversegmentation", None)
+    if module is None:
+        pytest.skip(
+            "'liversegmentation' module not registered -- Stage-2 completion "
+            "routes to the shell degrade-gracefully stub; the module-logic "
+            "route cannot be exercised.  Ensure --additional-module-paths "
+            "includes LiverSegmentation/."
+        )
+    try:
+        import LiverSegmentation  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(
+            f"LiverSegmentation not importable ({exc}); "
+            "ensure --additional-module-paths includes LiverSegmentation/."
+        )
+    return slicer, LiverSegmentation.LiverSegmentationLogic()
+
+
+def _make_stage2_complete(logic):
+    """Land one canonical, SCT-tagged segment so ``isStageComplete()`` is True.
+
+    Uses the orchestrator's own accept/tag seams
+    (``getOrCreateCanonicalSegmentation`` + ``tagSegmentWithSct``) rather than a
+    hand-built node, so the routing test agrees with the module on what
+    "SCT-tagged canonical segment" means — the same construction the module's
+    own ``isStageComplete()`` semantics suite uses.
+    """
+    canonical = logic.getOrCreateCanonicalSegmentation()
+    segId = canonical.GetSegmentation().AddEmptySegment("liver", "Liver")
+    # Liver parenchyma SNOMED-CT code per ADR-0024 §"Output contract".
+    logic.tagSegmentWithSct(canonical, segId, "10200004", "Liver")
+
+
+def test_stage2_routing_delegates_to_module_logic_when_complete():
+    """``_stageIsComplete(1)`` is True when the module logic reports done.
+
+    Pins the Stage-2 routing invariant: with a canonical SCT-tagged
+    segmentation in the scene, the shell must return True for row 1 — proving
+    it delegated to ``LiverSegmentationLogic.isStageComplete()`` and did NOT
+    short-circuit on the always-False ``_stage2IsComplete`` stub.
+
+    RED-as-skip until the fix lands: the current ``shellPredicate`` dict routes
+    row 1 to the stub, so this asserts False and fails once reached.  Skips
+    cleanly while the module is absent (the degrade-gracefully path).
+
+    ADR-0023 §"Per-stage state-indicator semantics"; ADR-0024 §"Output contract".
+    """
+    slicer, logic = _liversegmentation_logic_or_skip()
+    _clear_scene()
+    _make_stage2_complete(logic)
+
+    widget = _liver_widget_no_setup()
+    try:
+        assert widget._stageIsComplete(1) is True, (
+            "_stageIsComplete(1) must delegate to the LiverSegmentation module "
+            "logic (True with a canonical SCT-tagged segment), not the "
+            "always-False _stage2IsComplete stub."
+        )
+    finally:
+        slicer.mrmlScene.Clear(0)
+
+
+def test_stage2_routing_false_without_canonical_segment():
+    """``_stageIsComplete(1)`` is False with no canonical SCT-tagged segment.
+
+    The module-logic route must still report False on an empty scene (the same
+    answer the stub gave), so removing the stub entry does not spuriously flip
+    Stage 2 to done.
+
+    ADR-0023 §"Per-stage state-indicator semantics" (soft-done is canonical-only).
+    """
+    slicer, logic = _liversegmentation_logic_or_skip()  # noqa: F841 — registration gate
+    _clear_scene()
+
+    widget = _liver_widget_no_setup()
+    assert widget._stageIsComplete(1) is False, (
+        "_stageIsComplete(1) must be False with no canonical SCT-tagged "
+        "segment (empty scene), whether via the stub or the module-logic route."
+    )
+
+
+def test_stage2_routing_does_not_regress_shell_rows():
+    """Rows 0/5 stay shell-owned; the injection override still wins.
+
+    Regression guard for the routing fix: removing the row-1 ``shellPredicate``
+    entry must not disturb the shell-owned rows (0 -> ``_stage1IsComplete``,
+    5 -> ``_stage6IsComplete``) nor the ``_injectedStageCompletion`` test
+    override (``_injectStageCompletionForTesting``), which short-circuits ALL
+    rows before any predicate dispatch.
+
+    ADR-0023 §"Shell composition (Option H)"; injection override pinned by
+    ``test_state_indicators_reflect_isstagecomplete``.
+    """
+    slicer = _import_slicer_or_skip()  # noqa: F841 — scene/widget gate
+    _clear_scene()
+    widget = _liver_widget_no_setup()
+
+    # Shell-owned rows: empty scene -> both False (Stage 1 has no LiverRole
+    # volume; Stage 6 has no logged write).  Unaffected by the row-1 change.
+    assert widget._stageIsComplete(0) is False
+    assert widget._stageIsComplete(5) is False
+
+    # The injection override must still short-circuit every row, including the
+    # now-module-routed row 1.
+    widget._injectStageCompletionForTesting([True, True, True, True, True, True])
+    try:
+        for row in range(6):
+            assert widget._stageIsComplete(row) is True, (
+                f"_injectedStageCompletion must override row {row} regardless "
+                "of the per-row routing."
+            )
+    finally:
+        widget._injectStageCompletionForTesting(None)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -320,6 +320,16 @@ class _StructureCard:
 
     def onRun(self):
         volume = self._widget.logic.selectInputVolume()
+        if volume is None:
+            # No portal-venous working volume tagged in Stage 1 -- do NOT run the
+            # backend on None (a silent no-op that reads as success); surface the
+            # missing hand-off instead (ADR-0024 Stage-1/Stage-2 hand-off).
+            self.statusLabel.setText(
+                "Tag a PortalVenous volume in Case Setup (Stage 1) first."
+            )
+            self.acceptButton.setEnabled(False)
+            self.rejectButton.setEnabled(False)
+            return
         self.progressBar.setVisible(True)
         try:
             self._scratch = self._widget.logic.segment(volume, self._sctCode)

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_card_run_produces_scratch.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_card_run_produces_scratch.py
@@ -144,5 +144,160 @@ def test_card_run_produces_exactly_one_scratch_node(monkeypatch):
     )
 
 
+# =========================================================================== #
+# Silent-hand-off GUARD — a card Run with no PortalVenous volume must not
+# silently drive the backend with a None volume.
+# =========================================================================== #
+#
+# ``_StructureCard.onRun`` calls ``self._widget.logic.segment(volume, ...)``
+# where ``volume = selectInputVolume()`` is None when no Stage-1
+# ``LiverRole='PortalVenous'`` volume exists.  A None volume must NOT reach
+# ``segment()`` (no scratch node minted, no misleading progress bar); instead
+# the card surfaces feedback on ``statusLabel`` and leaves Accept/Reject
+# disabled.  The counterpart: WITH a PortalVenous volume, Run proceeds.
+#
+# ADR-0024 §"Per-structure micro-workflows" (the Stage-1/Stage-2 hand-off is
+# an explicit precondition, not a silent no-op); test-first per ADR-0027.
+
+
+def _require_qt_widget_or_skip():
+    from conftest import _require_qt_widget
+
+    _require_qt_widget()
+
+
+def _make_card_or_skip(slicer, orch, sctCode):
+    """Build one ``_StructureCard`` GL-free on a stand-in widget.
+
+    The card only touches its owning widget through ``self._widget.logic``;
+    it does not need the full ``LiverSegmentationWidget`` (which builds a
+    QTabWidget + scene observers).  A minimal stand-in carrying the real
+    orchestrator ``logic`` exercises the real ``selectInputVolume`` /
+    ``segment`` paths while keeping construction cheap and GL-free (only the
+    card's own QPushButton/QLabel/QProgressBar are built; nothing renders).
+
+    ``_refreshTabGlyphs`` is stubbed on the stand-in so ``onAccept``'s call is
+    a no-op here (glyph refresh is covered by the accepted-glyph suite).
+    """
+    _require_qt_widget_or_skip()
+    try:
+        import LiverSegmentation  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(f"LiverSegmentation not importable ({exc}).")
+
+    card_cls = getattr(LiverSegmentation, "_StructureCard", None)
+    if card_cls is None:
+        pytest.fail(
+            "LiverSegmentation must expose the per-structure card controller "
+            "(_StructureCard) that owns onRun -- ADR-0024 "
+            "§'Per-structure micro-workflows'."
+        )
+
+    class _StandInWidget:
+        def __init__(self, logic):
+            self.logic = logic
+
+        def _refreshTabGlyphs(self):
+            pass
+
+    widget = _StandInWidget(orch)
+    card = card_cls(widget, "Liver", sctCode)
+    return card
+
+
+def test_card_run_without_portalvenous_volume_does_not_segment(monkeypatch):
+    """Run with no PortalVenous volume mints no scratch node + surfaces feedback.
+
+    ADR-0024 §"Per-structure micro-workflows": Stage 2 works on the Stage-1
+    PortalVenous volume.  With none tagged, ``selectInputVolume()`` is None;
+    onRun must NOT hand a None volume to ``segment()`` (no scratch node), and
+    must surface actionable feedback on ``statusLabel`` while leaving
+    Accept/Reject disabled and the progress bar hidden.
+
+    RED-as-skip until the guard lands: today's onRun calls ``segment(None,...)``
+    -> ``_runTotalSegmentator(None,...)`` -> a scratch node, and sets the
+    "Review the result" text with Accept/Reject enabled.
+
+    The backend seam is monkeypatched so, even under the current (unfixed)
+    behaviour, no real inference runs and the leak-checking teardown stays
+    honest.
+    """
+    slicer, orch = _orchestrator_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    if not hasattr(orch, "segment"):
+        pytest.fail(
+            "orchestrator must expose segment(volume, sctTarget) per ADR-0024 "
+            "-- not yet implemented."
+        )
+    _mock_backend_segment(monkeypatch, slicer, orch)
+
+    card = _make_card_or_skip(slicer, orch, SCT_LIVER_CODE)
+
+    # No PortalVenous volume in the scene: selectInputVolume() -> None.
+    assert orch.selectInputVolume() is None, (
+        "precondition: no PortalVenous-role volume exists for this test."
+    )
+
+    card.onRun()
+
+    assert len(_segmentation_nodes(slicer, ROLE_SCRATCH)) == 0, (
+        "onRun with no PortalVenous volume must NOT call segment() -- no "
+        "scratch node may be minted from a None input (ADR-0024 Stage-1/"
+        "Stage-2 hand-off precondition)."
+    )
+    status = card.statusLabel.text
+    assert status and status != "Idle" and "Review the result" not in status, (
+        "onRun must surface actionable feedback on statusLabel (e.g. 'Tag a "
+        "PortalVenous volume in Case Setup first.'), not the post-run "
+        f"'Review the result' text; got {status!r}."
+    )
+    assert card.acceptButton.enabled is False, (
+        "Accept must stay disabled when Run did not produce a result."
+    )
+    assert card.rejectButton.enabled is False, (
+        "Reject must stay disabled when Run did not produce a result."
+    )
+    assert card.progressBar.visible is False, (
+        "the progress bar must not be left visible when Run short-circuits."
+    )
+
+
+def test_card_run_with_portalvenous_volume_still_segments(monkeypatch):
+    """Run WITH a PortalVenous volume still drives the backend + mints scratch.
+
+    Counterpart to the guard: the short-circuit must be scoped to the
+    missing-input case only.  With a Stage-1 PortalVenous volume present,
+    onRun proceeds — one scratch node, Accept/Reject enabled.
+
+    ADR-0024 §"Per-structure micro-workflows".
+    """
+    slicer, orch = _orchestrator_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    if not hasattr(orch, "segment"):
+        pytest.fail(
+            "orchestrator must expose segment(volume, sctTarget) per ADR-0024 "
+            "-- not yet implemented."
+        )
+
+    _add_input_volume(slicer)  # LiverRole='PortalVenous'
+    _mock_backend_segment(monkeypatch, slicer, orch)
+
+    card = _make_card_or_skip(slicer, orch, SCT_LIVER_CODE)
+    card.onRun()
+
+    assert len(_segmentation_nodes(slicer, ROLE_SCRATCH)) == 1, (
+        "onRun with a PortalVenous volume must proceed and mint exactly one "
+        "scratch node (ADR-0024 §'Per-structure micro-workflows')."
+    )
+    assert card.acceptButton.enabled is True, (
+        "Accept must be enabled after a successful Run."
+    )
+    assert card.rejectButton.enabled is True, (
+        "Reject must be enabled after a successful Run."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

#527 **Slice A** — two pure-Python fixes making the Stage-2 (Anatomy) workflow
honest end-to-end. First of three slices toward Stage 2 being usable without
in-app AI (Slice B = Stage-3 SCT liver lookup; Slice C = load-a-segmentation +
per-structure SCT tagging). Contributes to #527.

## Fixes

- **Stage-2 completion routing** (`Liver.py:_stageIsComplete`). The
  `shellPredicate` dict pinned row 1 to the always-False `_stage2IsComplete`
  stub, short-circuiting before the module-logic lookup — so a completed anatomy
  stage never flipped its indicator. Dropped the row-1 entry. Because
  LiverSegmentation is a **scripted** module whose `isStageComplete` lives on the
  Python `LiverSegmentationLogic` (not the wrapped `module.logic()`), the module
  path now resolves a fresh `LiverSegmentationLogic` instance — it reads the same
  scene, so no module widget is built — and falls back to the graceful-
  degradation `False` when the module is absent (ADR-0023 §Stage 2).
- **Silent hand-off guard** (`LiverSegmentation.py:_StructureCard.onRun`). When
  `selectInputVolume()` is `None` (no `LiverRole='PortalVenous'` volume tagged in
  Case Setup), `onRun` called `segment(None)` unguarded — a silent no-op that
  read as success. Now it surfaces "Tag a PortalVenous volume in Case Setup
  (Stage 1) first" and leaves Accept/Reject disabled (ADR-0024 hand-off).

## Test-first (ADR-0027)

Extends two existing suites (no new files). Routing: `_stageIsComplete(1)` is
True with a canonical SCT-tagged segmentation, False on an empty scene, and
rows 0/5 + the injection override don't regress — via a setup-free
`_liver_widget_no_setup` so it's verifiable headless. Guard: a card Run with no
PortalVenous volume produces no scratch node + surfaces feedback; a tagged
volume still segments.

**6/6 pass launched** (routing + guard). GL-free; skip cleanly bare / when the
module is absent.

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
