### PR TITLE
BUG: Commit the resectogram locator on click, not on hover

### DIFF
--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -280,7 +280,32 @@ class ResectogramPipeline(_PipelineBase):
 
         if self._data_node is None:
             return False, sys.float_info.max
+        # Commit on a LEFT-BUTTON PRESS only, never on move/hover: the strip
+        # maps every in-view pixel, but claiming move events made the marker
+        # track the cursor and park at the (0, 0) corner on the spurious move
+        # fired when the cursor left the view (`ADR-0025`_ §Click-to-reslice).
+        if not self._is_commit_event(eventData):
+            return False, sys.float_info.max
         return True, 0.0
+
+    @staticmethod
+    def _is_commit_event(eventData: Any) -> bool:  # noqa: N803 - VTK arg name
+        """True iff ``eventData`` is a left-button press.
+
+        The resectogram commits the locator on click only; a move/hover leaves
+        the marker where it was last clicked.  Tolerant of an event lacking
+        ``GetType`` (declines) and of ``vtk`` being unavailable (declines) so
+        the GL-free seam never raises from the interaction hot path.
+        """
+        getter = getattr(eventData, "GetType", None)
+        if getter is None:
+            return False
+        try:
+            import vtk
+
+            return getter() == vtk.vtkCommand.LeftButtonPressEvent
+        except Exception:  # pragma: no cover - defensive; vtk always present in-app
+            return False
 
     def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
         """Source the click pixel and drive the locator producer.
@@ -291,6 +316,11 @@ class ResectogramPipeline(_PipelineBase):
         Returns ``True`` iff a world point was produced (the interaction logic
         keeps focus on a Pipeline that returns ``True``).
         """
+        # Defence-in-depth: the LayerDM logic only routes here after
+        # CanProcessInteractionEvent claimed the event, but re-check so a move
+        # can never write the locator even if dispatched directly.
+        if not self._is_commit_event(eventData):
+            return False
         getter = getattr(eventData, "GetDisplayPosition", None)
         if getter is None:
             return False

--- a/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
+++ b/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
@@ -272,11 +272,21 @@ class _FakeInteractionEventData:
     display->world and is therefore :0-only).
     """
 
-    def __init__(self, display_xy):
+    def __init__(self, display_xy, event_type="__leftpress__"):
         self._display_xy = tuple(display_xy)
+        # Default to a left-button press -- the seam commits on click only
+        # (ADR-0025 click-to-reslice), so the common test fixture is a click.
+        if event_type == "__leftpress__":
+            import vtk
+
+            event_type = vtk.vtkCommand.LeftButtonPressEvent
+        self._event_type = event_type
 
     def GetDisplayPosition(self):  # noqa: N802 - VTK verb
         return self._display_xy
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._event_type
 
 
 def _inject_state(pipeline, carrier, mat_ratio, viewport_size):
@@ -564,6 +574,50 @@ def test_can_process_interaction_event_gated_on_data_node():
         "displayed (the strip maps every in-view pixel)."
     )
     assert distance2 == pytest.approx(0.0)
+
+
+def test_can_process_declines_mouse_move_commits_on_click_only():
+    """Invariant 4b: the seam commits the locator on a LEFT-BUTTON PRESS only,
+    never on a mouse-move/hover (ADR-0025 click-to-reslice).
+
+    Without this filter the seam claimed (and processed) every move event, so
+    the marker tracked the cursor and parked at the (0, 0) corner on the
+    spurious move fired when the cursor left the view.  A move must be declined
+    even when a surface is displayed; ``ProcessInteractionEvent`` on a move must
+    be a no-op returning ``False``.
+    """
+    import sys
+
+    import vtk
+
+    slicer = _slicer_or_skip()
+    carrier = _make_affine_carrier_or_skip(slicer, "SeamMoveDeclined")
+    locator = _single_locator_or_skip(slicer)
+
+    pipeline = _pipeline_or_skip(slicer)
+    _inject_state(pipeline, carrier, mat_ratio=(1.0, 1.0), viewport_size=(256, 256))
+    _seam_or_skip_pending(pipeline)
+
+    move = _FakeInteractionEventData(
+        (10.0, 10.0), event_type=vtk.vtkCommand.MouseMoveEvent
+    )
+    can, distance2 = pipeline.CanProcessInteractionEvent(move)
+    assert can is False, (
+        "CanProcessInteractionEvent must DECLINE a mouse-move even with a "
+        "surface displayed -- the resectogram commits on click only."
+    )
+    assert distance2 == pytest.approx(sys.float_info.max)
+
+    handled = pipeline.ProcessInteractionEvent(move)
+    assert handled is False, (
+        "ProcessInteractionEvent on a mouse-move must be a no-op returning "
+        "False -- no locator write on hover."
+    )
+    written = tuple(locator.GetPickedPositionWorld())
+    assert written == pytest.approx((0.0, 0.0, 0.0), abs=WORLD_TOL), (
+        "A declined move must leave the locator untouched (still at its unset "
+        f"origin); got {written}."
+    )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

`CanProcessInteractionEvent` claimed every interaction event once a surface was displayed, so the resectogram locator seam processed mouse-move/hover events, not just clicks. The locator marker therefore tracked the cursor and parked at the (0, 0) resectogram corner on the spurious move fired when the cursor left the view. Both seam methods now gate on a left-button press via a new `_is_commit_event` helper: a move is declined by `CanProcessInteractionEvent` and is a no-op in `ProcessInteractionEvent`, so the marker lands where the surgeon clicks and stays there. The helper tolerates an event without `GetType` and `vtk` being unavailable so the GL-free seam never raises from the interaction hot path.

## ADR references

- ADR-0025: locator architecture (§Click-to-reslice) — the resectogram commits the locator on click.
- ADR-0027: invariant-test-first.

## Conformance

- `LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py::test_can_process_declines_mouse_move_commits_on_click_only`: a mouse-move is declined by `CanProcessInteractionEvent` and a no-op in `ProcessInteractionEvent` (locator untouched); the existing click-path invariant still holds.

## Test plan

- [x] Collects + skips cleanly under bare `PythonSlicer -m pytest` (seam suite is launched-only)
- [ ] Launched harness confirms decline-on-move / commit-on-click — **relies on CI** (author could not run the launched harness locally)

## UX impact

The resectogram locator marker now updates only on a left-click, not on hover — fixes the marker tracking the cursor and snapping to the corner on cursor-leave. No state-machine change. Screenshot deferred; the pre-fix hover behaviour was confirmed live and this pins the click-only contract.