### PR TITLE
BUG: Run the Liver shell suites in CI + repair their drift

### DIFF
--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -733,13 +733,30 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       logic = module.logic()
     except Exception:  # pragma: no cover — defensive
       logic = None
-    for attr in ("IsStageComplete", "isStageComplete"):
-      query = getattr(logic, attr, None) if logic is not None else None
-      if callable(query):
-        try:
-          return bool(query())
-        except Exception:  # pragma: no cover — defensive
-          return False
+    # SCRIPTED modules wrap their C++ stage logic as ``self()._cppLogic``
+    # (VascularTerritories): ``module.logic()`` returns the generic
+    # ``vtkSlicerScriptedLoadableModuleLogic`` shim, which never carries the
+    # predicate -- and the C++ module object refuses new attributes, so the
+    # specialized logic cannot be grafted onto it.  Query the Python module
+    # instance's ``_cppLogic`` alongside the plain logic.
+    candidates = [logic]
+    # The scripted module's Python instance registers itself as
+    # ``slicer.modules.<ModuleName>Instance`` (the ScriptedLoadableModule
+    # convention); ``module.name`` gives the CamelCase module name.
+    try:
+      instance = getattr(slicer.modules, module.name + "Instance", None)
+    except Exception:  # pragma: no cover — defensive
+      instance = None
+    if instance is not None:
+      candidates.append(getattr(instance, "_cppLogic", None))
+    for candidate in candidates:
+      for attr in ("IsStageComplete", "isStageComplete"):
+        query = getattr(candidate, attr, None) if candidate is not None else None
+        if callable(query):
+          try:
+            return bool(query())
+          except Exception:  # pragma: no cover — defensive
+            return False
 
     # LiverSegmentation is a SCRIPTED module: its ``isStageComplete`` lives on
     # the Python ``LiverSegmentationLogic``, not the wrapped module logic that

--- a/Liver/Testing/Python/CMakeLists.txt
+++ b/Liver/Testing/Python/CMakeLists.txt
@@ -175,7 +175,16 @@ set(_liver_additional_module_paths
 # Same test roots as the bare ``pytest_scaffold`` entries, plus the Stage-2
 # surgeon-UI invariant tree: its scene/widget tests SKIP under bare pytest and
 # only execute meaningfully inside a launched qSlicerApplication (ADR-0024).
+# Root ORDER is load-bearing: pytest prepends every root's conftest dir to
+# sys.path at session start, so the LAST-listed root wins any test's plain
+# `import conftest`.  LiverSegmentation's tests import their conftest by
+# name (23 sites), so its root stays LAST; the Liver shell root -- whose
+# tests import the shared slicer_pytest_support instead -- goes first.
 set(_launched_test_roots
+  # The Liver shell's own suites: widget-level, so they skip under the
+  # bare rows -- omitting this root meant they executed NOWHERE in CI
+  # and drifted silently (11 failures accumulated unseen).
+  "${CMAKE_SOURCE_DIR}/Liver/Testing/Python"
   "${CMAKE_SOURCE_DIR}/Testing/Python"
   "${CMAKE_SOURCE_DIR}/LiverResections/Testing/Python"
   "${CMAKE_SOURCE_DIR}/LiverSegmentation/Testing/Python"

--- a/Liver/Testing/Python/conftest.py
+++ b/Liver/Testing/Python/conftest.py
@@ -77,15 +77,36 @@ def _launched_scene_cleanup():
         return
 
     baseline = scene.GetNumberOfNodes()
+    baseline_ids = {
+        scene.GetNthNode(i).GetID()
+        for i in range(baseline)
+        if scene.GetNthNode(i) is not None
+    }
 
     yield
 
     scene.Clear(0)
     remaining = scene.GetNumberOfNodes()
-    assert remaining <= baseline, (
+    # SINGLETON-tagged nodes are scene-owned framework state (module
+    # parameter nodes, singleton views): they exist the moment any code
+    # touches their module, survive Clear() BY DESIGN, are re-minted by
+    # live widgets if removed, and the scene reclaims them at app
+    # shutdown -- they cannot trip vtkDebugLeaks.  Only NON-singleton
+    # growth indicates a real test leak.
+    survivors = [
+        scene.GetNthNode(i)
+        for i in range(remaining)
+        if scene.GetNthNode(i) is not None
+        and scene.GetNthNode(i).GetID() not in baseline_ids
+        and not scene.GetNthNode(i).GetSingletonTag()
+    ]
+    named = ", ".join(
+        f"{n.GetClassName()}(name={n.GetName()!r})" for n in survivors
+    )
+    assert not survivors, (
         "MRML scene GREW past its pre-test baseline even after Clear(): "
-        f"{remaining} node(s) remain vs {baseline} at test start.  A node "
-        "Clear() cannot reclaim survives to process shutdown and trips "
-        "vtkDebugLeaks, failing the launched harness.  Tear down every node "
-        "the test created."
+        f"{len(survivors)} non-singleton node(s) the test created survive.  "
+        "A node Clear() cannot reclaim survives to process shutdown and "
+        "trips vtkDebugLeaks, failing the launched harness.  Tear down "
+        f"every node the test created.  Survivors: [{named}]"
     )

--- a/Liver/Testing/Python/test_case_setup_volume_roles.py
+++ b/Liver/Testing/Python/test_case_setup_volume_roles.py
@@ -88,9 +88,9 @@ SCALAR_VOLUME_CLASS = "vtkMRMLScalarVolumeNode"
 
 def _slicer_or_skip():
     """Return the launched-Slicer ``slicer`` module, or skip under bare pytest."""
-    from conftest import (  # type: ignore[import-not-found]
-        _import_slicer_or_skip,
-        _require_mrml_scene,
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
     )
 
     _require_mrml_scene()

--- a/Liver/Testing/Python/test_liver_shell_isstagecomplete.py
+++ b/Liver/Testing/Python/test_liver_shell_isstagecomplete.py
@@ -51,9 +51,11 @@ import pytest
 # --------------------------------------------------------------------------- #
 
 # Re-export under the names this file's call sites already use.
-from conftest import (  # type: ignore[import-not-found]  # noqa: E402
-    _import_slicer_or_skip,
-    _require_mrml_scene as _require_mrml_scene_or_skip,
+# Shared support module, NOT `from conftest import`: with multiple pytest
+# roots the first root's conftest wins the module name (launched harness).
+from slicer_pytest_support import (  # noqa: E402
+    import_slicer_or_skip as _import_slicer_or_skip,
+    require_mrml_scene as _require_mrml_scene_or_skip,
 )
 
 
@@ -77,15 +79,30 @@ def _resections_logic():
 
 
 def _territories_logic():
-    """Resolve the C++ ``vtkSlicerVascularTerritoriesLogic`` instance."""
+    """Resolve the C++ ``vtkSlicerVascularTerritoriesLogic`` instance.
+
+    VascularTerritories is a SCRIPTED module: ``module.logic()`` returns the
+    generic scripted-logic shim, and the C++ module object refuses grafted
+    attributes -- the specialized logic lives on the Python module instance
+    as ``module.self()._cppLogic`` (the same route the Liver shell queries).
+    """
     slicer = _import_slicer_or_skip()
-    try:
-        return slicer.modules.vascularterritories.logic()
-    except AttributeError as exc:
+    module = getattr(slicer.modules, "vascularterritories", None)
+    if module is None:
         pytest.skip(
-            f"VascularTerritories module not available ({exc}); "
-            "ensure --additional-module-paths includes VascularTerritories."
+            "VascularTerritories module not available; ensure "
+            "--additional-module-paths includes VascularTerritories."
         )
+    instance = getattr(slicer.modules, "VascularTerritoriesInstance", None)
+    logic = getattr(instance, "_cppLogic", None)
+    if instance is None:
+        pytest.skip(
+            "VascularTerritories module instance not registered "
+            "(slicer.modules.VascularTerritoriesInstance missing)."
+        )
+    if logic is None:
+        pytest.skip("VascularTerritories specialized logic not built.")
+    return logic
 
 
 def _volumetry_logic():
@@ -112,8 +129,8 @@ def _volumetry_logic():
 
 def _liver_widget():
     """Instantiate a fresh ``LiverWidget`` rooted on a throwaway parent."""
-    from conftest import _require_qt_widget  # type: ignore[import-not-found]
-    _require_qt_widget()
+    from slicer_pytest_support import require_qt_widget
+    require_qt_widget()
 
     _import_slicer_or_skip()
     try:
@@ -125,9 +142,41 @@ def _liver_widget():
             "ensure --additional-module-paths includes Liver/."
         )
     parent = qt.QWidget()
+    qt.QVBoxLayout(parent)  # ScriptedLoadableModuleWidget reads parent.layout()
     widget = Liver.LiverWidget(parent)
     widget.setup()
     return widget
+
+
+def _remove_shell_singletons():
+    """Remove the singleton nodes ``LiverWidget.setup()`` mints.
+
+    ``setup()`` composes the stage pages, which ensure the resectogram
+    singleton view (+ its camera).  Singletons SURVIVE ``scene.Clear()``,
+    so the launched leak-guard fixture sees the scene grown past its
+    baseline unless the test removes them explicitly.
+    """
+    import slicer
+
+    scene = slicer.mrmlScene
+    doomed = []
+    for i in range(scene.GetNumberOfNodesByClass("vtkMRMLViewNode")):
+        node = scene.GetNthNodeByClass(i, "vtkMRMLViewNode")
+        if node is not None and node.GetSingletonTag() == "LiverResectogram":
+            doomed.append(node)
+    for i in range(scene.GetNumberOfNodesByClass("vtkMRMLCameraNode")):
+        node = scene.GetNthNodeByClass(i, "vtkMRMLCameraNode")
+        if node is not None and (node.GetActiveTag() or "").startswith("vtkMRMLViewNode") and any(
+            d.GetID() == node.GetActiveTag() for d in doomed
+        ):
+            doomed.append(node)
+        elif node is not None and "Resectogram" in (node.GetName() or ""):
+            doomed.append(node)
+    # Module PARAMETER nodes (singleton vtkMRMLScriptedModuleNode) are
+    # deliberately NOT removed: live widgets re-mint them on removal, and
+    # the leak-guard fixture excludes singleton-tagged nodes by design.
+    for node in doomed:
+        scene.RemoveNode(node)
 
 
 def _liver_widget_no_setup():
@@ -138,8 +187,8 @@ def _liver_widget_no_setup():
     so skipping ``setup()`` keeps these tests verifiable headless
     (``--no-main-window``), where ``setup()``'s ``self.layout`` is ``None``.
     """
-    from conftest import _require_qt_widget  # type: ignore[import-not-found]
-    _require_qt_widget()
+    from slicer_pytest_support import require_qt_widget
+    require_qt_widget()
 
     _import_slicer_or_skip()
     try:
@@ -147,7 +196,9 @@ def _liver_widget_no_setup():
         import Liver  # type: ignore[import-not-found]
     except ImportError as exc:
         pytest.skip(f"Liver scripted module not importable ({exc}).")
-    return Liver.LiverWidget(qt.QWidget())
+    parent = qt.QWidget()
+    qt.QVBoxLayout(parent)  # ScriptedLoadableModuleWidget reads parent.layout()
+    return Liver.LiverWidget(parent)
 
 
 # =========================================================================== #
@@ -170,13 +221,16 @@ def test_t2_stage1_predicate_exists_on_shell():
     ``_stage1IsComplete`` member.
     """
     widget = _liver_widget()
-    assert callable(getattr(widget, "_stage1IsComplete", None)), (
-        "LiverWidget._stage1IsComplete() not found."
-    )
-    result = widget._stage1IsComplete()
-    assert isinstance(result, bool), (
-        f"_stage1IsComplete() must return bool; got {type(result).__name__}."
-    )
+    try:
+        assert callable(getattr(widget, "_stage1IsComplete", None)), (
+            "LiverWidget._stage1IsComplete() not found."
+        )
+        result = widget._stage1IsComplete()
+        assert isinstance(result, bool), (
+            f"_stage1IsComplete() must return bool; got {type(result).__name__}."
+        )
+    finally:
+        _remove_shell_singletons()
 
 
 def test_t2_stage2_predicate_degrades_gracefully():
@@ -191,17 +245,21 @@ def test_t2_stage2_predicate_degrades_gracefully():
     ``_stage2IsComplete`` member.
     """
     widget = _liver_widget()
-    assert callable(getattr(widget, "_stage2IsComplete", None)), (
-        "LiverWidget._stage2IsComplete() not found."
-    )
-    # In the v2.0 sidebar, LiverSegmentation module is absent (the
-    # LiverSegmentation work is a v2.1 deliverable).  Predicate must
-    # still resolve cleanly.
-    result = widget._stage2IsComplete()
-    assert result is False, (
-        "Stage 2 predicate must return False while LiverSegmentation "
-        "module is absent; the sidebar entry should be disabled-greyed."
-    )
+    try:
+        assert callable(getattr(widget, "_stage2IsComplete", None)), (
+            "LiverWidget._stage2IsComplete() not found."
+        )
+        # Graceful degradation: the predicate must resolve cleanly and
+        # return a bool whether or not LiverSegmentation is in the build
+        # (it IS present in v2.0 -- the anatomy import shipped -- so the
+        # value tracks the scene, False on an empty one).
+        result = widget._stage2IsComplete()
+        assert result is False, (
+            "Stage 2 predicate must return False on an empty scene; the "
+            "sidebar entry should read pending."
+        )
+    finally:
+        _remove_shell_singletons()
 
 
 def test_t2_stage3_predicate_exists_on_territories_logic():
@@ -296,7 +354,10 @@ def test_t3_stage1_semantics_empty_scene_returns_false():
     """
     _clear_scene()
     widget = _liver_widget()
-    assert widget._stage1IsComplete() is False
+    try:
+        assert widget._stage1IsComplete() is False
+    finally:
+        _remove_shell_singletons()
 
 
 def test_t3_stage1_semantics_tagged_volume_returns_true():
@@ -312,12 +373,15 @@ def test_t3_stage1_semantics_tagged_volume_returns_true():
     widget = _liver_widget()
 
     volume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode")
-    # ``LiverRole`` is the per-volume role tag from ADR-0023 §"Decision"
-    # item 1 ("assign per-volume role tags").  Convention pending
-    # implementer; the test pins only the attribute presence.
-    volume.SetAttribute("LiverRole", "PortalVenous")
+    try:
+        # ``LiverRole`` is the per-volume role tag from ADR-0023 §"Decision"
+        # item 1 ("assign per-volume role tags").
+        volume.SetAttribute("LiverRole", "PortalVenous")
 
-    assert widget._stage1IsComplete() is True
+        assert widget._stage1IsComplete() is True
+    finally:
+        slicer.mrmlScene.RemoveNode(volume)
+        _remove_shell_singletons()
 
 
 def test_t3_stage3_semantics_empty_scene_returns_false():

--- a/Liver/Testing/Python/test_liver_shell_sidebar.py
+++ b/Liver/Testing/Python/test_liver_shell_sidebar.py
@@ -84,9 +84,9 @@ def _instantiate_liver_widget():
     # Widget-level tests need qt.QWidget — bare ``PythonSlicer -m pytest``
     # leaves PythonQt's qt module importable but without QWidget.  Skip
     # gracefully when the launched-Slicer harness isn't in play.
-    from conftest import (  # type: ignore[import-not-found]
-        _import_slicer_or_skip,
-        _require_qt_widget,
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_qt_widget as _require_qt_widget,
     )
     _require_qt_widget()
 
@@ -101,6 +101,7 @@ def _instantiate_liver_widget():
         )
 
     parent = qt.QWidget()
+    qt.QVBoxLayout(parent)  # ScriptedLoadableModuleWidget reads parent.layout()
     widget = Liver.LiverWidget(parent)
     widget.setup()
     return widget
@@ -295,9 +296,9 @@ def test_state_indicators_reflect_isstagecomplete():
 # ``import Liver`` guard.
 
 def _import_liver_or_skip():
-    from conftest import (  # type: ignore[import-not-found]
-        _import_slicer_or_skip,
-        _require_qt_widget,
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_qt_widget as _require_qt_widget,
     )
 
     # LiverWidget subclasses ScriptedLoadableModuleWidget, whose class body needs

--- a/Testing/Python/unit/test_bezier_surface_node.py
+++ b/Testing/Python/unit/test_bezier_surface_node.py
@@ -488,12 +488,12 @@ def test_display_defaults(mrml_module):
     assert list(node.GetResectionGridColor()) == pytest.approx([0.0, 0.0, 0.0])
     assert node.GetResectionOpacity() == pytest.approx(1.0)
     assert node.GetGridVisibility() is False
-    # Grid defaults match the resection mapper's own (divisions 20,
-    # thickness factor 9.5) so a fresh display node renders the control-grid
-    # overlay -- the earlier 0/0 defaults overwrote the mapper uniforms and
-    # suppressed the grid entirely.
-    assert node.GetGridDivisions() == pytest.approx(20.0)
-    assert node.GetGridThickness() == pytest.approx(9.5)
+    # Grid OFF by default (0 divisions / 0 thickness): the 1:1 locator
+    # marker carries the resectogram<->surface correspondence, so the
+    # procedural grid overlay is visual noise; the setters keep it
+    # available for debugging.
+    assert node.GetGridDivisions() == pytest.approx(0.0)
+    assert node.GetGridThickness() == pytest.approx(0.0)
     assert node.GetGrid3DVisibility() is True
     assert node.GetGrid2DVisibility() is False
     assert node.GetWidgetVisibility() is True

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -132,14 +132,12 @@ class VascularTerritories(ScriptedLoadableModule):
       return
     self._cppLogic = vtkSlicerVascularTerritoriesLogic()
     self._cppLogic.SetMRMLScene(slicer.mrmlScene)
-    # Expose the specialized Logic on ``slicer.modules.vascularterritories``
-    # so test helpers and downstream code can fetch it (the default
-    # ``slicer.modules.vascularterritories.logic()`` returns a generic
-    # ``vtkSlicerScriptedLoadableModuleLogic`` because this is a
-    # scripted module).
-    module = getattr(slicer.modules, "vascularterritories", None)
-    if module is not None:
-      module.specializedLogic = self._cppLogic
+    # The specialized Logic is reachable as
+    # ``slicer.modules.vascularterritories.self()._cppLogic`` (the scripted
+    # module's Python instance).  Do NOT assign it onto the C++ module
+    # object -- qSlicerScriptedLoadableModule refuses new attributes, which
+    # raised at every startup and left downstream consumers (the Stage-3
+    # IsStageComplete contract) resolving the generic scripted logic.
 
 #
 # Register sample data sets in Sample Data module


### PR DESCRIPTION
Closes #551.

The Liver shell suites (`Liver/Testing/Python`) were never among the launched test roots, so they executed nowhere in CI and drifted silently — 11 failures had accumulated unseen. This PR makes them pass in the full four-root CI shape and adds the root so they stay enforced.

**Product fix uncovered by the suite**
- The IsStageComplete contract was already implemented but unreachable for scripted stage modules: VascularTerritories tried to graft its specialized C++ logic onto the C++ module object (`module.specializedLogic = ...`), which `qSlicerScriptedLoadableModule` refuses — the same AttributeError that printed at every application startup. The logic is now resolved via the `slicer.modules.<Name>Instance` convention, and the Liver shell's per-stage completion lookup queries the module instance's `_cppLogic` alongside `module.logic()`. Stage-3/4 indicators now read their real predicates.

**Test repairs**
- Widget fixtures built `LiverWidget` on a layout-less parent (`setup()` reads `parent.layout()`) — fixtures now mint a layout-bearing parent.
- Three files imported helpers `from conftest`, which multi-root launched runs resolve to the wrong root's file — moved to the shared `slicer_pytest_support` module.
- The stage-2 pin claimed LiverSegmentation is absent from v2.0 (it shipped) — re-pinned to false-on-empty-scene semantics.
- Widget-minting tests tear down the shell singletons they create; a stray Python grid-defaults pin still asserting the pre-grid-off 20/9.5 defaults is aligned (a two-harness miss the soft-gated launched row had hidden).

**Leak-guard upgrade**
- The scene leak guard now NAMES surviving nodes in its assertion (class/name) and excludes singleton-tagged nodes from the growth check: module parameter nodes are scene-owned framework state that live widgets re-mint on removal — only non-singleton growth indicates a real test leak.

**CI enforcement**
- `Liver/Testing/Python` joins the launched test roots. Root ORDER is load-bearing and documented in place: pytest prepends every root's conftest dir to sys.path at session start, so the last-listed root wins any plain `import conftest` — LiverSegmentation's tests rely on that name and its root stays last.

Validated in the exact four-root CI shape: 354 passed, 0 failures from this scope (one unrelated network flake: the dcmqi schema test fetches from raw.githubusercontent at test time and hit HTTP 429 — possibly worth its own issue).