### PR TITLE
COMP: Add launched module-registration diagnostic (#460)

### DIFF
--- a/Liver/Testing/Python/CMakeLists.txt
+++ b/Liver/Testing/Python/CMakeLists.txt
@@ -191,6 +191,11 @@ add_test(
     # removed build trees otherwise surface as "The shared library was not
     # found." at module registration and the launched tests skip).
     --testing
+    # Diagnostic for the #460 launched-registration gap: dumps the module
+    # discovery/instantiation/load process so a CI log shows WHICH modules fail
+    # (liverresections / liversegmentation / core cameras+segmentations were
+    # absent from slicer.modules) and why.  Cheap; remove once #460 is closed.
+    --verbose-module-discovery
     # Generated AdditionalLauncherSettings.ini: puts this build's and the
     # SlicerLayerDisplayableManager dependency's library + PYTHONPATH entries on
     # the launcher so the module .so files and their LayerDM-linked dependencies

--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -125,10 +125,36 @@ def main(argv: list[str] | None = None) -> int:
         argv = sys.argv
 
     _unshadow_pypi_packaging()
+    _log_module_registration_snapshot()
 
     import pytest
 
     return int(pytest.main(_test_roots(argv)))
+
+
+def _log_module_registration_snapshot() -> None:
+    """Print the registered-module set + factory failures (issue #460 diagnostic).
+
+    A pure STATE READ -- no ``processEvents`` / signal-connect (those crash the
+    launched harness during startup).  Shows exactly which modules are on
+    ``slicer.modules`` at the moment pytest collects, so a CI log reveals why
+    launched tests skip ``'<name>' module not registered``.  Best-effort:
+    never raises, never blocks the run.  Remove once #460 is understood.
+    """
+    try:
+        import slicer  # type: ignore[import-not-found]
+
+        manager = slicer.app.moduleManager()
+        names = sorted(manager.modulesNames()) if manager is not None else []
+        print(f"[launched-diag #460] {len(names)} modules registered: {names}", flush=True)
+
+        factory = manager.factoryManager() if manager is not None else None
+        for attr in ("ignoredModuleNames", "failedModuleNames"):
+            getter = getattr(factory, attr, None)
+            if getter is not None:
+                print(f"[launched-diag #460] {attr}: {sorted(getter())}", flush=True)
+    except Exception as exc:  # pragma: no cover - diagnostic must never break the run
+        print(f"[launched-diag #460] snapshot unavailable: {exc!r}", flush=True)
 
 
 def _exit(code: int) -> None:


### PR DESCRIPTION
## Summary

Adds observability to pin down the launched-harness registration gap behind the soft-gated `pytest_launched` row (#460). In CI, launched tests skip with `'<name>' module not registered` — `liverresections`, `liversegmentation`, and even core `cameras` / `segmentations` are absent from `slicer.modules` — yet **all** modules register in a local launched run, so the cause is invisible from here.

Two zero-risk, read-only diagnostics:
- `--verbose-module-discovery` on the launched Slicer invocation (dumps the discovery/instantiate/load process).
- A best-effort **registered-module snapshot** printed by `run_pytest_launched.py` right before pytest collects — a pure state read (`moduleManager().modulesNames()` + factory ignored/failed lists). **No** `processEvents` / signal-connect (those crash the harness during startup — verified).

The next CI run then *shows* which modules fail to register there and why, instead of guessing. Temporary — remove once #460 is closed.

## ADR references

- N/A — diagnostic/observability change toward resolving #460.

## Conformance

- N/A — no behavioural change; the snapshot is best-effort and never raises.

## Test plan

- [x] Local launched harness still runs green with the snapshot (36 passed, 1 skipped; no crash from the diagnostic) — the snapshot printed all 123 locally-registered modules.
- [ ] CI `pytest_launched` log now carries `[launched-diag #460] … modules registered: …` + `--verbose-module-discovery` output (the point of this PR).

## UX impact

N/A — test-harness diagnostic

Diagnostic for #460 (the launched-registration half; the packaging half is #546).