### PR TITLE
BUG: Hide embedded stage widgets' duplicate developer tools

### DIFF
--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -387,7 +387,24 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         rep = None
     if rep is None:
       return self._buildUnavailablePage(self._STAGE_NAMES[index]), False
+    self._suppressEmbeddedDeveloperTools(rep)
     return rep, True
+
+  @staticmethod
+  def _suppressEmbeddedDeveloperTools(rep):
+    """Hide an embedded scripted sub-module's own developer-tools collapsible.
+
+    Each embedded scripted stage widget runs ``ScriptedLoadableModuleWidget.setup``,
+    which (with Developer Mode enabled) appends its own "Reload & Test"
+    collapsible.  Inside the shell that duplicates the shell's single developer
+    section, so the embedded one is hidden here -- the shell owns the one at the
+    top.  Loadable (C++) module reps have no such collapsible; the guards make
+    this a no-op for them and when Developer Mode is off.
+    """
+    inner = rep.self() if hasattr(rep, "self") else None
+    button = getattr(inner, "reloadCollapsibleButton", None)
+    if button is not None:
+      button.setVisible(False)
 
   #: Human-facing dropdown labels for the machine-stable LiverRole values that
   #: aren't already presentable (the stored value is decoupled from the label).

--- a/Liver/Testing/Python/test_liver_shell_sidebar.py
+++ b/Liver/Testing/Python/test_liver_shell_sidebar.py
@@ -295,8 +295,16 @@ def test_state_indicators_reflect_isstagecomplete():
 # ``import Liver`` guard.
 
 def _import_liver_or_skip():
-    from conftest import _import_slicer_or_skip  # type: ignore[import-not-found]
+    from conftest import (  # type: ignore[import-not-found]
+        _import_slicer_or_skip,
+        _require_qt_widget,
+    )
 
+    # LiverWidget subclasses ScriptedLoadableModuleWidget, whose class body needs
+    # qt.QWidget; the bare pytest row leaves it undefined (import Liver succeeds
+    # but Liver.LiverWidget is absent).  Guard on QWidget first, mirroring
+    # _instantiate_liver_widget, so this skips cleanly bare and runs launched.
+    _require_qt_widget()
     _import_slicer_or_skip()
     try:
         import Liver  # type: ignore[import-not-found]
@@ -304,6 +312,11 @@ def _import_liver_or_skip():
         pytest.skip(
             f"Liver scripted module not importable ({exc}); "
             "ensure the additional-module-paths include Liver/."
+        )
+    if not hasattr(Liver, "LiverWidget"):
+        pytest.skip(
+            "Liver.LiverWidget unavailable (no launched qSlicerApplication); "
+            "the developer-tools suppression seam runs under the launched harness."
         )
     return Liver
 

--- a/Liver/Testing/Python/test_liver_shell_sidebar.py
+++ b/Liver/Testing/Python/test_liver_shell_sidebar.py
@@ -279,3 +279,83 @@ def test_state_indicators_reflect_isstagecomplete():
                 f"Row {row} mocked as pending; expected 'pending', "
                 f"got {state!r}."
             )
+
+
+# --------------------------------------------------------------------------- #
+# Embedded developer-tools suppression — one shell, one "Reload & Test" section.
+# --------------------------------------------------------------------------- #
+#
+# Each embedded scripted stage widget runs
+# ``ScriptedLoadableModuleWidget.setup``, which (with Developer Mode on)
+# appends its OWN "Reload & Test" collapsible.  Inside the shell that would
+# duplicate the shell's single developer section, so ``_resolveStagePage``
+# hides the embedded one via ``_suppressEmbeddedDeveloperTools``.  The helper
+# is pure Python (operates on a rep's ``.self().reloadCollapsibleButton``), so
+# it is pinned here with a fake rep -- no launched view required beyond the
+# ``import Liver`` guard.
+
+def _import_liver_or_skip():
+    from conftest import _import_slicer_or_skip  # type: ignore[import-not-found]
+
+    _import_slicer_or_skip()
+    try:
+        import Liver  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(
+            f"Liver scripted module not importable ({exc}); "
+            "ensure the additional-module-paths include Liver/."
+        )
+    return Liver
+
+
+class _FakeButton:
+    def __init__(self):
+        self.visible = True
+
+    def setVisible(self, value):  # noqa: N802 - Qt verb
+        self.visible = value
+
+
+class _FakeInner:
+    def __init__(self, button):
+        self.reloadCollapsibleButton = button
+
+
+class _FakeRep:
+    def __init__(self, inner):
+        self._inner = inner
+
+    def self(self):
+        return self._inner
+
+
+def test_embedded_developer_tools_hidden_on_scripted_rep():
+    """A scripted sub-module rep's own developer collapsible is hidden."""
+    Liver = _import_liver_or_skip()
+
+    button = _FakeButton()
+    rep = _FakeRep(_FakeInner(button))
+
+    Liver.LiverWidget._suppressEmbeddedDeveloperTools(rep)
+
+    assert button.visible is False, (
+        "The embedded scripted stage's own 'Reload & Test' collapsible must "
+        "be hidden -- the shell owns the single developer section at the top."
+    )
+
+
+def test_embedded_developer_tools_suppression_is_noop_for_loadable_rep():
+    """Reps without a ``.self()``/collapsible (loadable C++, Developer Mode off)
+    are left untouched and raise nothing."""
+    Liver = _import_liver_or_skip()
+
+    class _RepNoSelf:
+        pass
+
+    class _RepNoButton:
+        def self(self):
+            return object()
+
+    # Neither shape has a reloadCollapsibleButton; the call must be a safe no-op.
+    Liver.LiverWidget._suppressEmbeddedDeveloperTools(_RepNoSelf())
+    Liver.LiverWidget._suppressEmbeddedDeveloperTools(_RepNoButton())


### PR DESCRIPTION
## Summary

Fixes duplicated developer-tool panels in the Liver shell. The shell embeds each sub-module's `widgetRepresentation()` as a stage tab; each embedded **scripted** stage widget runs `ScriptedLoadableModuleWidget.setup()`, which — with Developer Mode enabled — appends its own "Reload & Test" collapsible. Inside the shell that duplicated the shell's single developer section, so scripted stages (e.g. Anatomy Definition) showed a second set of developer buttons. `_resolveStagePage` now hides the embedded rep's `reloadCollapsibleButton`; the shell keeps the single section at the top. Guards on `.self()` + the attribute so it's a no-op for loadable (C++) reps and when Developer Mode is off.

## ADR references

- ADR-0023: unified GUI stage workflow (§Shell composition) — the shell composes cached `widgetRepresentation()`s; this keeps a single developer surface across the composed stages.

## Conformance

- `Liver/Testing/Python/test_liver_shell_sidebar.py`: `test_embedded_developer_tools_hidden_on_scripted_rep` (scripted rep collapsible hidden) + `test_embedded_developer_tools_suppression_is_noop_for_loadable_rep` (no-op / no raise for loadable / Developer-Mode-off reps). Red→green.

## Test plan

- [x] `PythonSlicer -m pytest test_liver_shell_sidebar.py -k developer_tools` — 2 passed (bare)

## UX impact

Removes the duplicate "Reload & Test" developer-tools collapsible that appeared inside scripted stage tabs. Visible only with Developer Mode enabled; no change to the surgeon-facing UI. State-machine unchanged (composition-only). No screenshot — the change is the *absence* of a redundant dev-mode-only panel.