### PR TITLE
ENH: Compute the distance map on Stage-2 accept + auto-attach to plans

### DIFF
--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -62,8 +62,12 @@
 
 // MRML includes
 #include <vtkMRMLScene.h>
+#include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLSelectionNode.h>
 #include <vtkMRMLSegmentationNode.h>
+
+#include <string>
+#include <vector>
 
 // VTK includes
 #include <vtkObjectFactory.h>
@@ -157,6 +161,24 @@ vtkMRMLResectionPlanNode* vtkSlicerLiverResectionsLogic::CreateResectionPlan(con
   // node to write and the consumers (shader marker, click-to-reslice) have one
   // to read (ADR-0025 §Consumer: exactly one in v2.0).
   this->EnsureLocatorNode();
+
+  // The Stage-2 canonical import computes a distance-map volume tagged
+  // DistanceMap/Computed (the v1 selector contract).  Auto-attach it so
+  // Planning opens with the plan's distance-map input ready (ADR-0031: the
+  // map lives on the plan wrapper) -- no map in the scene leaves the
+  // reference unset, exactly as before.  Untagged vector volumes are ignored.
+  std::vector<vtkMRMLNode*> vectorVolumes;
+  scene->GetNodesByClass("vtkMRMLVectorVolumeNode", vectorVolumes);
+  for (vtkMRMLNode* candidate : vectorVolumes)
+  {
+    const char* isDistanceMap = candidate->GetAttribute("DistanceMap");
+    const char* isComputed = candidate->GetAttribute("Computed");
+    if (isDistanceMap && isComputed && std::string(isDistanceMap) == "True" && std::string(isComputed) == "True")
+    {
+      plan->SetAndObserveDistanceMapVolumeNode(vtkMRMLScalarVolumeNode::SafeDownCast(candidate));
+      break;
+    }
+  }
 
   // The plan starts in Init (ADR-0019); the control grid is seeded by the
   // placement step, not here.

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -112,6 +112,23 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections"
     )
 
+    # #538 trigger, plan side -- CreateResectionPlan auto-attaches the
+    # scene's computed distance map (DistanceMap='True' + Computed='True')
+    # via SetAndObserveDistanceMapVolumeNode (ADR-0031), so Planning opens
+    # ready after the Stage-2 canonical import.  Scene + wrapped-C++
+    # needing: runs under the launched `pytest_launched` row, skips
+    # cleanly here under bare pytest.
+    add_test(
+      NAME LiverResections_plan_distance_map_autoattach
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_resection_plan_distance_map_autoattach.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_plan_distance_map_autoattach PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;distance-map"
+    )
+
     # T5.2-f -- Subject-Hierarchy collection invariant (ADR-0023
     # §"MRML scene organisation"): the wrapper vtkMRMLLiverResectionNode
     # collects under a scene-root "Resections" folder; the hidden Bezier

--- a/LiverResections/Testing/Python/test_resection_plan_distance_map_autoattach.py
+++ b/LiverResections/Testing/Python/test_resection_plan_distance_map_autoattach.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""CreateResectionPlan auto-attaches the scene's computed distance map (#538).
+
+Stage-2 accept (the canonical import) computes a distance-map volume tagged
+``DistanceMap='True'`` / ``Computed='True'``.  For Planning to open ready, a
+freshly created resection plan must reference it without a manual step:
+``vtkSlicerLiverResectionsLogic::CreateResectionPlan`` resolves the scene's
+single computed distance map and wires it via
+``SetAndObserveDistanceMapVolumeNode`` (ADR-0031 -- the distance map lives on
+the plan wrapper).  When no computed map exists, the plan is created with no
+distance-map reference, exactly as before.
+
+Scene-needing + wrapped-C++ (launched ``pytest_launched`` row); skips cleanly
+under bare pytest.  RED until the auto-attach lands in the logic (ADR-0027 --
+C++ cannot skip-pending, so this fails red on the pre-implementation tree).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _logic_or_skip():
+    from conftest import _import_slicer_or_skip, _require_mrml_scene
+
+    slicer = _import_slicer_or_skip()
+    _require_mrml_scene()
+    module = getattr(slicer.modules, "liverresections", None)
+    if module is None:
+        pytest.skip("liverresections module not registered in this build.")
+    return slicer, module.logic()
+
+
+def _computed_map(slicer, name="DistanceMap"):
+    import numpy as np
+
+    volume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLVectorVolumeNode", name)
+    slicer.util.updateVolumeFromArray(
+        volume, np.zeros((8, 8, 8, 2), dtype=np.float32)
+    )
+    volume.SetAttribute("DistanceMap", "True")
+    volume.SetAttribute("Computed", "True")
+    return volume
+
+
+def test_create_resection_plan_attaches_computed_distance_map():
+    """A computed map in the scene reaches the new plan's wrapper reference."""
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    dmap = _computed_map(slicer)
+    plan = logic.CreateResectionPlan("AutoAttach")
+    assert plan is not None
+
+    attached = plan.GetDistanceMapVolumeNode()
+    assert attached is not None and attached.GetID() == dmap.GetID(), (
+        "CreateResectionPlan must auto-attach the scene's computed distance "
+        "map (DistanceMap='True' + Computed='True') so Planning opens ready "
+        "(#538 / ADR-0031)."
+    )
+
+
+def test_create_resection_plan_without_map_leaves_reference_unset():
+    """No computed map in the scene -> the plan reference stays unset."""
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    plan = logic.CreateResectionPlan("NoMap")
+    assert plan is not None
+    assert plan.GetDistanceMapVolumeNode() is None, (
+        "with no computed distance map in the scene the plan must be created "
+        "with no distance-map reference (previous behaviour)."
+    )
+
+
+def test_create_resection_plan_ignores_untagged_vector_volumes():
+    """A vector volume WITHOUT the computed tags must not be attached."""
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    import numpy as np
+
+    stray = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLVectorVolumeNode", "Stray")
+    slicer.util.updateVolumeFromArray(
+        stray, np.zeros((4, 4, 4, 2), dtype=np.float32)
+    )
+
+    plan = logic.CreateResectionPlan("IgnoresStray")
+    assert plan is not None
+    assert plan.GetDistanceMapVolumeNode() is None, (
+        "only a volume tagged DistanceMap='True' + Computed='True' may be "
+        "auto-attached; arbitrary vector volumes must be ignored."
+    )

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -542,7 +542,69 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
         # them visible, so the anatomy renders through to Planning (#539) --
         # otherwise the main 3D view is empty entering Stage 4.
         self.ensureSurfaceRepresentation(sourceSegmentationNode)
+        # The canonical import is the explicit human action completing Stage 2
+        # (ADR-0023 Stage-2 hand-off), so it also computes the composed
+        # distance map Stage 4 consumes (ADR-0031: the map is the resection
+        # plan's input) -- Planning then opens with the map ready.
+        self.ensureDistanceMap(sourceSegmentationNode)
         return sourceSegmentationNode
+
+    #: Downsampling applied to the auto-computed distance map.  A full-res
+    #: 4-channel float map of a 512-cubed CT is on the order of a gigabyte;
+    #: halving each axis keeps the memory footprint workable while remaining
+    #: adequate for the resection shader's margin bands.  A Stage-4 recompute
+    #: control can re-expose the choice later (the v1 GUI had a spinbox).
+    DISTANCE_MAP_DOWNSAMPLING = 2.0
+
+    #: Name + attribute contract of the auto-computed distance-map volume
+    #: (the tags the v1 distance-map selectors filtered on).
+    DISTANCE_MAP_NODE_NAME = "DistanceMap"
+
+    def ensureDistanceMap(self, segmentationNode):
+        """Compute the composed distance map for the canonical segmentation.
+
+        Resolves the Stage-1 reference volume (``LiverRole='PortalVenous'``,
+        via :meth:`selectInputVolume`), resolves-or-creates the tagged
+        ``vtkMRMLVectorVolumeNode`` output, and runs the per-channel
+        signed-Maurer compute (``LiverSegmentationLib.distance_maps``).
+        Returns the output node, or ``None`` when there is nothing to do --
+        no segmentation, no reference volume, or no SCT-tagged channel
+        resolves (graceful degradation; the canonical import itself must
+        never fail on the map).
+        """
+        if segmentationNode is None:
+            return None
+        reference = self.selectInputVolume()
+        if reference is None:
+            return None
+
+        from LiverSegmentationLib import distance_maps
+
+        # Resolve-or-create the single tagged output so a re-import
+        # recomputes in place instead of piling up volumes.
+        output = None
+        for node in slicer.util.getNodesByClass("vtkMRMLVectorVolumeNode"):
+            if node.GetAttribute("DistanceMap") == "True":
+                output = node
+                break
+        created = output is None
+        if created:
+            output = slicer.mrmlScene.AddNewNodeByClass(
+                "vtkMRMLVectorVolumeNode", self.DISTANCE_MAP_NODE_NAME
+            )
+
+        computed = distance_maps.compute_distance_map_for_segmentation(
+            segmentationNode,
+            reference,
+            output,
+            downsampling_rate=self.DISTANCE_MAP_DOWNSAMPLING,
+        )
+        if computed is None and created:
+            # No channel resolved (e.g. no SCT-tagged segments): drop the
+            # node we minted rather than leaving an empty untagged shell.
+            slicer.mrmlScene.RemoveNode(output)
+            return None
+        return computed
 
     def ensureSurfaceRepresentation(self, segmentationNode):
         """Create the 3D closed-surface representation + make it visible.

--- a/LiverSegmentation/Testing/Python/CMakeLists.txt
+++ b/LiverSegmentation/Testing/Python/CMakeLists.txt
@@ -132,6 +132,12 @@ set(_liverseg_pytest_files
   # renders through Planning.  Scene-needing (segmentation converter); runs
   # under the launched `pytest_launched` row, skips cleanly bare.
   test_liversegmentation_segment_surface_representation.py
+  # #538 trigger -- importing the canonical segmentation also computes the
+  # tagged distance map (reference volume from the Stage-1 LiverRole tag;
+  # resolve-or-create output; graceful degradation without a reference).
+  # Scene-needing (converter + SimpleITK); launched `pytest_launched` row,
+  # skips cleanly bare.
+  test_liversegmentation_distance_map_on_import.py
 )
 
 foreach(_pytest_file IN LISTS _liverseg_pytest_files)

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_distance_map_on_import.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_distance_map_on_import.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Stage-2 canonical import triggers the distance-map computation (#538).
+
+The distance-map volume is consumed throughout Stage 4 (the resection plan's
+distance-map reference, the resectogram, the resection mappers) but nothing in
+the v2 workflow produced it -- Planning opened with no map.  The explicit
+human action that completes Stage 2 is the **import-as-canonical** click, so
+that hook (the same one that creates the 3D surface representations) also
+computes the composed distance map via the new ``ensureDistanceMap`` logic
+seam:
+
+  * reference volume resolved from the Stage-1 ``LiverRole='PortalVenous'``
+    tag (``selectInputVolume``);
+  * output is a resolve-or-create ``vtkMRMLVectorVolumeNode`` tagged
+    ``DistanceMap='True'`` / ``Computed='True'`` (the v1 selector contract);
+  * no reference volume -> the import still succeeds and no map is minted
+    (graceful degradation, mirroring the surface-representation seam).
+
+Scene-needing (segmentation converter + SimpleITK compute), so this runs under
+the launched ``pytest_launched`` row and skips cleanly under bare pytest.
+Skips-pending until ``ensureDistanceMap`` lands (RED before impl, ADR-0027).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+SCT_LIVER_CODE = "10200004"
+SEAM = "ensureDistanceMap"
+
+
+def _logic_or_skip():
+    from conftest import _import_slicer_or_skip, _require_mrml_scene
+
+    slicer = _import_slicer_or_skip()
+    _require_mrml_scene()
+    try:
+        import LiverSegmentation  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(
+            f"LiverSegmentation not importable ({exc}); "
+            "ensure --additional-module-paths includes LiverSegmentation/."
+        )
+    return slicer, LiverSegmentation.LiverSegmentationLogic()
+
+
+def _require_seam(logic):
+    if not hasattr(logic, SEAM):
+        pytest.skip(
+            f"LiverSegmentationLogic.{SEAM}() not implemented -- #538 "
+            "skip-pending until the distance-map trigger seam lands."
+        )
+
+
+def _require_segmentations_module(slicer):
+    if not hasattr(slicer.modules, "segmentations"):
+        pytest.skip(
+            "Segmentations module not loaded; the distance-map trigger "
+            "invariant runs in a fully loaded Slicer."
+        )
+
+
+def _source_segmentation_with_geometry(slicer):
+    """A source segmentation with one real-geometry segment (cube labelmap)."""
+    import numpy as np
+
+    labelmap = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLLabelMapVolumeNode", "LoadedLM"
+    )
+    arr = np.zeros((24, 24, 24), dtype=np.int16)
+    arr[6:18, 6:18, 6:18] = 1
+    slicer.util.updateVolumeFromArray(labelmap, arr)
+
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode", "Loaded")
+    slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(
+        labelmap, node
+    )
+    slicer.mrmlScene.RemoveNode(labelmap)
+    segmentation = node.GetSegmentation()
+    assert segmentation.GetNumberOfSegments() >= 1
+    return node, segmentation.GetNthSegmentID(0)
+
+
+def _reference_volume(slicer):
+    """A Stage-1 role-tagged scalar reference volume."""
+    import numpy as np
+
+    from LiverSegmentationLib.roles import LIVER_ROLE_PORTAL_VENOUS, set_volume_role
+
+    volume = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLScalarVolumeNode", "ReferenceCT"
+    )
+    slicer.util.updateVolumeFromArray(volume, np.zeros((24, 24, 24), dtype=np.int16))
+    assert set_volume_role(volume, LIVER_ROLE_PORTAL_VENOUS)
+    return volume
+
+
+def _distance_map_volumes(slicer):
+    return [
+        node
+        for node in slicer.util.getNodesByClass("vtkMRMLVectorVolumeNode")
+        if node.GetAttribute("DistanceMap") == "True"
+    ]
+
+
+def test_import_as_canonical_computes_tagged_distance_map():
+    """Importing the canonical segmentation mints a computed distance map."""
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+    _require_seam(logic)
+    _require_segmentations_module(slicer)
+
+    _reference_volume(slicer)
+    source, segId = _source_segmentation_with_geometry(slicer)
+
+    canonical = logic.importSegmentationAsCanonical(
+        source, {segId: (SCT_LIVER_CODE, "Liver")}
+    )
+    assert canonical is not None
+
+    maps = _distance_map_volumes(slicer)
+    assert len(maps) == 1, (
+        "import-as-canonical must produce exactly one DistanceMap-tagged "
+        f"vector volume (#538); found {len(maps)}."
+    )
+    dmap = maps[0]
+    assert dmap.GetAttribute("Computed") == "True"
+    assert dmap.GetImageData() is not None, "distance map must carry image data"
+    assert dmap.GetImageData().GetNumberOfScalarComponents() >= 1
+
+
+def test_reimport_reuses_the_distance_map_node():
+    """A second import recomputes onto the SAME tagged node (no duplicates)."""
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+    _require_seam(logic)
+    _require_segmentations_module(slicer)
+
+    _reference_volume(slicer)
+    source, segId = _source_segmentation_with_geometry(slicer)
+    assignments = {segId: (SCT_LIVER_CODE, "Liver")}
+
+    logic.importSegmentationAsCanonical(source, assignments)
+    logic.importSegmentationAsCanonical(source, assignments)
+
+    maps = _distance_map_volumes(slicer)
+    assert len(maps) == 1, (
+        "re-importing must reuse the existing DistanceMap node, not mint "
+        f"another; found {len(maps)}."
+    )
+
+
+def test_import_without_reference_volume_still_succeeds():
+    """No Stage-1 reference volume -> import succeeds, no map is minted."""
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+    _require_seam(logic)
+    _require_segmentations_module(slicer)
+
+    source, segId = _source_segmentation_with_geometry(slicer)
+    canonical = logic.importSegmentationAsCanonical(
+        source, {segId: (SCT_LIVER_CODE, "Liver")}
+    )
+    assert canonical is not None, (
+        "a missing reference volume must degrade gracefully -- the canonical "
+        "import itself succeeds."
+    )
+    assert _distance_map_volumes(slicer) == [], (
+        "without a reference volume no distance map can be computed; none "
+        "must be minted."
+    )


### PR DESCRIPTION
## Summary

Closes the Stage-2 → Stage-4 hand-off gap from the real-anatomy walkthrough: the distance-map *compute* existed (#542) but nothing triggered it, so Planning opened with no map. Scope note: the full accept/contract machinery (#440) is ADR-gated and stays v2.1; the v2.0 trigger rides the **existing explicit human action** that completes Stage 2 — the canonical import (the same hook the surface representations use).

Two halves, test-first (RED pins → implementation):

1. **`importSegmentationAsCanonical` computes the map** via a new `ensureDistanceMap` seam: reference volume resolved from the Stage-1 `LiverRole='PortalVenous'` tag, resolve-or-create `vtkMRMLVectorVolumeNode` output tagged `DistanceMap`/`Computed` (the v1 selector contract), per-channel signed-Maurer compute at 2× downsampling (full-res 4-channel float of a 512³ CT ≈ 1 GB). Graceful no-op without a reference volume or resolvable channel — the import itself never fails on the map.
2. **`CreateResectionPlan` auto-attaches** the scene's computed map through `SetAndObserveDistanceMapVolumeNode` (ADR-0031: the map lives on the plan wrapper). Untagged vector volumes ignored; empty scene leaves the reference unset as before.

Net: load volume → tag role → import canonical → **Planning opens with anatomy in 3D and the plan's distance map attached**.

## ADR references

- ADR-0023 §Stage 2 hand-off — the canonical import is the stage-completing action; it now produces the downstream inputs.
- ADR-0031 — distance map on the resection-plan wrapper; the auto-attach realises "Planning opens ready".
- ADR-0027 — invariant-test-first (RED commit precedes implementation).

## Conformance

- `test_liversegmentation_distance_map_on_import.py`: import mints exactly one tagged, computed, image-carrying map; re-import reuses the node; no reference volume → import succeeds, no map.
- `test_resection_plan_distance_map_autoattach.py`: computed map reaches the new plan's reference; no map → unset; untagged vector volumes ignored.

## Test plan

- [x] RED first: 3 skip-pending (Python seam) + 1 hard-fail (C++ attach case), degenerate cases already green
- [x] GREEN after: launched run 161 passed / 0 failed (was 157 + 1 failed + 3 pending)
- [x] Both new files skip cleanly under bare pytest (two-harness discipline)
- [x] Incremental build clean (new warnings: none; pre-existing only)

## UX impact

No new UI. The existing "Import as canonical" action now takes a few seconds longer (the compute); the result is that Stage 4 works without manual data plumbing. State-machine unchanged.

Part of #538 (completes it together with the merged compute core). #440 remains v2.1 with its ADR gate intact.