### PR TITLE
ENH: Stage-2 load-a-segmentation + per-structure SCT tagging (#527 Slice C)

### DIFF
--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -69,9 +69,12 @@ SCT_MASS_CODE = "4147007"
 
 #: Stage-1 / Stage-2 hand-off: Stage 2 segments the portal-venous-phase
 #: volume Stage 1 flags with this attribute (ADR-0024 §"Per-structure
-#: micro-workflows").
-LIVER_ROLE_ATTRIBUTE = "LiverRole"
-LIVER_ROLE_PORTAL_VENOUS = "PortalVenous"
+#: micro-workflows").  Single source of truth is the shared role vocabulary
+#: that Case Setup (Stage 1) writes; re-exported here for the readers below.
+from LiverSegmentationLib.roles import (  # noqa: E402
+    LIVER_ROLE_ATTRIBUTE,
+    LIVER_ROLE_PORTAL_VENOUS,
+)
 
 
 #: Dotted name the TotalSegmentator wrapper lives under.  The wrapper sits in
@@ -422,6 +425,37 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
         if canonical is not None:
             return canonical
         return self._createSegmentationWithRole(ROLE_CANONICAL, "Anatomy: Canonical")
+
+    def importSegmentationAsCanonical(self, sourceSegmentationNode, assignments):
+        """Promote a loaded segmentation to the canonical node, SCT-tagging it.
+
+        The v2.0 path to a canonical segmentation WITHOUT in-app AI (deferred to
+        v2.1): the surgeon loads a segmentation and assigns each segment a
+        structure.  ``assignments`` maps ``segmentId -> (sctCode, meaning)``.
+        Marks ``sourceSegmentationNode`` as THE canonical node (ADR-0024
+        §"Output contract" — exactly one; any prior canonical is demoted) and
+        SCT-tags each assigned segment via :meth:`tagSegmentWithSct`, so
+        :meth:`isStructureAccepted` / :meth:`isStageComplete` report the
+        structures.  A no-op returning ``None`` when the source is missing / not
+        a segmentation, or no assignments are given.
+        """
+        if sourceSegmentationNode is None or not sourceSegmentationNode.IsA(
+            "vtkMRMLSegmentationNode"
+        ):
+            return None
+        if not assignments:
+            return None
+
+        # Exactly one canonical node: demote any prior canonical before
+        # promoting the loaded one.
+        existing = self._findCanonicalSegmentation()
+        if existing is not None and existing is not sourceSegmentationNode:
+            existing.SetAttribute(ROLE_ATTRIBUTE, None)
+
+        sourceSegmentationNode.SetAttribute(ROLE_ATTRIBUTE, ROLE_CANONICAL)
+        for segmentId, (code, meaning) in assignments.items():
+            self.tagSegmentWithSct(sourceSegmentationNode, segmentId, code, meaning)
+        return sourceSegmentationNode
 
     def createScratchSegmentation(self):
         """Mint an orchestrator-private scratch segmentation node.

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -171,6 +171,9 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         self.logic = None
         self.structureTabs = None
         self._backendStatusLabel = None
+        # Load-a-segmentation affordance (the v2.0 no-AI path); built in setup().
+        self._loadSegCombo = None
+        self._loadSegTable = None
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)
 
@@ -186,6 +189,8 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             page = self._buildStructureCard(title, sctCode)
             self.structureTabs.addTab(page, f"{GLYPH_PENDING}  {title}")
         self.layout.addWidget(self.structureTabs)
+
+        self.layout.addWidget(self._buildLoadSegmentationSection())
 
         self.layout.addWidget(self._buildBackendStatusRow())
 
@@ -247,6 +252,97 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         preDownload.connect("clicked()", self.onPreDownload)
         layout.addWidget(preDownload)
         return row
+
+    def _buildLoadSegmentationSection(self):
+        """Build the "load an existing segmentation" affordance (ADR-0024).
+
+        The v2.0 path to a canonical segmentation WITHOUT in-app AI (deferred to
+        v2.1): pick a loaded ``vtkMRMLSegmentationNode``, assign each of its
+        segments a structure, and Import -> the logic promotes it to canonical
+        and SCT-tags the assigned segments (``importSegmentationAsCanonical``).
+        """
+        box = qt.QGroupBox("Load an existing segmentation")
+        box.setObjectName("LoadSegmentationSection")
+        layout = qt.QVBoxLayout(box)
+        layout.addWidget(qt.QLabel(
+            "Load a segmentation via Add Data, select it here, assign each "
+            "segment a structure, then Import as the canonical segmentation."))
+
+        combo = slicer.qMRMLNodeComboBox()
+        combo.setObjectName("LoadSegmentationComboBox")
+        combo.nodeTypes = ["vtkMRMLSegmentationNode"]
+        combo.addEnabled = False
+        combo.removeEnabled = False
+        combo.noneEnabled = True
+        combo.setMRMLScene(slicer.mrmlScene)
+        combo.connect("currentNodeChanged(vtkMRMLNode*)", self._onLoadSegmentationSelected)
+        layout.addWidget(combo)
+
+        table = qt.QTableWidget()
+        table.setObjectName("LoadSegmentationAssignTable")
+        table.setColumnCount(2)
+        table.setHorizontalHeaderLabels(["Segment", "Structure"])
+        table.horizontalHeader().setStretchLastSection(True)
+        table.editTriggers = qt.QAbstractItemView.NoEditTriggers
+        layout.addWidget(table)
+
+        importButton = qt.QPushButton("Import as canonical segmentation")
+        importButton.setObjectName("ImportSegmentationButton")
+        importButton.connect("clicked()", self._onImportSegmentationAsCanonical)
+        layout.addWidget(importButton)
+
+        self._loadSegCombo = combo
+        self._loadSegTable = table
+        return box
+
+    def _onLoadSegmentationSelected(self, node):
+        """Repopulate the per-segment structure-assignment table."""
+        table = self._loadSegTable
+        if table is None:
+            return
+        segmentIds = []
+        if node is not None:
+            segmentation = node.GetSegmentation()
+            segmentIds = list(segmentation.GetSegmentIDs())
+        table.setRowCount(len(segmentIds))
+        for row, segmentId in enumerate(segmentIds):
+            segment = node.GetSegmentation().GetSegment(segmentId)
+            name = segment.GetName() if segment is not None else segmentId
+            nameItem = qt.QTableWidgetItem(name)
+            nameItem.setData(qt.Qt.UserRole, segmentId)
+            table.setItem(row, 0, nameItem)
+
+            picker = qt.QComboBox()
+            picker.addItem("(skip)", None)
+            for title, sctCode in STRUCTURE_TABS:
+                picker.addItem(title, sctCode)
+            table.setCellWidget(row, 1, picker)
+
+    def _onImportSegmentationAsCanonical(self):
+        """Collect the structure assignments and promote the loaded node."""
+        combo = self._loadSegCombo
+        table = self._loadSegTable
+        if combo is None or table is None or self.logic is None:
+            return
+        node = combo.currentNode()
+        if node is None:
+            return
+        assignments = {}
+        for row in range(table.rowCount):
+            nameItem = table.item(row, 0)
+            picker = table.cellWidget(row, 1)
+            if nameItem is None or picker is None:
+                continue
+            sctCode = picker.itemData(picker.currentIndex)
+            if sctCode is None:
+                continue  # "(skip)"
+            segmentId = nameItem.data(qt.Qt.UserRole)
+            meaning = picker.itemText(picker.currentIndex)
+            assignments[segmentId] = (sctCode, meaning)
+        if not assignments:
+            return
+        self.logic.importSegmentationAsCanonical(node, assignments)
+        self._refreshTabGlyphs()
 
     def onPreDownload(self):
         """Pre-download the AI backend without minting a node.

--- a/LiverSegmentation/Testing/Python/CMakeLists.txt
+++ b/LiverSegmentation/Testing/Python/CMakeLists.txt
@@ -110,6 +110,13 @@ set(_liverseg_pytest_files
   test_liversegmentation_structure_accepted_glyph.py
   test_liversegmentation_backend_status_row.py
   test_liversegmentation_segment_input_selection.py
+  # SLICE C -- Stage 2 produces the canonical, per-structure-SCT-tagged
+  # segmentation by LOADING one (in-app AI deferred to v2.1); pins the
+  # importSegmentationAsCanonical logic seam (ADR-0024 §"Output contract",
+  # ADR-0011).  Scene-needing (launched `pytest_launched` row); skips cleanly
+  # bare.  The vocab-collapse companion (C2) rides the existing pure-Python
+  # test_liversegmentation_import_purity.py row.
+  test_liversegmentation_import_as_canonical.py
   # T5.2-f -- shared Subject-Hierarchy folder utility reachability +
   # Anatomy placement through vtkSlicerSubjectHierarchyFolders
   # (ADR-0023 §"MRML scene organisation").  Wrapped-C++-from-Python

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_import_as_canonical.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_import_as_canonical.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""SLICE C — Stage 2 produces a canonical, SCT-tagged segmentation by LOADING.
+
+In v2.0 the in-app AI backend is deferred to v2.1 (ADR-0024 §"Lazy install for
+AI backends"): the surgeon-usable path for Stage 2 is to LOAD an existing
+segmentation (from disk / a prior tool) and promote it to the case's single
+canonical ``vtkMRMLSegmentationNode``, SCT-tagging each structure so downstream
+stages can dispatch on the code (ADR-0011; ADR-0024 §"Output contract").
+
+This pins the new logic seam ``importSegmentationAsCanonical`` on
+``LiverSegmentationLogic``:
+
+    importSegmentationAsCanonical(self, sourceSegmentationNode, assignments)
+        -> canonicalNode | None
+
+where ``assignments`` maps ``segmentId -> (sctCode, meaning)``.  The observable
+contract (NOT the internal mechanism — promote-in-place vs copy is the
+implementer's call, see the module note) is:
+
+  * afterwards the single canonical node (the one ``_findCanonicalSegmentation``
+    returns, role attribute ``canonical``) holds one SCT-tagged segment per
+    assignment;
+  * ``isStructureAccepted(sctCode)`` is True for each assigned structure;
+  * ``isStageComplete()`` is True (soft-done, ADR-0023 §"Per-stage
+    state-indicator semantics": >=1 SCT-tagged canonical segment);
+  * a degenerate call (empty ``assignments`` or ``None`` source) is a no-op
+    that does NOT flip Stage 2 complete and does not raise.
+
+Fixtures are built through the module's OWN seams — a source segmentation node
+minted via ``getOrCreateCanonicalSegmentation`` is unavailable pre-promotion,
+so the source is a plain scene ``vtkMRMLSegmentationNode`` with
+``AddEmptySegment`` segments, mirroring the ``AddEmptySegment`` construction the
+isstagecomplete-semantics + accept suites use.  The SCT codes match ADR-0024
+§"Output contract" (Liver 10200004; Portal vein 32764006).
+
+Scene-needing: launched-Slicer harness (``pytest_launched``).  SKIP-PENDING on
+the not-yet-implemented ``importSegmentationAsCanonical`` (RED before impl,
+green after); skips cleanly under bare ``PythonSlicer -m pytest``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+MODULE_NAME = "liversegmentation"
+ROLE_ATTRIBUTE = "LiverSegmentation.Role"
+ROLE_CANONICAL = "canonical"
+
+# SCT type codes per ADR-0024 §"Output contract", confirmed against the
+# Resources/Terminology/LabelToSCT/ bridges.
+SCT_LIVER_CODE = "10200004"
+SCT_PORTAL_VEIN_CODE = "32764006"
+
+# The logic seam this slice introduces (skip-pending until implemented).
+IMPORT_SEAM = "importSegmentationAsCanonical"
+
+
+def _logic_or_skip():
+    from conftest import _import_slicer_or_skip, _require_mrml_scene
+
+    _require_mrml_scene()
+    slicer = _import_slicer_or_skip()
+    module = getattr(slicer.modules, MODULE_NAME, None)
+    if module is None:
+        pytest.skip(
+            f"'{MODULE_NAME}' module not registered -- ADR-0024 Stage-2 "
+            "deliverable absent; the load-as-canonical flow cannot be exercised."
+        )
+    try:
+        import LiverSegmentation  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(
+            f"LiverSegmentation not importable ({exc}); "
+            "ensure --additional-module-paths includes LiverSegmentation/."
+        )
+    return slicer, LiverSegmentation.LiverSegmentationLogic()
+
+
+def _require_seam(logic):
+    """SKIP-PENDING until the load-as-canonical seam lands (RED before impl)."""
+    if not hasattr(logic, IMPORT_SEAM):
+        pytest.skip(
+            f"LiverSegmentationLogic.{IMPORT_SEAM}() not implemented -- SLICE C "
+            "load-as-canonical deliverable absent (ADR-0024 §'Output "
+            "contract').  This invariant pins its observable contract for when "
+            "it lands."
+        )
+
+
+def _source_segmentation(slicer, labels):
+    """Mint a plain (un-roled) source segmentation with named empty segments.
+
+    Stands in for a loaded-from-disk segmentation the surgeon promotes.  Built
+    through ``AddEmptySegment`` the same way the isstagecomplete-semantics +
+    accept suites construct their fixtures.  Returns ``(node, {label: segId})``.
+    """
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode", "Loaded")
+    segmentation = node.GetSegmentation()
+    ids = {label: segmentation.AddEmptySegment(label, label) for label in labels}
+    return node, ids
+
+
+def test_import_single_structure_makes_stage_complete_and_accepted():
+    """C1a — loading a liver segment + assigning SCT 10200004 completes Stage 2.
+
+    ADR-0024 §"Output contract" + ADR-0023 soft-done: promoting a loaded
+    segmentation whose liver segment is assigned SCT ``10200004`` yields a
+    canonical node with one SCT-tagged segment, so ``isStructureAccepted`` for
+    the liver code and ``isStageComplete`` are both True.
+    """
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+    _require_seam(logic)
+
+    source, ids = _source_segmentation(slicer, ["liver"])
+    assignments = {ids["liver"]: (SCT_LIVER_CODE, "Liver")}
+
+    canonical = logic.importSegmentationAsCanonical(source, assignments)
+
+    assert canonical is not None, (
+        "importSegmentationAsCanonical must return the canonical node when "
+        "given a source + non-empty assignments (ADR-0024 §'Output contract')."
+    )
+    assert canonical.GetAttribute(ROLE_ATTRIBUTE) == ROLE_CANONICAL, (
+        "the returned node must carry the canonical role attribute -- it is "
+        "THE single Stage-2 output downstream stages consume."
+    )
+    assert logic.isStructureAccepted(SCT_LIVER_CODE) is True, (
+        f"isStructureAccepted({SCT_LIVER_CODE}) must be True after the liver "
+        "segment is promoted + SCT-tagged (ADR-0011 dispatch key)."
+    )
+    assert logic.isStageComplete() is True, (
+        "isStageComplete() must be True once the canonical node holds one "
+        "SCT-tagged segment (ADR-0023 soft-done)."
+    )
+
+
+def test_import_multiple_structures_accepts_each_and_completes_stage():
+    """C1b — assigning liver + portal vein accepts both; Stage 2 completes.
+
+    ADR-0024 §"Output contract": one SCT-tagged segment per structure in the
+    single canonical node.  Loading a segmentation with liver + portal-vein
+    segments and assigning SCT ``10200004`` / ``32764006`` makes
+    ``isStructureAccepted`` True for BOTH, and ``isStageComplete`` True.
+    """
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+    _require_seam(logic)
+
+    source, ids = _source_segmentation(slicer, ["liver", "portal"])
+    assignments = {
+        ids["liver"]: (SCT_LIVER_CODE, "Liver"),
+        ids["portal"]: (SCT_PORTAL_VEIN_CODE, "Portal vein"),
+    }
+
+    logic.importSegmentationAsCanonical(source, assignments)
+
+    assert logic.isStructureAccepted(SCT_LIVER_CODE) is True, (
+        f"liver SCT {SCT_LIVER_CODE} must be accepted after multi-structure "
+        "import (ADR-0024 §'Output contract')."
+    )
+    assert logic.isStructureAccepted(SCT_PORTAL_VEIN_CODE) is True, (
+        f"portal-vein SCT {SCT_PORTAL_VEIN_CODE} must be accepted after "
+        "multi-structure import (ADR-0024 §'Output contract')."
+    )
+    assert logic.isStageComplete() is True, (
+        "isStageComplete() must be True with >=1 SCT-tagged canonical segment "
+        "(ADR-0023 soft-done)."
+    )
+
+
+def test_import_degenerate_is_noop_and_does_not_complete_stage():
+    """C1c — empty assignments / None source is a no-op; Stage 2 stays incomplete.
+
+    A degenerate promotion must NOT flip Stage 2 complete (ADR-0023 soft-done
+    is >=1 SCT-tagged canonical segment) and must NOT raise -- an accidental
+    empty load cannot silently satisfy the stage.
+    """
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+    _require_seam(logic)
+
+    # None source.
+    result_none = logic.importSegmentationAsCanonical(None, {})
+    assert logic.isStageComplete() is False, (
+        "a None-source import must not complete Stage 2 (ADR-0023 soft-done)."
+    )
+
+    # Empty assignments over a real source: nothing gets SCT-tagged.
+    source, _ = _source_segmentation(slicer, ["liver"])
+    result_empty = logic.importSegmentationAsCanonical(source, {})
+    assert logic.isStageComplete() is False, (
+        "an empty-assignments import must not complete Stage 2 -- no segment "
+        "carries an SCT tag (ADR-0023 soft-done; ADR-0024 §'Output contract')."
+    )
+
+    # The degenerate return shape is the implementer's call (None or an empty
+    # canonical node); the pinned invariant is the no-op on completion, not the
+    # return value.  Reference the results so a stricter contract can assert on
+    # them later without an unused-variable lint.
+    assert result_none is None or result_none.IsA("vtkMRMLSegmentationNode")
+    assert result_empty is None or result_empty.IsA("vtkMRMLSegmentationNode")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_import_purity.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_import_purity.py
@@ -55,6 +55,11 @@ import pytest
 # Module-under-test import targets per ADR-0024 §"Module layout".
 MODULE_IMPORT = "LiverSegmentation"
 WRAPPER_IMPORT = "LiverSegmentationLib.ToolWrappers.TotalSegmentator"
+# Shared volume-role vocabulary module (the single source of truth for the
+# Stage-1 -> Stage-2 role attribute + values, ADR-0023 §"Subject Hierarchy
+# management convention" hand-off).  SLICE C collapses the module's duplicated
+# LiverRole constants onto this module.
+ROLES_IMPORT = "LiverSegmentationLib.roles"
 
 # The AI package that must NOT be imported at module-import time.
 FORBIDDEN_PACKAGE = "totalsegmentator"
@@ -191,6 +196,175 @@ def test_import_triggers_no_pip_install_and_no_totalsegmentator(target):
     )
     assert result == _RESULT_PURE, (
         f"unexpected import-purity verdict for '{target}': {result!r}." + diag
+    )
+
+
+# --------------------------------------------------------------------------- #
+# C2 — LiverRole vocabulary collapse: single source of truth.
+# --------------------------------------------------------------------------- #
+#
+# SLICE C (ADR-0024 §"Output contract" hand-off + ADR-0023 §"Subject Hierarchy
+# management convention"): the module must NOT redeclare its own copy of the
+# LiverRole attribute key / PortalVenous value.  The shared vocabulary lives in
+# ``LiverSegmentationLib.roles`` (one module both Stage-1 and Stage-2 import),
+# so the stored attribute key + value cannot drift.  Today the module carries a
+# duplicate literal pair (module-level ``LIVER_ROLE_ATTRIBUTE`` /
+# ``LIVER_ROLE_PORTAL_VENOUS``); the collapse points those names at the roles
+# module.  This test pins the observable contract: whatever the module exposes
+# under those names must EQUAL the roles module's values.
+#
+# Runs in a CHILD interpreter (same isolation contract as the purity probes,
+# module docstring): both modules resolve on ``_MODULE_ROOT``; the child never
+# touches this process's ``sys.modules``.  ``LiverSegmentationLib.roles`` is
+# pure-Python (no ``import slicer`` at module top level), so the child needs a
+# fake ``slicer`` only for the scripted-module top-level imports, exactly like
+# the purity child above.
+
+_VOCAB_CHILD_PROGRAM = textwrap.dedent(
+    f"""
+    import importlib
+    import json
+    import sys
+    import types
+
+    # Minimal fake ``slicer`` + ``qt`` + ``vtk`` so ``import LiverSegmentation``
+    # (a scripted module) resolves its top-level imports without a Slicer
+    # build: ``import qt`` / ``import vtk`` / ``from
+    # slicer.ScriptedLoadableModule import *`` / ``from slicer.util import
+    # VTKObservationMixin``.  ``LiverSegmentationLib.roles`` is already
+    # slicer-free.  Injecting the stubs (rather than relying on the launched
+    # interpreter's real modules) keeps the comparison identical bare vs
+    # launched -- the vocab constants are plain module-level literals that need
+    # no live Slicer to read.
+    # The module's classes multiply-inherit
+    # ``ScriptedLoadableModuleWidget`` + ``VTKObservationMixin``; give the
+    # stubs DISTINCT (non-overlapping) MROs so ``class X(A, B)`` resolves
+    # consistently in the stubbed child.
+    class _VTKObservationMixin:
+        pass
+
+    scripted = types.ModuleType("slicer.ScriptedLoadableModule")
+    for _name in (
+        "ScriptedLoadableModule",
+        "ScriptedLoadableModuleWidget",
+        "ScriptedLoadableModuleLogic",
+        "ScriptedLoadableModuleTest",
+    ):
+        setattr(scripted, _name, type(_name, (), {{}}))
+
+    fake_util = types.ModuleType("slicer.util")
+    fake_util.VTKObservationMixin = _VTKObservationMixin
+    fake_slicer = types.ModuleType("slicer")
+    fake_slicer.util = fake_util
+    fake_slicer.ScriptedLoadableModule = scripted
+    sys.modules["slicer"] = fake_slicer
+    sys.modules["slicer.util"] = fake_util
+    sys.modules["slicer.ScriptedLoadableModule"] = scripted
+    sys.modules["qt"] = types.ModuleType("qt")
+    sys.modules["vtk"] = types.ModuleType("vtk")
+
+    def _emit(**payload):
+        print(json.dumps(payload))
+
+    try:
+        roles = importlib.import_module({ROLES_IMPORT!r})
+    except ImportError as exc:
+        _emit(result="ROLES_NOT_IMPORTABLE", error=str(exc))
+        raise SystemExit(0)
+
+    try:
+        module = importlib.import_module({MODULE_IMPORT!r})
+    except ImportError as exc:
+        _emit(result="MODULE_NOT_IMPORTABLE", error=str(exc))
+        raise SystemExit(0)
+
+    if getattr(module, "__file__", None) is None:
+        _emit(result="MODULE_NOT_IMPORTABLE", error="resolved to namespace package")
+        raise SystemExit(0)
+
+    _emit(
+        result="COMPARED",
+        roles_attribute=getattr(roles, "LIVER_ROLE_ATTRIBUTE", None),
+        roles_portal=getattr(roles, "LIVER_ROLE_PORTAL_VENOUS", None),
+        module_has_attribute=hasattr(module, "LIVER_ROLE_ATTRIBUTE"),
+        module_has_portal=hasattr(module, "LIVER_ROLE_PORTAL_VENOUS"),
+        module_attribute=getattr(module, "LIVER_ROLE_ATTRIBUTE", None),
+        module_portal=getattr(module, "LIVER_ROLE_PORTAL_VENOUS", None),
+    )
+    raise SystemExit(0)
+    """
+)
+
+
+def test_liverrole_vocab_is_single_source_of_truth():
+    """The module's LiverRole constants equal LiverSegmentationLib.roles'.
+
+    SLICE C vocabulary collapse (ADR-0024 §"Output contract" Stage-1/Stage-2
+    hand-off; ADR-0023 §"Subject Hierarchy management convention"): the shared
+    ``LiverSegmentationLib.roles`` module is the ONE definition of the
+    ``LiverRole`` attribute key and the ``PortalVenous`` value.  The Stage-2
+    module must not carry a divergent copy — whatever it exposes as
+    ``LIVER_ROLE_ATTRIBUTE`` / ``LIVER_ROLE_PORTAL_VENOUS`` must be exactly the
+    roles module's values, so the stored key + value cannot drift between the
+    two sides of the hand-off.
+
+    Runs in a child interpreter (same isolation as the purity probes) and
+    skips cleanly when either module is absent on the bare-pytest import path;
+    the invariant is pinned for when the module lands.
+    """
+    from conftest import run_purity_child
+
+    verdict = run_purity_child(_VOCAB_CHILD_PROGRAM)
+    result = verdict.get("result")
+
+    diag = (
+        f"\nchild returncode: {verdict.get('_returncode')}"
+        f"\nchild stdout:\n{verdict.get('_stdout')}"
+        f"\nchild stderr:\n{verdict.get('_stderr')}"
+    )
+
+    if result in ("ROLES_NOT_IMPORTABLE", "MODULE_NOT_IMPORTABLE"):
+        pytest.skip(
+            f"vocab-collapse target not importable in the child "
+            f"({result}: {verdict.get('error')}) -- SLICE C deliverable absent "
+            "on this import path.  Invariant pins the single-source-of-truth "
+            "contract for when the collapse lands."
+        )
+
+    assert result == "COMPARED", (
+        "vocab-collapse child emitted no parseable verdict -- it likely "
+        f"crashed before reporting.{diag}"
+    )
+
+    # The roles module is authoritative; the child read its values.
+    assert verdict.get("roles_attribute") == "LiverRole", (
+        "LiverSegmentationLib.roles.LIVER_ROLE_ATTRIBUTE must be 'LiverRole' "
+        "(the shipped stored key, ADR-0023 hand-off)." + diag
+    )
+    assert verdict.get("roles_portal") == "PortalVenous", (
+        "LiverSegmentationLib.roles.LIVER_ROLE_PORTAL_VENOUS must be "
+        "'PortalVenous' (the phase Stage 2 selects)." + diag
+    )
+
+    # The collapse contract: the module exposes the SAME values, sourced from
+    # the roles module rather than a local literal.
+    assert verdict.get("module_has_attribute"), (
+        "LiverSegmentation must expose LIVER_ROLE_ATTRIBUTE (sourced from "
+        "LiverSegmentationLib.roles after SLICE C's vocab collapse)." + diag
+    )
+    assert verdict.get("module_has_portal"), (
+        "LiverSegmentation must expose LIVER_ROLE_PORTAL_VENOUS (sourced from "
+        "LiverSegmentationLib.roles after SLICE C's vocab collapse)." + diag
+    )
+    assert verdict.get("module_attribute") == verdict.get("roles_attribute"), (
+        "LiverSegmentation.LIVER_ROLE_ATTRIBUTE must EQUAL "
+        "LiverSegmentationLib.roles.LIVER_ROLE_ATTRIBUTE -- one source of "
+        "truth, no divergent copy (SLICE C collapse)." + diag
+    )
+    assert verdict.get("module_portal") == verdict.get("roles_portal"), (
+        "LiverSegmentation.LIVER_ROLE_PORTAL_VENOUS must EQUAL "
+        "LiverSegmentationLib.roles.LIVER_ROLE_PORTAL_VENOUS -- one source of "
+        "truth, no divergent copy (SLICE C collapse)." + diag
     )
 
 


### PR DESCRIPTION
## Summary

#527 **Slice C** — makes Stage 2 (Anatomy) produce a canonical, per-structure
SCT-tagged segmentation by **loading** one, the v2.0 path without in-app AI
(inference deferred to v2.1, #529). Second of three slices (Slice A = routing +
guard, #531; Slice B = Stage-3 SCT liver lookup). Contributes to #527.

## What landed

- **Logic seam** `importSegmentationAsCanonical(sourceNode, assignments)` —
  promotes a loaded segmentation to THE canonical node (ADR-0024 §"Output
  contract" — exactly one; any prior canonical is demoted) and SCT-tags each
  assigned segment via `tagSegmentWithSct`, so `isStructureAccepted` /
  `isStageComplete` report the structures (ADR-0011). No-op returning `None` on
  a missing/non-segmentation source or empty assignments.
- **Vocab collapse** — `LiverSegmentation.py`'s duplicated `LIVER_ROLE_ATTRIBUTE`
  / `LIVER_ROLE_PORTAL_VENOUS` now re-import from the shared
  `LiverSegmentationLib.roles` (single source of truth Case Setup also writes).
- **Load affordance** — a "Load an existing segmentation" section (selector +
  per-segment structure-assignment table + Import) driving the logic seam and
  refreshing the per-structure tab glyphs.

## Test-first (ADR-0027)

New GL-free invariants (launched; skip cleanly bare), RED-then-green:
single-structure import (liver `10200004`) completes Stage 2 + accepts the
structure; multi-structure (liver + portal `32764006`) accepts each; a
degenerate call is a no-op; plus a vocab single-source-of-truth check. Logic
tests pass launched.

## Scope / verification

The Qt affordance is verified interactively (builds on a live display); the
logic is pinned by the GL-free seam tests. Full end-to-end (load → assign →
Import → Stage 2 ✓ → Stage 3 consumes) closes with Slice B (Stage-3 SCT lookup).

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
