### PR TITLE
BUG: Sync slicer.modules attributes before launched pytest (#460)

### DIFF
--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -125,11 +125,44 @@ def main(argv: list[str] | None = None) -> int:
         argv = sys.argv
 
     _unshadow_pypi_packaging()
+    _sync_slicer_modules_attributes()
     _log_module_registration_snapshot()
 
     import pytest
 
     return int(pytest.main(_test_roots(argv)))
+
+
+def _sync_slicer_modules_attributes() -> None:
+    """Populate ``slicer.modules.<name>`` from the module manager (issue #460).
+
+    ``slicer.modules.<name>`` is set by ``slicerqt.setSlicerModules`` via the
+    ``moduleManager.moduleLoaded(QString)`` signal (Slicer ``slicerqt.py``).
+    That signal-driven Python attribute LAGS in the CI launched harness -- the
+    modules are fully registered on the C++ ``moduleManager()`` (verified: all
+    modules present) but the ``slicer.modules`` attributes are not yet set when
+    the driver runs pytest immediately at ``--python-script`` time.  Tests that
+    check ``getattr(slicer.modules, name)`` then skip/fail with a false
+    ``'<name>' module not registered``.
+
+    Replicate ``setSlicerModules`` SYNCHRONOUSLY for every registered module --
+    a pure ``moduleManager()`` read + ``setattr``, NO ``processEvents`` /
+    signal-connect (those crash the harness during startup).  Idempotent: for
+    modules whose attribute is already set it re-assigns the same object.
+    Best-effort: never raises.
+    """
+    try:
+        import slicer  # type: ignore[import-not-found]
+
+        manager = slicer.app.moduleManager()
+        if manager is None:
+            return
+        for name in manager.modulesNames():
+            module = manager.module(name)
+            if module is not None:
+                setattr(slicer.modules, name.lower(), module)
+    except Exception as exc:  # pragma: no cover - best-effort, must not break the run
+        print(f"[launched #460] slicer.modules sync skipped: {exc!r}", flush=True)
 
 
 def _log_module_registration_snapshot() -> None:


### PR DESCRIPTION
## Summary

Fixes the launched-harness false `'<name>' module not registered` skips/failures behind the soft-gated `pytest_launched` row (#460).

**Root cause (not a registration race — confirmed via the #547 diagnostic):** the C++ `moduleManager()` has *every* module in CI (the snapshot printed all 153, including `LiverSegmentation` / `LiverResections` / `Cameras` / `Segmentations`), but `slicer.modules.<name>` is populated by `slicerqt.setSlicerModules` off the `moduleManager.moduleLoaded(QString)` **signal**. That signal-driven Python attribute lags in the CI launched harness, so `getattr(slicer.modules, name)` — what the tests check — is `None` when the driver runs pytest immediately at `--python-script` time. Locally the attribute is set by test time, which is why it only bit CI.

**Fix:** before pytest, synchronously replicate `setSlicerModules` for every registered module — `setattr(slicer.modules, name.lower(), moduleManager().module(name))`. A pure manager-read + `setattr`; **no** `processEvents`/signal-connect (verified to crash the harness during startup). Idempotent, best-effort.

## ADR references

- N/A — test-harness fix. Unblocks execution of ADR-0024/0025 launched invariants.

## Conformance

- No new test: the payoff is that the *existing* launched scripted-module tests (`test_liversegmentation_*`, the LiverResections locator/pipeline tests) now execute instead of skipping. Verified in the CI `pytest_launched` log for this PR.

## Test plan

- [x] Local launched harness still green (36 passed, 1 skipped; no crash — the sync is an idempotent no-op where attributes are already set)
- [ ] CI `pytest_launched`: the `liversegmentation`/`liverresections` "not registered" skips/failures clear (the point of this PR — validated in the launched-row log)

## UX impact

N/A — test-harness fix

The launched half of #460. Pairs with #546 (the packaging half) and #547 (the diagnostic that pinned this).