### PR TITLE
BUG: Keep the launched app alive across window teardown (#460)

### DIFF
--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -125,7 +125,7 @@ def main(argv: list[str] | None = None) -> int:
         argv = sys.argv
 
     _unshadow_pypi_packaging()
-    _sync_slicer_modules_attributes()
+    _disable_quit_on_last_window_closed()
     _log_module_registration_snapshot()
 
     import pytest
@@ -133,36 +133,25 @@ def main(argv: list[str] | None = None) -> int:
     return int(pytest.main(_test_roots(argv)))
 
 
-def _sync_slicer_modules_attributes() -> None:
-    """Populate ``slicer.modules.<name>`` from the module manager (issue #460).
+def _disable_quit_on_last_window_closed() -> None:
+    """Stop a test's window teardown from quitting the app mid-suite (#460).
 
-    ``slicer.modules.<name>`` is set by ``slicerqt.setSlicerModules`` via the
-    ``moduleManager.moduleLoaded(QString)`` signal (Slicer ``slicerqt.py``).
-    That signal-driven Python attribute LAGS in the CI launched harness -- the
-    modules are fully registered on the C++ ``moduleManager()`` (verified: all
-    modules present) but the ``slicer.modules`` attributes are not yet set when
-    the driver runs pytest immediately at ``--python-script`` time.  Tests that
-    check ``getattr(slicer.modules, name)`` then skip/fail with a false
-    ``'<name>' module not registered``.
-
-    Replicate ``setSlicerModules`` SYNCHRONOUSLY for every registered module --
-    a pure ``moduleManager()`` read + ``setattr``, NO ``processEvents`` /
-    signal-connect (those crash the harness during startup).  Idempotent: for
-    modules whose attribute is already set it re-assigns the same object.
-    Best-effort: never raises.
+    With ``--no-main-window`` Qt's default ``quitOnLastWindowClosed`` is true,
+    so a test that creates and then destroys a top-level widget (e.g. the
+    workflow arena's standalone ``qMRMLThreeDWidget``) QUEUES an application
+    quit on ``lastWindowClosed``.  The first later test that spins the event
+    loop delivers it -> ``aboutToQuit`` -> the module manager unloads every
+    module mid-run -> all later ``slicer.modules.<name>`` consults fail with a
+    false "module not registered" (mass attribute wipe observed: 169 -> 4).
+    Disabling the flag keeps the suite in one live application; the driver's
+    ``_exit`` still terminates explicitly.
     """
     try:
         import slicer  # type: ignore[import-not-found]
 
-        manager = slicer.app.moduleManager()
-        if manager is None:
-            return
-        for name in manager.modulesNames():
-            module = manager.module(name)
-            if module is not None:
-                setattr(slicer.modules, name.lower(), module)
-    except Exception as exc:  # pragma: no cover - best-effort, must not break the run
-        print(f"[launched #460] slicer.modules sync skipped: {exc!r}", flush=True)
+        slicer.app.setQuitOnLastWindowClosed(False)
+    except Exception as exc:  # pragma: no cover - best-effort
+        print(f"[launched #460] quitOnLastWindowClosed not disabled: {exc!r}", flush=True)
 
 
 def _log_module_registration_snapshot() -> None:


### PR DESCRIPTION
## Summary

The **actual root cause** of #460's launched-row "module not registered" failures, found by per-test attribute tracing after the #548 sync (based on a signal-lag theory) proved ineffective:

With `--no-main-window`, Qt's default `quitOnLastWindowClosed` is **true**. A test that creates then destroys a top-level widget — the workflow arena's standalone `qMRMLThreeDWidget` — **queues an application quit** on `lastWindowClosed`. The first later test that spins the event loop delivers it → `aboutToQuit` → the module manager **unloads every module mid-suite** (traced: `slicer.modules` attribute count drops 169 → 4 during one test) → every later `slicer.modules.<name>` consult fails with a false "module not registered". It only reproduces when the workflow root runs before the module roots — exactly the CI root order, and why single-root local runs always passed (and why it looked environment-specific).

**Fix:** disable `quitOnLastWindowClosed` in the driver before pytest. The driver's `_exit` still terminates the app explicitly. Also removes `_sync_slicer_modules_attributes` (#548): tracing shows attributes are already correct at driver start; the wipe happens mid-run, which the sync cannot address.

## ADR references

- N/A — test-harness fix (unblocks execution of ADR-0024/0025 launched invariants).

## Conformance

- Full three-root run locally (same roots as CI): **1 failed / 212 passed / 85 skipped → 0 failed / 283 passed / 15 skipped**, zero "not registered".

## Test plan

- [x] Local launched harness, full CI root set: 283 passed, 0 failed, 0 "not registered"
- [x] Per-test attribute tracer confirms no mid-run attribute wipe with the fix
- [ ] CI `pytest_launched` row goes green → then the soft-gate (`continue-on-error`, ci.yml) can be promoted back to gating in a follow-up

## UX impact

N/A — test-harness fix

Closes the launched half of #460 (packaging half was #546; diagnosis trail: #547 → #548 → this).