### PR TITLE
ENH: Stage-6 Export UI — save the resection plan to .lrp.json

### DIFF
--- a/Liver/CMakeLists.txt
+++ b/Liver/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MODULE_PYTHON_RESOURCES
   Resources/UI/ResectionsWidget.ui
   Resources/UI/DistanceMapsWidget.ui
   Resources/UI/ResectogramWidget.ui
+  Resources/UI/StageExportWidget.ui
   )
 
 #-----------------------------------------------------------------------------

--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -535,37 +535,23 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def _buildStage6Page(self):
     """Shell-owned Export UI (ADR-0023 §Stage 6; ADR-0004 Python).
 
-    Select a resection plan and Save it to a ``.lrp.json`` (schema v2, via
-    ``vtkMRMLResectionPlanStorageNode``).  A successful write records
-    ``Stage6.LastWriteOK`` on the shell state node, flipping ``_stage6IsComplete``.
+    The static panel is authored in ``Resources/UI/StageExportWidget.ui`` (a
+    designer-editable layout) and loaded here; only the runtime wiring — scene
+    binding + the Save signal — stays in code.  Select a resection plan and
+    Save it to a ``.lrp.json`` (schema v2, via ``vtkMRMLResectionPlanStorageNode``);
+    a successful write records ``Stage6.LastWriteOK`` on the shell state node,
+    flipping ``_stage6IsComplete``.
     """
-    page = qt.QWidget()
-    layout = qt.QVBoxLayout(page)
-    layout.addWidget(qt.QLabel(
-      "Export — select a resection plan and save it to disk (Stage 6)."))
-
-    row = qt.QHBoxLayout()
-    row.addWidget(qt.QLabel("Plan:"))
-    combo = slicer.qMRMLNodeComboBox()
-    combo.setObjectName("ExportPlanComboBox")
-    combo.nodeTypes = ["vtkMRMLResectionPlanNode"]
-    combo.addEnabled = False
-    combo.removeEnabled = False
-    combo.noneEnabled = True
-    combo.setMRMLScene(slicer.mrmlScene)
-    row.addWidget(combo, 1)
-    saveButton = qt.QPushButton("Save…")
-    saveButton.setObjectName("ExportSaveButton")
-    saveButton.connect("clicked()", self._onExportSaveClicked)
-    row.addWidget(saveButton)
-    layout.addLayout(row)
-
-    self._exportStatusLabel = qt.QLabel("")
-    self._exportStatusLabel.setObjectName("ExportStatusLabel")
-    layout.addWidget(self._exportStatusLabel)
-    layout.addStretch(1)
-
-    self._exportPlanCombo = combo
+    page = slicer.util.loadUI(self.resourcePath("UI/StageExportWidget.ui"))
+    page.setMRMLScene(slicer.mrmlScene)
+    ui = slicer.util.childWidgetVariables(page)
+    # Bind the selector's scene explicitly -- the root qMRMLWidget's
+    # setMRMLScene does not reliably propagate to the child selector at
+    # build time (before the page is parented/shown).
+    ui.ExportPlanComboBox.setMRMLScene(slicer.mrmlScene)
+    ui.ExportSaveButton.connect("clicked()", self._onExportSaveClicked)
+    self._exportPlanCombo = ui.ExportPlanComboBox
+    self._exportStatusLabel = ui.ExportStatusLabel
     return page
 
   def _onExportSaveClicked(self):

--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -226,6 +226,10 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self._caseSetupRoleCombo = None
     self._caseSetupTable = None
 
+    # Stage-6 Export widgets (built in ``_buildStage6Page``).
+    self._exportPlanCombo = None
+    self._exportStatusLabel = None
+
   def setup(self):
     """Build the six-stage navigation shell.
 
@@ -529,16 +533,90 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     return widget, True
 
   def _buildStage6Page(self):
-    """Shell-owned Export placeholder (ADR-0023 §Stage 6).
+    """Shell-owned Export UI (ADR-0023 §Stage 6; ADR-0004 Python).
 
-    Real Export UI lands in a follow-up; T5.2-d ships only the page
-    placeholder + the "last write OK" predicate.
+    Select a resection plan and Save it to a ``.lrp.json`` (schema v2, via
+    ``vtkMRMLResectionPlanStorageNode``).  A successful write records
+    ``Stage6.LastWriteOK`` on the shell state node, flipping ``_stage6IsComplete``.
     """
     page = qt.QWidget()
     layout = qt.QVBoxLayout(page)
-    layout.addWidget(qt.QLabel("Export — save the resection plan to disk (Stage 6)."))
+    layout.addWidget(qt.QLabel(
+      "Export — select a resection plan and save it to disk (Stage 6)."))
+
+    row = qt.QHBoxLayout()
+    row.addWidget(qt.QLabel("Plan:"))
+    combo = slicer.qMRMLNodeComboBox()
+    combo.setObjectName("ExportPlanComboBox")
+    combo.nodeTypes = ["vtkMRMLResectionPlanNode"]
+    combo.addEnabled = False
+    combo.removeEnabled = False
+    combo.noneEnabled = True
+    combo.setMRMLScene(slicer.mrmlScene)
+    row.addWidget(combo, 1)
+    saveButton = qt.QPushButton("Save…")
+    saveButton.setObjectName("ExportSaveButton")
+    saveButton.connect("clicked()", self._onExportSaveClicked)
+    row.addWidget(saveButton)
+    layout.addLayout(row)
+
+    self._exportStatusLabel = qt.QLabel("")
+    self._exportStatusLabel.setObjectName("ExportStatusLabel")
+    layout.addWidget(self._exportStatusLabel)
     layout.addStretch(1)
+
+    self._exportPlanCombo = combo
     return page
+
+  def _onExportSaveClicked(self):
+    """Prompt for a path and export the selected plan (the :0 entry point)."""
+    combo = self._exportPlanCombo
+    plan = combo.currentNode() if combo is not None else None
+    if plan is None:
+      if self._exportStatusLabel is not None:
+        self._exportStatusLabel.setText("Select a resection plan to export.")
+      return
+    path = qt.QFileDialog.getSaveFileName(
+      None, "Export resection plan", "", "Liver resection plan (*.lrp.json)")
+    if not path:
+      return
+    ok = self._exportResectionPlan(plan, path)
+    if self._exportStatusLabel is not None:
+      self._exportStatusLabel.setText("Saved." if ok else "Export failed.")
+    self._refreshStageIndicators()
+
+  def _liverShellStateNode(self):
+    """Get-or-create the shell's scene-level state node (survives save/load).
+
+    A ``vtkMRMLScriptedModuleNode`` named ``LiverShellState`` under module
+    ``Liver`` -- the standard pattern for module-owned scene-level state
+    (ADR-0023 §"Shell composition (Option H)").
+    """
+    for node in slicer.util.getNodesByClass("vtkMRMLScriptedModuleNode"):
+      if node.GetModuleName() == "Liver" and node.GetName() == "LiverShellState":
+        return node
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScriptedModuleNode", "LiverShellState")
+    node.SetModuleName("Liver")
+    return node
+
+  def _recordStage6Write(self, ok):
+    """Record 'last write OK' so ``_stage6IsComplete`` reflects it."""
+    self._liverShellStateNode().SetParameter(
+      "Stage6.LastWriteOK", "True" if ok else "False")
+
+  def _exportResectionPlan(self, planNode, path):
+    """Write ``planNode`` to ``path`` (.lrp.json); record success.
+
+    Returns ``True`` iff the write succeeded, recording ``Stage6.LastWriteOK``.
+    A no-op returning ``False`` on a missing plan / path (does NOT mark the
+    stage complete).
+    """
+    if planNode is None or not path:
+      return False
+    ok = bool(slicer.util.saveNode(planNode, path))
+    if ok:
+      self._recordStage6Write(True)
+    return ok
 
   def _buildUnavailablePage(self, stageName):
     """Placeholder shown when a stage's owning module is not registered."""

--- a/Liver/Resources/UI/StageExportWidget.ui
+++ b/Liver/Resources/UI/StageExportWidget.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StageExportWidget</class>
+ <widget class="qMRMLWidget" name="StageExportWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>380</width>
+    <height>150</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="ExportIntroLabel">
+     <property name="text">
+      <string>Export — select a resection plan and save it to disk (Stage 6).</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="planRow">
+     <item>
+      <widget class="QLabel" name="PlanLabel">
+       <property name="text">
+        <string>Plan:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="qMRMLNodeComboBox" name="ExportPlanComboBox">
+       <property name="nodeTypes">
+        <stringlist>
+         <string>vtkMRMLResectionPlanNode</string>
+        </stringlist>
+       </property>
+       <property name="addEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="removeEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="noneEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="ExportSaveButton">
+       <property name="text">
+        <string>Save…</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="ExportStatusLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Liver/Testing/Python/test_liver_shell_isstagecomplete.py
+++ b/Liver/Testing/Python/test_liver_shell_isstagecomplete.py
@@ -268,7 +268,7 @@ def test_t2_stage6_predicate_exists_on_shell():
     Red-fails on ``60c78df``: ``LiverWidget`` has no
     ``_stage6IsComplete`` member.
     """
-    widget = _liver_widget()
+    widget = _liver_widget_no_setup()  # predicate needs no sidebar/layout
     assert callable(getattr(widget, "_stage6IsComplete", None))
     result = widget._stage6IsComplete()
     assert isinstance(result, bool)
@@ -545,6 +545,82 @@ def test_stage2_routing_does_not_regress_shell_rows():
             )
     finally:
         widget._injectStageCompletionForTesting(None)
+
+
+# =========================================================================== #
+# Stage-6 Export — writing a plan flips the completion predicate
+# =========================================================================== #
+#
+# Contract (ADR-0023 §Stage 6): the shell-owned Export writes the resection
+# plan (.lrp.json via vtkMRMLResectionPlanStorageNode) and, on success, records
+# "last write OK" on the LiverShellState node so _stage6IsComplete flips true.
+# The testable seam is the shell's export core (_exportResectionPlan /
+# _recordStage6Write); the file dialog + Save button are :0-only.  Tests
+# skip-pending until the seam lands (ADR-0027).
+
+
+def _resection_plan_or_skip():
+    """Mint a resection plan via the C++ create-API, or skip."""
+    logic = _resections_logic()
+    if not hasattr(logic, "CreateResectionPlan"):
+        pytest.skip("vtkSlicerLiverResectionsLogic has no CreateResectionPlan.")
+    plan = logic.CreateResectionPlan("ExportTest")
+    if plan is None:
+        pytest.skip("CreateResectionPlan returned None.")
+    return plan
+
+
+def test_stage6_export_writes_plan_and_marks_complete(tmp_path):
+    """_exportResectionPlan writes the .lrp.json and flips Stage 6 complete."""
+    _clear_scene()
+    widget = _liver_widget_no_setup()
+    if not hasattr(widget, "_exportResectionPlan"):
+        pytest.skip("LiverWidget._exportResectionPlan not present -- Stage-6 "
+                    "export seam has not landed (ADR-0027).")
+    plan = _resection_plan_or_skip()
+    path = str(tmp_path / "plan.lrp.json")
+
+    assert widget._stage6IsComplete() is False
+    result = widget._exportResectionPlan(plan, path)
+    assert result is True, (
+        f"_exportResectionPlan must return True on a successful write; got {result!r}."
+    )
+    import os
+    assert os.path.exists(path), (
+        f"_exportResectionPlan must write the .lrp.json to {path}."
+    )
+    assert widget._stage6IsComplete() is True, (
+        "a successful export must record Stage6.LastWriteOK so _stage6IsComplete "
+        "flips true (ADR-0023 §Stage 6)."
+    )
+
+
+def test_stage6_record_write_flips_predicate():
+    """_recordStage6Write(True/False) drives _stage6IsComplete."""
+    _clear_scene()
+    widget = _liver_widget_no_setup()
+    if not hasattr(widget, "_recordStage6Write"):
+        pytest.skip("LiverWidget._recordStage6Write not present (ADR-0027).")
+
+    widget._recordStage6Write(True)
+    assert widget._stage6IsComplete() is True
+    widget._recordStage6Write(False)
+    assert widget._stage6IsComplete() is False
+
+
+def test_stage6_export_none_plan_is_noop(tmp_path):
+    """Exporting no plan is a no-op returning False; Stage 6 stays incomplete."""
+    _clear_scene()
+    widget = _liver_widget_no_setup()
+    if not hasattr(widget, "_exportResectionPlan"):
+        pytest.skip("LiverWidget._exportResectionPlan not present (ADR-0027).")
+    result = widget._exportResectionPlan(None, str(tmp_path / "none.lrp.json"))
+    assert result is False, (
+        "_exportResectionPlan(None, ...) must be a no-op returning False."
+    )
+    assert widget._stage6IsComplete() is False, (
+        "a failed/degenerate export must not mark Stage 6 complete."
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Builds the **Stage-6 Export** UI, replacing the placeholder label — the last
v2.0 stage placeholder. A surgeon selects a resection plan and saves it to a
`.lrp.json` (schema v2, via the existing `vtkMRMLResectionPlanStorageNode`); a
successful write records `Stage6.LastWriteOK` on the shell's `LiverShellState`
node, flipping `_stage6IsComplete` and the sidebar indicator.

Closes #528.

## What landed

- **`_exportResectionPlan(planNode, path)`** — the GL-free testable core:
  writes the plan via `slicer.util.saveNode` (the registered `.lrp.json`
  storage node) and, on success, calls `_recordStage6Write(True)`. No-op
  returning `False` on a missing plan/path (does not mark the stage complete).
- **`_recordStage6Write` / `_liverShellStateNode`** — get-or-create the
  scene-level `LiverShellState` scripted-module node and set the
  `Stage6.LastWriteOK` parameter `_stage6IsComplete` reads.
- **Export panel** (ADR-0004 Python, ADR-0023 §Stage 6): a
  `vtkMRMLResectionPlanNode` selector + Save… (file dialog) + status label,
  refreshing the stage indicators on write.

## Test-first (ADR-0027)

Extends the shell suite: a successful export writes the file + marks Stage 6
complete; `_recordStage6Write(True/False)` drives the predicate; a None-plan
export is a no-op returning `False`. Also converts the Stage-6
predicate-existence test to the setup-free widget helper so it's verifiable
headless. **4/4 Stage-6 tests pass launched.**

## Scope / verification

The file dialog + Save button are verified interactively (panel confirmed to
build on a live display: selector + Save + status); the export/record **logic**
is pinned by the GL-free seam tests.

With this + #533 (Slice B) merged, every stage of the Liver workflow (Case Setup
→ Anatomy → Territories → Planning → Volumetry → Export) is functional — the
v2.0 end-to-end goal.

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
