### PR TITLE
ENH: Control polygon as a first-class display aspect (ADR-0033)

### DIFF
--- a/Docs/adr/0033-control-polygon-display-aspect.md
+++ b/Docs/adr/0033-control-polygon-display-aspect.md
@@ -1,0 +1,137 @@
+# 0033. Control polygon as a first-class display aspect
+
+- **Status:** Accepted
+- **Date:** 2026-07-08
+- **Deciders:** Rafael Palomar
+- **Supersedes (in part):** the interaction *siting* in
+  [ADR-0032](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0032-v2-interaction-via-layerdm-pipeline-seam.md)
+  ("the Pipeline now mediates both render and edit" on
+  `LiverBezierSurfacePipeline`) and the per-role-glyph rendering notes in
+  [ADR-0014](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0014-livermarkups-dissolution.md)
+  §3.  ADR-0032's seam *mechanism* (interaction through the LayerDM
+  Pipeline overrides — no widget, no custom DisplayableManager) stands
+  unchanged; only *which* Pipeline hosts the control-polygon interaction
+  moves.
+- **PR:** <filled in on merge>
+
+## Context
+
+The first live render of the v2 Planning surface (real anatomy,
+2026-07-08) exposed that the **control polygon** — the `Rows × Cols`
+control-point handles plus their connecting edges — is not rendered at
+all.  The ADR-0032 per-point drag works, but the surgeon drags blind:
+`vtkSlicerLiverBezierControlPolygonGeometry.BuildControlPolygonCells`
+(the Algorithm-library cells builder) has zero production consumers, and
+`BezierPlanningRepresentation` renders only the surface actor (the
+shader-drawn *resection grid* is a surface feature and must not be
+confused with the control polygon).
+
+Maintainer review of the first fix attempt (rendering the polygon inside
+`BezierPlanningRepresentation`) identified three properties that make the
+control polygon a first-class display aspect rather than surface
+decoration:
+
+1. **Distinct visual properties.** Handle radius / colours / edge styling
+   share nothing with the surface's shader fields
+   (margins, distance-field colouring, resection grid) — they do not
+   belong on `vtkMRMLParametricSurfaceDisplayNode`.
+2. **It owns interaction.** The per-point drag targets *handles*, not the
+   surface.  Hosting it on the surface Pipeline forces a blanket
+   `CanProcessInteractionEvent` claim; a polygon-owned Pipeline can
+   return a *real* display-space distance-to-nearest-handle `distance2`,
+   giving LayerDM's focus arbitration something meaningful to arbitrate.
+3. **Independent visibility.** Showing/hiding the handles must not touch
+   the surface — and per-view control (handles in one 3D view, not
+   another) falls out of a dedicated display node's `ViewNodeIDs`.
+
+## Decision
+
+The control polygon becomes a first-class display aspect of the
+parametric-surface carrier, using MRML's native
+one-displayable-many-display-nodes pattern:
+
+1. **`vtkMRMLControlPolygonDisplayNode`** — a new display-node type
+   carrying the polygon's visual properties: `HandleRadius` (default 2.5,
+   v1 glyph parity), `HandleColor`, `EdgeColor`, `EdgeWidth`.  Base
+   `vtkMRMLDisplayNode` provides independent `Visibility` and
+   `ViewNodeIDs`.  Registered via `RegisterNodeClass`
+   ([ADR-0013](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md)
+   §5 call 1).
+2. **`vtkMRMLBezierSurfaceNode::CreateDefaultDisplayNodes` mints both**
+   display nodes — the surface display and the control-polygon display —
+   on the same carrier.
+3. **`ControlPolygonPipeline`** (Python, `LayerDMLib` base) — created by
+   a factory creator keyed on `(vtkMRMLViewNode,
+   vtkMRMLControlPolygonDisplayNode)` (ADR-0013 §1: one Pipeline per
+   display-node type; §5 call 3).  It renders the handles (plain-VTK
+   sphere glyphs over the control grid) and the polygon edges
+   (`BuildControlPolygonCells` — the Algorithm-library SSOT shared with
+   the v2.1 NURBS sibling per
+   [ADR-0018](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0018-nurbs-extension-surface.md)),
+   and is state-gated: visible in `Planning` only (hidden through
+   `Init` and after `Planning → Confirmed`, preserving ADR-0014's
+   Confirmed-hides-polygon behaviour via the
+   [ADR-0019](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0019-resection-state-machine.md)
+   state machine).
+4. **Interaction migrates** (the superseding part): the Planning
+   per-point drag — `CanProcessInteractionEvent` /
+   `ProcessInteractionEvent` plus the nearest-control-point kernel —
+   moves from `LiverBezierSurfacePipeline` to `ControlPolygonPipeline`.
+   `CanProcessInteractionEvent` computes the real display-space distance
+   to the nearest handle, so focus arbitration works when other
+   interactive Pipelines share the view.  The Init-mode placements
+   (slicing-plane / distance-spheroid points) are surface/init
+   interactions and **stay** on `LiverBezierSurfacePipeline`.
+5. **Forward-compatibility:** the v2.1 ring-group manipulation (grouped
+   control-point drag) lands on `ControlPolygonPipeline`; the ring
+   taxonomy stays in the Algorithm library beside
+   `BuildControlPolygonCells`.
+
+## Alternatives considered
+
+### A. Render the polygon inside `BezierPlanningRepresentation`
+One Pipeline renders surface + polygon; interaction stays where ADR-0032
+put it.  Rejected: conflates two unrelated visual property sets on one
+display node; leaves `CanProcessInteractionEvent` as a blanket claim with
+no meaningful `distance2`; polygon visibility cannot be controlled
+per-view or independently of the surface node's decoration fields.
+
+### B. A standalone `vtkAbstractWidget` for the polygon
+Already rejected by ADR-0032 (competing render/picker stack, second
+interaction authority).  Nothing here changes that.
+
+### C. Defer entirely to the v2.1 grouped-manipulation work
+Rejected: v1 parity requires visible handles in v2.0 — the ADR-0032 drag
+is unusable without them.  Only the *grouped* manipulation is v2.1.
+
+## Consequences
+
+**Easier.** Focus arbitration becomes real (distance-based, not
+blanket); display concerns separate cleanly; the v2.1 ring-group work
+has its natural home; handles can be styled/hidden/per-view'd without
+touching the surface.
+
+**Harder / new seams.**
+- Two display nodes per carrier: scene IO, `CopyContent`, and the
+  create path must handle both (the Pipeline late-binding hook —
+  `OnReferenceToDisplayNodeAdded` — already covers the creation-ordering
+  race for any number of display nodes).
+- The ADR-0032 edit-seam tests migrate from the surface Pipeline to
+  `ControlPolygonPipeline`.
+- One more registered node class and factory creator (still within
+  ADR-0013 §5's three-call contract; no custom DisplayableManager).
+
+## Conformance
+
+- [test] `ControlPolygonPipeline` unit invariants: handles + edges follow
+  the control grid; Planning-only visibility; display-node styling
+  reaches the actors; `CanProcessInteractionEvent` returns finite
+  `distance2` near a handle and declines far away / in non-Planning
+  states.
+- [test] The migrated edit-seam invariants (drag writes
+  `SetControlPoint`) run against `ControlPolygonPipeline`.
+- [test] `vtkMRMLControlPolygonDisplayNode` CxxTest: defaults, XML
+  round-trip, `CopyContent`.
+- [review] `CreateDefaultDisplayNodes` mints both display nodes; the
+  surface Pipeline no longer claims Planning-state pointer events.
+- [future] Ring-group manipulation (v2.1) extends this Pipeline.

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -51,6 +51,7 @@ adr/0029-stage1-case-setup-contract.md
 adr/0030-ci-slicer-image-pinning.md
 adr/0031-distance-map-input-on-resection-plan.md
 adr/0032-v2-interaction-via-layerdm-pipeline-seam.md
+adr/0033-control-polygon-display-aspect.md
 ```
 
 ```{toctree}

--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -23,6 +23,7 @@
 
 set(LiverResectionsLib_PYTHON_SCRIPTS
   __init__.py
+  ControlPolygonPipeline.py
   DistanceMaps.py
   LiverBezierSurfacePipeline.py
   LocatorReslicer.py

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -101,6 +101,10 @@ class ControlPolygonPipeline(_PipelineBase):
         self._last_update_key: Any | None = None
         self._update_count = 0
 
+        # Last (state, geometry-digest) a render was requested for — the
+        # observer callback's render-request gate (see ``_on_node_modified``).
+        self._last_render_key: tuple | None = None
+
         # -- handles: control-point sphere glyphs ------------------------- #
         self._handles_polydata = vtk.vtkPolyData()
         self._handles_polydata.SetPoints(vtk.vtkPoints())
@@ -487,8 +491,56 @@ class ControlPolygonPipeline(_PipelineBase):
             pass
 
     def _on_node_modified(self, caller: Any, event: str) -> None:
+        """Re-run ``UpdatePipeline`` and repaint when the geometry changed.
+
+        The render request is gated on the (state, control-point geometry
+        digest) tuple actually changing (the ResectogramPipeline pattern):
+        a Planning drag advances the digest and repaints the handles live;
+        a render-induced ``Modified`` at fixed geometry does not re-request,
+        so no render feedback loop.
+        """
         del caller, event
         self.UpdatePipeline()
+
+        render_key = (
+            _safe_get_state(self._data_node),
+            _control_points_digest(self._data_node),
+        )
+        if render_key == self._last_render_key:
+            return
+        self._last_render_key = render_key
+
+        request_render = getattr(self, "RequestRender", None)
+        if request_render is not None:
+            try:
+                request_render()
+            except Exception:  # pragma: no cover - defensive (stub bases)
+                pass
+
+
+def _control_points_digest(node: Any) -> tuple:
+    """Digest of the carrier's control-point positions (render-request gate).
+
+    Mirrors the ResectogramPipeline's memo digest: a control-point edit
+    changes the digest, a render-induced ``Modified`` at fixed geometry does
+    not — the discrimination that keeps drags repainting live while blocking
+    a render feedback loop.  Empty tuple for nodes missing the grid accessor
+    (stubs) or on a read failure.
+    """
+    if node is None:
+        return ()
+    grid_getter = getattr(node, "GetControlGridVector", None)
+    if grid_getter is None:
+        return ()
+    try:
+        grid = grid_getter()
+        usable = len(grid) - (len(grid) % 3)
+        return tuple(
+            (grid[base], grid[base + 1], grid[base + 2])
+            for base in range(0, usable, 3)
+        )
+    except Exception:  # pragma: no cover - defensive
+        return ()
 
 
 def registerControlPolygonPipelineCreator() -> None:  # noqa: N802 - project convention

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -125,10 +125,17 @@ class ControlPolygonPipeline(_PipelineBase):
         self._handles_actor.SetMapper(self._handles_mapper)
 
         # -- edges: the control polygon ----------------------------------- #
+        # Rendered as world-space TUBES, not GL lines: line width is a pixel
+        # quantity that reads hairline-thin over a liver-scale scene, while
+        # a tube shares the handles' world metric (the display node's
+        # EdgeWidth is the tube radius in mm).
         self._edges_polydata = vtk.vtkPolyData()
         self._edges_polydata.SetPoints(vtk.vtkPoints())
+        self._edges_tube = vtk.vtkTubeFilter()
+        self._edges_tube.SetInputData(self._edges_polydata)
+        self._edges_tube.SetNumberOfSides(12)
         self._edges_mapper = vtk.vtkPolyDataMapper()
-        self._edges_mapper.SetInputData(self._edges_polydata)
+        self._edges_mapper.SetInputConnection(self._edges_tube.GetOutputPort())
         self._edges_actor = vtk.vtkActor()
         self._edges_actor.SetMapper(self._edges_mapper)
 
@@ -519,7 +526,7 @@ class ControlPolygonPipeline(_PipelineBase):
         edge_width = getattr(display, "GetEdgeWidth", None) if display else None
         if edge_width is not None:
             try:
-                self._edges_actor.GetProperty().SetLineWidth(float(edge_width()))
+                self._edges_tube.SetRadius(float(edge_width()))
             except Exception:  # pragma: no cover - defensive
                 pass
 

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -143,6 +143,26 @@ class ControlPolygonPipeline(_PipelineBase):
         self._handles_actor.SetVisibility(False)
         self._edges_actor.SetVisibility(False)
 
+        # -- hover halo: glow highlight for the handle under the cursor --- #
+        # A slightly larger sphere on a PRIVATE overlay renderer carrying a
+        # vtkOutlineGlowPass (the blur-to-halo pass).  The overlay renderer
+        # is required because qMRMLThreeDView resets SetPass(nullptr) on the
+        # view renderer on every view-node ModifiedEvent (the resectogram
+        # blur-pass precedent).  Hover state is fed by the arbitration
+        # moves CanProcessInteractionEvent already receives -- bare moves
+        # stay declined, so camera interaction is untouched.
+        self._hover_index: int | None = None
+        self._halo_sphere = vtk.vtkSphereSource()
+        self._halo_sphere.SetPhiResolution(16)
+        self._halo_sphere.SetThetaResolution(16)
+        self._halo_mapper = vtk.vtkPolyDataMapper()
+        self._halo_mapper.SetInputConnection(self._halo_sphere.GetOutputPort())
+        self._halo_actor = vtk.vtkActor()
+        self._halo_actor.SetMapper(self._halo_mapper)
+        self._halo_actor.GetProperty().SetColor(1.0, 0.9, 0.2)
+        self._halo_actor.SetVisibility(False)
+        self._halo_renderer: Any | None = None
+
     # ------------------------------------------------------------------ #
     # LayerDM lifecycle
     # ------------------------------------------------------------------ #
@@ -197,8 +217,53 @@ class ControlPolygonPipeline(_PipelineBase):
             display = base_getter() if base_getter is not None else None
             if display is not None:
                 self.SetDisplayNode(display)
+        self._attach_halo_renderer(renderer)
         self._last_update_key = None
         self.UpdatePipeline()
+
+    def _attach_halo_renderer(self, renderer: Any) -> None:
+        """Build the private glow overlay on ``renderer``'s window.
+
+        A dedicated overlay ``vtkRenderer`` (camera shared with the view
+        renderer) carries the halo actor and a ``vtkOutlineGlowPass`` -- the
+        blur-to-halo pass -- so qMRMLThreeDView's SetPass(nullptr) reset on
+        the VIEW renderer never clobbers it (the resectogram blur-pass
+        precedent).  Degrades to the plain halo sphere when the pass class
+        or the render window is unavailable (bare unit layer).
+        """
+        window = getattr(renderer, "GetRenderWindow", None)
+        window = window() if window is not None else None
+        if window is None or self._halo_renderer is not None:
+            return
+        try:
+            overlay = vtk.vtkRenderer()
+            overlay.SetLayer(max(1, window.GetNumberOfLayers()))
+            window.SetNumberOfLayers(overlay.GetLayer() + 1)
+            overlay.InteractiveOff()
+            overlay.SetActiveCamera(renderer.GetActiveCamera())
+            overlay.AddActor(self._halo_actor)
+            glow = getattr(vtk, "vtkOutlineGlowPass", None)
+            steps = getattr(vtk, "vtkRenderStepsPass", None)
+            if glow is not None and steps is not None:
+                glow_pass = glow()
+                glow_pass.SetDelegatePass(steps())
+                overlay.SetPass(glow_pass)
+            window.AddRenderer(overlay)
+            self._halo_renderer = overlay
+        except Exception:  # pragma: no cover - defensive (fake renderers)
+            self._halo_renderer = None
+
+    def _detach_halo_renderer(self) -> None:
+        overlay = self._halo_renderer
+        self._halo_renderer = None
+        if overlay is None:
+            return
+        try:
+            window = overlay.GetRenderWindow()
+            if window is not None:
+                window.RemoveRenderer(overlay)
+        except Exception:  # pragma: no cover - defensive
+            pass
 
     def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
         if renderer is not None:
@@ -246,6 +311,9 @@ class ControlPolygonPipeline(_PipelineBase):
         self._display_node = None
         self._data_node = None
         self._drag_index = None
+        self._hover_index = None
+        self._halo_actor.SetVisibility(False)
+        self._detach_halo_renderer()
 
     # ------------------------------------------------------------------ #
     # Interaction -- the Planning per-point drag (ADR-0033, ex ADR-0032)
@@ -282,12 +350,58 @@ class ControlPolygonPipeline(_PipelineBase):
                 return True, 0.0
             return False, sys.float_info.max
 
+        if etype == vtk.vtkCommand.MouseMoveEvent:
+            # Bare hover: update the halo highlight as a SIDE EFFECT of the
+            # arbitration call and decline -- camera moves stay unclaimed.
+            idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
+            within = (
+                idx is not None
+                and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+            )
+            self._set_hover(idx if within else None)
+            return False, sys.float_info.max
         if etype != vtk.vtkCommand.LeftButtonPressEvent:
             return False, sys.float_info.max
         _, distance2 = self._nearest_control_point_in_display(renderer, eventData)
         if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
             return True, distance2
         return False, sys.float_info.max
+
+    def _set_hover(self, index: int | None) -> None:
+        """Show/move the halo on handle ``index`` (``None`` hides it).
+
+        Idempotent per hover change: repositions the halo, syncs its radius
+        to the handle glyphs (scaled up so the glow reads as a ring), and
+        requests exactly one render when the hovered handle actually
+        changed.
+        """
+        if index == self._hover_index:
+            return
+        self._hover_index = index
+        if index is None:
+            self._halo_actor.SetVisibility(False)
+        else:
+            carrier = self._data_node
+            grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
+            if grid_getter is None:
+                return
+            try:
+                grid = grid_getter()
+                base = int(index) * 3
+                self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * 1.35)
+                self._halo_actor.SetPosition(grid[base], grid[base + 1], grid[base + 2])
+                self._halo_actor.SetVisibility(True)
+            except Exception:  # pragma: no cover - defensive
+                return
+        request_render = getattr(self, "RequestRender", None)
+        if request_render is not None:
+            try:
+                request_render()
+            except Exception:  # pragma: no cover - defensive (stub bases)
+                pass
+
+    def GetHaloActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._halo_actor
 
     def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
         """Drive the press/move/release grab (Planning edit).
@@ -325,6 +439,7 @@ class ControlPolygonPipeline(_PipelineBase):
 
         if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
             self._drag_index = None
+            self._set_hover(None)
             return False  # grab over -- release the focus
 
         if etype == vtk.vtkCommand.MouseMoveEvent:
@@ -334,6 +449,8 @@ class ControlPolygonPipeline(_PipelineBase):
             if world is None:
                 return True  # keep the grab; this move just didn't resolve
             self._apply_world_point_to_control_point(self._drag_index, world)
+            hover, self._hover_index = self._drag_index, None
+            self._set_hover(hover)  # halo follows the grabbed handle
             return True
 
         return False

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -186,6 +186,17 @@ class ControlPolygonPipeline(_PipelineBase):
         if renderer is not None:
             renderer.AddActor(self._edges_actor)
             renderer.AddActor(self._handles_actor)
+        # ``OnRendererRemoved`` -> ``cleanup()`` cleared the node handles;
+        # re-derive them from the base's retained display node, or the
+        # renderer churn leaves the pipeline displayless forever and every
+        # styling field silently stays at the raw VTK defaults (the
+        # tiny-handles / hairline-white-edges failure mode).  Mirrors the
+        # ResectogramPipeline's OnRendererAdded re-attach.
+        if self._display_node is None:
+            base_getter = getattr(self, "GetDisplayNode", None)
+            display = base_getter() if base_getter is not None else None
+            if display is not None:
+                self.SetDisplayNode(display)
         self._last_update_key = None
         self.UpdatePipeline()
 

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -105,6 +105,10 @@ class ControlPolygonPipeline(_PipelineBase):
         # observer callback's render-request gate (see ``_on_node_modified``).
         self._last_render_key: tuple | None = None
 
+        # Flat row-major index of the handle currently GRABBED by the
+        # press/move/release gesture — None when no drag is in flight.
+        self._drag_index: int | None = None
+
         # -- handles: control-point sphere glyphs ------------------------- #
         self._handles_polydata = vtk.vtkPolyData()
         self._handles_polydata.SetPoints(vtk.vtkPoints())
@@ -223,6 +227,7 @@ class ControlPolygonPipeline(_PipelineBase):
             self._detach_observer(node)
         self._display_node = None
         self._data_node = None
+        self._drag_index = None
 
     # ------------------------------------------------------------------ #
     # Interaction -- the Planning per-point drag (ADR-0033, ex ADR-0032)
@@ -231,18 +236,35 @@ class ControlPolygonPipeline(_PipelineBase):
     def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
         """Return ``(canProcess, distance2)`` for the LayerDM focus logic.
 
-        Claims the event iff the carrier is editable (``Planning``,
-        ADR-0019) and the cursor is within ``CONTROL_POINT_PICK_RADIUS_PX``
-        of a handle in display space.  ``distance2`` is the real squared
-        display distance to the nearest handle -- the meaningful arbitration
-        value ADR-0033 moves here for.
+        The per-point edit is a press/move/release GRAB, not proximity
+        chasing: without a grab, only a LEFT-BUTTON PRESS within
+        ``CONTROL_POINT_PICK_RADIUS_PX`` of a handle is claimed (with the
+        real squared display distance as the arbitration value, ADR-0033);
+        while a handle is grabbed, mouse moves and the ending release are
+        claimed unconditionally (distance2 0 -- the grab owns the gesture).
+        A hover move never edits: claiming bare moves made a released mouse
+        keep deforming the surface on mere proximity.
         """
         import sys
 
         if _safe_get_state(self._data_node) != STATE_PLANNING:
+            self._drag_index = None  # a state flip mid-gesture drops the grab
             return False, sys.float_info.max
         renderer = self._safe_get_renderer()
         if renderer is None:
+            self._drag_index = None
+            return False, sys.float_info.max
+
+        etype = _event_type(eventData)
+        if self._drag_index is not None:
+            if etype in (
+                vtk.vtkCommand.MouseMoveEvent,
+                vtk.vtkCommand.LeftButtonReleaseEvent,
+            ):
+                return True, 0.0
+            return False, sys.float_info.max
+
+        if etype != vtk.vtkCommand.LeftButtonPressEvent:
             return False, sys.float_info.max
         _, distance2 = self._nearest_control_point_in_display(renderer, eventData)
         if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
@@ -250,23 +272,80 @@ class ControlPolygonPipeline(_PipelineBase):
         return False, sys.float_info.max
 
     def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
-        """Move the nearest control point to the cursor (Planning edit).
+        """Drive the press/move/release grab (Planning edit).
 
-        Returns True iff geometry changed (the interaction logic keeps focus
-        on a pipeline that returns True).
+        Press within the pick radius grabs the nearest handle and returns
+        True (the interaction logic keeps focus on a pipeline that returns
+        True); moves while grabbed edit THE GRABBED handle -- not whichever
+        is momentarily nearest -- so the gesture cannot hop between points;
+        the release clears the grab and returns False, releasing the focus.
         """
         renderer = self._safe_get_renderer()
         if renderer is None:
+            self._drag_index = None
             return False
         if _safe_get_state(self._data_node) != STATE_PLANNING:
+            self._drag_index = None
             return False
-        idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-        if idx is None or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
+
+        etype = _event_type(eventData)
+
+        if self._drag_index is None:
+            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                return False
+            idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
+            if (
+                idx is None
+                or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+            ):
+                return False
+            self._drag_index = idx
+            world = self._event_world_at_control_point(renderer, eventData, idx)
+            if world is not None:
+                self._apply_world_point_to_control_point(idx, world)
+            return True
+
+        if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
+            self._drag_index = None
+            return False  # grab over -- release the focus
+
+        if etype == vtk.vtkCommand.MouseMoveEvent:
+            world = self._event_world_at_control_point(
+                renderer, eventData, self._drag_index
+            )
+            if world is None:
+                return True  # keep the grab; this move just didn't resolve
+            self._apply_world_point_to_control_point(self._drag_index, world)
+            return True
+
+        return False
+
+    def _apply_world_point_to_control_point(self, index: int, world: Any) -> bool:
+        """Move the carrier's control point ``index`` to RAS ``world``.
+
+        The grabbed-index write kernel: unlike the nearest-point kernel it
+        never re-picks, so a drag cannot hop to another handle mid-gesture.
+        Refuses outside ``Planning`` (ADR-0019).
+        """
+        carrier = self._data_node
+        if carrier is None or _safe_get_state(carrier) != STATE_PLANNING:
             return False
-        world = self._event_world_at_control_point(renderer, eventData, idx)
-        if world is None:
+        cols_getter = getattr(carrier, "GetCols", None)
+        set_point = getattr(carrier, "SetControlPoint", None)
+        if None in (cols_getter, set_point):
             return False
-        return self._apply_world_point_to_nearest_control_point(world) is not None
+        try:
+            cols = int(cols_getter())
+            set_point(
+                int(index) // cols,
+                int(index) % cols,
+                float(world[0]),
+                float(world[1]),
+                float(world[2]),
+            )
+        except Exception:  # pragma: no cover - defensive
+            return False
+        return True
 
     def _apply_world_point_to_nearest_control_point(self, world: Any) -> int | None:
         """Move the carrier's nearest control point to RAS ``world``.
@@ -516,6 +595,22 @@ class ControlPolygonPipeline(_PipelineBase):
                 request_render()
             except Exception:  # pragma: no cover - defensive (stub bases)
                 pass
+
+
+def _event_type(eventData: Any) -> int | None:  # noqa: N803 - VTK arg name
+    """Read the VTK event-type id off ``eventData`` defensively.
+
+    ``None`` for events lacking ``GetType`` (stubs) or on a read failure —
+    the callers then decline, so the grab state machine never raises from
+    the interaction hot path.
+    """
+    getter = getattr(eventData, "GetType", None)
+    if getter is None:
+        return None
+    try:
+        return int(getter())
+    except Exception:  # pragma: no cover - defensive
+        return None
 
 
 def _control_points_digest(node: Any) -> tuple:

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -1,0 +1,535 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""LayerDM Pipeline for the parametric surface's control polygon (ADR-0033).
+
+The control polygon -- the ``Rows x Cols`` control-point handles plus their
+connecting edges -- is a first-class display aspect of the Bezier carrier,
+keyed on its OWN display node (``vtkMRMLControlPolygonDisplayNode``, the
+carrier's second display node) per ADR-0013 §1: one Pipeline per display-node
+type.  This Pipeline:
+
+* renders the handles (plain-VTK sphere glyphs over the control grid) and the
+  polygon edges (``vtkSlicerLiverBezierControlPolygonGeometry.
+  BuildControlPolygonCells`` -- the Algorithm-library SSOT shared with the
+  v2.1 NURBS sibling per ADR-0018);
+* is state-gated: visible in ``Planning`` only (ADR-0019 state machine;
+  preserves the Confirmed-hides-polygon behaviour of ADR-0014);
+* HOSTS the Planning per-point drag (ADR-0033 supersedes the ADR-0032 siting
+  on ``LiverBezierSurfacePipeline``): ``CanProcessInteractionEvent`` returns
+  the real display-space distance to the nearest handle, so LayerDM's focus
+  arbitration has something meaningful to arbitrate.
+
+The Init-mode placements (slicing-plane / distance-spheroid points) are
+surface/init interactions and stay on ``LiverBezierSurfacePipeline``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import vtk
+
+from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+
+# State constants + safe accessors shared with the sibling Pipeline (single
+# source within this package; the integers mirror the C++ enum on
+# vtkMRMLBezierSurfaceNode).
+try:  # pragma: no cover - exercised once per import path
+    from .LiverBezierSurfacePipeline import (
+        STATE_PLANNING,
+        _safe_get_mtime,
+        _safe_get_state,
+    )
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    from LiverBezierSurfacePipeline import (  # type: ignore[no-redef]
+        STATE_PLANNING,
+        _safe_get_mtime,
+        _safe_get_state,
+    )
+
+#: The Algorithm-library cells builder (reachable only via the
+#: vtkSlicerLiverResectionsModuleAlgorithmPython wrapping inside a launched
+#: Slicer -- NOT on the ``slicer``/``vtk`` namespaces).
+CONTROL_POLYGON_GEOMETRY_CLASS = "vtkSlicerLiverBezierControlPolygonGeometry"
+
+#: Display-space pick radius for the per-point drag, in pixels (the ADR-0032
+#: value, unchanged by the ADR-0033 re-siting).
+CONTROL_POINT_PICK_RADIUS_PX = 20.0
+
+_REGISTERED = False
+
+
+def _resolve_control_polygon_geometry() -> Any | None:
+    """Resolve the wrapped Algorithm cells-builder class, or ``None``.
+
+    Algorithm-library classes are exposed ONLY on the
+    ``vtkSlicerLiverResectionsModuleAlgorithmPython`` wrapping (never on the
+    ``slicer`` / ``vtk`` namespaces).  ``None`` in the bare-VTK unit layer,
+    where tests inject a fake via the ``_control_polygon_geometry`` seam.
+    """
+    try:
+        import vtkSlicerLiverResectionsModuleAlgorithmPython as algorithm
+    except ImportError:
+        return None
+    return getattr(algorithm, CONTROL_POLYGON_GEOMETRY_CLASS, None)
+
+
+class ControlPolygonPipeline(_PipelineBase):
+    """Renders + edits the control polygon of a parametric surface carrier.
+
+    Created by LayerDM's manager via the creator registered by
+    ``registerControlPolygonPipelineCreator()``; keyed on
+    ``vtkMRMLControlPolygonDisplayNode`` (ADR-0033).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.SetPythonObject(self)
+
+        self._display_node: Any | None = None
+        self._data_node: Any | None = None
+        self._renderer: Any | None = None
+        self._observer_tags: dict = {}
+        self._observed_node_refs: list = []
+
+        # Injectable Algorithm-builder seam (bare-VTK unit layer); resolved
+        # lazily from the wrapping on first use in production.
+        self._control_polygon_geometry: Any | None = None
+        #: (rows, cols) the current edge cells were built for.
+        self._edge_cells_shape: tuple | None = None
+
+        self._last_update_key: Any | None = None
+        self._update_count = 0
+
+        # -- handles: control-point sphere glyphs ------------------------- #
+        self._handles_polydata = vtk.vtkPolyData()
+        self._handles_polydata.SetPoints(vtk.vtkPoints())
+        self._handle_sphere = vtk.vtkSphereSource()
+        self._handle_sphere.SetPhiResolution(12)
+        self._handle_sphere.SetThetaResolution(12)
+        self._handles_glyph = vtk.vtkGlyph3D()
+        self._handles_glyph.SetInputData(self._handles_polydata)
+        self._handles_glyph.SetSourceConnection(self._handle_sphere.GetOutputPort())
+        self._handles_glyph.ScalingOff()
+        self._handles_mapper = vtk.vtkPolyDataMapper()
+        self._handles_mapper.SetInputConnection(self._handles_glyph.GetOutputPort())
+        self._handles_actor = vtk.vtkActor()
+        self._handles_actor.SetMapper(self._handles_mapper)
+
+        # -- edges: the control polygon ----------------------------------- #
+        self._edges_polydata = vtk.vtkPolyData()
+        self._edges_polydata.SetPoints(vtk.vtkPoints())
+        self._edges_mapper = vtk.vtkPolyDataMapper()
+        self._edges_mapper.SetInputData(self._edges_polydata)
+        self._edges_actor = vtk.vtkActor()
+        self._edges_actor.SetMapper(self._edges_mapper)
+
+        # Hidden until a Planning-state carrier arrives.
+        self._handles_actor.SetVisibility(False)
+        self._edges_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # LayerDM lifecycle
+    # ------------------------------------------------------------------ #
+
+    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
+        """Attach the display node, derive the data node, wire observers."""
+        if self._display_node is not None:
+            self._detach_observer(self._display_node)
+        if self._data_node is not None:
+            self._detach_observer(self._data_node)
+
+        super().SetDisplayNode(displayNode)
+
+        self._display_node = displayNode
+        self._data_node = None
+        if displayNode is not None:
+            getter = getattr(displayNode, "GetDisplayableNode", None)
+            if getter is not None:
+                self._data_node = getter()
+            self._attach_observer(displayNode)
+            if self._data_node is not None:
+                self._attach_observer(self._data_node)
+        self._last_update_key = None
+
+    def OnReferenceToDisplayNodeAdded(self, fromNode: Any, role: Any = None) -> None:  # noqa: N802 - VTK verb
+        """Adopt the displayable when it links to our display node late.
+
+        Same late-binding contract as the sibling surface Pipeline: the
+        production creation ordering hands ``SetDisplayNode`` a display node
+        whose displayable link does not exist yet; the LayerDM manager calls
+        this hook at the exact link moment with ``fromNode`` == the carrier.
+        """
+        if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
+            self._data_node = fromNode
+            self._attach_observer(fromNode)
+            self._last_update_key = None
+        self.UpdatePipeline()
+
+    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        self._renderer = renderer
+        if renderer is not None:
+            renderer.AddActor(self._edges_actor)
+            renderer.AddActor(self._handles_actor)
+        self._last_update_key = None
+        self.UpdatePipeline()
+
+    def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        if renderer is not None:
+            try:
+                renderer.RemoveActor(self._handles_actor)
+                renderer.RemoveActor(self._edges_actor)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        self._renderer = None
+        self.cleanup()
+
+    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        """Reconcile handles + edges against the carrier grid and display."""
+        # Late-bind the data node (creation-ordering tolerance; see
+        # OnReferenceToDisplayNodeAdded).
+        if self._data_node is None and self._display_node is not None:
+            getter = getattr(self._display_node, "GetDisplayableNode", None)
+            displayable = getter() if getter is not None else None
+            if displayable is not None:
+                self._data_node = displayable
+                self._attach_observer(displayable)
+                self._last_update_key = None
+
+        state = _safe_get_state(self._data_node)
+        key = (
+            state,
+            _safe_get_mtime(self._data_node),
+            _safe_get_mtime(self._display_node),
+        )
+        if key == self._last_update_key:
+            return
+        self._last_update_key = key
+        self._update_count += 1
+
+        visible = self._compute_visibility(state)
+        self._handles_actor.SetVisibility(visible)
+        self._edges_actor.SetVisibility(visible)
+        if visible:
+            self._refresh_geometry()
+        self._apply_display_node()
+
+    def cleanup(self) -> None:
+        for node in list(self._observed_node_refs):
+            self._detach_observer(node)
+        self._display_node = None
+        self._data_node = None
+
+    # ------------------------------------------------------------------ #
+    # Interaction -- the Planning per-point drag (ADR-0033, ex ADR-0032)
+    # ------------------------------------------------------------------ #
+
+    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
+        """Return ``(canProcess, distance2)`` for the LayerDM focus logic.
+
+        Claims the event iff the carrier is editable (``Planning``,
+        ADR-0019) and the cursor is within ``CONTROL_POINT_PICK_RADIUS_PX``
+        of a handle in display space.  ``distance2`` is the real squared
+        display distance to the nearest handle -- the meaningful arbitration
+        value ADR-0033 moves here for.
+        """
+        import sys
+
+        if _safe_get_state(self._data_node) != STATE_PLANNING:
+            return False, sys.float_info.max
+        renderer = self._safe_get_renderer()
+        if renderer is None:
+            return False, sys.float_info.max
+        _, distance2 = self._nearest_control_point_in_display(renderer, eventData)
+        if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
+            return True, distance2
+        return False, sys.float_info.max
+
+    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
+        """Move the nearest control point to the cursor (Planning edit).
+
+        Returns True iff geometry changed (the interaction logic keeps focus
+        on a pipeline that returns True).
+        """
+        renderer = self._safe_get_renderer()
+        if renderer is None:
+            return False
+        if _safe_get_state(self._data_node) != STATE_PLANNING:
+            return False
+        idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
+        if idx is None or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
+            return False
+        world = self._event_world_at_control_point(renderer, eventData, idx)
+        if world is None:
+            return False
+        return self._apply_world_point_to_nearest_control_point(world) is not None
+
+    def _apply_world_point_to_nearest_control_point(self, world: Any) -> int | None:
+        """Move the carrier's nearest control point to RAS ``world``.
+
+        The GL-free interaction kernel (ADR-0032 mechanics, re-sited here by
+        ADR-0033): finds the carrier's control point nearest ``world``, moves
+        it via ``SetControlPoint``, and returns its flat row-major index.  A
+        no-op returning ``None`` when the carrier is absent or not in
+        ``Planning`` (ADR-0019).
+        """
+        carrier = self._data_node
+        if carrier is None or _safe_get_state(carrier) != STATE_PLANNING:
+            return None
+        rows_getter = getattr(carrier, "GetRows", None)
+        cols_getter = getattr(carrier, "GetCols", None)
+        grid_getter = getattr(carrier, "GetControlGridVector", None)
+        set_point = getattr(carrier, "SetControlPoint", None)
+        if None in (rows_getter, cols_getter, grid_getter, set_point):
+            return None
+        try:
+            rows = int(rows_getter())
+            cols = int(cols_getter())
+            grid = grid_getter()
+            wx, wy, wz = float(world[0]), float(world[1]), float(world[2])
+        except Exception:  # pragma: no cover - defensive
+            return None
+
+        best_idx = None
+        best_d2 = None
+        for i in range(rows * cols):
+            dx = grid[i * 3 + 0] - wx
+            dy = grid[i * 3 + 1] - wy
+            dz = grid[i * 3 + 2] - wz
+            d2 = dx * dx + dy * dy + dz * dz
+            if best_d2 is None or d2 < best_d2:
+                best_d2 = d2
+                best_idx = i
+        if best_idx is None:
+            return None
+        set_point(best_idx // cols, best_idx % cols, wx, wy, wz)
+        return best_idx
+
+    def _nearest_control_point_in_display(self, renderer: Any, eventData: Any):
+        """``(flat_index, distance2)`` of the handle nearest the event pixel."""
+        import sys
+
+        carrier = self._data_node
+        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
+        cols_getter = getattr(carrier, "GetCols", None) if carrier else None
+        rows_getter = getattr(carrier, "GetRows", None) if carrier else None
+        if None in (grid_getter, cols_getter, rows_getter):
+            return None, sys.float_info.max
+        try:
+            grid = grid_getter()
+            rows = int(rows_getter())
+            cols = int(cols_getter())
+            ex, ey = eventData.GetDisplayPosition()
+        except Exception:  # pragma: no cover - defensive
+            return None, sys.float_info.max
+
+        best_idx = None
+        best_d2 = sys.float_info.max
+        for i in range(rows * cols):
+            renderer.SetWorldPoint(grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2], 1.0)
+            renderer.WorldToDisplay()
+            dx, dy, _dz = renderer.GetDisplayPoint()
+            d2 = (dx - ex) ** 2 + (dy - ey) ** 2
+            if d2 < best_d2:
+                best_d2 = d2
+                best_idx = i
+        return best_idx, best_d2
+
+    def _event_world_at_control_point(self, renderer: Any, eventData: Any, idx: int):
+        """Back-project the event pixel onto control point ``idx``'s depth."""
+        carrier = self._data_node
+        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
+        cols_getter = getattr(carrier, "GetCols", None) if carrier else None
+        if None in (grid_getter, cols_getter):
+            return None
+        try:
+            grid = grid_getter()
+            ex, ey = eventData.GetDisplayPosition()
+            renderer.SetWorldPoint(grid[idx * 3 + 0], grid[idx * 3 + 1], grid[idx * 3 + 2], 1.0)
+            renderer.WorldToDisplay()
+            _dx, _dy, dz = renderer.GetDisplayPoint()
+            renderer.SetDisplayPoint(float(ex), float(ey), dz)
+            renderer.DisplayToWorld()
+            wx, wy, wz, ww = renderer.GetWorldPoint()
+        except Exception:  # pragma: no cover - defensive
+            return None
+        if ww == 0.0:
+            return None
+        return (wx / ww, wy / ww, wz / ww)
+
+    # ------------------------------------------------------------------ #
+    # Geometry + styling
+    # ------------------------------------------------------------------ #
+
+    def _compute_visibility(self, state: Any) -> bool:
+        """Planning-only, further gated by the display node's Visibility."""
+        if state != STATE_PLANNING:
+            return False
+        display = self._display_node
+        vis_getter = getattr(display, "GetVisibility", None) if display else None
+        if vis_getter is not None:
+            try:
+                return bool(vis_getter())
+            except Exception:  # pragma: no cover - defensive
+                return True
+        return True
+
+    def _refresh_geometry(self) -> None:
+        """Rebuild handle points + polygon edges from the carrier grid."""
+        carrier = self._data_node
+        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
+        if grid_getter is None:
+            grid_getter = getattr(carrier, "GetControlGrid", None) if carrier else None
+        if grid_getter is None:
+            return
+        rows = int(getattr(carrier, "GetRows", lambda: 4)())
+        cols = int(getattr(carrier, "GetCols", lambda: 4)())
+        try:
+            raw = grid_getter()
+            points = vtk.vtkPoints()
+            points.SetNumberOfPoints(rows * cols)
+            for i in range(rows * cols):
+                points.SetPoint(i, float(raw[i * 3]), float(raw[i * 3 + 1]), float(raw[i * 3 + 2]))
+        except Exception:  # pragma: no cover - defensive
+            return
+
+        self._handles_polydata.SetPoints(points)
+        self._handles_polydata.Modified()
+        self._edges_polydata.SetPoints(points)
+
+        shape = (rows, cols)
+        if shape != self._edge_cells_shape:
+            geometry = self._control_polygon_geometry
+            if geometry is None:
+                geometry = _resolve_control_polygon_geometry()
+                self._control_polygon_geometry = geometry
+            if geometry is not None:
+                cells = geometry.BuildControlPolygonCells(rows, cols)
+                if cells is not None:
+                    self._edges_polydata.SetLines(cells)
+                    self._edge_cells_shape = shape
+        self._edges_polydata.Modified()
+
+    def _apply_display_node(self) -> None:
+        """Push the display node's styling onto the actors."""
+        display = self._display_node
+        radius_getter = getattr(display, "GetHandleRadius", None) if display else None
+        if radius_getter is not None:
+            try:
+                self._handle_sphere.SetRadius(float(radius_getter()))
+            except Exception:  # pragma: no cover - defensive
+                pass
+        handle_color = getattr(display, "GetHandleColor", None) if display else None
+        if handle_color is not None:
+            try:
+                c = handle_color()
+                self._handles_actor.GetProperty().SetColor(float(c[0]), float(c[1]), float(c[2]))
+            except Exception:  # pragma: no cover - defensive
+                pass
+        edge_color = getattr(display, "GetEdgeColor", None) if display else None
+        if edge_color is not None:
+            try:
+                c = edge_color()
+                self._edges_actor.GetProperty().SetColor(float(c[0]), float(c[1]), float(c[2]))
+            except Exception:  # pragma: no cover - defensive
+                pass
+        edge_width = getattr(display, "GetEdgeWidth", None) if display else None
+        if edge_width is not None:
+            try:
+                self._edges_actor.GetProperty().SetLineWidth(float(edge_width()))
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+    # ------------------------------------------------------------------ #
+    # Introspection (unit tests) + plumbing
+    # ------------------------------------------------------------------ #
+
+    def GetDataNode(self) -> Any | None:  # noqa: N802 - VTK verb
+        return self._data_node
+
+    def GetHandlesActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._handles_actor
+
+    def GetEdgesActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._edges_actor
+
+    def GetHandlesPolyData(self) -> Any:  # noqa: N802 - VTK verb
+        return self._handles_polydata
+
+    def GetEdgesPolyData(self) -> Any:  # noqa: N802 - VTK verb
+        return self._edges_polydata
+
+    def GetUpdateCount(self) -> int:  # noqa: N802 - VTK verb
+        return self._update_count
+
+    def _safe_get_renderer(self) -> Any | None:
+        return self._renderer
+
+    def _attach_observer(self, node: Any) -> None:
+        if node is None or not hasattr(node, "AddObserver"):
+            return
+        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
+        self._observer_tags.setdefault(id(node), []).append(tag)
+        if node not in self._observed_node_refs:
+            self._observed_node_refs.append(node)
+
+    def _detach_observer(self, node: Any) -> None:
+        if node is None:
+            return
+        for tag in self._observer_tags.pop(id(node), []):
+            try:
+                node.RemoveObserver(tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        try:
+            self._observed_node_refs.remove(node)
+        except ValueError:
+            pass
+
+    def _on_node_modified(self, caller: Any, event: str) -> None:
+        del caller, event
+        self.UpdatePipeline()
+
+
+def registerControlPolygonPipelineCreator() -> None:  # noqa: N802 - project convention
+    """Register the ``ControlPolygonPipeline`` creator with LayerDM.
+
+    Idempotent (module-level flag), mirroring ``registerPipelineCreator``.
+    The creator matches ``(vtkMRMLViewNode, vtkMRMLControlPolygonDisplayNode)``
+    and EXCLUDES the resectogram singleton view: that view is owned solely by
+    the ResectogramPipeline (its strip + locator click seam), and leaking
+    surface-family pipelines into it puts interactive actors where they do
+    not belong.
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return
+
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLControlPolygonDisplayNode,
+        vtkMRMLLayerDMPipelineFactory,
+        vtkMRMLLayerDMPipelineScriptedCreator,
+        vtkMRMLViewNode,
+    )
+
+    try:
+        from .ResectogramViewManager import RESECTOGRAM_VIEW_SINGLETON_TAG
+    except ImportError:  # pragma: no cover - top-level import path
+        from ResectogramViewManager import (  # type: ignore[no-redef]
+            RESECTOGRAM_VIEW_SINGLETON_TAG,
+        )
+
+    def tryCreate(viewNode, node):
+        if not isinstance(viewNode, vtkMRMLViewNode):
+            return None
+        tag_getter = getattr(viewNode, "GetSingletonTag", None)
+        if tag_getter is not None and tag_getter() == RESECTOGRAM_VIEW_SINGLETON_TAG:
+            return None
+        if not isinstance(node, vtkMRMLControlPolygonDisplayNode):
+            return None
+        return ControlPolygonPipeline()
+
+    creator = vtkMRMLLayerDMPipelineScriptedCreator()
+    creator.SetPythonCallback(tryCreate)
+    vtkMRMLLayerDMPipelineFactory.GetInstance().AddPipelineCreator(creator)
+    _REGISTERED = True

--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -577,27 +577,19 @@ class LiverBezierSurfacePipeline(_PipelineBase):
     # ------------------------------------------------------------------ #
 
     #: Pick radius (display pixels) within which a click grabs a control point.
-    _CONTROL_POINT_PICK_RADIUS_PX = 20.0
-
     def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
-        """Return ``(canProcess, distance2)`` for the LayerDM interaction logic.
+        """Decline pointer events -- the surface Pipeline no longer edits.
 
-        The pipeline can process the event iff the carrier is editable
-        (Planning, ADR-0019) and the cursor is within
-        ``_CONTROL_POINT_PICK_RADIUS_PX`` of a control point in display space.
-        ``distance2`` is the squared display distance to the nearest control
-        point (smaller wins focus in the interaction logic).
+        ADR-0033 re-sited the Planning per-point drag onto the control
+        polygon's own Pipeline (``ControlPolygonPipeline``), which returns a
+        real display-space distance to the nearest handle for LayerDM's
+        focus arbitration.  The Init-mode placements handled by
+        ``ProcessInteractionEvent`` below are driven by the Stage-4
+        placement flow, not by pointer-focus claims.
         """
+        del eventData
         import sys
 
-        if _safe_get_state(self._data_node) != STATE_PLANNING:
-            return False, sys.float_info.max
-        renderer = self._safe_get_renderer()
-        if renderer is None:
-            return False, sys.float_info.max
-        _, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-        if distance2 <= self._CONTROL_POINT_PICK_RADIUS_PX * self._CONTROL_POINT_PICK_RADIUS_PX:
-            return True, distance2
         return False, sys.float_info.max
 
     def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
@@ -606,8 +598,8 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         * ``Init`` + ``SlicingPlane`` — PLACE the next slicing-plane init point
           at the cursor's world position (back-projected onto the focal plane,
           since there is no picked point yet to supply depth).
-        * ``Planning`` — EDIT: move the nearest control point to the cursor's
-          world position (back-projected onto that point's depth).
+        * ``Planning`` — no-op here: the per-point edit lives on
+          ``ControlPolygonPipeline`` (ADR-0033).
 
         Returns True iff geometry changed (the interaction logic keeps focus on
         a pipeline that returns True).
@@ -630,15 +622,8 @@ class LiverBezierSurfacePipeline(_PipelineBase):
                 return False
             return self._place_distance_spheroid_init_point(world) is not None
 
-        if state == STATE_PLANNING:
-            idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-            if idx is None or distance2 > self._CONTROL_POINT_PICK_RADIUS_PX * self._CONTROL_POINT_PICK_RADIUS_PX:
-                return False
-            world = self._event_world_at_control_point(renderer, eventData, idx)
-            if world is None:
-                return False
-            return self._apply_world_point_to_nearest_control_point(world) is not None
-
+        # The Planning per-point drag lives on ControlPolygonPipeline
+        # (ADR-0033); this Pipeline handles only the Init placements above.
         return False
 
     def _place_slicing_plane_init_point(self, world: Any) -> int | None:
@@ -729,114 +714,6 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             renderer.WorldToDisplay()
             _fx, _fy, fz = renderer.GetDisplayPoint()
             renderer.SetDisplayPoint(float(ex), float(ey), fz)
-            renderer.DisplayToWorld()
-            wx, wy, wz, ww = renderer.GetWorldPoint()
-        except Exception:  # pragma: no cover - defensive
-            return None
-        if ww == 0.0:
-            return None
-        return (wx / ww, wy / ww, wz / ww)
-
-    def _apply_world_point_to_nearest_control_point(self, world: Any) -> int | None:
-        """Move the carrier's nearest control point to RAS ``world``.
-
-        The GL-free interaction kernel (ADR-0032): takes a world point
-        directly (no renderer / picking), finds the carrier's control point
-        nearest ``world``, moves it there via ``SetControlPoint``, and returns
-        its flat row-major index (``row * Cols + col``).  A no-op returning
-        ``None`` when the carrier is absent or not editable — editing is
-        allowed only in the ``Planning`` state (ADR-0019); ``Init`` has no
-        control polygon yet and ``Confirmed`` is read-only audit data.
-        """
-        carrier = self._data_node
-        if carrier is None or _safe_get_state(carrier) != STATE_PLANNING:
-            return None
-        rows_getter = getattr(carrier, "GetRows", None)
-        cols_getter = getattr(carrier, "GetCols", None)
-        grid_getter = getattr(carrier, "GetControlGridVector", None)
-        set_point = getattr(carrier, "SetControlPoint", None)
-        if None in (rows_getter, cols_getter, grid_getter, set_point):
-            return None
-        try:
-            rows = int(rows_getter())
-            cols = int(cols_getter())
-            grid = grid_getter()
-            wx, wy, wz = float(world[0]), float(world[1]), float(world[2])
-        except Exception:  # pragma: no cover - defensive
-            return None
-
-        best_idx = None
-        best_d2 = None
-        for i in range(rows * cols):
-            dx = grid[i * 3 + 0] - wx
-            dy = grid[i * 3 + 1] - wy
-            dz = grid[i * 3 + 2] - wz
-            d2 = dx * dx + dy * dy + dz * dz
-            if best_d2 is None or d2 < best_d2:
-                best_d2 = d2
-                best_idx = i
-        if best_idx is None:
-            return None
-        set_point(best_idx // cols, best_idx % cols, wx, wy, wz)
-        return best_idx
-
-    def _nearest_control_point_in_display(self, renderer: Any, eventData: Any):
-        """Return ``(flat_index, distance2)`` of the control point nearest the
-        event's display position, projecting each control point world→display.
-
-        ``(None, inf)`` when there is no carrier / grid.  Pure geometry given a
-        renderer — the display projection needs the renderer's active camera.
-        """
-        import sys
-
-        carrier = self._data_node
-        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
-        cols_getter = getattr(carrier, "GetCols", None) if carrier else None
-        rows_getter = getattr(carrier, "GetRows", None) if carrier else None
-        if None in (grid_getter, cols_getter, rows_getter):
-            return None, sys.float_info.max
-        try:
-            grid = grid_getter()
-            rows = int(rows_getter())
-            cols = int(cols_getter())
-            ex, ey = eventData.GetDisplayPosition()
-        except Exception:  # pragma: no cover - defensive
-            return None, sys.float_info.max
-
-        best_idx = None
-        best_d2 = sys.float_info.max
-        for i in range(rows * cols):
-            renderer.SetWorldPoint(grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2], 1.0)
-            renderer.WorldToDisplay()
-            dx, dy, _dz = renderer.GetDisplayPoint()
-            d2 = (dx - ex) ** 2 + (dy - ey) ** 2
-            if d2 < best_d2:
-                best_d2 = d2
-                best_idx = i
-        return best_idx, best_d2
-
-    def _event_world_at_control_point(self, renderer: Any, eventData: Any, idx: int):
-        """Back-project the event's display position onto the depth of control
-        point ``idx``, returning the RAS ``(x, y, z)`` the point should move to.
-
-        Uses the picked control point's current depth (display z) so a drag
-        slides the point in the camera-facing plane through its own depth —
-        the conventional control-point drag behaviour.  ``None`` on failure.
-        """
-        carrier = self._data_node
-        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
-        cols_getter = getattr(carrier, "GetCols", None) if carrier else None
-        if None in (grid_getter, cols_getter):
-            return None
-        try:
-            grid = grid_getter()
-            ex, ey = eventData.GetDisplayPosition()
-            # Display z (depth) of the picked control point.
-            renderer.SetWorldPoint(grid[idx * 3 + 0], grid[idx * 3 + 1], grid[idx * 3 + 2], 1.0)
-            renderer.WorldToDisplay()
-            _dx, _dy, dz = renderer.GetDisplayPoint()
-            # Cursor display position at that depth -> world.
-            renderer.SetDisplayPoint(float(ex), float(ey), dz)
             renderer.DisplayToWorld()
             wx, wy, wz, ww = renderer.GetWorldPoint()
         except Exception:  # pragma: no cover - defensive

--- a/LiverResections/LiverResectionsLib/__init__.py
+++ b/LiverResections/LiverResectionsLib/__init__.py
@@ -20,6 +20,10 @@ from .LiverBezierSurfacePipeline import (
     LiverBezierSurfacePipeline,
     registerPipelineCreator,
 )
+from .ControlPolygonPipeline import (
+    ControlPolygonPipeline,
+    registerControlPolygonPipelineCreator,
+)
 from .ResectogramPipeline import (
     ResectogramPipeline,
     registerResectogramPipelineCreator,
@@ -32,6 +36,8 @@ from .ResectogramViewManager import (
 __all__ = [
     "LiverBezierSurfacePipeline",
     "registerPipelineCreator",
+    "ControlPolygonPipeline",
+    "registerControlPolygonPipelineCreator",
     "ResectogramPipeline",
     "registerResectogramPipelineCreator",
     "ResectogramViewManager",

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -55,6 +55,7 @@
 #include "vtkMRMLResectogramDisplayNode.h"
 #include "vtkMRMLResectionPlanNode.h"
 #include "vtkMRMLResectionPlanStorageNode.h"
+#include "vtkMRMLControlPolygonDisplayNode.h"
 #include "vtkMRMLLocatorNode.h"
 #include "vtkMRMLLocatorDisplayNode.h"
 
@@ -207,6 +208,11 @@ void vtkSlicerLiverResectionsLogic::RegisterNodes()
   // persistence flows through the plan storage node below.
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLParametricSurfaceDisplayNode>::New());
+
+  // Control-polygon display aspect (ADR-0033): the carrier's SECOND display
+  // node, keying the ControlPolygonPipeline (handles + edges + the
+  // per-point drag) independently of the surface display above.
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLControlPolygonDisplayNode>::New());
 
   // T3 ResectogramPipeline display node (ADR-0013 §1 + §5).  The
   // resectogram is the flattened 2D image of the Bezier (u, v) domain

--- a/LiverResections/MRML/CMakeLists.txt
+++ b/LiverResections/MRML/CMakeLists.txt
@@ -15,6 +15,8 @@ set(${KIT}_SRCS
   vtkMRMLParametricSurfaceDisplayNode.cxx
   vtkMRMLResectogramDisplayNode.h
   vtkMRMLResectogramDisplayNode.cxx
+  vtkMRMLControlPolygonDisplayNode.h
+  vtkMRMLControlPolygonDisplayNode.cxx
   vtkMRMLResectionPlanNode.h
   vtkMRMLResectionPlanNode.cxx
   vtkMRMLResectionPlanStorageNode.h

--- a/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/MRML/Testing/Cxx/CMakeLists.txt
@@ -12,6 +12,7 @@ set(KIT_TEST_SRCS
   vtkMRMLBezierSurfaceNodeTest1.cxx
   vtkMRMLParametricSurfaceDisplayNodeTest1.cxx
   vtkMRMLResectogramDisplayNodeTest1.cxx
+  vtkMRMLControlPolygonDisplayNodeTest1.cxx
   vtkMRMLAbstractParametricSurfaceNodeTest1.cxx
   vtkMRMLResectionPlanNodeTest1.cxx
   vtkMRMLResectionPlanStorageNodeTest1.cxx
@@ -52,6 +53,7 @@ slicerMacroConfigureModuleCxxTestDriver(
 SIMPLE_TEST(vtkMRMLBezierSurfaceNodeTest1)
 SIMPLE_TEST(vtkMRMLParametricSurfaceDisplayNodeTest1)
 SIMPLE_TEST(vtkMRMLResectogramDisplayNodeTest1)
+SIMPLE_TEST(vtkMRMLControlPolygonDisplayNodeTest1)
 SIMPLE_TEST(vtkMRMLAbstractParametricSurfaceNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanNodeTest1)
 SIMPLE_TEST(vtkMRMLResectionPlanStorageNodeTest1)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
@@ -66,7 +66,7 @@ int testDefaults()
   vtkNew<vtkMRMLControlPolygonDisplayNode> node;
 
   // HandleRadius sized for a liver-scale scene (v1's 2.5 read too small).
-  CHECK_DOUBLE(node->GetHandleRadius(), 4.0);
+  CHECK_DOUBLE(node->GetHandleRadius(), 6.0);
   double handleColor[3] = { 0.0, 0.0, 0.0 };
   node->GetHandleColor(handleColor);
   CHECK_DOUBLE(handleColor[0], 1.0);
@@ -74,10 +74,10 @@ int testDefaults()
   CHECK_DOUBLE(handleColor[2], 1.0);
   double edgeColor[3] = { 0.0, 0.0, 0.0 };
   node->GetEdgeColor(edgeColor);
-  CHECK_DOUBLE(edgeColor[0], 0.7);
-  CHECK_DOUBLE(edgeColor[1], 0.7);
-  CHECK_DOUBLE(edgeColor[2], 0.7);
-  CHECK_DOUBLE(node->GetEdgeWidth(), 1.0);
+  CHECK_DOUBLE(edgeColor[0], 1.0);
+  CHECK_DOUBLE(edgeColor[1], 0.0);
+  CHECK_DOUBLE(edgeColor[2], 0.0);
+  CHECK_DOUBLE(node->GetEdgeWidth(), 1.5);
 
   CHECK_STRING(node->GetNodeTagName(), "ControlPolygonDisplay");
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
@@ -1,0 +1,218 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the control-polygon display aspect (see ADR-0033).
+
+==============================================================================*/
+
+// LiverResections MRML includes
+#include "vtkMRMLControlPolygonDisplayNode.h"
+
+// MRML includes (ctkTest assertion macros)
+#include "vtkMRMLCoreTestingMacros.h"
+#include <vtkMRMLScene.h>
+
+// VTK includes
+#include <vtkNew.h>
+
+// STD includes
+#include <cctype>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// ADR-0033 §Conformance -- the control-polygon display node's accessor
+// surface: v1-parity defaults (HandleRadius 2.5), setter round-trips, the
+// XML write/read round-trip and CopyContent, mirroring the sibling
+// vtkMRMLResectogramDisplayNodeTest1 shape.
+
+namespace
+{
+
+int testDefaults()
+{
+  vtkNew<vtkMRMLControlPolygonDisplayNode> node;
+
+  // HandleRadius matches the retired v1 widget's glyph radius (ADR-0033).
+  CHECK_DOUBLE(node->GetHandleRadius(), 2.5);
+  double handleColor[3] = { 0.0, 0.0, 0.0 };
+  node->GetHandleColor(handleColor);
+  CHECK_DOUBLE(handleColor[0], 1.0);
+  CHECK_DOUBLE(handleColor[1], 1.0);
+  CHECK_DOUBLE(handleColor[2], 1.0);
+  double edgeColor[3] = { 0.0, 0.0, 0.0 };
+  node->GetEdgeColor(edgeColor);
+  CHECK_DOUBLE(edgeColor[0], 0.7);
+  CHECK_DOUBLE(edgeColor[1], 0.7);
+  CHECK_DOUBLE(edgeColor[2], 0.7);
+  CHECK_DOUBLE(node->GetEdgeWidth(), 1.0);
+
+  CHECK_STRING(node->GetNodeTagName(), "ControlPolygonDisplay");
+  return EXIT_SUCCESS;
+}
+
+int testSettersAndGetters()
+{
+  vtkNew<vtkMRMLControlPolygonDisplayNode> node;
+
+  node->SetHandleRadius(4.0);
+  CHECK_DOUBLE(node->GetHandleRadius(), 4.0);
+  node->SetHandleColor(0.1, 0.2, 0.3);
+  double handleColor[3] = { 0.0, 0.0, 0.0 };
+  node->GetHandleColor(handleColor);
+  CHECK_DOUBLE(handleColor[0], 0.1);
+  CHECK_DOUBLE(handleColor[1], 0.2);
+  CHECK_DOUBLE(handleColor[2], 0.3);
+  node->SetEdgeColor(0.4, 0.5, 0.6);
+  double edgeColor[3] = { 0.0, 0.0, 0.0 };
+  node->GetEdgeColor(edgeColor);
+  CHECK_DOUBLE(edgeColor[0], 0.4);
+  CHECK_DOUBLE(edgeColor[1], 0.5);
+  CHECK_DOUBLE(edgeColor[2], 0.6);
+  node->SetEdgeWidth(2.5);
+  CHECK_DOUBLE(node->GetEdgeWidth(), 2.5);
+  return EXIT_SUCCESS;
+}
+
+int testXMLRoundTrip()
+{
+  vtkNew<vtkMRMLControlPolygonDisplayNode> source;
+  vtkNew<vtkMRMLScene> scene;
+  source->SetScene(scene.GetPointer());
+
+  source->SetHandleRadius(4.0);
+  source->SetHandleColor(0.1, 0.2, 0.3);
+  source->SetEdgeColor(0.4, 0.5, 0.6);
+  source->SetEdgeWidth(2.5);
+
+  std::ostringstream out;
+  source->WriteXML(out, 0);
+  const std::string xml = out.str();
+
+  // Parse name="value" attribute pairs out of the WriteXML output.
+  std::vector<std::string> storage;
+  std::size_t pos = 0;
+  while (pos < xml.size())
+  {
+    while (pos < xml.size() && std::isspace(static_cast<unsigned char>(xml[pos])))
+    {
+      ++pos;
+    }
+    if (pos >= xml.size())
+    {
+      break;
+    }
+    const std::size_t eq = xml.find('=', pos);
+    if (eq == std::string::npos)
+    {
+      break;
+    }
+    std::string name = xml.substr(pos, eq - pos);
+    if (eq + 1 >= xml.size() || xml[eq + 1] != '"')
+    {
+      break;
+    }
+    const std::size_t valStart = eq + 2;
+    const std::size_t valEnd = xml.find('"', valStart);
+    if (valEnd == std::string::npos)
+    {
+      break;
+    }
+    storage.push_back(name);
+    storage.push_back(xml.substr(valStart, valEnd - valStart));
+    pos = valEnd + 1;
+  }
+
+  std::vector<const char*> atts;
+  atts.reserve(storage.size() + 1);
+  for (const auto& s : storage)
+  {
+    atts.push_back(s.c_str());
+  }
+  atts.push_back(nullptr);
+
+  vtkNew<vtkMRMLControlPolygonDisplayNode> sink;
+  sink->SetScene(scene.GetPointer());
+  sink->ReadXMLAttributes(atts.data());
+
+  CHECK_DOUBLE_TOLERANCE(sink->GetHandleRadius(), source->GetHandleRadius(), 1e-5);
+  double sourceHandle[3] = { 0.0, 0.0, 0.0 };
+  double sinkHandle[3] = { 0.0, 0.0, 0.0 };
+  source->GetHandleColor(sourceHandle);
+  sink->GetHandleColor(sinkHandle);
+  for (int i = 0; i < 3; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sinkHandle[i], sourceHandle[i], 1e-5);
+  }
+  double sourceEdge[3] = { 0.0, 0.0, 0.0 };
+  double sinkEdge[3] = { 0.0, 0.0, 0.0 };
+  source->GetEdgeColor(sourceEdge);
+  sink->GetEdgeColor(sinkEdge);
+  for (int i = 0; i < 3; ++i)
+  {
+    CHECK_DOUBLE_TOLERANCE(sinkEdge[i], sourceEdge[i], 1e-5);
+  }
+  CHECK_DOUBLE_TOLERANCE(sink->GetEdgeWidth(), source->GetEdgeWidth(), 1e-5);
+  return EXIT_SUCCESS;
+}
+
+int testCopyContent()
+{
+  vtkNew<vtkMRMLControlPolygonDisplayNode> source;
+  source->SetHandleRadius(4.0);
+  source->SetEdgeWidth(2.5);
+
+  vtkNew<vtkMRMLControlPolygonDisplayNode> sink;
+  sink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
+
+  CHECK_DOUBLE(sink->GetHandleRadius(), 4.0);
+  CHECK_DOUBLE(sink->GetEdgeWidth(), 2.5);
+
+  // Mutating source must not affect sink (deep-copy semantics).
+  source->SetHandleRadius(1.0);
+  CHECK_DOUBLE(sink->GetHandleRadius(), 4.0);
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+int vtkMRMLControlPolygonDisplayNodeTest1(int, char*[])
+{
+  CHECK_EXIT_SUCCESS(testDefaults());
+  CHECK_EXIT_SUCCESS(testSettersAndGetters());
+  CHECK_EXIT_SUCCESS(testXMLRoundTrip());
+  CHECK_EXIT_SUCCESS(testCopyContent());
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
@@ -65,8 +65,8 @@ int testDefaults()
 {
   vtkNew<vtkMRMLControlPolygonDisplayNode> node;
 
-  // HandleRadius matches the retired v1 widget's glyph radius (ADR-0033).
-  CHECK_DOUBLE(node->GetHandleRadius(), 2.5);
+  // HandleRadius sized for a liver-scale scene (v1's 2.5 read too small).
+  CHECK_DOUBLE(node->GetHandleRadius(), 4.0);
   double handleColor[3] = { 0.0, 0.0, 0.0 };
   node->GetHandleColor(handleColor);
   CHECK_DOUBLE(handleColor[0], 1.0);

--- a/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
+++ b/LiverResections/MRML/vtkMRMLBezierSurfaceNode.cxx
@@ -39,6 +39,7 @@
 
 // This module MRML includes
 #include "vtkMRMLBezierSurfaceNode.h"
+#include "vtkMRMLControlPolygonDisplayNode.h"
 #include "vtkMRMLParametricSurfaceDisplayNode.h"
 
 // MRML includes
@@ -391,6 +392,14 @@ void vtkMRMLBezierSurfaceNode::CreateDefaultDisplayNodes()
   auto displayNode = vtkSmartPointer<vtkMRMLParametricSurfaceDisplayNode>::New();
   this->GetScene()->AddNode(displayNode);
   this->SetAndObserveDisplayNodeID(displayNode->GetID());
+
+  // The control polygon is a first-class display aspect with its OWN display
+  // node (ADR-0033): mint it alongside the surface display so the
+  // ControlPolygonPipeline renders the handles + edges and hosts the
+  // per-point drag, independently visible/stylable from the surface.
+  auto controlPolygonDisplayNode = vtkSmartPointer<vtkMRMLControlPolygonDisplayNode>::New();
+  this->GetScene()->AddNode(controlPolygonDisplayNode);
+  this->AddAndObserveDisplayNodeID(controlPolygonDisplayNode->GetID());
 }
 
 //------------------------------------------------------------------------------

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
@@ -51,9 +51,9 @@ vtkMRMLNodeNewMacro(vtkMRMLControlPolygonDisplayNode);
 
 //------------------------------------------------------------------------------
 vtkMRMLControlPolygonDisplayNode::vtkMRMLControlPolygonDisplayNode()
-  // HandleRadius matches the retired v1 widget's glyph radius so the v2
-  // handles read at the familiar size (ADR-0033).
-  : HandleRadius(2.5)
+  // HandleRadius reads clearly over a liver-scale (~200 mm) scene; the v1
+  // widget's 2.5 glyph radius proved too small in hands-on use (ADR-0033).
+  : HandleRadius(4.0)
   , HandleColor{ 1.0, 1.0, 1.0 }
   , EdgeColor{ 0.7, 0.7, 0.7 }
   , EdgeWidth(1.0)

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
@@ -53,10 +53,10 @@ vtkMRMLNodeNewMacro(vtkMRMLControlPolygonDisplayNode);
 vtkMRMLControlPolygonDisplayNode::vtkMRMLControlPolygonDisplayNode()
   // HandleRadius reads clearly over a liver-scale (~200 mm) scene; the v1
   // widget's 2.5 glyph radius proved too small in hands-on use (ADR-0033).
-  : HandleRadius(4.0)
+  : HandleRadius(6.0)
   , HandleColor{ 1.0, 1.0, 1.0 }
-  , EdgeColor{ 0.7, 0.7, 0.7 }
-  , EdgeWidth(1.0)
+  , EdgeColor{ 1.0, 0.0, 0.0 }
+  , EdgeWidth(1.5)
 {
 }
 

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
@@ -1,0 +1,121 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the control-polygon display aspect (see ADR-0033).
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLControlPolygonDisplayNode.h"
+
+// MRML includes
+#include <vtkMRMLNodePropertyMacros.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLControlPolygonDisplayNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLControlPolygonDisplayNode::vtkMRMLControlPolygonDisplayNode()
+  // HandleRadius matches the retired v1 widget's glyph radius so the v2
+  // handles read at the familiar size (ADR-0033).
+  : HandleRadius(2.5)
+  , HandleColor{ 1.0, 1.0, 1.0 }
+  , EdgeColor{ 0.7, 0.7, 0.7 }
+  , EdgeWidth(1.0)
+{
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLControlPolygonDisplayNode::~vtkMRMLControlPolygonDisplayNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLControlPolygonDisplayNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent);
+
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLFloatMacro(handleRadius, HandleRadius);
+  vtkMRMLWriteXMLVectorMacro(handleColor, HandleColor, double, 3);
+  vtkMRMLWriteXMLVectorMacro(edgeColor, EdgeColor, double, 3);
+  vtkMRMLWriteXMLFloatMacro(edgeWidth, EdgeWidth);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLControlPolygonDisplayNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+
+  Superclass::ReadXMLAttributes(atts);
+
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLFloatMacro(handleRadius, HandleRadius);
+  vtkMRMLReadXMLVectorMacro(handleColor, HandleColor, double, 3);
+  vtkMRMLReadXMLVectorMacro(edgeColor, EdgeColor, double, 3);
+  vtkMRMLReadXMLFloatMacro(edgeWidth, EdgeWidth);
+  vtkMRMLReadXMLEndMacro();
+
+  this->EndModify(disabledModify);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLControlPolygonDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyFloatMacro(HandleRadius);
+  vtkMRMLCopyVectorMacro(HandleColor, double, 3);
+  vtkMRMLCopyVectorMacro(EdgeColor, double, 3);
+  vtkMRMLCopyFloatMacro(EdgeWidth);
+  vtkMRMLCopyEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLControlPolygonDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintFloatMacro(HandleRadius);
+  vtkMRMLPrintVectorMacro(HandleColor, double, 3);
+  vtkMRMLPrintVectorMacro(EdgeColor, double, 3);
+  vtkMRMLPrintFloatMacro(EdgeWidth);
+  vtkMRMLPrintEndMacro();
+}

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
@@ -66,11 +66,13 @@
  * \par Field roster
  *
  *   - ``HandleRadius`` — control-point handle sphere radius in world
- *     units (default 2.5, matching the retired v1 widget's glyph
- *     radius).
+ *     units (default 4.0; the v1 widget's 2.5 read too small over a
+ *     liver-scale scene).
  *   - ``HandleColor`` — handle sphere colour.
  *   - ``EdgeColor`` — polygon edge colour.
- *   - ``EdgeWidth`` — polygon edge line width in pixels.
+ *   - ``EdgeWidth`` — polygon edge TUBE radius in world units (the
+ *     edges render as vtkTubeFilter tubes, not GL lines, so they share
+ *     the handles' world metric).
  *
  * Base ``vtkMRMLDisplayNode`` supplies the independent ``Visibility``
  * and per-view ``ViewNodeIDs`` (ADR-0033 §Decision 1).
@@ -116,7 +118,7 @@ public:
   vtkSetVector3Macro(EdgeColor, double);
   vtkGetVector3Macro(EdgeColor, double);
 
-  /// Polygon edge line width, pixels.
+  /// Polygon edge tube radius, world units.
   vtkSetMacro(EdgeWidth, double);
   vtkGetMacro(EdgeWidth, double);
 

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
@@ -1,0 +1,137 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was originally developed for the Slicer-Liver extension as
+  part of the control-polygon display aspect (see ADR-0033).
+
+==============================================================================*/
+
+#ifndef __vtkmrmlcontrolpolygondisplaynode_h_
+#define __vtkmrmlcontrolpolygondisplaynode_h_
+
+#include "vtkSlicerLiverResectionsModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLDisplayNode.h>
+
+// VTK includes
+#include <vtkSetGet.h>
+
+/**
+ * \class vtkMRMLControlPolygonDisplayNode
+ *
+ * \brief Display node for the parametric surface's control polygon.
+ *
+ * Per ADR-0033 the control polygon — the ``Rows x Cols`` control-point
+ * handles plus their connecting edges — is a first-class display aspect
+ * of the parametric-surface carrier, distinct from the surface itself:
+ * it has its own visual properties, hosts the per-point drag
+ * interaction, and is shown/hidden independently of the surface.  The
+ * carrier's ``CreateDefaultDisplayNodes`` therefore mints TWO display
+ * nodes (MRML's one-displayable-many-display-nodes pattern): the
+ * ``vtkMRMLParametricSurfaceDisplayNode`` keying the surface Pipeline
+ * and THIS node keying the ``ControlPolygonPipeline``
+ * (ADR-0013 §1: one LayerDM Pipeline per display-node type).
+ *
+ * \par Field roster
+ *
+ *   - ``HandleRadius`` — control-point handle sphere radius in world
+ *     units (default 2.5, matching the retired v1 widget's glyph
+ *     radius).
+ *   - ``HandleColor`` — handle sphere colour.
+ *   - ``EdgeColor`` — polygon edge colour.
+ *   - ``EdgeWidth`` — polygon edge line width in pixels.
+ *
+ * Base ``vtkMRMLDisplayNode`` supplies the independent ``Visibility``
+ * and per-view ``ViewNodeIDs`` (ADR-0033 §Decision 1).
+ */
+class VTK_SLICER_LIVERRESECTIONS_MODULE_MRML_EXPORT vtkMRMLControlPolygonDisplayNode : public vtkMRMLDisplayNode
+{
+public:
+  static vtkMRMLControlPolygonDisplayNode* New();
+  vtkTypeMacro(vtkMRMLControlPolygonDisplayNode, vtkMRMLDisplayNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Get node XML tag name (like Volume, Model).
+  const char* GetNodeTagName() override { return "ControlPolygonDisplay"; }
+
+  /// Read node attributes from XML.
+  void ReadXMLAttributes(const char** atts) override;
+
+  /// Write this node's information to a MRML file in XML format.
+  void WriteXML(ostream& of, int indent) override;
+
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  void CopyContent(vtkMRMLNode* anode, bool deepCopy = true) override;
+
+  //--------------------------------------------------------------------------
+  // Control-polygon display fields (ADR-0033)
+  //--------------------------------------------------------------------------
+
+  /// Control-point handle sphere radius, world units.
+  vtkSetMacro(HandleRadius, double);
+  vtkGetMacro(HandleRadius, double);
+
+  /// Control-point handle colour.
+  vtkSetVector3Macro(HandleColor, double);
+  vtkGetVector3Macro(HandleColor, double);
+
+  /// Polygon edge colour.
+  vtkSetVector3Macro(EdgeColor, double);
+  vtkGetVector3Macro(EdgeColor, double);
+
+  /// Polygon edge line width, pixels.
+  vtkSetMacro(EdgeWidth, double);
+  vtkGetMacro(EdgeWidth, double);
+
+protected:
+  vtkMRMLControlPolygonDisplayNode();
+  ~vtkMRMLControlPolygonDisplayNode() override;
+
+private:
+  vtkMRMLControlPolygonDisplayNode(const vtkMRMLControlPolygonDisplayNode&) = delete;
+  void operator=(const vtkMRMLControlPolygonDisplayNode&) = delete;
+
+  double HandleRadius;
+  double HandleColor[3];
+  double EdgeColor[3];
+  double EdgeWidth;
+};
+
+#endif //__vtkmrmlcontrolpolygondisplaynode_h_

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
@@ -66,7 +66,7 @@
  * \par Field roster
  *
  *   - ``HandleRadius`` — control-point handle sphere radius in world
- *     units (default 4.0; the v1 widget's 2.5 read too small over a
+ *     units (default 6.0; the v1 widget's 2.5 read too small over a
  *     liver-scale scene).
  *   - ``HandleColor`` — handle sphere colour.
  *   - ``EdgeColor`` — polygon edge colour.

--- a/LiverResections/Testing/Python/test_pipeline_control_point_edit.py
+++ b/LiverResections/Testing/Python/test_pipeline_control_point_edit.py
@@ -101,16 +101,19 @@ def _slicer_or_skip():
 
 
 def _make_pipeline_or_skip():
+    # ADR-0033 re-sited the Planning per-point drag onto the control
+    # polygon's own Pipeline (superseding the ADR-0032 siting on the
+    # surface Pipeline these invariants originally pinned).
     try:
-        from LiverResectionsLib.LiverBezierSurfacePipeline import (
-            LiverBezierSurfacePipeline,
+        from LiverResectionsLib.ControlPolygonPipeline import (
+            ControlPolygonPipeline,
         )
     except Exception as exc:  # pragma: no cover - import-environment dependent
         pytest.skip(
-            f"LiverBezierSurfacePipeline not importable ({exc!r}) -- LayerDMLib "
+            f"ControlPolygonPipeline not importable ({exc!r}) -- LayerDMLib "
             "not reachable in this environment."
         )
-    return LiverBezierSurfacePipeline()
+    return ControlPolygonPipeline()
 
 
 def _resection_logic_or_skip(slicer):

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -196,6 +196,7 @@ void qSlicerLiverResectionsModule::setup()
                                    "    import LiverResectionsLib\n"
                                    "    LiverResectionsLib.registerPipelineCreator()\n"
                                    "    LiverResectionsLib.registerResectogramPipelineCreator()\n"
+                                   "    LiverResectionsLib.registerControlPolygonPipelineCreator()\n"
                                    "except ImportError as exc:\n"
                                    "    import logging\n"
                                    "    logging.critical('LiverResections: LayerDM Pipeline creator not registered (%s)'\n"

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -239,3 +239,78 @@ def test_geometry_edit_requests_render(pipeline_module, polygon_nodes):
         "(the render feedback-loop guard)."
     )
     pipeline.cleanup()
+
+
+class _TypedEvent:
+    """Interaction event stub carrying a VTK event type + display position."""
+
+    def __init__(self, etype, pos=(0.0, 0.0)):
+        self._etype = etype
+        self._pos = pos
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+def test_drag_is_press_grab_move_release(pipeline_module, polygon_nodes):
+    """The per-point drag is a press/move/release GRAB, not proximity chasing.
+
+    A hover move near a handle must never edit; a left-button press within
+    the pick radius grabs ONE handle; moves while grabbed edit THAT handle
+    (even if the cursor drifts nearer another one); the release ends the
+    grab (returns False so the focus is released) and subsequent hover
+    moves are declined again.
+    """
+    import vtk
+
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+    data.SetState(1)  # Planning
+
+    # GL-free seams: a live-renderer stand-in + deterministic pick geometry.
+    pipeline._safe_get_renderer = lambda: object()
+    pipeline._nearest_control_point_in_display = lambda r, e: (5, 4.0)
+    pipeline._event_world_at_control_point = lambda r, e, i: (50.0, 60.0, 5.0)
+
+    move = _TypedEvent(vtk.vtkCommand.MouseMoveEvent)
+    press = _TypedEvent(vtk.vtkCommand.LeftButtonPressEvent)
+    release = _TypedEvent(vtk.vtkCommand.LeftButtonReleaseEvent)
+
+    can, _ = pipeline.CanProcessInteractionEvent(move)
+    assert can is False, "a hover move (no grab) must not be claimed"
+    assert pipeline.ProcessInteractionEvent(move) is False
+
+    can, d2 = pipeline.CanProcessInteractionEvent(press)
+    assert can is True and d2 == pytest.approx(4.0)
+    assert pipeline.ProcessInteractionEvent(press) is True, "press begins the grab"
+
+    can, _ = pipeline.CanProcessInteractionEvent(move)
+    assert can is True, "moves while grabbed are claimed"
+    # The cursor now reads nearer ANOTHER handle -- the grab must stick to 5.
+    pipeline._nearest_control_point_in_display = lambda r, e: (0, 1.0)
+    assert pipeline.ProcessInteractionEvent(move) is True
+    grid = data.GetControlGridVector()
+    assert (grid[15], grid[16], grid[17]) == pytest.approx((50.0, 60.0, 5.0)), (
+        "the move edits the GRABBED handle (index 5), not the nearest one"
+    )
+    assert (grid[0], grid[1], grid[2]) == pytest.approx((0.0, 0.0, 5.0)), (
+        "handle 0 (now nearest) must be untouched mid-grab"
+    )
+
+    can, _ = pipeline.CanProcessInteractionEvent(release)
+    assert can is True, "the release while grabbed is claimed (ends the grab)"
+    assert pipeline.ProcessInteractionEvent(release) is False, (
+        "release ends the grab and releases the focus"
+    )
+
+    can, _ = pipeline.CanProcessInteractionEvent(move)
+    assert can is False, (
+        "after release, hover moves must be declined again -- the "
+        "released-mouse-still-edits failure mode."
+    )
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Invariants for the ``ControlPolygonPipeline`` (ADR-0033).
+
+The control polygon is a first-class display aspect: its own display node
+(``vtkMRMLControlPolygonDisplayNode``, the carrier's second display node) keys
+its own LayerDM Pipeline, which renders the handles + edges and hosts the
+Planning per-point drag with a real display-space ``distance2``.
+
+Pins (ADR-0033 §Conformance):
+
+* handles + edges follow the carrier's control grid;
+* edge cells come from the (injected) Algorithm builder, once per shape;
+* Planning-only visibility, further gated by the display node's Visibility;
+* the drag kernel writes ``SetControlPoint`` in Planning and refuses
+  otherwise;
+* ``CanProcessInteractionEvent`` declines outside Planning / without a
+  renderer (the finite-distance2 arbitration path needs a live camera and is
+  exercised on the interactive pass);
+* the late-binding hook adopts a displayable linked after ``SetDisplayNode``.
+
+These need the wrapped MRML nodes + LayerDMLib, so they run under the
+launched ``pytest_launched`` row and skip cleanly under bare pytest.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("LayerDMLib")
+
+
+@pytest.fixture
+def pipeline_module():
+    import ControlPolygonPipeline as mod
+
+    return mod
+
+
+@pytest.fixture
+def polygon_nodes():
+    """A carrier + control-polygon display node pair, linked."""
+    import slicer
+
+    scene = slicer.mrmlScene
+    data = scene.AddNewNodeByClass("vtkMRMLBezierSurfaceNode")
+    display = scene.AddNewNodeByClass("vtkMRMLControlPolygonDisplayNode")
+    data.AddAndObserveDisplayNodeID(display.GetID())
+    try:
+        yield data, display
+    finally:
+        scene.RemoveNode(display)
+        scene.RemoveNode(data)
+
+
+class _FakeGeometry:
+    calls: list = []
+
+    @staticmethod
+    def BuildControlPolygonCells(rows, cols):  # noqa: N802 - VTK verb
+        import vtk
+
+        _FakeGeometry.calls.append((rows, cols))
+        cells = vtk.vtkCellArray()
+        for r in range(rows):
+            line = vtk.vtkPolyLine()
+            line.GetPointIds().SetNumberOfIds(cols)
+            for c in range(cols):
+                line.GetPointIds().SetId(c, r * cols + c)
+            cells.InsertNextCell(line)
+        return cells
+
+
+def _seed_grid(data):
+    for r in range(4):
+        for c in range(4):
+            data.SetControlPoint(r, c, float(c) * 10.0, float(r) * 10.0, 5.0)
+
+
+def test_handles_and_edges_follow_the_grid(pipeline_module, polygon_nodes):
+    """Planning state + seeded grid -> 16 handle points + builder-cells edges."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline._control_polygon_geometry = _FakeGeometry
+    _FakeGeometry.calls = []
+    pipeline.SetDisplayNode(display)
+
+    _seed_grid(data)
+    data.SetState(1)  # Planning
+    pipeline.UpdatePipeline()
+
+    handles = pipeline.GetHandlesPolyData()
+    assert handles.GetNumberOfPoints() == 16
+    assert handles.GetPoint(5) == pytest.approx((10.0, 10.0, 5.0))
+    edges = pipeline.GetEdgesPolyData()
+    assert edges.GetNumberOfPoints() == 16
+    assert edges.GetNumberOfLines() == 4
+    assert _FakeGeometry.calls == [(4, 4)], "cells built once, with (rows, cols)"
+    pipeline.cleanup()
+
+
+def test_visibility_is_planning_only_and_display_gated(pipeline_module, polygon_nodes):
+    """Hidden in Init; visible in Planning; hidden when the display says so."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline._control_polygon_geometry = _FakeGeometry
+    pipeline.SetDisplayNode(display)
+
+    pipeline.UpdatePipeline()  # Init (default state)
+    assert pipeline.GetHandlesActor().GetVisibility() == 0
+    assert pipeline.GetEdgesActor().GetVisibility() == 0
+
+    _seed_grid(data)
+    data.SetState(1)  # Planning
+    pipeline.UpdatePipeline()
+    assert pipeline.GetHandlesActor().GetVisibility() == 1
+    assert pipeline.GetEdgesActor().GetVisibility() == 1
+
+    display.SetVisibility(False)
+    pipeline.UpdatePipeline()
+    assert pipeline.GetHandlesActor().GetVisibility() == 0, (
+        "the display node's Visibility must hide the polygon independently "
+        "of the surface (ADR-0033)."
+    )
+    pipeline.cleanup()
+
+
+def test_display_styling_reaches_the_actors(pipeline_module, polygon_nodes):
+    """HandleRadius / colors / EdgeWidth flow display node -> actors."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline._control_polygon_geometry = _FakeGeometry
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+    data.SetState(1)
+    display.SetHandleColor(0.1, 0.2, 0.3)
+    display.SetEdgeColor(0.4, 0.5, 0.6)
+    display.SetEdgeWidth(3.0)
+    pipeline.UpdatePipeline()
+
+    assert pipeline.GetHandlesActor().GetProperty().GetColor() == pytest.approx((0.1, 0.2, 0.3))
+    assert pipeline.GetEdgesActor().GetProperty().GetColor() == pytest.approx((0.4, 0.5, 0.6))
+    assert pipeline.GetEdgesActor().GetProperty().GetLineWidth() == pytest.approx(3.0)
+    pipeline.cleanup()
+
+
+def test_drag_kernel_moves_nearest_point_in_planning_only(pipeline_module, polygon_nodes):
+    """The GL-free kernel writes SetControlPoint in Planning; refuses in Init."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+
+    # Init: editing refused (ADR-0019).
+    assert pipeline._apply_world_point_to_nearest_control_point((1.0, 1.0, 5.0)) is None
+
+    data.SetState(1)  # Planning
+    moved = pipeline._apply_world_point_to_nearest_control_point((1.0, 2.0, 5.0))
+    assert moved == 0, "the nearest control point (index 0 at origin) moves"
+    grid = data.GetControlGridVector()
+    assert (grid[0], grid[1], grid[2]) == pytest.approx((1.0, 2.0, 5.0))
+    pipeline.cleanup()
+
+
+def test_can_process_declines_without_planning_or_renderer(pipeline_module, polygon_nodes):
+    """Arbitration preconditions: Planning state AND a live renderer."""
+    import sys
+
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+
+    class _Event:
+        def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+            return (0.0, 0.0)
+
+    can, d2 = pipeline.CanProcessInteractionEvent(_Event())
+    assert can is False and d2 == pytest.approx(sys.float_info.max), "Init declines"
+
+    data.SetState(1)
+    can, d2 = pipeline.CanProcessInteractionEvent(_Event())
+    assert can is False, "no renderer -> declines (display->world needs a camera)"
+    pipeline.cleanup()
+
+
+def test_late_bound_displayable_is_adopted(pipeline_module):
+    """The reference-added hook + UpdatePipeline late-bind the carrier."""
+    import slicer
+
+    scene = slicer.mrmlScene
+    data = scene.AddNewNodeByClass("vtkMRMLBezierSurfaceNode")
+    display = scene.AddNewNodeByClass("vtkMRMLControlPolygonDisplayNode")
+    try:
+        pipeline = pipeline_module.ControlPolygonPipeline()
+        pipeline.SetDisplayNode(display)
+        assert pipeline.GetDataNode() is None
+
+        data.AddAndObserveDisplayNodeID(display.GetID())
+        pipeline.OnReferenceToDisplayNodeAdded(data, "display")
+        assert pipeline.GetDataNode() is data
+        pipeline.cleanup()
+    finally:
+        scene.RemoveNode(display)
+        scene.RemoveNode(data)

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -318,3 +318,43 @@ def test_drag_is_press_grab_move_release(pipeline_module, polygon_nodes):
         "released-mouse-still-edits failure mode."
     )
     pipeline.cleanup()
+
+
+class _ChurnRenderer:
+    def AddActor(self, actor):  # noqa: N802 - VTK verb
+        pass
+
+    def RemoveActor(self, actor):  # noqa: N802 - VTK verb
+        pass
+
+
+def test_styling_survives_renderer_churn(pipeline_module, polygon_nodes):
+    """Renderer churn must not leave the pipeline displayless.
+
+    The manager's lifecycle removes and re-adds the renderer around
+    ``SetDisplayNode`` (and on view rebuilds).  ``OnRendererRemoved`` ->
+    ``cleanup()`` clears the node handles; ``OnRendererAdded`` must
+    re-derive them from the base's retained display node, or the pipeline
+    runs displayless forever and every styling field silently stays at the
+    raw VTK defaults (0.5-radius spheres, hairline white lines -- the
+    'tiny control points' failure mode observed live).
+    """
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline._control_polygon_geometry = _FakeGeometry
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+    data.SetState(1)  # Planning
+
+    renderer = _ChurnRenderer()
+    pipeline.OnRendererRemoved(renderer)  # cleanup() clears the node handles
+    pipeline.OnRendererAdded(renderer)    # must re-derive + restyle
+
+    assert pipeline.GetDataNode() is data, "the carrier must be re-derived"
+    assert pipeline._handle_sphere.GetRadius() == pytest.approx(
+        display.GetHandleRadius()
+    ), "the display styling must reach the glyph source after the churn"
+    assert pipeline._edges_tube.GetRadius() == pytest.approx(
+        display.GetEdgeWidth()
+    ), "the display styling must reach the edge tubes after the churn"
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -141,7 +141,11 @@ def test_display_styling_reaches_the_actors(pipeline_module, polygon_nodes):
 
     assert pipeline.GetHandlesActor().GetProperty().GetColor() == pytest.approx((0.1, 0.2, 0.3))
     assert pipeline.GetEdgesActor().GetProperty().GetColor() == pytest.approx((0.4, 0.5, 0.6))
-    assert pipeline.GetEdgesActor().GetProperty().GetLineWidth() == pytest.approx(3.0)
+    assert pipeline._edges_tube.GetRadius() == pytest.approx(3.0), (
+        "EdgeWidth is the edge TUBE radius (world units) -- edges render "
+        "as vtkTubeFilter tubes, not GL lines (pixel line width reads "
+        "hairline-thin at liver scale)."
+    )
     pipeline.cleanup()
 
 

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -358,3 +358,51 @@ def test_styling_survives_renderer_churn(pipeline_module, polygon_nodes):
         display.GetEdgeWidth()
     ), "the display styling must reach the edge tubes after the churn"
     pipeline.cleanup()
+
+
+def test_hover_highlights_nearest_handle(pipeline_module, polygon_nodes):
+    """A bare hover near a handle shows the halo; far away hides it.
+
+    Hover detection is a SIDE EFFECT of the arbitration moves the LayerDM
+    logic already sends through ``CanProcessInteractionEvent``: the bare
+    move is still DECLINED (camera interaction untouched), but the halo
+    actor is positioned on the hovered handle and a render is requested --
+    exactly once per hover change, not per move event.
+    """
+    import vtk
+
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline._control_polygon_geometry = _FakeGeometry
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+    data.SetState(1)  # Planning
+
+    pipeline._safe_get_renderer = lambda: object()
+    pipeline._nearest_control_point_in_display = lambda r, e: (5, 4.0)
+    renders = []
+    pipeline.RequestRender = lambda: renders.append(1)
+
+    move = _TypedEvent(vtk.vtkCommand.MouseMoveEvent)
+    can, _ = pipeline.CanProcessInteractionEvent(move)
+    assert can is False, "bare hover moves stay declined"
+    assert pipeline.GetHaloActor().GetVisibility() == 1, (
+        "hovering within the pick radius must show the halo"
+    )
+    assert tuple(pipeline.GetHaloActor().GetPosition()) == pytest.approx(
+        (10.0, 10.0, 5.0)
+    ), "the halo sits on the hovered handle (index 5)"
+    n = len(renders)
+    assert n >= 1, "the hover change requests a render"
+
+    pipeline.CanProcessInteractionEvent(move)  # same hover -- no re-request
+    assert len(renders) == n, "an unchanged hover must not re-request renders"
+
+    pipeline._nearest_control_point_in_display = (
+        lambda r, e: (None, 1e12)
+    )  # cursor far from every handle
+    pipeline.CanProcessInteractionEvent(move)
+    assert pipeline.GetHaloActor().GetVisibility() == 0, (
+        "leaving the pick radius hides the halo"
+    )
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -204,3 +204,38 @@ def test_late_bound_displayable_is_adopted(pipeline_module):
     finally:
         scene.RemoveNode(display)
         scene.RemoveNode(data)
+
+
+def test_geometry_edit_requests_render(pipeline_module, polygon_nodes):
+    """A control-point edit must request a render; MTime churn must not.
+
+    The observer callback re-runs ``UpdatePipeline`` but historically never
+    requested a render, so a Planning drag moved the handles/edges polydata
+    while the 3D view stayed frozen until an unrelated render (camera orbit)
+    repainted it.  The request is gated on the (state, geometry-digest)
+    tuple (the ResectogramPipeline pattern) so a render-induced ``Modified``
+    at fixed geometry cannot open a render feedback loop.
+    """
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline._control_polygon_geometry = _FakeGeometry
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+    data.SetState(1)  # Planning
+
+    renders = []
+    pipeline.RequestRender = lambda: renders.append(1)
+
+    data.SetControlPoint(0, 0, 1.0, 2.0, 3.0)
+    assert renders, (
+        "a control-point edit must request a render -- without it the "
+        "handles freeze mid-drag until an unrelated render repaints them."
+    )
+
+    before = len(renders)
+    data.Modified()  # no geometry change -- render-churn signature
+    assert len(renders) == before, (
+        "a Modified at fixed geometry must not re-request a render "
+        "(the render feedback-loop guard)."
+    )
+    pipeline.cleanup()


### PR DESCRIPTION
## Summary

The first live render of the Planning surface exposed that the **control polygon** (the `Rows×Cols` handles + edges the surgeon drags) was never rendered — the ADR-0032 per-point drag worked, but blind; `BuildControlPolygonCells` had zero production consumers. (Not to be confused with the shader-drawn *resection grid*, which is a surface feature.)

Per maintainer review, the control polygon is a **first-class display aspect** — distinct visual properties, its own interaction, independently disableable — designed in **ADR-0033** (in this PR), which supersedes ADR-0032's interaction *siting* while keeping its seam mechanism:

1. **`vtkMRMLControlPolygonDisplayNode`** — the carrier's *second* display node (MRML's one-displayable-many-display-nodes pattern; `CreateDefaultDisplayNodes` mints both). Fields: `HandleRadius` (2.5, v1 glyph parity), `HandleColor`, `EdgeColor`, `EdgeWidth`; base class provides independent `Visibility` + per-view `ViewNodeIDs`.
2. **`ControlPolygonPipeline`** — keyed on the new display type (ADR-0013 §1). Renders sphere-glyph handles + Algorithm-built edges following the control grid; **Planning-only** visibility (ADR-0019), further gated by the display node; late-binds the carrier via `OnReferenceToDisplayNodeAdded`; its creator **excludes the resectogram singleton view** (the leak class of the open resectogram-view issue).
3. **Interaction re-sited**: the per-point drag kernels move here; `CanProcessInteractionEvent` returns the *real* display-space distance to the nearest handle — LayerDM focus arbitration gets a meaningful `distance2` instead of the surface Pipeline's blanket claim. The surface Pipeline keeps only the Init-mode placements. The edit-seam invariant tests re-point unchanged in substance.

## ADR references

- **ADR-0033 (new, in this PR)** — the design; supersedes (in part) ADR-0032 + ADR-0014 §3 rendering notes.
- ADR-0013 §1/§5 — one Pipeline per display-node type; the three-call registration contract (no custom DM).
- ADR-0018 — `BuildControlPolygonCells` stays the Algorithm-library SSOT shared with the v2.1 NURBS sibling.
- ADR-0019 — Planning-only editability/visibility.

## Conformance

- `vtkMRMLControlPolygonDisplayNodeTest1` (CxxTest): defaults, setters, XML round-trip, CopyContent.
- `Testing/Python/unit/test_control_polygon_pipeline.py` (6 pins): grid-following handles+edges, builder-cells once per shape, Planning-only + display-gated visibility, styling flow, drag-kernel Planning gate, arbitration preconditions, late binding.
- `test_pipeline_control_point_edit.py` — the ADR-0032 edit invariants, now running against the new home.

## Test plan

- [x] CxxTest passes
- [x] Full three-root launched run: **289 passed / 0 failed**
- [x] Live demo on real anatomy: handles + edges render on the Planning surface (maintainer eyeball in progress)

## UX impact

The surgeon can now *see* the control points they drag: white handle spheres + gray polygon edges on the Planning surface, hidden in Init/Confirmed, toggleable independently of the surface. Styling lives on the new display node. State-machine unchanged (ADR-0019 gates as before).

Implements ADR-0033. Related: the v2.1 ring-group manipulation lands on this Pipeline.