### PR TITLE
ENH: Port the Stage-2 distance-map computation (compute core + segment-export layer)

### DIFF
--- a/LiverSegmentation/CMakeLists.txt
+++ b/LiverSegmentation/CMakeLists.txt
@@ -54,6 +54,7 @@ slicerMacroBuildScriptedModule(
 set(LiverSegmentationLib_PYTHON_SCRIPTS
   __init__.py
   roles.py
+  distance_maps.py
   ToolWrappers/__init__.py
   ToolWrappers/TotalSegmentator.py
   )

--- a/LiverSegmentation/LiverSegmentationLib/distance_maps.py
+++ b/LiverSegmentation/LiverSegmentationLib/distance_maps.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Stage-2 (Anatomy) distance-map computation (issue #538).
+
+Ports the v1 distance-map algorithm into the v2 workflow: for each anatomical
+channel a **signed Maurer distance map**, composed into one multi-component
+volume the resection mappers consume (``vtkMRMLResectionPlanNode`` distance-map
+reference; the ``vtkOpenGLBezierResectionPolyDataMapper`` shader reads the
+per-channel distances for the resection margins / colouring).
+
+Two layers:
+
+* PURE core -- ``signed_distance_map`` / ``compose_distance_map`` -- SimpleITK
+  only, no Slicer scene, unit-tested in bare pytest.
+* Slicer-coupled -- ``compute_distance_map_for_segmentation`` -- resolves the
+  SCT-tagged canonical segments (ADR-0011), exports each to a labelmap, and
+  composes the channels onto an output vector volume node.  Triggered on the
+  Stage-2 accept transition (ADR-0023 §Stage 2; phase contracts #440).
+
+Channel order matches v1: ``[tumour, parenchyma, hepatic, portal]``; absent
+channels are skipped (so component indices are dense over the present channels).
+Parenchyma (the liver) is the required channel -- the resection needs it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# SCT codes identifying the canonical segments (ADR-0011).  Keyed by the v1
+# channel order.
+CHANNEL_SCT_CODES = {
+    "tumor": "4147007",       # Mass (SCT)
+    "parenchyma": "10200004",  # Liver (SCT)
+    "hepatic": "8993003",      # Hepatic vein (SCT)
+    "portal": "32764006",      # Portal vein (SCT)
+}
+CHANNEL_ORDER = ("tumor", "parenchyma", "hepatic", "portal")
+
+# v1 SignedMaurerDistanceMap flags (image, insideIsPositive, squaredDistance,
+# useImageSpacing) == (image, False, False, True): signed (inside < 0), true
+# Euclidean distance in world units.
+_MAURER_INSIDE_IS_POSITIVE = False
+_MAURER_SQUARED = False
+_MAURER_USE_IMAGE_SPACING = True
+
+
+def signed_distance_map(labelmap_image: Any) -> Any:
+    """Signed Maurer distance map of a binary ``labelmap_image`` (SimpleITK).
+
+    Inside the label is negative, outside positive, in world units -- matching
+    the v1 convention the resection shader expects.
+    """
+    import SimpleITK as sitk
+
+    return sitk.SignedMaurerDistanceMap(
+        labelmap_image,
+        _MAURER_INSIDE_IS_POSITIVE,
+        _MAURER_SQUARED,
+        _MAURER_USE_IMAGE_SPACING,
+    )
+
+
+def compose_distance_map(channel_images: list, downsampling_rate: float = 1) -> Any:
+    """Compose per-channel signed distance maps into one multi-component image.
+
+    ``channel_images`` is an ordered list aligned to :data:`CHANNEL_ORDER`;
+    ``None`` entries (absent channels) are skipped.  Returns the composed
+    SimpleITK image, or ``None`` when no channel is present.  A single present
+    channel returns a one-component image (no ``Compose`` needed).
+    """
+    import SimpleITK as sitk
+
+    present = [img for img in channel_images if img is not None]
+    if not present:
+        return None
+
+    distances = [signed_distance_map(img) for img in present]
+
+    if downsampling_rate and downsampling_rate != 1:
+        distances = [
+            _resample(sitk, d, downsampling_rate) for d in distances
+        ]
+
+    if len(distances) == 1:
+        return distances[0]
+    return sitk.Compose(*distances)
+
+
+def _resample(sitk: Any, image: Any, downsampling_rate: float) -> Any:
+    """Downsample ``image`` by ``downsampling_rate`` with linear interpolation.
+
+    Mirrors the v1 origin/spacing recentring so the resampled map stays aligned
+    with the input geometry.
+    """
+    size = image.GetSize()
+    spacing = image.GetSpacing()
+    origin = image.GetOrigin()
+    direction = image.GetDirection()
+
+    new_size = [max(1, round(n / downsampling_rate)) for n in size]
+    physical = [spacing[i] * size[i] for i in range(3)]
+    new_spacing = [physical[i] / float(new_size[i]) for i in range(3)]
+    # Recentre the output origin for the changed spacing (v1 imageResample).
+    new_origin = [
+        origin[i] + (new_spacing[i] / 2.0 - spacing[i] / 2.0) * direction[i * 4]
+        for i in range(3)
+    ]
+
+    resampler = sitk.ResampleImageFilter()
+    resampler.SetOutputSpacing(new_spacing)
+    resampler.SetSize([int(n) for n in new_size])
+    resampler.SetOutputOrigin(new_origin)
+    resampler.SetOutputDirection(direction)
+    resampler.SetInterpolator(sitk.sitkLinear)
+    return resampler.Execute(image)
+
+
+def compute_distance_map_for_segmentation(
+    segmentation_node: Any,
+    reference_volume_node: Any,
+    output_volume_node: Any,
+    downsampling_rate: float = 1,
+) -> Any:
+    """Compute the composed distance map for a canonical segmentation.
+
+    Resolves each SCT-tagged channel segment (ADR-0011), exports it to a
+    labelmap against ``reference_volume_node``, and composes the per-channel
+    signed distance maps onto ``output_volume_node`` (a
+    ``vtkMRMLVectorVolumeNode``), tagged ``DistanceMap`` / ``Computed`` so the
+    resection distance-map selectors pick it up.  Returns ``output_volume_node``
+    on success, ``None`` when no channel (not even parenchyma) resolves.
+    """
+    import sitkUtils
+    import slicer
+    import vtk
+
+    seg = segmentation_node.GetSegmentation()
+
+    channel_images = []
+    for channel in CHANNEL_ORDER:
+        segment_id = _segment_id_for_sct(seg, CHANNEL_SCT_CODES[channel])
+        if segment_id is None:
+            channel_images.append(None)
+            continue
+        labelmap = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLLabelMapVolumeNode", f"__dmap_{channel}"
+        )
+        ids = vtk.vtkStringArray()
+        ids.InsertNextValue(segment_id)
+        slicer.modules.segmentations.logic().ExportSegmentsToLabelmapNode(
+            segmentation_node, ids, labelmap, reference_volume_node
+        )
+        channel_images.append(sitkUtils.PullVolumeFromSlicer(labelmap))
+        slicer.mrmlScene.RemoveNode(labelmap)
+
+    composed = compose_distance_map(channel_images, downsampling_rate)
+    if composed is None:
+        return None
+
+    sitkUtils.PushVolumeToSlicer(
+        composed, targetNode=output_volume_node, className="vtkMRMLVectorVolumeNode"
+    )
+    output_volume_node.SetAttribute("DistanceMap", "True")
+    output_volume_node.SetAttribute("Computed", "True")
+    return output_volume_node
+
+
+def _segment_id_for_sct(segmentation: Any, sct_code: str) -> Any:
+    """Return the segment id whose terminology entry carries ``sct_code``.
+
+    Scans the segments' ``TerminologyEntry`` tag for the ``SCT^<code>^`` marker
+    the canonical import writes (ADR-0011), mirroring the C++ resolver in
+    ``vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId``.
+    """
+    marker = f"SCT^{sct_code}^"
+    for i in range(segmentation.GetNumberOfSegments()):
+        segment = segmentation.GetNthSegment(i)
+        entry = vtk_tag(segment, "TerminologyEntry")
+        if entry and marker in entry:
+            return segmentation.GetNthSegmentID(i)
+    return None
+
+
+def vtk_tag(segment: Any, tag_name: str) -> str:
+    """Read a VTK segment tag, returning ``""`` when unset."""
+    holder = [""]
+    if segment.GetTag(tag_name, holder):
+        return holder[0]
+    return ""

--- a/LiverSegmentation/LiverSegmentationLib/distance_maps.py
+++ b/LiverSegmentation/LiverSegmentationLib/distance_maps.py
@@ -171,20 +171,18 @@ def _segment_id_for_sct(segmentation: Any, sct_code: str) -> Any:
 
     Scans the segments' ``TerminologyEntry`` tag for the ``SCT^<code>^`` marker
     the canonical import writes (ADR-0011), mirroring the C++ resolver in
-    ``vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId``.
+    ``vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId`` and the Python
+    reader ``LiverSegmentationLogic._sctTagTexts`` (``vtk.reference`` out-param:
+    ``vtkSegment.GetTag`` takes a ``std::string&``, not a Python list).
     """
+    import vtk
+
     marker = f"SCT^{sct_code}^"
     for i in range(segmentation.GetNumberOfSegments()):
         segment = segmentation.GetNthSegment(i)
-        entry = vtk_tag(segment, "TerminologyEntry")
-        if entry and marker in entry:
+        entry = vtk.reference("")
+        if not segment.GetTag("TerminologyEntry", entry):
+            continue
+        if marker in str(entry):
             return segmentation.GetNthSegmentID(i)
     return None
-
-
-def vtk_tag(segment: Any, tag_name: str) -> str:
-    """Read a VTK segment tag, returning ``""`` when unset."""
-    holder = [""]
-    if segment.GetTag(tag_name, holder):
-        return holder[0]
-    return ""

--- a/LiverSegmentation/Testing/Python/CMakeLists.txt
+++ b/LiverSegmentation/Testing/Python/CMakeLists.txt
@@ -122,6 +122,11 @@ set(_liverseg_pytest_files
   # (ADR-0023 §"MRML scene organisation").  Wrapped-C++-from-Python
   # reachability is launched-only; skips cleanly under bare pytest.
   test_liversegmentation_subject_hierarchy_folders_reachability.py
+  # #538 -- Stage-2 distance-map computation port.  Pins the PURE SimpleITK
+  # core (signed Maurer per channel + compose); runs bare when SimpleITK +
+  # NumPy are present, skips cleanly otherwise.  The Slicer-coupled
+  # segment-export layer is exercised in the launched harness.
+  test_distance_maps.py
 )
 
 foreach(_pytest_file IN LISTS _liverseg_pytest_files)

--- a/LiverSegmentation/Testing/Python/test_distance_maps.py
+++ b/LiverSegmentation/Testing/Python/test_distance_maps.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Invariants for the Stage-2 distance-map computation (issue #538).
+
+Ports the v1 distance-map algorithm into the v2 Anatomy stage: per anatomical
+channel (tumour / parenchyma / hepatic / portal) a signed Maurer distance map,
+composed into one multi-component volume the resection mappers consume.
+
+These pin the PURE SimpleITK core (``LiverSegmentationLib.distance_maps``),
+which needs no Slicer scene -- the Slicer-coupled segment-export + node wiring
+is exercised separately in the launched harness.  Skips cleanly when SimpleITK
+or NumPy are unavailable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _deps_or_skip():
+    try:
+        import numpy as np  # type: ignore[import-not-found]
+        import SimpleITK as sitk  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"SimpleITK / NumPy unavailable ({exc}).")
+    return np, sitk
+
+
+def _cube_labelmap(np, sitk, size=20, half=4):
+    """A binary labelmap with a solid cube of 1s centred in a size^3 volume."""
+    arr = np.zeros((size, size, size), dtype=np.uint8)
+    c = size // 2
+    arr[c - half:c + half, c - half:c + half, c - half:c + half] = 1
+    return sitk.GetImageFromArray(arr)
+
+
+def test_signed_distance_is_negative_inside_positive_outside():
+    """Signed Maurer map: inside the label < 0, outside > 0 (v1 flag parity)."""
+    np, sitk = _deps_or_skip()
+    from LiverSegmentationLib.distance_maps import signed_distance_map
+
+    d = signed_distance_map(_cube_labelmap(np, sitk))
+    arr = sitk.GetArrayFromImage(d)
+    c = arr.shape[0] // 2
+    assert arr[c, c, c] < 0.0, "voxel inside the label must have negative distance"
+    assert arr[0, 0, 0] > 0.0, "voxel outside the label must have positive distance"
+
+
+def test_compose_yields_one_component_per_present_channel():
+    """Only the present (non-None) channels compose, in order."""
+    np, sitk = _deps_or_skip()
+    from LiverSegmentationLib.distance_maps import compose_distance_map
+
+    a = _cube_labelmap(np, sitk)
+    b = _cube_labelmap(np, sitk)
+    composed = compose_distance_map([a, None, b, None])
+    assert composed is not None
+    assert composed.GetNumberOfComponentsPerPixel() == 2
+
+
+def test_compose_returns_none_when_no_channels_present():
+    """No channels -> nothing to compose (caller treats as a no-op)."""
+    _np, _sitk = _deps_or_skip()
+    from LiverSegmentationLib.distance_maps import compose_distance_map
+
+    assert compose_distance_map([None, None, None, None]) is None

--- a/LiverSegmentation/Testing/Python/test_distance_maps.py
+++ b/LiverSegmentation/Testing/Python/test_distance_maps.py
@@ -24,7 +24,17 @@ def _deps_or_skip():
         import SimpleITK as sitk  # type: ignore[import-not-found]
     except ImportError as exc:  # pragma: no cover - env-dependent
         pytest.skip(f"SimpleITK / NumPy unavailable ({exc}).")
-    return np, sitk
+    try:
+        # LiverSegmentationLib is on the path in the launched harness + when the
+        # module dir is staged; the bare CTest row runs from the source root
+        # without it, so skip cleanly there (mirrors test_case_setup_volume_roles).
+        from LiverSegmentationLib import distance_maps  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - bare-row path
+        pytest.skip(
+            f"LiverSegmentationLib not importable ({exc}) -- bare pytest row "
+            "lacks the module path; runs under the launched harness."
+        )
+    return np, sitk, distance_maps
 
 
 def _cube_labelmap(np, sitk, size=20, half=4):
@@ -37,10 +47,9 @@ def _cube_labelmap(np, sitk, size=20, half=4):
 
 def test_signed_distance_is_negative_inside_positive_outside():
     """Signed Maurer map: inside the label < 0, outside > 0 (v1 flag parity)."""
-    np, sitk = _deps_or_skip()
-    from LiverSegmentationLib.distance_maps import signed_distance_map
+    np, sitk, distance_maps = _deps_or_skip()
 
-    d = signed_distance_map(_cube_labelmap(np, sitk))
+    d = distance_maps.signed_distance_map(_cube_labelmap(np, sitk))
     arr = sitk.GetArrayFromImage(d)
     c = arr.shape[0] // 2
     assert arr[c, c, c] < 0.0, "voxel inside the label must have negative distance"
@@ -49,19 +58,17 @@ def test_signed_distance_is_negative_inside_positive_outside():
 
 def test_compose_yields_one_component_per_present_channel():
     """Only the present (non-None) channels compose, in order."""
-    np, sitk = _deps_or_skip()
-    from LiverSegmentationLib.distance_maps import compose_distance_map
+    np, sitk, distance_maps = _deps_or_skip()
 
     a = _cube_labelmap(np, sitk)
     b = _cube_labelmap(np, sitk)
-    composed = compose_distance_map([a, None, b, None])
+    composed = distance_maps.compose_distance_map([a, None, b, None])
     assert composed is not None
     assert composed.GetNumberOfComponentsPerPixel() == 2
 
 
 def test_compose_returns_none_when_no_channels_present():
     """No channels -> nothing to compose (caller treats as a no-op)."""
-    _np, _sitk = _deps_or_skip()
-    from LiverSegmentationLib.distance_maps import compose_distance_map
+    _np, _sitk, distance_maps = _deps_or_skip()
 
-    assert compose_distance_map([None, None, None, None]) is None
+    assert distance_maps.compose_distance_map([None, None, None, None]) is None


### PR DESCRIPTION
## Summary

Ports the v2 Stage-2 distance-map **computation** into the codebase — the v1 algorithm was never carried into the v2 workflow, so the resection distance-map input was consumed everywhere but never produced. Lands the pure SimpleITK core (`signed_distance_map` + `compose_distance_map`: per-channel signed Maurer distance → composed 4-channel volume) plus the Slicer-coupled `compute_distance_map_for_segmentation` that resolves the SCT-tagged canonical segments, exports each to a labelmap, and composes them onto a tagged vector-volume output. Confirmed against real anatomy: produces a valid 4-channel float distance map.

**Scope:** this is the compute layer only. Triggering it on the Stage-2 accept transition is deferred to #440 (phase contracts); the resection surface render itself is blocked separately by #541 (texture upload).

## ADR references

- ADR-0011: SCT terminology — channel segments resolved by `SCT^<code>^` terminology tag.
- ADR-0031: distance-map input on the resection-plan wrapper — the produced volume is the input this consumes.
- ADR-0004: Python for non-node logic — the port is pure Python.
- ADR-0027: invariant-test-first — pure core landed red→green.

## Conformance

- `LiverSegmentation/Testing/Python/test_distance_maps.py` pins the pure core: signed-distance sign convention (inside < 0), one component per present channel, `None` when no channels present.

## Test plan

- [x] `PythonSlicer -m pytest test_distance_maps.py` — 3 passed (bare, SimpleITK core)
- [ ] Launched harness exercises the Slicer-coupled segment-export layer (CI)

## UX impact

N/A — non-UI change

Part of #538.