### PR TITLE
BUG: Recover the resection render (data-node late binding + texture discipline)

### DIFF
--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -219,6 +219,11 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         # invariant.
         self._last_update_key: tuple | None = None
 
+        # Last (state, initMode, geometry-digest) a render was requested
+        # for — the observer callback's render-request gate (see
+        # ``_on_node_modified``).
+        self._last_render_key: tuple | None = None
+
         # SlicingPlane Init-placement progress (ADR-0032 slice 3a): how many
         # of the fixed two slicing-plane init points have been placed on the
         # current carrier.  The node has no on-node placed-count (the array is
@@ -1069,14 +1074,39 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             pass
 
     def _on_node_modified(self, caller: Any, event: str) -> None:
-        """VTK observer callback — re-runs ``UpdatePipeline()``.
+        """VTK observer callback — re-runs ``UpdatePipeline()`` + repaints.
 
         Signature matches what VTK passes ``AddObserver`` callbacks:
         ``(caller, event_name_or_id)``.  Both arguments are unused —
         ``UpdatePipeline()`` re-reads node state directly.
+
+        Requests a render when the VISIBLE dispatch inputs — the
+        ``(state, initMode)`` tuple and the control-point geometry digest —
+        actually changed (the ResectogramPipeline pattern): without the
+        request, a Planning drag mutates the surface polydata while the 3D
+        view stays frozen until an unrelated render (e.g. a camera orbit)
+        repaints it.  Gating on the digest rather than ``GetMTime`` keeps a
+        render-induced ``Modified`` at fixed geometry from re-requesting —
+        the render feedback-loop guard.
         """
         del caller, event  # observers route uniformly into UpdatePipeline()
         self.UpdatePipeline()
+
+        render_key = (
+            _safe_get_state(self._data_node),
+            _safe_get_init_mode(self._data_node),
+            _control_points_digest(self._data_node),
+        )
+        if render_key == self._last_render_key:
+            return
+        self._last_render_key = render_key
+
+        request_render = getattr(self, "RequestRender", None)
+        if request_render is not None:
+            try:
+                request_render()
+            except Exception:  # pragma: no cover - defensive (stub bases)
+                pass
 
 
 # --------------------------------------------------------------------------- #
@@ -1125,6 +1155,31 @@ def _safe_get_mtime(node: Any) -> int:
         return int(getter())
     except Exception:  # pragma: no cover - defensive
         return 0
+
+
+def _control_points_digest(node: Any) -> tuple:
+    """Digest of the carrier's control-point positions (render-request gate).
+
+    Mirrors the ResectogramPipeline's memo digest: a control-point edit
+    changes the digest, a render-induced ``Modified`` at fixed geometry does
+    not — the discrimination that keeps drags repainting live while blocking
+    a render feedback loop.  Empty tuple for nodes missing the grid accessor
+    (stubs) or on a read failure.
+    """
+    if node is None:
+        return ()
+    grid_getter = getattr(node, "GetControlGridVector", None)
+    if grid_getter is None:
+        return ()
+    try:
+        grid = grid_getter()
+        usable = len(grid) - (len(grid) % 3)
+        return tuple(
+            (grid[base], grid[base + 1], grid[base + 2])
+            for base in range(0, usable, 3)
+        )
+    except Exception:  # pragma: no cover - defensive
+        return ()
 
 
 # --------------------------------------------------------------------------- #

--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -314,6 +314,26 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         # Restart DistanceSpheroid init-placement for the new carrier (slice 3b).
         self._distance_spheroid_points_placed = 0
 
+    def OnReferenceToDisplayNodeAdded(self, fromNode: Any, role: Any = None) -> None:  # noqa: N802 - VTK verb
+        """Adopt the displayable when it links to our display node late.
+
+        The production creation ordering (``CreateDefaultDisplayNodes``) adds
+        the display node to the scene -- firing the LayerDM creator and
+        ``SetDisplayNode`` -- BEFORE ``SetAndObserveDisplayNodeID`` links it
+        to the carrier, so the data node derived as ``None``.  The LayerDM
+        manager calls this hook at the exact link moment with ``fromNode`` ==
+        the referencing displayable (the carrier); adopt it and re-dispatch.
+        Without this the Pipeline stays permanently data-node-less (no
+        observers, no dispatch, the default unit patch renders).
+        """
+        if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
+            self._data_node = fromNode
+            self._attach_observer(fromNode)
+            self._last_update_key = None
+            self._last_resection_scan_mtime = None
+            self._last_locator_scan_mtime = None
+        self.UpdatePipeline()
+
     def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
         """Dispatch the active Representation by ``(state, initMode)``.
 
@@ -326,6 +346,23 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         changes (and on ``ResetDisplay()``).
         """
         self._ensure_representations()
+
+        # Late-bind the data node (the production creation ordering):
+        # ``CreateDefaultDisplayNodes`` adds the display node to the scene --
+        # firing the LayerDM creator and this Pipeline's ``SetDisplayNode`` --
+        # BEFORE ``SetAndObserveDisplayNodeID`` links it to the carrier, so
+        # ``GetDisplayableNode()`` was None at derivation time.  Re-derive
+        # here; adopting also attaches the carrier observer so subsequent
+        # control-grid edits re-dispatch.
+        if self._data_node is None and self._display_node is not None:
+            getter = getattr(self._display_node, "GetDisplayableNode", None)
+            displayable = getter() if getter is not None else None
+            if displayable is not None:
+                self._data_node = displayable
+                self._attach_observer(displayable)
+                self._last_update_key = None
+                self._last_resection_scan_mtime = None
+                self._last_locator_scan_mtime = None
 
         # Reverse-resolve the orchestrating wrapper when no explicit one was
         # set (ADR-0031).  The LayerDM creator hands the Pipeline only the

--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -429,6 +429,24 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         self._current_representation_name = active_name
 
         active = self._representations.get(active_name) if active_name else None
+
+        # Only the ACTIVE Representation's actors may sit on the renderer.
+        # All four are constructed against the renderer, so without this the
+        # inactive ones linger -- most visibly the SlicingPlaneInit plane +
+        # marker spheres surviving the Init -> Planning switch as a stray
+        # second surface (ADR-0013 §6: constructed once, reused; but only the
+        # dispatched one renders).  SetRenderer(None) detaches idempotently;
+        # re-attach the active one only when it lost its renderer (avoids
+        # duplicate AddActor calls).
+        renderer = self._safe_get_renderer()
+        for rep in self._representations.values():
+            if rep is None or rep is active:
+                continue
+            if getattr(rep, "_renderer", None) is not None:
+                rep.SetRenderer(None)
+        if active is not None and renderer is not None and getattr(active, "_renderer", None) is not renderer:
+            active.SetRenderer(renderer)
+
         if active is not None:
             # Thread the orchestrating wrapper to Representations that consume
             # its path-specific inputs (the Planning surface reads the

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -652,13 +652,23 @@ class FlattenedSurfaceRepresentation:
         render_window = self._render_window()
         if render_window is None:
             return None
-        # Defer until the GL context is REALIZED: before the window's first
-        # render the vtkOpenGLState texture-format table is still empty, so
-        # the upload fails noisily ("Failed to determine texture parameters")
-        # even though the hardware supports the format.  Returning None takes
-        # the caller's deferred path and a later update retries.
-        initialized = getattr(render_window, "GetInitialized", None)
-        if initialized is not None and not initialized():
+        # This bind runs OUTSIDE the render pass (Representation.update()), so
+        # the GL context must be made current explicitly -- and before the
+        # window's first render there is no usable context at all (the
+        # vtkOpenGLState texture-format table is empty, so the upload fails
+        # noisily).  Probe with MakeCurrent/IsCurrent: not-current after the
+        # attempt means not-yet-realized -> return None so the caller's
+        # deferred path retries on a later update.  NOTE: GetInitialized() is
+        # NOT a usable gate here -- a Qt-managed vtkGenericOpenGLRenderWindow
+        # never sets it (Qt owns the context) and it would defer forever.
+        make_current = getattr(render_window, "MakeCurrent", None)
+        if make_current is not None:
+            try:
+                make_current()
+            except Exception:  # pragma: no cover - defensive
+                return None
+        is_current = getattr(render_window, "IsCurrent", None)
+        if is_current is not None and not is_current():
             return None
         # The display node's TextureNumComps defaults to 0 (unset) and the
         # workflow never writes it; a 0-component upload fails format

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -588,7 +588,13 @@ class FlattenedSurfaceRepresentation:
             self._distance_map_volume = volume
             return
 
+        # The display node's TextureNumComps defaults to 0 (unset); fall back
+        # to the image's own component count so both the upload and the
+        # shader's uTextureNumComps branch (>2 selects the multi-channel
+        # margin-band path) see the real value.
         num_comps = _safe_get_int(display_node, "GetTextureNumComps", default=0)
+        if num_comps <= 0:
+            num_comps = image_data.GetNumberOfScalarComponents()
         texture = self._create_distance_map_texture(image_data, num_comps)
         if texture is None:
             # The GL render window is not live yet (texture build deferred):
@@ -605,6 +611,9 @@ class FlattenedSurfaceRepresentation:
         # attribute survives to outlive the C++ teardown).
         self._distance_map_volume = volume
         bind(texture)
+        set_comps = getattr(mapper, "SetTextureNumComps", None)
+        if set_comps is not None:
+            set_comps(int(num_comps))
         self._apply_distance_map_matrices(volume, image_data)
         del texture
 
@@ -643,6 +652,19 @@ class FlattenedSurfaceRepresentation:
         render_window = self._render_window()
         if render_window is None:
             return None
+        # Defer until the GL context is REALIZED: before the window's first
+        # render the vtkOpenGLState texture-format table is still empty, so
+        # the upload fails noisily ("Failed to determine texture parameters")
+        # even though the hardware supports the format.  Returning None takes
+        # the caller's deferred path and a later update retries.
+        initialized = getattr(render_window, "GetInitialized", None)
+        if initialized is not None and not initialized():
+            return None
+        # The display node's TextureNumComps defaults to 0 (unset) and the
+        # workflow never writes it; a 0-component upload fails format
+        # resolution deterministically.  The image knows its own count.
+        if int(num_comps) <= 0:
+            num_comps = image_data.GetNumberOfScalarComponents()
         try:
             texture = helper_factory()
             texture.SetContext(render_window)
@@ -657,7 +679,11 @@ class FlattenedSurfaceRepresentation:
                 texture.SetMagnificationFilter(linear)
             texture.SetBorderColor(1000.0, 1000.0, 0.0, 0.0)
             dimensions = image_data.GetDimensions()
-            texture.CreateSeq3DFromRaw(
+            # A VTK upload failure is NOT a Python exception: check the
+            # boolean result.  Handing a failed texture to the caller binds
+            # it, and the already-bound idempotency guard then blocks every
+            # retry -- the resectogram stays white for the session.
+            if not texture.CreateSeq3DFromRaw(
                 dimensions[0],
                 dimensions[1],
                 dimensions[2],
@@ -665,7 +691,8 @@ class FlattenedSurfaceRepresentation:
                 vtk.VTK_FLOAT,
                 image_data.GetScalarPointer(),
                 0,
-            )
+            ):
+                return None
         except Exception:  # pragma: no cover - defensive
             return None
         return texture

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -196,6 +196,16 @@ class FlattenedSurfaceRepresentation:
         # C++ pipeline on the Python heap (a vtkDebugLeaks trip).
         self._distance_map_volume: Any | None = None
 
+        # The effective texture component count derived at bind time (the
+        # display node's ``TextureNumComps`` when set, else the image's own
+        # component count).  ``_apply_display_node`` runs on EVERY update,
+        # BEFORE the texture path, and the display field defaults to 0
+        # (unset); without this record it would push that 0 over the value
+        # the bind derived, and the already-bound short-circuit would never
+        # re-push it — comps 0 disables the shader's margin-band branch, so
+        # the strip goes grid-only from the second reconcile onwards.
+        self._effective_texture_num_comps: int = 0
+
         # The orchestrating ``vtkMRMLResectionPlanNode`` wrapper, set by the
         # ResectogramPipeline via ``SetResectionPlanNode`` (ADR-0031).  It
         # carries the distance-shading input set the flattened strip reads --
@@ -270,6 +280,7 @@ class FlattenedSurfaceRepresentation:
                 except Exception:  # pragma: no cover - defensive
                     pass
         self._distance_map_volume = None
+        self._effective_texture_num_comps = 0
 
         if self._renderer is not None:
             self._detach_blur_pass(self._renderer)
@@ -370,6 +381,11 @@ class FlattenedSurfaceRepresentation:
         texture_num_comps = _safe_get_int(
             display_node, "GetTextureNumComps", default=0
         )
+        if texture_num_comps <= 0:
+            # Display field unset (the default): fall back to the effective
+            # count derived at bind time so a routine reconcile does not
+            # clobber it (see ``_effective_texture_num_comps``).
+            texture_num_comps = self._effective_texture_num_comps
 
         if self._resection_actor_2d is not None:
             self._resection_actor_2d.SetVisibility(bool(show_2d))
@@ -586,6 +602,7 @@ class FlattenedSurfaceRepresentation:
             # sampling a volume that is gone (the v1 warning branch).
             bind(None)
             self._distance_map_volume = volume
+            self._effective_texture_num_comps = 0
             return
 
         # The display node's TextureNumComps defaults to 0 (unset); fall back
@@ -604,6 +621,7 @@ class FlattenedSurfaceRepresentation:
             # stays False, so the idempotency guard above does not short it).
             bind(None)
             self._distance_map_volume = volume
+            self._effective_texture_num_comps = 0
             return
 
         # Hand the texture to the mapper's vtkSmartPointer and drop the
@@ -611,6 +629,10 @@ class FlattenedSurfaceRepresentation:
         # attribute survives to outlive the C++ teardown).
         self._distance_map_volume = volume
         bind(texture)
+        # Record the effective count so ``_apply_display_node`` (which runs
+        # first on every later update, off the display's unset-0 default)
+        # does not clobber it once the already-bound short-circuit engages.
+        self._effective_texture_num_comps = int(num_comps)
         set_comps = getattr(mapper, "SetTextureNumComps", None)
         if set_comps is not None:
             set_comps(int(num_comps))

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLParametricSurfaceDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLParametricSurfaceDisplayNodeTest1.cxx
@@ -72,12 +72,12 @@ int testDefaults()
 
   CHECK_DOUBLE(node->GetResectionOpacity(), 1.0f);
   CHECK_BOOL(node->GetGridVisibility(), false);
-  // Grid defaults match the resection mapper's own (divisions 20, thickness
-  // factor 9.5) so a fresh display node renders the control-grid overlay --
-  // the earlier 0/0 defaults overwrote the mapper uniforms and suppressed
-  // the grid entirely.
-  CHECK_DOUBLE(node->GetGridDivisions(), 20.0f);
-  CHECK_DOUBLE(node->GetGridThickness(), 9.5f);
+  // Grid OFF by default (0 divisions / 0 thickness): with the 1:1 locator
+  // marker carrying the resectogram<->surface correspondence, the
+  // procedural grid overlay is visual noise; it stays settable for
+  // debugging via the setters.
+  CHECK_DOUBLE(node->GetGridDivisions(), 0.0f);
+  CHECK_DOUBLE(node->GetGridThickness(), 0.0f);
   CHECK_BOOL(node->GetGrid3DVisibility(), true);
   CHECK_BOOL(node->GetGrid2DVisibility(), false);
   CHECK_BOOL(node->GetWidgetVisibility(), true);

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLParametricSurfaceDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLParametricSurfaceDisplayNodeTest1.cxx
@@ -72,8 +72,12 @@ int testDefaults()
 
   CHECK_DOUBLE(node->GetResectionOpacity(), 1.0f);
   CHECK_BOOL(node->GetGridVisibility(), false);
-  CHECK_DOUBLE(node->GetGridDivisions(), 0.0f);
-  CHECK_DOUBLE(node->GetGridThickness(), 0.0f);
+  // Grid defaults match the resection mapper's own (divisions 20, thickness
+  // factor 9.5) so a fresh display node renders the control-grid overlay --
+  // the earlier 0/0 defaults overwrote the mapper uniforms and suppressed
+  // the grid entirely.
+  CHECK_DOUBLE(node->GetGridDivisions(), 20.0f);
+  CHECK_DOUBLE(node->GetGridThickness(), 9.5f);
   CHECK_BOOL(node->GetGrid3DVisibility(), true);
   CHECK_BOOL(node->GetGrid2DVisibility(), false);
   CHECK_BOOL(node->GetWidgetVisibility(), true);

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLResectogramDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLResectogramDisplayNodeTest1.cxx
@@ -43,7 +43,11 @@ int testDefaults()
 {
   vtkNew<vtkMRMLResectogramDisplayNode> node;
 
-  CHECK_BOOL(node->GetShowResection2D(), false);
+  // ShowResection2D defaults TRUE: this display node keys only the
+  // dedicated strip pipeline, and its singleton view exists solely to
+  // show the strip -- invisible-by-default renders the view empty
+  // (grid/border only) until some UI flips a toggle nothing owns.
+  CHECK_BOOL(node->GetShowResection2D(), true);
   CHECK_BOOL(node->GetMirrorDisplay(), false);
   CHECK_BOOL(node->GetEnableFlexibleBoundary(), false);
   CHECK_INT(node->GetTextureNumComps(), 0);
@@ -62,8 +66,9 @@ int testSettersAndGetters()
 {
   vtkNew<vtkMRMLResectogramDisplayNode> node;
 
-  node->SetShowResection2D(true);
-  CHECK_BOOL(node->GetShowResection2D(), true);
+  // Exercise the NON-default value (default is now true).
+  node->SetShowResection2D(false);
+  CHECK_BOOL(node->GetShowResection2D(), false);
   node->SetMirrorDisplay(true);
   CHECK_BOOL(node->GetMirrorDisplay(), true);
   node->SetEnableFlexibleBoundary(true);
@@ -84,7 +89,9 @@ int testXMLRoundTrip()
   vtkNew<vtkMRMLScene> scene;
   source->SetScene(scene.GetPointer());
 
-  source->SetShowResection2D(true);
+  // ShowResection2D uses the NON-default false so the round-trip proves
+  // the XML attribute is actually written and read (default is true).
+  source->SetShowResection2D(false);
   source->SetMirrorDisplay(true);
   source->SetEnableFlexibleBoundary(true);
   source->SetTextureNumComps(4);
@@ -153,7 +160,8 @@ int testXMLRoundTrip()
 int testCopyContent()
 {
   vtkNew<vtkMRMLResectogramDisplayNode> source;
-  source->SetShowResection2D(true);
+  // NON-default false so CopyContent must actually transfer it.
+  source->SetShowResection2D(false);
   source->SetTextureNumComps(4);
   source->SetBlurEnabled(true);
   source->SetBlurRadius(3.5);
@@ -161,7 +169,7 @@ int testCopyContent()
   vtkNew<vtkMRMLResectogramDisplayNode> sink;
   sink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
 
-  CHECK_BOOL(sink->GetShowResection2D(), true);
+  CHECK_BOOL(sink->GetShowResection2D(), false);
   CHECK_INT(sink->GetTextureNumComps(), 4);
   CHECK_BOOL(sink->GetBlurEnabled(), true);
   CHECK_DOUBLE(sink->GetBlurRadius(), 3.5);
@@ -191,7 +199,8 @@ int testCopyContent()
 int testModifiedEventsOnSetters()
 {
   vtkNew<vtkMRMLResectogramDisplayNode> node;
-  EXPECT_MTIME_ADVANCES(node, node->SetShowResection2D(true));
+  // false: the setter must CHANGE the value to fire Modified (default true).
+  EXPECT_MTIME_ADVANCES(node, node->SetShowResection2D(false));
   EXPECT_MTIME_ADVANCES(node, node->SetMirrorDisplay(true));
   EXPECT_MTIME_ADVANCES(node, node->SetEnableFlexibleBoundary(true));
   EXPECT_MTIME_ADVANCES(node, node->SetTextureNumComps(4));

--- a/LiverResections/MRML/vtkMRMLParametricSurfaceDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLParametricSurfaceDisplayNode.cxx
@@ -57,14 +57,14 @@ vtkMRMLParametricSurfaceDisplayNode::vtkMRMLParametricSurfaceDisplayNode()
   , ResectionMarginColor{ 1.0f, 0.0f, 0.0f }
   , UncertaintyMarginColor{ 1.0f, 1.0f, 0.0f }
   , ResectionOpacity(1.0f)
-  // Grid defaults MATCH the mapper's own (vtkOpenGLBezierResectionPolyDataMapper
-  // ctor: GridDivisions 20, GridThicknessFactor 9.5): the display node's
-  // values overwrite the mapper uniforms on every update, so 0-division /
-  // 0-thickness defaults rendered NO control-grid overlay on the Planning
-  // surface (the shader draws the grid procedurally from these; v1 parity).
+  // Grid OFF by default (0 divisions / 0 thickness): the 1:1 locator
+  // marker carries the resectogram<->surface correspondence, so the
+  // procedural grid overlay is visual noise.  The display node's values
+  // overwrite the mapper uniforms on every update; the setters keep the
+  // grid available for debugging.
   , GridVisibility(false)
-  , GridDivisions(20.0f)
-  , GridThickness(9.5f)
+  , GridDivisions(0.0f)
+  , GridThickness(0.0f)
   , Grid3DVisibility(true)
   , Grid2DVisibility(false)
   , WidgetVisibility(true)

--- a/LiverResections/MRML/vtkMRMLParametricSurfaceDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLParametricSurfaceDisplayNode.cxx
@@ -57,9 +57,14 @@ vtkMRMLParametricSurfaceDisplayNode::vtkMRMLParametricSurfaceDisplayNode()
   , ResectionMarginColor{ 1.0f, 0.0f, 0.0f }
   , UncertaintyMarginColor{ 1.0f, 1.0f, 0.0f }
   , ResectionOpacity(1.0f)
+  // Grid defaults MATCH the mapper's own (vtkOpenGLBezierResectionPolyDataMapper
+  // ctor: GridDivisions 20, GridThicknessFactor 9.5): the display node's
+  // values overwrite the mapper uniforms on every update, so 0-division /
+  // 0-thickness defaults rendered NO control-grid overlay on the Planning
+  // surface (the shader draws the grid procedurally from these; v1 parity).
   , GridVisibility(false)
-  , GridDivisions(0.0f)
-  , GridThickness(0.0f)
+  , GridDivisions(20.0f)
+  , GridThickness(9.5f)
   , Grid3DVisibility(true)
   , Grid2DVisibility(false)
   , WidgetVisibility(true)

--- a/LiverResections/MRML/vtkMRMLResectogramDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLResectogramDisplayNode.cxx
@@ -52,7 +52,9 @@ vtkMRMLNodeNewMacro(vtkMRMLResectogramDisplayNode);
 
 //------------------------------------------------------------------------------
 vtkMRMLResectogramDisplayNode::vtkMRMLResectogramDisplayNode()
-  : ShowResection2D(false)
+  // TRUE by default: this node keys only the dedicated strip pipeline,
+  // and the resectogram singleton view exists solely to show the strip.
+  : ShowResection2D(true)
   , MirrorDisplay(false)
   , EnableFlexibleBoundary(false)
   , TextureNumComps(0)

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -157,17 +157,20 @@ void vtkOpenGLBezierResectionPolyDataMapper::BuildBufferObjects(vtkRenderer* ren
       int dimensions[3] = { 0, 0, 0 };
       image->GetDimensions(dimensions);
 
-      // Build only when there is an INITIALIZED GL context, the image is
-      // non-empty, and its scalars are allocated: Create3DFromRaw on a
-      // null/short buffer would upload garbage or abort, and on a
-      // not-yet-realized context vtkOpenGLState's texture-format table is
-      // still empty, so format resolution fails ("Failed to determine
-      // texture parameters") even though the hardware supports the format.
-      // Otherwise leave DistanceMapTexture untouched and do NOT advance
-      // DistanceMapBuiltMTime, so the shader takes its no-distance-map path
-      // and a later render retries once the image/context is valid
-      // (ADR-0003: MRML and GL state must not diverge).
-      const bool canBuild = renWin != nullptr && renWin->GetInitialized() && dimensions[0] > 0 && dimensions[1] > 0 && dimensions[2] > 0 && image->GetScalarPointer() != nullptr;
+      // Build only when there is a live GL context, the image is non-empty,
+      // and its scalars are allocated: Create3DFromRaw on a null/short buffer
+      // would upload garbage or abort.  NOTE: do NOT gate on
+      // renWin->GetInitialized() here -- a Qt-managed
+      // vtkGenericOpenGLRenderWindow never sets that flag (Qt owns the
+      // context), so the gate would defer the build forever.  This method
+      // runs inside the render pass, where the context is current by
+      // construction; upload validity is judged by Create3DFromRaw's result
+      // below.  Otherwise leave DistanceMapTexture untouched and do NOT
+      // advance DistanceMapBuiltMTime, so the shader takes its
+      // no-distance-map path and a later render retries once the
+      // image/context is valid (ADR-0003: MRML and GL state must not
+      // diverge).
+      const bool canBuild = renWin != nullptr && dimensions[0] > 0 && dimensions[1] > 0 && dimensions[2] > 0 && image->GetScalarPointer() != nullptr;
       if (canBuild)
       {
         vtkNew<vtkTextureObject> texture;

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -157,13 +157,17 @@ void vtkOpenGLBezierResectionPolyDataMapper::BuildBufferObjects(vtkRenderer* ren
       int dimensions[3] = { 0, 0, 0 };
       image->GetDimensions(dimensions);
 
-      // Build only when there is a live GL context, the image is non-empty,
-      // and its scalars are allocated: Create3DFromRaw on a null/short buffer
-      // would upload garbage or abort.  Otherwise leave DistanceMapTexture
-      // untouched and do NOT advance DistanceMapBuiltMTime, so the shader takes
-      // its no-distance-map path and a later render retries once the
-      // image/context is valid (ADR-0003: MRML and GL state must not diverge).
-      const bool canBuild = renWin != nullptr && dimensions[0] > 0 && dimensions[1] > 0 && dimensions[2] > 0 && image->GetScalarPointer() != nullptr;
+      // Build only when there is an INITIALIZED GL context, the image is
+      // non-empty, and its scalars are allocated: Create3DFromRaw on a
+      // null/short buffer would upload garbage or abort, and on a
+      // not-yet-realized context vtkOpenGLState's texture-format table is
+      // still empty, so format resolution fails ("Failed to determine
+      // texture parameters") even though the hardware supports the format.
+      // Otherwise leave DistanceMapTexture untouched and do NOT advance
+      // DistanceMapBuiltMTime, so the shader takes its no-distance-map path
+      // and a later render retries once the image/context is valid
+      // (ADR-0003: MRML and GL state must not diverge).
+      const bool canBuild = renWin != nullptr && renWin->GetInitialized() && dimensions[0] > 0 && dimensions[1] > 0 && dimensions[2] > 0 && image->GetScalarPointer() != nullptr;
       if (canBuild)
       {
         vtkNew<vtkTextureObject> texture;
@@ -174,10 +178,18 @@ void vtkOpenGLBezierResectionPolyDataMapper::BuildBufferObjects(vtkRenderer* ren
         texture->SetMinificationFilter(vtkTextureObject::Linear);
         texture->SetMagnificationFilter(vtkTextureObject::Linear);
         texture->SetBorderColor(1000.0f, 1000.0f, 0.0f, 0.0f);
-        texture->Create3DFromRaw(dimensions[0], dimensions[1], dimensions[2], image->GetNumberOfScalarComponents(), image->GetScalarType(), image->GetScalarPointer());
 
-        this->Impl->DistanceMapTexture = texture;
-        this->Impl->DistanceMapBuiltMTime = image->GetMTime();
+        // Cache the texture + advance the built-MTime ONLY on a successful
+        // upload.  Caching an upload that failed (e.g. the one-shot
+        // format-resolution failure on an early, half-realized context)
+        // permanently wedges the mapper: the MTime guard never retries, the
+        // broken texture breaks the draw, and the surface renders invisible
+        // for the rest of the session.
+        if (texture->Create3DFromRaw(dimensions[0], dimensions[1], dimensions[2], image->GetNumberOfScalarComponents(), image->GetScalarType(), image->GetScalarPointer()))
+        {
+          this->Impl->DistanceMapTexture = texture;
+          this->Impl->DistanceMapBuiltMTime = image->GetMTime();
+        }
       }
     }
   }

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -76,8 +76,11 @@ public:
     , ResectionOpacity(1.0f)
     , InterpolatedMargins(false)
     , ResectionClipOut(false)
-    , GridDivisions(20)
-    , GridThicknessFactor(9.5f)
+    // Grid OFF by default -- the 1:1 locator marker carries the
+    // resectogram<->surface correspondence; the display node's values
+    // overwrite these uniforms on every update anyway.
+    , GridDivisions(0)
+    , GridThicknessFactor(0.0f)
     , LocatorPosition{ 0.0f, 0.0f, 0.0f }
     , LocatorRadius(0.0f)
   {

--- a/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp
+++ b/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp
@@ -74,6 +74,10 @@ public:
     , ResectionColor{ 1.0f, 1.0f, 1.0f }
     , ResectionGridColor{ 0.0f, 0.0f, 0.0f }
     , InterpolatedMargins(false)
+    // Grid uniforms OFF (and, previously, UNINITIALIZED -- the strip's
+    // stray grid came from indeterminate values reaching the shader).
+    , GridDivisions(0)
+    , GridThicknessFactor(0.0f)
     , ShowResection2D(false)
     , PortalContourThickness(0.3f)
     , HepaticContourThickness(0.3f)

--- a/Testing/Python/unit/test_bezier_surface_node.py
+++ b/Testing/Python/unit/test_bezier_surface_node.py
@@ -488,8 +488,12 @@ def test_display_defaults(mrml_module):
     assert list(node.GetResectionGridColor()) == pytest.approx([0.0, 0.0, 0.0])
     assert node.GetResectionOpacity() == pytest.approx(1.0)
     assert node.GetGridVisibility() is False
-    assert node.GetGridDivisions() == pytest.approx(0.0)
-    assert node.GetGridThickness() == pytest.approx(0.0)
+    # Grid defaults match the resection mapper's own (divisions 20,
+    # thickness factor 9.5) so a fresh display node renders the control-grid
+    # overlay -- the earlier 0/0 defaults overwrote the mapper uniforms and
+    # suppressed the grid entirely.
+    assert node.GetGridDivisions() == pytest.approx(20.0)
+    assert node.GetGridThickness() == pytest.approx(9.5)
     assert node.GetGrid3DVisibility() is True
     assert node.GetGrid2DVisibility() is False
     assert node.GetWidgetVisibility() is True

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -505,3 +505,118 @@ def test_blur_reconcile_tolerates_no_renderer(rep_module):
     rep.update(_StubDisplayNode(blur_enabled=True), _StubDataNode())
     assert not rep.IsBlurPassAttached()
     rep.cleanup()
+
+
+# --------------------------------------------------------------------------- #
+# Distance-map texture build discipline (resectogram render-blocker class).
+# --------------------------------------------------------------------------- #
+#
+# The resectogram strip rendered permanently white because the texture build
+# path had three defects, each pinned GL-free here through injected seams:
+#
+#   1. ``TextureNumComps`` (display node) defaults to 0 and nothing writes it,
+#      so ``CreateSeq3DFromRaw`` was asked for a 0-component texture -- format
+#      resolution fails deterministically.  The image KNOWS its component
+#      count; the build must fall back to it.
+#   2. ``CreateSeq3DFromRaw``'s boolean result was ignored (a VTK error is not
+#      a Python exception), so a FAILED upload was bound to the mapper and the
+#      already-bound idempotency guard prevented every retry.
+#   3. A not-yet-realized render window (``GetInitialized()`` False) has an
+#      empty texture-format table; attempting the upload there fails noisily.
+#      The build must defer (return None) so a later update retries.
+
+
+class _FakeTextureHelper:
+    """Records CreateSeq3DFromRaw args; configurable success/failure."""
+
+    instances: list = []
+    create_result = True
+
+    def __init__(self):
+        self.calls = []
+        _FakeTextureHelper.instances.append(self)
+
+    def SetContext(self, ctx):  # noqa: N802 - VTK verb
+        self.context = ctx
+
+    def SetBorderColor(self, *rgba):  # noqa: N802 - VTK verb
+        pass
+
+    def CreateSeq3DFromRaw(self, nx, ny, nz, comps, dtype, ptr, seq):  # noqa: N802
+        self.calls.append(dict(dims=(nx, ny, nz), comps=comps))
+        return _FakeTextureHelper.create_result
+
+
+class _FakeRenderWindow:
+    def __init__(self, initialized=True):
+        self._initialized = initialized
+
+    def GetInitialized(self):  # noqa: N802 - VTK verb
+        return self._initialized
+
+
+class _FakeImage3D:
+    def GetDimensions(self):  # noqa: N802 - VTK verb
+        return (8, 8, 8)
+
+    def GetNumberOfScalarComponents(self):  # noqa: N802 - VTK verb
+        return 4
+
+    def GetScalarPointer(self):  # noqa: N802 - VTK verb
+        return None
+
+
+def _texture_build_rep(rep_module, monkeypatch, initialized=True):
+    import Representations.FlattenedSurfaceRepresentation as fsr
+
+    _FakeTextureHelper.instances = []
+    _FakeTextureHelper.create_result = True
+    monkeypatch.setattr(
+        fsr, "_import_texture_object_helper", lambda: _FakeTextureHelper
+    )
+    rep = rep_module()
+    monkeypatch.setattr(
+        rep, "_render_window", lambda: _FakeRenderWindow(initialized=initialized)
+    )
+    return rep
+
+
+def test_texture_build_derives_comps_from_image_when_display_unset(
+    rep_module, monkeypatch
+):
+    """Display ``TextureNumComps`` 0 (the unset default) -> the image's
+    component count reaches the upload, not 0."""
+    rep = _texture_build_rep(rep_module, monkeypatch)
+    texture = rep._create_distance_map_texture(_FakeImage3D(), 0)
+    assert texture is not None
+    assert _FakeTextureHelper.instances[-1].calls[-1]["comps"] == 4, (
+        "a 0 (unset) display TextureNumComps must fall back to the image's "
+        "component count -- a 0-component upload fails format resolution "
+        "deterministically."
+    )
+
+
+def test_texture_build_returns_none_on_failed_upload(rep_module, monkeypatch):
+    """A False CreateSeq3DFromRaw -> None (deferred retry), NOT a broken
+    texture that the caller binds and the idempotency guard then pins."""
+    rep = _texture_build_rep(rep_module, monkeypatch)
+    _FakeTextureHelper.create_result = False
+    texture = rep._create_distance_map_texture(_FakeImage3D(), 4)
+    assert texture is None, (
+        "a failed upload must not be handed to the caller -- binding it "
+        "permanently wedges the resectogram (already-bound guard blocks "
+        "every retry)."
+    )
+
+
+def test_texture_build_defers_until_window_initialized(rep_module, monkeypatch):
+    """An unrealized render window -> None without attempting the upload."""
+    rep = _texture_build_rep(rep_module, monkeypatch, initialized=False)
+    texture = rep._create_distance_map_texture(_FakeImage3D(), 4)
+    assert texture is None
+    assert _FakeTextureHelper.instances == [] or not any(
+        h.calls for h in _FakeTextureHelper.instances
+    ), (
+        "no upload may be attempted on a not-yet-realized window (empty "
+        "texture-format table -> guaranteed noisy failure)."
+    )

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -630,3 +630,73 @@ def test_texture_build_defers_until_window_initialized(rep_module, monkeypatch):
         "no upload may be attempted on a not-yet-realized window (empty "
         "texture-format table -> guaranteed noisy failure)."
     )
+
+
+class _StubMapperWithTexture(_StubMapperWithMatRatio):
+    """MatRatio stub extended with the distance-map texture accessors."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.texture = None
+
+    def SetDistanceMapTextureObject(self, texture) -> None:  # noqa: N802
+        self.texture = texture
+
+    def GetDistanceMapTextureObject(self):  # noqa: N802 - VTK verb
+        return self.texture
+
+    def SetRasToIjkMatrixT(self, _matrix) -> None:  # noqa: N802 - VTK verb
+        pass
+
+    def SetIjkToTextureMatrixT(self, _matrix) -> None:  # noqa: N802 - VTK verb
+        pass
+
+
+class _StubDistanceMapVolume:
+    def __init__(self, image) -> None:
+        self._image = image
+
+    def GetImageData(self):  # noqa: N802 - VTK verb
+        return self._image
+
+    def GetRASToIJKMatrix(self, _matrix) -> None:  # noqa: N802 - VTK verb
+        pass
+
+
+class _StubResectionPlanNode:
+    def __init__(self, volume) -> None:
+        self._volume = volume
+
+    def GetDistanceMapVolumeNode(self):  # noqa: N802 - VTK verb
+        return self._volume
+
+
+def test_effective_comps_survive_subsequent_updates(rep_module, monkeypatch):
+    """A later ``update()`` must not clobber the bind-time effective comps.
+
+    The display node's ``TextureNumComps`` defaults to 0 (unset) and nothing
+    writes it, so ``_apply_display_node`` -- which runs on EVERY update,
+    BEFORE the texture path -- must not push that 0 over the effective
+    component count derived at bind time.  Comps 0 disables the shader's
+    ``uTextureNumComps > 2`` margin-band branch: the strip renders grid-only
+    (empty) from the second reconcile onwards (any drag / blur / camera
+    update) even though the texture stays bound.
+    """
+    rep = _texture_build_rep(rep_module, monkeypatch)
+    mapper = _StubMapperWithTexture()
+    rep._resection_mapper_2d = mapper
+    rep.SetResectionPlanNode(
+        _StubResectionPlanNode(_StubDistanceMapVolume(_FakeImage3D()))
+    )
+
+    display = _StubDisplayNode(texture_num_comps=0)  # the real-world default
+    rep.update(display, _StubDataNode())
+    assert mapper.texture is not None, "precondition: the texture bound"
+    assert mapper.texture_num_comps == 4, "precondition: image comps pushed"
+
+    rep.update(display, _StubDataNode())  # any later reconcile
+    assert mapper.texture_num_comps == 4, (
+        "the display default (0) clobbered the bind-time effective "
+        "TextureNumComps on a subsequent update -- the already-bound "
+        "short-circuit never re-pushes it, so the strip goes grid-only."
+    )

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -548,11 +548,21 @@ class _FakeTextureHelper:
 
 
 class _FakeRenderWindow:
-    def __init__(self, initialized=True):
-        self._initialized = initialized
+    """Fake window whose context can be made current or not (realization).
 
-    def GetInitialized(self):  # noqa: N802 - VTK verb
-        return self._initialized
+    Mirrors the Qt-managed ``vtkGenericOpenGLRenderWindow`` reality: the
+    usable-context probe is MakeCurrent + IsCurrent -- ``GetInitialized()``
+    is never set on Qt-owned contexts and must not be used as a gate.
+    """
+
+    def __init__(self, initialized=True):
+        self._current = initialized
+
+    def MakeCurrent(self):  # noqa: N802 - VTK verb
+        pass
+
+    def IsCurrent(self):  # noqa: N802 - VTK verb
+        return self._current
 
 
 class _FakeImage3D:

--- a/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
+++ b/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
@@ -221,3 +221,58 @@ def test_pipeline_reference_added_hook_adopts_displayable(pipeline_module):
     finally:
         scene.RemoveNode(display)
         scene.RemoveNode(data)
+
+
+class _FakeRenderer:
+    """Records AddActor/RemoveActor so attach state is observable."""
+
+    def __init__(self):
+        self.actors = []
+
+    def AddActor(self, actor):  # noqa: N802 - VTK verb
+        if actor not in self.actors:
+            self.actors.append(actor)
+
+    def RemoveActor(self, actor):  # noqa: N802 - VTK verb
+        if actor in self.actors:
+            self.actors.remove(actor)
+
+
+def test_pipeline_hides_inactive_representation_on_state_switch(
+    pipeline_module, bezier_nodes, monkeypatch
+):
+    """Init -> Planning must DETACH the init representation's actors.
+
+    All four Representations are constructed against the renderer, so the
+    SlicingPlaneInit plane + marker spheres stayed attached (and visible at
+    the origin) after the carrier switched to Planning -- the stray 'second
+    resection with a control point' seen in the 3D view.  Dispatch must leave
+    only the ACTIVE representation's actors on the renderer.
+    """
+    data, display = bezier_nodes
+    fake = _FakeRenderer()
+    pipeline = pipeline_module.LiverBezierSurfacePipeline()
+    monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: fake)
+    pipeline.SetDisplayNode(display)
+
+    # Init state (default): dispatch attaches the init representation.
+    pipeline.UpdatePipeline()
+    init_rep = pipeline.GetRepresentation("SlicingPlaneInit")
+    planning_rep = pipeline.GetRepresentation("BezierPlanning")
+    assert init_rep is not None and planning_rep is not None
+
+    data.SetState(1)  # Planning
+    pipeline.UpdatePipeline()
+
+    init_renderer = getattr(init_rep, "_renderer", "missing")
+    assert init_renderer is None, (
+        "the inactive SlicingPlaneInit representation must be detached from "
+        "the renderer after the Init -> Planning switch (its plane + marker "
+        "spheres otherwise linger as a stray second surface)."
+    )
+    planning_renderer = getattr(planning_rep, "_renderer", "missing")
+    assert planning_renderer is fake, (
+        "the ACTIVE BezierPlanning representation must be attached to the "
+        "pipeline's renderer."
+    )
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
+++ b/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
@@ -276,3 +276,36 @@ def test_pipeline_hides_inactive_representation_on_state_switch(
         "pipeline's renderer."
     )
     pipeline.cleanup()
+
+
+def test_geometry_edit_requests_render(pipeline_module, bezier_nodes):
+    """A control-point edit must request a render; MTime churn must not.
+
+    The observer callback re-runs ``UpdatePipeline`` but historically never
+    requested a render, so a Planning drag mutated the surface polydata while
+    the 3D view stayed frozen until an unrelated render (camera orbit)
+    repainted it.  The request is gated on the control-point GEOMETRY digest
+    (the ResectogramPipeline pattern): a render-induced ``Modified`` at fixed
+    geometry must NOT re-request (render feedback loop).
+    """
+    data, display = bezier_nodes
+    pipeline = pipeline_module.LiverBezierSurfacePipeline()
+    pipeline.SetDisplayNode(display)
+    data.SetState(1)  # Planning
+
+    renders = []
+    pipeline.RequestRender = lambda: renders.append(1)
+
+    data.SetControlPoint(0, 0, 1.0, 2.0, 3.0)
+    assert renders, (
+        "a control-point edit must request a render -- without it the 3D "
+        "view repaints only on the next unrelated render (frozen drag)."
+    )
+
+    before = len(renders)
+    data.Modified()  # no geometry change -- render-churn signature
+    assert len(renders) == before, (
+        "a Modified at fixed geometry must not re-request a render "
+        "(the render feedback-loop guard)."
+    )
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
+++ b/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
@@ -153,3 +153,71 @@ def test_pipeline_update_is_idempotent(pipeline_module, bezier_nodes):
     assert second == first, "UpdatePipeline must be idempotent on no-change"
 
     pipeline.cleanup()
+
+
+def test_pipeline_adopts_late_bound_displayable(pipeline_module):
+    """A data node linked AFTER SetDisplayNode is adopted on the next update.
+
+    The production creation ordering (``CreateDefaultDisplayNodes``) adds the
+    display node to the scene -- firing the LayerDM creator and this
+    Pipeline's ``SetDisplayNode`` -- BEFORE ``SetAndObserveDisplayNodeID``
+    links it to the carrier.  ``GetDisplayableNode()`` is None at that
+    moment; without late re-derivation the Pipeline stays permanently
+    data-node-less (no observers, no dispatch, default unit patch renders).
+    ``UpdatePipeline`` must re-derive and adopt the displayable once the
+    link exists.
+    """
+    import slicer
+
+    scene = slicer.mrmlScene
+    data = scene.AddNewNodeByClass("vtkMRMLBezierSurfaceNode")
+    display = scene.AddNewNodeByClass("vtkMRMLParametricSurfaceDisplayNode")
+    try:
+        pipeline = pipeline_module.LiverBezierSurfacePipeline()
+        # Production ordering: display handed over BEFORE the carrier link.
+        pipeline.SetDisplayNode(display)
+        assert pipeline.GetDataNode() is None, "no link yet -- nothing to derive"
+
+        data.AddAndObserveDisplayNodeID(display.GetID())
+        pipeline.UpdatePipeline()
+        assert pipeline.GetDataNode() is data, (
+            "UpdatePipeline must re-derive the data node once the display "
+            "node is linked to its displayable -- otherwise the Pipeline "
+            "created during CreateDefaultDisplayNodes never dispatches."
+        )
+        pipeline.cleanup()
+    finally:
+        scene.RemoveNode(display)
+        scene.RemoveNode(data)
+
+
+def test_pipeline_reference_added_hook_adopts_displayable(pipeline_module):
+    """``OnReferenceToDisplayNodeAdded`` adopts the referencing displayable.
+
+    This is the LayerDM manager's designed late-binding notification: its
+    node-reference observer calls the hook with ``fromNode`` == the
+    displayable that just referenced our display node.  The Pipeline must
+    adopt it as the data node and re-dispatch -- this is the PRODUCTION path
+    that revives a Pipeline created during ``CreateDefaultDisplayNodes``
+    (before the display<->displayable link existed).
+    """
+    import slicer
+
+    scene = slicer.mrmlScene
+    data = scene.AddNewNodeByClass("vtkMRMLBezierSurfaceNode")
+    display = scene.AddNewNodeByClass("vtkMRMLParametricSurfaceDisplayNode")
+    try:
+        pipeline = pipeline_module.LiverBezierSurfacePipeline()
+        pipeline.SetDisplayNode(display)
+        assert pipeline.GetDataNode() is None
+
+        data.AddAndObserveDisplayNodeID(display.GetID())
+        pipeline.OnReferenceToDisplayNodeAdded(data, "display")
+        assert pipeline.GetDataNode() is data, (
+            "the reference-added hook must adopt the referencing displayable "
+            "as the data node (LayerDM late binding)."
+        )
+        pipeline.cleanup()
+    finally:
+        scene.RemoveNode(display)
+        scene.RemoveNode(data)


### PR DESCRIPTION
## Summary

Fixes #541 — the resection surface rendered invisible and the resectogram strip white. Diagnosed live on real anatomy (pipeline introspection + in-process render captures); the causes were **three independent defects**, each now fixed + pinned:

1. **The actual invisible-surface cause: the pipeline never received its data node.** The LayerDM creator fires from the scene's NodeAdded *during* `CreateDefaultDisplayNodes`, **before** `SetAndObserveDisplayNodeID` links display↔carrier, so `SetDisplayNode` derived `GetDisplayableNode()==None` — permanently: no observers, no dispatch (`updateCount=1, activeRep=None`), and what actually rendered was `vtkBezierSurfaceSource`'s **default unit patch** (1 mm, invisible beside a 200 mm liver). Fix: implement the LayerDM manager's designed late-binding hook `OnReferenceToDisplayNodeAdded` (adopt the referencing carrier at the link moment) + defensive re-derivation in `UpdatePipeline`.
2. **Texture uploads wedged permanently on first failure.** Both texture paths ignored the upload's boolean result (a VTK error is not a Python exception): the C++ mapper cached a broken texture + advanced its MTime guard; the resectogram bind handed the broken texture to the mapper where the already-bound idempotency guard blocked every retry. Fix: check results, cache only on success (retry path preserved).
3. **The resectogram asked for a 0-component texture, deterministically.** `TextureNumComps` defaults to 0 and nothing writes it → format resolution always failed (the one-per-session "Failed to determine texture parameters") → strip white. Fix: derive the count from the image and push it to the mapper so the shader's `uTextureNumComps>2` margin-band branch engages. Context gates use `MakeCurrent`/`IsCurrent` (a Qt-managed `vtkGenericOpenGLRenderWindow` never sets `GetInitialized` — first-cut gate corrected in-branch).

**Validation:** after the fix the live pipeline reports `updateCount=20 / activeRep=BezierPlanning / dataNode set`, and the **resection surface renders cutting through the liver** (in-process `vtkWindowToImageFilter` capture on the full automatic workflow), with zero texture errors. Launched suite: **252 passed / 0 failed** (also un-skipped previously-skipping pipeline tests). Margin-band colouring engages once the computed distance map is attached to the plan (#553).

## ADR references

- ADR-0013 §5/§6 — pipeline lifecycle; the late-binding hook is the upstream-designed notification.
- ADR-0003 — MRML and GL state must not diverge (the retry discipline).
- ADR-0027 — invariant-test-first (RED pins precede each fix).

## Conformance

- `test_liver_bezier_surface_pipeline.py`: late-bound displayable adoption via `UpdatePipeline` (production ordering) + the `OnReferenceToDisplayNodeAdded` hook.
- `test_flattened_surface_representation.py`: comps derived from the image when the display value is unset; failed upload returns None (no broken-texture bind); unrealized window defers without attempting.

## Test plan

- [x] RED→GREEN for all five new pins (launched: 252 passed / 0 failed)
- [x] Existing mapper CxxTests pass
- [x] Live end-to-end on real anatomy: surface renders (capture), zero texture errors, pipeline dispatching
- [ ] Interactive `:0` eyeball on the merged combination with #553 (margin bands need the attached map)

## UX impact

The resection surface is now visible in the 3D view (previously nothing rendered). No new UI. Render capture from the validation session shows the plane cutting the liver with the corner border markers.

Fixes #541.