### PR TITLE
ENH: Author LiverSegmentation static panels as .ui

### DIFF
--- a/LiverSegmentation/CMakeLists.txt
+++ b/LiverSegmentation/CMakeLists.txt
@@ -25,6 +25,8 @@ set(MODULE_PYTHON_SCRIPTS
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
   Resources/UI/${MODULE_NAME}.ui
+  Resources/UI/BackendStatusRow.ui
+  Resources/UI/LoadSegmentationSection.ui
   )
 
 #-----------------------------------------------------------------------------

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -243,14 +243,10 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         sub-affordance of the Liver shell's Stage 6; this local row migrates
         there when that panel lands.
         """
-        row = qt.QWidget()
-        layout = qt.QHBoxLayout(row)
-        self._backendStatusLabel = qt.QLabel()
-        layout.addWidget(self._backendStatusLabel)
-        layout.addStretch(1)
-        preDownload = qt.QPushButton("Pre-download AI backend")
-        preDownload.connect("clicked()", self.onPreDownload)
-        layout.addWidget(preDownload)
+        row = slicer.util.loadUI(self.resourcePath("UI/BackendStatusRow.ui"))
+        ui = slicer.util.childWidgetVariables(row)
+        self._backendStatusLabel = ui.BackendStatusLabel
+        ui.PreDownloadButton.connect("clicked()", self.onPreDownload)
         return row
 
     def _buildLoadSegmentationSection(self):
@@ -261,35 +257,16 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         segments a structure, and Import -> the logic promotes it to canonical
         and SCT-tags the assigned segments (``importSegmentationAsCanonical``).
         """
-        box = qt.QGroupBox("Load an existing segmentation")
-        box.setObjectName("LoadSegmentationSection")
-        layout = qt.QVBoxLayout(box)
-        layout.addWidget(qt.QLabel(
-            "Load a segmentation via Add Data, select it here, assign each "
-            "segment a structure, then Import as the canonical segmentation."))
-
-        combo = slicer.qMRMLNodeComboBox()
-        combo.setObjectName("LoadSegmentationComboBox")
-        combo.nodeTypes = ["vtkMRMLSegmentationNode"]
-        combo.addEnabled = False
-        combo.removeEnabled = False
-        combo.noneEnabled = True
+        box = slicer.util.loadUI(self.resourcePath("UI/LoadSegmentationSection.ui"))
+        ui = slicer.util.childWidgetVariables(box)
+        combo = ui.LoadSegmentationComboBox
+        # Bind the selector's scene explicitly -- the root is a plain QGroupBox,
+        # so there is no qMRMLWidget setMRMLScene to propagate.
         combo.setMRMLScene(slicer.mrmlScene)
         combo.connect("currentNodeChanged(vtkMRMLNode*)", self._onLoadSegmentationSelected)
-        layout.addWidget(combo)
-
-        table = qt.QTableWidget()
-        table.setObjectName("LoadSegmentationAssignTable")
-        table.setColumnCount(2)
-        table.setHorizontalHeaderLabels(["Segment", "Structure"])
+        table = ui.LoadSegmentationAssignTable
         table.horizontalHeader().setStretchLastSection(True)
-        table.editTriggers = qt.QAbstractItemView.NoEditTriggers
-        layout.addWidget(table)
-
-        importButton = qt.QPushButton("Import as canonical segmentation")
-        importButton.setObjectName("ImportSegmentationButton")
-        importButton.connect("clicked()", self._onImportSegmentationAsCanonical)
-        layout.addWidget(importButton)
+        ui.ImportSegmentationButton.connect("clicked()", self._onImportSegmentationAsCanonical)
 
         self._loadSegCombo = combo
         self._loadSegTable = table

--- a/LiverSegmentation/Resources/UI/BackendStatusRow.ui
+++ b/LiverSegmentation/Resources/UI/BackendStatusRow.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BackendStatusRow</class>
+ <widget class="QWidget" name="BackendStatusRow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>380</width>
+    <height>40</height>
+   </rect>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QLabel" name="BackendStatusLabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QPushButton" name="PreDownloadButton">
+     <property name="text">
+      <string>Pre-download AI backend</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/LiverSegmentation/Resources/UI/LoadSegmentationSection.ui
+++ b/LiverSegmentation/Resources/UI/LoadSegmentationSection.ui
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LoadSegmentationSection</class>
+ <widget class="QGroupBox" name="LoadSegmentationSection">
+  <property name="title">
+   <string>Load an existing segmentation</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="LoadSegmentationIntroLabel">
+     <property name="text">
+      <string>Load a segmentation via Add Data, select it here, assign each segment a structure, then Import as the canonical segmentation.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="qMRMLNodeComboBox" name="LoadSegmentationComboBox">
+     <property name="nodeTypes">
+      <stringlist>
+       <string>vtkMRMLSegmentationNode</string>
+      </stringlist>
+     </property>
+     <property name="addEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="removeEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="noneEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="LoadSegmentationAssignTable">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <column>
+      <property name="text">
+       <string>Segment</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Structure</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="ImportSegmentationButton">
+     <property name="text">
+      <string>Import as canonical segmentation</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary

Adopts `.ui` for the two **static** Stage-2 (LiverSegmentation) panels, following
the Export-panel precedent (#534) — layout in designer-editable `.ui`, only
runtime wiring in code. No behaviour change.

- **`Resources/UI/BackendStatusRow.ui`** — the backend status label +
  Pre-download button (`_buildBackendStatusRow`).
- **`Resources/UI/LoadSegmentationSection.ui`** — the load-a-segmentation frame:
  intro, segmentation selector, the assignment table (a static shell; rows stay
  code-populated from the loaded segmentation), and the Import button
  (`_buildLoadSegmentationSection`).

Both load via the module's `resourcePath`; code keeps only the selector scene
binding, the signals, and the per-segment table rows.

## Verification

Logic unchanged and pinned by the GL-free seam tests
(`importSegmentationAsCanonical`, the card-run guard) — all green. Both panels
verified loading + scene-bound on an interactive display.

## Deliberately not converted

The per-structure card (`_StructureCard`) stays programmatic: its merged
Slice-A guard test constructs it directly and reads its widgets, so a `.ui`
swap needs a view/controller split (tracked separately). Case Setup (Liver
shell) is a clean candidate too but its `Liver.py`/`CMakeLists` edits overlap
the in-review Export `.ui` (#534); it follows once that merges.

---
*Drafted with the assistance of Claude (Opus 4.8, Anthropic).*
