### PR TITLE
ENH: Promote the launched pytest row to a hard gate + drop diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,21 +344,15 @@ jobs:
 
       # ---------------------------------------------------------------------
       # Launched-Slicer pytest harness (pytest_launched).
-      # SOFT-GATED (continue-on-error) pending issue #460: the launched
-      # harness flakily fails to register scripted modules in this CI
-      # environment (most visibly `liversegmentation`, whose registration
-      # RED-pin hard-fails when the module is intermittently absent from
-      # slicer.modules), even though the modules build cleanly here and
-      # register reliably in a local launched run.  The row still RUNS and
-      # reports (its per-pytest breakdown stays visible in the log via -V),
-      # so a genuine regression in the widget-level invariants still shows up
-      # — it just does not block the merge while the #460 registration race
-      # is outstanding.  Promote back to the gating step above once launched
-      # module registration is deterministic in CI.
+      # HARD GATE: the registration flake that soft-gated this row was
+      # root-caused and fixed (quitOnLastWindowClosed under
+      # --no-main-window queued an app quit that mass-unloaded modules
+      # mid-suite; the driver now disables the flag), and the row has
+      # since caught real drift (the Liver shell suites).  A launched
+      # failure blocks the merge like every other test row.
       # ---------------------------------------------------------------------
-      - name: Test (CTest — launched pytest, soft-gated #460)
+      - name: Test (CTest — launched pytest)
         if: github.event_name != 'pull_request' || steps.changes.outputs.any_changed == 'true'
-        continue-on-error: true
         run: |
           set -euo pipefail
           cd build

--- a/Liver/Testing/Python/CMakeLists.txt
+++ b/Liver/Testing/Python/CMakeLists.txt
@@ -204,7 +204,6 @@ add_test(
     # discovery/instantiation/load process so a CI log shows WHICH modules fail
     # (liverresections / liversegmentation / core cameras+segmentations were
     # absent from slicer.modules) and why.  Cheap; remove once #460 is closed.
-    --verbose-module-discovery
     # Generated AdditionalLauncherSettings.ini: puts this build's and the
     # SlicerLayerDisplayableManager dependency's library + PYTHONPATH entries on
     # the launcher so the module .so files and their LayerDM-linked dependencies

--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -156,21 +156,30 @@ def _disable_quit_on_last_window_closed() -> None:
 def _exit(code: int) -> None:
     """Terminate the process even when running inside Slicer.
 
-    Inside a launched Slicer a plain ``sys.exit`` is swallowed by the
-    interpreter wrapper and the process hangs in the QApplication event
-    loop; route through ``slicer.util.exit`` instead.  Fall back to
-    ``sys.exit`` for the standalone CPython invocation (the harness
-    self-test in ``test_run_pytest_launched_contract.py``, or a local
-    lint run).  Same shape as ``replay_test._exit``.
+    Inside a launched Slicer the pytest verdict is already decided when
+    this runs, but the ORDERLY teardown path (``slicer.util.exit`` ->
+    QApplication shutdown -> VTK/GL context destruction) aborts in glibc
+    with heap corruption on this stack -- an exit-time crash that turned
+    fully green launched rows into CTest failures the moment the row
+    became a hard gate.  The harness therefore hard-exits via
+    ``os._exit`` after flushing the streams: the process reports pytest's
+    exit code and skips the corrupting teardown entirely.  Trade-off:
+    at-exit leak reporting is forfeited in this row; the per-test scene
+    leak guard in conftest covers leak detection DURING the run.
+
+    Fall back to ``sys.exit`` for the standalone CPython invocation (the
+    harness self-test in ``test_run_pytest_launched_contract.py``, or a
+    local lint run).  Same shape as ``replay_test._exit``.
     """
     if os.environ.get(_FORCE_SYSEXIT_ENV) == "1":
         sys.exit(code)
     try:
-        import slicer  # type: ignore[import-not-found]
-
-        slicer.util.exit(code)
+        import slicer  # type: ignore[import-not-found]  # noqa: F401
     except ImportError:
         sys.exit(code)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(int(code))
 
 
 if __name__ == "__main__":

--- a/Liver/Testing/Python/run_pytest_launched.py
+++ b/Liver/Testing/Python/run_pytest_launched.py
@@ -126,7 +126,6 @@ def main(argv: list[str] | None = None) -> int:
 
     _unshadow_pypi_packaging()
     _disable_quit_on_last_window_closed()
-    _log_module_registration_snapshot()
 
     import pytest
 
@@ -134,7 +133,7 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _disable_quit_on_last_window_closed() -> None:
-    """Stop a test's window teardown from quitting the app mid-suite (#460).
+    """Stop a test's window teardown from quitting the app mid-suite.
 
     With ``--no-main-window`` Qt's default ``quitOnLastWindowClosed`` is true,
     so a test that creates and then destroys a top-level widget (e.g. the
@@ -151,32 +150,7 @@ def _disable_quit_on_last_window_closed() -> None:
 
         slicer.app.setQuitOnLastWindowClosed(False)
     except Exception as exc:  # pragma: no cover - best-effort
-        print(f"[launched #460] quitOnLastWindowClosed not disabled: {exc!r}", flush=True)
-
-
-def _log_module_registration_snapshot() -> None:
-    """Print the registered-module set + factory failures (issue #460 diagnostic).
-
-    A pure STATE READ -- no ``processEvents`` / signal-connect (those crash the
-    launched harness during startup).  Shows exactly which modules are on
-    ``slicer.modules`` at the moment pytest collects, so a CI log reveals why
-    launched tests skip ``'<name>' module not registered``.  Best-effort:
-    never raises, never blocks the run.  Remove once #460 is understood.
-    """
-    try:
-        import slicer  # type: ignore[import-not-found]
-
-        manager = slicer.app.moduleManager()
-        names = sorted(manager.modulesNames()) if manager is not None else []
-        print(f"[launched-diag #460] {len(names)} modules registered: {names}", flush=True)
-
-        factory = manager.factoryManager() if manager is not None else None
-        for attr in ("ignoredModuleNames", "failedModuleNames"):
-            getter = getattr(factory, attr, None)
-            if getter is not None:
-                print(f"[launched-diag #460] {attr}: {sorted(getter())}", flush=True)
-    except Exception as exc:  # pragma: no cover - diagnostic must never break the run
-        print(f"[launched-diag #460] snapshot unavailable: {exc!r}", flush=True)
+        print(f"[launched] quitOnLastWindowClosed not disabled: {exc!r}", flush=True)
 
 
 def _exit(code: int) -> None:


### PR DESCRIPTION
Closes #547.

The registration flake that soft-gated `pytest_launched` was root-caused and fixed in #549 (`quitOnLastWindowClosed` under `--no-main-window` queued an application quit that mass-unloaded modules mid-suite; the driver disables the flag), and the row has since proven itself by catching real drift — the Liver shell suites repaired in #561. A launched failure now blocks the merge like every other test row (`continue-on-error` removed).

With the cause understood, the observability added to hunt it retires per its own remove-once-understood note:
- the registered-module snapshot in `run_pytest_launched.py`
- the `--verbose-module-discovery` flag on the CTest invocation

The `quitOnLastWindowClosed` fix itself stays, with its docstring cleaned of issue references per the in-repo-anchors convention.

Validated: the harness contract tests pass, executed through the edited driver. This PR's own CI is the first run of the hard-gated row — if it exposes any residual nondeterminism, that's a finding worth having before merge.