### PR TITLE
ENH: Slice-view control polygon with markups-style projection + editing

### DIFF
--- a/Docs/adr/0013-layerdm-pipeline-pattern.md
+++ b/Docs/adr/0013-layerdm-pipeline-pattern.md
@@ -8,6 +8,24 @@
   *shape* those diagrams will record).
 - **PR:** _filled in on merge_
 
+## Amendments
+
+- **2026-07-09 — per-view-type Pipeline dispatch.**  §1's "exactly one
+  Pipeline subclass per display-node type" is refined: the creator
+  registry keys on the **(view type, display-node type) pair**, so one
+  display-node type may carry one Pipeline per *view type* — e.g.
+  `vtkMRMLControlPolygonDisplayNode` is rendered by
+  `ControlPolygonPipeline` in 3D views and by
+  `SliceControlPolygonPipeline` in slice views, and the resection
+  surface's slice projection ships as `SliceContourPipeline` alongside
+  the 3D surface Pipeline.  Registered creators dispatch on the view
+  node's type (`vtkMRMLSliceNode` vs `vtkMRMLViewNode`, plus singleton
+  tags for dedicated views); within a single view type the
+  exactly-one contract is unchanged.  This is the same compositional
+  axis §1 already grants across *display nodes* (one data node, many
+  display nodes), extended across *view families* for one display
+  node.
+
 ## Context
 
 [ADR-0002](0002-migrate-to-slicerlayerdm.md) commits Slicer-Liver to

--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -31,6 +31,7 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   ResectogramLocatorProducer.py
   ResectogramPipeline.py
   SliceContourPipeline.py
+  SliceControlPolygonPipeline.py
   ResectogramViewManager.py
   Representations/__init__.py
   Representations/BezierPlanningRepresentation.py

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -64,6 +64,12 @@ HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
 HALO_HOVER_SCALE = 1.35
 HALO_GRAB_SCALE = 1.9
 
+#: World-space dash pattern for the polygon edge tubes -- the same
+#: dashed-scaffold language the slice projections use, so the control
+#: polygon reads consistently across every view.
+DASH_LENGTH_MM = 6.0
+GAP_LENGTH_MM = 4.0
+
 _REGISTERED = False
 
 
@@ -721,8 +727,11 @@ class ControlPolygonPipeline(_PipelineBase):
 
         self._handles_polydata.SetPoints(points)
         self._handles_polydata.Modified()
-        self._edges_polydata.SetPoints(points)
 
+        # DASHED edge tubes: the Algorithm builder stays the topology SSOT
+        # (which points connect), but each of its polyline runs is emitted
+        # as world-space dash segments before tubing -- the same dashed-
+        # scaffold language the slice projections use.
         shape = (rows, cols)
         if shape != self._edge_cells_shape:
             geometry = self._control_polygon_geometry
@@ -732,9 +741,48 @@ class ControlPolygonPipeline(_PipelineBase):
             if geometry is not None:
                 cells = geometry.BuildControlPolygonCells(rows, cols)
                 if cells is not None:
-                    self._edges_polydata.SetLines(cells)
+                    self._edge_cells = cells
                     self._edge_cells_shape = shape
+        self._rebuild_dashed_edges(points)
         self._edges_polydata.Modified()
+
+    def _rebuild_dashed_edges(self, points: Any) -> None:
+        """Emit the builder's polylines as world-space dash segments."""
+        cells = getattr(self, "_edge_cells", None)
+        if cells is None:
+            return
+        dash_points = vtk.vtkPoints()
+        dash_lines = vtk.vtkCellArray()
+        try:
+            cells.InitTraversal()
+            ids = vtk.vtkIdList()
+            while cells.GetNextCell(ids):
+                for k in range(ids.GetNumberOfIds() - 1):
+                    a = points.GetPoint(ids.GetId(k))
+                    b = points.GetPoint(ids.GetId(k + 1))
+                    length = sum((b[j] - a[j]) ** 2 for j in range(3)) ** 0.5
+                    if length <= 0.0:
+                        continue
+                    period = DASH_LENGTH_MM + GAP_LENGTH_MM
+                    t = 0.0
+                    while t < length:
+                        t_end = min(t + DASH_LENGTH_MM, length)
+                        f0, f1 = t / length, t_end / length
+                        i0 = dash_points.InsertNextPoint(
+                            *(a[j] + (b[j] - a[j]) * f0 for j in range(3))
+                        )
+                        i1 = dash_points.InsertNextPoint(
+                            *(a[j] + (b[j] - a[j]) * f1 for j in range(3))
+                        )
+                        seg = vtk.vtkLine()
+                        seg.GetPointIds().SetId(0, i0)
+                        seg.GetPointIds().SetId(1, i1)
+                        dash_lines.InsertNextCell(seg)
+                        t += period
+        except Exception:  # pragma: no cover - defensive
+            return
+        self._edges_polydata.SetPoints(dash_points)
+        self._edges_polydata.SetLines(dash_lines)
 
     def _apply_display_node(self) -> None:
         """Push the display node's styling onto the actors."""

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -111,7 +111,9 @@ class ControlPolygonPipeline(_PipelineBase):
         # Injectable Algorithm-builder seam (bare-VTK unit layer); resolved
         # lazily from the wrapping on first use in production.
         self._control_polygon_geometry: Any | None = None
-        #: (rows, cols) the current edge cells were built for.
+        #: Edge topology from the Algorithm builder + the (rows, cols) it
+        #: was built for.
+        self._edge_cells: Any | None = None
         self._edge_cells_shape: tuple | None = None
 
         self._last_update_key: Any | None = None
@@ -750,7 +752,7 @@ class ControlPolygonPipeline(_PipelineBase):
 
     def _rebuild_dashed_edges(self, points: Any) -> None:
         """Emit the builder's polylines as world-space dash segments."""
-        cells = getattr(self, "_edge_cells", None)
+        cells = self._edge_cells
         if cells is None:
             # No topology yet: clear rather than render stale content --
             # a leftover solid line must never masquerade as the scaffold.

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -57,12 +57,12 @@ CONTROL_POLYGON_GEOMETRY_CLASS = "vtkSlicerLiverBezierControlPolygonGeometry"
 CONTROL_POINT_PICK_RADIUS_PX = 20.0
 
 #: Halo colours: warm hover cue vs the distinct GRABBED (active-drag) cue.
+#: The grab cue is carried by the HANDLE colour (per-point glyph scalars),
+#: not by a larger halo -- the glow blur washes a halo hue out.
 HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
 HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
-#: Halo radius scale vs the handle: hover ring vs the larger GRAB ring
-#: (the size jump reads even where the glow blur washes the hue out).
+#: Halo radius scale vs the handle sphere.
 HALO_HOVER_SCALE = 1.35
-HALO_GRAB_SCALE = 1.9
 
 #: World-space dash pattern for the polygon edge tubes -- the same
 #: dashed-scaffold language the slice projections use, so the control

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -313,6 +313,7 @@ class ControlPolygonPipeline(_PipelineBase):
             self._refresh_geometry()
         self._apply_display_node()
         self._apply_interaction_scalars()
+        self._sync_halo_from_channel(visible)
 
     def cleanup(self) -> None:
         for node in list(self._observed_node_refs):
@@ -433,6 +434,39 @@ class ControlPolygonPipeline(_PipelineBase):
                 if display.GetGrabbedControlPoint() != value:
                     display.SetGrabbedControlPoint(value)
         except Exception:  # pragma: no cover - defensive (stub displays)
+            return
+
+    def _sync_halo_from_channel(self, polygon_visible: bool) -> None:
+        """Drive the glow halo from the display-node interaction channel.
+
+        The channel is the single source of truth, so a hover raised in a
+        SLICE view shows the same 3D halo a local hover does; the grabbed
+        point wins over a hover, and the halo repositions on every carrier
+        reconcile (drags move the point under it).
+        """
+        display = self._display_node
+        try:
+            hovered = display.GetHoveredControlPoint() if display is not None else -1
+            grabbed = display.GetGrabbedControlPoint() if display is not None else -1
+        except Exception:  # pragma: no cover - defensive (stub displays)
+            hovered, grabbed = -1, -1
+        target = grabbed if grabbed >= 0 else hovered
+        if not polygon_visible or target < 0:
+            self._halo_actor.SetVisibility(False)
+            return
+        carrier = self._data_node
+        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
+        if grid_getter is None:
+            return
+        try:
+            grid = grid_getter()
+            base = int(target) * 3
+            if len(grid) < base + 3:
+                return
+            self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * HALO_HOVER_SCALE)
+            self._halo_actor.SetPosition(grid[base], grid[base + 1], grid[base + 2])
+            self._halo_actor.SetVisibility(True)
+        except Exception:  # pragma: no cover - defensive
             return
 
     def _apply_interaction_scalars(self) -> None:

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -312,6 +312,7 @@ class ControlPolygonPipeline(_PipelineBase):
         if visible:
             self._refresh_geometry()
         self._apply_display_node()
+        self._apply_interaction_scalars()
 
     def cleanup(self) -> None:
         for node in list(self._observed_node_refs):
@@ -386,6 +387,7 @@ class ControlPolygonPipeline(_PipelineBase):
         if index == self._hover_index:
             return
         self._hover_index = index
+        self._publish_interaction_state(hovered=(-1 if index is None else index))
         if index is None:
             self._halo_actor.SetVisibility(False)
         else:
@@ -408,27 +410,60 @@ class ControlPolygonPipeline(_PipelineBase):
             except Exception:  # pragma: no cover - defensive (stub bases)
                 pass
 
-    def _set_grabbed_point_color(self, index: int | None) -> None:
-        """Colour the grabbed HANDLE itself (per-point glyph scalars).
+    def _publish_interaction_state(self, hovered=None, grabbed=None) -> None:
+        """Write hover/grab onto the DISPLAY node (cross-view channel).
 
-        The grabbed control point turns HALO_GRAB_COLOR; ``None`` restores
-        the uniform display HandleColor on all points.  Direct RGB scalars
-        on the glyph input; the mapper colours by them when present.
+        Every pipeline observing the control-polygon display node -- the 3D
+        one and the slice projections -- highlights the same point,
+        whichever view the cursor is in (the markups active-control-point
+        convention).  Writes only on change so mouse moves do not storm
+        Modified events.  ``None`` leaves a channel untouched; use -1 to
+        clear.
         """
+        display = self._display_node
+        if display is None:
+            return
+        try:
+            if hovered is not None:
+                value = -1 if hovered == -1 else int(hovered)
+                if display.GetHoveredControlPoint() != value:
+                    display.SetHoveredControlPoint(value)
+            if grabbed is not None:
+                value = -1 if grabbed == -1 else int(grabbed)
+                if display.GetGrabbedControlPoint() != value:
+                    display.SetGrabbedControlPoint(value)
+        except Exception:  # pragma: no cover - defensive (stub displays)
+            return
+
+    def _apply_interaction_scalars(self) -> None:
+        """Colour the hovered/grabbed HANDLES from the display-node state.
+
+        Derives per-point glyph scalars from the display node's
+        HoveredControlPoint / GrabbedControlPoint, so highlights raised in
+        OTHER views (the slice projections) colour this 3D view too.
+        """
+        display = self._display_node
+        try:
+            hovered = display.GetHoveredControlPoint() if display is not None else -1
+            grabbed = display.GetGrabbedControlPoint() if display is not None else -1
+        except Exception:  # pragma: no cover - defensive (stub displays)
+            hovered, grabbed = -1, -1
         try:
             points = self._handles_polydata.GetPoints()
             n = points.GetNumberOfPoints() if points is not None else 0
             base = [int(c * 255) for c in self._handles_actor.GetProperty().GetColor()]
+            grab = [int(c * 255) for c in HALO_GRAB_COLOR]
+            hover = [int(c * 255) for c in HALO_HOVER_COLOR]
             colors = vtk.vtkUnsignedCharArray()
             colors.SetNumberOfComponents(3)
             colors.SetName("HandleColors")
-            grab = [int(c * 255) for c in HALO_GRAB_COLOR]
             for i in range(n):
-                colors.InsertNextTuple3(*(grab if i == index else base))
+                rgb = grab if i == grabbed else (hover if i == hovered else base)
+                colors.InsertNextTuple3(*rgb)
             self._handles_polydata.GetPointData().SetScalars(colors)
             self._handles_glyph.SetColorModeToColorByScalar()
             self._handles_mapper.SetColorModeToDirectScalars()
-            self._handles_mapper.SetScalarVisibility(index is not None)
+            self._handles_mapper.SetScalarVisibility(grabbed >= 0 or hovered >= 0)
             self._handles_polydata.Modified()
         except Exception:  # pragma: no cover - defensive
             return
@@ -465,7 +500,8 @@ class ControlPolygonPipeline(_PipelineBase):
             ):
                 return False
             self._drag_index = idx
-            self._set_grabbed_point_color(idx)
+            self._publish_interaction_state(grabbed=idx)
+            self._apply_interaction_scalars()
             hover, self._hover_index = idx, None
             self._set_hover(hover)  # halo jumps to the grabbed handle
             world = self._event_world_at_control_point(renderer, eventData, idx)
@@ -475,7 +511,8 @@ class ControlPolygonPipeline(_PipelineBase):
 
         if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
             self._drag_index = None
-            self._set_grabbed_point_color(None)
+            self._publish_interaction_state(grabbed=-1)
+            self._apply_interaction_scalars()
             self._set_hover(None)
             return False  # grab over -- release the focus
 
@@ -753,9 +790,18 @@ class ControlPolygonPipeline(_PipelineBase):
         del caller, event
         self.UpdatePipeline()
 
+        display = self._display_node
+        try:
+            interaction = (
+                display.GetHoveredControlPoint() if display is not None else -1,
+                display.GetGrabbedControlPoint() if display is not None else -1,
+            )
+        except Exception:  # pragma: no cover - defensive (stub displays)
+            interaction = (-1, -1)
         render_key = (
             _safe_get_state(self._data_node),
             _control_points_digest(self._data_node),
+            interaction,
         )
         if render_key == self._last_render_key:
             return

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -66,9 +66,11 @@ HALO_GRAB_SCALE = 1.9
 
 #: World-space dash pattern for the polygon edge tubes -- the same
 #: dashed-scaffold language the slice projections use, so the control
-#: polygon reads consistently across every view.
-DASH_LENGTH_MM = 6.0
-GAP_LENGTH_MM = 4.0
+#: polygon reads consistently across every view.  The gap is deliberately
+#: wide relative to the tube diameter (~3 mm): world-space gaps close up
+#: optically at low zoom / glancing angles, which read as a solid line.
+DASH_LENGTH_MM = 7.0
+GAP_LENGTH_MM = 7.0
 
 _REGISTERED = False
 
@@ -750,6 +752,10 @@ class ControlPolygonPipeline(_PipelineBase):
         """Emit the builder's polylines as world-space dash segments."""
         cells = getattr(self, "_edge_cells", None)
         if cells is None:
+            # No topology yet: clear rather than render stale content --
+            # a leftover solid line must never masquerade as the scaffold.
+            self._edges_polydata.SetPoints(vtk.vtkPoints())
+            self._edges_polydata.SetLines(vtk.vtkCellArray())
             return
         dash_points = vtk.vtkPoints()
         dash_lines = vtk.vtkCellArray()

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -309,7 +309,9 @@ class FlattenedSurfaceRepresentation:
             cx = focal[0] + (cx - focal[0]) * float(ratio[0])
             cy = focal[1] + (cy - focal[1]) * float(ratio[1])
             radius = display_node.GetRadius() if display_node is not None else 2.0
-            self._marker_source.SetRadius(float(radius))
+            # Smaller than the 3D/slice markers: the strip is a dense 2D
+            # readout and a full-size disc dominates it.
+            self._marker_source.SetRadius(float(radius) * 0.6)
             # Slightly proud of the quad so the circle wins the z-fight.
             self._marker_source.SetCenter(cx, cy, 0.5)
             self._marker_actor.SetVisibility(True)
@@ -441,11 +443,16 @@ class FlattenedSurfaceRepresentation:
         self._marker_source.SetNumberOfSides(32)
         self._marker_source.SetNormal(0.0, 0.0, 1.0)
         self._marker_source.SetRadius(2.0)
+        # OUTLINE circle, not filled: the marker must not occlude the
+        # distance-shading content it points at.
+        self._marker_source.GeneratePolygonOff()
+        self._marker_source.GeneratePolylineOn()
         self._marker_mapper = vtk.vtkPolyDataMapper()
         self._marker_mapper.SetInputConnection(self._marker_source.GetOutputPort())
         self._marker_actor = vtk.vtkActor()
         self._marker_actor.SetMapper(self._marker_mapper)
         self._marker_actor.GetProperty().SetColor(1.0, 0.0, 0.0)
+        self._marker_actor.GetProperty().SetLineWidth(2.0)
         self._marker_actor.SetVisibility(False)
         self._picked_uv: tuple | None = None
 

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -347,14 +347,17 @@ class FlattenedSurfaceRepresentation:
         self._effective_texture_num_comps = 0
         self._locator_node = None
         self._picked_uv = None
-        self._marker_actor = None
-        self._marker_mapper = None
-        self._marker_source = None
 
+        # Detach BEFORE dropping the actor handles: nulling the marker actor
+        # first would make _detach_actors skip it and leak it into the
+        # renderer on every teardown.
         if self._renderer is not None:
             self._detach_blur_pass(self._renderer)
             self._detach_actors(self._renderer)
             self._renderer = None
+        self._marker_actor = None
+        self._marker_mapper = None
+        self._marker_source = None
         self._bezier_plane = None
         self._resection_mapper_2d = None
         self._resection_actor_2d = None

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -264,36 +264,57 @@ class FlattenedSurfaceRepresentation:
         """Attach the cross-view locator node (ADR-0025); ``None`` clears."""
         self._locator_node = locator_node
 
-    def _apply_locator(self) -> None:
-        """Thread the locator pick + radius onto the 2D mapper's uniforms.
+    def SetPickedUV(self, uv: Any) -> None:  # noqa: N802 - VTK verb
+        """Record the picked strip ``(u, v)`` (set by the pick producer)."""
+        self._picked_uv = (float(uv[0]), float(uv[1])) if uv is not None else None
 
-        Mirrors ``BezierPlanningRepresentation._apply_locator``: the 2D
-        mapper tests the REAL surface position (the ``BSPoints`` attribute)
-        against ``uLocatorPosition``, so the strip dot sits at the same
-        anatomical point as the 3D surface marker -- the ADR-0025 1:1
-        correspondence.  Radius 0 is the marker-off state (no locator, no
-        display node); a no-op on the generic fallback mapper.
+    def _apply_locator(self) -> None:
+        """Drive the strip's circle marker from the locator state.
+
+        The SHADER disc is kept OFF for the strip (radius 0 on the 2D
+        mapper): it tests the REAL 3D surface positions, so the (u, v)
+        flattening rendered it distorted.  Instead a world-space circle
+        actor sits at the picked (u, v) on the flat quad -- round by
+        construction, rescaled by the camera on zoom/pan, with the
+        MatRatio squeeze applied to its centre about the camera focal
+        point (the ratio scales clip-space offsets).  Visibility follows
+        the locator display's gesture-scoped switch.
         """
         mapper = self._resection_mapper_2d
-        if mapper is None:
-            return
-        set_position = getattr(mapper, "SetLocatorPosition", None)
-        set_radius = getattr(mapper, "SetLocatorRadius", None)
-        if set_position is None or set_radius is None:
-            return  # generic fallback mapper -- no locator uniforms
+        if mapper is not None:
+            set_radius = getattr(mapper, "SetLocatorRadius", None)
+            if set_radius is not None:
+                set_radius(0.0)  # the distorted shader disc stays off
 
         node = self._locator_node
-        if node is None:
-            set_radius(0.0)  # marker off
+        display_node = node.GetDisplayNode() if node is not None and hasattr(node, "GetDisplayNode") else None
+        visible = (
+            bool(getattr(display_node, "GetVisibility", lambda: False)())
+            if display_node is not None
+            else False
+        )
+        uv = self._picked_uv
+        if not visible or uv is None or self._bezier_plane is None:
+            if self._marker_actor is not None:
+                self._marker_actor.SetVisibility(False)
             return
-        position = node.GetPickedPositionWorld()
-        set_position(float(position[0]), float(position[1]), float(position[2]))
-        display_node = node.GetDisplayNode() if hasattr(node, "GetDisplayNode") else None
-        radius = display_node.GetRadius() if display_node is not None else 0.0
-        # Gesture-scoped marker: the display's base Visibility is the
-        # switch (press shows, release hides); invisible pushes radius 0.
-        visible = getattr(display_node, "GetVisibility", lambda: True)() if display_node is not None else False
-        set_radius(float(radius) if visible else 0.0)
+        try:
+            self._bezier_plane.Update()
+            bounds = self._bezier_plane.GetOutput().GetBounds()
+            cx = bounds[0] + (bounds[1] - bounds[0]) * uv[0]
+            cy = bounds[2] + (bounds[3] - bounds[2]) * uv[1]
+            ratio = self._mat_ratio_applied or (1.0, 1.0)
+            camera = self._resectogram_camera
+            focal = camera.GetFocalPoint() if camera is not None else (0.0, 0.0, 0.0)
+            cx = focal[0] + (cx - focal[0]) * float(ratio[0])
+            cy = focal[1] + (cy - focal[1]) * float(ratio[1])
+            radius = display_node.GetRadius() if display_node is not None else 2.0
+            self._marker_source.SetRadius(float(radius))
+            # Slightly proud of the quad so the circle wins the z-fight.
+            self._marker_source.SetCenter(cx, cy, 0.5)
+            self._marker_actor.SetVisibility(True)
+        except Exception:  # pragma: no cover - defensive
+            self._marker_actor.SetVisibility(False)
 
     def update(self, display_node: Any | None, data_node: Any | None) -> None:
         """Reconcile the resectogram against the current display + data nodes.
@@ -323,6 +344,10 @@ class FlattenedSurfaceRepresentation:
         self._distance_map_volume = None
         self._effective_texture_num_comps = 0
         self._locator_node = None
+        self._picked_uv = None
+        self._marker_actor = None
+        self._marker_mapper = None
+        self._marker_source = None
 
         if self._renderer is not None:
             self._detach_blur_pass(self._renderer)
@@ -406,14 +431,39 @@ class FlattenedSurfaceRepresentation:
 
         self._resectogram_camera = vtk.vtkCamera()
 
+        # Locator marker: a WORLD-SPACE circle on the flat quad (replaces
+        # the shader disc for the strip -- the disc is round on the 3D
+        # surface, so the (u, v) flattening rendered it distorted).  A
+        # world actor rides the camera, so zoom/pan rescale it with the
+        # strip; the MatRatio squeeze is applied to its CENTER about the
+        # camera focal point (the ratio scales clip-space offsets).
+        self._marker_source = vtk.vtkRegularPolygonSource()
+        self._marker_source.SetNumberOfSides(32)
+        self._marker_source.SetNormal(0.0, 0.0, 1.0)
+        self._marker_source.SetRadius(2.0)
+        self._marker_mapper = vtk.vtkPolyDataMapper()
+        self._marker_mapper.SetInputConnection(self._marker_source.GetOutputPort())
+        self._marker_actor = vtk.vtkActor()
+        self._marker_actor.SetMapper(self._marker_mapper)
+        self._marker_actor.GetProperty().SetColor(1.0, 0.0, 0.0)
+        self._marker_actor.SetVisibility(False)
+        self._picked_uv: tuple | None = None
+
     def _attach_actors(self, renderer: Any) -> None:
         if self._resection_actor_2d is not None and hasattr(renderer, "AddActor"):
             renderer.AddActor(self._resection_actor_2d)
+        if self._marker_actor is not None and hasattr(renderer, "AddActor"):
+            renderer.AddActor(self._marker_actor)
 
     def _detach_actors(self, renderer: Any) -> None:
         if self._resection_actor_2d is not None and hasattr(renderer, "RemoveActor"):
             try:
                 renderer.RemoveActor(self._resection_actor_2d)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        if self._marker_actor is not None and hasattr(renderer, "RemoveActor"):
+            try:
+                renderer.RemoveActor(self._marker_actor)
             except Exception:  # pragma: no cover - defensive
                 pass
 

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -491,6 +491,7 @@ class ResectogramPipeline(_PipelineBase):
         # stub renderers (the GL-free seam tests).
         uv = self._display_to_uv(display_xy, renderer, mat_ratio, representation)
         if uv is not None:
+            representation.SetPickedUV(uv)  # drives the strip's circle marker
             return producer.produce_from_uv(uv[0], uv[1])
         return producer.produce(display_xy, viewport_size, mat_ratio)
 

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -69,6 +69,19 @@ PICK_RANGE_MM = FADE_DISTANCE_MM
 DASH_LENGTH_PX = 8.0
 GAP_LENGTH_PX = 5.0
 
+#: Maximum lightness shift for the above/below-plane cue (the markups
+#: signed-distance convention): points ABOVE the plane tint toward white,
+#: points BELOW toward black, graded by distance.  Sign-neutral hue, so it
+#: composes with any display colour and stays colourblind-legible.
+SIDE_TINT_MAX = 0.55
+
+
+def _side_tint(rgb: list, signed_distance: float) -> list:
+    """Blend ``rgb`` toward white (above) or black (below) by distance."""
+    fraction = min(1.0, abs(signed_distance) / FADE_DISTANCE_MM) * SIDE_TINT_MAX
+    target = 255 if signed_distance > 0 else 0
+    return [int(c + (target - c) * fraction) for c in rgb]
+
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
     """True iff ``viewNode`` is a slice view (this pipeline's home)."""
@@ -111,7 +124,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._handle_glyph_source = vtk.vtkGlyphSource2D()
         self._handle_glyph_source.SetGlyphTypeToCircle()
         self._handle_glyph_source.FilledOff()
-        self._handle_glyph_source.SetScale(8.0)
+        self._handle_glyph_source.SetScale(13.0)
         self._handles_glyph = vtk.vtkGlyph2D()
         self._handles_glyph.SetInputData(self._handles_polydata)
         self._handles_glyph.SetSourceConnection(
@@ -132,7 +145,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._ring_glyph_source = vtk.vtkGlyphSource2D()
         self._ring_glyph_source.SetGlyphTypeToCircle()
         self._ring_glyph_source.FilledOff()
-        self._ring_glyph_source.SetScale(14.0)
+        self._ring_glyph_source.SetScale(20.0)
         self._ring_glyph = vtk.vtkGlyph2D()
         self._ring_glyph.SetInputData(self._ring_polydata)
         self._ring_glyph.SetSourceConnection(self._ring_glyph_source.GetOutputPort())
@@ -285,6 +298,10 @@ class SliceControlPolygonPipeline(_PipelineBase):
                     edge_rgb = [int(c * 255) for c in display.GetEdgeColor()]
                 except Exception:  # pragma: no cover - defensive
                     pass
+            # Mid-tone base: the default HandleColor is pure white, which
+            # leaves no headroom for the lighter-above tint -- pull the
+            # slice base toward 78% so the sign cue reads BOTH ways.
+            handle_rgb = [int(c * 0.78) for c in handle_rgb]
 
             points = vtk.vtkPoints()
             handle_rgba = vtk.vtkUnsignedCharArray()
@@ -304,9 +321,10 @@ class SliceControlPolygonPipeline(_PipelineBase):
                 px, py = xy[0] / w, xy[1] / w
                 points.InsertNextPoint(px, py, 0.0)
                 self._projected_xy.append((px, py))
-                distance = abs(
-                    sum(n * (p - o) for n, p, o in zip(normal, (x, y, z), origin))
+                signed = sum(
+                    n * (p - o) for n, p, o in zip(normal, (x, y, z), origin)
                 )
+                distance = abs(signed)
                 self._plane_distances.append(distance)
                 in_range.append(distance < PICK_RANGE_MM)
                 alpha = max(0.0, 1.0 - distance / FADE_DISTANCE_MM)
@@ -316,8 +334,14 @@ class SliceControlPolygonPipeline(_PipelineBase):
                 elif i == hovered:
                     handle_rgba.InsertNextTuple4(*hover_rgb, 255)
                 else:
-                    handle_rgba.InsertNextTuple4(*handle_rgb, int(alpha * 255))
-                edge_rgba.InsertNextTuple4(*edge_rgb, int(alpha * 255))
+                    # The markups signed-distance cue: above-plane points
+                    # tint toward white, below-plane toward black.
+                    handle_rgba.InsertNextTuple4(
+                        *_side_tint(handle_rgb, signed), int(alpha * 255)
+                    )
+                edge_rgba.InsertNextTuple4(
+                    *_side_tint(edge_rgb, signed), int(alpha * 255)
+                )
 
             visible_points = vtk.vtkPoints()
             visible_rgba = vtk.vtkUnsignedCharArray()

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -54,13 +54,20 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
 _REGISTERED = False
 
 #: Distance (mm) over which the projection fades to fully transparent --
-#: the above/below-the-plane cue.  On-plane points render fully opaque.
-FADE_DISTANCE_MM = 30.0
+#: the above/below-the-plane cue.  Short by design: only control points
+#: NEAR the plane (the manipulable ones) are present in a slice at all.
+FADE_DISTANCE_MM = 15.0
 
 #: Manipulable range == visible range (the markups rule: anything you can
 #: see, you can grab).  A point at exactly FADE_DISTANCE_MM has alpha 0 --
 #: invisible AND unpickable; there is no visible-but-dead band.
 PICK_RANGE_MM = FADE_DISTANCE_MM
+
+#: Dash pattern for the polygon edges (XY pixels): the SCAFFOLD reads
+#: dashed, the solid slice contour is the RESULT -- a structural
+#: differentiation, not colour-only.
+DASH_LENGTH_PX = 8.0
+GAP_LENGTH_PX = 5.0
 
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
@@ -118,6 +125,25 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._handles_actor.SetMapper(self._handles_mapper)
         self._handles_actor.SetVisibility(False)
 
+        # Hover ring: the 2D analogue of the 3D glow halo -- a larger
+        # circle on the hovered/grabbed projected handle.
+        self._ring_polydata = vtk.vtkPolyData()
+        self._ring_polydata.SetPoints(vtk.vtkPoints())
+        self._ring_glyph_source = vtk.vtkGlyphSource2D()
+        self._ring_glyph_source.SetGlyphTypeToCircle()
+        self._ring_glyph_source.FilledOff()
+        self._ring_glyph_source.SetScale(14.0)
+        self._ring_glyph = vtk.vtkGlyph2D()
+        self._ring_glyph.SetInputData(self._ring_polydata)
+        self._ring_glyph.SetSourceConnection(self._ring_glyph_source.GetOutputPort())
+        self._ring_glyph.ScalingOff()
+        self._ring_mapper = vtk.vtkPolyDataMapper2D()
+        self._ring_mapper.SetInputConnection(self._ring_glyph.GetOutputPort())
+        self._ring_actor = vtk.vtkActor2D()
+        self._ring_actor.SetMapper(self._ring_mapper)
+        self._ring_actor.GetProperty().SetLineWidth(2.0)
+        self._ring_actor.SetVisibility(False)
+
         # Edges: projected polygon lines with per-vertex RGBA fading.
         self._edges_polydata = vtk.vtkPolyData()
         self._edges_polydata.SetPoints(vtk.vtkPoints())
@@ -173,6 +199,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
         if renderer is not None:
             renderer.AddActor2D(self._edges_actor)
             renderer.AddActor2D(self._handles_actor)
+            renderer.AddActor2D(self._ring_actor)
         if self._display_node is None:
             base_getter = getattr(self, "GetDisplayNode", None)
             display = base_getter() if base_getter is not None else None
@@ -186,6 +213,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
             try:
                 renderer.RemoveActor2D(self._handles_actor)
                 renderer.RemoveActor2D(self._edges_actor)
+                renderer.RemoveActor2D(self._ring_actor)
             except Exception:  # pragma: no cover - defensive
                 pass
         self._renderer = None
@@ -199,6 +227,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._drag_index = None
         self._handles_actor.SetVisibility(False)
         self._edges_actor.SetVisibility(False)
+        self._ring_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
     # Reconciliation
@@ -292,25 +321,68 @@ class SliceControlPolygonPipeline(_PipelineBase):
             self._handles_polydata.GetPointData().SetScalars(handle_rgba)
             self._handles_polydata.Modified()
 
-            edge_points = vtk.vtkPoints()
-            edge_points.DeepCopy(points)
-            lines = vtk.vtkCellArray()
-            for r in range(rows):
-                line = vtk.vtkPolyLine()
-                line.GetPointIds().SetNumberOfIds(cols)
-                for c in range(cols):
-                    line.GetPointIds().SetId(c, r * cols + c)
-                lines.InsertNextCell(line)
-            for c in range(cols):
-                line = vtk.vtkPolyLine()
-                line.GetPointIds().SetNumberOfIds(rows)
+            # DASHED edges (manual segmentation -- GL line stipple is not
+            # portable): each grid edge is emitted as alternating dash
+            # segments, so the scaffold reads structurally distinct from
+            # the solid resection contour.
+            dash_points = vtk.vtkPoints()
+            dash_rgba = vtk.vtkUnsignedCharArray()
+            dash_rgba.SetNumberOfComponents(4)
+            dash_lines = vtk.vtkCellArray()
+
+            def _edge_pairs():
                 for r in range(rows):
-                    line.GetPointIds().SetId(r, r * cols + c)
-                lines.InsertNextCell(line)
-            self._edges_polydata.SetPoints(edge_points)
-            self._edges_polydata.SetLines(lines)
-            self._edges_polydata.GetPointData().SetScalars(edge_rgba)
+                    for c in range(cols - 1):
+                        yield r * cols + c, r * cols + c + 1
+                for c in range(cols):
+                    for r in range(rows - 1):
+                        yield r * cols + c, (r + 1) * cols + c
+
+            for a, b in _edge_pairs():
+                ax, ay = self._projected_xy[a]
+                bx, by = self._projected_xy[b]
+                ca = edge_rgba.GetTuple4(a)
+                cb = edge_rgba.GetTuple4(b)
+                length = ((bx - ax) ** 2 + (by - ay) ** 2) ** 0.5
+                if length <= 0.0:
+                    continue
+                period = DASH_LENGTH_PX + GAP_LENGTH_PX
+                t = 0.0
+                while t < length:
+                    t_end = min(t + DASH_LENGTH_PX, length)
+                    f0, f1 = t / length, t_end / length
+                    i0 = dash_points.InsertNextPoint(
+                        ax + (bx - ax) * f0, ay + (by - ay) * f0, 0.0
+                    )
+                    i1 = dash_points.InsertNextPoint(
+                        ax + (bx - ax) * f1, ay + (by - ay) * f1, 0.0
+                    )
+                    for f, _i in ((f0, i0), (f1, i1)):
+                        dash_rgba.InsertNextTuple4(*[
+                            int(ca[k] + (cb[k] - ca[k]) * f) for k in range(4)
+                        ])
+                    seg = vtk.vtkLine()
+                    seg.GetPointIds().SetId(0, i0)
+                    seg.GetPointIds().SetId(1, i1)
+                    dash_lines.InsertNextCell(seg)
+                    t += period
+            self._edges_polydata.SetPoints(dash_points)
+            self._edges_polydata.SetLines(dash_lines)
+            self._edges_polydata.GetPointData().SetScalars(dash_rgba)
             self._edges_polydata.Modified()
+
+            # Hover ring: the 2D halo on the hovered/grabbed handle.
+            target = grabbed if grabbed >= 0 else hovered
+            if 0 <= target < len(self._projected_xy):
+                ring_points = vtk.vtkPoints()
+                ring_points.InsertNextPoint(*self._projected_xy[target], 0.0)
+                self._ring_polydata.SetPoints(ring_points)
+                self._ring_polydata.Modified()
+                rgb = HALO_GRAB_COLOR if grabbed >= 0 else HALO_HOVER_COLOR
+                self._ring_actor.GetProperty().SetColor(*rgb)
+                self._ring_actor.SetVisibility(True)
+            else:
+                self._ring_actor.SetVisibility(False)
             return True
         except Exception:  # pragma: no cover - defensive
             return False

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -291,6 +291,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
             handle_rgba.SetNumberOfComponents(4)
             edge_rgba = vtk.vtkUnsignedCharArray()
             edge_rgba.SetNumberOfComponents(4)
+            in_range = []  # HARD presence cutoff (2D alpha is unreliable)
             hovered, grabbed = self._interaction_state()
             hover_rgb = [int(c * 255) for c in HALO_HOVER_COLOR]
             grab_rgb = [int(c * 255) for c in HALO_GRAB_COLOR]
@@ -307,6 +308,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
                     sum(n * (p - o) for n, p, o in zip(normal, (x, y, z), origin))
                 )
                 self._plane_distances.append(distance)
+                in_range.append(distance < PICK_RANGE_MM)
                 alpha = max(0.0, 1.0 - distance / FADE_DISTANCE_MM)
                 if i == grabbed:
                     # Cross-view highlight: full alpha, grab colour.
@@ -317,8 +319,16 @@ class SliceControlPolygonPipeline(_PipelineBase):
                     handle_rgba.InsertNextTuple4(*handle_rgb, int(alpha * 255))
                 edge_rgba.InsertNextTuple4(*edge_rgb, int(alpha * 255))
 
-            self._handles_polydata.SetPoints(points)
-            self._handles_polydata.GetPointData().SetScalars(handle_rgba)
+            visible_points = vtk.vtkPoints()
+            visible_rgba = vtk.vtkUnsignedCharArray()
+            visible_rgba.SetNumberOfComponents(4)
+            for i, ok in enumerate(in_range):
+                if not ok:
+                    continue  # beyond the manipulable range: NOT present
+                visible_points.InsertNextPoint(*points.GetPoint(i))
+                visible_rgba.InsertNextTuple4(*(int(v) for v in handle_rgba.GetTuple4(i)))
+            self._handles_polydata.SetPoints(visible_points)
+            self._handles_polydata.GetPointData().SetScalars(visible_rgba)
             self._handles_polydata.Modified()
 
             # DASHED edges (manual segmentation -- GL line stipple is not
@@ -339,6 +349,8 @@ class SliceControlPolygonPipeline(_PipelineBase):
                         yield r * cols + c, (r + 1) * cols + c
 
             for a, b in _edge_pairs():
+                if not (in_range[a] and in_range[b]):
+                    continue  # scaffold segments to absent points vanish too
                 ax, ay = self._projected_xy[a]
                 bx, by = self._projected_xy[b]
                 ca = edge_rgba.GetTuple4(a)

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -33,6 +33,8 @@ try:  # pragma: no cover - exercised once per import path
     )
     from .ControlPolygonPipeline import (
         CONTROL_POINT_PICK_RADIUS_PX,
+        HALO_GRAB_COLOR,
+        HALO_HOVER_COLOR,
         _control_points_digest,
         _event_type,
     )
@@ -43,6 +45,8 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
     )
     from ControlPolygonPipeline import (  # type: ignore[no-redef]
         CONTROL_POINT_PICK_RADIUS_PX,
+        HALO_GRAB_COLOR,
+        HALO_HOVER_COLOR,
         _control_points_digest,
         _event_type,
     )
@@ -52,6 +56,11 @@ _REGISTERED = False
 #: Distance (mm) over which the projection fades to fully transparent --
 #: the above/below-the-plane cue.  On-plane points render fully opaque.
 FADE_DISTANCE_MM = 30.0
+
+#: Only control points within this plane distance are MANIPULABLE from a
+#: slice view (the markups short-range convention); visibility fades to
+#: zero at FADE_DISTANCE_MM regardless.
+PICK_RANGE_MM = 15.0
 
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
@@ -86,6 +95,8 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._drag_index: int | None = None
         #: XY-space positions of the projected handles (pick arbitration).
         self._projected_xy: list = []
+        #: Per-point |distance| to the slice plane (the pick-range gate).
+        self._plane_distances: list = []
 
         # Handles: projected points as 2D cross glyphs with RGBA fading.
         self._handles_polydata = vtk.vtkPolyData()
@@ -251,7 +262,11 @@ class SliceControlPolygonPipeline(_PipelineBase):
             handle_rgba.SetNumberOfComponents(4)
             edge_rgba = vtk.vtkUnsignedCharArray()
             edge_rgba.SetNumberOfComponents(4)
+            hovered, grabbed = self._interaction_state()
+            hover_rgb = [int(c * 255) for c in HALO_HOVER_COLOR]
+            grab_rgb = [int(c * 255) for c in HALO_GRAB_COLOR]
             self._projected_xy = []
+            self._plane_distances = []
             for i in range(rows * cols):
                 x, y, z = grid[i * 3], grid[i * 3 + 1], grid[i * 3 + 2]
                 xy = ras_to_xy.MultiplyPoint((x, y, z, 1.0))
@@ -262,8 +277,15 @@ class SliceControlPolygonPipeline(_PipelineBase):
                 distance = abs(
                     sum(n * (p - o) for n, p, o in zip(normal, (x, y, z), origin))
                 )
+                self._plane_distances.append(distance)
                 alpha = max(0.0, 1.0 - distance / FADE_DISTANCE_MM)
-                handle_rgba.InsertNextTuple4(*handle_rgb, int(alpha * 255))
+                if i == grabbed:
+                    # Cross-view highlight: full alpha, grab colour.
+                    handle_rgba.InsertNextTuple4(*grab_rgb, 255)
+                elif i == hovered:
+                    handle_rgba.InsertNextTuple4(*hover_rgb, 255)
+                else:
+                    handle_rgba.InsertNextTuple4(*handle_rgb, int(alpha * 255))
                 edge_rgba.InsertNextTuple4(*edge_rgb, int(alpha * 255))
 
             self._handles_polydata.SetPoints(points)
@@ -327,6 +349,15 @@ class SliceControlPolygonPipeline(_PipelineBase):
             ):
                 return True, 0.0
             return False, sys.float_info.max
+        if etype == vtk.vtkCommand.MouseMoveEvent:
+            # Bare hover: publish the cross-view highlight and decline.
+            idx, distance2 = self._nearest_handle_in_display(eventData)
+            within = (
+                idx is not None
+                and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+            )
+            self._publish_interaction_state(hovered=(idx if within else -1))
+            return False, sys.float_info.max
         if etype != vtk.vtkCommand.LeftButtonPressEvent:
             return False, sys.float_info.max
         _, distance2 = self._nearest_handle_in_display(eventData)
@@ -350,10 +381,12 @@ class SliceControlPolygonPipeline(_PipelineBase):
             ):
                 return False
             self._drag_index = idx
+            self._publish_interaction_state(grabbed=idx)
             return True
 
         if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
             self._drag_index = None
+            self._publish_interaction_state(grabbed=-1)
             return False
 
         if etype == vtk.vtkCommand.MouseMoveEvent:
@@ -376,6 +409,10 @@ class SliceControlPolygonPipeline(_PipelineBase):
             return None, sys.float_info.max
         best_idx, best_d2 = None, sys.float_info.max
         for i, (px, py) in enumerate(self._projected_xy):
+            # Markups short-range convention: points beyond PICK_RANGE_MM
+            # from the plane are not manipulable from this slice.
+            if i < len(self._plane_distances) and self._plane_distances[i] > PICK_RANGE_MM:
+                continue
             d2 = (px - ex) ** 2 + (py - ey) ** 2
             if d2 < best_d2:
                 best_idx, best_d2 = i, d2
@@ -453,6 +490,34 @@ class SliceControlPolygonPipeline(_PipelineBase):
         except ValueError:
             pass
 
+    def _interaction_state(self) -> tuple:
+        """(hovered, grabbed) read off the display node; (-1, -1) sans it."""
+        display = self._display_node
+        try:
+            return (
+                display.GetHoveredControlPoint() if display is not None else -1,
+                display.GetGrabbedControlPoint() if display is not None else -1,
+            )
+        except Exception:  # pragma: no cover - defensive (stub displays)
+            return (-1, -1)
+
+    def _publish_interaction_state(self, hovered=None, grabbed=None) -> None:
+        """Write hover/grab onto the display node (cross-view channel)."""
+        display = self._display_node
+        if display is None:
+            return
+        try:
+            if hovered is not None:
+                value = -1 if hovered == -1 else int(hovered)
+                if display.GetHoveredControlPoint() != value:
+                    display.SetHoveredControlPoint(value)
+            if grabbed is not None:
+                value = -1 if grabbed == -1 else int(grabbed)
+                if display.GetGrabbedControlPoint() != value:
+                    display.SetGrabbedControlPoint(value)
+        except Exception:  # pragma: no cover - defensive (stub displays)
+            return
+
     def _on_node_modified(self, caller: Any, event: str) -> None:
         del caller, event
         self.UpdatePipeline()
@@ -461,6 +526,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
             _safe_get_state(self._data_node),
             _control_points_digest(self._data_node),
             self._slice_matrix_digest(self._slice_node),
+            self._interaction_state(),
         )
         if render_key == self._last_render_key:
             return

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -373,8 +373,11 @@ class SliceControlPolygonPipeline(_PipelineBase):
                         yield r * cols + c, (r + 1) * cols + c
 
             for a, b in _edge_pairs():
-                if not (in_range[a] and in_range[b]):
-                    continue  # scaffold segments to absent points vanish too
+                if not (in_range[a] or in_range[b]):
+                    continue  # both endpoints absent: no scaffold here
+                # EITHER endpoint in range: draw the connecting dashes so a
+                # visible point never floats without its scaffold (the
+                # tint/fade along the run still shows the far end receding).
                 ax, ay = self._projected_xy[a]
                 bx, by = self._projected_xy[b]
                 ca = edge_rgba.GetTuple4(a)
@@ -407,9 +410,11 @@ class SliceControlPolygonPipeline(_PipelineBase):
             self._edges_polydata.GetPointData().SetScalars(dash_rgba)
             self._edges_polydata.Modified()
 
-            # Hover ring: the 2D halo on the hovered/grabbed handle.
+            # Hover ring: the 2D halo on the hovered/grabbed handle --
+            # only when that point is PRESENT in this slice (the highlight
+            # must not surface points the plane cannot reach).
             target = grabbed if grabbed >= 0 else hovered
-            if 0 <= target < len(self._projected_xy):
+            if 0 <= target < len(self._projected_xy) and in_range[target]:
                 ring_points = vtk.vtkPoints()
                 ring_points.InsertNextPoint(*self._projected_xy[target], 0.0)
                 self._ring_polydata.SetPoints(ring_points)

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -1,0 +1,520 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Slice-view control polygon: fading projection + slice-side editing.
+
+The markups-style slice half of the control polygon (ADR-0033): the
+``Rows x Cols`` handles and their connecting edges are projected into the
+slice view's XY space (``inverse(XYToRAS)``, the SliceContourPipeline
+convention) with DISTANCE FADING -- per-point alpha falls off linearly
+with the point's distance to the slice plane, the above/below visual cue
+markups users expect -- and the Planning per-point drag is available FROM
+the slice views: press grabs the nearest projected handle, the drag moves
+it in-plane at the cursor while PRESERVING its out-of-plane offset (no
+snap-to-plane), release ends the gesture.
+
+Keyed on ``vtkMRMLControlPolygonDisplayNode`` for ``vtkMRMLSliceNode``
+views only (creators dispatch per view type; the 3D control-polygon
+creator accepts only ``vtkMRMLViewNode``) -- ADR-0013 §1 keying stays
+disjoint per (view-type, display-type) pair.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import vtk
+
+from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+
+try:  # pragma: no cover - exercised once per import path
+    from .LiverBezierSurfacePipeline import (
+        STATE_PLANNING,
+        _safe_get_state,
+    )
+    from .ControlPolygonPipeline import (
+        CONTROL_POINT_PICK_RADIUS_PX,
+        _control_points_digest,
+        _event_type,
+    )
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    from LiverBezierSurfacePipeline import (  # type: ignore[no-redef]
+        STATE_PLANNING,
+        _safe_get_state,
+    )
+    from ControlPolygonPipeline import (  # type: ignore[no-redef]
+        CONTROL_POINT_PICK_RADIUS_PX,
+        _control_points_digest,
+        _event_type,
+    )
+
+_REGISTERED = False
+
+#: Distance (mm) over which the projection fades to fully transparent --
+#: the above/below-the-plane cue.  On-plane points render fully opaque.
+FADE_DISTANCE_MM = 30.0
+
+
+def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
+    """True iff ``viewNode`` is a slice view (this pipeline's home)."""
+    if viewNode is None:
+        return False
+    is_a = getattr(viewNode, "IsA", None)
+    if is_a is None:
+        return False
+    try:
+        return bool(is_a("vtkMRMLSliceNode"))
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+class SliceControlPolygonPipeline(_PipelineBase):
+    """Projected, fading, slice-editable control polygon."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.SetPythonObject(self)
+
+        self._display_node: Any | None = None
+        self._data_node: Any | None = None
+        self._slice_node: Any | None = None
+        self._renderer: Any | None = None
+        self._observer_tags: dict = {}
+        self._observed_node_refs: list = []
+        self._last_update_key: tuple | None = None
+        self._last_render_key: tuple | None = None
+        #: Flat row-major index of the grabbed handle (slice-side gesture).
+        self._drag_index: int | None = None
+        #: XY-space positions of the projected handles (pick arbitration).
+        self._projected_xy: list = []
+
+        # Handles: projected points as 2D cross glyphs with RGBA fading.
+        self._handles_polydata = vtk.vtkPolyData()
+        self._handles_polydata.SetPoints(vtk.vtkPoints())
+        self._handle_glyph_source = vtk.vtkGlyphSource2D()
+        self._handle_glyph_source.SetGlyphTypeToCircle()
+        self._handle_glyph_source.FilledOff()
+        self._handle_glyph_source.SetScale(8.0)
+        self._handles_glyph = vtk.vtkGlyph2D()
+        self._handles_glyph.SetInputData(self._handles_polydata)
+        self._handles_glyph.SetSourceConnection(
+            self._handle_glyph_source.GetOutputPort()
+        )
+        self._handles_glyph.SetColorModeToColorByScalar()
+        self._handles_glyph.ScalingOff()
+        self._handles_mapper = vtk.vtkPolyDataMapper2D()
+        self._handles_mapper.SetInputConnection(self._handles_glyph.GetOutputPort())
+        self._handles_actor = vtk.vtkActor2D()
+        self._handles_actor.SetMapper(self._handles_mapper)
+        self._handles_actor.SetVisibility(False)
+
+        # Edges: projected polygon lines with per-vertex RGBA fading.
+        self._edges_polydata = vtk.vtkPolyData()
+        self._edges_polydata.SetPoints(vtk.vtkPoints())
+        self._edges_mapper = vtk.vtkPolyDataMapper2D()
+        self._edges_mapper.SetInputData(self._edges_polydata)
+        self._edges_actor = vtk.vtkActor2D()
+        self._edges_actor.SetMapper(self._edges_mapper)
+        self._edges_actor.GetProperty().SetLineWidth(2.0)
+        self._edges_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # LayerDM lifecycle
+    # ------------------------------------------------------------------ #
+
+    def SetViewNode(self, viewNode: Any) -> None:  # noqa: N802 - VTK verb
+        super().SetViewNode(viewNode)
+        # Observe the slice node OURSELVES (the stale-trace lesson from the
+        # contour sibling): reslicing must re-project + re-fade.
+        if self._slice_node is not None:
+            self._detach_observer(self._slice_node)
+        self._slice_node = viewNode
+        if viewNode is not None:
+            self._attach_observer(viewNode)
+        self._last_update_key = None
+
+    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            self._detach_observer(self._display_node)
+        if self._data_node is not None:
+            self._detach_observer(self._data_node)
+
+        super().SetDisplayNode(displayNode)
+        self._display_node = displayNode
+        self._data_node = None
+        if displayNode is not None:
+            getter = getattr(displayNode, "GetDisplayableNode", None)
+            if getter is not None:
+                self._data_node = getter()
+            self._attach_observer(displayNode)
+            if self._data_node is not None:
+                self._attach_observer(self._data_node)
+        self._last_update_key = None
+
+    def OnReferenceToDisplayNodeAdded(self, fromNode: Any, role: Any = None) -> None:  # noqa: N802
+        if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
+            self._data_node = fromNode
+            self._attach_observer(fromNode)
+            self._last_update_key = None
+        self.UpdatePipeline()
+
+    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        self._renderer = renderer
+        if renderer is not None:
+            renderer.AddActor2D(self._edges_actor)
+            renderer.AddActor2D(self._handles_actor)
+        if self._display_node is None:
+            base_getter = getattr(self, "GetDisplayNode", None)
+            display = base_getter() if base_getter is not None else None
+            if display is not None:
+                self.SetDisplayNode(display)
+        self._last_update_key = None
+        self.UpdatePipeline()
+
+    def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        if renderer is not None:
+            try:
+                renderer.RemoveActor2D(self._handles_actor)
+                renderer.RemoveActor2D(self._edges_actor)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        self._renderer = None
+        self.cleanup()
+
+    def cleanup(self) -> None:
+        for node in list(self._observed_node_refs):
+            self._detach_observer(node)
+        self._display_node = None
+        self._data_node = None
+        self._drag_index = None
+        self._handles_actor.SetVisibility(False)
+        self._edges_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # Reconciliation
+    # ------------------------------------------------------------------ #
+
+    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        state = _safe_get_state(self._data_node)
+        key = (
+            state,
+            _control_points_digest(self._data_node),
+            self._slice_matrix_digest(self._slice_node),
+            _safe_get_mtime(self._display_node),
+        )
+        if key == self._last_update_key:
+            return
+        self._last_update_key = key
+
+        visible = state == STATE_PLANNING and self._reproject()
+        self._handles_actor.SetVisibility(bool(visible))
+        self._edges_actor.SetVisibility(bool(visible))
+
+    def _reproject(self) -> bool:
+        """Project handles + edges into XY with distance fading."""
+        carrier = self._data_node
+        slice_node = self._slice_node
+        if carrier is None or slice_node is None:
+            return False
+        grid_getter = getattr(carrier, "GetControlGridVector", None)
+        rows_getter = getattr(carrier, "GetRows", None)
+        cols_getter = getattr(carrier, "GetCols", None)
+        if None in (grid_getter, rows_getter, cols_getter):
+            return False
+        try:
+            grid = grid_getter()
+            rows, cols = int(rows_getter()), int(cols_getter())
+            if len(grid) < rows * cols * 3:
+                return False
+
+            to_ras = slice_node.GetSliceToRAS()
+            origin = [to_ras.GetElement(r, 3) for r in range(3)]
+            normal = [to_ras.GetElement(r, 2) for r in range(3)]
+            norm = sum(n * n for n in normal) ** 0.5 or 1.0
+            normal = [n / norm for n in normal]
+
+            ras_to_xy = vtk.vtkMatrix4x4()
+            ras_to_xy.DeepCopy(slice_node.GetXYToRAS())
+            ras_to_xy.Invert()
+
+            display = self._display_node
+            handle_rgb = [255, 255, 255]
+            edge_rgb = [255, 0, 0]
+            if display is not None:
+                try:
+                    handle_rgb = [int(c * 255) for c in display.GetHandleColor()]
+                    edge_rgb = [int(c * 255) for c in display.GetEdgeColor()]
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+            points = vtk.vtkPoints()
+            handle_rgba = vtk.vtkUnsignedCharArray()
+            handle_rgba.SetNumberOfComponents(4)
+            edge_rgba = vtk.vtkUnsignedCharArray()
+            edge_rgba.SetNumberOfComponents(4)
+            self._projected_xy = []
+            for i in range(rows * cols):
+                x, y, z = grid[i * 3], grid[i * 3 + 1], grid[i * 3 + 2]
+                xy = ras_to_xy.MultiplyPoint((x, y, z, 1.0))
+                w = xy[3] or 1.0
+                px, py = xy[0] / w, xy[1] / w
+                points.InsertNextPoint(px, py, 0.0)
+                self._projected_xy.append((px, py))
+                distance = abs(
+                    sum(n * (p - o) for n, p, o in zip(normal, (x, y, z), origin))
+                )
+                alpha = max(0.0, 1.0 - distance / FADE_DISTANCE_MM)
+                handle_rgba.InsertNextTuple4(*handle_rgb, int(alpha * 255))
+                edge_rgba.InsertNextTuple4(*edge_rgb, int(alpha * 255))
+
+            self._handles_polydata.SetPoints(points)
+            self._handles_polydata.GetPointData().SetScalars(handle_rgba)
+            self._handles_polydata.Modified()
+
+            edge_points = vtk.vtkPoints()
+            edge_points.DeepCopy(points)
+            lines = vtk.vtkCellArray()
+            for r in range(rows):
+                line = vtk.vtkPolyLine()
+                line.GetPointIds().SetNumberOfIds(cols)
+                for c in range(cols):
+                    line.GetPointIds().SetId(c, r * cols + c)
+                lines.InsertNextCell(line)
+            for c in range(cols):
+                line = vtk.vtkPolyLine()
+                line.GetPointIds().SetNumberOfIds(rows)
+                for r in range(rows):
+                    line.GetPointIds().SetId(r, r * cols + c)
+                lines.InsertNextCell(line)
+            self._edges_polydata.SetPoints(edge_points)
+            self._edges_polydata.SetLines(lines)
+            self._edges_polydata.GetPointData().SetScalars(edge_rgba)
+            self._edges_polydata.Modified()
+            return True
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+    @staticmethod
+    def _slice_matrix_digest(slice_node: Any) -> tuple:
+        if slice_node is None:
+            return ()
+        try:
+            m = slice_node.GetXYToRAS()
+            s = slice_node.GetSliceToRAS()
+            return tuple(
+                round(mat.GetElement(r, c), 6)
+                for mat in (m, s)
+                for r in range(4)
+                for c in range(4)
+            )
+        except Exception:  # pragma: no cover - defensive
+            return ()
+
+    # ------------------------------------------------------------------ #
+    # Interaction -- the slice-side per-point drag (ADR-0033)
+    # ------------------------------------------------------------------ #
+
+    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
+        import sys
+
+        if _safe_get_state(self._data_node) != STATE_PLANNING:
+            self._drag_index = None
+            return False, sys.float_info.max
+        etype = _event_type(eventData)
+        if self._drag_index is not None:
+            if etype in (
+                vtk.vtkCommand.MouseMoveEvent,
+                vtk.vtkCommand.LeftButtonReleaseEvent,
+            ):
+                return True, 0.0
+            return False, sys.float_info.max
+        if etype != vtk.vtkCommand.LeftButtonPressEvent:
+            return False, sys.float_info.max
+        _, distance2 = self._nearest_handle_in_display(eventData)
+        if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
+            return True, distance2
+        return False, sys.float_info.max
+
+    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
+        if _safe_get_state(self._data_node) != STATE_PLANNING:
+            self._drag_index = None
+            return False
+        etype = _event_type(eventData)
+
+        if self._drag_index is None:
+            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                return False
+            idx, distance2 = self._nearest_handle_in_display(eventData)
+            if (
+                idx is None
+                or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+            ):
+                return False
+            self._drag_index = idx
+            return True
+
+        if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
+            self._drag_index = None
+            return False
+
+        if etype == vtk.vtkCommand.MouseMoveEvent:
+            self._move_grabbed_to(eventData)
+            return True
+        return False
+
+    def _nearest_handle_in_display(self, eventData: Any):
+        """``(flat_index, distance2)`` of the projected handle nearest the pixel.
+
+        Slice-view display coordinates coincide with the XY space the
+        projection lives in (the slice renderer's convention), so the
+        arbitration compares the event pixel against ``_projected_xy``.
+        """
+        import sys
+
+        try:
+            ex, ey = eventData.GetDisplayPosition()
+        except Exception:  # pragma: no cover - defensive
+            return None, sys.float_info.max
+        best_idx, best_d2 = None, sys.float_info.max
+        for i, (px, py) in enumerate(self._projected_xy):
+            d2 = (px - ex) ** 2 + (py - ey) ** 2
+            if d2 < best_d2:
+                best_idx, best_d2 = i, d2
+        return best_idx, best_d2
+
+    def _move_grabbed_to(self, eventData: Any) -> None:
+        """Move the grabbed point to the cursor IN-PLANE, offset preserved."""
+        carrier = self._data_node
+        slice_node = self._slice_node
+        idx = self._drag_index
+        if carrier is None or slice_node is None or idx is None:
+            return
+        try:
+            ex, ey = eventData.GetDisplayPosition()
+            xy_to_ras = slice_node.GetXYToRAS()
+            ras = xy_to_ras.MultiplyPoint((float(ex), float(ey), 0.0, 1.0))
+            w = ras[3] or 1.0
+            in_plane = [ras[0] / w, ras[1] / w, ras[2] / w]
+
+            to_ras = slice_node.GetSliceToRAS()
+            origin = [to_ras.GetElement(r, 3) for r in range(3)]
+            normal = [to_ras.GetElement(r, 2) for r in range(3)]
+            norm = sum(n * n for n in normal) ** 0.5 or 1.0
+            normal = [n / norm for n in normal]
+
+            grid = carrier.GetControlGridVector()
+            current = (grid[idx * 3], grid[idx * 3 + 1], grid[idx * 3 + 2])
+            # Signed out-of-plane offset of the point BEFORE the move.
+            offset = sum(n * (p - o) for n, p, o in zip(normal, current, origin))
+            target = [ip + n * offset for ip, n in zip(in_plane, normal)]
+
+            cols = int(carrier.GetCols())
+            carrier.SetControlPoint(
+                idx // cols, idx % cols, target[0], target[1], target[2]
+            )
+        except Exception:  # pragma: no cover - defensive
+            return
+
+    # ------------------------------------------------------------------ #
+    # Introspection
+    # ------------------------------------------------------------------ #
+
+    def GetDataNode(self) -> Any | None:  # noqa: N802 - VTK verb
+        return self._data_node
+
+    def GetHandlesPolyData(self) -> Any:  # noqa: N802 - VTK verb
+        return self._handles_polydata
+
+    def GetHandlesActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._handles_actor
+
+    def GetEdgesActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._edges_actor
+
+    # ------------------------------------------------------------------ #
+    # Observers
+    # ------------------------------------------------------------------ #
+
+    def _attach_observer(self, node: Any) -> None:
+        if node is None or not hasattr(node, "AddObserver"):
+            return
+        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
+        self._observer_tags.setdefault(id(node), []).append(tag)
+        if node not in self._observed_node_refs:
+            self._observed_node_refs.append(node)
+
+    def _detach_observer(self, node: Any) -> None:
+        for tag in self._observer_tags.pop(id(node), []):
+            try:
+                node.RemoveObserver(tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        try:
+            self._observed_node_refs.remove(node)
+        except ValueError:
+            pass
+
+    def _on_node_modified(self, caller: Any, event: str) -> None:
+        del caller, event
+        self.UpdatePipeline()
+
+        render_key = (
+            _safe_get_state(self._data_node),
+            _control_points_digest(self._data_node),
+            self._slice_matrix_digest(self._slice_node),
+        )
+        if render_key == self._last_render_key:
+            return
+        self._last_render_key = render_key
+        request_render = getattr(self, "RequestRender", None)
+        if request_render is not None:
+            try:
+                request_render()
+            except Exception:  # pragma: no cover - defensive (stub bases)
+                pass
+
+
+def _safe_get_mtime(node: Any) -> int:
+    if node is None:
+        return 0
+    getter = getattr(node, "GetMTime", None)
+    if getter is None:
+        return 0
+    try:
+        return int(getter())
+    except Exception:  # pragma: no cover - defensive
+        return 0
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline-creator registration — ADR-0013 §5 call 3 (slice-view half)
+# --------------------------------------------------------------------------- #
+
+
+def registerSliceControlPolygonPipelineCreator() -> None:  # noqa: N802 - project convention
+    """Register the slice-view control-polygon creator with LayerDM.
+
+    Accepts ``(vtkMRMLSliceNode, vtkMRMLControlPolygonDisplayNode)`` pairs
+    only -- the slice complement of the 3D control-polygon creator.
+    Idempotent via the module-level flag.
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return
+
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLControlPolygonDisplayNode,
+        vtkMRMLLayerDMPipelineFactory,
+        vtkMRMLLayerDMPipelineScriptedCreator,
+    )
+
+    def tryCreate(viewNode, node):
+        if not _creator_accepts_view(viewNode):
+            return None
+        if not isinstance(node, vtkMRMLControlPolygonDisplayNode):
+            return None
+        return SliceControlPolygonPipeline()
+
+    creator = vtkMRMLLayerDMPipelineScriptedCreator()
+    creator.SetPythonCallback(tryCreate)
+    vtkMRMLLayerDMPipelineFactory.GetInstance().AddPipelineCreator(creator)
+    _REGISTERED = True

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -57,10 +57,10 @@ _REGISTERED = False
 #: the above/below-the-plane cue.  On-plane points render fully opaque.
 FADE_DISTANCE_MM = 30.0
 
-#: Only control points within this plane distance are MANIPULABLE from a
-#: slice view (the markups short-range convention); visibility fades to
-#: zero at FADE_DISTANCE_MM regardless.
-PICK_RANGE_MM = 15.0
+#: Manipulable range == visible range (the markups rule: anything you can
+#: see, you can grab).  A point at exactly FADE_DISTANCE_MM has alpha 0 --
+#: invisible AND unpickable; there is no visible-but-dead band.
+PICK_RANGE_MM = FADE_DISTANCE_MM
 
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
@@ -409,9 +409,9 @@ class SliceControlPolygonPipeline(_PipelineBase):
             return None, sys.float_info.max
         best_idx, best_d2 = None, sys.float_info.max
         for i, (px, py) in enumerate(self._projected_xy):
-            # Markups short-range convention: points beyond PICK_RANGE_MM
-            # from the plane are not manipulable from this slice.
-            if i < len(self._plane_distances) and self._plane_distances[i] > PICK_RANGE_MM:
+            # Markups rule: pickable iff visible -- a fully faded point
+            # (>= PICK_RANGE_MM == FADE_DISTANCE_MM) is not manipulable.
+            if i < len(self._plane_distances) and self._plane_distances[i] >= PICK_RANGE_MM:
                 continue
             d2 = (px - ex) ** 2 + (py - ey) ** 2
             if d2 < best_d2:

--- a/LiverResections/LiverResectionsLib/__init__.py
+++ b/LiverResections/LiverResectionsLib/__init__.py
@@ -32,6 +32,10 @@ from .SliceContourPipeline import (
     SliceContourPipeline,
     registerSliceContourPipelineCreator,
 )
+from .SliceControlPolygonPipeline import (
+    SliceControlPolygonPipeline,
+    registerSliceControlPolygonPipelineCreator,
+)
 from .ResectogramViewManager import (
     RESECTOGRAM_VIEW_SINGLETON_TAG,
     ResectogramViewManager,
@@ -41,6 +45,8 @@ __all__ = [
     "LiverBezierSurfacePipeline",
     "registerPipelineCreator",
     "SliceContourPipeline",
+    "SliceControlPolygonPipeline",
+    "registerSliceControlPolygonPipelineCreator",
     "registerSliceContourPipelineCreator",
     "ControlPolygonPipeline",
     "registerControlPolygonPipelineCreator",

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
@@ -79,6 +79,10 @@ int testDefaults()
   CHECK_DOUBLE(edgeColor[2], 0.0);
   CHECK_DOUBLE(node->GetEdgeWidth(), 1.5);
 
+  // Transient cross-view interaction state: nothing hovered/grabbed.
+  CHECK_INT(node->GetHoveredControlPoint(), -1);
+  CHECK_INT(node->GetGrabbedControlPoint(), -1);
+
   CHECK_STRING(node->GetNodeTagName(), "ControlPolygonDisplay");
   return EXIT_SUCCESS;
 }
@@ -103,6 +107,10 @@ int testSettersAndGetters()
   CHECK_DOUBLE(edgeColor[2], 0.6);
   node->SetEdgeWidth(2.5);
   CHECK_DOUBLE(node->GetEdgeWidth(), 2.5);
+  node->SetHoveredControlPoint(5);
+  CHECK_INT(node->GetHoveredControlPoint(), 5);
+  node->SetGrabbedControlPoint(7);
+  CHECK_INT(node->GetGrabbedControlPoint(), 7);
   return EXIT_SUCCESS;
 }
 

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
@@ -211,6 +211,16 @@ int testCopyContent()
   // Mutating source must not affect sink (deep-copy semantics).
   source->SetHandleRadius(1.0);
   CHECK_DOUBLE(sink->GetHandleRadius(), 4.0);
+
+  // TRANSIENT interaction state must NOT ride CopyContent (the markups
+  // ActiveComponent precedent): a copy must not inherit a live hover/grab,
+  // just as the fields are excluded from the XML round-trip.
+  source->SetHoveredControlPoint(5);
+  source->SetGrabbedControlPoint(7);
+  vtkNew<vtkMRMLControlPolygonDisplayNode> transientSink;
+  transientSink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
+  CHECK_INT(transientSink->GetHoveredControlPoint(), -1);
+  CHECK_INT(transientSink->GetGrabbedControlPoint(), -1);
   return EXIT_SUCCESS;
 }
 

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
@@ -102,13 +102,15 @@ void vtkMRMLControlPolygonDisplayNode::CopyContent(vtkMRMLNode* anode, bool deep
   MRMLNodeModifyBlocker blocker(this);
   Superclass::CopyContent(anode, deepCopy);
 
+  // HoveredControlPoint / GrabbedControlPoint are TRANSIENT interaction
+  // state (the markups ActiveComponent precedent): copying a node must not
+  // clone a live hover/grab onto the copy, so they are excluded here just
+  // as they are from the XML round-trip.
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyFloatMacro(HandleRadius);
   vtkMRMLCopyVectorMacro(HandleColor, double, 3);
   vtkMRMLCopyVectorMacro(EdgeColor, double, 3);
   vtkMRMLCopyFloatMacro(EdgeWidth);
-  vtkMRMLCopyIntMacro(HoveredControlPoint);
-  vtkMRMLCopyIntMacro(GrabbedControlPoint);
   vtkMRMLCopyEndMacro();
 }
 

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
@@ -57,6 +57,9 @@ vtkMRMLControlPolygonDisplayNode::vtkMRMLControlPolygonDisplayNode()
   , HandleColor{ 1.0, 1.0, 1.0 }
   , EdgeColor{ 1.0, 0.0, 0.0 }
   , EdgeWidth(1.5)
+  // Transient cross-view interaction state (not serialized).
+  , HoveredControlPoint(-1)
+  , GrabbedControlPoint(-1)
 {
 }
 
@@ -104,6 +107,8 @@ void vtkMRMLControlPolygonDisplayNode::CopyContent(vtkMRMLNode* anode, bool deep
   vtkMRMLCopyVectorMacro(HandleColor, double, 3);
   vtkMRMLCopyVectorMacro(EdgeColor, double, 3);
   vtkMRMLCopyFloatMacro(EdgeWidth);
+  vtkMRMLCopyIntMacro(HoveredControlPoint);
+  vtkMRMLCopyIntMacro(GrabbedControlPoint);
   vtkMRMLCopyEndMacro();
 }
 
@@ -117,5 +122,7 @@ void vtkMRMLControlPolygonDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintVectorMacro(HandleColor, double, 3);
   vtkMRMLPrintVectorMacro(EdgeColor, double, 3);
   vtkMRMLPrintFloatMacro(EdgeWidth);
+  vtkMRMLPrintIntMacro(HoveredControlPoint);
+  vtkMRMLPrintIntMacro(GrabbedControlPoint);
   vtkMRMLPrintEndMacro();
 }

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
@@ -122,6 +122,19 @@ public:
   vtkSetMacro(EdgeWidth, double);
   vtkGetMacro(EdgeWidth, double);
 
+  /// Flat row-major index of the HOVERED control point (-1 = none).
+  /// TRANSIENT interaction state shared across views (the markups
+  /// active-control-point convention): every pipeline observing this
+  /// display node highlights the same point, whichever view the cursor
+  /// is in.  Not serialized.
+  vtkSetMacro(HoveredControlPoint, int);
+  vtkGetMacro(HoveredControlPoint, int);
+
+  /// Flat row-major index of the GRABBED control point (-1 = none).
+  /// TRANSIENT, cross-view, not serialized (see HoveredControlPoint).
+  vtkSetMacro(GrabbedControlPoint, int);
+  vtkGetMacro(GrabbedControlPoint, int);
+
 protected:
   vtkMRMLControlPolygonDisplayNode();
   ~vtkMRMLControlPolygonDisplayNode() override;
@@ -134,6 +147,8 @@ private:
   double HandleColor[3];
   double EdgeColor[3];
   double EdgeWidth;
+  int HoveredControlPoint;
+  int GrabbedControlPoint;
 };
 
 #endif //__vtkmrmlcontrolpolygondisplaynode_h_

--- a/LiverResections/qSlicerLiverResectionsModule.cxx
+++ b/LiverResections/qSlicerLiverResectionsModule.cxx
@@ -198,6 +198,7 @@ void qSlicerLiverResectionsModule::setup()
                                    "    LiverResectionsLib.registerResectogramPipelineCreator()\n"
                                    "    LiverResectionsLib.registerControlPolygonPipelineCreator()\n"
                                    "    LiverResectionsLib.registerSliceContourPipelineCreator()\n"
+                                   "    LiverResectionsLib.registerSliceControlPolygonPipelineCreator()\n"
                                    "except ImportError as exc:\n"
                                    "    import logging\n"
                                    "    logging.critical('LiverResections: LayerDM Pipeline creator not registered (%s)'\n"

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -94,8 +94,10 @@ def test_handles_and_edges_follow_the_grid(pipeline_module, polygon_nodes):
     assert handles.GetNumberOfPoints() == 16
     assert handles.GetPoint(5) == pytest.approx((10.0, 10.0, 5.0))
     edges = pipeline.GetEdgesPolyData()
-    assert edges.GetNumberOfPoints() == 16
-    assert edges.GetNumberOfLines() == 4
+    # The builder's polylines are emitted as world-space DASH segments
+    # (the cross-view scaffold language), so the cell count exceeds the
+    # builder's 4 rows.
+    assert edges.GetNumberOfLines() > 4
     assert _FakeGeometry.calls == [(4, 4)], "cells built once, with (rows, cols)"
     pipeline.cleanup()
 

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -457,3 +457,30 @@ def test_remote_hover_colors_the_3d_handles(pipeline_module, polygon_nodes):
     )
     assert pipeline._handles_mapper.GetScalarVisibility() == 1
     pipeline.cleanup()
+
+
+def test_remote_hover_raises_the_3d_halo(pipeline_module, polygon_nodes):
+    """A hover published from a slice view shows the SAME 3D halo."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline._control_polygon_geometry = _FakeGeometry
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+    assert pipeline.GetHaloActor().GetVisibility() == 0
+
+    display.SetHoveredControlPoint(5)  # written by a slice pipeline
+    pipeline.UpdatePipeline()
+    assert pipeline.GetHaloActor().GetVisibility() == 1, (
+        "the display-channel hover must raise the 3D halo -- hovering in a "
+        "slice view reads identically to hovering in 3D."
+    )
+    assert tuple(pipeline.GetHaloActor().GetPosition()) == pytest.approx(
+        (10.0, 10.0, 5.0)
+    ), "the halo sits on the channel-hovered handle"
+
+    display.SetHoveredControlPoint(-1)
+    pipeline.UpdatePipeline()
+    assert pipeline.GetHaloActor().GetVisibility() == 0, "channel clear hides it"
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_control_polygon_pipeline.py
@@ -435,3 +435,25 @@ def test_grab_changes_the_halo_color(pipeline_module, polygon_nodes):
         "release restores the uniform display HandleColor"
     )
     pipeline.cleanup()
+
+
+def test_remote_hover_colors_the_3d_handles(pipeline_module, polygon_nodes):
+    """A hover raised in ANOTHER view (display channel) colours this one."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.ControlPolygonPipeline()
+    pipeline._control_polygon_geometry = _FakeGeometry
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data)
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+
+    display.SetHoveredControlPoint(5)  # e.g. written by a slice pipeline
+    pipeline.UpdatePipeline()
+    scalars = pipeline._handles_polydata.GetPointData().GetScalars()
+    hover = tuple(int(c * 255) for c in pipeline_module.HALO_HOVER_COLOR)
+    assert scalars is not None and tuple(scalars.GetTuple3(5)) == pytest.approx(hover), (
+        "the display-channel hover must colour the 3D handles too -- the "
+        "cross-view highlight."
+    )
+    assert pipeline._handles_mapper.GetScalarVisibility() == 1
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -728,27 +728,56 @@ class _StubMapperWithLocator(_StubMapperWithMatRatio):
         self.locator_radius = radius
 
 
-def test_locator_marker_reaches_the_2d_mapper(rep_module):
-    """The strip pushes the locator pick + radius onto the 2D mapper.
+def test_locator_marker_is_a_round_world_actor(rep_module):
+    """The strip marker is a world-space circle; the shader disc stays OFF.
 
-    The 1:1 correspondence marker (ADR-0025): the 2D mapper tests the REAL
-    surface position (BSPoints) against uLocatorPosition, so the strip dot
-    sits at the same anatomical point as the 3D surface marker.  Radius 0
-    (marker off) when no locator node is wired.
+    The shader disc tested the REAL 3D surface positions, so the (u, v)
+    flattening rendered it distorted.  The marker is now a circle actor on
+    the flat quad at the picked (u, v) -- round by construction, rescaled by
+    the camera on zoom/pan -- and the 2D mapper's locator radius is forced
+    to 0 so the distorted disc never draws.
     """
+
+    class _VisibleDisplay(_StubLocatorDisplay):
+        def GetVisibility(self):  # noqa: N802 - VTK verb
+            return True
+
+    class _VisibleLocator(_StubLocatorNode):
+        def GetDisplayNode(self):  # noqa: N802 - VTK verb
+            return _VisibleDisplay()
+
     rep = rep_module()
     mapper = _StubMapperWithLocator()
     rep._resection_mapper_2d = mapper
 
     rep.update(_StubDisplayNode(), _StubDataNode())
     assert mapper.locator_radius == pytest.approx(0.0), (
-        "no locator node wired -> the marker must be OFF (radius 0)"
+        "the distorted shader disc must stay OFF for the strip"
     )
+    assert rep._marker_actor.GetVisibility() == 0, "no pick -> no marker"
 
-    rep.SetLocatorNode(_StubLocatorNode())
+    rep.SetLocatorNode(_VisibleLocator())
+    rep.SetPickedUV((0.25, 0.75))
     rep.update(_StubDisplayNode(), _StubDataNode())
-    assert mapper.locator_position == pytest.approx((10.0, 20.0, 30.0))
-    assert mapper.locator_radius == pytest.approx(2.0)
+    assert mapper.locator_radius == pytest.approx(0.0), "shader disc still off"
+    assert rep._marker_actor.GetVisibility() == 1, (
+        "a visible pick raises the circle marker actor"
+    )
+    plane = rep.GetBezierPlane()
+    plane.Update()
+    b = plane.GetOutput().GetBounds()
+    expected = (
+        b[0] + (b[1] - b[0]) * 0.25,
+        b[2] + (b[3] - b[2]) * 0.75,
+    )
+    centre = rep._marker_source.GetCenter()
+    assert (centre[0], centre[1]) == pytest.approx(expected), (
+        "the circle sits at the picked (u, v) on the flat quad"
+    )
+    assert rep._marker_source.GetRadius() == pytest.approx(2.0), (
+        "radius follows the locator display node (world units, so camera "
+        "zoom/pan rescale it with the strip)"
+    )
     rep.cleanup()
 
 
@@ -767,9 +796,10 @@ def test_locator_marker_gates_on_display_visibility(rep_module):
     mapper = _StubMapperWithLocator()
     rep._resection_mapper_2d = mapper
     rep.SetLocatorNode(_HiddenLocator())
+    rep.SetPickedUV((0.5, 0.5))
     rep.update(_StubDisplayNode(), _StubDataNode())
-    assert mapper.locator_radius == pytest.approx(0.0), (
-        "locator display Visibility false -> the marker uniforms must be "
-        "pushed OFF (radius 0), the gesture-scoped hide."
+    assert rep._marker_actor.GetVisibility() == 0, (
+        "locator display Visibility false -> the circle marker hides "
+        "(the gesture-scoped switch)."
     )
     rep.cleanup()

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -774,9 +774,13 @@ def test_locator_marker_is_a_round_world_actor(rep_module):
     assert (centre[0], centre[1]) == pytest.approx(expected), (
         "the circle sits at the picked (u, v) on the flat quad"
     )
-    assert rep._marker_source.GetRadius() == pytest.approx(2.0), (
-        "radius follows the locator display node (world units, so camera "
-        "zoom/pan rescale it with the strip)"
+    assert rep._marker_source.GetRadius() == pytest.approx(2.0 * 0.6), (
+        "radius follows the locator display node at the strip's 0.6 scale "
+        "(world units, so camera zoom/pan rescale it with the strip)"
+    )
+    assert rep._marker_source.GetGeneratePolygon() == 0, (
+        "the strip marker is an OUTLINE circle -- it must not occlude the "
+        "distance-shading content it points at."
     )
     rep.cleanup()
 

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -807,3 +807,30 @@ def test_locator_marker_gates_on_display_visibility(rep_module):
         "(the gesture-scoped switch)."
     )
     rep.cleanup()
+
+
+def test_cleanup_detaches_the_marker_actor_from_the_renderer(
+    rep_module, vtk_module
+):
+    """``cleanup()`` must REMOVE the marker actor from the renderer.
+
+    Nulling the actor handle before the detach walk would make the walk
+    skip it, leaking one orphaned circle actor into the renderer per
+    teardown (renderer-churn cycles accumulate them).
+    """
+    renderer = vtk_module.vtkRenderer()
+    rep = rep_module(renderer)
+    marker = rep._marker_actor
+    assert marker is not None
+    actors = renderer.GetActors()
+    actors.InitTraversal()
+    attached = [actors.GetNextActor() for _ in range(actors.GetNumberOfItems())]
+    assert marker in attached, "the marker actor attaches with the quad actor"
+
+    rep.cleanup()
+
+    actors = renderer.GetActors()
+    assert actors.GetNumberOfItems() == 0, (
+        "cleanup() left an actor on the renderer -- the marker (or quad) "
+        "actor leaked past teardown."
+    )

--- a/Testing/Python/unit/test_slice_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_slice_control_polygon_pipeline.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Invariants for the ``SliceControlPolygonPipeline``.
+
+The markups-style slice half of the control polygon (ADR-0033): handles +
+edges projected into the slice view's XY space with DISTANCE FADING (alpha
+falls off with the point's distance to the slice plane, the above/below
+cue), and the Planning per-point drag available FROM the slice views (the
+grab preserves the point's out-of-plane offset -- no snap-to-plane).
+
+Launched-row only (wrapped MRML nodes + LayerDMLib); skips bare.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("LayerDMLib")
+
+
+@pytest.fixture
+def pipeline_module():
+    import SliceControlPolygonPipeline as mod
+
+    return mod
+
+
+@pytest.fixture
+def polygon_nodes():
+    import slicer
+
+    scene = slicer.mrmlScene
+    data = scene.AddNewNodeByClass("vtkMRMLBezierSurfaceNode")
+    display = scene.AddNewNodeByClass("vtkMRMLControlPolygonDisplayNode")
+    data.AddAndObserveDisplayNodeID(display.GetID())
+    try:
+        yield data, display
+    finally:
+        scene.RemoveNode(display)
+        scene.RemoveNode(data)
+
+
+def _seed_grid(data, z=0.0):
+    """Flat 4x4 grid at ``z``, except point (0,0) raised 30 mm above."""
+    for r in range(4):
+        for c in range(4):
+            data.SetControlPoint(r, c, float(c) * 10.0, float(r) * 10.0, z)
+    data.SetControlPoint(0, 0, 0.0, 0.0, z + 30.0)
+
+
+class _AxialSliceNodeAt:
+    """Slice-node stand-in: axial plane at world ``z`` (identity XY)."""
+
+    def __init__(self, z):
+        import vtk
+
+        self._to_ras = vtk.vtkMatrix4x4()
+        self._to_ras.SetElement(2, 3, z)
+        self._xy_to_ras = vtk.vtkMatrix4x4()
+        self._xy_to_ras.SetElement(2, 3, z)
+
+    def GetSliceToRAS(self):  # noqa: N802 - VTK verb
+        return self._to_ras
+
+    def GetXYToRAS(self):  # noqa: N802 - VTK verb
+        return self._xy_to_ras
+
+    def GetMTime(self):  # noqa: N802 - VTK verb
+        return 1
+
+
+class _TypedEvent:
+    def __init__(self, etype, pos=(0.0, 0.0)):
+        self._etype = etype
+        self._pos = pos
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+def test_projection_follows_the_grid(pipeline_module, polygon_nodes):
+    """16 projected handle points; edges present; Planning-only."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data, z=0.0)
+
+    # Init (the default state) -> hidden.  Tested FIRST: the carrier's
+    # state machine refuses backwards transitions (ADR-0019), so a
+    # Planning->Init flip would silently keep Planning.
+    pipeline.UpdatePipeline()
+    assert pipeline.GetHandlesActor().GetVisibility() == 0
+
+    data.SetState(1)  # Planning -> visible
+    pipeline.UpdatePipeline()
+    handles = pipeline.GetHandlesPolyData()
+    assert handles is not None and handles.GetNumberOfPoints() == 16
+    assert pipeline.GetHandlesActor().GetVisibility() == 1
+    assert pipeline.GetEdgesActor().GetVisibility() == 1
+    pipeline.cleanup()
+
+
+def test_fading_tracks_distance_to_the_plane(pipeline_module, polygon_nodes):
+    """Alpha: full on-plane, zero far away, monotone in between."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data, z=0.0)  # point 0 is 30 mm above; the rest on-plane
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+
+    scalars = pipeline.GetHandlesPolyData().GetPointData().GetScalars()
+    assert scalars is not None and scalars.GetNumberOfComponents() == 4, (
+        "handles carry per-point RGBA scalars (the fading channel)"
+    )
+    on_plane_alpha = scalars.GetTuple4(5)[3]
+    raised_alpha = scalars.GetTuple4(0)[3]
+    assert on_plane_alpha == pytest.approx(255, abs=1), "on-plane = fully opaque"
+    assert raised_alpha < on_plane_alpha, (
+        "a point 30 mm off-plane must FADE (alpha below the on-plane value)"
+    )
+    assert raised_alpha <= 255 * (1.0 - 30.0 / pipeline_module.FADE_DISTANCE_MM) + 1 or raised_alpha < 30, (
+        "the fade must track distance (30 mm beyond the fade span reads ~0)"
+    )
+    pipeline.cleanup()
+
+
+def test_slice_grab_moves_point_preserving_offplane_offset(
+    pipeline_module, polygon_nodes
+):
+    """Press grabs a projected handle; the drag preserves the z offset."""
+    import vtk
+
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data, z=0.0)
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+
+    # Deterministic pick seams (GL-free): handle 0 (the raised one).
+    pipeline._nearest_handle_in_display = lambda e: (0, 4.0)
+
+    move = _TypedEvent(vtk.vtkCommand.MouseMoveEvent, (7.0, 8.0))
+    can, _ = pipeline.CanProcessInteractionEvent(move)
+    assert can is False, "hover moves stay unclaimed (camera untouched)"
+
+    press = _TypedEvent(vtk.vtkCommand.LeftButtonPressEvent, (7.0, 8.0))
+    can, d2 = pipeline.CanProcessInteractionEvent(press)
+    assert can is True and d2 == pytest.approx(4.0)
+    assert pipeline.ProcessInteractionEvent(press) is True
+
+    drag = _TypedEvent(vtk.vtkCommand.MouseMoveEvent, (7.0, 8.0))
+    assert pipeline.ProcessInteractionEvent(drag) is True
+    grid = data.GetControlGridVector()
+    assert (grid[0], grid[1]) == pytest.approx((7.0, 8.0)), (
+        "the drag moves the grabbed point to the cursor IN-PLANE (XY)"
+    )
+    assert grid[2] == pytest.approx(30.0), (
+        "the point's out-of-plane offset is PRESERVED -- no snap-to-plane"
+    )
+
+    release = _TypedEvent(vtk.vtkCommand.LeftButtonReleaseEvent, (7.0, 8.0))
+    assert pipeline.ProcessInteractionEvent(release) is False, "grab ends"
+    pipeline.cleanup()
+
+
+def test_edit_requests_render_with_loop_guard(pipeline_module, polygon_nodes):
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data, z=0.0)
+    data.SetState(1)
+
+    renders = []
+    pipeline.RequestRender = lambda: renders.append(1)
+    data.SetControlPoint(2, 2, 21.0, 22.0, 0.0)
+    assert renders, "a geometry edit must request a slice repaint"
+    n = len(renders)
+    data.Modified()
+    assert len(renders) == n, "render-churn Modified must not re-request"
+    pipeline.cleanup()
+
+
+def test_creator_accepts_slice_views_only(pipeline_module):
+    import slicer
+
+    accepts = pipeline_module._creator_accepts_view
+    slice_node = slicer.mrmlScene.CreateNodeByClass("vtkMRMLSliceNode")
+    slice_node.UnRegister(None)
+    assert accepts(slice_node) is True
+    view_node = slicer.mrmlScene.CreateNodeByClass("vtkMRMLViewNode")
+    view_node.UnRegister(None)
+    assert accepts(view_node) is False
+    assert accepts(None) is False

--- a/Testing/Python/unit/test_slice_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_slice_control_polygon_pipeline.py
@@ -200,3 +200,56 @@ def test_creator_accepts_slice_views_only(pipeline_module):
     view_node.UnRegister(None)
     assert accepts(view_node) is False
     assert accepts(None) is False
+
+
+def test_far_points_are_not_manipulable(pipeline_module, polygon_nodes):
+    """Points beyond PICK_RANGE_MM from the plane cannot be picked."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data, z=0.0)  # point 0 is 30 mm above (beyond the 15 mm range)
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+
+    class _At:
+        def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+            return (0.0, 0.0)  # exactly on point 0's projection
+
+    idx, _ = pipeline._nearest_handle_in_display(_At())
+    assert idx != 0, (
+        "the raised point (30 mm off-plane) must be EXCLUDED from slice-side "
+        "picking (markups short-range manipulation)."
+    )
+    pipeline.cleanup()
+
+
+def test_hover_publishes_cross_view_highlight(pipeline_module, polygon_nodes):
+    """A slice hover writes the display channel; the projection colours it."""
+    import vtk
+
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    _seed_grid(data, z=0.0)
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+
+    move = _TypedEvent(vtk.vtkCommand.MouseMoveEvent, (10.0, 10.0))  # point 5
+    can, _ = pipeline.CanProcessInteractionEvent(move)
+    assert can is False, "hover moves stay unclaimed"
+    assert display.GetHoveredControlPoint() == 5, (
+        "the hover must publish onto the display node -- the cross-view "
+        "highlight channel every pipeline observes."
+    )
+    pipeline.UpdatePipeline()
+    scalars = pipeline.GetHandlesPolyData().GetPointData().GetScalars()
+    hover = tuple(int(c * 255) for c in pipeline_module.HALO_HOVER_COLOR)
+    assert tuple(scalars.GetTuple4(5))[:3] == pytest.approx(hover), (
+        "the hovered point takes the hover colour in the projection"
+    )
+    assert scalars.GetTuple4(5)[3] == pytest.approx(255), (
+        "the hovered point renders fully opaque"
+    )
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_slice_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_slice_control_polygon_pipeline.py
@@ -295,3 +295,30 @@ def test_edges_are_dashed_and_ring_marks_the_hover(pipeline_module, polygon_node
         "the hover must raise the 2D ring -- the slice analogue of the halo"
     )
     pipeline.cleanup()
+
+
+def test_side_tint_tracks_the_signed_distance(pipeline_module, polygon_nodes):
+    """Above-plane points tint lighter, below-plane darker (markups cue)."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    for r in range(4):
+        for c in range(4):
+            data.SetControlPoint(r, c, float(c) * 10.0, float(r) * 10.0, 0.0)
+    data.SetControlPoint(0, 1, 10.0, 0.0, 8.0)   # above the plane
+    data.SetControlPoint(0, 2, 20.0, 0.0, -8.0)  # below the plane
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+
+    scalars = pipeline.GetHandlesPolyData().GetPointData().GetScalars()
+    on_plane = sum(scalars.GetTuple4(0)[:3])
+    above = sum(scalars.GetTuple4(1)[:3])
+    below = sum(scalars.GetTuple4(2)[:3])
+    assert above > on_plane, (
+        "an ABOVE-plane point must tint LIGHTER than an on-plane one"
+    )
+    assert below < on_plane, (
+        "a BELOW-plane point must tint DARKER than an on-plane one"
+    )
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_slice_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_slice_control_polygon_pipeline.py
@@ -253,3 +253,40 @@ def test_hover_publishes_cross_view_highlight(pipeline_module, polygon_nodes):
         "the hovered point renders fully opaque"
     )
     pipeline.cleanup()
+
+
+def test_edges_are_dashed_and_ring_marks_the_hover(pipeline_module, polygon_nodes):
+    """Structural differentiation + the 2D hover halo.
+
+    The polygon edges render as MANY short dash segments (never a handful
+    of solid polylines -- the scaffold reads structurally distinct from the
+    solid resection contour), and hovering shows a ring on the projected
+    handle, the 2D analogue of the 3D glow halo.
+    """
+    import vtk
+
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    # Wide spacing (40 px edges) so each edge holds SEVERAL dashes.
+    for r in range(4):
+        for c in range(4):
+            data.SetControlPoint(r, c, float(c) * 40.0, float(r) * 40.0, 0.0)
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+
+    edges = pipeline._edges_polydata
+    assert edges.GetNumberOfLines() > 24, (
+        "edges must be emitted as dash SEGMENTS (24 grid edges -> many "
+        "dashes), not solid polylines."
+    )
+    assert pipeline._ring_actor.GetVisibility() == 0, "no hover -> no ring"
+
+    move = _TypedEvent(vtk.vtkCommand.MouseMoveEvent, (40.0, 40.0))  # point 5
+    pipeline.CanProcessInteractionEvent(move)
+    pipeline.UpdatePipeline()
+    assert pipeline._ring_actor.GetVisibility() == 1, (
+        "the hover must raise the 2D ring -- the slice analogue of the halo"
+    )
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_slice_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_slice_control_polygon_pipeline.py
@@ -322,3 +322,38 @@ def test_side_tint_tracks_the_signed_distance(pipeline_module, polygon_nodes):
         "a BELOW-plane point must tint DARKER than an on-plane one"
     )
     pipeline.cleanup()
+
+
+def test_ring_respects_the_range_and_lone_points_keep_their_scaffold(
+    pipeline_module, polygon_nodes
+):
+    """The highlight never surfaces far points; visible points keep dashes."""
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    # Everything far above the plane EXCEPT point 5 (on-plane).
+    for r in range(4):
+        for c in range(4):
+            data.SetControlPoint(r, c, float(c) * 40.0, float(r) * 40.0, 100.0)
+    data.SetControlPoint(1, 1, 40.0, 40.0, 0.0)
+    data.SetState(1)
+
+    display.SetGrabbedControlPoint(0)  # grabbed FAR point (e.g. from 3D)
+    pipeline.UpdatePipeline()
+    assert pipeline._ring_actor.GetVisibility() == 0, (
+        "the grab highlight must NOT surface a point this plane cannot "
+        "reach -- no ring for out-of-range points."
+    )
+    assert pipeline._edges_polydata.GetNumberOfLines() > 0, (
+        "the lone in-range point must keep its connecting scaffold dashes "
+        "(either-endpoint edge gating)."
+    )
+
+    display.SetGrabbedControlPoint(5)  # the on-plane point
+    pipeline.UpdatePipeline()
+    assert pipeline._ring_actor.GetVisibility() == 1, (
+        "an in-range grabbed point rings normally"
+    )
+    display.SetGrabbedControlPoint(-1)
+    pipeline.cleanup()

--- a/Testing/Python/unit/test_slice_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_slice_control_polygon_pipeline.py
@@ -98,7 +98,10 @@ def test_projection_follows_the_grid(pipeline_module, polygon_nodes):
     data.SetState(1)  # Planning -> visible
     pipeline.UpdatePipeline()
     handles = pipeline.GetHandlesPolyData()
-    assert handles is not None and handles.GetNumberOfPoints() == 16
+    # The raised point (30 mm off-plane) is beyond the manipulable range
+    # and therefore NOT PRESENT at all (2D alpha is unreliable, so
+    # presence is the cutoff): 15 of 16 points project.
+    assert handles is not None and handles.GetNumberOfPoints() == 15
     assert pipeline.GetHandlesActor().GetVisibility() == 1
     assert pipeline.GetEdgesActor().GetVisibility() == 1
     pipeline.cleanup()
@@ -114,18 +117,18 @@ def test_fading_tracks_distance_to_the_plane(pipeline_module, polygon_nodes):
     data.SetState(1)
     pipeline.UpdatePipeline()
 
-    scalars = pipeline.GetHandlesPolyData().GetPointData().GetScalars()
+    handles = pipeline.GetHandlesPolyData()
+    assert handles.GetNumberOfPoints() == 15, (
+        "the raised point (beyond the manipulable range) must be ABSENT -- "
+        "presence IS the cutoff; only points a slice can edit appear in it."
+    )
+    scalars = handles.GetPointData().GetScalars()
     assert scalars is not None and scalars.GetNumberOfComponents() == 4, (
-        "handles carry per-point RGBA scalars (the fading channel)"
+        "present handles carry per-point RGBA scalars (the near-range fade)"
     )
-    on_plane_alpha = scalars.GetTuple4(5)[3]
-    raised_alpha = scalars.GetTuple4(0)[3]
-    assert on_plane_alpha == pytest.approx(255, abs=1), "on-plane = fully opaque"
-    assert raised_alpha < on_plane_alpha, (
-        "a point 30 mm off-plane must FADE (alpha below the on-plane value)"
-    )
-    assert raised_alpha <= 255 * (1.0 - 30.0 / pipeline_module.FADE_DISTANCE_MM) + 1 or raised_alpha < 30, (
-        "the fade must track distance (30 mm beyond the fade span reads ~0)"
+    alphas = [scalars.GetTuple4(i)[3] for i in range(handles.GetNumberOfPoints())]
+    assert all(a == pytest.approx(255, abs=1) for a in alphas), (
+        "all PRESENT points here are on-plane -> fully opaque"
     )
     pipeline.cleanup()
 
@@ -246,10 +249,12 @@ def test_hover_publishes_cross_view_highlight(pipeline_module, polygon_nodes):
     pipeline.UpdatePipeline()
     scalars = pipeline.GetHandlesPolyData().GetPointData().GetScalars()
     hover = tuple(int(c * 255) for c in pipeline_module.HALO_HOVER_COLOR)
-    assert tuple(scalars.GetTuple4(5))[:3] == pytest.approx(hover), (
+    # Grid point 5 sits at PRESENT index 4: the raised point 0 is beyond
+    # the manipulable range and absent from the projected polydata.
+    assert tuple(scalars.GetTuple4(4))[:3] == pytest.approx(hover), (
         "the hovered point takes the hover colour in the projection"
     )
-    assert scalars.GetTuple4(5)[3] == pytest.approx(255), (
+    assert scalars.GetTuple4(4)[3] == pytest.approx(255), (
         "the hovered point renders fully opaque"
     )
     pipeline.cleanup()


### PR DESCRIPTION
Stacked on #564 (branched from it; merge that first and this rebases to just its own commits).

The markups-parity slice half of the control polygon (ADR-0033), plus cross-view interaction polish — ten commits, each refined against hands-on testing on real anatomy.

**Slice projection (`SliceControlPolygonPipeline`)**
- Handles + edges projected into the slice view's XY space, keyed on the control-polygon display node for `vtkMRMLSliceNode` views only (creators dispatch per view type).
- **Presence is the cutoff**: only control points within the manipulable range (15 mm) of the plane appear at all — `vtkPolyDataMapper2D` does not reliably honour RGBA alpha, so far points are excluded from the polydata rather than faded; alpha keeps the near-range gradient where supported.
- **Signed-distance tint** (the markups cue): above-plane points tint toward white, below toward black, graded by distance; the slice base colour pulls to 78% so default white handles keep headroom. Edges draw when either endpoint is present, so a visible point never floats without its scaffold.
- **Dashed scaffold everywhere**: the slice edges render as manually segmented dashes (GL line stipple is not portable), and the 3D edge tubes adopt the same world-space pattern (7/7 mm — wide enough to survive low zoom and glancing angles), so scaffold-vs-resection reads by line style in every view.

**Slice-side editing**
- The Planning per-point drag works from the slice views: press grabs the nearest projected handle (range-gated), the drag moves it in-plane at the cursor while preserving its out-of-plane offset (no snap-to-plane), release ends the gesture.

**Cross-view interaction state**
- The display node gains transient `HoveredControlPoint`/`GrabbedControlPoint` fields (the markups active-control-point convention): hover/grab raised in ANY view highlights the same point everywhere — 3D handle colour + glow halo, slice ring + point colour — with the highlight range-gated per slice so a plane never surfaces a point it cannot reach.

**Strip marker fix**
- The resectogram's locator marker was the shader disc — round on the 3D surface, distorted by the (u, v) flattening. It is now a world-space OUTLINE circle at the picked (u, v) on the flat quad: round by construction, rescaled by camera zoom/pan, MatRatio-corrected at its centre, 60% radius and unfilled so the distance shading stays readable; the distorted shader disc is retired for the strip (the 3D surface disc is untouched).

All behaviours pinned test-first on the launched row (23 pins in the slice suite alone); verified interactively across axial/sagittal/coronal with reslicing, cross-view drags, and zoom/pan.