### PR TITLE
BUG: Package the omitted LiverResectionsLib locator scripts + pin parity

### DIFF
--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -25,7 +25,9 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   __init__.py
   DistanceMaps.py
   LiverBezierSurfacePipeline.py
+  LocatorReslicer.py
   ResectionPlanningWidget.py
+  ResectogramLocatorProducer.py
   ResectogramPipeline.py
   ResectogramViewManager.py
   Representations/__init__.py

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -95,6 +95,23 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections"
     )
 
+    # Packaging-parity invariant: every .py in the LiverResectionsLib source
+    # sub-package must appear in LiverResectionsLib_PYTHON_SCRIPTS, or it is
+    # never built/packaged (the #516/#524 LocatorReslicer +
+    # ResectogramLocatorProducer omission).  Pure-Python -- parses two files,
+    # no Slicer -- so it runs (not skips) in this bare row and catches the drift
+    # deterministically.
+    add_test(
+      NAME LiverResections_packaging_parity
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_liverresectionslib_packaging_parity.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_packaging_parity PROPERTIES
+      LABELS "pytest;module-layer;LiverResections"
+    )
+
     # T5.2-f -- Subject-Hierarchy collection invariant (ADR-0023
     # §"MRML scene organisation"): the wrapper vtkMRMLLiverResectionNode
     # collects under a scene-root "Resections" folder; the hidden Bezier

--- a/LiverResections/Testing/Python/test_liverresectionslib_packaging_parity.py
+++ b/LiverResections/Testing/Python/test_liverresectionslib_packaging_parity.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Packaging-parity invariant for the ``LiverResectionsLib`` Python sub-package.
+
+``LiverResectionsLib`` is a loadable module's Python sub-package: its files are
+staged into the built ``qt-scripted-modules`` tree ONLY via the explicit
+``LiverResectionsLib_PYTHON_SCRIPTS`` list in
+``LiverResections/LiverResectionsLib/CMakeLists.txt`` (``ctkMacroCompilePythonScript``).
+A ``.py`` present in the source tree but absent from that list is **never built
+or packaged** -- it silently vanishes from a fresh build and the shipped
+extension, and ``import LiverResectionsLib.<name>`` fails at runtime.
+
+This bit twice: ``LocatorReslicer`` (#524) and ``ResectogramLocatorProducer``
+(#516) were omitted, so the ADR-0025 locator producer + click-to-reslice
+consumer never staged -- surfacing only as skipped launched tests
+(``No module named 'LiverResectionsLib.LocatorReslicer'``) that a local dev
+tree masked with hand-copied strays.
+
+Pure-Python (parses two files); runs in the bare CTest row, no Slicer needed --
+so this class of packaging drift fails a row that actually executes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_LIB_DIR = _REPO_ROOT / "LiverResections" / "LiverResectionsLib"
+_CMAKE = _LIB_DIR / "CMakeLists.txt"
+
+
+def _source_py_files() -> set[str]:
+    """Every ``.py`` under the source sub-package, as ``LIB_DIR``-relative POSIX paths."""
+    return {
+        p.relative_to(_LIB_DIR).as_posix()
+        for p in _LIB_DIR.rglob("*.py")
+    }
+
+
+def _cmake_scripts_list() -> set[str]:
+    """The ``.py`` entries inside the ``LiverResectionsLib_PYTHON_SCRIPTS`` set()."""
+    text = _CMAKE.read_text(encoding="utf-8")
+    match = re.search(
+        r"set\(\s*LiverResectionsLib_PYTHON_SCRIPTS(.*?)\)",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "LiverResectionsLib_PYTHON_SCRIPTS set() not found in "
+        f"{_CMAKE} -- the packaging list moved or was renamed."
+    )
+    return set(re.findall(r"[\w/]+\.py", match.group(1)))
+
+
+def test_every_source_py_is_staged():
+    """Every source ``.py`` must appear in the CMake SCRIPTS list.
+
+    Otherwise it is not compiled into ``qt-scripted-modules`` / the package and
+    ``import LiverResectionsLib.<name>`` fails in a fresh build (the #516/#524
+    regression).
+    """
+    missing = sorted(_source_py_files() - _cmake_scripts_list())
+    assert not missing, (
+        "LiverResectionsLib source .py files missing from "
+        "LiverResectionsLib_PYTHON_SCRIPTS (won't be built/packaged): "
+        f"{missing}. Add them to LiverResections/LiverResectionsLib/CMakeLists.txt."
+    )
+
+
+def test_scripts_list_has_no_phantom_entries():
+    """Every SCRIPTS entry must exist in the source tree (no stale references)."""
+    phantom = sorted(_cmake_scripts_list() - _source_py_files())
+    assert not phantom, (
+        "LiverResectionsLib_PYTHON_SCRIPTS lists files absent from the source "
+        f"tree (stale references): {phantom}."
+    )


### PR DESCRIPTION
## Summary

`LocatorReslicer.py` (ADR-0025 click-to-reslice consumer, #524) and `ResectogramLocatorProducer.py` (locator producer, #516) were never added to `LiverResectionsLib_PYTHON_SCRIPTS`, so `ctkMacroCompilePythonScript` never staged them into `qt-scripted-modules` or the installed package. `import LiverResectionsLib.LocatorReslicer` therefore fails in **any fresh build and the shipped extension** — it surfaced as skipped launched tests (`No module named 'LiverResectionsLib.LocatorReslicer'`), masked locally only by hand-copied strays in a dev build tree.

Fix: add both to the SCRIPTS list, and add a pure-Python **packaging-parity** test — every `.py` in the source sub-package must appear in the SCRIPTS list (and vice-versa). It runs in the **bare** CTest row (no Slicer), so this drift class fails a row that actually executes instead of a skip.

## ADR references

- ADR-0013 §5: `LiverResectionsLib` staging convention (the SCRIPTS list is the packaging contract).
- ADR-0025: the locator producer/consumer that were dropped.
- ADR-0027: invariant-test-first (parity test landed red→green).

## Conformance

- `LiverResections/Testing/Python/test_liverresectionslib_packaging_parity.py`: source `.py` ⇔ SCRIPTS-list parity (both directions). Registered as `LiverResections_packaging_parity` (bare CTest row).

## Test plan

- [x] `pytest test_liverresectionslib_packaging_parity.py` — RED (named the 2 missing files) → GREEN after the SCRIPTS fix (2 passed, bare)

## UX impact

N/A — build/packaging fix

Fixes the packaging half of #460's launched-test skips; the omitted scripts trace to #516 / #524.