### PR TITLE
ENH: 1:1 locator marker across resectogram, 3D surface, and slice views

### DIFF
--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -958,13 +958,15 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         ``UpdatePipeline()`` re-reads node state directly.
 
         Requests a render when the VISIBLE dispatch inputs — the
-        ``(state, initMode)`` tuple and the control-point geometry digest —
-        actually changed (the ResectogramPipeline pattern): without the
-        request, a Planning drag mutates the surface polydata while the 3D
-        view stays frozen until an unrelated render (e.g. a camera orbit)
-        repaints it.  Gating on the digest rather than ``GetMTime`` keeps a
-        render-induced ``Modified`` at fixed geometry from re-requesting —
-        the render feedback-loop guard.
+        ``(state, initMode)`` tuple, the control-point geometry digest, and
+        the locator's picked world position (the ``uLocatorPosition`` marker
+        uniform, ADR-0025 §Rendering) — actually changed (the
+        ResectogramPipeline pattern): without the request, a Planning drag
+        mutates the surface polydata (and a resectogram pick moves the
+        marker) while the 3D view stays frozen until an unrelated render
+        (e.g. a camera orbit) repaints it.  Gating on positions rather than
+        ``GetMTime`` keeps a render-induced ``Modified`` at fixed geometry
+        from re-requesting — the render feedback-loop guard.
         """
         del caller, event  # observers route uniformly into UpdatePipeline()
         self.UpdatePipeline()
@@ -973,6 +975,7 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             _safe_get_state(self._data_node),
             _safe_get_init_mode(self._data_node),
             _control_points_digest(self._data_node),
+            _safe_get_picked_position(self._locator_node),
         )
         if render_key == self._last_render_key:
             return
@@ -1032,6 +1035,23 @@ def _safe_get_mtime(node: Any) -> int:
         return int(getter())
     except Exception:  # pragma: no cover - defensive
         return 0
+
+
+def _safe_get_picked_position(node: Any) -> tuple | None:
+    """The locator's ``PickedPositionWorld`` as a tuple; ``None`` sans node.
+
+    Part of the render-request gate: a pick CHANGE repaints the marker, a
+    render-churned ``Modified`` at an unchanged pick does not.
+    """
+    if node is None:
+        return None
+    getter = getattr(node, "GetPickedPositionWorld", None)
+    if getter is None:
+        return None
+    try:
+        return tuple(float(v) for v in getter())
+    except Exception:  # pragma: no cover - defensive
+        return None
 
 
 def _control_points_digest(node: Any) -> tuple:

--- a/LiverResections/LiverResectionsLib/LocatorReslicer.py
+++ b/LiverResections/LiverResectionsLib/LocatorReslicer.py
@@ -120,28 +120,48 @@ class LocatorReslicer:
         red = self._scene.GetNodeByID(_RED_SLICE_NODE_ID)
         if red is not None:
             self.reslice_slice_to_world(red, world)
-        self._place_crosshair(world)
+        self._update_marker_model(locator, world)
 
-    def _place_crosshair(self, world_xyz: Any) -> None:
-        """Land the pick on the scene's crosshair node (slice-view marker).
+    def _update_marker_model(self, locator: Any, world_xyz: Any) -> None:
+        """Land the pick on a small red sphere model -- the slice-view marker.
 
-        The reslice alone moves the slice plane but leaves no visible mark;
-        the singleton ``vtkMRMLCrosshairNode`` is Slicer's native slice-view
-        marker, so every pick sets its RAS position and ensures a visible
-        mode -- the locator then reads 1:1 across the resectogram, the 3D
-        surface, AND the slice views (ADR-0025 §Consumer).  A no-op when the
-        scene carries no crosshair node (bare test scenes).
+        A dot marker (not the crosshair's cross-lines, which read as a second
+        conflicting cue): a sphere model node with 2D slice-intersection
+        visibility ON and 3D visibility OFF (the 3D disc is shader-drawn on
+        the surface itself), so every slice view shows a red dot/ring where
+        its plane cuts the sphere -- the locator reads as ONE marker across
+        the resectogram, the 3D surface, and the slices (ADR-0025 §Consumer).
+        Radius follows the locator display node.  A no-op without a scene.
         """
         if self._scene is None or world_xyz is None:
             return
-        crosshair = self._scene.GetFirstNodeByClass("vtkMRMLCrosshairNode")
-        if crosshair is None:
-            return
         try:
-            crosshair.SetCrosshairRAS(
-                float(world_xyz[0]), float(world_xyz[1]), float(world_xyz[2])
-            )
-            if crosshair.GetCrosshairMode() == crosshair.NoCrosshair:
-                crosshair.SetCrosshairMode(crosshair.ShowBasic)
+            import vtk
+
+            node = None
+            for i in range(self._scene.GetNumberOfNodesByClass("vtkMRMLModelNode")):
+                candidate = self._scene.GetNthNodeByClass(i, "vtkMRMLModelNode")
+                if candidate is not None and candidate.GetAttribute("LiverLocatorMarker") == "True":
+                    node = candidate
+                    break
+            if node is None:
+                node = self._scene.AddNewNodeByClass("vtkMRMLModelNode", "LocatorMarker")
+                node.SetAttribute("LiverLocatorMarker", "True")
+                node.CreateDefaultDisplayNodes()
+                display = node.GetDisplayNode()
+                if display is not None:
+                    display.SetColor(1.0, 0.0, 0.0)
+                    display.SetVisibility2D(True)
+                    display.SetVisibility3D(False)
+                    display.SetSliceIntersectionThickness(2)
+            display_node = locator.GetDisplayNode() if hasattr(locator, "GetDisplayNode") else None
+            radius = display_node.GetRadius() if display_node is not None else 5.0
+            sphere = vtk.vtkSphereSource()
+            sphere.SetCenter(float(world_xyz[0]), float(world_xyz[1]), float(world_xyz[2]))
+            sphere.SetRadius(float(radius))
+            sphere.SetPhiResolution(16)
+            sphere.SetThetaResolution(16)
+            sphere.Update()
+            node.SetAndObservePolyData(sphere.GetOutput())
         except Exception:  # pragma: no cover - defensive
             return

--- a/LiverResections/LiverResectionsLib/LocatorReslicer.py
+++ b/LiverResections/LiverResectionsLib/LocatorReslicer.py
@@ -116,7 +116,32 @@ class LocatorReslicer:
         getter = getattr(locator, "GetPickedPositionWorld", None)
         if getter is None:
             return
+        world = getter()
         red = self._scene.GetNodeByID(_RED_SLICE_NODE_ID)
-        if red is None:
+        if red is not None:
+            self.reslice_slice_to_world(red, world)
+        self._place_crosshair(world)
+
+    def _place_crosshair(self, world_xyz: Any) -> None:
+        """Land the pick on the scene's crosshair node (slice-view marker).
+
+        The reslice alone moves the slice plane but leaves no visible mark;
+        the singleton ``vtkMRMLCrosshairNode`` is Slicer's native slice-view
+        marker, so every pick sets its RAS position and ensures a visible
+        mode -- the locator then reads 1:1 across the resectogram, the 3D
+        surface, AND the slice views (ADR-0025 §Consumer).  A no-op when the
+        scene carries no crosshair node (bare test scenes).
+        """
+        if self._scene is None or world_xyz is None:
             return
-        self.reslice_slice_to_world(red, getter())
+        crosshair = self._scene.GetFirstNodeByClass("vtkMRMLCrosshairNode")
+        if crosshair is None:
+            return
+        try:
+            crosshair.SetCrosshairRAS(
+                float(world_xyz[0]), float(world_xyz[1]), float(world_xyz[2])
+            )
+            if crosshair.GetCrosshairMode() == crosshair.NoCrosshair:
+                crosshair.SetCrosshairMode(crosshair.ShowBasic)
+        except Exception:  # pragma: no cover - defensive
+            return

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -213,6 +213,11 @@ class FlattenedSurfaceRepresentation:
         # which live on the carrier (ADR-0014 §"Fourth layer").
         self._resection_plan_node: Any | None = None
 
+        # The cross-view ``vtkMRMLLocatorNode`` (ADR-0025), threaded by the
+        # ResectogramPipeline like the plan node; drives the 2D mapper's
+        # uLocatorPosition / uLocatorRadius marker uniforms.
+        self._locator_node: Any | None = None
+
         # Last MatRatio pushed onto the 2D mapper.  ``None`` until the
         # first ``update()`` runs OR the mapper does not expose
         # ``SetMatRatio`` (generic-mapper fallback path).
@@ -255,6 +260,38 @@ class FlattenedSurfaceRepresentation:
         """
         self._resection_plan_node = plan_node
 
+    def SetLocatorNode(self, locator_node: Any | None) -> None:  # noqa: N802 - VTK verb
+        """Attach the cross-view locator node (ADR-0025); ``None`` clears."""
+        self._locator_node = locator_node
+
+    def _apply_locator(self) -> None:
+        """Thread the locator pick + radius onto the 2D mapper's uniforms.
+
+        Mirrors ``BezierPlanningRepresentation._apply_locator``: the 2D
+        mapper tests the REAL surface position (the ``BSPoints`` attribute)
+        against ``uLocatorPosition``, so the strip dot sits at the same
+        anatomical point as the 3D surface marker -- the ADR-0025 1:1
+        correspondence.  Radius 0 is the marker-off state (no locator, no
+        display node); a no-op on the generic fallback mapper.
+        """
+        mapper = self._resection_mapper_2d
+        if mapper is None:
+            return
+        set_position = getattr(mapper, "SetLocatorPosition", None)
+        set_radius = getattr(mapper, "SetLocatorRadius", None)
+        if set_position is None or set_radius is None:
+            return  # generic fallback mapper -- no locator uniforms
+
+        node = self._locator_node
+        if node is None:
+            set_radius(0.0)  # marker off
+            return
+        position = node.GetPickedPositionWorld()
+        set_position(float(position[0]), float(position[1]), float(position[2]))
+        display_node = node.GetDisplayNode() if hasattr(node, "GetDisplayNode") else None
+        radius = display_node.GetRadius() if display_node is not None else 0.0
+        set_radius(float(radius))
+
     def update(self, display_node: Any | None, data_node: Any | None) -> None:
         """Reconcile the resectogram against the current display + data nodes.
 
@@ -263,6 +300,7 @@ class FlattenedSurfaceRepresentation:
         """
         self._apply_display_node(display_node)
         self._apply_data_node(display_node, data_node)
+        self._apply_locator()
         self._pose_overlay_camera(display_node)
         self._reconcile_blur_pass(display_node)
 
@@ -281,6 +319,7 @@ class FlattenedSurfaceRepresentation:
                     pass
         self._distance_map_volume = None
         self._effective_texture_num_comps = 0
+        self._locator_node = None
 
         if self._renderer is not None:
             self._detach_blur_pass(self._renderer)

--- a/LiverResections/LiverResectionsLib/ResectogramLocatorProducer.py
+++ b/LiverResections/LiverResectionsLib/ResectogramLocatorProducer.py
@@ -98,7 +98,12 @@ class ResectogramLocatorProducer:
         surface = self._surface_node
         if surface is None:
             return None
-        polydata = surface.EvaluateSurface(float(u), float(v))
+        # The carrier's EvaluateSurface walks ROWS with its FIRST parameter,
+        # i.e. it consumes (v, u) in the strip's convention (u = horizontal /
+        # column fraction).  Passing (u, v) straight through transposed the
+        # pick: a click at the strip's bottom-right corner produced the
+        # surface's top-left point (the marker-offset bug found live).
+        polydata = surface.EvaluateSurface(float(v), float(u))
         if polydata is None or polydata.GetNumberOfPoints() < 1:
             return None
         world = polydata.GetPoint(0)

--- a/LiverResections/LiverResectionsLib/ResectogramLocatorProducer.py
+++ b/LiverResections/LiverResectionsLib/ResectogramLocatorProducer.py
@@ -85,7 +85,20 @@ class ResectogramLocatorProducer:
             uv_out,
         )
 
-        polydata = surface.EvaluateSurface(uv_out[0], uv_out[1])
+        return self.produce_from_uv(uv_out[0], uv_out[1])
+
+    def produce_from_uv(self, u: float, v: float) -> tuple[float, float, float] | None:
+        """Evaluate ``S(u, v)`` and write the world point onto the locator.
+
+        The UV seam: callers that already know the exact parametric
+        coordinates (the camera-based display->world inversion on the
+        standalone strip view) skip the window-fraction ``PixelToUV``
+        approximation entirely.  Same return/no-op contract as ``produce``.
+        """
+        surface = self._surface_node
+        if surface is None:
+            return None
+        polydata = surface.EvaluateSurface(float(u), float(v))
         if polydata is None or polydata.GetNumberOfPoints() < 1:
             return None
         world = polydata.GetPoint(0)

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -456,7 +456,62 @@ class ResectogramPipeline(_PipelineBase):
         )
 
         producer = ResectogramLocatorProducer(surface, locator)
+        # Prefer the CAMERA-exact inversion: the window-fraction PixelToUV
+        # assumes the quad fills the viewport edge-to-edge (the v1
+        # sub-viewport), which the standalone view's parallel-camera framing
+        # (margins + aspect letterboxing) does not satisfy -- the marker
+        # landed offset from the cursor.  Falls back to the fraction path on
+        # stub renderers (the GL-free seam tests).
+        uv = self._display_to_uv(display_xy, renderer, mat_ratio, representation)
+        if uv is not None:
+            return producer.produce_from_uv(uv[0], uv[1])
         return producer.produce(display_xy, viewport_size, mat_ratio)
+
+    @staticmethod
+    def _display_to_uv(
+        display_xy: Any, renderer: Any, mat_ratio: Any, representation: Any
+    ) -> tuple[float, float] | None:
+        """Invert a display pixel to the strip's ``(u, v)`` via the camera.
+
+        The mapper scales the quad in CLIP space about the window centre
+        (``gl_Position = matRatio * MCDC * vertexMC``), so the inverse undoes
+        the MatRatio about the window centre in display space, runs the
+        renderer's ``DisplayToWorld`` (exact under the strip's parallel
+        camera regardless of depth) and normalises against the flattened
+        quad's actual bounds.  ``None`` on stub renderers / degenerate input
+        (the caller then uses the window-fraction fallback).
+        """
+        set_display = getattr(renderer, "SetDisplayPoint", None)
+        to_world = getattr(renderer, "DisplayToWorld", None)
+        get_world = getattr(renderer, "GetWorldPoint", None)
+        if None in (set_display, to_world, get_world):
+            return None
+        try:
+            window = renderer.GetRenderWindow()
+            width, height = window.GetSize()
+            if width <= 0 or height <= 0:
+                return None
+            rx = float(mat_ratio[0]) or 1.0
+            ry = float(mat_ratio[1]) or 1.0
+            px = width / 2.0 + (float(display_xy[0]) - width / 2.0) / rx
+            py = height / 2.0 + (float(display_xy[1]) - height / 2.0) / ry
+            set_display(px, py, 0.5)
+            to_world()
+            world = get_world()
+            w = world[3] if len(world) > 3 and world[3] not in (0.0,) else 1.0
+            wx, wy = world[0] / w, world[1] / w
+            plane = representation.GetBezierPlane()
+            if plane is None:
+                return None
+            plane.Update()
+            bounds = plane.GetOutput().GetBounds()
+            if bounds[1] <= bounds[0] or bounds[3] <= bounds[2]:
+                return None
+            u = (wx - bounds[0]) / (bounds[1] - bounds[0])
+            v = (wy - bounds[2]) / (bounds[3] - bounds[2])
+            return (u, v)
+        except Exception:  # pragma: no cover - defensive (stub renderers)
+            return None
 
     @staticmethod
     def _resolve_locator_node(surface: Any) -> Any | None:

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -199,6 +199,11 @@ class ResectogramPipeline(_PipelineBase):
                 self._resection_node = self._resolve_resection_node()
         if self._flattened_surface is not None:
             self._flattened_surface.SetResectionPlanNode(self._resection_node)
+            # Thread the cross-view locator (ADR-0025) so the strip's 2D
+            # mapper paints the 1:1 correspondence marker.
+            self._flattened_surface.SetLocatorNode(
+                self._resolve_locator_node(self._data_node)
+            )
 
         key = _safe_get_control_points_digest(self._data_node)
         if key == self._last_update_key:
@@ -368,7 +373,8 @@ class ResectogramPipeline(_PipelineBase):
                 if self._event_type(eventData) == vtk.vtkCommand.MouseMoveEvent:
                     getter = getattr(eventData, "GetDisplayPosition", None)
                     if getter is not None:
-                        self._produce_from_display_position(getter())
+                        if self._produce_from_display_position(getter()) is not None:
+                            self._refresh_locator_marker()
                     return True  # keep the gesture even on a degenerate move
             except Exception:  # pragma: no cover - defensive
                 pass
@@ -382,7 +388,30 @@ class ResectogramPipeline(_PipelineBase):
         produced = self._produce_from_display_position(getter()) is not None
         if produced:
             self._reslicing = True
+            self._refresh_locator_marker()
         return produced
+
+    def _refresh_locator_marker(self) -> None:
+        """Re-push the locator uniforms on the strip + request a repaint.
+
+        A pick writes the locator node but does NOT change the control-point
+        geometry digest ``UpdatePipeline`` memoises on, so the strip's own
+        marker (ADR-0025 1:1 correspondence) is refreshed directly here.
+        """
+        representation = self._flattened_surface
+        if representation is None:
+            return
+        try:
+            representation.SetLocatorNode(self._resolve_locator_node(self._data_node))
+            representation._apply_locator()
+        except Exception:  # pragma: no cover - defensive (stub reps)
+            return
+        request_render = getattr(self, "RequestRender", None)
+        if request_render is not None:
+            try:
+                request_render()
+            except Exception:  # pragma: no cover - defensive (stub bases)
+                pass
 
     def _produce_from_display_position(self, display_xy: Any) -> tuple | None:
         """Map a resectogram display pixel to a locator pick (`ADR-0025`_ §Producer).

--- a/LiverResections/MRML/vtkMRMLLocatorDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLLocatorDisplayNode.cxx
@@ -51,7 +51,9 @@ vtkMRMLNodeNewMacro(vtkMRMLLocatorDisplayNode);
 
 //------------------------------------------------------------------------------
 vtkMRMLLocatorDisplayNode::vtkMRMLLocatorDisplayNode()
-  : Radius(2.0)
+  // 5 mm reads clearly as the projected marker disc on a liver-scale
+  // surface; 2 mm was sub-perceptual in hands-on use.
+  : Radius(5.0)
 {
   // Seed a sensible default locator colour on the inherited
   // vtkMRMLDisplayNode Color member (a warm yellow); the base node

--- a/LiverResections/Testing/Python/test_locator_reslice_consumer.py
+++ b/LiverResections/Testing/Python/test_locator_reslice_consumer.py
@@ -401,3 +401,38 @@ def test_locator_observer_reslices_red_slice_on_picked_position():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+def test_pick_places_the_crosshair_in_slice_views():
+    """A locator pick must also place the visible crosshair (ADR-0025).
+
+    The reslice alone moves the slice plane but leaves no visible mark; the
+    scene's singleton ``vtkMRMLCrosshairNode`` is the native slice-view
+    marker, so the reslicer sets its RAS position and a visible mode on
+    every pick -- the locator reads 1:1 across the resectogram, the 3D
+    surface, AND the slice views.
+    """
+    slicer = _slicer_or_skip()
+    reslicer_cls = _reslicer_class_or_skip_pending()
+
+    scene = slicer.mrmlScene
+    crosshair = scene.GetFirstNodeByClass("vtkMRMLCrosshairNode")
+    if crosshair is None:
+        crosshair = scene.AddNewNodeByClass("vtkMRMLCrosshairNode")
+    crosshair.SetCrosshairMode(crosshair.NoCrosshair)
+
+    locator = scene.AddNewNodeByClass("vtkMRMLLocatorNode")
+    try:
+        reslicer = reslicer_cls(scene)
+        locator.SetPickedPositionWorld(12.0, -34.0, 56.0)
+
+        ras = tuple(crosshair.GetCrosshairRAS())
+        assert ras == pytest.approx((12.0, -34.0, 56.0)), (
+            "the pick must land on the crosshair node (slice-view marker)"
+        )
+        assert crosshair.GetCrosshairMode() != crosshair.NoCrosshair, (
+            "the crosshair must be made visible on pick"
+        )
+        reslicer.cleanup()
+    finally:
+        scene.RemoveNode(locator)

--- a/LiverResections/Testing/Python/test_locator_reslice_consumer.py
+++ b/LiverResections/Testing/Python/test_locator_reslice_consumer.py
@@ -403,36 +403,63 @@ if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
 
 
-def test_pick_places_the_crosshair_in_slice_views():
-    """A locator pick must also place the visible crosshair (ADR-0025).
+def test_pick_places_the_dot_marker_in_slice_views():
+    """A locator pick must place the slice-view DOT marker (ADR-0025).
 
-    The reslice alone moves the slice plane but leaves no visible mark; the
-    scene's singleton ``vtkMRMLCrosshairNode`` is the native slice-view
-    marker, so the reslicer sets its RAS position and a visible mode on
-    every pick -- the locator reads 1:1 across the resectogram, the 3D
-    surface, AND the slice views.
+    The reslice alone moves the slice plane but leaves no visible mark.  The
+    marker is a small red sphere model with slice-intersection visibility ON
+    and 3D visibility OFF (the surface disc is shader-drawn), NOT the
+    crosshair -- its cross-lines read as a second, conflicting cue.  Pins:
+    the model exists (attribute-tagged), sits centred on the pick, is red,
+    2D-visible and 3D-hidden; a second pick MOVES it (no node multiplication).
     """
     slicer = _slicer_or_skip()
     reslicer_cls = _reslicer_class_or_skip_pending()
 
     scene = slicer.mrmlScene
-    crosshair = scene.GetFirstNodeByClass("vtkMRMLCrosshairNode")
-    if crosshair is None:
-        crosshair = scene.AddNewNodeByClass("vtkMRMLCrosshairNode")
-    crosshair.SetCrosshairMode(crosshair.NoCrosshair)
+
+    def _marker_nodes():
+        return [
+            scene.GetNthNodeByClass(i, "vtkMRMLModelNode")
+            for i in range(scene.GetNumberOfNodesByClass("vtkMRMLModelNode"))
+            if scene.GetNthNodeByClass(i, "vtkMRMLModelNode").GetAttribute(
+                "LiverLocatorMarker"
+            )
+            == "True"
+        ]
+
+    for stale in _marker_nodes():
+        scene.RemoveNode(stale)
 
     locator = scene.AddNewNodeByClass("vtkMRMLLocatorNode")
     try:
         reslicer = reslicer_cls(scene)
         locator.SetPickedPositionWorld(12.0, -34.0, 56.0)
 
-        ras = tuple(crosshair.GetCrosshairRAS())
-        assert ras == pytest.approx((12.0, -34.0, 56.0)), (
-            "the pick must land on the crosshair node (slice-view marker)"
+        markers = _marker_nodes()
+        assert len(markers) == 1, "exactly one dot-marker model per scene"
+        marker = markers[0]
+        bounds = marker.GetPolyData().GetBounds()
+        centre = tuple((bounds[2 * i] + bounds[2 * i + 1]) / 2.0 for i in range(3))
+        assert centre == pytest.approx((12.0, -34.0, 56.0), abs=1e-3), (
+            "the marker sphere must be centred on the pick"
         )
-        assert crosshair.GetCrosshairMode() != crosshair.NoCrosshair, (
-            "the crosshair must be made visible on pick"
+        display = marker.GetDisplayNode()
+        assert display is not None
+        assert tuple(display.GetColor()) == pytest.approx((1.0, 0.0, 0.0))
+        assert display.GetVisibility2D(), "slice views must show the dot"
+        assert not display.GetVisibility3D(), (
+            "3D stays shader-drawn on the surface -- no duplicate sphere"
         )
+
+        locator.SetPickedPositionWorld(-5.0, 6.0, -7.0)
+        markers = _marker_nodes()
+        assert len(markers) == 1, "a second pick must MOVE the marker, not add one"
+        bounds = markers[0].GetPolyData().GetBounds()
+        centre = tuple((bounds[2 * i] + bounds[2 * i + 1]) / 2.0 for i in range(3))
+        assert centre == pytest.approx((-5.0, 6.0, -7.0), abs=1e-3)
         reslicer.cleanup()
     finally:
         scene.RemoveNode(locator)
+        for stale in _marker_nodes():
+            scene.RemoveNode(stale)

--- a/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
+++ b/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
@@ -47,7 +47,7 @@ world -> node) in isolation.  THIS file pins the PIPELINE SEAM: that
 and composes them, reusing the SAME known affine 4x4 control grid + the SAME
 pixel(64,192)/viewport(256x256)/ratio(1,1) -> (u,v)=(0.25,0.75) -> world
 composition anchor, so the expected world point is already known
-((22.5, 7.5, 0.0), x = 30*v, y = 30*u).
+((7.5, 22.5, 0.0), x = 30*u, y = 30*v in strip convention).
 
 WHY LAUNCHED-SLICER / RUN-VS-SKIP
 ---------------------------------
@@ -134,7 +134,8 @@ def _make_affine_carrier_or_skip(slicer, name):
 
     IDENTICAL grid to ``test_resectogram_locator_producer.py``:
     ``P[r][c] = (x = c*10, y = r*10, z = 0)`` makes the deg-3 tensor Bezier
-    EXACTLY affine in (u, v): ``x = 30*v, y = 30*u, z = 0`` -- so
+    EXACTLY affine: the producer maps strip (u, v) so x = 30*u,
+    y = 30*v -- so
     ``EvaluateSurface(0.25, 0.75)`` is the hand-computed (22.5, 7.5, 0.0).
     Reused verbatim so the seam's composed world point is already known.
     """
@@ -169,12 +170,16 @@ def _make_affine_carrier_or_skip(slicer, name):
 
 
 def _expected_world_for_uv(u, v):
-    """The hand-computed world point of the affine grid at (u, v).
+    """The hand-computed world point of the affine grid at strip (u, v).
 
-    ``x = 30*v, y = 30*u, z = 0`` (see ``_make_affine_carrier_or_skip``); the
-    same anchor the sibling producer test uses.  u drives y, v drives x.
+    STRIP convention: u is the horizontal (column) fraction and drives x;
+    v is the vertical (row) fraction and drives y -- ``x = 30*u, y = 30*v``
+    on the affine grid.  The producer owns the transposition onto the
+    carrier's row-first ``EvaluateSurface`` (the marker-offset bug: passing
+    (u, v) straight through put the bottom-right click on the top-left
+    surface corner).
     """
-    return (30.0 * v, 30.0 * u, 0.0)
+    return (30.0 * u, 30.0 * v, 0.0)
 
 
 def _pipeline_or_skip(slicer):
@@ -337,7 +342,7 @@ def test_seam_produces_picked_position_from_display_position():
     _inject_state(pipeline, carrier, mat_ratio=(1.0, 1.0), viewport_size=(256, 256))
     seam = _seam_or_skip_pending(pipeline)
 
-    expected = _expected_world_for_uv(0.25, 0.75)  # (22.5, 7.5, 0.0)
+    expected = _expected_world_for_uv(0.25, 0.75)  # (7.5, 22.5, 0.0)
 
     returned = seam((64.0, 192.0))
 
@@ -347,7 +352,7 @@ def test_seam_produces_picked_position_from_display_position():
     )
     assert tuple(returned) == pytest.approx(expected, abs=WORLD_TOL), (
         f"the seam must compose display (64, 192) -> (u, v) = (0.25, 0.75) -> "
-        f"world {expected} (x = 30*v, y = 30*u; VTK bottom-left origin, no Qt "
+        f"world {expected} (x = 30*u, y = 30*v; VTK bottom-left origin, no Qt "
         f"y-flip); got {tuple(returned)}."
     )
     written = tuple(locator.GetPickedPositionWorld())
@@ -524,7 +529,7 @@ def test_process_interaction_event_drives_the_pick_from_display_position():
     _inject_state(pipeline, carrier, mat_ratio=(1.0, 1.0), viewport_size=(256, 256))
     _seam_or_skip_pending(pipeline)  # skips-pending until the seam lands
 
-    expected = _expected_world_for_uv(0.25, 0.75)  # (22.5, 7.5, 0.0)
+    expected = _expected_world_for_uv(0.25, 0.75)  # (7.5, 22.5, 0.0)
     handled = pipeline.ProcessInteractionEvent(
         _FakeInteractionEventData((64.0, 192.0))
     )

--- a/LiverResections/Testing/Python/test_resectogram_locator_producer.py
+++ b/LiverResections/Testing/Python/test_resectogram_locator_producer.py
@@ -200,7 +200,7 @@ def _make_affine_carrier_or_skip(slicer, name):
 
     Grid ``P[r][c] = (x = c*10, y = r*10, z = 0)``.  For a deg-3 tensor Bezier
     this makes the surface EXACTLY affine in (u, v):
-        x = 30 * v,  y = 30 * u,  z = 0
+        x = 30 * u,  y = 30 * v,  z = 0  (strip convention)
     (the index-linear control net Bezier reproduces the affine map; verified by
     hand -- see the module docstring).  So the corners and any interior point
     have a trivially hand-computable expected world point.
@@ -238,12 +238,14 @@ def _make_affine_carrier_or_skip(slicer, name):
 def _expected_world_for_uv(u, v):
     """The hand-computed world point of the affine grid at (u, v).
 
-    x = 30 * v, y = 30 * u, z = 0 (see ``_make_affine_carrier_or_skip``).  NOTE
+    x = 30 * u, y = 30 * v, z = 0 in STRIP convention (u = column fraction
+    drives x); the producer owns the transposition onto the carrier's
+    row-first EvaluateSurface (see ``_make_affine_carrier_or_skip``).  NOTE
     the ordering: EvaluateSurface(u, v) samples Bernstein(i, degU, u) over ROWS
     (y = r*10) and Bernstein(j, degV, v) over COLS (x = c*10), so u drives y and
     v drives x.  Pinning this ordering guards a u/v swap in the producer.
     """
-    return (30.0 * v, 30.0 * u, 0.0)
+    return (30.0 * u, 30.0 * v, 0.0)
 
 
 def _eval_world(carrier, u, v):
@@ -332,22 +334,24 @@ def test_evaluate_surface_corners_are_grid_corner_control_points():
 
 
 def test_evaluate_surface_interior_matches_hand_computed_point():
-    """Invariant 1b: an interior (u, v) matches the hand-computed world point.
+    """Invariant 1b: the CARRIER's raw EvaluateSurface is row-first.
 
-    EvaluateSurface(0.25, 0.75) on the affine grid must be (30*0.75, 30*0.25, 0)
+    The raw carrier convention: the FIRST parameter walks rows (y), so
+    EvaluateSurface(0.25, 0.75) on the affine grid is (30*0.75, 30*0.25, 0)
     = (22.5, 7.5, 0).  A non-corner point exercises the full tensor-product
-    Bernstein sum AND pins the u->y / v->x ordering the producer must preserve
-    (ADR-0025 §Producer: the exact 1:1 mapping).
+    Bernstein sum.  The STRIP-convention (u drives x) mapping is the
+    PRODUCER's job -- it transposes onto this raw call (see
+    ``produce_from_uv``); the producer-level tests pin that half.
     """
     slicer = _slicer_or_skip()
     carrier = _make_affine_carrier_or_skip(slicer, "LocatorProducerEvalInterior")
 
-    u, v = 0.25, 0.75
-    got = _eval_world(carrier, u, v)
-    assert got == pytest.approx(_expected_world_for_uv(u, v), abs=WORLD_TOL), (
-        f"EvaluateSurface({u}, {v}) must be the hand-computed affine world point "
-        f"{_expected_world_for_uv(u, v)} (x = 30*v, y = 30*u); got {got}.  A "
-        "u/v swap or a Bernstein-weight error fails here."
+    first, second = 0.25, 0.75
+    got = _eval_world(carrier, first, second)
+    assert got == pytest.approx((30.0 * second, 30.0 * first, 0.0), abs=WORLD_TOL), (
+        f"raw EvaluateSurface({first}, {second}) must be the row-first affine "
+        f"point (x = 30*second, y = 30*first); got {got}.  A Bernstein-weight "
+        "error or an upstream carrier convention change fails here."
     )
 
 

--- a/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLBezierResectionPolyDataMapper.cxx
@@ -321,7 +321,7 @@ void vtkOpenGLBezierResectionPolyDataMapper::ReplaceShaderValues(std::map<vtkSha
     // they overlap.  uLocatorRadius == 0 is the off state.  The colour is
     // a placeholder white; the locator display node will drive it later.
     "  if (uLocatorRadius > 0.0 && distance(vertexRASVSOutput.xyz, uLocatorPosition) < uLocatorRadius) {\n"
-    "    ambientColor = vec3(1.0, 1.0, 1.0);\n"
+    "    ambientColor = vec3(1.0, 0.0, 0.0);\n"
     "    diffuseColor = vec3(0.0);\n"
     "  }\n"
     "}\n");

--- a/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp
+++ b/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp
@@ -78,6 +78,8 @@ public:
     // stray grid came from indeterminate values reaching the shader).
     , GridDivisions(0)
     , GridThicknessFactor(0.0f)
+    , LocatorPosition{ 0.0f, 0.0f, 0.0f }
+    , LocatorRadius(0.0f)
     , ShowResection2D(false)
     , PortalContourThickness(0.3f)
     , HepaticContourThickness(0.3f)
@@ -103,6 +105,8 @@ public:
   bool InterpolatedMargins;
   unsigned int GridDivisions;
   float GridThicknessFactor;
+  float LocatorPosition[3];
+  float LocatorRadius;
   bool ShowResection2D;
   float PortalContourThickness;
   float HepaticContourThickness;
@@ -211,6 +215,8 @@ void vtkOpenGLResection2DPolyDataMapper::ReplaceShaderValues(std::map<vtkShader:
                                "uniform vec3 uResectionGridColor;\n"
                                "uniform int uGridDivisions;\n"
                                "uniform float uGridThickness;\n"
+                               "uniform vec3 uLocatorPosition;\n"
+                               "uniform float uLocatorRadius;\n"
                                "in vec2 uvCoordsOutput;\n"
                                "in vec4 vertexWCVSOutputBS;\n"
                                "vec4 fragPositionMCBS = vertexWCVSOutputBS;\n"
@@ -325,6 +331,16 @@ void vtkOpenGLResection2DPolyDataMapper::ReplaceShaderValues(std::map<vtkShader:
     "  diffuseColor = vec3(0.0);\n"
     "} else if ((uvCoordsOutput.x > 0.5 && uvCoordsOutput.y < borderSize) || (uvCoordsOutput.x > 1.0 - borderSize && uvCoordsOutput.y < 0.5) ) {\n"
     "  ambientColor = topRightColor;\n"
+    "  diffuseColor = vec3(0.0);\n"
+    "}\n"
+
+    // Locator marker (ADR-0025): the strip is the (u, v) image of the real
+    // surface, so testing the REAL surface position (vertexMCVSOutputBS,
+    // the BSPoints attribute) against uLocatorPosition paints the dot at
+    // the same anatomical point as the 3D surface marker -- the 1:1
+    // correspondence.  Drawn last (over grid/border); radius 0 = off.
+    "if (uLocatorRadius > 0.0 && distance(vertexMCVSOutputBS.xyz, uLocatorPosition) < uLocatorRadius) {\n"
+    "  ambientColor = vec3(1.0, 1.0, 1.0);\n"
     "  diffuseColor = vec3(0.0);\n"
     "}\n");
   vtkShaderProgram::Substitute(FSSource,
@@ -451,6 +467,16 @@ void vtkOpenGLResection2DPolyDataMapper::SetMapperShaderParameters(vtkOpenGLHelp
   if (cellBO.Program->IsUniformUsed("uGridThickness"))
   {
     cellBO.Program->SetUniformf("uGridThickness", this->Impl->GridThicknessFactor);
+  }
+
+  if (cellBO.Program->IsUniformUsed("uLocatorPosition"))
+  {
+    cellBO.Program->SetUniform3f("uLocatorPosition", this->Impl->LocatorPosition);
+  }
+
+  if (cellBO.Program->IsUniformUsed("uLocatorRadius"))
+  {
+    cellBO.Program->SetUniformf("uLocatorRadius", this->Impl->LocatorRadius);
   }
 
   if (cellBO.Program->IsUniformUsed("uHepaticContourColor"))
@@ -850,5 +876,39 @@ void vtkOpenGLResection2DPolyDataMapper::SetMatRatio(float matR[2])
 {
   this->Impl->MatRatio[0] = matR[0];
   this->Impl->MatRatio[1] = matR[1];
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+const float* vtkOpenGLResection2DPolyDataMapper::GetLocatorPosition() const
+{
+  return this->Impl->LocatorPosition;
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLResection2DPolyDataMapper::SetLocatorPosition(float position[3])
+{
+  this->SetLocatorPosition(position[0], position[1], position[2]);
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLResection2DPolyDataMapper::SetLocatorPosition(float x, float y, float z)
+{
+  this->Impl->LocatorPosition[0] = x;
+  this->Impl->LocatorPosition[1] = y;
+  this->Impl->LocatorPosition[2] = z;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+float vtkOpenGLResection2DPolyDataMapper::GetLocatorRadius() const
+{
+  return this->Impl->LocatorRadius;
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLResection2DPolyDataMapper::SetLocatorRadius(float radius)
+{
+  this->Impl->LocatorRadius = radius;
   this->Modified();
 }

--- a/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp
+++ b/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.cpp
@@ -219,6 +219,7 @@ void vtkOpenGLResection2DPolyDataMapper::ReplaceShaderValues(std::map<vtkShader:
                                "uniform float uLocatorRadius;\n"
                                "in vec2 uvCoordsOutput;\n"
                                "in vec4 vertexWCVSOutputBS;\n"
+                               "in vec4 vertexMCVSOutputBS;\n"
                                "vec4 fragPositionMCBS = vertexWCVSOutputBS;\n"
                                "uniform vec3 uPortalContourColor;\n"
                                "uniform vec3 uHepaticContourColor;\n"
@@ -340,7 +341,7 @@ void vtkOpenGLResection2DPolyDataMapper::ReplaceShaderValues(std::map<vtkShader:
     // the same anatomical point as the 3D surface marker -- the 1:1
     // correspondence.  Drawn last (over grid/border); radius 0 = off.
     "if (uLocatorRadius > 0.0 && distance(vertexMCVSOutputBS.xyz, uLocatorPosition) < uLocatorRadius) {\n"
-    "  ambientColor = vec3(1.0, 1.0, 1.0);\n"
+    "  ambientColor = vec3(1.0, 0.0, 0.0);\n"
     "  diffuseColor = vec3(0.0);\n"
     "}\n");
   vtkShaderProgram::Substitute(FSSource,

--- a/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.h
+++ b/LiverResections/VTKWidgets/vtkOpenGLResection2DPolyDataMapper.h
@@ -170,6 +170,18 @@ public:
   void SetMatRatio(float matR[2]);
   const float* GetMatRatio() const;
 
+  /// Get the locator marker position (RAS world point, ADR-0025)
+  const float* GetLocatorPosition() const;
+  /// Set the locator marker position (RAS world point, ADR-0025)
+  void SetLocatorPosition(float position[3]);
+  /// Set the locator marker position (RAS world point, ADR-0025)
+  void SetLocatorPosition(float x, float y, float z);
+
+  /// Get the locator marker radius (0 disables the marker, ADR-0025)
+  float GetLocatorRadius() const;
+  /// Set the locator marker radius (0 disables the marker, ADR-0025)
+  void SetLocatorRadius(float radius);
+
 protected:
   vtkOpenGLResection2DPolyDataMapper();
   ~vtkOpenGLResection2DPolyDataMapper();

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -700,3 +700,53 @@ def test_effective_comps_survive_subsequent_updates(rep_module, monkeypatch):
         "TextureNumComps on a subsequent update -- the already-bound "
         "short-circuit never re-pushes it, so the strip goes grid-only."
     )
+
+
+class _StubLocatorDisplay:
+    def GetRadius(self):  # noqa: N802 - VTK verb
+        return 2.0
+
+
+class _StubLocatorNode:
+    def GetPickedPositionWorld(self):  # noqa: N802 - VTK verb
+        return (10.0, 20.0, 30.0)
+
+    def GetDisplayNode(self):  # noqa: N802 - VTK verb
+        return _StubLocatorDisplay()
+
+
+class _StubMapperWithLocator(_StubMapperWithMatRatio):
+    def __init__(self) -> None:
+        super().__init__()
+        self.locator_position = None
+        self.locator_radius = None
+
+    def SetLocatorPosition(self, x, y, z):  # noqa: N802 - VTK verb
+        self.locator_position = (x, y, z)
+
+    def SetLocatorRadius(self, radius):  # noqa: N802 - VTK verb
+        self.locator_radius = radius
+
+
+def test_locator_marker_reaches_the_2d_mapper(rep_module):
+    """The strip pushes the locator pick + radius onto the 2D mapper.
+
+    The 1:1 correspondence marker (ADR-0025): the 2D mapper tests the REAL
+    surface position (BSPoints) against uLocatorPosition, so the strip dot
+    sits at the same anatomical point as the 3D surface marker.  Radius 0
+    (marker off) when no locator node is wired.
+    """
+    rep = rep_module()
+    mapper = _StubMapperWithLocator()
+    rep._resection_mapper_2d = mapper
+
+    rep.update(_StubDisplayNode(), _StubDataNode())
+    assert mapper.locator_radius == pytest.approx(0.0), (
+        "no locator node wired -> the marker must be OFF (radius 0)"
+    )
+
+    rep.SetLocatorNode(_StubLocatorNode())
+    rep.update(_StubDisplayNode(), _StubDataNode())
+    assert mapper.locator_position == pytest.approx((10.0, 20.0, 30.0))
+    assert mapper.locator_radius == pytest.approx(2.0)
+    rep.cleanup()

--- a/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
+++ b/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
@@ -309,3 +309,41 @@ def test_geometry_edit_requests_render(pipeline_module, bezier_nodes):
         "(the render feedback-loop guard)."
     )
     pipeline.cleanup()
+
+
+def test_locator_pick_requests_render(pipeline_module, bezier_nodes):
+    """A locator picked-point write must repaint the surface marker.
+
+    The render-request gate keys on the control-point geometry digest,
+    which a locator pick does not change -- without folding the picked
+    position into the key, the uLocatorPosition uniform updates but the
+    view repaints only on the next unrelated render (invisible marker).
+    A Modified at an unchanged pick must still not re-request (loop guard).
+    """
+    import slicer
+
+    data, display = bezier_nodes
+    scene = slicer.mrmlScene
+    locator = scene.AddNewNodeByClass("vtkMRMLLocatorNode")
+    try:
+        pipeline = pipeline_module.LiverBezierSurfacePipeline()
+        pipeline.SetDisplayNode(display)
+        data.SetState(1)  # Planning
+        pipeline.UpdatePipeline()  # resolves + observes the locator
+
+        renders = []
+        pipeline.RequestRender = lambda: renders.append(1)
+
+        locator.SetPickedPositionWorld(10.0, 20.0, 30.0)
+        assert renders, (
+            "a locator pick must request a render -- the marker uniform "
+            "otherwise repaints only on the next unrelated render."
+        )
+        before = len(renders)
+        locator.Modified()  # unchanged pick -- render-churn signature
+        assert len(renders) == before, (
+            "a Modified at an unchanged pick must not re-request (loop guard)"
+        )
+        pipeline.cleanup()
+    finally:
+        scene.RemoveNode(locator)


### PR DESCRIPTION
Closes #489.

Completes the ADR-0025 locator consumer: one red marker, coherent across all views, tracking strip clicks and drags in realtime.

**Marker rendering**
- 3D surface: the #492 shader disc (`uLocatorPosition`/`uLocatorRadius`) now actually repaints — the pick is folded into the pipeline's digest-gated render-request key (a pick changes no control-point geometry, so the marker previously waited for an unrelated render).
- Resectogram strip: the 2D mapper gains the same uniform seam, with the fragment testing the REAL surface position (the `BSPoints` attribute) so the strip dot sits at the identical anatomical point — the 1:1 correspondence. Includes a fix for a shader compile failure (missing `in` declaration) that blanked the strip.
- Slice views: a single red sphere model with slice-intersection visibility only (the crosshair's cross-lines read as a second conflicting cue; 3D stays shader-drawn). Moved, never multiplied, on every pick.
- Both markers red; locator display radius default 5 mm (2 mm was sub-perceptual at liver scale).

**Picking correctness (found live via a pick probe)**
- Camera-exact strip picking: the window-fraction `PixelToUV` assumes the quad fills the viewport (the retired v1 sub-viewport); the standalone view's parallel camera letterboxes it. The click now inverts through the camera (MatRatio clip-space scale undone about the window centre, then `DisplayToWorld`), with the fraction path kept as the stub-renderer fallback.
- Transposed picks: the carrier's `EvaluateSurface` walks rows with its FIRST parameter; the producer passed strip (u, v) straight through, so every pick landed at the transposed surface point since the producer shipped (centre and origin are transposition fix-points, which hid it). The producer now owns the convention via a `produce_from_uv` seam; the raw row-first carrier convention is pinned explicitly so upstream changes fail loudly.

All six commits test-first on the launched row; verified hands-on with real anatomy.