### PR TITLE
BUG: Import the shared pytest support, not conftest, in the autoattach test

### DIFF
--- a/LiverResections/Testing/Python/test_resection_plan_distance_map_autoattach.py
+++ b/LiverResections/Testing/Python/test_resection_plan_distance_map_autoattach.py
@@ -23,10 +23,12 @@ import pytest
 
 
 def _logic_or_skip():
-    from conftest import _import_slicer_or_skip, _require_mrml_scene
+    # The shared support module, not `conftest`: with multiple pytest roots the
+    # first root's conftest wins the name and the underscore re-exports differ.
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
 
-    slicer = _import_slicer_or_skip()
-    _require_mrml_scene()
+    require_mrml_scene()
+    slicer = import_slicer_or_skip()
     module = getattr(slicer.modules, "liverresections", None)
     if module is None:
         pytest.skip("liverresections module not registered in this build.")


### PR DESCRIPTION
With multiple pytest roots on the launched harness the first root's conftest wins the module name, so `from conftest import ...` resolves to the wrong file and the underscore re-exports differ. Import the guards from the shared `slicer_pytest_support` module directly, matching the sibling LiverResections tests.

The Stage-2 trigger PR (#553) was squash-merged before this one-hunk fix landed on its feature branch, so preview carries the conftest import.