### PR TITLE
ENH: Find the liver segment by SCT tag in VascularTerritories (#527 Slice B)

### DIFF
--- a/VascularTerritories/Logic/Testing/Cxx/CMakeLists.txt
+++ b/VascularTerritories/Logic/Testing/Cxx/CMakeLists.txt
@@ -8,6 +8,10 @@ set(KIT ${PROJECT_NAME})
 #-----------------------------------------------------------------------------
 set(KIT_TEST_SRCS
   vtkSlicerVascularTerritoriesLogicTest1.cxx
+  # Liver segment resolved by SCT structure tag (ADR-0011 liver code), NOT the
+  # segment name "liver", so the Stage-2 canonical segmentation (SCT-tagged,
+  # arbitrary segment names) feeds Stage 3 (ADR-0024 §Output contract).
+  vtkSlicerVascularTerritoriesLogicLiverSegmentIdTest.cxx
   # CHARACTERIZATION of the CURRENT Subject-Hierarchy collection
   # behaviour (ADR-0023 §"MRML scene organisation"), landed per
   # ADR-0003 §"refactors that preserve behaviour" / ADR-0027 BEFORE the

--- a/VascularTerritories/Logic/Testing/Cxx/vtkSlicerVascularTerritoriesLogicLiverSegmentIdTest.cxx
+++ b/VascularTerritories/Logic/Testing/Cxx/vtkSlicerVascularTerritoriesLogicLiverSegmentIdTest.cxx
@@ -1,0 +1,106 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2021-2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==============================================================================*/
+
+// Pins that the liver segment is resolved by its SNOMED-CT structure tag
+// (ADR-0011 liver code 10200004), NOT by the segment name "liver" -- so the
+// canonical segmentation Stage 2 produces (SCT-tagged, arbitrary segment names)
+// feeds Stage 3.  A decoy segment literally named "liver" but WITHOUT the SCT
+// tag must be ignored; the SCT-tagged segment (differently named) must win.
+
+#include "vtkSlicerVascularTerritoriesLogic.h"
+
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+#include <vtkMRMLSegmentationNode.h>
+
+#include <vtkNew.h>
+#include <vtkSegmentation.h>
+#include <vtkSegment.h>
+#include <vtkOrientedImageData.h>
+
+#include <string>
+
+namespace
+{
+// A TerminologyEntry tag whose type triple carries the SCT liver code, in the
+// shape LiverSegmentation.tagSegmentWithSct writes (SCT^<code>^<meaning>).
+const char* LIVER_TERMINOLOGY_TAG = "Segmentation category and type - DICOM master list"
+                                    "~SCT^85756007^Tissue"
+                                    "~SCT^10200004^Liver"
+                                    "~^^~Anatomic codes - DICOM master list~^^~^^";
+} // namespace
+
+int vtkSlicerVascularTerritoriesLogicLiverSegmentIdTest(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
+{
+  vtkNew<vtkSlicerVascularTerritoriesLogic> logic;
+
+  // Null input is a no-op returning an empty id (not a crash).
+  CHECK_STD_STRING(logic->GetLiverSegmentId(nullptr), "");
+
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLSegmentationNode> segmentationNode;
+  scene->AddNode(segmentationNode);
+  vtkSegmentation* segmentation = segmentationNode->GetSegmentation();
+  const std::string masterRep = "Binary labelmap";
+  segmentation->SetSourceRepresentationName(masterRep);
+
+  // Each segment carries a minimal binary-labelmap representation so AddSegment
+  // need not construct one (GetLiverSegmentId reads only names + tags, but the
+  // test-driver's error-output check trips on a construction ERR).
+  vtkNew<vtkOrientedImageData> decoyLabelmap;
+  decoyLabelmap->SetExtent(0, 1, 0, 1, 0, 1);
+  decoyLabelmap->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+  vtkNew<vtkSegment> decoy;
+  decoy->SetName("liver"); // named "liver" but NO SCT tag -- the old name lookup's trap
+  decoy->AddRepresentation(masterRep, decoyLabelmap);
+  segmentation->AddSegment(decoy, "decoy");
+
+  vtkNew<vtkOrientedImageData> liverLabelmap;
+  liverLabelmap->SetExtent(0, 1, 0, 1, 0, 1);
+  liverLabelmap->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+  vtkNew<vtkSegment> liver;
+  liver->SetName("Segment_1"); // a DIFFERENT name, carrying the SCT liver tag
+  liver->AddRepresentation(masterRep, liverLabelmap);
+  liver->SetTag("TerminologyEntry", LIVER_TERMINOLOGY_TAG);
+  segmentation->AddSegment(liver, "parenchyma");
+
+  const std::string decoyId = "decoy";
+  const std::string liverId = "parenchyma";
+  const std::string resolved = logic->GetLiverSegmentId(segmentationNode);
+  CHECK_STD_STRING(resolved, liverId);
+  CHECK_BOOL(resolved == decoyId, false);
+
+  return EXIT_SUCCESS;
+}

--- a/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
+++ b/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
@@ -49,6 +49,8 @@
 
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLSegmentationNode.h>
+#include <vtkSegmentation.h>
+#include <vtkSegment.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLDisplayNode.h>
 
@@ -292,6 +294,13 @@ void vtkSlicerVascularTerritoriesLogic::InitializeCenterlineSearchModel(vtkMRMLM
   {
     std::cout << "Error: No PointData in centerline model" << std::endl;
   }
+}
+
+//----------------------------------------------------------------------------
+std::string vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId(vtkMRMLSegmentationNode* vtkNotUsed(segmentationNode))
+{
+  // STUB (RED): the real body scans segments for the SCT liver tag.
+  return "";
 }
 
 void vtkSlicerVascularTerritoriesLogic::calculateVascularTerritoryMap(vtkMRMLSegmentationNode* vascularTerritorySegmentationNode,

--- a/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
+++ b/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
@@ -297,9 +297,38 @@ void vtkSlicerVascularTerritoriesLogic::InitializeCenterlineSearchModel(vtkMRMLM
 }
 
 //----------------------------------------------------------------------------
-std::string vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId(vtkMRMLSegmentationNode* vtkNotUsed(segmentationNode))
+std::string vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId(vtkMRMLSegmentationNode* segmentationNode)
 {
-  // STUB (RED): the real body scans segments for the SCT liver tag.
+  if (!segmentationNode)
+  {
+    return "";
+  }
+  vtkSegmentation* segmentation = segmentationNode->GetSegmentation();
+  if (!segmentation)
+  {
+    return "";
+  }
+  // Match the liver by its SNOMED-CT structure code in the TerminologyEntry
+  // tag (ADR-0011 liver code), NOT by the segment name -- Stage 2 emits an
+  // SCT-tagged canonical segmentation with arbitrary segment names.  Substring
+  // match on scheme+code, tolerant of the meaning string (mirrors the Stage-2
+  // isStructureAccepted check).
+  const std::string liverToken = "SCT^10200004";
+  std::vector<std::string> segmentIds;
+  segmentation->GetSegmentIDs(segmentIds);
+  for (const std::string& segmentId : segmentIds)
+  {
+    vtkSegment* segment = segmentation->GetSegment(segmentId);
+    if (!segment)
+    {
+      continue;
+    }
+    std::string tag;
+    if (segment->GetTag("TerminologyEntry", tag) && tag.find(liverToken) != std::string::npos)
+    {
+      return segmentId;
+    }
+  }
   return "";
 }
 
@@ -326,8 +355,10 @@ void vtkSlicerVascularTerritoriesLogic::calculateVascularTerritoryMap(vtkMRMLSeg
     return;
   }
 
-  // Get voxels tagged as liver
-  std::string segmentId = segmentation->GetSegmentation()->GetSegmentIdBySegmentName("liver");
+  // Get voxels tagged as liver -- resolved by SCT structure tag (ADR-0011),
+  // not the segment name, so the Stage-2 SCT-tagged canonical segmentation
+  // feeds Stage 3 (ADR-0024 §Output contract).
+  std::string segmentId = this->GetLiverSegmentId(segmentation);
   // Check metadata for segmentation
   vtkSegmentation* segm = segmentation->GetSegmentation();
   int numberOfSegments = segm->GetNumberOfSegments();

--- a/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.h
+++ b/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.h
@@ -48,6 +48,8 @@
 #include <vtkObject.h>
 #include <vtkSmartPointer.h>
 
+#include <string>
+
 // Forward delcarations
 class vtkKdTreePointLocator;
 class vtkMRMLLabelMapVolumeNode;
@@ -112,6 +114,14 @@ public:
                                      vtkMRMLModelNode* centerlineModel,
                                      vtkMRMLColorNode* colormap);
   void preprocessAndDecimate(vtkPolyData* surfacePolyData, vtkPolyData* returnPolyData);
+
+  /// Return the segment id of the liver parenchyma in ``segmentationNode``,
+  /// resolved by its SNOMED-CT structure tag (ADR-0011 liver code 10200004 in
+  /// the segment's ``TerminologyEntry`` tag), NOT by the segment name "liver".
+  /// This matches what Stage 2 writes (an SCT-tagged canonical segmentation
+  /// with arbitrary segment names).  Empty string when there is no scene / no
+  /// segmentation / no SCT-liver-tagged segment.
+  std::string GetLiverSegmentId(vtkMRMLSegmentationNode* segmentationNode);
 
 protected:
   vtkSlicerVascularTerritoriesLogic();


### PR DESCRIPTION
## Summary

#527 **Slice B** (final slice) — switches VascularTerritories to find the liver
segment by its **SNOMED-CT structure tag**, not the segment name `"liver"`, so
the SCT-tagged canonical segmentation Stage 2 produces (arbitrary segment names)
feeds Stage 3. Completes #527 alongside Slice A (#531, merged) and Slice C
(#532, merged). Contributes to #527.

## Change

- New `vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId(segmentationNode)` —
  scans the segmentation for the segment whose `TerminologyEntry` tag carries
  the SCT liver code `10200004` (ADR-0011), substring-matched on scheme+code
  (tolerant of the meaning string, mirroring the Stage-2 `isStructureAccepted`
  check). Empty string on no scene / no segmentation / no SCT-liver segment.
- `calculateVascularTerritoryMap` now calls `GetLiverSegmentId` instead of
  `GetSegmentIdBySegmentName("liver")` (ADR-0024 §Output contract).

## Test-first (ADR-0027)

New CxxTest: a decoy segment literally named `"liver"` but **untagged**, plus a
differently-named segment carrying the SCT liver tag — asserts the SCT-tagged
one wins (the decoy is ignored) and null input is a no-op. Landed RED (stub) →
GREEN (real body); verified via the launcher (`Slicer --launch …`). Registered
in `KIT_TEST_SRCS` so CI's configure picks it up.

## Closes the loop

With #531/#532 merged, this makes the case → anatomy → territories path
consistent on the SCT contract: Case Setup tags volumes → Stage 2 emits an
SCT-tagged canonical segmentation → Stage 3 finds the liver by that tag.

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
