### PR TITLE
BUG: Keep surface-family pipelines out of the resectogram view

### DIFF
--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -1080,6 +1080,31 @@ def _safe_get_mtime(node: Any) -> int:
 _REGISTERED = False
 
 
+def _is_resectogram_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
+    """Whether ``viewNode`` is the dedicated resectogram singleton view.
+
+    That view is owned solely by the ``ResectogramPipeline`` (the
+    flattened strip + locator click seam, ADR-0023 §Stage-4); the
+    surface-family creators must decline it, or the deformable 3D
+    surface pipeline is instantiated INSIDE the flattened 2D strip.
+    Recognised by the MRML ``SingletonTag`` the view manager mints the
+    view with; defensively False for anything lacking the accessor.
+    """
+    tag_getter = getattr(viewNode, "GetSingletonTag", None)
+    if tag_getter is None:
+        return False
+    try:
+        from .ResectogramViewManager import RESECTOGRAM_VIEW_SINGLETON_TAG
+    except ImportError:  # pragma: no cover - top-level import path
+        from ResectogramViewManager import (  # type: ignore[no-redef]
+            RESECTOGRAM_VIEW_SINGLETON_TAG,
+        )
+    try:
+        return tag_getter() == RESECTOGRAM_VIEW_SINGLETON_TAG
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
 def registerPipelineCreator() -> None:
     """Register the ``LiverBezierSurfacePipeline`` creator with LayerDM.
 
@@ -1127,6 +1152,11 @@ def registerPipelineCreator() -> None:
         # there so other registered creators (or no creator at all)
         # handle the slice path.
         if not isinstance(viewNode, vtkMRMLViewNode):
+            return None
+        # The resectogram singleton view is the ResectogramPipeline's
+        # alone (ADR-0023 §Stage-4) — decline it so the deformable 3D
+        # surface never renders inside the flattened strip.
+        if _is_resectogram_view(viewNode):
             return None
         if not isinstance(node, vtkMRMLParametricSurfaceDisplayNode):
             return None

--- a/LiverResections/LiverResectionsLib/ResectogramViewManager.py
+++ b/LiverResections/LiverResectionsLib/ResectogramViewManager.py
@@ -109,7 +109,13 @@ class ResectogramViewManager:
             self._view_node = existing
             return existing
 
-        view = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLViewNode")
+        # Configure BEFORE AddNode: LayerDM pipeline creators are consulted
+        # the moment the node enters the scene, and the surface-family
+        # creators exclude this view BY its singleton tag (ADR-0023
+        # §Stage-4) -- an add-then-tag order leaks deformable surface
+        # pipelines into the flattened strip.
+        view = slicer.mrmlScene.CreateNodeByClass("vtkMRMLViewNode")
+        view.UnRegister(None)
         view.SetName(_RESECTOGRAM_VIEW_LAYOUT_NAME)
         view.SetSingletonTag(RESECTOGRAM_VIEW_SINGLETON_TAG)
         view.SetLayoutName(_RESECTOGRAM_VIEW_LAYOUT_NAME)
@@ -118,6 +124,7 @@ class ResectogramViewManager:
         # and axis labels (the Hyperprobe precedent does the same).
         view.SetBoxVisible(False)
         view.SetAxisLabelsVisible(False)
+        view = slicer.mrmlScene.AddNode(view)
         self._view_node = view
         return view
 

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -604,6 +604,24 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections;resectogram;stage4"
     )
 
+    # The resectogram view node must carry its singleton tag AT scene-add
+    # time (ADR-0023 §Stage-4): LayerDM pipeline creators are consulted the
+    # moment a view node enters the scene, and the surface-family creators
+    # exclude the strip view BY that tag -- an add-then-tag order leaks
+    # deformable surface pipelines into the flattened strip.  Runs under
+    # the launched `pytest_launched` row (needs slicer.mrmlScene); SKIPS
+    # CLEANLY here under bare pytest.
+    add_test(
+      NAME LiverResections_resectogram_view_tag_at_add
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_resectogram_view_tag_at_add.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_resectogram_view_tag_at_add PROPERTIES
+      LABELS "pytest;module-layer;LiverResections;resectogram;stage4"
+    )
+
     # T3-g3 -- custom enlarge/restore of the embedded resectogram widget
     # (ADR-0023 §Stage-4).  Slicer's built-in double-click maximize is unusable
     # (it realises a SECOND layout-managed widget on the singleton view node

--- a/LiverResections/Testing/Python/test_resectogram_view_tag_at_add.py
+++ b/LiverResections/Testing/Python/test_resectogram_view_tag_at_add.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The resectogram view node must carry its singleton tag AT scene-add time.
+
+LayerDM reacts to scene node-add events: pipeline creators can be
+consulted for a view node the moment it enters the scene.  The view
+manager previously added the node FIRST and tagged it after
+(``AddNewNodeByClass`` then ``SetSingletonTag``), so every creator that
+excludes the resectogram view by its tag — the surface-family creators
+per ADR-0023 §Stage-4 — saw an untagged node and leaked deformable
+surface pipelines into the flattened strip view.
+
+Pinned here with a real scene observer: a ``NodeAddedEvent`` listener
+must observe the singleton tag (and the layout name) already set on the
+view node when the add event fires.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _slicer_or_skip():
+    # Shared support module, NOT ``from conftest import`` (multi-root runs
+    # resolve `conftest` to the first root's file).
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()
+
+
+def test_singleton_tag_visible_to_node_added_observers():
+    slicer = _slicer_or_skip()
+    try:
+        from LiverResectionsLib.ResectogramViewManager import (
+            RESECTOGRAM_VIEW_SINGLETON_TAG,
+            ResectogramViewManager,
+        )
+    except Exception:
+        pytest.skip("LiverResectionsLib.ResectogramViewManager not importable.")
+
+    import vtk
+
+    scene = slicer.mrmlScene
+    # A pre-existing tagged singleton would short-circuit creation; drop it
+    # so this test exercises the CREATE path.
+    stale = []
+    for i in range(scene.GetNumberOfNodesByClass("vtkMRMLViewNode")):
+        node = scene.GetNthNodeByClass(i, "vtkMRMLViewNode")
+        if node is not None and node.GetSingletonTag() == RESECTOGRAM_VIEW_SINGLETON_TAG:
+            stale.append(node)
+    for node in stale:
+        scene.RemoveNode(node)
+
+    seen = {}
+
+    @vtk.calldata_type(vtk.VTK_OBJECT)
+    def _on_node_added(caller, event, callData):
+        if callData is not None and callData.IsA("vtkMRMLViewNode"):
+            seen["tag"] = callData.GetSingletonTag()
+            seen["layout"] = callData.GetLayoutName()
+
+    tag = scene.AddObserver(slicer.vtkMRMLScene.NodeAddedEvent, _on_node_added)
+    try:
+        manager = ResectogramViewManager()
+        view = manager.ensureViewNode()
+        assert view is not None
+        assert seen, "the observer saw no vtkMRMLViewNode add event"
+        assert seen["tag"] == RESECTOGRAM_VIEW_SINGLETON_TAG, (
+            "the singleton tag must be set BEFORE the node enters the scene "
+            "-- creators consulted at node-add time otherwise see an "
+            "untagged view and leak surface pipelines into the strip view."
+        )
+        assert seen["layout"], "the layout name must also be set before add"
+    finally:
+        scene.RemoveObserver(tag)
+        node = manager.getViewNode()
+        if node is not None:
+            scene.RemoveNode(node)

--- a/Testing/Python/unit/test_bezier_creator_view_exclusion.py
+++ b/Testing/Python/unit/test_bezier_creator_view_exclusion.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""View-exclusion pin for the Bezier surface-family pipeline creators.
+
+The resectogram singleton view is owned solely by the
+``ResectogramPipeline`` (its strip + locator click seam, ADR-0023
+§Stage-4): surface-family pipelines leaking into it put deformable,
+interactive actors inside the flattened 2D strip.  The Bezier creator
+matched ANY ``vtkMRMLViewNode``, so the 3D surface pipeline was
+instantiated inside the resectogram view too — the strip appeared to
+deform (and host surface interaction) during Planning drags.
+
+Pinned here, GL-free: the module-level ``_is_resectogram_view``
+predicate the creator's ``tryCreate`` consults recognises the
+resectogram singleton view by its MRML ``SingletonTag`` and nothing
+else.  (The creator closure itself needs ``slicer``-namespace classes,
+so its wiring is exercised on the launched/interactive rows.)
+
+References
+----------
+* ADR-0013 §5 — pipeline-creator registration.
+* ADR-0023 §Stage-4 — the dedicated resectogram view.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+pytest.importorskip("LayerDMLib")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "LiverResections" / "LiverResectionsLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+@pytest.fixture
+def pipeline_module():
+    import LiverBezierSurfacePipeline as mod
+
+    return mod
+
+
+class _TaggedView:
+    def __init__(self, tag):
+        self._tag = tag
+
+    def GetSingletonTag(self):  # noqa: N802 - VTK verb
+        return self._tag
+
+
+class _UntaggedView:
+    """A view node shape without ``GetSingletonTag`` (defensive path)."""
+
+
+def test_resectogram_singleton_view_is_recognised(pipeline_module):
+    from ResectogramViewManager import RESECTOGRAM_VIEW_SINGLETON_TAG
+
+    assert (
+        pipeline_module._is_resectogram_view(
+            _TaggedView(RESECTOGRAM_VIEW_SINGLETON_TAG)
+        )
+        is True
+    ), (
+        "the Bezier creator must recognise (and decline) the resectogram "
+        "singleton view -- the 3D surface pipeline deforming inside the "
+        "flattened strip is the leak this pin guards."
+    )
+
+
+def test_ordinary_views_are_not_excluded(pipeline_module):
+    assert pipeline_module._is_resectogram_view(_TaggedView(None)) is False
+    assert pipeline_module._is_resectogram_view(_TaggedView("Default")) is False
+    assert pipeline_module._is_resectogram_view(_UntaggedView()) is False
+    assert pipeline_module._is_resectogram_view(None) is False


### PR DESCRIPTION
Closes #540.

The dedicated resectogram singleton view is owned solely by the ResectogramPipeline (ADR-0023 Stage-4): the flattened strip is a fixed plane whose content comes from the distance-map texture. Two stacked bugs let the deformable 3D surface pipeline render (and deform, during Planning drags) inside it:

1. **No view exclusion in the Bezier creator** — it matched any `vtkMRMLViewNode`. It now declines the resectogram view via a module-level `_is_resectogram_view` predicate keyed on the MRML singleton tag (pinned GL-free at the unit layer).
2. **The tag arrived too late to matter** — the view manager added the view node to the scene *first* and set the singleton tag after, while LayerDM consults pipeline creators the moment a node enters the scene, so every tag-based exclusion saw an untagged node. The manager now configures the node fully (tag, layout name/label, decoration) *before* `AddNode`. Pinned on the launched row with a real `NodeAddedEvent` observer asserting the tag is visible at add time (RED on the old ordering).

Verified live: the pipeline-per-view census shows the surface and control-polygon pipelines confined to the anatomy view, with only the ResectogramPipeline in the strip view.