### PR TITLE
ENH: Case Setup panel as .ui + StructureCard view/controller split

### DIFF
--- a/Liver/CMakeLists.txt
+++ b/Liver/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MODULE_PYTHON_RESOURCES
   Resources/UI/DistanceMapsWidget.ui
   Resources/UI/ResectogramWidget.ui
   Resources/UI/StageExportWidget.ui
+  Resources/UI/StageCaseSetupWidget.ui
   )
 
 #-----------------------------------------------------------------------------

--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -432,45 +432,29 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       layout.addStretch(1)
       return page
 
-    page = qt.QWidget()
-    layout = qt.QVBoxLayout(page)
-    layout.addWidget(qt.QLabel(
-      "Case Setup — load volume(s) via Add Data, then tag each with its "
-      "acquisition-phase role."))
+    # Static panel authored in ``Resources/UI/StageCaseSetupWidget.ui``
+    # (designer-editable, the Stage-6 Export pattern); only the runtime
+    # wiring -- role population, signals, scene binding, the code-populated
+    # volumes-x-roles table refresh -- stays here.
+    page = slicer.util.loadUI(self.resourcePath("UI/StageCaseSetupWidget.ui"))
+    page.setMRMLScene(slicer.mrmlScene)
+    ui = slicer.util.childWidgetVariables(page)
 
-    row = qt.QHBoxLayout()
-    row.addWidget(qt.QLabel("Volume:"))
-    volumeCombo = slicer.qMRMLNodeComboBox()
-    volumeCombo.setObjectName("CaseSetupVolumeComboBox")
-    volumeCombo.nodeTypes = ["vtkMRMLScalarVolumeNode"]
-    volumeCombo.addEnabled = False
-    volumeCombo.removeEnabled = False
-    volumeCombo.noneEnabled = True
+    volumeCombo = ui.CaseSetupVolumeComboBox
+    # Bind the selector's scene explicitly -- the root qMRMLWidget's
+    # setMRMLScene does not reliably propagate to the child selector at
+    # build time (before the page is parented/shown).
     volumeCombo.setMRMLScene(slicer.mrmlScene)
     volumeCombo.connect("currentNodeChanged(vtkMRMLNode*)", self._onCaseSetupVolumeChanged)
-    row.addWidget(volumeCombo, 1)
 
-    row.addWidget(qt.QLabel("Role:"))
-    roleCombo = qt.QComboBox()
-    roleCombo.setObjectName("CaseSetupRoleComboBox")
+    roleCombo = ui.CaseSetupRoleComboBox
     for value in roles.LIVER_ROLES:
       roleCombo.addItem(self._caseSetupRoleLabel(value), value)
-    row.addWidget(roleCombo)
 
-    assignButton = qt.QPushButton("Assign role")
-    assignButton.setObjectName("CaseSetupAssignButton")
-    assignButton.connect("clicked()", self._onCaseSetupAssignRole)
-    row.addWidget(assignButton)
-    layout.addLayout(row)
+    ui.CaseSetupAssignButton.connect("clicked()", self._onCaseSetupAssignRole)
 
-    table = qt.QTableWidget()
-    table.setObjectName("CaseSetupRoleTable")
-    table.setColumnCount(2)
-    table.setHorizontalHeaderLabels(["Volume", "Role"])
+    table = ui.CaseSetupRoleTable
     table.horizontalHeader().setStretchLastSection(True)
-    table.editTriggers = qt.QAbstractItemView.NoEditTriggers
-    table.selectionBehavior = qt.QAbstractItemView.SelectRows
-    layout.addWidget(table, 1)
 
     self._caseSetupVolumeCombo = volumeCombo
     self._caseSetupRoleCombo = roleCombo

--- a/Liver/Resources/UI/StageCaseSetupWidget.ui
+++ b/Liver/Resources/UI/StageCaseSetupWidget.ui
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StageCaseSetupWidget</class>
+ <widget class="qMRMLWidget" name="StageCaseSetupWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>380</width>
+    <height>240</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="CaseSetupIntroLabel">
+     <property name="text">
+      <string>Case Setup — load volume(s) via Add Data, then tag each with its acquisition-phase role.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="assignRow">
+     <item>
+      <widget class="QLabel" name="VolumeLabel">
+       <property name="text">
+        <string>Volume:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="qMRMLNodeComboBox" name="CaseSetupVolumeComboBox">
+       <property name="nodeTypes">
+        <stringlist>
+         <string>vtkMRMLScalarVolumeNode</string>
+        </stringlist>
+       </property>
+       <property name="addEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="removeEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="noneEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="RoleLabel">
+       <property name="text">
+        <string>Role:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="CaseSetupRoleComboBox"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="CaseSetupAssignButton">
+       <property name="text">
+        <string>Assign role</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="CaseSetupRoleTable">
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <column>
+      <property name="text">
+       <string>Volume</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Role</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/LiverSegmentation/CMakeLists.txt
+++ b/LiverSegmentation/CMakeLists.txt
@@ -26,6 +26,7 @@ set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
   Resources/UI/${MODULE_NAME}.ui
   Resources/UI/BackendStatusRow.ui
+  Resources/UI/StructureCard.ui
   Resources/UI/LoadSegmentationSection.ui
   )
 

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -213,20 +213,17 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         Editor (ADR-0024 §"Per-structure micro-workflows").  The card holds
         its own scratch node between Run and Accept/Reject.
         """
-        page = qt.QWidget()
-        layout = qt.QVBoxLayout(page)
-
-        card = _StructureCard(self, title, sctCode)
-        layout.addWidget(card.runButton)
-        layout.addWidget(card.statusLabel)
-        layout.addWidget(card.progressBar)
-
-        actions = qt.QHBoxLayout()
-        actions.addWidget(card.acceptButton)
-        actions.addWidget(card.rejectButton)
-        actions.addWidget(card.editButton)
-        layout.addLayout(actions)
-        layout.addStretch(1)
+        # Layout authored in ``Resources/UI/StructureCard.ui`` (one reusable
+        # designer file backs all four cards); the controller binds the
+        # loaded widgets (view/controller split, ADR-0029).
+        page = slicer.util.loadUI(self.resourcePath("UI/StructureCard.ui"))
+        view = slicer.util.childWidgetVariables(page)
+        card = _StructureCard(self, title, sctCode, view=view)
+        # The widget owns its card controllers explicitly (previously they
+        # survived only through PythonQt signal references).
+        if not hasattr(self, "_structureCards"):
+            self._structureCards = []
+        self._structureCards.append(card)
         return page
 
     def _buildBackendStatusRow(self):
@@ -374,18 +371,34 @@ class _StructureCard:
     Accept/Reject; delegates all node lifecycle to the orchestrator.
     """
 
-    def __init__(self, widget, title, sctCode):
+    def __init__(self, widget, title, sctCode, view=None):
         self._widget = widget
         self._sctCode = sctCode
         self._scratch = None
 
-        self.runButton = qt.QPushButton(f"Run TotalSegmentator ({title})")
-        self.statusLabel = qt.QLabel("Idle")
-        self.progressBar = qt.QProgressBar()
+        if view is not None:
+            # VIEW/CONTROLLER split (ADR-0029): the widgets come from the
+            # designer-authored ``Resources/UI/StructureCard.ui`` as a
+            # ``childWidgetVariables`` namespace -- BIND them, do not build.
+            self.runButton = view.RunButton
+            self.statusLabel = view.StatusLabel
+            self.progressBar = view.ProgressBar
+            self.acceptButton = view.AcceptButton
+            self.rejectButton = view.RejectButton
+            self.editButton = view.EditButton
+            self.runButton.setText(f"Run TotalSegmentator ({title})")
+            self.statusLabel.setText("Idle")
+        else:
+            # Programmatic fallback -- the GL-free unit path (and any host
+            # without resourcePath) constructs the same six widgets.
+            self.runButton = qt.QPushButton(f"Run TotalSegmentator ({title})")
+            self.statusLabel = qt.QLabel("Idle")
+            self.progressBar = qt.QProgressBar()
+            self.acceptButton = qt.QPushButton("Accept")
+            self.rejectButton = qt.QPushButton("Reject")
+            self.editButton = qt.QPushButton("Edit in Segment Editor")
+
         self.progressBar.setVisible(False)
-        self.acceptButton = qt.QPushButton("Accept")
-        self.rejectButton = qt.QPushButton("Reject")
-        self.editButton = qt.QPushButton("Edit in Segment Editor")
         self.acceptButton.setEnabled(False)
         self.rejectButton.setEnabled(False)
 

--- a/LiverSegmentation/Resources/UI/StructureCard.ui
+++ b/LiverSegmentation/Resources/UI/StructureCard.ui
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StructureCard</class>
+ <widget class="QWidget" name="StructureCard">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>360</width>
+    <height>180</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QPushButton" name="RunButton">
+     <property name="text">
+      <string>Run TotalSegmentator</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="StatusLabel">
+     <property name="text">
+      <string>Idle</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="ProgressBar">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="actionsRow">
+     <item>
+      <widget class="QPushButton" name="AcceptButton">
+       <property name="text">
+        <string>Accept</string>
+       </property>
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="RejectButton">
+       <property name="text">
+        <string>Reject</string>
+       </property>
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="EditButton">
+       <property name="text">
+        <string>Edit in Segment Editor</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_card_run_produces_scratch.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_card_run_produces_scratch.py
@@ -301,3 +301,50 @@ def test_card_run_with_portalvenous_volume_still_segments(monkeypatch):
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+def test_card_binds_an_injected_view():
+    """The card is a CONTROLLER: given a view namespace, it binds -- not builds.
+
+    The .ui-authored card (ADR-0029 designer-editable panels) supplies the
+    six widgets as a ``childWidgetVariables`` namespace; the controller must
+    adopt them (same public attribute names as the programmatic fallback),
+    stamp the per-structure Run text, apply the initial enabled/hidden
+    state, and wire the signals -- without constructing replacement widgets.
+    """
+    from conftest import _import_slicer_or_skip
+
+    _import_slicer_or_skip()
+    _require_qt_widget_or_skip()
+    import qt
+
+    try:
+        import LiverSegmentation as module
+    except ImportError as exc:
+        pytest.skip(f"LiverSegmentation module not importable ({exc}).")
+
+    class _View:
+        pass
+
+    view = _View()
+    view.RunButton = qt.QPushButton("placeholder")
+    view.StatusLabel = qt.QLabel("placeholder")
+    view.ProgressBar = qt.QProgressBar()
+    view.AcceptButton = qt.QPushButton("Accept")
+    view.RejectButton = qt.QPushButton("Reject")
+    view.EditButton = qt.QPushButton("Edit in Segment Editor")
+
+    class _StandInWidget:
+        logic = None
+
+    card = module._StructureCard(_StandInWidget(), "Liver", "10200004", view=view)
+    assert card.runButton is view.RunButton, "the controller must BIND the view"
+    assert card.statusLabel is view.StatusLabel
+    assert card.progressBar is view.ProgressBar
+    assert card.runButton.text == "Run TotalSegmentator (Liver)", (
+        "the controller stamps the per-structure Run text on the bound view"
+    )
+    assert card.statusLabel.text == "Idle"
+    assert card.acceptButton.enabled is False
+    assert card.rejectButton.enabled is False
+    assert card.progressBar.visible is False


### PR DESCRIPTION
Closes #536.

Continues the designer-editable `.ui` adoption for static Liver panels (the pattern #534/#535 established: layout in `.ui`, only runtime wiring in code).

**1. Case Setup panel (clean conversion)**
`Liver.py:_buildStage1Page`'s static frame (volume selector + role dropdown + Assign + tagged-volumes table) moves to `Liver/Resources/UI/StageCaseSetupWidget.ui`, mirroring the Stage-6 Export panel — including the explicit child-selector scene binding the Export loader documents. Runtime wiring kept in code: role population from the shared `LiverSegmentationLib.roles` vocabulary, signal connections, and the code-populated volumes×roles table refresh. The roles-module-absent fallback is unchanged. (The #534 ordering gate this issue named has cleared — both #534 and #535 are merged.)

**2. `_StructureCard` view/controller split (the real refactor, test-first)**
One reusable `LiverSegmentation/Resources/UI/StructureCard.ui` now backs all four per-structure cards. `_StructureCard` gains a `view` kwarg accepting the `childWidgetVariables` namespace of the loaded page: the controller **binds** the six widgets, stamps the per-structure Run text, applies the initial enabled/hidden state, and wires the signals — constructing nothing. The programmatic fallback path is unchanged, so the GL-free unit construction (`_StructureCard(widget, title, sctCode)`) and every existing card behaviour pin keep passing; the bind seam is pinned by a new test. The widget also owns its card controllers explicitly now (they previously stayed alive only through PythonQt signal references).

Per the issue, `ResectionPlanningWidget`, `_buildShellSidebar`, and `LiverSegmentationWidget.setup` stay programmatic (composition/wiring, not static forms).

Validated: LiverSegmentation + Liver suites green (82 passed / 0 failed) on a local merge with #561's shell-test repairs; on this branch alone, CI's launched row will show the known pre-#561 shell-suite failures until #561 merges — the two branches touch different `Liver.py` regions and merge cleanly, so ordering is free.