### PR TITLE
ENH: Project the resection onto the slice views + locator UX hardening

### DIFF
--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   ResectionPlanningWidget.py
   ResectogramLocatorProducer.py
   ResectogramPipeline.py
+  SliceContourPipeline.py
   ResectogramViewManager.py
   Representations/__init__.py
   Representations/BezierPlanningRepresentation.py

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -56,6 +56,10 @@ CONTROL_POLYGON_GEOMETRY_CLASS = "vtkSlicerLiverBezierControlPolygonGeometry"
 #: value, unchanged by the ADR-0033 re-siting).
 CONTROL_POINT_PICK_RADIUS_PX = 20.0
 
+#: Halo colours: warm hover cue vs the distinct GRABBED (active-drag) cue.
+HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
+HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
+
 _REGISTERED = False
 
 
@@ -159,7 +163,7 @@ class ControlPolygonPipeline(_PipelineBase):
         self._halo_mapper.SetInputConnection(self._halo_sphere.GetOutputPort())
         self._halo_actor = vtk.vtkActor()
         self._halo_actor.SetMapper(self._halo_mapper)
-        self._halo_actor.GetProperty().SetColor(1.0, 0.9, 0.2)
+        self._halo_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
         self._halo_actor.SetVisibility(False)
         self._halo_renderer: Any | None = None
 
@@ -432,6 +436,9 @@ class ControlPolygonPipeline(_PipelineBase):
             ):
                 return False
             self._drag_index = idx
+            self._halo_actor.GetProperty().SetColor(*HALO_GRAB_COLOR)
+            hover, self._hover_index = idx, None
+            self._set_hover(hover)  # halo jumps to the grabbed handle
             world = self._event_world_at_control_point(renderer, eventData, idx)
             if world is not None:
                 self._apply_world_point_to_control_point(idx, world)
@@ -439,6 +446,7 @@ class ControlPolygonPipeline(_PipelineBase):
 
         if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
             self._drag_index = None
+            self._halo_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
             self._set_hover(None)
             return False  # grab over -- release the focus
 

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -396,8 +396,7 @@ class ControlPolygonPipeline(_PipelineBase):
             try:
                 grid = grid_getter()
                 base = int(index) * 3
-                scale = HALO_GRAB_SCALE if self._drag_index is not None else HALO_HOVER_SCALE
-                self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * scale)
+                self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * HALO_HOVER_SCALE)
                 self._halo_actor.SetPosition(grid[base], grid[base + 1], grid[base + 2])
                 self._halo_actor.SetVisibility(True)
             except Exception:  # pragma: no cover - defensive
@@ -408,6 +407,31 @@ class ControlPolygonPipeline(_PipelineBase):
                 request_render()
             except Exception:  # pragma: no cover - defensive (stub bases)
                 pass
+
+    def _set_grabbed_point_color(self, index: int | None) -> None:
+        """Colour the grabbed HANDLE itself (per-point glyph scalars).
+
+        The grabbed control point turns HALO_GRAB_COLOR; ``None`` restores
+        the uniform display HandleColor on all points.  Direct RGB scalars
+        on the glyph input; the mapper colours by them when present.
+        """
+        try:
+            points = self._handles_polydata.GetPoints()
+            n = points.GetNumberOfPoints() if points is not None else 0
+            base = [int(c * 255) for c in self._handles_actor.GetProperty().GetColor()]
+            colors = vtk.vtkUnsignedCharArray()
+            colors.SetNumberOfComponents(3)
+            colors.SetName("HandleColors")
+            grab = [int(c * 255) for c in HALO_GRAB_COLOR]
+            for i in range(n):
+                colors.InsertNextTuple3(*(grab if i == index else base))
+            self._handles_polydata.GetPointData().SetScalars(colors)
+            self._handles_glyph.SetColorModeToColorByScalar()
+            self._handles_mapper.SetColorModeToDirectScalars()
+            self._handles_mapper.SetScalarVisibility(index is not None)
+            self._handles_polydata.Modified()
+        except Exception:  # pragma: no cover - defensive
+            return
 
     def GetHaloActor(self) -> Any:  # noqa: N802 - VTK verb
         return self._halo_actor
@@ -441,7 +465,7 @@ class ControlPolygonPipeline(_PipelineBase):
             ):
                 return False
             self._drag_index = idx
-            self._halo_actor.GetProperty().SetColor(*HALO_GRAB_COLOR)
+            self._set_grabbed_point_color(idx)
             hover, self._hover_index = idx, None
             self._set_hover(hover)  # halo jumps to the grabbed handle
             world = self._event_world_at_control_point(renderer, eventData, idx)
@@ -451,7 +475,7 @@ class ControlPolygonPipeline(_PipelineBase):
 
         if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
             self._drag_index = None
-            self._halo_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
+            self._set_grabbed_point_color(None)
             self._set_hover(None)
             return False  # grab over -- release the focus
 

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -59,6 +59,10 @@ CONTROL_POINT_PICK_RADIUS_PX = 20.0
 #: Halo colours: warm hover cue vs the distinct GRABBED (active-drag) cue.
 HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
 HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
+#: Halo radius scale vs the handle: hover ring vs the larger GRAB ring
+#: (the size jump reads even where the glow blur washes the hue out).
+HALO_HOVER_SCALE = 1.35
+HALO_GRAB_SCALE = 1.9
 
 _REGISTERED = False
 
@@ -392,7 +396,8 @@ class ControlPolygonPipeline(_PipelineBase):
             try:
                 grid = grid_getter()
                 base = int(index) * 3
-                self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * 1.35)
+                scale = HALO_GRAB_SCALE if self._drag_index is not None else HALO_HOVER_SCALE
+                self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * scale)
                 self._halo_actor.SetPosition(grid[base], grid[base + 1], grid[base + 2])
                 self._halo_actor.SetVisibility(True)
             except Exception:  # pragma: no cover - defensive

--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -976,6 +976,7 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             _safe_get_init_mode(self._data_node),
             _control_points_digest(self._data_node),
             _safe_get_picked_position(self._locator_node),
+            _safe_get_locator_visibility(self._locator_node),
         )
         if render_key == self._last_render_key:
             return
@@ -1035,6 +1036,19 @@ def _safe_get_mtime(node: Any) -> int:
         return int(getter())
     except Exception:  # pragma: no cover - defensive
         return 0
+
+
+def _safe_get_locator_visibility(node: Any) -> bool | None:
+    """The locator display's Visibility (the marker switch); None sans node."""
+    if node is None:
+        return None
+    display = node.GetDisplayNode() if hasattr(node, "GetDisplayNode") else None
+    if display is None:
+        return None
+    try:
+        return bool(display.GetVisibility())
+    except Exception:  # pragma: no cover - defensive
+        return None
 
 
 def _safe_get_picked_position(node: Any) -> tuple | None:

--- a/LiverResections/LiverResectionsLib/LocatorReslicer.py
+++ b/LiverResections/LiverResectionsLib/LocatorReslicer.py
@@ -41,7 +41,6 @@ from typing import Any
 
 _LOCATOR_NODE_CLASS = "vtkMRMLLocatorNode"
 #: The orthogonal slice driven by a resectogram click (v2.0 scope: Red only).
-_RED_SLICE_NODE_ID = "vtkMRMLSliceNodeRed"
 
 
 class LocatorReslicer:
@@ -117,9 +116,14 @@ class LocatorReslicer:
         if getter is None:
             return
         world = getter()
-        red = self._scene.GetNodeByID(_RED_SLICE_NODE_ID)
-        if red is not None:
-            self.reslice_slice_to_world(red, world)
+        # Jump EVERY slice view onto the pick (orientation preserved --
+        # JumpSliceByOffsetting translates along each plane's own normal):
+        # the earlier Red-only jump left the other planes stale while their
+        # markers/contours rendered, which read as broken.
+        for i in range(self._scene.GetNumberOfNodesByClass("vtkMRMLSliceNode")):
+            slice_node = self._scene.GetNthNodeByClass(i, "vtkMRMLSliceNode")
+            if slice_node is not None:
+                self.reslice_slice_to_world(slice_node, world)
         self._update_marker_model(locator, world)
 
     def _update_marker_model(self, locator: Any, world_xyz: Any) -> None:

--- a/LiverResections/LiverResectionsLib/LocatorReslicer.py
+++ b/LiverResections/LiverResectionsLib/LocatorReslicer.py
@@ -40,11 +40,10 @@ from __future__ import annotations
 from typing import Any
 
 _LOCATOR_NODE_CLASS = "vtkMRMLLocatorNode"
-#: The orthogonal slice driven by a resectogram click (v2.0 scope: Red only).
 
 
 class LocatorReslicer:
-    """Observes the single locator node and reslices the Red slice to its pick."""
+    """Observes the single locator node and jumps ALL slice views to its pick."""
 
     def __init__(self, scene: Any) -> None:
         self._scene = scene

--- a/LiverResections/LiverResectionsLib/LocatorReslicer.py
+++ b/LiverResections/LiverResectionsLib/LocatorReslicer.py
@@ -160,6 +160,13 @@ class LocatorReslicer:
                     display.SetSliceIntersectionThickness(2)
             display_node = locator.GetDisplayNode() if hasattr(locator, "GetDisplayNode") else None
             radius = display_node.GetRadius() if display_node is not None else 5.0
+            # Gesture-scoped marker (same switch the shader discs gate on).
+            marker_visible = (
+                bool(display_node.GetVisibility()) if display_node is not None else True
+            )
+            model_display = node.GetDisplayNode()
+            if model_display is not None:
+                model_display.SetVisibility2D(marker_visible)
             sphere = vtk.vtkSphereSource()
             sphere.SetCenter(float(world_xyz[0]), float(world_xyz[1]), float(world_xyz[2]))
             sphere.SetRadius(float(radius))

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -284,7 +284,10 @@ class BezierPlanningRepresentation:
 
         display_node = node.GetDisplayNode() if hasattr(node, "GetDisplayNode") else None
         radius = display_node.GetRadius() if display_node is not None else 0.0
-        set_radius(float(radius))
+        # Gesture-scoped marker: the display's base Visibility is the
+        # switch (press shows, release hides); invisible pushes radius 0.
+        visible = getattr(display_node, "GetVisibility", lambda: True)() if display_node is not None else False
+        set_radius(float(radius) if visible else 0.0)
 
     def cleanup(self) -> None:
         """Detach actors from the renderer and drop the VTK pipeline."""

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -290,7 +290,10 @@ class FlattenedSurfaceRepresentation:
         set_position(float(position[0]), float(position[1]), float(position[2]))
         display_node = node.GetDisplayNode() if hasattr(node, "GetDisplayNode") else None
         radius = display_node.GetRadius() if display_node is not None else 0.0
-        set_radius(float(radius))
+        # Gesture-scoped marker: the display's base Visibility is the
+        # switch (press shows, release hides); invisible pushes radius 0.
+        visible = getattr(display_node, "GetVisibility", lambda: True)() if display_node is not None else False
+        set_radius(float(radius) if visible else 0.0)
 
     def update(self, display_node: Any | None, data_node: Any | None) -> None:
         """Reconcile the resectogram against the current display + data nodes.

--- a/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
+++ b/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
@@ -161,6 +161,12 @@ class ResectionPlanningWidget(qt.QWidget):
         # scene's single vtkMRMLLocatorNode and reslices the orthogonal slice to
         # the picked point.  This widget owns its lifetime.
         self._locatorReslicer = None
+        # The single long-lived view manager for the dedicated resectogram
+        # view.  ONE instance per widget: the manager attaches the default-deny
+        # scene + slice-display observers, so a fresh manager per drawer
+        # refresh would stack a new observer set on every re-open.  This
+        # widget owns its lifetime (detached in cleanup()).
+        self._resectogramViewManager = None
 
         self._setupUi()
         self.refreshResectogramDrawer()
@@ -391,7 +397,9 @@ class ResectionPlanningWidget(qt.QWidget):
         # strip alone in it (display-node + view-node + camera configuration;
         # no custom DisplayableManager, ADR-0013 §5).  Per ADR-0004 the
         # view-manager class is Python and is imported + called DIRECTLY here.
-        manager = ResectogramViewManager()
+        if self._resectogramViewManager is None:
+            self._resectogramViewManager = ResectogramViewManager()
+        manager = self._resectogramViewManager
         view = manager.ensureViewNode()
         manager.configureView(view, displayNode, carrier)
 
@@ -771,6 +779,11 @@ class ResectionPlanningWidget(qt.QWidget):
         if self._locatorReslicer is not None:
             self._locatorReslicer.cleanup()
             self._locatorReslicer = None
+        # The view manager's default-deny observers (on the scene + slice
+        # display nodes, both of which outlive this panel).
+        if self._resectogramViewManager is not None:
+            self._resectogramViewManager.cleanup()
+            self._resectogramViewManager = None
         # VTK node observers (on scene nodes that outlive this panel).
         if self._activeResectionNode is not None and self._activeNodeObservationTag is not None:
             self._activeResectionNode.RemoveObserver(self._activeNodeObservationTag)

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -369,6 +369,7 @@ class ResectogramPipeline(_PipelineBase):
 
                 if self._event_type(eventData) == vtk.vtkCommand.LeftButtonReleaseEvent:
                     self._reslicing = False
+                    self._set_locator_marker_visible(False)
                     return False  # gesture over -- release the focus
                 if self._event_type(eventData) == vtk.vtkCommand.MouseMoveEvent:
                     getter = getattr(eventData, "GetDisplayPosition", None)
@@ -388,8 +389,30 @@ class ResectogramPipeline(_PipelineBase):
         produced = self._produce_from_display_position(getter()) is not None
         if produced:
             self._reslicing = True
+            self._set_locator_marker_visible(True)
             self._refresh_locator_marker()
         return produced
+
+    def _set_locator_marker_visible(self, visible: bool) -> None:
+        """Flip the marker switch: the locator DISPLAY node's Visibility.
+
+        Gesture-scoped semantics (the locator is a transient probe, not an
+        annotation): the opening press shows the marker, the closing release
+        hides it.  All consumers -- the 3D shader disc, the strip disc, the
+        slice dot model -- gate on this field.  ``locator.Modified()`` kicks
+        the consumers observing the locator node itself.
+        """
+        locator = self._resolve_locator_node(self._data_node)
+        if locator is None:
+            return
+        display = locator.GetDisplayNode() if hasattr(locator, "GetDisplayNode") else None
+        if display is None:
+            return
+        try:
+            display.SetVisibility(bool(visible))
+            locator.Modified()
+        except Exception:  # pragma: no cover - defensive
+            return
 
     def _refresh_locator_marker(self) -> None:
         """Re-push the locator uniforms on the strip + request a repaint.

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -413,6 +413,10 @@ class ResectogramPipeline(_PipelineBase):
             locator.Modified()
         except Exception:  # pragma: no cover - defensive
             return
+        # Re-push the strip's own uniforms + repaint: the strip pipeline's
+        # reconciliation keys on geometry, which a visibility flip does not
+        # touch, and the produce path only runs on picks -- not on release.
+        self._refresh_locator_marker()
 
     def _refresh_locator_marker(self) -> None:
         """Re-push the locator uniforms on the strip + request a repaint.

--- a/LiverResections/LiverResectionsLib/ResectogramViewManager.py
+++ b/LiverResections/LiverResectionsLib/ResectogramViewManager.py
@@ -297,13 +297,14 @@ class ResectogramViewManager:
             slicer, resectogramViewID
         )
 
-        count = scene.GetNumberOfNodesByClass("vtkMRMLDisplayableNode")
+        # Walk EVERY display node directly: display nodes hanging off
+        # non-displayable owners (vtkMRMLSliceDisplayNode on the slice
+        # nodes -- the slice-in-3D representation) are invisible to a
+        # displayable-based walk and leaked into the strip.
+        count = scene.GetNumberOfNodesByClass("vtkMRMLDisplayNode")
         for index in range(count):
-            node = scene.GetNthNodeByClass(index, "vtkMRMLDisplayableNode")
-            if node is None:
-                continue
-            for dIndex in range(node.GetNumberOfDisplayNodes()):
-                display = node.GetNthDisplayNode(dIndex)
+            display = scene.GetNthNodeByClass(index, "vtkMRMLDisplayNode")
+            if True:
                 if display is None or display.IsA("vtkMRMLResectogramDisplayNode"):
                     continue
 
@@ -363,6 +364,13 @@ class ResectogramViewManager:
         """
         scene = slicer.mrmlScene
         ids = []
+        # ALL non-strip views -- 3D AND slice: a display node restricted
+        # only to 3D views would stop rendering in the slice views (the
+        # vtkMRMLSliceDisplayNode slice-in-3D case).
+        for index in range(scene.GetNumberOfNodesByClass("vtkMRMLSliceNode")):
+            node = scene.GetNthNodeByClass(index, "vtkMRMLSliceNode")
+            if node is not None:
+                ids.append(node.GetID())
         count = scene.GetNumberOfNodesByClass("vtkMRMLViewNode")
         for index in range(count):
             node = scene.GetNthNodeByClass(index, "vtkMRMLViewNode")

--- a/LiverResections/LiverResectionsLib/ResectogramViewManager.py
+++ b/LiverResections/LiverResectionsLib/ResectogramViewManager.py
@@ -242,6 +242,20 @@ class ResectogramViewManager:
             slicer.vtkMRMLScene.NodeAddedEvent, _onNodeAdded
         )
         self._observed_scene = scene
+        # Slicer's show-in-3D logic REWRITES the slice display nodes'
+        # ViewNodeIDs on every toggle, clobbering the deny; re-deny on
+        # their Modified (idempotent: _setViewNodeIDsIfChanged only writes
+        # on a real change, so no observer loop).
+        self._slice_display_tags = []
+        for i in range(scene.GetNumberOfNodesByClass("vtkMRMLSliceDisplayNode")):
+            node = scene.GetNthNodeByClass(i, "vtkMRMLSliceDisplayNode")
+            if node is None:
+                continue
+            tag = node.AddObserver(
+                "ModifiedEvent",
+                lambda caller, event: self._onDisplayNodeAdded(slicer, caller),
+            )
+            self._slice_display_tags.append((node, tag))
 
     def _onDisplayNodeAdded(self, slicer: Any, node: Any) -> None:  # noqa: N802
         view = self._view_node
@@ -272,6 +286,12 @@ class ResectogramViewManager:
                 pass
         self._scene_observer_tag = None
         self._observed_scene = None
+        for node, tag in getattr(self, "_slice_display_tags", []):
+            try:
+                node.RemoveObserver(tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        self._slice_display_tags = []
 
     @staticmethod
     def _restrictAnatomyAwayFromView(  # noqa: N802 - Slicer/Qt verb convention

--- a/LiverResections/LiverResectionsLib/ResectogramViewManager.py
+++ b/LiverResections/LiverResectionsLib/ResectogramViewManager.py
@@ -94,6 +94,12 @@ class ResectogramViewManager:
         # observed scene, attached by configureView, detached by cleanup().
         self._scene_observer_tag: int | None = None
         self._observed_scene: Any | None = None
+        # Re-entrancy latch for the deny handler: the deny WRITES ViewNodeIDs,
+        # which fires the very ModifiedEvent the handler observes.  The
+        # change-guarded write converges on its own, but the latch makes the
+        # non-recursion structural rather than dependent on the guard's
+        # order-sensitive list compare.
+        self._in_deny = False
 
     def ensureViewNode(self) -> Any:  # noqa: N802 - Slicer/Qt verb convention
         """Return the dedicated resectogram view node, creating it once.
@@ -259,8 +265,9 @@ class ResectogramViewManager:
 
     def _onDisplayNodeAdded(self, slicer: Any, node: Any) -> None:  # noqa: N802
         view = self._view_node
-        if view is None or node is None:
+        if view is None or node is None or self._in_deny:
             return
+        self._in_deny = True
         try:
             if not node.IsA("vtkMRMLDisplayNode") or node.IsA("vtkMRMLResectogramDisplayNode"):
                 return
@@ -276,6 +283,8 @@ class ResectogramViewManager:
             self._setViewNodeIDsIfChanged(node, target)
         except Exception:  # pragma: no cover - observer must never raise
             return
+        finally:
+            self._in_deny = False
 
     def cleanup(self) -> None:
         """Detach the default-deny observer (symmetric with configureView)."""
@@ -324,22 +333,21 @@ class ResectogramViewManager:
         count = scene.GetNumberOfNodesByClass("vtkMRMLDisplayNode")
         for index in range(count):
             display = scene.GetNthNodeByClass(index, "vtkMRMLDisplayNode")
-            if True:
-                if display is None or display.IsA("vtkMRMLResectogramDisplayNode"):
-                    continue
+            if display is None or display.IsA("vtkMRMLResectogramDisplayNode"):
+                continue
 
-                existing = [
-                    display.GetNthViewNodeID(i)
-                    for i in range(display.GetNumberOfViewNodeIDs())
-                ]
-                # Drop the resectogram view if it was previously allowed; keep
-                # any other explicit restriction the node already carried.
-                kept = [
-                    viewID for viewID in existing if viewID != resectogramViewID
-                ]
-                target = kept if kept else anatomyViewIDs
+            existing = [
+                display.GetNthViewNodeID(i)
+                for i in range(display.GetNumberOfViewNodeIDs())
+            ]
+            # Drop the resectogram view if it was previously allowed; keep
+            # any other explicit restriction the node already carried.
+            kept = [
+                viewID for viewID in existing if viewID != resectogramViewID
+            ]
+            target = kept if kept else anatomyViewIDs
 
-                ResectogramViewManager._setViewNodeIDsIfChanged(display, target)
+            ResectogramViewManager._setViewNodeIDsIfChanged(display, target)
 
     @staticmethod
     def _setViewNodeIDsIfChanged(  # noqa: N802 - Slicer/Qt verb convention

--- a/LiverResections/LiverResectionsLib/ResectogramViewManager.py
+++ b/LiverResections/LiverResectionsLib/ResectogramViewManager.py
@@ -94,6 +94,9 @@ class ResectogramViewManager:
         # observed scene, attached by configureView, detached by cleanup().
         self._scene_observer_tag: int | None = None
         self._observed_scene: Any | None = None
+        # Per-slice-display re-deny observers: (node, tag) pairs, attached by
+        # _attachDefaultDenyObserver, detached by cleanup().
+        self._slice_display_tags: list = []
         # Re-entrancy latch for the deny handler: the deny WRITES ViewNodeIDs,
         # which fires the very ModifiedEvent the handler observes.  The
         # change-guarded write converges on its own, but the latch makes the
@@ -295,7 +298,7 @@ class ResectogramViewManager:
                 pass
         self._scene_observer_tag = None
         self._observed_scene = None
-        for node, tag in getattr(self, "_slice_display_tags", []):
+        for node, tag in self._slice_display_tags:
             try:
                 node.RemoveObserver(tag)
             except Exception:  # pragma: no cover - defensive

--- a/LiverResections/LiverResectionsLib/ResectogramViewManager.py
+++ b/LiverResections/LiverResectionsLib/ResectogramViewManager.py
@@ -90,6 +90,10 @@ class ResectogramViewManager:
 
     def __init__(self) -> None:
         self._view_node: Any | None = None
+        # Default-deny scene observer (see _onDisplayNodeAdded): tag +
+        # observed scene, attached by configureView, detached by cleanup().
+        self._scene_observer_tag: int | None = None
+        self._observed_scene: Any | None = None
 
     def ensureViewNode(self) -> Any:  # noqa: N802 - Slicer/Qt verb convention
         """Return the dedicated resectogram view node, creating it once.
@@ -180,6 +184,7 @@ class ResectogramViewManager:
             self._setViewNodeIDsIfChanged(displayNode, [resectogramViewID])
 
         self._restrictAnatomyAwayFromView(slicer, resectogramViewID)
+        self._attachDefaultDenyObserver(slicer)
         self._applyViewNodeBackground(viewNode)
         self._frameCamera(slicer, viewNode, displayNode)
 
@@ -210,6 +215,63 @@ class ResectogramViewManager:
             return
         viewNode.SetBackgroundColor(*target)
         viewNode.SetBackgroundColor2(*target)
+
+    def _attachDefaultDenyObserver(self, slicer: Any) -> None:  # noqa: N802
+        """WHITELIST the strip view: default-deny every display node on arrival.
+
+        The configure-time sweep only covers display nodes present at that
+        moment; anything created later (slice-in-3D models, future nodes)
+        defaulted to the all-views EMPTY ViewNodeIDs and leaked into the
+        strip.  A scene ``NodeAddedEvent`` observer restricts every arriving
+        display node away from the resectogram view unless it is on the
+        allowlist (the resectogram display node itself) -- only what the
+        strip wants ever appears in it.
+        """
+        if self._scene_observer_tag is not None:
+            return
+        import vtk
+
+        scene = slicer.mrmlScene
+
+        @vtk.calldata_type(vtk.VTK_OBJECT)
+        def _onNodeAdded(caller, event, callData):  # noqa: N803 - VTK callback
+            self._onDisplayNodeAdded(slicer, callData)
+
+        self._onNodeAddedCallback = _onNodeAdded  # keep the closure alive
+        self._scene_observer_tag = scene.AddObserver(
+            slicer.vtkMRMLScene.NodeAddedEvent, _onNodeAdded
+        )
+        self._observed_scene = scene
+
+    def _onDisplayNodeAdded(self, slicer: Any, node: Any) -> None:  # noqa: N802
+        view = self._view_node
+        if view is None or node is None:
+            return
+        try:
+            if not node.IsA("vtkMRMLDisplayNode") or node.IsA("vtkMRMLResectogramDisplayNode"):
+                return
+            resectogramViewID = view.GetID()
+            existing = [
+                node.GetNthViewNodeID(i)
+                for i in range(node.GetNumberOfViewNodeIDs())
+            ]
+            kept = [viewID for viewID in existing if viewID != resectogramViewID]
+            target = kept if kept else self._anatomyViewNodeIDs(
+                slicer, resectogramViewID
+            )
+            self._setViewNodeIDsIfChanged(node, target)
+        except Exception:  # pragma: no cover - observer must never raise
+            return
+
+    def cleanup(self) -> None:
+        """Detach the default-deny observer (symmetric with configureView)."""
+        if self._observed_scene is not None and self._scene_observer_tag is not None:
+            try:
+                self._observed_scene.RemoveObserver(self._scene_observer_tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        self._scene_observer_tag = None
+        self._observed_scene = None
 
     @staticmethod
     def _restrictAnatomyAwayFromView(  # noqa: N802 - Slicer/Qt verb convention

--- a/LiverResections/LiverResectionsLib/SliceContourPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceContourPipeline.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""LayerDM Pipeline projecting the resection surface onto slice views.
+
+The resection surface intersected with a slice plane is a CONTOUR -- the
+surgeon's 2D projection of the plan (the T2 render cutover's deferred
+slice-view half).  This Pipeline is keyed on the same
+``vtkMRMLParametricSurfaceDisplayNode`` the 3D surface Pipeline owns, but
+its creator accepts ``vtkMRMLSliceNode`` views ONLY (LayerDM creators
+dispatch per view TYPE; the 3D creator declines slice nodes, this one
+declines everything else) -- ADR-0013 §1 keying stays disjoint per
+(view-type, display-type) pair.
+
+Composition: the carrier's control grid feeds a ``vtkBezierSurfaceSource``
+tessellation, a ``vtkCutter`` slices it with the plane from the slice
+node's ``SliceToRAS`` (origin = 4th column, normal = 3rd), and the RAS
+contour is transformed by ``inverse(XYToRAS)`` into the slice view's XY
+space for a ``vtkActor2D`` -- the coordinate convention slice-view
+displayable managers render in.
+
+Lifecycle mirrors the sibling pipelines (no-arg ctor; SetDisplayNode
+derives the carrier + observers; OnRendererAdded re-derives after churn;
+digest-gated RequestRender on edits).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import vtk
+
+from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+
+try:  # pragma: no cover - exercised once per import path
+    from .LiverBezierSurfacePipeline import (
+        STATE_CONFIRMED,
+        STATE_PLANNING,
+        _control_points_digest,
+        _safe_get_state,
+    )
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    from LiverBezierSurfacePipeline import (  # type: ignore[no-redef]
+        STATE_CONFIRMED,
+        STATE_PLANNING,
+        _control_points_digest,
+        _safe_get_state,
+    )
+
+_REGISTERED = False
+
+
+def _resolve_surface_source() -> Any | None:
+    """The wrapped ``vtkBezierSurfaceSource``, or ``None`` off-path."""
+    try:
+        import vtkSlicerLiverResectionsModuleVTKWidgetsPython as widgets
+
+        cls = getattr(widgets, "vtkBezierSurfaceSource", None)
+        if cls is not None:
+            return cls
+    except ImportError:
+        pass
+    try:
+        import slicer
+
+        return getattr(slicer, "vtkBezierSurfaceSource", None)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
+    """True iff ``viewNode`` is a slice view (this pipeline's home)."""
+    if viewNode is None:
+        return False
+    is_a = getattr(viewNode, "IsA", None)
+    if is_a is None:
+        return False
+    try:
+        return bool(is_a("vtkMRMLSliceNode"))
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+class SliceContourPipeline(_PipelineBase):
+    """Renders the surface/slice-plane intersection contour in XY space."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.SetPythonObject(self)
+
+        self._display_node: Any | None = None
+        self._data_node: Any | None = None
+        self._slice_node: Any | None = None
+        self._renderer: Any | None = None
+        self._observer_tags: dict = {}
+        self._observed_node_refs: list = []
+        self._last_update_key: tuple | None = None
+        self._last_render_key: tuple | None = None
+
+        # RAS-space assembly: tessellated patch -> plane cut.
+        self._surface_source: Any | None = None  # lazy (wrapped class)
+        self._cut_plane = vtk.vtkPlane()
+        self._cutter = vtk.vtkCutter()
+        self._cutter.SetCutFunction(self._cut_plane)
+
+        # XY-space presentation: RAS contour -> inverse(XYToRAS) -> 2D actor.
+        self._xy_transform = vtk.vtkTransform()
+        self._transform_filter = vtk.vtkTransformPolyDataFilter()
+        self._transform_filter.SetTransform(self._xy_transform)
+        self._contour_mapper = vtk.vtkPolyDataMapper2D()
+        self._contour_actor = vtk.vtkActor2D()
+        self._contour_actor.SetMapper(self._contour_mapper)
+        self._contour_actor.GetProperty().SetColor(1.0, 0.0, 0.0)
+        self._contour_actor.GetProperty().SetLineWidth(2.0)
+        self._contour_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # LayerDM lifecycle
+    # ------------------------------------------------------------------ #
+
+    def SetViewNode(self, viewNode: Any) -> None:  # noqa: N802 - VTK verb
+        super().SetViewNode(viewNode)
+        self._slice_node = viewNode
+        self._last_update_key = None
+
+    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            self._detach_observer(self._display_node)
+        if self._data_node is not None:
+            self._detach_observer(self._data_node)
+
+        super().SetDisplayNode(displayNode)
+        self._display_node = displayNode
+        self._data_node = None
+        if displayNode is not None:
+            getter = getattr(displayNode, "GetDisplayableNode", None)
+            if getter is not None:
+                self._data_node = getter()
+            self._attach_observer(displayNode)
+            if self._data_node is not None:
+                self._attach_observer(self._data_node)
+        self._last_update_key = None
+
+    def OnReferenceToDisplayNodeAdded(self, fromNode: Any, role: Any = None) -> None:  # noqa: N802
+        if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
+            self._data_node = fromNode
+            self._attach_observer(fromNode)
+            self._last_update_key = None
+        self.UpdatePipeline()
+
+    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        self._renderer = renderer
+        if renderer is not None:
+            renderer.AddActor2D(self._contour_actor)
+        # Re-derive after renderer churn (cleanup clears the node handles).
+        if self._display_node is None:
+            base_getter = getattr(self, "GetDisplayNode", None)
+            display = base_getter() if base_getter is not None else None
+            if display is not None:
+                self.SetDisplayNode(display)
+        self._last_update_key = None
+        self.UpdatePipeline()
+
+    def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        if renderer is not None:
+            try:
+                renderer.RemoveActor2D(self._contour_actor)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        self._renderer = None
+        self.cleanup()
+
+    def cleanup(self) -> None:
+        for node in list(self._observed_node_refs):
+            self._detach_observer(node)
+        self._display_node = None
+        self._data_node = None
+        self._contour_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # Reconciliation
+    # ------------------------------------------------------------------ #
+
+    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        slice_node = self._slice_node
+        state = _safe_get_state(self._data_node)
+        key = (
+            state,
+            _control_points_digest(self._data_node),
+            self._slice_matrix_digest(slice_node),
+        )
+        if key == self._last_update_key:
+            return
+        self._last_update_key = key
+
+        visible = state in (STATE_PLANNING, STATE_CONFIRMED)
+        contour = self._recompute_contour(slice_node) if visible else None
+        has_points = contour is not None and contour.GetNumberOfPoints() > 0
+        self._contour_actor.SetVisibility(bool(visible and has_points))
+
+    def _recompute_contour(self, slice_node: Any) -> Any | None:
+        """Tessellate, cut with the slice plane, transform into XY."""
+        carrier = self._data_node
+        if carrier is None or slice_node is None:
+            return None
+        grid_getter = getattr(carrier, "GetControlGridVector", None)
+        if grid_getter is None:
+            return None
+        source_cls = _resolve_surface_source()
+        if source_cls is None:
+            return None
+        try:
+            grid = grid_getter()
+            if len(grid) < 48:
+                return None
+            points = vtk.vtkPoints()
+            for base in range(0, 48, 3):
+                points.InsertNextPoint(grid[base], grid[base + 1], grid[base + 2])
+            if self._surface_source is None:
+                self._surface_source = source_cls()
+                self._surface_source.SetResolution(20, 20)
+            self._surface_source.SetControlPoints(points)
+
+            to_ras = slice_node.GetSliceToRAS()
+            self._cut_plane.SetOrigin(
+                to_ras.GetElement(0, 3), to_ras.GetElement(1, 3), to_ras.GetElement(2, 3)
+            )
+            self._cut_plane.SetNormal(
+                to_ras.GetElement(0, 2), to_ras.GetElement(1, 2), to_ras.GetElement(2, 2)
+            )
+            self._cutter.SetInputConnection(self._surface_source.GetOutputPort())
+
+            xy_to_ras = vtk.vtkMatrix4x4()
+            xy_to_ras.DeepCopy(slice_node.GetXYToRAS())
+            xy_to_ras.Invert()
+            self._xy_transform.SetMatrix(xy_to_ras)
+            self._transform_filter.SetInputConnection(self._cutter.GetOutputPort())
+            self._transform_filter.Update()
+            output = self._transform_filter.GetOutput()
+            self._contour_mapper.SetInputConnection(self._transform_filter.GetOutputPort())
+            return output
+        except Exception:  # pragma: no cover - defensive
+            return None
+
+    @staticmethod
+    def _slice_matrix_digest(slice_node: Any) -> tuple:
+        """A value digest of the slice pose (reslicing must recut)."""
+        if slice_node is None:
+            return ()
+        try:
+            m = slice_node.GetXYToRAS()
+            s = slice_node.GetSliceToRAS()
+            return tuple(
+                round(mat.GetElement(r, c), 6)
+                for mat in (m, s)
+                for r in range(4)
+                for c in range(4)
+            )
+        except Exception:  # pragma: no cover - defensive
+            return ()
+
+    # ------------------------------------------------------------------ #
+    # Introspection
+    # ------------------------------------------------------------------ #
+
+    def GetDataNode(self) -> Any | None:  # noqa: N802 - VTK verb
+        return self._data_node
+
+    def GetContourActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._contour_actor
+
+    def GetContourPolyData(self) -> Any | None:  # noqa: N802 - VTK verb
+        try:
+            return self._transform_filter.GetOutput()
+        except Exception:  # pragma: no cover - defensive
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Observers
+    # ------------------------------------------------------------------ #
+
+    def _attach_observer(self, node: Any) -> None:
+        if node is None or not hasattr(node, "AddObserver"):
+            return
+        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
+        self._observer_tags.setdefault(id(node), []).append(tag)
+        if node not in self._observed_node_refs:
+            self._observed_node_refs.append(node)
+
+    def _detach_observer(self, node: Any) -> None:
+        for tag in self._observer_tags.pop(id(node), []):
+            try:
+                node.RemoveObserver(tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        try:
+            self._observed_node_refs.remove(node)
+        except ValueError:
+            pass
+
+    def _on_node_modified(self, caller: Any, event: str) -> None:
+        """Reconcile + repaint when the visible inputs actually changed."""
+        del caller, event
+        self.UpdatePipeline()
+
+        render_key = (
+            _safe_get_state(self._data_node),
+            _control_points_digest(self._data_node),
+            self._slice_matrix_digest(self._slice_node),
+        )
+        if render_key == self._last_render_key:
+            return
+        self._last_render_key = render_key
+        request_render = getattr(self, "RequestRender", None)
+        if request_render is not None:
+            try:
+                request_render()
+            except Exception:  # pragma: no cover - defensive (stub bases)
+                pass
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline-creator registration — ADR-0013 §5 call 3 (slice-view half)
+# --------------------------------------------------------------------------- #
+
+
+def registerSliceContourPipelineCreator() -> None:  # noqa: N802 - project convention
+    """Register the ``SliceContourPipeline`` creator with LayerDM.
+
+    Accepts ``(vtkMRMLSliceNode, vtkMRMLParametricSurfaceDisplayNode)``
+    pairs only -- the slice-view complement of the 3D surface creator's
+    3D-only gating.  Idempotent via the module-level flag.
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return
+
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLLayerDMPipelineFactory,
+        vtkMRMLLayerDMPipelineScriptedCreator,
+        vtkMRMLParametricSurfaceDisplayNode,
+    )
+
+    def tryCreate(viewNode, node):
+        if not _creator_accepts_view(viewNode):
+            return None
+        if not isinstance(node, vtkMRMLParametricSurfaceDisplayNode):
+            return None
+        return SliceContourPipeline()
+
+    creator = vtkMRMLLayerDMPipelineScriptedCreator()
+    creator.SetPythonCallback(tryCreate)
+    vtkMRMLLayerDMPipelineFactory.GetInstance().AddPipelineCreator(creator)
+    _REGISTERED = True

--- a/LiverResections/LiverResectionsLib/SliceContourPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceContourPipeline.py
@@ -95,6 +95,9 @@ class SliceContourPipeline(_PipelineBase):
         self._observed_node_refs: list = []
         self._last_update_key: tuple | None = None
         self._last_render_key: tuple | None = None
+        #: Geometry digest of the LAST tessellation feed: pose-only recuts
+        #: (reslicing) reuse the cached patch instead of re-tessellating.
+        self._last_fed_geometry: tuple | None = None
 
         # RAS-space assembly: tessellated patch -> plane cut.
         self._surface_source: Any | None = None  # lazy (wrapped class)
@@ -220,13 +223,20 @@ class SliceContourPipeline(_PipelineBase):
             grid = grid_getter()
             if len(grid) < 48:
                 return None
-            points = vtk.vtkPoints()
-            for base in range(0, 48, 3):
-                points.InsertNextPoint(grid[base], grid[base + 1], grid[base + 2])
             if self._surface_source is None:
                 self._surface_source = source_cls()
                 self._surface_source.SetResolution(20, 20)
-            self._surface_source.SetControlPoints(points)
+            geometry = _control_points_digest(carrier)
+            if geometry != self._last_fed_geometry:
+                # Feed (and re-tessellate) ONLY on real geometry change: a
+                # fresh vtkPoints always marks the source modified, so an
+                # unconditional feed re-tessellated the full patch on every
+                # pose-only recut -- three pipelines x every reslice event.
+                points = vtk.vtkPoints()
+                for base in range(0, 48, 3):
+                    points.InsertNextPoint(grid[base], grid[base + 1], grid[base + 2])
+                self._surface_source.SetControlPoints(points)
+                self._last_fed_geometry = geometry
 
             to_ras = slice_node.GetSliceToRAS()
             self._cut_plane.SetOrigin(

--- a/LiverResections/LiverResectionsLib/SliceContourPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceContourPipeline.py
@@ -119,7 +119,15 @@ class SliceContourPipeline(_PipelineBase):
 
     def SetViewNode(self, viewNode: Any) -> None:  # noqa: N802 - VTK verb
         super().SetViewNode(viewNode)
+        # Observe the slice node OURSELVES: reslicing modifies the slice
+        # node, and without this observer the contour keeps rendering the
+        # stale cut (the digest keys on the pose but nothing re-runs the
+        # reconciliation).
+        if self._slice_node is not None:
+            self._detach_observer(self._slice_node)
         self._slice_node = viewNode
+        if viewNode is not None:
+            self._attach_observer(viewNode)
         self._last_update_key = None
 
     def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb

--- a/LiverResections/LiverResectionsLib/__init__.py
+++ b/LiverResections/LiverResectionsLib/__init__.py
@@ -28,6 +28,10 @@ from .ResectogramPipeline import (
     ResectogramPipeline,
     registerResectogramPipelineCreator,
 )
+from .SliceContourPipeline import (
+    SliceContourPipeline,
+    registerSliceContourPipelineCreator,
+)
 from .ResectogramViewManager import (
     RESECTOGRAM_VIEW_SINGLETON_TAG,
     ResectogramViewManager,
@@ -36,6 +40,8 @@ from .ResectogramViewManager import (
 __all__ = [
     "LiverBezierSurfacePipeline",
     "registerPipelineCreator",
+    "SliceContourPipeline",
+    "registerSliceContourPipelineCreator",
     "ControlPolygonPipeline",
     "registerControlPolygonPipelineCreator",
     "ResectogramPipeline",

--- a/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
+++ b/LiverResections/Logic/vtkSlicerLiverResectionsLogic.cxx
@@ -214,6 +214,12 @@ vtkMRMLLocatorNode* vtkSlicerLiverResectionsLogic::EnsureLocatorNode()
   // flag, ADR-0025 §"The node").
   locator->CreateDefaultDisplayNodes();
   locator->SetLocatorActive(true);
+  // Gesture-scoped marker: hidden until the first pick gesture opens
+  // (the strip press flips the display Visibility; release clears it).
+  if (vtkMRMLDisplayNode* displayNode = locator->GetDisplayNode())
+  {
+    displayNode->SetVisibility(false);
+  }
   return locator;
 }
 

--- a/LiverResections/Testing/Python/test_locator_reslice_consumer.py
+++ b/LiverResections/Testing/Python/test_locator_reslice_consumer.py
@@ -463,3 +463,55 @@ def test_pick_places_the_dot_marker_in_slice_views():
         scene.RemoveNode(locator)
         for stale in _marker_nodes():
             scene.RemoveNode(stale)
+
+
+def test_pick_jumps_all_slice_views():
+    """A locator pick reslices EVERY slice view onto the picked point.
+
+    The single-slice (Red-only) behaviour left the other planes stale --
+    their markers/contours rendered but their offsets never moved.  Each
+    slice node's plane must pass through the pick afterwards (orientation
+    preserved: JumpSliceByOffsetting translates along the normal only).
+    """
+    slicer = _slicer_or_skip()
+    reslicer_cls = _reslicer_class_or_skip_pending()
+
+    scene = slicer.mrmlScene
+    # Mint two slice nodes with distinct orientations: the headless
+    # launched scene carries no default Red/Yellow/Green, and this pin
+    # must ASSERT (not skip) that every slice node jumps.  The pick also
+    # mints the dot-marker model; both are torn down below.
+    minted = []
+    for orientation in ("Axial", "Sagittal"):
+        node = scene.AddNewNodeByClass("vtkMRMLSliceNode")
+        node.SetOrientation(orientation)
+        minted.append(node)
+    slice_nodes = [
+        scene.GetNthNodeByClass(i, "vtkMRMLSliceNode")
+        for i in range(scene.GetNumberOfNodesByClass("vtkMRMLSliceNode"))
+    ]
+
+    locator = scene.AddNewNodeByClass("vtkMRMLLocatorNode")
+    try:
+        reslicer = reslicer_cls(scene)
+        pick = (23.0, -41.0, 67.0)
+        locator.SetPickedPositionWorld(*pick)
+
+        for node in slice_nodes:
+            to_ras = node.GetSliceToRAS()
+            origin = [to_ras.GetElement(r, 3) for r in range(3)]
+            normal = [to_ras.GetElement(r, 2) for r in range(3)]
+            distance = abs(sum(n * (p - o) for n, p, o in zip(normal, pick, origin)))
+            assert distance < 1e-3, (
+                f"{node.GetName()}: plane must pass through the pick "
+                f"(plane-to-point distance {distance:.4f})."
+            )
+        reslicer.cleanup()
+    finally:
+        scene.RemoveNode(locator)
+        for node in minted:
+            scene.RemoveNode(node)
+        for i in range(scene.GetNumberOfNodesByClass("vtkMRMLModelNode") - 1, -1, -1):
+            model = scene.GetNthNodeByClass(i, "vtkMRMLModelNode")
+            if model is not None and model.GetAttribute("LiverLocatorMarker") == "True":
+                scene.RemoveNode(model)

--- a/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
+++ b/LiverResections/Testing/Python/test_resectogram_locator_pipeline_seam.py
@@ -720,3 +720,42 @@ def test_drag_reslices_continuously_between_press_and_release():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+def test_marker_visibility_is_gesture_scoped():
+    """Press shows the marker, release hides it (transient-probe semantics).
+
+    The locator display node's base ``Visibility`` is the marker switch all
+    consumers gate on: the strip gesture flips it true on the opening press
+    and false on the closing release, so the marker never lingers like an
+    annotation.  The reslice itself is unaffected (planes stay jumped).
+    """
+    import vtk
+
+    slicer = _slicer_or_skip()
+    carrier = _make_affine_carrier_or_skip(slicer, "SeamMarkerGesture")
+    locator = _single_locator_or_skip(slicer)
+    display = locator.GetDisplayNode()
+    if display is None:
+        locator.CreateDefaultDisplayNodes()
+        display = locator.GetDisplayNode()
+    if display is None:
+        pytest.skip("locator display node unavailable in this build.")
+    display.SetVisibility(False)
+
+    pipeline = _pipeline_or_skip(slicer)
+    _inject_state(pipeline, carrier, mat_ratio=(1.0, 1.0), viewport_size=(256, 256))
+    _seam_or_skip_pending(pipeline)
+
+    press = _FakeInteractionEventData((64.0, 64.0))
+    assert pipeline.ProcessInteractionEvent(press) is True
+    assert display.GetVisibility(), "the opening press must SHOW the marker"
+
+    release = _FakeInteractionEventData(
+        (64.0, 64.0), event_type=vtk.vtkCommand.LeftButtonReleaseEvent
+    )
+    pipeline.ProcessInteractionEvent(release)
+    assert not display.GetVisibility(), (
+        "the closing release must HIDE the marker -- it is a transient "
+        "probe, not a markup-like annotation."
+    )

--- a/LiverResections/Testing/Python/test_resectogram_view_tag_at_add.py
+++ b/LiverResections/Testing/Python/test_resectogram_view_tag_at_add.py
@@ -77,3 +77,59 @@ def test_singleton_tag_visible_to_node_added_observers():
         node = manager.getViewNode()
         if node is not None:
             scene.RemoveNode(node)
+
+
+def test_display_nodes_added_after_configure_stay_out_of_the_strip():
+    """WHITELIST semantics: a display node arriving later is denied.
+
+    The configure-time sweep covers only nodes present at that moment;
+    slice-in-3D models (and any future display node) arrive later with the
+    all-views EMPTY ViewNodeIDs and leaked into the strip.  The manager's
+    default-deny observer must restrict every arriving display node away
+    from the resectogram view -- only the allowlisted resectogram display
+    ever appears in it.
+    """
+    slicer = _slicer_or_skip_local()
+    try:
+        from LiverResectionsLib.ResectogramViewManager import ResectogramViewManager
+    except Exception:
+        pytest.skip("ResectogramViewManager not importable.")
+
+    scene = slicer.mrmlScene
+    # An anatomy view must exist for the deny-target to be non-empty
+    # (production always has View1); mint one so the pin is order-free.
+    anatomy = scene.AddNewNodeByClass("vtkMRMLViewNode")
+    manager = ResectogramViewManager()
+    view = manager.ensureViewNode()
+    try:
+        manager._attachDefaultDenyObserver(slicer)
+
+        model = scene.AddNewNodeByClass("vtkMRMLModelNode")
+        model.CreateDefaultDisplayNodes()
+        display = model.GetDisplayNode()
+        ids = [
+            display.GetNthViewNodeID(i)
+            for i in range(display.GetNumberOfViewNodeIDs())
+        ]
+        assert ids, (
+            "an arriving display node must not keep the all-views EMPTY "
+            "ViewNodeIDs -- that leaks it into the strip."
+        )
+        assert view.GetID() not in ids, (
+            "the strip view must be DENIED by default to arriving display "
+            "nodes (whitelist semantics)."
+        )
+        manager.cleanup()
+        scene.RemoveNode(model)
+    finally:
+        node = manager.getViewNode()
+        if node is not None:
+            scene.RemoveNode(node)
+        scene.RemoveNode(anatomy)
+
+
+def _slicer_or_skip_local():
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()

--- a/LiverResections/Testing/Python/test_resectogram_view_tag_at_add.py
+++ b/LiverResections/Testing/Python/test_resectogram_view_tag_at_add.py
@@ -128,6 +128,52 @@ def test_display_nodes_added_after_configure_stay_out_of_the_strip():
         scene.RemoveNode(anatomy)
 
 
+def test_slice_display_rewrite_is_re_denied_without_recursing():
+    """Slicer's show-in-3D toggle REWRITES slice-display ViewNodeIDs; the
+    manager re-denies on their ModifiedEvent.  The deny itself WRITES
+    ViewNodeIDs (firing the very event it observes), so this pin also
+    proves the handler converges instead of recursing: the test finishing
+    at all IS the non-recursion assertion.
+    """
+    slicer = _slicer_or_skip_local()
+    try:
+        from LiverResectionsLib.ResectogramViewManager import ResectogramViewManager
+    except Exception:
+        pytest.skip("ResectogramViewManager not importable.")
+
+    scene = slicer.mrmlScene
+    anatomy = scene.AddNewNodeByClass("vtkMRMLViewNode")
+    sliceDisplay = scene.AddNewNodeByClass("vtkMRMLSliceDisplayNode")
+    if sliceDisplay is None:
+        pytest.skip("vtkMRMLSliceDisplayNode not registered in this scene.")
+    manager = ResectogramViewManager()
+    view = manager.ensureViewNode()
+    try:
+        # Attach AFTER the slice display exists so the re-deny observer
+        # covers it (production order: configureView runs against the
+        # main layout's already-present slice displays).
+        manager._attachDefaultDenyObserver(slicer)
+
+        # Simulate the show-in-3D rewrite: Slicer re-grants the strip view.
+        sliceDisplay.AddViewNodeID(view.GetID())
+
+        ids = [
+            sliceDisplay.GetNthViewNodeID(i)
+            for i in range(sliceDisplay.GetNumberOfViewNodeIDs())
+        ]
+        assert view.GetID() not in ids, (
+            "a slice-display ViewNodeIDs rewrite that re-grants the strip "
+            "view must be re-denied on its ModifiedEvent."
+        )
+    finally:
+        manager.cleanup()
+        node = manager.getViewNode()
+        if node is not None:
+            scene.RemoveNode(node)
+        scene.RemoveNode(sliceDisplay)
+        scene.RemoveNode(anatomy)
+
+
 def _slicer_or_skip_local():
     from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
 

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -197,6 +197,7 @@ void qSlicerLiverResectionsModule::setup()
                                    "    LiverResectionsLib.registerPipelineCreator()\n"
                                    "    LiverResectionsLib.registerResectogramPipelineCreator()\n"
                                    "    LiverResectionsLib.registerControlPolygonPipelineCreator()\n"
+                                   "    LiverResectionsLib.registerSliceContourPipelineCreator()\n"
                                    "except ImportError as exc:\n"
                                    "    import logging\n"
                                    "    logging.critical('LiverResections: LayerDM Pipeline creator not registered (%s)'\n"

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -406,3 +406,29 @@ def test_hover_highlights_nearest_handle(pipeline_module, polygon_nodes):
         "leaving the pick radius hides the halo"
     )
     pipeline.cleanup()
+
+
+def test_grab_changes_the_halo_color(pipeline_module, polygon_nodes):
+    """Press flips the halo to the grab colour; release restores hover."""
+    import vtk
+
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+    data.SetState(1)
+    pipeline._safe_get_renderer = lambda: object()
+    pipeline._nearest_control_point_in_display = lambda r, e: (5, 4.0)
+    pipeline._event_world_at_control_point = lambda r, e, i: (1.0, 2.0, 5.0)
+
+    press = _TypedEvent(vtk.vtkCommand.LeftButtonPressEvent)
+    release = _TypedEvent(vtk.vtkCommand.LeftButtonReleaseEvent)
+    assert pipeline.ProcessInteractionEvent(press) is True
+    assert pipeline.GetHaloActor().GetProperty().GetColor() == pytest.approx(
+        pipeline_module.HALO_GRAB_COLOR
+    ), "the grabbed handle must read as ACTIVE via the halo colour"
+    pipeline.ProcessInteractionEvent(release)
+    assert pipeline.GetHaloActor().GetProperty().GetColor() == pytest.approx(
+        pipeline_module.HALO_HOVER_COLOR
+    ), "release restores the hover colour"
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -424,11 +424,14 @@ def test_grab_changes_the_halo_color(pipeline_module, polygon_nodes):
     press = _TypedEvent(vtk.vtkCommand.LeftButtonPressEvent)
     release = _TypedEvent(vtk.vtkCommand.LeftButtonReleaseEvent)
     assert pipeline.ProcessInteractionEvent(press) is True
-    assert pipeline.GetHaloActor().GetProperty().GetColor() == pytest.approx(
-        pipeline_module.HALO_GRAB_COLOR
-    ), "the grabbed handle must read as ACTIVE via the halo colour"
+    scalars = pipeline._handles_polydata.GetPointData().GetScalars()
+    grab = tuple(int(c * 255) for c in pipeline_module.HALO_GRAB_COLOR)
+    assert scalars is not None and tuple(scalars.GetTuple3(5)) == pytest.approx(grab), (
+        "the grabbed HANDLE itself must take the grab colour (per-point scalar)"
+    )
+    assert pipeline._handles_mapper.GetScalarVisibility() == 1
     pipeline.ProcessInteractionEvent(release)
-    assert pipeline.GetHaloActor().GetProperty().GetColor() == pytest.approx(
-        pipeline_module.HALO_HOVER_COLOR
-    ), "release restores the hover colour"
+    assert pipeline._handles_mapper.GetScalarVisibility() == 0, (
+        "release restores the uniform display HandleColor"
+    )
     pipeline.cleanup()

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -750,3 +750,26 @@ def test_locator_marker_reaches_the_2d_mapper(rep_module):
     assert mapper.locator_position == pytest.approx((10.0, 20.0, 30.0))
     assert mapper.locator_radius == pytest.approx(2.0)
     rep.cleanup()
+
+
+def test_locator_marker_gates_on_display_visibility(rep_module):
+    """An invisible locator display pushes radius 0 (marker off)."""
+
+    class _HiddenDisplay(_StubLocatorDisplay):
+        def GetVisibility(self):  # noqa: N802 - VTK verb
+            return False
+
+    class _HiddenLocator(_StubLocatorNode):
+        def GetDisplayNode(self):  # noqa: N802 - VTK verb
+            return _HiddenDisplay()
+
+    rep = rep_module()
+    mapper = _StubMapperWithLocator()
+    rep._resection_mapper_2d = mapper
+    rep.SetLocatorNode(_HiddenLocator())
+    rep.update(_StubDisplayNode(), _StubDataNode())
+    assert mapper.locator_radius == pytest.approx(0.0), (
+        "locator display Visibility false -> the marker uniforms must be "
+        "pushed OFF (radius 0), the gesture-scoped hide."
+    )
+    rep.cleanup()

--- a/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
+++ b/Testing/Python/unit/test_liver_bezier_surface_pipeline.py
@@ -347,3 +347,33 @@ def test_locator_pick_requests_render(pipeline_module, bezier_nodes):
         pipeline.cleanup()
     finally:
         scene.RemoveNode(locator)
+
+
+def test_marker_visibility_toggle_requests_render(pipeline_module, bezier_nodes):
+    """Hiding the marker at a FIXED pick must still repaint the surface."""
+    import slicer
+
+    data, display = bezier_nodes
+    scene = slicer.mrmlScene
+    locator = scene.AddNewNodeByClass("vtkMRMLLocatorNode")
+    locator.CreateDefaultDisplayNodes()
+    try:
+        pipeline = pipeline_module.LiverBezierSurfacePipeline()
+        pipeline.SetDisplayNode(display)
+        data.SetState(1)
+        pipeline.UpdatePipeline()
+
+        locator.SetPickedPositionWorld(1.0, 2.0, 3.0)
+        renders = []
+        pipeline.RequestRender = lambda: renders.append(1)
+
+        ldisplay = locator.GetDisplayNode()
+        ldisplay.SetVisibility(not ldisplay.GetVisibility())
+        locator.Modified()
+        assert renders, (
+            "a marker visibility flip at a fixed pick must request a render "
+            "-- the release-hides-the-marker gesture repaints through here."
+        )
+        pipeline.cleanup()
+    finally:
+        scene.RemoveNode(locator)

--- a/Testing/Python/unit/test_slice_contour_pipeline.py
+++ b/Testing/Python/unit/test_slice_contour_pipeline.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Invariants for the ``SliceContourPipeline`` (T2.6-DM-2D).
+
+The resection surface's intersection with a slice plane is the surgeon's
+2D projection of the plan.  A dedicated LayerDM pipeline -- keyed on the
+same ``vtkMRMLParametricSurfaceDisplayNode`` but created only for
+``vtkMRMLSliceNode`` views (creators dispatch per view TYPE) -- cuts the
+tessellated surface with the slice plane and renders the contour in the
+slice view's XY space.
+
+Pins:
+
+* the cut contour follows the carrier's control grid (a flat grid at a
+  known z, cut by an axial plane through it, yields a non-empty line);
+* visibility is gated on an editable/complete state with a full grid;
+* a control-point edit requests a render (digest-gated, loop-guarded);
+* the creator seam: slice views accepted, 3D + resectogram views declined.
+
+Launched-row only (wrapped MRML nodes + LayerDMLib); skips bare.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("LayerDMLib")
+
+
+@pytest.fixture
+def pipeline_module():
+    import SliceContourPipeline as mod
+
+    return mod
+
+
+@pytest.fixture
+def surface_nodes():
+    import slicer
+
+    scene = slicer.mrmlScene
+    data = scene.AddNewNodeByClass("vtkMRMLBezierSurfaceNode")
+    display = scene.AddNewNodeByClass("vtkMRMLParametricSurfaceDisplayNode")
+    data.AddAndObserveDisplayNodeID(display.GetID())
+    try:
+        yield data, display
+    finally:
+        scene.RemoveNode(display)
+        scene.RemoveNode(data)
+
+
+def _seed_flat_grid(data, z=10.0):
+    for r in range(4):
+        for c in range(4):
+            data.SetControlPoint(r, c, float(c) * 10.0, float(r) * 10.0, z)
+
+
+class _AxialSliceNodeAt:
+    """Slice-node stand-in: axial plane at world ``z`` (identity XY)."""
+
+    def __init__(self, z):
+        import vtk
+
+        self._to_ras = vtk.vtkMatrix4x4()
+        self._to_ras.SetElement(2, 3, z)  # translate the plane to z
+        self._xy_to_ras = vtk.vtkMatrix4x4()
+
+    def GetSliceToRAS(self):  # noqa: N802 - VTK verb
+        return self._to_ras
+
+    def GetXYToRAS(self):  # noqa: N802 - VTK verb
+        return self._xy_to_ras
+
+    def GetMTime(self):  # noqa: N802 - VTK verb
+        return 1
+
+
+def test_contour_follows_the_grid_cut(pipeline_module, surface_nodes):
+    """An axial cut through the flat grid yields a non-empty contour."""
+    data, display = surface_nodes
+    pipeline = pipeline_module.SliceContourPipeline()
+    pipeline.SetDisplayNode(display)
+    pipeline._slice_node = _AxialSliceNodeAt(10.0)
+
+    _seed_flat_grid(data, z=10.0)
+    data.SetState(1)  # Planning
+    pipeline.UpdatePipeline()
+
+    contour = pipeline.GetContourPolyData()
+    assert contour is not None and contour.GetNumberOfPoints() > 0, (
+        "the slice plane passes THROUGH the flat grid -- the cut must "
+        "produce contour points."
+    )
+    assert pipeline.GetContourActor().GetVisibility() == 1
+    pipeline.cleanup()
+
+
+def test_offplane_cut_is_empty_and_hidden(pipeline_module, surface_nodes):
+    """A plane far from the surface yields no contour; the actor hides."""
+    data, display = surface_nodes
+    pipeline = pipeline_module.SliceContourPipeline()
+    pipeline.SetDisplayNode(display)
+    pipeline._slice_node = _AxialSliceNodeAt(500.0)
+
+    _seed_flat_grid(data, z=10.0)
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+
+    contour = pipeline.GetContourPolyData()
+    assert contour is None or contour.GetNumberOfPoints() == 0
+    assert pipeline.GetContourActor().GetVisibility() == 0
+    pipeline.cleanup()
+
+
+def test_edit_requests_render_with_loop_guard(pipeline_module, surface_nodes):
+    """A control-point edit repaints; Modified at fixed geometry does not."""
+    data, display = surface_nodes
+    pipeline = pipeline_module.SliceContourPipeline()
+    pipeline.SetDisplayNode(display)
+    pipeline._slice_node = _AxialSliceNodeAt(10.0)
+    _seed_flat_grid(data, z=10.0)
+    data.SetState(1)
+
+    renders = []
+    pipeline.RequestRender = lambda: renders.append(1)
+    data.SetControlPoint(0, 0, 1.0, 2.0, 10.0)
+    assert renders, "a geometry edit must request a slice repaint"
+    n = len(renders)
+    data.Modified()
+    assert len(renders) == n, "render-churn Modified must not re-request"
+    pipeline.cleanup()
+
+
+def test_creator_accepts_slice_views_only(pipeline_module):
+    """The creator seam: slice node in, 3D + resectogram views out."""
+    import slicer
+
+    accepts = pipeline_module._creator_accepts_view
+
+    slice_node = slicer.mrmlScene.CreateNodeByClass("vtkMRMLSliceNode")
+    slice_node.UnRegister(None)
+    assert accepts(slice_node) is True
+
+    view_node = slicer.mrmlScene.CreateNodeByClass("vtkMRMLViewNode")
+    view_node.UnRegister(None)
+    assert accepts(view_node) is False, "3D views belong to the surface pipeline"
+    assert accepts(None) is False

--- a/Testing/Python/unit/test_slice_contour_pipeline.py
+++ b/Testing/Python/unit/test_slice_contour_pipeline.py
@@ -145,3 +145,38 @@ def test_creator_accepts_slice_views_only(pipeline_module):
     view_node.UnRegister(None)
     assert accepts(view_node) is False, "3D views belong to the surface pipeline"
     assert accepts(None) is False
+
+
+def test_reslicing_recuts_the_contour(pipeline_module, surface_nodes):
+    """Moving the slice plane must recut + repaint the projection."""
+    import slicer
+
+    data, display = surface_nodes
+    scene = slicer.mrmlScene
+    slice_node = scene.AddNewNodeByClass("vtkMRMLSliceNode")
+    try:
+        pipeline = pipeline_module.SliceContourPipeline()
+        pipeline.SetViewNode(slice_node)
+        pipeline.SetDisplayNode(display)
+        _seed_flat_grid(data, z=10.0)
+        data.SetState(1)
+
+        slice_node.GetSliceToRAS().SetElement(2, 3, 10.0)  # through the grid
+        slice_node.Modified()
+        pipeline.UpdatePipeline()
+        assert pipeline.GetContourActor().GetVisibility() == 1
+
+        renders = []
+        pipeline.RequestRender = lambda: renders.append(1)
+        slice_node.GetSliceToRAS().SetElement(2, 3, 500.0)  # far away
+        slice_node.Modified()
+        assert renders, (
+            "a slice-pose change must reach the pipeline (slice-node "
+            "observer) and request a repaint -- the stale-trace bug."
+        )
+        assert pipeline.GetContourActor().GetVisibility() == 0, (
+            "the recut at the far plane must empty + hide the contour."
+        )
+        pipeline.cleanup()
+    finally:
+        scene.RemoveNode(slice_node)


### PR DESCRIPTION
Implements the deferred slice-view half of the render cutover (the 3D creator's 3D-only gating note) plus the locator/interaction refinements found in hands-on testing. Ten commits, all test-first, all demo-verified on real anatomy.

**Resection projection in the slice views**
- New `SliceContourPipeline`: keyed on the parametric-surface display node but created for `vtkMRMLSliceNode` views only (creators dispatch per view type). The carrier's grid feeds a `vtkBezierSurfaceSource` tessellation, a `vtkCutter` slices it with the plane from `SliceToRAS`, and the RAS contour transforms by `inverse(XYToRAS)` into a red 2-px `vtkActor2D` in the slice view's XY space.
- Reconciliation is digest-gated on BOTH the control-point geometry and the slice pose; the pipeline observes its slice node so reslicing recuts (the stale-trace bug), and pose-only recuts reuse the cached tessellation (PERF: a fresh `vtkPoints` always marks the source modified, so every reslice event was re-tessellating the patch three times).

**Locator UX**
- Every slice view jumps onto the pick (was Red-only — the other planes read as broken while their markers rendered).
- The marker is gesture-scoped: the locator display node's `Visibility` is the switch — press shows, release hides, in ALL views (strip disc, 3D surface disc, slice dots); hidden by default at creation. The 3D pipeline's render key gained the visibility so the hide repaints; the strip re-pushes its uniforms on the toggle.
- The grabbed control point turns green while held (per-point glyph scalars; the halo keeps its hover styling).

**Strip view isolation (whitelist semantics)**
- The one-shot configure sweep was a ban list: display nodes created or rewritten later leaked into the strip (slice-in-3D). The view manager now walks every `vtkMRMLDisplayNode` directly (slice display nodes hang off VIEW nodes, invisible to a displayable-based walk), denies arrivals via a scene `NodeAddedEvent` observer, and re-denies on the slice display nodes' `ModifiedEvent` — Slicer's show-in-3D logic rewrites their view lists on every toggle. Deny-targets include slice views so slice-view rendering is not collateral damage.

Validated: contour/seam/reslicer/CP suites green on the launched row (incl. new pins for each behaviour); interactive verification of contours following drags and reslices, all-views marker hide, the green grab cue, and repeated slice-in-3D toggles staying out of the strip.