### PR TITLE
BUG: Capture real Python coverage (Slicer Python + launched leg)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+#
+# coverage.py configuration for the Python coverage measurement
+# (ADR-0021; CI wiring in .github/workflows/ci.yml, coverage job).
+#
+# [run] omit: test code must not count toward source coverage --
+# mirrors the gcovr `--exclude '.*Testing.*'` on the C++ side.
+#
+# [paths]: the launched-Slicer coverage leg measures the STAGED module
+# tree (``<build>/lib/Slicer-*/qt-scripted-modules/...``) because the
+# launched app imports the staged copies, not the source files.  These
+# aliases let ``coverage combine`` fold the staged records back onto the
+# source files so bare + launched legs merge into one per-file record.
+# coverage.py's aliasing is directory-prefix based, so only the Python
+# sub-PACKAGES can be remapped here; the flat staged scripted modules
+# (``qt-scripted-modules/<Module>.py``) are remapped afterwards by
+# .github/scripts/fix_coverage_paths.py.
+
+[run]
+omit =
+    */Testing/*
+    */__pycache__/*
+
+[paths]
+liverresectionslib =
+    LiverResections/LiverResectionsLib/
+    */qt-scripted-modules/LiverResectionsLib/
+liversegmentationlib =
+    LiverSegmentation/LiverSegmentationLib/
+    */qt-scripted-modules/LiverSegmentationLib/

--- a/.github/scripts/fix_coverage_paths.py
+++ b/.github/scripts/fix_coverage_paths.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Normalize + remap coverage-py.xml paths, merging duplicate file records.
+
+coverage.py's [paths] aliasing is directory-prefix-only, so the launched leg's
+flat scripted modules (qt-scripted-modules/<Module>.py) survive as build-tree
+paths.  Normalize every filename to repo-relative, rewrite staged flat modules
+to their source location (<dir>/<Module>.py discovered dynamically), and merge
+duplicate records by per-line max hits.
+
+Usage: fix_coverage_paths.py <coverage-py.xml> <repo-root>.
+"""
+
+import glob
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+xml_path = sys.argv[1]
+root_dir = os.path.abspath(sys.argv[2])
+STAGED = re.compile(r".*qt-scripted-modules/([A-Za-z_]+\.py)$")
+
+
+def source_for(basename):
+    """Repo-relative source path of a staged flat module, or None."""
+    hits = [
+        p
+        for p in glob.glob(os.path.join(root_dir, "*", basename))
+        if "build" not in p and "Testing" not in p
+    ]
+    return os.path.relpath(hits[0], root_dir) if len(hits) == 1 else None
+
+
+tree = ET.parse(xml_path)
+root = tree.getroot()
+by_name = {}
+for pkg in root.iter("package"):
+    for classes in pkg.iter("classes"):
+        for cls in list(classes):
+            fn = cls.get("filename")
+            if os.path.isabs(fn):
+                fn = os.path.relpath(fn, root_dir)
+            staged = STAGED.match(fn)
+            if staged:
+                src = source_for(staged.group(1))
+                if src:
+                    fn = src
+            cls.set("filename", fn)
+            if fn in by_name:
+                keep = {ln.get("number"): ln for ln in by_name[fn].find("lines")}
+                for ln in cls.find("lines"):
+                    number = ln.get("number")
+                    if number in keep:
+                        merged = max(int(keep[number].get("hits")), int(ln.get("hits")))
+                        keep[number].set("hits", str(merged))
+                    else:
+                        by_name[fn].find("lines").append(ln)
+                classes.remove(cls)
+            else:
+                by_name[fn] = cls
+
+tot_hits = 0
+tot_lines = 0
+for fn, cls in by_name.items():
+    lines = cls.find("lines")
+    n_lines = len(lines)
+    n_hits = sum(1 for ln in lines if int(ln.get("hits")) > 0)
+    cls.set("line-rate", str(n_hits / n_lines if n_lines else 0))
+    tot_hits += n_hits
+    tot_lines += n_lines
+root.set("line-rate", str(tot_hits / tot_lines if tot_lines else 0))
+
+for sources in root.iter("sources"):
+    for child in list(sources):
+        sources.remove(child)
+
+tree.write(xml_path, xml_declaration=True)
+print(
+    f"fixed: {len(by_name)} files, overall "
+    f"{100 * tot_hits / max(tot_lines, 1):.1f}% ({tot_hits}/{tot_lines})"
+)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,15 @@ jobs:
           # any Python coverage data.
           /tmp/coverage-venv/bin/pip install 'gcovr>=7' 'pytest-cov>=5' 'pytest>=8' 'numpy>=1.24'
           echo "/tmp/coverage-venv/bin" >> "$GITHUB_PATH"
+          # Python coverage must run under SLICER's Python (PythonSlicer):
+          # the venv's plain python3 cannot import vtk / slicer / SimpleITK,
+          # so the unit layer collection-errors and ~nothing executes --
+          # which is why the ``py`` flag reported 0.2% while the SAME tests
+          # pass in build-test (whose CTest rows use Slicer's Python).
+          # pytest is already importable from Slicer's Python; add
+          # pytest-cov (and its ``coverage`` dependency) beside it.
+          PYTHONSLICER="${Slicer_DIR}/../python-install/bin/PythonSlicer"
+          "${PYTHONSLICER}" -m pip install 'pytest-cov>=5'
 
       - name: Verify Slicer build tree
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
@@ -569,12 +578,13 @@ jobs:
           set -euo pipefail
           cd build-coverage
           # Same exclusion set as build-test (LiverBezierVisualTest_* +
-          # pytest_launched, the latter soft-gated pending issue #460's
-          # launched-harness module-registration race); coverage % drift
-          # between the two jobs is acceptable as long as the same set of
-          # tests actually runs in both.
-          # fail_ci_if_error is false on the upload step so a single
-          # failed instrumented test does not block the rest of the PR.
+          # pytest_launched); the launched row runs SEPARATELY below with
+          # Python-coverage env injected, so excluding it here avoids a
+          # double run.  Coverage % drift between the two jobs is
+          # acceptable as long as the same set of tests actually runs in
+          # both.  fail_ci_if_error is false on the upload step so a
+          # single failed instrumented test does not block the rest of
+          # the PR.
           ctest -V --no-tests=error \
                 --exclude-regex '^(LiverBezierVisualTest_.*|pytest_launched)$' || true
 
@@ -619,52 +629,94 @@ jobs:
           XML
             }
 
-      - name: Run pytest with coverage
+      # Python coverage, leg 1 of 2 — BARE run under Slicer's Python.
+      #
+      # Runs the same three roots as the launched row.  Must use
+      # PythonSlicer, not the venv's plain python3: the unit layer
+      # (Testing/Python/unit) imports vtk/numpy and the module suites
+      # import SimpleITK — under plain python3 they collection-error /
+      # skip and pytest-cov measured ~nothing (the ``py`` flag reported
+      # 0.2% with every Representation at 0% while the SAME tests pass
+      # in build-test).  ``--cov`` on the SOURCE trees also enumerates
+      # never-imported files at 0%, giving the scripted modules honest
+      # visibility in the report.  Data-file only (no XML yet): leg 2
+      # appends launched-run data and the combine step below emits the
+      # final XML.
+      - name: Python coverage (bare, Slicer Python)
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        env:
+          COVERAGE_RCFILE: ${{ github.workspace }}/.coveragerc
+          COVERAGE_FILE: ${{ github.workspace }}/.coverage.bare
         run: |
           set -euo pipefail
-          # Per ADR-0021 §"Out of scope", Slicer-launcher Python
-          # coverage (wrapped MRML bindings) is opt-in per test and may
-          # not be reachable from a plain pytest invocation in the
-          # image.  Run what we can: discover the two pytest roots
-          # (``Testing/Python/`` declared in pytest.ini as the project
-          # default, plus ``LiverResections/Testing/Python/`` for the
-          # module-local test_harness suite) and emit a Cobertura XML
-          # measuring the actual Python source module
-          # ``LiverResections/LiverResectionsLib``.
-          #
-          # The earlier discovery path (``LiverResectionsLib`` from the
-          # repo root) matched no directory: the module lives at
-          # ``LiverResections/LiverResectionsLib`` and the tests live
-          # under ``Testing/Python/`` and ``LiverResections/Testing/Python/``.
-          # ``find`` returned nothing, the ``else`` branch fired, and an
-          # empty coverage-py.xml shipped to Codecov.
-          test_roots=()
-          [ -d Testing/Python ] && test_roots+=(Testing/Python)
-          [ -d LiverResections/Testing/Python ] && test_roots+=(LiverResections/Testing/Python)
-          if [ ${#test_roots[@]} -gt 0 ] && \
-             find "${test_roots[@]}" \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit | grep -q .; then
-            # ``--continue-on-collection-errors``: one bad module
-            # (e.g. a missing optional dep) shouldn't abort the
-            # entire session and prevent pytest-cov from writing the
-            # XML for the modules that DO collect.  Belt-and-braces
-            # alongside the numpy install above — there will always
-            # be a future test module that imports something opt-
-            # ional, and we want partial Python coverage rather than
-            # none in that case.
-            python3 -m pytest "${test_roots[@]}" \
-              --continue-on-collection-errors \
-              --cov=LiverResections/LiverResectionsLib \
-              --cov-report=xml:coverage-py.xml \
-              --cov-report=term \
-              || true
-          else
-            echo "::notice::No pytest tests discovered under Testing/Python or LiverResections/Testing/Python — emitting empty coverage-py.xml."
+          PYTHONSLICER="${Slicer_DIR}/../python-install/bin/PythonSlicer"
+          "${PYTHONSLICER}" -m pytest \
+              Testing/Python \
+              LiverResections/Testing/Python \
+              LiverSegmentation/Testing/Python \
+            --continue-on-collection-errors \
+            --cov=Liver \
+            --cov=LiverSegmentation \
+            --cov=LiverResections/LiverResectionsLib \
+            --cov=LiverVolumetry \
+            --cov=VascularTerritories \
+            --cov-report= \
+            || true
+
+      # Python coverage, leg 2 of 2 — the LAUNCHED row, with coverage
+      # injected via PYTEST_ADDOPTS (pytest.main in
+      # run_pytest_launched.py honours it).  The launched app imports
+      # the STAGED module tree, so --cov targets the build's
+      # qt-scripted-modules dir; .coveragerc [paths] + the fix script
+      # below fold those records back onto the source files.
+      # Non-blocking (|| true): the launched row itself is exercised as
+      # a gate in build-test; here it only contributes coverage data.
+      - name: Python coverage (launched row)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        env:
+          COVERAGE_RCFILE: ${{ github.workspace }}/.coveragerc
+          COVERAGE_FILE: ${{ github.workspace }}/.coverage.launched
+        run: |
+          set -euo pipefail
+          staged="$(ls -d "$GITHUB_WORKSPACE"/build-coverage/lib/Slicer-*/qt-scripted-modules 2>/dev/null | head -1 || true)"
+          if [ -z "${staged}" ]; then
+            echo "::warning::No staged qt-scripted-modules dir found — skipping launched Python coverage."
+            exit 0
+          fi
+          export PYTEST_ADDOPTS="--cov=${staged} --cov-report= -p no:cacheprovider"
+          cd build-coverage
+          ctest -V --no-tests=error --tests-regex '^pytest_launched$' || true
+
+      # Merge the two legs into coverage-py.xml.  ``coverage combine``
+      # applies the .coveragerc [paths] aliases (staged Lib packages ->
+      # source); fix_coverage_paths.py then normalizes to repo-relative
+      # paths, remaps the flat staged scripted modules
+      # (qt-scripted-modules/<Module>.py -> <Module>/<Module>.py), and
+      # merges duplicate per-file records.  Any failure falls back to an
+      # empty Cobertura skeleton so the Codecov upload step still has a
+      # file (it tolerates empty coverage but errors on missing files).
+      - name: Generate coverage-py.xml (combine + remap)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
+        env:
+          COVERAGE_RCFILE: ${{ github.workspace }}/.coveragerc
+        run: |
+          set -euo pipefail
+          PYTHONSLICER="${Slicer_DIR}/../python-install/bin/PythonSlicer"
+          {
+            data_files=()
+            [ -f .coverage.bare ] && data_files+=(.coverage.bare)
+            [ -f .coverage.launched ] && data_files+=(.coverage.launched)
+            [ ${#data_files[@]} -gt 0 ] \
+              && "${PYTHONSLICER}" -m coverage combine "${data_files[@]}" \
+              && "${PYTHONSLICER}" -m coverage xml -o coverage-py.xml \
+              && python3 .github/scripts/fix_coverage_paths.py coverage-py.xml "$GITHUB_WORKSPACE"
+          } || {
+            echo "::warning::Python coverage combine/remap produced no usable data — uploading empty coverage-py.xml."
             cat > coverage-py.xml <<'XML'
           <?xml version="1.0" ?>
           <coverage version="0"><sources/><packages/></coverage>
           XML
-          fi
+          }
 
       - name: Upload coverage to Codecov
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'


### PR DESCRIPTION
## Summary

Fixes #550 — the `py` Codecov flag reported **0.2%** (6/2,790 lines, byte-identical to the `cxx` flag) because the coverage job ran pytest under the venv's **plain python3**, where `vtk`/`slicer`/`SimpleITK` are unimportable — the unit layer collection-errored and ~nothing executed. It also measured only `LiverResections/LiverResectionsLib`, so the scripted-module trees were absent from the report entirely.

Three-leg rework:
1. **Bare leg under Slicer's Python** (PythonSlicer + pytest-cov), same three roots as the launched row, `--cov` on the five source trees — never-imported files now show honestly at 0%.
2. **Launched leg**: re-runs the (post-#549) `pytest_launched` row with coverage injected via `PYTEST_ADDOPTS`, measuring the **staged** module tree the launched app actually imports.
3. **Combine + remap**: `.coveragerc [paths]` folds staged Lib packages back onto source; `.github/scripts/fix_coverage_paths.py` normalizes to repo-relative paths, remaps the flat staged scripted modules (directory-prefix `[paths]` can't), and merges duplicate records. Empty-skeleton fallback preserved.

**Full local rehearsal with the checked-in files: Python 0.2% → 54.7%** (LiverResectionsLib **77.3%**, LiverSegmentation **46.3%**; Liver / LiverVolumetry / VascularTerritories visible at 0% — real, now-measured gaps; Liver's never-executing shell tests are tracked in #551).

## ADR references

- ADR-0021: coverage measurement — completes the "first cut" Python leg that was silently empty; the job stays informational/non-blocking.

## Conformance

- Local three-leg rehearsal (bare → launched → combine+remap) with the exact checked-in `.coveragerc` + fix script: 0 absolute/build paths, 0 duplicate records, 24 files, 54.7%.

## Test plan

- [x] Bare leg local: 130 passed under PythonSlicer with 5 `--cov` targets (data-only)
- [x] Launched leg local: 283 passed with `PYTEST_ADDOPTS` coverage tracing (identical result to the no-coverage run)
- [x] Combine + remap local: repo-relative, dedup'd, 54.7%
- [x] `fix_coverage_paths.py` ruff-clean
- [ ] The coverage job's own run on this PR: `py` flag diverges from `cxx` and reports real numbers (job is non-blocking, so iteration is safe)

## UX impact

N/A — CI/coverage change

Fixes #550. Related: #551 (Liver shell tests never execute — their 0% is now honestly visible), #549 (made the launched leg possible).