### PR TITLE
Boundary-guard sweep + slice-projection review follow-ups

### DIFF
--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -197,9 +197,7 @@ class ControlPolygonPipeline(_PipelineBase):
         self._display_node = displayNode
         self._data_node = None
         if displayNode is not None:
-            getter = getattr(displayNode, "GetDisplayableNode", None)
-            if getter is not None:
-                self._data_node = getter()
+            self._data_node = displayNode.GetDisplayableNode()
             self._attach_observer(displayNode)
             if self._data_node is not None:
                 self._attach_observer(self._data_node)
@@ -213,31 +211,36 @@ class ControlPolygonPipeline(_PipelineBase):
         whose displayable link does not exist yet; the LayerDM manager calls
         this hook at the exact link moment with ``fromNode`` == the carrier.
         """
-        if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
-            self._data_node = fromNode
-            self._attach_observer(fromNode)
-            self._last_update_key = None
-        self.UpdatePipeline()
+        try:
+            if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
+                self._data_node = fromNode
+                self._attach_observer(fromNode)
+                self._last_update_key = None
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        self._renderer = renderer
-        if renderer is not None:
-            renderer.AddActor(self._edges_actor)
-            renderer.AddActor(self._handles_actor)
-        # ``OnRendererRemoved`` -> ``cleanup()`` cleared the node handles;
-        # re-derive them from the base's retained display node, or the
-        # renderer churn leaves the pipeline displayless forever and every
-        # styling field silently stays at the raw VTK defaults (the
-        # tiny-handles / hairline-white-edges failure mode).  Mirrors the
-        # ResectogramPipeline's OnRendererAdded re-attach.
-        if self._display_node is None:
-            base_getter = getattr(self, "GetDisplayNode", None)
-            display = base_getter() if base_getter is not None else None
-            if display is not None:
-                self.SetDisplayNode(display)
-        self._attach_halo_renderer(renderer)
-        self._last_update_key = None
-        self.UpdatePipeline()
+        try:
+            self._renderer = renderer
+            if renderer is not None:
+                renderer.AddActor(self._edges_actor)
+                renderer.AddActor(self._handles_actor)
+            # ``OnRendererRemoved`` -> ``cleanup()`` cleared the node handles;
+            # re-derive them from the base's retained display node, or the
+            # renderer churn leaves the pipeline displayless forever and every
+            # styling field silently stays at the raw VTK defaults (the
+            # tiny-handles / hairline-white-edges failure mode).  Mirrors the
+            # ResectogramPipeline's OnRendererAdded re-attach.
+            if self._display_node is None:
+                display = self.GetDisplayNode()
+                if display is not None:
+                    self.SetDisplayNode(display)
+            self._attach_halo_renderer(renderer)
+            self._last_update_key = None
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def _attach_halo_renderer(self, renderer: Any) -> None:
         """Build the private glow overlay on ``renderer``'s window.
@@ -284,22 +287,28 @@ class ControlPolygonPipeline(_PipelineBase):
             pass
 
     def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        if renderer is not None:
-            try:
+        try:
+            if renderer is not None:
                 renderer.RemoveActor(self._handles_actor)
                 renderer.RemoveActor(self._edges_actor)
-            except Exception:  # pragma: no cover - defensive
-                pass
-        self._renderer = None
-        self.cleanup()
+            self._renderer = None
+            self.cleanup()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
         """Reconcile handles + edges against the carrier grid and display."""
+        try:
+            self._reconcile()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _reconcile(self) -> None:
+        """``UpdatePipeline``'s body — plain attribute access throughout."""
         # Late-bind the data node (creation-ordering tolerance; see
         # OnReferenceToDisplayNodeAdded).
         if self._data_node is None and self._display_node is not None:
-            getter = getattr(self._display_node, "GetDisplayableNode", None)
-            displayable = getter() if getter is not None else None
+            displayable = self._display_node.GetDisplayableNode()
             if displayable is not None:
                 self._data_node = displayable
                 self._attach_observer(displayable)
@@ -353,39 +362,42 @@ class ControlPolygonPipeline(_PipelineBase):
         """
         import sys
 
-        if _safe_get_state(self._data_node) != STATE_PLANNING:
-            self._drag_index = None  # a state flip mid-gesture drops the grab
-            return False, sys.float_info.max
-        renderer = self._safe_get_renderer()
-        if renderer is None:
-            self._drag_index = None
-            return False, sys.float_info.max
+        try:
+            if _safe_get_state(self._data_node) != STATE_PLANNING:
+                self._drag_index = None  # a state flip mid-gesture drops the grab
+                return False, sys.float_info.max
+            renderer = self._safe_get_renderer()
+            if renderer is None:
+                self._drag_index = None
+                return False, sys.float_info.max
 
-        etype = _event_type(eventData)
-        if self._drag_index is not None:
-            if etype in (
-                vtk.vtkCommand.MouseMoveEvent,
-                vtk.vtkCommand.LeftButtonReleaseEvent,
-            ):
-                return True, 0.0
-            return False, sys.float_info.max
+            etype = _event_type(eventData)
+            if self._drag_index is not None:
+                if etype in (
+                    vtk.vtkCommand.MouseMoveEvent,
+                    vtk.vtkCommand.LeftButtonReleaseEvent,
+                ):
+                    return True, 0.0
+                return False, sys.float_info.max
 
-        if etype == vtk.vtkCommand.MouseMoveEvent:
-            # Bare hover: update the halo highlight as a SIDE EFFECT of the
-            # arbitration call and decline -- camera moves stay unclaimed.
-            idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-            within = (
-                idx is not None
-                and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
-            )
-            self._set_hover(idx if within else None)
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                # Bare hover: update the halo highlight as a SIDE EFFECT of the
+                # arbitration call and decline -- camera moves stay unclaimed.
+                idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
+                within = (
+                    idx is not None
+                    and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+                )
+                self._set_hover(idx if within else None)
+                return False, sys.float_info.max
+            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                return False, sys.float_info.max
+            _, distance2 = self._nearest_control_point_in_display(renderer, eventData)
+            if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
+                return True, distance2
             return False, sys.float_info.max
-        if etype != vtk.vtkCommand.LeftButtonPressEvent:
+        except Exception:  # pragma: no cover - C++ boundary must never raise
             return False, sys.float_info.max
-        _, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-        if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
-            return True, distance2
-        return False, sys.float_info.max
 
     def _set_hover(self, index: int | None) -> None:
         """Show/move the halo on handle ``index`` (``None`` hides it).
@@ -403,23 +415,14 @@ class ControlPolygonPipeline(_PipelineBase):
             self._halo_actor.SetVisibility(False)
         else:
             carrier = self._data_node
-            grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
-            if grid_getter is None:
+            if carrier is None:
                 return
-            try:
-                grid = grid_getter()
-                base = int(index) * 3
-                self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * HALO_HOVER_SCALE)
-                self._halo_actor.SetPosition(grid[base], grid[base + 1], grid[base + 2])
-                self._halo_actor.SetVisibility(True)
-            except Exception:  # pragma: no cover - defensive
-                return
-        request_render = getattr(self, "RequestRender", None)
-        if request_render is not None:
-            try:
-                request_render()
-            except Exception:  # pragma: no cover - defensive (stub bases)
-                pass
+            grid = carrier.GetControlGridVector()
+            base = int(index) * 3
+            self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * HALO_HOVER_SCALE)
+            self._halo_actor.SetPosition(grid[base], grid[base + 1], grid[base + 2])
+            self._halo_actor.SetVisibility(True)
+        self.RequestRender()
 
     def _publish_interaction_state(self, hovered=None, grabbed=None) -> None:
         """Write hover/grab onto the DISPLAY node (cross-view channel).
@@ -434,17 +437,14 @@ class ControlPolygonPipeline(_PipelineBase):
         display = self._display_node
         if display is None:
             return
-        try:
-            if hovered is not None:
-                value = -1 if hovered == -1 else int(hovered)
-                if display.GetHoveredControlPoint() != value:
-                    display.SetHoveredControlPoint(value)
-            if grabbed is not None:
-                value = -1 if grabbed == -1 else int(grabbed)
-                if display.GetGrabbedControlPoint() != value:
-                    display.SetGrabbedControlPoint(value)
-        except Exception:  # pragma: no cover - defensive (stub displays)
-            return
+        if hovered is not None:
+            value = -1 if hovered == -1 else int(hovered)
+            if display.GetHoveredControlPoint() != value:
+                display.SetHoveredControlPoint(value)
+        if grabbed is not None:
+            value = -1 if grabbed == -1 else int(grabbed)
+            if display.GetGrabbedControlPoint() != value:
+                display.SetGrabbedControlPoint(value)
 
     def _sync_halo_from_channel(self, polygon_visible: bool) -> None:
         """Drive the glow halo from the display-node interaction channel.
@@ -455,29 +455,22 @@ class ControlPolygonPipeline(_PipelineBase):
         reconcile (drags move the point under it).
         """
         display = self._display_node
-        try:
-            hovered = display.GetHoveredControlPoint() if display is not None else -1
-            grabbed = display.GetGrabbedControlPoint() if display is not None else -1
-        except Exception:  # pragma: no cover - defensive (stub displays)
-            hovered, grabbed = -1, -1
+        hovered = display.GetHoveredControlPoint() if display is not None else -1
+        grabbed = display.GetGrabbedControlPoint() if display is not None else -1
         target = grabbed if grabbed >= 0 else hovered
         if not polygon_visible or target < 0:
             self._halo_actor.SetVisibility(False)
             return
         carrier = self._data_node
-        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
-        if grid_getter is None:
+        if carrier is None:
             return
-        try:
-            grid = grid_getter()
-            base = int(target) * 3
-            if len(grid) < base + 3:
-                return
-            self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * HALO_HOVER_SCALE)
-            self._halo_actor.SetPosition(grid[base], grid[base + 1], grid[base + 2])
-            self._halo_actor.SetVisibility(True)
-        except Exception:  # pragma: no cover - defensive
+        grid = carrier.GetControlGridVector()
+        base = int(target) * 3
+        if len(grid) < base + 3:
             return
+        self._halo_sphere.SetRadius(self._handle_sphere.GetRadius() * HALO_HOVER_SCALE)
+        self._halo_actor.SetPosition(grid[base], grid[base + 1], grid[base + 2])
+        self._halo_actor.SetVisibility(True)
 
     def _apply_interaction_scalars(self) -> None:
         """Colour the hovered/grabbed HANDLES from the display-node state.
@@ -487,30 +480,24 @@ class ControlPolygonPipeline(_PipelineBase):
         OTHER views (the slice projections) colour this 3D view too.
         """
         display = self._display_node
-        try:
-            hovered = display.GetHoveredControlPoint() if display is not None else -1
-            grabbed = display.GetGrabbedControlPoint() if display is not None else -1
-        except Exception:  # pragma: no cover - defensive (stub displays)
-            hovered, grabbed = -1, -1
-        try:
-            points = self._handles_polydata.GetPoints()
-            n = points.GetNumberOfPoints() if points is not None else 0
-            base = [int(c * 255) for c in self._handles_actor.GetProperty().GetColor()]
-            grab = [int(c * 255) for c in HALO_GRAB_COLOR]
-            hover = [int(c * 255) for c in HALO_HOVER_COLOR]
-            colors = vtk.vtkUnsignedCharArray()
-            colors.SetNumberOfComponents(3)
-            colors.SetName("HandleColors")
-            for i in range(n):
-                rgb = grab if i == grabbed else (hover if i == hovered else base)
-                colors.InsertNextTuple3(*rgb)
-            self._handles_polydata.GetPointData().SetScalars(colors)
-            self._handles_glyph.SetColorModeToColorByScalar()
-            self._handles_mapper.SetColorModeToDirectScalars()
-            self._handles_mapper.SetScalarVisibility(grabbed >= 0 or hovered >= 0)
-            self._handles_polydata.Modified()
-        except Exception:  # pragma: no cover - defensive
-            return
+        hovered = display.GetHoveredControlPoint() if display is not None else -1
+        grabbed = display.GetGrabbedControlPoint() if display is not None else -1
+        points = self._handles_polydata.GetPoints()
+        n = points.GetNumberOfPoints() if points is not None else 0
+        base = [int(c * 255) for c in self._handles_actor.GetProperty().GetColor()]
+        grab = [int(c * 255) for c in HALO_GRAB_COLOR]
+        hover = [int(c * 255) for c in HALO_HOVER_COLOR]
+        colors = vtk.vtkUnsignedCharArray()
+        colors.SetNumberOfComponents(3)
+        colors.SetName("HandleColors")
+        for i in range(n):
+            rgb = grab if i == grabbed else (hover if i == hovered else base)
+            colors.InsertNextTuple3(*rgb)
+        self._handles_polydata.GetPointData().SetScalars(colors)
+        self._handles_glyph.SetColorModeToColorByScalar()
+        self._handles_mapper.SetColorModeToDirectScalars()
+        self._handles_mapper.SetScalarVisibility(grabbed >= 0 or hovered >= 0)
+        self._handles_polydata.Modified()
 
     def GetHaloActor(self) -> Any:  # noqa: N802 - VTK verb
         return self._halo_actor
@@ -524,54 +511,57 @@ class ControlPolygonPipeline(_PipelineBase):
         is momentarily nearest -- so the gesture cannot hop between points;
         the release clears the grab and returns False, releasing the focus.
         """
-        renderer = self._safe_get_renderer()
-        if renderer is None:
-            self._drag_index = None
-            return False
-        if _safe_get_state(self._data_node) != STATE_PLANNING:
-            self._drag_index = None
-            return False
-
-        etype = _event_type(eventData)
-
-        if self._drag_index is None:
-            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+        try:
+            renderer = self._safe_get_renderer()
+            if renderer is None:
+                self._drag_index = None
                 return False
-            idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-            if (
-                idx is None
-                or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
-            ):
+            if _safe_get_state(self._data_node) != STATE_PLANNING:
+                self._drag_index = None
                 return False
-            self._drag_index = idx
-            self._publish_interaction_state(grabbed=idx)
-            self._apply_interaction_scalars()
-            hover, self._hover_index = idx, None
-            self._set_hover(hover)  # halo jumps to the grabbed handle
-            world = self._event_world_at_control_point(renderer, eventData, idx)
-            if world is not None:
-                self._apply_world_point_to_control_point(idx, world)
-            return True
 
-        if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
-            self._drag_index = None
-            self._publish_interaction_state(grabbed=-1)
-            self._apply_interaction_scalars()
-            self._set_hover(None)
-            return False  # grab over -- release the focus
+            etype = _event_type(eventData)
 
-        if etype == vtk.vtkCommand.MouseMoveEvent:
-            world = self._event_world_at_control_point(
-                renderer, eventData, self._drag_index
-            )
-            if world is None:
-                return True  # keep the grab; this move just didn't resolve
-            self._apply_world_point_to_control_point(self._drag_index, world)
-            hover, self._hover_index = self._drag_index, None
-            self._set_hover(hover)  # halo follows the grabbed handle
-            return True
+            if self._drag_index is None:
+                if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                    return False
+                idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
+                if (
+                    idx is None
+                    or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+                ):
+                    return False
+                self._drag_index = idx
+                self._publish_interaction_state(grabbed=idx)
+                self._apply_interaction_scalars()
+                hover, self._hover_index = idx, None
+                self._set_hover(hover)  # halo jumps to the grabbed handle
+                world = self._event_world_at_control_point(renderer, eventData, idx)
+                if world is not None:
+                    self._apply_world_point_to_control_point(idx, world)
+                return True
 
-        return False
+            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
+                self._drag_index = None
+                self._publish_interaction_state(grabbed=-1)
+                self._apply_interaction_scalars()
+                self._set_hover(None)
+                return False  # grab over -- release the focus
+
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                world = self._event_world_at_control_point(
+                    renderer, eventData, self._drag_index
+                )
+                if world is None:
+                    return True  # keep the grab; this move just didn't resolve
+                self._apply_world_point_to_control_point(self._drag_index, world)
+                hover, self._hover_index = self._drag_index, None
+                self._set_hover(hover)  # halo follows the grabbed handle
+                return True
+
+            return False
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False
 
     def _apply_world_point_to_control_point(self, index: int, world: Any) -> bool:
         """Move the carrier's control point ``index`` to RAS ``world``.
@@ -583,21 +573,14 @@ class ControlPolygonPipeline(_PipelineBase):
         carrier = self._data_node
         if carrier is None or _safe_get_state(carrier) != STATE_PLANNING:
             return False
-        cols_getter = getattr(carrier, "GetCols", None)
-        set_point = getattr(carrier, "SetControlPoint", None)
-        if None in (cols_getter, set_point):
-            return False
-        try:
-            cols = int(cols_getter())
-            set_point(
-                int(index) // cols,
-                int(index) % cols,
-                float(world[0]),
-                float(world[1]),
-                float(world[2]),
-            )
-        except Exception:  # pragma: no cover - defensive
-            return False
+        cols = int(carrier.GetCols())
+        carrier.SetControlPoint(
+            int(index) // cols,
+            int(index) % cols,
+            float(world[0]),
+            float(world[1]),
+            float(world[2]),
+        )
         return True
 
     def _apply_world_point_to_nearest_control_point(self, world: Any) -> int | None:
@@ -612,19 +595,10 @@ class ControlPolygonPipeline(_PipelineBase):
         carrier = self._data_node
         if carrier is None or _safe_get_state(carrier) != STATE_PLANNING:
             return None
-        rows_getter = getattr(carrier, "GetRows", None)
-        cols_getter = getattr(carrier, "GetCols", None)
-        grid_getter = getattr(carrier, "GetControlGridVector", None)
-        set_point = getattr(carrier, "SetControlPoint", None)
-        if None in (rows_getter, cols_getter, grid_getter, set_point):
-            return None
-        try:
-            rows = int(rows_getter())
-            cols = int(cols_getter())
-            grid = grid_getter()
-            wx, wy, wz = float(world[0]), float(world[1]), float(world[2])
-        except Exception:  # pragma: no cover - defensive
-            return None
+        rows = int(carrier.GetRows())
+        cols = int(carrier.GetCols())
+        grid = carrier.GetControlGridVector()
+        wx, wy, wz = float(world[0]), float(world[1]), float(world[2])
 
         best_idx = None
         best_d2 = None
@@ -638,7 +612,7 @@ class ControlPolygonPipeline(_PipelineBase):
                 best_idx = i
         if best_idx is None:
             return None
-        set_point(best_idx // cols, best_idx % cols, wx, wy, wz)
+        carrier.SetControlPoint(best_idx // cols, best_idx % cols, wx, wy, wz)
         return best_idx
 
     def _nearest_control_point_in_display(self, renderer: Any, eventData: Any):
@@ -646,18 +620,12 @@ class ControlPolygonPipeline(_PipelineBase):
         import sys
 
         carrier = self._data_node
-        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
-        cols_getter = getattr(carrier, "GetCols", None) if carrier else None
-        rows_getter = getattr(carrier, "GetRows", None) if carrier else None
-        if None in (grid_getter, cols_getter, rows_getter):
+        if carrier is None:
             return None, sys.float_info.max
-        try:
-            grid = grid_getter()
-            rows = int(rows_getter())
-            cols = int(cols_getter())
-            ex, ey = eventData.GetDisplayPosition()
-        except Exception:  # pragma: no cover - defensive
-            return None, sys.float_info.max
+        grid = carrier.GetControlGridVector()
+        rows = int(carrier.GetRows())
+        cols = int(carrier.GetCols())
+        ex, ey = eventData.GetDisplayPosition()
 
         best_idx = None
         best_d2 = sys.float_info.max
@@ -672,14 +640,16 @@ class ControlPolygonPipeline(_PipelineBase):
         return best_idx, best_d2
 
     def _event_world_at_control_point(self, renderer: Any, eventData: Any, idx: int):
-        """Back-project the event pixel onto control point ``idx``'s depth."""
+        """Back-project the event pixel onto control point ``idx``'s depth.
+
+        The try/except is FLOW, not a guard: a move that fails to resolve
+        returns ``None`` so the caller keeps the grab alive.
+        """
         carrier = self._data_node
-        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
-        cols_getter = getattr(carrier, "GetCols", None) if carrier else None
-        if None in (grid_getter, cols_getter):
+        if carrier is None:
             return None
         try:
-            grid = grid_getter()
+            grid = carrier.GetControlGridVector()
             ex, ey = eventData.GetDisplayPosition()
             renderer.SetWorldPoint(grid[idx * 3 + 0], grid[idx * 3 + 1], grid[idx * 3 + 2], 1.0)
             renderer.WorldToDisplay()
@@ -702,32 +672,22 @@ class ControlPolygonPipeline(_PipelineBase):
         if state != STATE_PLANNING:
             return False
         display = self._display_node
-        vis_getter = getattr(display, "GetVisibility", None) if display else None
-        if vis_getter is not None:
-            try:
-                return bool(vis_getter())
-            except Exception:  # pragma: no cover - defensive
-                return True
-        return True
+        if display is None:
+            return True
+        return bool(display.GetVisibility())
 
     def _refresh_geometry(self) -> None:
         """Rebuild handle points + polygon edges from the carrier grid."""
         carrier = self._data_node
-        grid_getter = getattr(carrier, "GetControlGridVector", None) if carrier else None
-        if grid_getter is None:
-            grid_getter = getattr(carrier, "GetControlGrid", None) if carrier else None
-        if grid_getter is None:
+        if carrier is None:
             return
-        rows = int(getattr(carrier, "GetRows", lambda: 4)())
-        cols = int(getattr(carrier, "GetCols", lambda: 4)())
-        try:
-            raw = grid_getter()
-            points = vtk.vtkPoints()
-            points.SetNumberOfPoints(rows * cols)
-            for i in range(rows * cols):
-                points.SetPoint(i, float(raw[i * 3]), float(raw[i * 3 + 1]), float(raw[i * 3 + 2]))
-        except Exception:  # pragma: no cover - defensive
-            return
+        raw = carrier.GetControlGridVector()
+        rows = int(carrier.GetRows())
+        cols = int(carrier.GetCols())
+        points = vtk.vtkPoints()
+        points.SetNumberOfPoints(rows * cols)
+        for i in range(rows * cols):
+            points.SetPoint(i, float(raw[i * 3]), float(raw[i * 3 + 1]), float(raw[i * 3 + 2]))
 
         self._handles_polydata.SetPoints(points)
         self._handles_polydata.Modified()
@@ -878,47 +838,35 @@ class ControlPolygonPipeline(_PipelineBase):
         so no render feedback loop.
         """
         del caller, event
-        self.UpdatePipeline()
-
-        display = self._display_node
         try:
+            self.UpdatePipeline()
+
+            display = self._display_node
             interaction = (
                 display.GetHoveredControlPoint() if display is not None else -1,
                 display.GetGrabbedControlPoint() if display is not None else -1,
             )
-        except Exception:  # pragma: no cover - defensive (stub displays)
-            interaction = (-1, -1)
-        render_key = (
-            _safe_get_state(self._data_node),
-            _control_points_digest(self._data_node),
-            interaction,
-        )
-        if render_key == self._last_render_key:
-            return
-        self._last_render_key = render_key
+            render_key = (
+                _safe_get_state(self._data_node),
+                _control_points_digest(self._data_node),
+                interaction,
+            )
+            if render_key == self._last_render_key:
+                return
+            self._last_render_key = render_key
 
-        request_render = getattr(self, "RequestRender", None)
-        if request_render is not None:
-            try:
-                request_render()
-            except Exception:  # pragma: no cover - defensive (stub bases)
-                pass
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
 
-def _event_type(eventData: Any) -> int | None:  # noqa: N803 - VTK arg name
-    """Read the VTK event-type id off ``eventData`` defensively.
+def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name
+    """The VTK event-type id off ``eventData``.
 
-    ``None`` for events lacking ``GetType`` (stubs) or on a read failure —
-    the callers then decline, so the grab state machine never raises from
-    the interaction hot path.
+    Called only inside the never-raise interaction boundaries, so plain
+    attribute access is fine here.
     """
-    getter = getattr(eventData, "GetType", None)
-    if getter is None:
-        return None
-    try:
-        return int(getter())
-    except Exception:  # pragma: no cover - defensive
-        return None
+    return int(eventData.GetType())
 
 
 def _control_points_digest(node: Any) -> tuple:
@@ -927,23 +875,16 @@ def _control_points_digest(node: Any) -> tuple:
     Mirrors the ResectogramPipeline's memo digest: a control-point edit
     changes the digest, a render-induced ``Modified`` at fixed geometry does
     not — the discrimination that keeps drags repainting live while blocking
-    a render feedback loop.  Empty tuple for nodes missing the grid accessor
-    (stubs) or on a read failure.
+    a render feedback loop.  Empty tuple when no carrier is attached.
     """
     if node is None:
         return ()
-    grid_getter = getattr(node, "GetControlGridVector", None)
-    if grid_getter is None:
-        return ()
-    try:
-        grid = grid_getter()
-        usable = len(grid) - (len(grid) % 3)
-        return tuple(
-            (grid[base], grid[base + 1], grid[base + 2])
-            for base in range(0, usable, 3)
-        )
-    except Exception:  # pragma: no cover - defensive
-        return ()
+    grid = node.GetControlGridVector()
+    usable = len(grid) - (len(grid) % 3)
+    return tuple(
+        (grid[base], grid[base + 1], grid[base + 2])
+        for base in range(0, usable, 3)
+    )
 
 
 def registerControlPolygonPipelineCreator() -> None:  # noqa: N802 - project convention
@@ -975,14 +916,16 @@ def registerControlPolygonPipelineCreator() -> None:  # noqa: N802 - project con
         )
 
     def tryCreate(viewNode, node):
-        if not isinstance(viewNode, vtkMRMLViewNode):
+        try:
+            if not isinstance(viewNode, vtkMRMLViewNode):
+                return None
+            if viewNode.GetSingletonTag() == RESECTOGRAM_VIEW_SINGLETON_TAG:
+                return None
+            if not isinstance(node, vtkMRMLControlPolygonDisplayNode):
+                return None
+            return ControlPolygonPipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
             return None
-        tag_getter = getattr(viewNode, "GetSingletonTag", None)
-        if tag_getter is not None and tag_getter() == RESECTOGRAM_VIEW_SINGLETON_TAG:
-            return None
-        if not isinstance(node, vtkMRMLControlPolygonDisplayNode):
-            return None
-        return ControlPolygonPipeline()
 
     creator = vtkMRMLLayerDMPipelineScriptedCreator()
     creator.SetPythonCallback(tryCreate)

--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -300,9 +300,7 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             # The data node lives on the display node's
             # ``GetDisplayableNode()`` accessor — the conventional
             # MRML back-reference.
-            getter = getattr(displayNode, "GetDisplayableNode", None)
-            if getter is not None:
-                self._data_node = getter()
+            self._data_node = displayNode.GetDisplayableNode()
             self._attach_observer(displayNode)
             if self._data_node is not None:
                 self._attach_observer(self._data_node)
@@ -331,13 +329,16 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         Without this the Pipeline stays permanently data-node-less (no
         observers, no dispatch, the default unit patch renders).
         """
-        if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
-            self._data_node = fromNode
-            self._attach_observer(fromNode)
-            self._last_update_key = None
-            self._last_resection_scan_mtime = None
-            self._last_locator_scan_mtime = None
-        self.UpdatePipeline()
+        try:
+            if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
+                self._data_node = fromNode
+                self._attach_observer(fromNode)
+                self._last_update_key = None
+                self._last_resection_scan_mtime = None
+                self._last_locator_scan_mtime = None
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
         """Dispatch the active Representation by ``(state, initMode)``.
@@ -350,6 +351,13 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         invokes when the display node, data node, or view state
         changes (and on ``ResetDisplay()``).
         """
+        try:
+            self._reconcile()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _reconcile(self) -> None:
+        """``UpdatePipeline``'s body — plain attribute access throughout."""
         self._ensure_representations()
 
         # Late-bind the data node (the production creation ordering):
@@ -360,8 +368,7 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         # here; adopting also attaches the carrier observer so subsequent
         # control-grid edits re-dispatch.
         if self._data_node is None and self._display_node is not None:
-            getter = getattr(self._display_node, "GetDisplayableNode", None)
-            displayable = getter() if getter is not None else None
+            displayable = self._display_node.GetDisplayableNode()
             if displayable is not None:
                 self._data_node = displayable
                 self._attach_observer(displayable)
@@ -447,9 +454,9 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         for rep in self._representations.values():
             if rep is None or rep is active:
                 continue
-            if getattr(rep, "_renderer", None) is not None:
+            if rep._renderer is not None:
                 rep.SetRenderer(None)
-        if active is not None and renderer is not None and getattr(active, "_renderer", None) is not renderer:
+        if active is not None and renderer is not None and active._renderer is not renderer:
             active.SetRenderer(renderer)
 
         if active is not None:
@@ -482,16 +489,22 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         until ``GetRenderer()`` returns a non-None value.
         """
         del renderer  # accessed via self.GetRenderer() inside the helper
-        self._ensure_representations()
-        # Re-emit a dispatch so the active Representation re-attaches
-        # its actors against the new renderer.
-        self._last_update_key = None
-        self.UpdatePipeline()
+        try:
+            self._ensure_representations()
+            # Re-emit a dispatch so the active Representation re-attaches
+            # its actors against the new renderer.
+            self._last_update_key = None
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
         """Tear down Representations when the renderer goes away."""
         del renderer
-        self.cleanup()
+        try:
+            self.cleanup()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     # ------------------------------------------------------------------ #
     # Public extras (orchestrating-state node + introspection)
@@ -529,8 +542,8 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         so a second ``commit()`` is a no-op (one-shot per resection).
         """
         state = _safe_get_state(self._data_node)
-        # Tolerate stub data nodes with no state accessor (None): treat a
-        # missing state as still-in-Init so the single transition fires.
+        # ``None`` state means no carrier is attached yet: treat it as
+        # still-in-Init so the single transition fires.
         if state not in (None, STATE_INIT):
             return
 
@@ -541,12 +554,8 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         # transition cannot re-fire (ADR-0019: irreversible 2-state
         # automaton; init data freezes to read-only audit data).
         self._pending_extraction = False
-        setter = getattr(self._data_node, "SetState", None)
-        if setter is not None:
-            try:
-                setter(STATE_PLANNING)
-            except Exception:  # pragma: no cover - defensive
-                pass
+        if self._data_node is not None:
+            self._data_node.SetState(STATE_PLANNING)
 
     def _resolve_target_model(self) -> Any | None:
         """Return the weakref'd target organ model node (ADR-0014 §1).
@@ -557,13 +566,9 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         Representations feed the extractor FROM here, not a hard-coded
         path or a silent ``None`` no-op.
         """
-        getter = getattr(self._data_node, "GetTargetModelNode", None)
-        if getter is None:
+        if self._data_node is None:
             return None
-        try:
-            return getter()
-        except Exception:  # pragma: no cover - defensive
-            return None
+        return self._data_node.GetTargetModelNode()
 
     def _resolve_resection_node(self) -> Any | None:
         """Reverse-resolve the ``vtkMRMLResectionPlanNode`` wrapper.
@@ -579,25 +584,17 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         data_node = self._data_node
         if data_node is None:
             return None
-        scene = getattr(data_node, "GetScene", lambda: None)()
+        scene = data_node.GetScene()
         if scene is None:
             return None
-        try:
-            plans = scene.GetNodesByClass("vtkMRMLResectionPlanNode")
-        except Exception:  # pragma: no cover - defensive
-            return None
+        plans = scene.GetNodesByClass("vtkMRMLResectionPlanNode")
         if plans is None:
             return None
         plans.InitTraversal()
         item = plans.GetNextItemAsObject()
         while item is not None:
-            getter = getattr(item, "GetGeometryNode", None)
-            if getter is not None:
-                try:
-                    if getter() is data_node:
-                        return item
-                except Exception:  # pragma: no cover - defensive
-                    pass
+            if item.GetGeometryNode() is data_node:
+                return item
             item = plans.GetNextItemAsObject()
         return None
 
@@ -664,27 +661,30 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         Returns True iff geometry changed (the interaction logic keeps focus on
         a pipeline that returns True).
         """
-        renderer = self._safe_get_renderer()
-        if renderer is None:
+        try:
+            renderer = self._safe_get_renderer()
+            if renderer is None:
+                return False
+            carrier = self._data_node
+            state = _safe_get_state(carrier)
+
+            if state == STATE_INIT and _safe_get_init_mode(carrier) == INIT_MODE_SLICING_PLANE:
+                world = self._event_world_on_focal_plane(renderer, eventData)
+                if world is None:
+                    return False
+                return self._place_slicing_plane_init_point(world) is not None
+
+            if state == STATE_INIT and _safe_get_init_mode(carrier) == INIT_MODE_DISTANCE_SPHEROID:
+                world = self._event_world_on_focal_plane(renderer, eventData)
+                if world is None:
+                    return False
+                return self._place_distance_spheroid_init_point(world) is not None
+
+            # The Planning per-point drag lives on ControlPolygonPipeline
+            # (ADR-0033); this Pipeline handles only the Init placements above.
             return False
-        carrier = self._data_node
-        state = _safe_get_state(carrier)
-
-        if state == STATE_INIT and _safe_get_init_mode(carrier) == INIT_MODE_SLICING_PLANE:
-            world = self._event_world_on_focal_plane(renderer, eventData)
-            if world is None:
-                return False
-            return self._place_slicing_plane_init_point(world) is not None
-
-        if state == STATE_INIT and _safe_get_init_mode(carrier) == INIT_MODE_DISTANCE_SPHEROID:
-            world = self._event_world_on_focal_plane(renderer, eventData)
-            if world is None:
-                return False
-            return self._place_distance_spheroid_init_point(world) is not None
-
-        # The Planning per-point drag lives on ControlPolygonPipeline
-        # (ADR-0033); this Pipeline handles only the Init placements above.
-        return False
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False
 
     def _place_slicing_plane_init_point(self, world: Any) -> int | None:
         """Place the next slicing-plane init point at RAS ``world``.
@@ -705,14 +705,12 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             return None
         if _safe_get_init_mode(carrier) != INIT_MODE_SLICING_PLANE:
             return None
-        set_point = getattr(carrier, "SetSlicingPlaneInitPoint", None)
-        if set_point is None or self._slicing_plane_points_placed >= 2:
+        if self._slicing_plane_points_placed >= 2:
             return None
         index = self._slicing_plane_points_placed
-        try:
-            placed = set_point(index, [float(world[0]), float(world[1]), float(world[2])])
-        except Exception:  # pragma: no cover - defensive
-            return None
+        placed = carrier.SetSlicingPlaneInitPoint(
+            index, [float(world[0]), float(world[1]), float(world[2])]
+        )
         if placed is False:  # the node's Init-only guard rejected it
             return None
         self._slicing_plane_points_placed += 1
@@ -738,21 +736,13 @@ class LiverBezierSurfacePipeline(_PipelineBase):
             return None
         if _safe_get_init_mode(carrier) != INIT_MODE_DISTANCE_SPHEROID:
             return None
-        set_point = getattr(carrier, "SetDistanceSpheroidInitPoint", None)
-        get_count = getattr(carrier, "GetNumberOfDistanceSpheroidInitPoints", None)
-        if set_point is None or get_count is None:
-            return None
-        try:
-            capacity = int(get_count())
-        except Exception:  # pragma: no cover - defensive
-            return None
+        capacity = int(carrier.GetNumberOfDistanceSpheroidInitPoints())
         if self._distance_spheroid_points_placed >= capacity:
             return None
         index = self._distance_spheroid_points_placed
-        try:
-            placed = set_point(index, [float(world[0]), float(world[1]), float(world[2])])
-        except Exception:  # pragma: no cover - defensive
-            return None
+        placed = carrier.SetDistanceSpheroidInitPoint(
+            index, [float(world[0]), float(world[1]), float(world[2])]
+        )
         if placed is False:  # the node's Init-only guard rejected it
             return None
         self._distance_spheroid_points_placed += 1
@@ -886,20 +876,13 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         self._representations_initialised = True
 
     def _safe_get_renderer(self) -> Any | None:
-        """Return ``self.GetRenderer()`` if available, else ``None``.
+        """Return ``self.GetRenderer()`` (``None`` until the manager
+        attaches a renderer).
 
-        The base ``vtkMRMLLayerDMPipelineI::GetRenderer`` is supplied
-        once the manager attaches the Pipeline to a renderer.  Tests
-        that construct the Pipeline before a renderer is wired need
-        the ``None`` fallback.
+        Kept as a named seam: interaction tests monkeypatch it to stand
+        in a live renderer without a GL context.
         """
-        getter = getattr(self, "GetRenderer", None)
-        if getter is None:
-            return None
-        try:
-            return getter()
-        except Exception:  # pragma: no cover - defensive
-            return None
+        return self.GetRenderer()
 
     def _select_representation(
         self, state: int | None, init_mode: int | None
@@ -969,86 +952,61 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         from re-requesting — the render feedback-loop guard.
         """
         del caller, event  # observers route uniformly into UpdatePipeline()
-        self.UpdatePipeline()
+        try:
+            self.UpdatePipeline()
 
-        render_key = (
-            _safe_get_state(self._data_node),
-            _safe_get_init_mode(self._data_node),
-            _control_points_digest(self._data_node),
-            _safe_get_picked_position(self._locator_node),
-            _safe_get_locator_visibility(self._locator_node),
-        )
-        if render_key == self._last_render_key:
-            return
-        self._last_render_key = render_key
+            render_key = (
+                _safe_get_state(self._data_node),
+                _safe_get_init_mode(self._data_node),
+                _control_points_digest(self._data_node),
+                _safe_get_picked_position(self._locator_node),
+                _safe_get_locator_visibility(self._locator_node),
+            )
+            if render_key == self._last_render_key:
+                return
+            self._last_render_key = render_key
 
-        request_render = getattr(self, "RequestRender", None)
-        if request_render is not None:
-            try:
-                request_render()
-            except Exception:  # pragma: no cover - defensive (stub bases)
-                pass
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
 
 # --------------------------------------------------------------------------- #
-# Safe accessors — tolerant of stub nodes that omit GetMTime / GetState etc.
+# Safe accessors — a ``None`` NODE is a real state (mid-teardown, not yet
+# linked); the accessors themselves are always-present carrier / locator API
+# and are called directly.
 # --------------------------------------------------------------------------- #
 
 
 def _safe_get_state(node: Any) -> int | None:
-    """Read ``GetState()`` off ``node`` defensively.
-
-    Returns ``None`` if the node is ``None`` or does not implement
-    ``GetState()``.
-    """
+    """``GetState()`` as an int; ``None`` when no node is attached."""
     if node is None:
         return None
-    getter = getattr(node, "GetState", None)
-    if getter is None:
-        return None
-    try:
-        return int(getter())
-    except Exception:  # pragma: no cover - defensive
-        return None
+    return int(node.GetState())
 
 
 def _safe_get_init_mode(node: Any) -> int | None:
-    """Read ``GetInitMode()`` off ``node`` defensively."""
+    """``GetInitMode()`` as an int; ``None`` when no node is attached."""
     if node is None:
         return None
-    getter = getattr(node, "GetInitMode", None)
-    if getter is None:
-        return None
-    try:
-        return int(getter())
-    except Exception:  # pragma: no cover - defensive
-        return None
+    return int(node.GetInitMode())
 
 
 def _safe_get_mtime(node: Any) -> int:
-    """Read ``GetMTime()`` off ``node`` defensively; 0 when unavailable."""
+    """``GetMTime()`` as an int; 0 when no node is attached."""
     if node is None:
         return 0
-    getter = getattr(node, "GetMTime", None)
-    if getter is None:
-        return 0
-    try:
-        return int(getter())
-    except Exception:  # pragma: no cover - defensive
-        return 0
+    return int(node.GetMTime())
 
 
 def _safe_get_locator_visibility(node: Any) -> bool | None:
     """The locator display's Visibility (the marker switch); None sans node."""
     if node is None:
         return None
-    display = node.GetDisplayNode() if hasattr(node, "GetDisplayNode") else None
+    display = node.GetDisplayNode()
     if display is None:
         return None
-    try:
-        return bool(display.GetVisibility())
-    except Exception:  # pragma: no cover - defensive
-        return None
+    return bool(display.GetVisibility())
 
 
 def _safe_get_picked_position(node: Any) -> tuple | None:
@@ -1059,13 +1017,7 @@ def _safe_get_picked_position(node: Any) -> tuple | None:
     """
     if node is None:
         return None
-    getter = getattr(node, "GetPickedPositionWorld", None)
-    if getter is None:
-        return None
-    try:
-        return tuple(float(v) for v in getter())
-    except Exception:  # pragma: no cover - defensive
-        return None
+    return tuple(float(v) for v in node.GetPickedPositionWorld())
 
 
 def _control_points_digest(node: Any) -> tuple:
@@ -1074,23 +1026,16 @@ def _control_points_digest(node: Any) -> tuple:
     Mirrors the ResectogramPipeline's memo digest: a control-point edit
     changes the digest, a render-induced ``Modified`` at fixed geometry does
     not — the discrimination that keeps drags repainting live while blocking
-    a render feedback loop.  Empty tuple for nodes missing the grid accessor
-    (stubs) or on a read failure.
+    a render feedback loop.  Empty tuple when no carrier is attached.
     """
     if node is None:
         return ()
-    grid_getter = getattr(node, "GetControlGridVector", None)
-    if grid_getter is None:
-        return ()
-    try:
-        grid = grid_getter()
-        usable = len(grid) - (len(grid) % 3)
-        return tuple(
-            (grid[base], grid[base + 1], grid[base + 2])
-            for base in range(0, usable, 3)
-        )
-    except Exception:  # pragma: no cover - defensive
-        return ()
+    grid = node.GetControlGridVector()
+    usable = len(grid) - (len(grid) % 3)
+    return tuple(
+        (grid[base], grid[base + 1], grid[base + 2])
+        for base in range(0, usable, 3)
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -282,11 +282,11 @@ class BezierPlanningRepresentation:
         position = node.GetPickedPositionWorld()
         set_position(float(position[0]), float(position[1]), float(position[2]))
 
-        display_node = node.GetDisplayNode() if hasattr(node, "GetDisplayNode") else None
+        display_node = node.GetDisplayNode()
         radius = display_node.GetRadius() if display_node is not None else 0.0
         # Gesture-scoped marker: the display's base Visibility is the
         # switch (press shows, release hides); invisible pushes radius 0.
-        visible = getattr(display_node, "GetVisibility", lambda: True)() if display_node is not None else False
+        visible = bool(display_node.GetVisibility()) if display_node is not None else False
         set_radius(float(radius) if visible else 0.0)
 
     def cleanup(self) -> None:
@@ -467,33 +467,22 @@ class BezierPlanningRepresentation:
         if data_node is None:
             return
 
-        # Prefer ``GetControlGridVector`` (``const std::vector<double>&`` ->
-        # a Python tuple) over ``GetControlGrid`` (``const double*``): VTK
+        # Read ``GetControlGridVector`` (``const std::vector<double>&`` ->
+        # a Python tuple), NOT ``GetControlGrid`` (``const double*``): VTK
         # cannot wrap a bare pointer return into an indexable buffer — from
         # Python it surfaces as an opaque pointer-string (``'_..._p_double'``)
         # whose ``[0]`` is the character ``'_'``, not a coordinate.  The
-        # vector accessor round-trips cleanly.  Stub data nodes in the
-        # unit-layer tests expose only ``GetControlGrid`` (a plain list), so
-        # fall back to it.
-        grid_getter = getattr(data_node, "GetControlGridVector", None)
-        if grid_getter is None:
-            grid_getter = getattr(data_node, "GetControlGrid", None)
-        if grid_getter is None:
-            return
+        # vector accessor round-trips cleanly.
 
         # Resolve (rows, cols) from the node — required to size the
-        # iteration over the flat control-grid return.  Default to 4×4 when
-        # the accessors are absent (legacy stubs in unit tests); the
-        # array-length check below catches any drift.
-        rows = int(getattr(data_node, "GetRows", lambda: 4)())
-        cols = int(getattr(data_node, "GetCols", lambda: 4)())
+        # iteration over the flat control-grid return; the array-length
+        # check below catches any drift.
+        rows = int(data_node.GetRows())
+        cols = int(data_node.GetCols())
         control_count = rows * cols
         flat_length = 3 * control_count
 
-        try:
-            raw = grid_getter()
-        except Exception:  # pragma: no cover - defensive
-            return
+        raw = data_node.GetControlGridVector()
         if raw is None:
             return
 

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -269,10 +269,6 @@ class FlattenedSurfaceRepresentation:
         """Attach the cross-view locator node (ADR-0025); ``None`` clears."""
         self._locator_node = locator_node
 
-    def SetPickedUV(self, uv: Any) -> None:  # noqa: N802 - VTK verb
-        """Record the picked strip ``(u, v)`` (set by the pick producer)."""
-        self._picked_uv = (float(uv[0]), float(uv[1])) if uv is not None else None
-
     def _apply_locator(self) -> None:
         """Drive the strip's circle marker from the locator state.
 
@@ -284,6 +280,11 @@ class FlattenedSurfaceRepresentation:
         MatRatio squeeze applied to its centre about the camera focal
         point (the ratio scales clip-space offsets).  Visibility follows
         the locator display's gesture-scoped switch.
+
+        BOTH marker inputs live on the locator node (ADR-0025: the node
+        is the locator-state carrier): the gesture-scoped display
+        Visibility AND the picked ``(u, v)`` (``GetPickedUV``; any
+        negative component is the "no pick yet" sentinel).
         """
         mapper = self._resection_mapper_2d
         if mapper is not None:
@@ -296,7 +297,11 @@ class FlattenedSurfaceRepresentation:
         visible = (
             bool(display_node.GetVisibility()) if display_node is not None else False
         )
-        uv = self._picked_uv
+        uv = None
+        if node is not None:
+            picked = node.GetPickedUV()
+            if picked is not None and picked[0] >= 0.0 and picked[1] >= 0.0:
+                uv = (float(picked[0]), float(picked[1]))
         if not visible or uv is None or self._bezier_plane is None:
             if self._marker_actor is not None:
                 self._marker_actor.SetVisibility(False)
@@ -347,7 +352,6 @@ class FlattenedSurfaceRepresentation:
         self._distance_map_volume = None
         self._effective_texture_num_comps = 0
         self._locator_node = None
-        self._picked_uv = None
 
         # Detach BEFORE dropping the actor handles: nulling the marker actor
         # first would make _detach_actors skip it and leak it into the
@@ -458,7 +462,6 @@ class FlattenedSurfaceRepresentation:
         self._marker_actor.GetProperty().SetColor(1.0, 0.0, 0.0)
         self._marker_actor.GetProperty().SetLineWidth(2.0)
         self._marker_actor.SetVisibility(False)
-        self._picked_uv: tuple | None = None
 
     def _attach_actors(self, renderer: Any) -> None:
         if self._resection_actor_2d is not None and hasattr(renderer, "AddActor"):

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -292,11 +292,9 @@ class FlattenedSurfaceRepresentation:
                 set_radius(0.0)  # the distorted shader disc stays off
 
         node = self._locator_node
-        display_node = node.GetDisplayNode() if node is not None and hasattr(node, "GetDisplayNode") else None
+        display_node = node.GetDisplayNode() if node is not None else None
         visible = (
-            bool(getattr(display_node, "GetVisibility", lambda: False)())
-            if display_node is not None
-            else False
+            bool(display_node.GetVisibility()) if display_node is not None else False
         )
         uv = self._picked_uv
         if not visible or uv is None or self._bezier_plane is None:
@@ -695,12 +693,18 @@ class FlattenedSurfaceRepresentation:
         already_bound = self._mapper_has_distance_map_texture(mapper)
         # Source the distance-map volume from the WRAPPER (ADR-0031), NOT the
         # data node / carrier — the distance map is a wrapper-owned input of
-        # the resection plan (ADR-0014 §"Fourth layer").
-        volume = _safe_call_getter(self._resection_plan_node, "GetDistanceMapVolumeNode")
+        # the resection plan (ADR-0014 §"Fourth layer").  A ``None`` plan (no
+        # owning wrapper) or a ``None`` volume is a real state — the
+        # no-distance-map fallback.
+        volume = (
+            self._resection_plan_node.GetDistanceMapVolumeNode()
+            if self._resection_plan_node is not None
+            else None
+        )
         if volume is self._distance_map_volume and already_bound:
             return  # unchanged + already bound — idempotent (ADR-0013 §3)
 
-        image_data = _safe_call_getter(volume, "GetImageData")
+        image_data = volume.GetImageData() if volume is not None else None
         if image_data is None:
             # No distance map (or no image data): drop any stale texture so
             # the mapper falls back to its no-distance-map path instead of
@@ -1175,26 +1179,6 @@ def _import_texture_object_helper() -> Any | None:
     return _import_wrapped_class("vtkMultiTextureObjectHelper")
 
 
-def _safe_call_getter(node: Any | None, getter_name: str) -> Any | None:
-    """Return ``node.<getter_name>()`` defensively, or ``None``.
-
-    Tolerant of a missing node, a missing accessor (stub nodes in unit
-    tests), or a raising getter.  Used to read the distance-map volume off
-    the data node (``GetDistanceMapVolumeNode`` — the same source the
-    scenario sets via ``SetDistanceMapVolumeNode``) and the volume's
-    ``GetImageData``.
-    """
-    if node is None:
-        return None
-    getter = getattr(node, getter_name, None)
-    if getter is None:
-        return None
-    try:
-        return getter()
-    except Exception:  # pragma: no cover - defensive
-        return None
-
-
 def _sampled_surface_resolution(sampled: Any) -> tuple[int, int]:
     """Best-effort ``(samplesU, samplesV)`` for a sampled surface grid.
 
@@ -1221,20 +1205,13 @@ def _read_control_points(data_node: Any | None) -> Any | None:
     control grid from the flat row-major vector ``GetControlGridVector``
     (length ``3 * 16`` = 48; ADR-0014 §"Fourth layer", ADR-0018 §1).  The v1
     markups control-point API is retired (ADR-0014 §"Dissolution"; ADR-0032
-    §"Consequences").  Returns ``None`` defensively when the accessor is
-    absent (stub data nodes), the grid is incomplete (< 16 defined points,
-    mid-placement), or a read raises — the caller then keeps the fixed-quad
-    fallback.
+    §"Consequences").  Returns ``None`` when there is no data node or the
+    grid is incomplete (< 16 defined points, mid-placement) — the caller
+    then keeps the fixed-quad fallback.
     """
     if data_node is None:
         return None
-    grid_getter = getattr(data_node, "GetControlGridVector", None)
-    if grid_getter is None:
-        return None
-    try:
-        grid = grid_getter()
-    except Exception:  # pragma: no cover - defensive
-        return None
+    grid = data_node.GetControlGridVector()
     if len(grid) != 16 * 3:  # the 16-point invariant (the only fed grid)
         return None
     points = vtk.vtkPoints()

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -115,6 +115,11 @@ _FLATTENED_QUAD_CONTROL_GRID = tuple(
     for x in (-60.0, -20.0, 20.0, 60.0)
 )
 
+# Strip marker radius as a fraction of the locator display radius: the
+# strip is a dense 2D readout and a full-size disc dominates it, so the
+# circle draws smaller than the 3D/slice markers.
+_MARKER_RADIUS_FACTOR = 0.6
+
 
 class FlattenedSurfaceRepresentation:
     """VTK assembly for the resectogram's flattened surface.
@@ -309,9 +314,7 @@ class FlattenedSurfaceRepresentation:
             cx = focal[0] + (cx - focal[0]) * float(ratio[0])
             cy = focal[1] + (cy - focal[1]) * float(ratio[1])
             radius = display_node.GetRadius() if display_node is not None else 2.0
-            # Smaller than the 3D/slice markers: the strip is a dense 2D
-            # readout and a full-size disc dominates it.
-            self._marker_source.SetRadius(float(radius) * 0.6)
+            self._marker_source.SetRadius(float(radius) * _MARKER_RADIUS_FACTOR)
             # Slightly proud of the quad so the circle wins the z-fight.
             self._marker_source.SetCenter(cx, cy, 0.5)
             self._marker_actor.SetVisibility(True)

--- a/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
+++ b/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
@@ -647,6 +647,14 @@ class ResectionPlanningWidget(qt.QWidget):
     def _onObservedSurfacePointModified(self, caller, event):
         self.scheduleResectogramRender()
 
+    def showEvent(self, event):  # noqa: N802 - Qt override
+        # Re-entering the module re-shows this panel with the embedded GL
+        # view's last frame discarded -- the strip reads BLACK until the
+        # next render request.  Kick one after the show has been processed
+        # (same one-turn deferral as the initial auto-populate kick).
+        # QWidget's own showEvent is a no-op, so no super chaining needed.
+        qt.QTimer.singleShot(0, self.scheduleResectogramRender)
+
     def scheduleResectogramRender(self):  # noqa: N802 - Slicer/Qt verb convention
         # Same realized-GL-context requirement as the embed: forcing a render
         # drives the distance-map texture upload; no live view to repaint

--- a/LiverResections/LiverResectionsLib/ResectogramLocatorProducer.py
+++ b/LiverResections/LiverResectionsLib/ResectogramLocatorProducer.py
@@ -111,4 +111,8 @@ class ResectogramLocatorProducer:
 
         if self._locator_node is not None:
             self._locator_node.SetPickedPositionWorld(point[0], point[1], point[2])
+            # The strip coordinate of the same pick rides the locator too
+            # (ADR-0025: the node is the locator-state carrier); the strip
+            # Representation reads it back to place its circle marker.
+            self._locator_node.SetPickedUV(float(u), float(v))
         return point

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -184,6 +184,13 @@ class ResectogramPipeline(_PipelineBase):
         the control-point structure, not the node ``GetMTime``, so the digest
         is the correct reactivity signal on both counts.
         """
+        try:
+            self._reconcile()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _reconcile(self) -> None:
+        """``UpdatePipeline``'s body — plain attribute access throughout."""
         self._ensure_representations()
 
         # Reverse-resolve the owning plan wrapper (scene-MTime-gated so a bare
@@ -225,6 +232,13 @@ class ResectogramPipeline(_PipelineBase):
         ``GetRenderer()`` returns a non-None value.
         """
         del renderer  # accessed via self.GetRenderer() inside the helper
+        try:
+            self._on_renderer_added()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _on_renderer_added(self) -> None:
+        """``OnRendererAdded``'s body — plain attribute access throughout."""
         self._ensure_representations()
         # ``OnRendererRemoved`` -> ``cleanup()`` detaches the node observers
         # (they are bundled with the renderer-scoped Representation teardown),
@@ -244,7 +258,10 @@ class ResectogramPipeline(_PipelineBase):
     def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
         """Tear down Representations when the renderer goes away."""
         del renderer
-        self.cleanup()
+        try:
+            self.cleanup()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     # ------------------------------------------------------------------ #
     # Introspection — used by the workflow / unit tests
@@ -289,47 +306,39 @@ class ResectogramPipeline(_PipelineBase):
         """
         import sys
 
-        if self._data_node is None:
-            return False, sys.float_info.max
-        # The reslice is a press/drag/release GESTURE: a left-button press
-        # starts it, moves are claimed only WHILE it holds (the continuous
-        # drag-reslice), and the ending release closes it.  A bare hover
-        # move is still declined: claiming ungrabbed moves made the marker
-        # track the cursor and park at the (0, 0) corner on the spurious
-        # move fired when the cursor left the view (`ADR-0025`_
-        # §Click-to-reslice).
-        etype = self._event_type(eventData)
-        if self._reslicing:
-            try:
+        try:
+            if self._data_node is None:
+                return False, sys.float_info.max
+            # The reslice is a press/drag/release GESTURE: a left-button press
+            # starts it, moves are claimed only WHILE it holds (the continuous
+            # drag-reslice), and the ending release closes it.  A bare hover
+            # move is still declined: claiming ungrabbed moves made the marker
+            # track the cursor and park at the (0, 0) corner on the spurious
+            # move fired when the cursor left the view (`ADR-0025`_
+            # §Click-to-reslice).
+            if self._reslicing:
                 import vtk
 
-                if etype in (
+                if self._event_type(eventData) in (
                     vtk.vtkCommand.MouseMoveEvent,
                     vtk.vtkCommand.LeftButtonReleaseEvent,
                 ):
                     return True, 0.0
-            except Exception:  # pragma: no cover - defensive
-                pass
+                return False, sys.float_info.max
+            if not self._is_commit_event(eventData):
+                return False, sys.float_info.max
+            return True, 0.0
+        except Exception:  # pragma: no cover - C++ boundary must never raise
             return False, sys.float_info.max
-        if not self._is_commit_event(eventData):
-            return False, sys.float_info.max
-        return True, 0.0
 
     @staticmethod
-    def _event_type(eventData: Any) -> int | None:  # noqa: N803 - VTK arg name
-        """Read the VTK event-type id off ``eventData`` defensively.
+    def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name
+        """The VTK event-type id off ``eventData``.
 
-        ``None`` for events lacking ``GetType`` (stubs) or on a read failure,
-        so the gesture state machine never raises from the interaction hot
-        path.
+        Called only inside the never-raise interaction boundaries, so plain
+        attribute access is fine here.
         """
-        getter = getattr(eventData, "GetType", None)
-        if getter is None:
-            return None
-        try:
-            return int(getter())
-        except Exception:  # pragma: no cover - defensive
-            return None
+        return int(eventData.GetType())
 
     @staticmethod
     def _is_commit_event(eventData: Any) -> bool:  # noqa: N803 - VTK arg name
@@ -337,19 +346,11 @@ class ResectogramPipeline(_PipelineBase):
 
         The press is the only event that can START the reslice gesture; a
         move/hover without a gesture in flight leaves the marker where it
-        was.  Tolerant of an event lacking ``GetType`` (declines) and of
-        ``vtk`` being unavailable (declines) so the GL-free seam never
-        raises from the interaction hot path.
+        was.
         """
-        getter = getattr(eventData, "GetType", None)
-        if getter is None:
-            return False
-        try:
-            import vtk
+        import vtk
 
-            return getter() == vtk.vtkCommand.LeftButtonPressEvent
-        except Exception:  # pragma: no cover - defensive; vtk always present in-app
-            return False
+        return eventData.GetType() == vtk.vtkCommand.LeftButtonPressEvent
 
     def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
         """Drive the press/drag/release reslice gesture.
@@ -363,8 +364,8 @@ class ResectogramPipeline(_PipelineBase):
         returns ``False``, releasing the interaction focus.  A bare hover
         move can never write the locator even if dispatched directly.
         """
-        if self._reslicing:
-            try:
+        try:
+            if self._reslicing:
                 import vtk
 
                 if self._event_type(eventData) == vtk.vtkCommand.LeftButtonReleaseEvent:
@@ -372,26 +373,25 @@ class ResectogramPipeline(_PipelineBase):
                     self._set_locator_marker_visible(False)
                     return False  # gesture over -- release the focus
                 if self._event_type(eventData) == vtk.vtkCommand.MouseMoveEvent:
-                    getter = getattr(eventData, "GetDisplayPosition", None)
-                    if getter is not None:
-                        if self._produce_from_display_position(getter()) is not None:
-                            self._refresh_locator_marker()
+                    position = eventData.GetDisplayPosition()
+                    if self._produce_from_display_position(position) is not None:
+                        self._refresh_locator_marker()
                     return True  # keep the gesture even on a degenerate move
-            except Exception:  # pragma: no cover - defensive
-                pass
-            return False
+                return False
 
-        if not self._is_commit_event(eventData):
+            if not self._is_commit_event(eventData):
+                return False
+            produced = (
+                self._produce_from_display_position(eventData.GetDisplayPosition())
+                is not None
+            )
+            if produced:
+                self._reslicing = True
+                self._set_locator_marker_visible(True)
+                self._refresh_locator_marker()
+            return produced
+        except Exception:  # pragma: no cover - C++ boundary must never raise
             return False
-        getter = getattr(eventData, "GetDisplayPosition", None)
-        if getter is None:
-            return False
-        produced = self._produce_from_display_position(getter()) is not None
-        if produced:
-            self._reslicing = True
-            self._set_locator_marker_visible(True)
-            self._refresh_locator_marker()
-        return produced
 
     def _set_locator_marker_visible(self, visible: bool) -> None:
         """Flip the marker switch: the locator DISPLAY node's Visibility.
@@ -405,14 +405,11 @@ class ResectogramPipeline(_PipelineBase):
         locator = self._resolve_locator_node(self._data_node)
         if locator is None:
             return
-        display = locator.GetDisplayNode() if hasattr(locator, "GetDisplayNode") else None
+        display = locator.GetDisplayNode()
         if display is None:
             return
-        try:
-            display.SetVisibility(bool(visible))
-            locator.Modified()
-        except Exception:  # pragma: no cover - defensive
-            return
+        display.SetVisibility(bool(visible))
+        locator.Modified()
         # Re-push the strip's own uniforms + repaint: the strip pipeline's
         # reconciliation keys on geometry, which a visibility flip does not
         # touch, and the produce path only runs on picks -- not on release.
@@ -433,12 +430,7 @@ class ResectogramPipeline(_PipelineBase):
             representation._apply_locator()
         except Exception:  # pragma: no cover - defensive (stub reps)
             return
-        request_render = getattr(self, "RequestRender", None)
-        if request_render is not None:
-            try:
-                request_render()
-            except Exception:  # pragma: no cover - defensive (stub bases)
-                pass
+        self.RequestRender()
 
     def _produce_from_display_position(self, display_xy: Any) -> tuple | None:
         """Map a resectogram display pixel to a locator pick (`ADR-0025`_ §Producer).
@@ -544,7 +536,7 @@ class ResectogramPipeline(_PipelineBase):
     @staticmethod
     def _resolve_locator_node(surface: Any) -> Any | None:
         """The scene's single cross-view ``vtkMRMLLocatorNode`` (`ADR-0025`_ §Consumer)."""
-        scene = getattr(surface, "GetScene", lambda: None)()
+        scene = surface.GetScene() if surface is not None else None
         if scene is None:
             return None
         return scene.GetFirstNodeByClass("vtkMRMLLocatorNode")
@@ -590,7 +582,7 @@ class ResectogramPipeline(_PipelineBase):
         if self._representations_initialised:
             return
 
-        renderer = self._safe_get_renderer()
+        renderer = self.GetRenderer()
 
         # Local imports to avoid a circular import.  Two import paths
         # supported, mirroring the Bezier Pipeline:
@@ -634,43 +626,19 @@ class ResectogramPipeline(_PipelineBase):
         data_node = self._data_node
         if data_node is None:
             return None
-        scene = getattr(data_node, "GetScene", lambda: None)()
+        scene = data_node.GetScene()
         if scene is None:
             return None
-        try:
-            plans = scene.GetNodesByClass("vtkMRMLResectionPlanNode")
-        except Exception:  # pragma: no cover - defensive
-            return None
+        plans = scene.GetNodesByClass("vtkMRMLResectionPlanNode")
         if plans is None:
             return None
         plans.InitTraversal()
         item = plans.GetNextItemAsObject()
         while item is not None:
-            getter = getattr(item, "GetGeometryNode", None)
-            if getter is not None:
-                try:
-                    if getter() is data_node:
-                        return item
-                except Exception:  # pragma: no cover - defensive
-                    pass
+            if item.GetGeometryNode() is data_node:
+                return item
             item = plans.GetNextItemAsObject()
         return None
-
-    def _safe_get_renderer(self) -> Any | None:
-        """Return ``self.GetRenderer()`` if available, else ``None``.
-
-        The base ``vtkMRMLLayerDMPipelineI::GetRenderer`` is supplied
-        once the manager attaches the Pipeline to a renderer.  Tests that
-        construct the Pipeline before a renderer is wired need the
-        ``None`` fallback.
-        """
-        getter = getattr(self, "GetRenderer", None)
-        if getter is None:
-            return None
-        try:
-            return getter()
-        except Exception:  # pragma: no cover - defensive
-            return None
 
     def _reattach_node_observers(self) -> None:
         """(Re-)wire the display + data node observers, idempotently.
@@ -695,9 +663,7 @@ class ResectogramPipeline(_PipelineBase):
         if self._display_node is None:
             return
 
-        getter = getattr(self._display_node, "GetDisplayableNode", None)
-        if getter is not None:
-            self._data_node = getter()
+        self._data_node = self._display_node.GetDisplayableNode()
         self._attach_observer(self._display_node)
         if self._data_node is not None:
             self._attach_observer(self._data_node)
@@ -761,21 +727,20 @@ class ResectogramPipeline(_PipelineBase):
         repaints live without the framework's own display-node event path.
         """
         del caller, event  # observers route uniformly into UpdatePipeline()
-        before = self._update_count
-        self.UpdatePipeline()
-        if self._update_count == before:
-            return  # short-circuited: no geometry change, no render
+        try:
+            before = self._update_count
+            self.UpdatePipeline()
+            if self._update_count == before:
+                return  # short-circuited: no geometry change, no render
 
-        request_render = getattr(self, "RequestRender", None)
-        if request_render is not None:
-            try:
-                request_render()
-            except Exception:  # pragma: no cover - defensive (stub bases)
-                pass
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
 
 # --------------------------------------------------------------------------- #
-# Safe accessors — tolerant of stub nodes that omit the markups accessors.
+# Safe accessors — a ``None`` node (or a node outside any scene) is a real
+# state; the accessors themselves are always-present MRML API.
 # --------------------------------------------------------------------------- #
 
 
@@ -786,16 +751,10 @@ def _safe_get_scene_mtime(node: Any) -> int | None:
     surface with no owning plan does not re-scan on every render — the scan
     re-runs only when the scene has changed since the last miss.
     """
-    scene = getattr(node, "GetScene", lambda: None)() if node is not None else None
+    scene = node.GetScene() if node is not None else None
     if scene is None:
         return None
-    getter = getattr(scene, "GetMTime", None)
-    if getter is None:
-        return None
-    try:
-        return int(getter())
-    except Exception:  # pragma: no cover - defensive
-        return None
+    return int(scene.GetMTime())
 
 
 def _safe_get_control_points_digest(node: Any) -> tuple:
@@ -813,24 +772,17 @@ def _safe_get_control_points_digest(node: Any) -> tuple:
     control polygon in a flat row-major grid read via ``GetControlGridVector``
     (ADR-0014 §"Fourth layer"); the v1 markups control-point API is retired
     (ADR-0014 §"Dissolution"; ADR-0032 §"Consequences").  Returns an empty
-    tuple when the node is missing the grid accessor (stub nodes in unit
-    tests) or a read raises — the key is then a constant, so a non-parametric
-    data node reconciles exactly once.
+    tuple when no data node is attached — the key is then a constant, so a
+    node-less pipeline reconciles exactly once.
     """
     if node is None:
         return ()
-    grid_getter = getattr(node, "GetControlGridVector", None)
-    if grid_getter is None:
-        return ()
-    try:
-        grid = grid_getter()
-        usable = len(grid) - (len(grid) % 3)
-        return tuple(
-            (grid[base], grid[base + 1], grid[base + 2])
-            for base in range(0, usable, 3)
-        )
-    except Exception:  # pragma: no cover - defensive
-        return ()
+    grid = node.GetControlGridVector()
+    usable = len(grid) - (len(grid) % 3)
+    return tuple(
+        (grid[base], grid[base + 1], grid[base + 2])
+        for base in range(0, usable, 3)
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -481,9 +481,12 @@ class ResectogramPipeline(_PipelineBase):
         # (margins + aspect letterboxing) does not satisfy -- the marker
         # landed offset from the cursor.  Falls back to the fraction path on
         # stub renderers (the GL-free seam tests).
+        # The producer writes BOTH the world point AND the picked (u, v)
+        # onto the locator node (ADR-0025: the node is the locator-state
+        # carrier); the strip Representation reads the (u, v) back off the
+        # locator to place its circle marker.
         uv = self._display_to_uv(display_xy, renderer, mat_ratio, representation)
         if uv is not None:
-            representation.SetPickedUV(uv)  # drives the strip's circle marker
             return producer.produce_from_uv(uv[0], uv[1])
         return producer.produce(display_xy, viewport_size, mat_ratio)
 

--- a/LiverResections/LiverResectionsLib/SliceContourPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceContourPipeline.py
@@ -168,6 +168,11 @@ class SliceContourPipeline(_PipelineBase):
             display = base_getter() if base_getter is not None else None
             if display is not None:
                 self.SetDisplayNode(display)
+        # Re-attach the slice-node observer too: cleanup() detached it with
+        # the rest, and the view node is not re-set after churn -- without
+        # this, reslicing stops recutting (the stale-trace bug, round two).
+        if self._slice_node is not None:
+            self._attach_observer(self._slice_node)
         self._last_update_key = None
         self.UpdatePipeline()
 

--- a/LiverResections/LiverResectionsLib/SliceContourPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceContourPipeline.py
@@ -68,15 +68,14 @@ def _resolve_surface_source() -> Any | None:
 
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
-    """True iff ``viewNode`` is a slice view (this pipeline's home)."""
-    if viewNode is None:
-        return False
-    is_a = getattr(viewNode, "IsA", None)
-    if is_a is None:
-        return False
+    """True iff ``viewNode`` is a slice view (this pipeline's home).
+
+    Part of the creator callback: LayerDM invokes it for every
+    ``(view, node)`` pair, so it must never raise.
+    """
     try:
-        return bool(is_a("vtkMRMLSliceNode"))
-    except Exception:  # pragma: no cover - defensive
+        return viewNode is not None and bool(viewNode.IsA("vtkMRMLSliceNode"))
+    except Exception:  # pragma: no cover - C++ boundary must never raise
         return False
 
 
@@ -143,47 +142,50 @@ class SliceContourPipeline(_PipelineBase):
         self._display_node = displayNode
         self._data_node = None
         if displayNode is not None:
-            getter = getattr(displayNode, "GetDisplayableNode", None)
-            if getter is not None:
-                self._data_node = getter()
+            self._data_node = displayNode.GetDisplayableNode()
             self._attach_observer(displayNode)
             if self._data_node is not None:
                 self._attach_observer(self._data_node)
         self._last_update_key = None
 
     def OnReferenceToDisplayNodeAdded(self, fromNode: Any, role: Any = None) -> None:  # noqa: N802
-        if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
-            self._data_node = fromNode
-            self._attach_observer(fromNode)
-            self._last_update_key = None
-        self.UpdatePipeline()
+        try:
+            if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
+                self._data_node = fromNode
+                self._attach_observer(fromNode)
+                self._last_update_key = None
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        self._renderer = renderer
-        if renderer is not None:
-            renderer.AddActor2D(self._contour_actor)
-        # Re-derive after renderer churn (cleanup clears the node handles).
-        if self._display_node is None:
-            base_getter = getattr(self, "GetDisplayNode", None)
-            display = base_getter() if base_getter is not None else None
-            if display is not None:
-                self.SetDisplayNode(display)
-        # Re-attach the slice-node observer too: cleanup() detached it with
-        # the rest, and the view node is not re-set after churn -- without
-        # this, reslicing stops recutting (the stale-trace bug, round two).
-        if self._slice_node is not None:
-            self._attach_observer(self._slice_node)
-        self._last_update_key = None
-        self.UpdatePipeline()
+        try:
+            self._renderer = renderer
+            if renderer is not None:
+                renderer.AddActor2D(self._contour_actor)
+            # Re-derive after renderer churn (cleanup clears the node handles).
+            if self._display_node is None:
+                display = self.GetDisplayNode()
+                if display is not None:
+                    self.SetDisplayNode(display)
+            # Re-attach the slice-node observer too: cleanup() detached it with
+            # the rest, and the view node is not re-set after churn -- without
+            # this, reslicing stops recutting (the stale-trace bug, round two).
+            if self._slice_node is not None:
+                self._attach_observer(self._slice_node)
+            self._last_update_key = None
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        if renderer is not None:
-            try:
+        try:
+            if renderer is not None:
                 renderer.RemoveActor2D(self._contour_actor)
-            except Exception:  # pragma: no cover - defensive
-                pass
-        self._renderer = None
-        self.cleanup()
+            self._renderer = None
+            self.cleanup()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def cleanup(self) -> None:
         for node in list(self._observed_node_refs):
@@ -197,6 +199,13 @@ class SliceContourPipeline(_PipelineBase):
     # ------------------------------------------------------------------ #
 
     def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        try:
+            self._reconcile()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _reconcile(self) -> None:
+        """``UpdatePipeline``'s body — plain attribute access throughout."""
         slice_node = self._slice_node
         state = _safe_get_state(self._data_node)
         key = (
@@ -218,14 +227,11 @@ class SliceContourPipeline(_PipelineBase):
         carrier = self._data_node
         if carrier is None or slice_node is None:
             return None
-        grid_getter = getattr(carrier, "GetControlGridVector", None)
-        if grid_getter is None:
-            return None
         source_cls = _resolve_surface_source()
         if source_cls is None:
             return None
         try:
-            grid = grid_getter()
+            grid = carrier.GetControlGridVector()
             if len(grid) < 48:
                 return None
             if self._surface_source is None:
@@ -323,22 +329,20 @@ class SliceContourPipeline(_PipelineBase):
     def _on_node_modified(self, caller: Any, event: str) -> None:
         """Reconcile + repaint when the visible inputs actually changed."""
         del caller, event
-        self.UpdatePipeline()
+        try:
+            self.UpdatePipeline()
 
-        render_key = (
-            _safe_get_state(self._data_node),
-            _control_points_digest(self._data_node),
-            self._slice_matrix_digest(self._slice_node),
-        )
-        if render_key == self._last_render_key:
-            return
-        self._last_render_key = render_key
-        request_render = getattr(self, "RequestRender", None)
-        if request_render is not None:
-            try:
-                request_render()
-            except Exception:  # pragma: no cover - defensive (stub bases)
-                pass
+            render_key = (
+                _safe_get_state(self._data_node),
+                _control_points_digest(self._data_node),
+                self._slice_matrix_digest(self._slice_node),
+            )
+            if render_key == self._last_render_key:
+                return
+            self._last_render_key = render_key
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
 
 # --------------------------------------------------------------------------- #

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -261,6 +261,11 @@ class SliceControlPolygonPipeline(_PipelineBase):
         visible = state == STATE_PLANNING and self._reproject()
         self._handles_actor.SetVisibility(bool(visible))
         self._edges_actor.SetVisibility(bool(visible))
+        if not visible:
+            # The ring is driven by the hover channel inside _reproject; a
+            # hover live at the moment the carrier leaves Planning would
+            # otherwise strand the ring over no handles.
+            self._ring_actor.SetVisibility(False)
 
     def _reproject(self) -> bool:
         """Project handles + edges into XY with distance fading."""

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -75,6 +75,18 @@ GAP_LENGTH_PX = 5.0
 #: composes with any display colour and stays colourblind-legible.
 SIDE_TINT_MAX = 0.55
 
+#: Mid-tone factor applied to the display HandleColor before tinting: the
+#: default handle colour is pure white, which leaves no headroom for the
+#: lighter-above tint -- pulling the base toward mid-tone makes BOTH tint
+#: directions visible.
+HANDLE_MIDTONE_FACTOR = 0.78
+
+#: Slice handle / hover-ring glyph diameters (XY pixels).  Larger than the
+#: default markups glyphs: the handles are grab targets, and the ring must
+#: read as a halo AROUND one.
+HANDLE_GLYPH_SCALE_PX = 13.0
+RING_GLYPH_SCALE_PX = 20.0
+
 
 def _side_tint(rgb: list, signed_distance: float) -> list:
     """Blend ``rgb`` toward white (above) or black (below) by distance."""
@@ -124,7 +136,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._handle_glyph_source = vtk.vtkGlyphSource2D()
         self._handle_glyph_source.SetGlyphTypeToCircle()
         self._handle_glyph_source.FilledOff()
-        self._handle_glyph_source.SetScale(13.0)
+        self._handle_glyph_source.SetScale(HANDLE_GLYPH_SCALE_PX)
         self._handles_glyph = vtk.vtkGlyph2D()
         self._handles_glyph.SetInputData(self._handles_polydata)
         self._handles_glyph.SetSourceConnection(
@@ -145,7 +157,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._ring_glyph_source = vtk.vtkGlyphSource2D()
         self._ring_glyph_source.SetGlyphTypeToCircle()
         self._ring_glyph_source.FilledOff()
-        self._ring_glyph_source.SetScale(20.0)
+        self._ring_glyph_source.SetScale(RING_GLYPH_SCALE_PX)
         self._ring_glyph = vtk.vtkGlyph2D()
         self._ring_glyph.SetInputData(self._ring_polydata)
         self._ring_glyph.SetSourceConnection(self._ring_glyph_source.GetOutputPort())
@@ -309,10 +321,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
                     edge_rgb = [int(c * 255) for c in display.GetEdgeColor()]
                 except Exception:  # pragma: no cover - defensive
                     pass
-            # Mid-tone base: the default HandleColor is pure white, which
-            # leaves no headroom for the lighter-above tint -- pull the
-            # slice base toward 78% so the sign cue reads BOTH ways.
-            handle_rgb = [int(c * 0.78) for c in handle_rgb]
+            handle_rgb = [int(c * HANDLE_MIDTONE_FACTOR) for c in handle_rgb]
 
             points = vtk.vtkPoints()
             handle_rgba = vtk.vtkUnsignedCharArray()

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -96,15 +96,14 @@ def _side_tint(rgb: list, signed_distance: float) -> list:
 
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
-    """True iff ``viewNode`` is a slice view (this pipeline's home)."""
-    if viewNode is None:
-        return False
-    is_a = getattr(viewNode, "IsA", None)
-    if is_a is None:
-        return False
+    """True iff ``viewNode`` is a slice view (this pipeline's home).
+
+    Part of the creator callback: LayerDM invokes it for every
+    ``(view, node)`` pair, so it must never raise.
+    """
     try:
-        return bool(is_a("vtkMRMLSliceNode"))
-    except Exception:  # pragma: no cover - defensive
+        return viewNode is not None and bool(viewNode.IsA("vtkMRMLSliceNode"))
+    except Exception:  # pragma: no cover - C++ boundary must never raise
         return False
 
 
@@ -204,51 +203,54 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._display_node = displayNode
         self._data_node = None
         if displayNode is not None:
-            getter = getattr(displayNode, "GetDisplayableNode", None)
-            if getter is not None:
-                self._data_node = getter()
+            self._data_node = displayNode.GetDisplayableNode()
             self._attach_observer(displayNode)
             if self._data_node is not None:
                 self._attach_observer(self._data_node)
         self._last_update_key = None
 
     def OnReferenceToDisplayNodeAdded(self, fromNode: Any, role: Any = None) -> None:  # noqa: N802
-        if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
-            self._data_node = fromNode
-            self._attach_observer(fromNode)
-            self._last_update_key = None
-        self.UpdatePipeline()
+        try:
+            if self._data_node is None and fromNode is not None and fromNode is not self._display_node:
+                self._data_node = fromNode
+                self._attach_observer(fromNode)
+                self._last_update_key = None
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        self._renderer = renderer
-        if renderer is not None:
-            renderer.AddActor2D(self._edges_actor)
-            renderer.AddActor2D(self._handles_actor)
-            renderer.AddActor2D(self._ring_actor)
-        if self._display_node is None:
-            base_getter = getattr(self, "GetDisplayNode", None)
-            display = base_getter() if base_getter is not None else None
-            if display is not None:
-                self.SetDisplayNode(display)
-        # Re-attach the slice-node observer too: cleanup() detached it with
-        # the rest, and the view node is not re-set after churn -- without
-        # this, reslicing stops reprojecting (the stale-trace bug, round
-        # two; mirrors the contour pipeline).
-        if self._slice_node is not None:
-            self._attach_observer(self._slice_node)
-        self._last_update_key = None
-        self.UpdatePipeline()
+        try:
+            self._renderer = renderer
+            if renderer is not None:
+                renderer.AddActor2D(self._edges_actor)
+                renderer.AddActor2D(self._handles_actor)
+                renderer.AddActor2D(self._ring_actor)
+            if self._display_node is None:
+                display = self.GetDisplayNode()
+                if display is not None:
+                    self.SetDisplayNode(display)
+            # Re-attach the slice-node observer too: cleanup() detached it with
+            # the rest, and the view node is not re-set after churn -- without
+            # this, reslicing stops reprojecting (the stale-trace bug, round
+            # two; mirrors the contour pipeline).
+            if self._slice_node is not None:
+                self._attach_observer(self._slice_node)
+            self._last_update_key = None
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        if renderer is not None:
-            try:
+        try:
+            if renderer is not None:
                 renderer.RemoveActor2D(self._handles_actor)
                 renderer.RemoveActor2D(self._edges_actor)
                 renderer.RemoveActor2D(self._ring_actor)
-            except Exception:  # pragma: no cover - defensive
-                pass
-        self._renderer = None
-        self.cleanup()
+            self._renderer = None
+            self.cleanup()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
     def cleanup(self) -> None:
         for node in list(self._observed_node_refs):
@@ -265,6 +267,13 @@ class SliceControlPolygonPipeline(_PipelineBase):
     # ------------------------------------------------------------------ #
 
     def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        try:
+            self._reconcile()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _reconcile(self) -> None:
+        """``UpdatePipeline``'s body — plain attribute access throughout."""
         state = _safe_get_state(self._data_node)
         key = (
             state,
@@ -291,14 +300,9 @@ class SliceControlPolygonPipeline(_PipelineBase):
         slice_node = self._slice_node
         if carrier is None or slice_node is None:
             return False
-        grid_getter = getattr(carrier, "GetControlGridVector", None)
-        rows_getter = getattr(carrier, "GetRows", None)
-        cols_getter = getattr(carrier, "GetCols", None)
-        if None in (grid_getter, rows_getter, cols_getter):
-            return False
         try:
-            grid = grid_getter()
-            rows, cols = int(rows_getter()), int(cols_getter())
+            grid = carrier.GetControlGridVector()
+            rows, cols = int(carrier.GetRows()), int(carrier.GetCols())
             if len(grid) < rows * cols * 3:
                 return False
 
@@ -471,61 +475,67 @@ class SliceControlPolygonPipeline(_PipelineBase):
     def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
         import sys
 
-        if _safe_get_state(self._data_node) != STATE_PLANNING:
-            self._drag_index = None
+        try:
+            if _safe_get_state(self._data_node) != STATE_PLANNING:
+                self._drag_index = None
+                return False, sys.float_info.max
+            etype = _event_type(eventData)
+            if self._drag_index is not None:
+                if etype in (
+                    vtk.vtkCommand.MouseMoveEvent,
+                    vtk.vtkCommand.LeftButtonReleaseEvent,
+                ):
+                    return True, 0.0
+                return False, sys.float_info.max
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                # Bare hover: publish the cross-view highlight and decline.
+                idx, distance2 = self._nearest_handle_in_display(eventData)
+                within = (
+                    idx is not None
+                    and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+                )
+                self._publish_interaction_state(hovered=(idx if within else -1))
+                return False, sys.float_info.max
+            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                return False, sys.float_info.max
+            _, distance2 = self._nearest_handle_in_display(eventData)
+            if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
+                return True, distance2
             return False, sys.float_info.max
-        etype = _event_type(eventData)
-        if self._drag_index is not None:
-            if etype in (
-                vtk.vtkCommand.MouseMoveEvent,
-                vtk.vtkCommand.LeftButtonReleaseEvent,
-            ):
-                return True, 0.0
+        except Exception:  # pragma: no cover - C++ boundary must never raise
             return False, sys.float_info.max
-        if etype == vtk.vtkCommand.MouseMoveEvent:
-            # Bare hover: publish the cross-view highlight and decline.
-            idx, distance2 = self._nearest_handle_in_display(eventData)
-            within = (
-                idx is not None
-                and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
-            )
-            self._publish_interaction_state(hovered=(idx if within else -1))
-            return False, sys.float_info.max
-        if etype != vtk.vtkCommand.LeftButtonPressEvent:
-            return False, sys.float_info.max
-        _, distance2 = self._nearest_handle_in_display(eventData)
-        if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
-            return True, distance2
-        return False, sys.float_info.max
 
     def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
-        if _safe_get_state(self._data_node) != STATE_PLANNING:
-            self._drag_index = None
-            return False
-        etype = _event_type(eventData)
-
-        if self._drag_index is None:
-            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+        try:
+            if _safe_get_state(self._data_node) != STATE_PLANNING:
+                self._drag_index = None
                 return False
-            idx, distance2 = self._nearest_handle_in_display(eventData)
-            if (
-                idx is None
-                or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
-            ):
+            etype = _event_type(eventData)
+
+            if self._drag_index is None:
+                if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                    return False
+                idx, distance2 = self._nearest_handle_in_display(eventData)
+                if (
+                    idx is None
+                    or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+                ):
+                    return False
+                self._drag_index = idx
+                self._publish_interaction_state(grabbed=idx)
+                return True
+
+            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
+                self._drag_index = None
+                self._publish_interaction_state(grabbed=-1)
                 return False
-            self._drag_index = idx
-            self._publish_interaction_state(grabbed=idx)
-            return True
 
-        if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
-            self._drag_index = None
-            self._publish_interaction_state(grabbed=-1)
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                self._move_grabbed_to(eventData)
+                return True
             return False
-
-        if etype == vtk.vtkCommand.MouseMoveEvent:
-            self._move_grabbed_to(eventData)
-            return True
-        return False
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False
 
     def _nearest_handle_in_display(self, eventData: Any):
         """``(flat_index, distance2)`` of the projected handle nearest the pixel.
@@ -536,10 +546,7 @@ class SliceControlPolygonPipeline(_PipelineBase):
         """
         import sys
 
-        try:
-            ex, ey = eventData.GetDisplayPosition()
-        except Exception:  # pragma: no cover - defensive
-            return None, sys.float_info.max
+        ex, ey = eventData.GetDisplayPosition()
         best_idx, best_d2 = None, sys.float_info.max
         for i, (px, py) in enumerate(self._projected_xy):
             # Markups rule: pickable iff visible -- a fully faded point
@@ -626,62 +633,49 @@ class SliceControlPolygonPipeline(_PipelineBase):
     def _interaction_state(self) -> tuple:
         """(hovered, grabbed) read off the display node; (-1, -1) sans it."""
         display = self._display_node
-        try:
-            return (
-                display.GetHoveredControlPoint() if display is not None else -1,
-                display.GetGrabbedControlPoint() if display is not None else -1,
-            )
-        except Exception:  # pragma: no cover - defensive (stub displays)
-            return (-1, -1)
+        return (
+            display.GetHoveredControlPoint() if display is not None else -1,
+            display.GetGrabbedControlPoint() if display is not None else -1,
+        )
 
     def _publish_interaction_state(self, hovered=None, grabbed=None) -> None:
         """Write hover/grab onto the display node (cross-view channel)."""
         display = self._display_node
         if display is None:
             return
-        try:
-            if hovered is not None:
-                value = -1 if hovered == -1 else int(hovered)
-                if display.GetHoveredControlPoint() != value:
-                    display.SetHoveredControlPoint(value)
-            if grabbed is not None:
-                value = -1 if grabbed == -1 else int(grabbed)
-                if display.GetGrabbedControlPoint() != value:
-                    display.SetGrabbedControlPoint(value)
-        except Exception:  # pragma: no cover - defensive (stub displays)
-            return
+        if hovered is not None:
+            value = -1 if hovered == -1 else int(hovered)
+            if display.GetHoveredControlPoint() != value:
+                display.SetHoveredControlPoint(value)
+        if grabbed is not None:
+            value = -1 if grabbed == -1 else int(grabbed)
+            if display.GetGrabbedControlPoint() != value:
+                display.SetGrabbedControlPoint(value)
 
     def _on_node_modified(self, caller: Any, event: str) -> None:
         del caller, event
-        self.UpdatePipeline()
+        try:
+            self.UpdatePipeline()
 
-        render_key = (
-            _safe_get_state(self._data_node),
-            _control_points_digest(self._data_node),
-            self._slice_matrix_digest(self._slice_node),
-            self._interaction_state(),
-        )
-        if render_key == self._last_render_key:
-            return
-        self._last_render_key = render_key
-        request_render = getattr(self, "RequestRender", None)
-        if request_render is not None:
-            try:
-                request_render()
-            except Exception:  # pragma: no cover - defensive (stub bases)
-                pass
+            render_key = (
+                _safe_get_state(self._data_node),
+                _control_points_digest(self._data_node),
+                self._slice_matrix_digest(self._slice_node),
+                self._interaction_state(),
+            )
+            if render_key == self._last_render_key:
+                return
+            self._last_render_key = render_key
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
 
 
 def _safe_get_mtime(node: Any) -> int:
+    """``GetMTime()`` as an int; 0 when no node is attached."""
     if node is None:
         return 0
-    getter = getattr(node, "GetMTime", None)
-    if getter is None:
-        return 0
-    try:
-        return int(getter())
-    except Exception:  # pragma: no cover - defensive
-        return 0
+    return int(node.GetMTime())
 
 
 # --------------------------------------------------------------------------- #

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -218,6 +218,12 @@ class SliceControlPolygonPipeline(_PipelineBase):
             display = base_getter() if base_getter is not None else None
             if display is not None:
                 self.SetDisplayNode(display)
+        # Re-attach the slice-node observer too: cleanup() detached it with
+        # the rest, and the view node is not re-set after churn -- without
+        # this, reslicing stops reprojecting (the stale-trace bug, round
+        # two; mirrors the contour pipeline).
+        if self._slice_node is not None:
+            self._attach_observer(self._slice_node)
         self._last_update_key = None
         self.UpdatePipeline()
 

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLLocatorNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLLocatorNodeTest1.cxx
@@ -216,6 +216,32 @@ int testCopyContentCarriesPresence()
 }
 
 //------------------------------------------------------------------------------
+// Invariant -- the picked (u, v) defaults to the (-1, -1) "no pick"
+// sentinel, follows its setter, and rides CopyContent beside its
+// PickedPositionWorld sibling (same transient family, same copy rule).
+int testPickedUV()
+{
+  vtkNew<vtkMRMLLocatorNode> node;
+  double uv[2] = { 0.0, 0.0 };
+  node->GetPickedUV(uv);
+  CHECK_DOUBLE_TOLERANCE(uv[0], -1.0, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(uv[1], -1.0, 1e-9);
+
+  const double picked[2] = { 0.25, 0.75 };
+  node->SetPickedUV(picked);
+  node->GetPickedUV(uv);
+  CHECK_DOUBLE_TOLERANCE(uv[0], 0.25, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(uv[1], 0.75, 1e-9);
+
+  vtkNew<vtkMRMLLocatorNode> sink;
+  sink->CopyContent(node.GetPointer());
+  sink->GetPickedUV(uv);
+  CHECK_DOUBLE_TOLERANCE(uv[0], 0.25, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(uv[1], 0.75, 1e-9);
+  return EXIT_SUCCESS;
+}
+
+//------------------------------------------------------------------------------
 // Invariant 4 -- CreateDefaultDisplayNodes creates exactly one
 // vtkMRMLLocatorDisplayNode and wires it as the node's display node.
 // (ADR-0025 §"The node" -- one display node for v2.0.)
@@ -287,6 +313,7 @@ int vtkMRMLLocatorNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testInstantiable());
   CHECK_EXIT_SUCCESS(testPresencePersistsPositionDoesNot());
   CHECK_EXIT_SUCCESS(testCopyContentCarriesPresence());
+  CHECK_EXIT_SUCCESS(testPickedUV());
   CHECK_EXIT_SUCCESS(testCreateDefaultDisplayNodes());
   CHECK_EXIT_SUCCESS(testDisplayNodeRoundTrip());
 

--- a/LiverResections/MRML/vtkMRMLLocatorNode.cxx
+++ b/LiverResections/MRML/vtkMRMLLocatorNode.cxx
@@ -59,6 +59,9 @@ vtkMRMLLocatorNode::vtkMRMLLocatorNode()
   this->PickedPositionWorld[0] = 0.0;
   this->PickedPositionWorld[1] = 0.0;
   this->PickedPositionWorld[2] = 0.0;
+  // Sentinel "no pick yet": consumers treat any negative component as unset.
+  this->PickedUV[0] = -1.0;
+  this->PickedUV[1] = -1.0;
 }
 
 //------------------------------------------------------------------------------
@@ -125,6 +128,7 @@ void vtkMRMLLocatorNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyBooleanMacro(LocatorActive);
   vtkMRMLCopyVectorMacro(PickedPositionWorld, double, 3);
+  vtkMRMLCopyVectorMacro(PickedUV, double, 2);
   vtkMRMLCopyEndMacro();
 }
 
@@ -136,5 +140,6 @@ void vtkMRMLLocatorNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintBooleanMacro(LocatorActive);
   vtkMRMLPrintVectorMacro(PickedPositionWorld, double, 3);
+  vtkMRMLPrintVectorMacro(PickedUV, double, 2);
   vtkMRMLPrintEndMacro();
 }

--- a/LiverResections/MRML/vtkMRMLLocatorNode.h
+++ b/LiverResections/MRML/vtkMRMLLocatorNode.h
@@ -112,6 +112,14 @@ public:
   vtkSetVector3Macro(PickedPositionWorld, double);
   vtkGetVector3Macro(PickedPositionWorld, double);
 
+  /// TRANSIENT live picked (u, v) in the flattened parametric domain —
+  /// the resectogram-strip coordinate of the same pick (ADR-0025
+  /// §Context: the strip is the 1:1 (u, v) image).  Sentinel (-1, -1)
+  /// means "no pick yet"; consumers must treat any negative component
+  /// as unset.  Same persistence rule as PickedPositionWorld.
+  vtkSetVector2Macro(PickedUV, double);
+  vtkGetVector2Macro(PickedUV, double);
+
   /// PERSISTED presence flag — "a locator exists / is shown".
   /// Round-trips through Copy / WriteXML / ReadXMLAttributes.
   vtkSetMacro(LocatorActive, bool);
@@ -126,6 +134,7 @@ private:
   void operator=(const vtkMRMLLocatorNode&) = delete;
 
   double PickedPositionWorld[3];
+  double PickedUV[2];
   bool LocatorActive;
 };
 

--- a/LiverResections/Testing/Python/test_ensure_locator_node.py
+++ b/LiverResections/Testing/Python/test_ensure_locator_node.py
@@ -210,6 +210,34 @@ def test_ensure_locator_node_creates_exactly_one_wired_active():
         _remove_locator(scene, locator)
 
 
+def test_ensure_locator_node_display_starts_hidden():
+    """Invariant 1b: the ensured locator's display starts HIDDEN.
+
+    The marker is gesture-scoped (the strip press flips the display
+    Visibility on; release clears it), so ``EnsureLocatorNode`` must leave
+    ``Visibility`` false -- an ensured locator must not paint a stray
+    marker before the first pick gesture.
+    """
+    slicer = _slicer_or_skip()
+    logic = _resection_logic_or_skip(slicer)
+    ensure = _ensure_method_or_skip_pending(logic)
+    scene = slicer.mrmlScene
+
+    _clear_existing_locators(slicer)
+    locator = None
+    try:
+        locator = ensure()
+        assert locator is not None, "EnsureLocatorNode() returned None."
+        display = locator.GetDisplayNode()
+        assert display is not None, "no display node wired."
+        assert not bool(display.GetVisibility()), (
+            "EnsureLocatorNode() must leave the locator display HIDDEN "
+            "(gesture-scoped marker: visible only between press and release)."
+        )
+    finally:
+        _remove_locator(scene, locator)
+
+
 # --------------------------------------------------------------------------- #
 # Invariant 2 -- idempotent: the second call returns the same singleton
 # --------------------------------------------------------------------------- #

--- a/LiverResections/Testing/Python/test_resection_planning_widget_v2_repoint.py
+++ b/LiverResections/Testing/Python/test_resection_planning_widget_v2_repoint.py
@@ -706,5 +706,31 @@ def test_place_resection_mints_and_selects_plan():
     )
 
 
+def test_reshow_kicks_a_resectogram_render():
+    """Re-showing the panel must request one embedded-view render.
+
+    Re-entering the module re-shows this panel with the embedded GL
+    view's last frame discarded -- without a fresh render request the
+    strip reads BLACK until some other interaction repaints it.  The
+    kick is deferred one event-loop turn (the show must be processed
+    before a forceRender can hit a realized surface), so the pin drains
+    the queue before asserting.
+    """
+    import qt  # type: ignore[import-not-found]
+    import slicer  # type: ignore[import-not-found]
+
+    widget = _widget_or_skip(slicer)
+    kicks = []
+    widget.scheduleResectogramRender = lambda: kicks.append(1)
+
+    widget.show()
+    qt.QApplication.processEvents()
+    assert kicks, (
+        "showEvent must schedule a resectogram render -- re-entering the "
+        "module otherwise leaves the strip black until a manual redraw."
+    )
+    widget.hide()
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverResections/Testing/Python/test_resectogram_locator_producer.py
+++ b/LiverResections/Testing/Python/test_resectogram_locator_producer.py
@@ -454,6 +454,12 @@ def test_producer_writes_picked_position_from_pixel():
         f"PickedPositionWorld (ADR-0025 §Producer); got {written}, expected "
         f"{expected}."
     )
+    written_uv = tuple(locator.GetPickedUV())
+    assert written_uv == pytest.approx((0.25, 0.75), abs=1e-9), (
+        "produce() must also write the picked (u, v) onto the locator node "
+        "(ADR-0025: the node is the locator-state carrier; the strip "
+        f"Representation reads it back to place its marker); got {written_uv}."
+    )
 
 
 def test_producer_degenerate_input_is_no_op_returning_none():

--- a/LiverResections/Testing/Python/test_resectogram_pipeline_memo_key.py
+++ b/LiverResections/Testing/Python/test_resectogram_pipeline_memo_key.py
@@ -62,6 +62,10 @@ class _StubDataNode:
     def GetControlGridVector(self):  # noqa: N802 - mirrors the VTK accessor
         return tuple(coord for point in self._points for coord in point)
 
+    def GetScene(self):  # noqa: N802 - mirrors the MRML accessor
+        # Not in any scene: the plan reverse-resolution scan is skipped.
+        return None
+
     def move(self, index, position):
         self._points[index] = list(position)
 

--- a/Testing/Python/unit/test_bezier_planning_representation.py
+++ b/Testing/Python/unit/test_bezier_planning_representation.py
@@ -78,8 +78,14 @@ class _StubDataNode:
     def __init__(self, control_grid: tuple = (0.0,) * 48) -> None:
         self.control_grid = control_grid
 
-    def GetControlGrid(self):
+    def GetControlGridVector(self):
         return self.control_grid
+
+    def GetRows(self) -> int:
+        return 4
+
+    def GetCols(self) -> int:
+        return 4
 
 
 # --------------------------------------------------------------------------- #

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -717,8 +717,15 @@ class _StubLocatorDisplay:
 
 
 class _StubLocatorNode:
+    def __init__(self, uv=(-1.0, -1.0)):
+        # (-1, -1) is the node's "no pick yet" sentinel.
+        self.uv = uv
+
     def GetPickedPositionWorld(self):  # noqa: N802 - VTK verb
         return (10.0, 20.0, 30.0)
+
+    def GetPickedUV(self):  # noqa: N802 - VTK verb
+        return self.uv
 
     def GetDisplayNode(self):  # noqa: N802 - VTK verb
         return _StubLocatorDisplay()
@@ -765,8 +772,9 @@ def test_locator_marker_is_a_round_world_actor(rep_module):
     )
     assert rep._marker_actor.GetVisibility() == 0, "no pick -> no marker"
 
-    rep.SetLocatorNode(_VisibleLocator())
-    rep.SetPickedUV((0.25, 0.75))
+    # The picked (u, v) is carried by the LOCATOR NODE (ADR-0025: the node
+    # is the locator-state carrier) -- the representation reads it there.
+    rep.SetLocatorNode(_VisibleLocator((0.25, 0.75)))
     rep.update(_StubDisplayNode(), _StubDataNode())
     assert mapper.locator_radius == pytest.approx(0.0), "shader disc still off"
     assert rep._marker_actor.GetVisibility() == 1, (
@@ -794,6 +802,32 @@ def test_locator_marker_is_a_round_world_actor(rep_module):
     rep.cleanup()
 
 
+def test_locator_marker_stays_off_at_the_no_pick_sentinel(rep_module):
+    """A visible display with the (-1, -1) sentinel UV shows NO marker.
+
+    The locator node carries (-1, -1) until the first pick gesture; the
+    representation must treat any negative component as "no pick" rather
+    than drawing a circle off the quad.
+    """
+
+    class _VisibleDisplay(_StubLocatorDisplay):
+        def GetVisibility(self):  # noqa: N802 - VTK verb
+            return True
+
+    class _VisibleLocator(_StubLocatorNode):
+        def GetDisplayNode(self):  # noqa: N802 - VTK verb
+            return _VisibleDisplay()
+
+    rep = rep_module()
+    rep._resection_mapper_2d = _StubMapperWithLocator()
+    rep.SetLocatorNode(_VisibleLocator())  # sentinel (-1, -1)
+    rep.update(_StubDisplayNode(), _StubDataNode())
+    assert rep._marker_actor.GetVisibility() == 0, (
+        "the (-1, -1) sentinel means no pick yet -- no marker."
+    )
+    rep.cleanup()
+
+
 def test_locator_marker_gates_on_display_visibility(rep_module):
     """An invisible locator display pushes radius 0 (marker off)."""
 
@@ -808,8 +842,7 @@ def test_locator_marker_gates_on_display_visibility(rep_module):
     rep = rep_module()
     mapper = _StubMapperWithLocator()
     rep._resection_mapper_2d = mapper
-    rep.SetLocatorNode(_HiddenLocator())
-    rep.SetPickedUV((0.5, 0.5))
+    rep.SetLocatorNode(_HiddenLocator((0.5, 0.5)))
     rep.update(_StubDisplayNode(), _StubDataNode())
     assert rep._marker_actor.GetVisibility() == 0, (
         "locator display Visibility false -> the circle marker hides "
@@ -838,8 +871,7 @@ def test_locator_marker_centre_squeezed_by_mat_ratio_about_focal(rep_module):
 
     rep = rep_module()
     rep._resection_mapper_2d = _StubMapperWithLocator()
-    rep.SetLocatorNode(_VisibleLocator())
-    rep.SetPickedUV((0.25, 0.75))
+    rep.SetLocatorNode(_VisibleLocator((0.25, 0.75)))
     rep.update(_StubDisplayNode(), _StubDataNode())
 
     plane = rep.GetBezierPlane()

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -242,6 +242,10 @@ def test_mat_ratio_isotropic_when_no_sampled_surface(rep_module):
         def GetSampledSurfacePoints(self):
             return None
 
+        def GetControlGridVector(self):  # noqa: N802 - VTK verb
+            # Incomplete grid (mid-placement): no Bezier evaluation either.
+            return ()
+
     rep.update(display, _EmptyDataNode())
     assert mapper.mat_ratio == pytest.approx([1.0, 1.0])
     rep.cleanup()
@@ -705,6 +709,11 @@ def test_effective_comps_survive_subsequent_updates(rep_module, monkeypatch):
 class _StubLocatorDisplay:
     def GetRadius(self):  # noqa: N802 - VTK verb
         return 2.0
+
+    def GetVisibility(self):  # noqa: N802 - VTK verb
+        # Matches the marker-off default the Representation assumed for a
+        # display lacking the accessor; visible variants override this.
+        return False
 
 
 class _StubLocatorNode:

--- a/Testing/Python/unit/test_flattened_surface_representation.py
+++ b/Testing/Python/unit/test_flattened_surface_representation.py
@@ -809,6 +809,55 @@ def test_locator_marker_gates_on_display_visibility(rep_module):
     rep.cleanup()
 
 
+def test_locator_marker_centre_squeezed_by_mat_ratio_about_focal(rep_module):
+    """A non-unity MatRatio squeezes the marker CENTRE about the camera focal.
+
+    The 2D mapper's MatRatio scales clip-space offsets, so the world-space
+    circle must apply the same squeeze to its centre -- offset from the
+    camera focal point scaled per-axis -- or the marker drifts off the
+    picked (u, v) whenever the flattened domain is non-square.  Only the
+    isotropic (1, 1) path was pinned before.
+    """
+
+    class _VisibleDisplay(_StubLocatorDisplay):
+        def GetVisibility(self):  # noqa: N802 - VTK verb
+            return True
+
+    class _VisibleLocator(_StubLocatorNode):
+        def GetDisplayNode(self):  # noqa: N802 - VTK verb
+            return _VisibleDisplay()
+
+    rep = rep_module()
+    rep._resection_mapper_2d = _StubMapperWithLocator()
+    rep.SetLocatorNode(_VisibleLocator())
+    rep.SetPickedUV((0.25, 0.75))
+    rep.update(_StubDisplayNode(), _StubDataNode())
+
+    plane = rep.GetBezierPlane()
+    plane.Update()
+    b = plane.GetOutput().GetBounds()
+    raw = (
+        b[0] + (b[1] - b[0]) * 0.25,
+        b[2] + (b[3] - b[2]) * 0.75,
+    )
+    focal = rep._resectogram_camera.GetFocalPoint()
+
+    # Inject the anisotropic squeeze and re-apply the locator alone (update()
+    # would recompute MatRatio from the stub nodes and overwrite it).
+    rep._mat_ratio_applied = (0.5, 1.0)
+    rep._apply_locator()
+
+    centre = rep._marker_source.GetCenter()
+    expected_x = focal[0] + (raw[0] - focal[0]) * 0.5
+    expected_y = focal[1] + (raw[1] - focal[1]) * 1.0
+    assert (centre[0], centre[1]) == pytest.approx((expected_x, expected_y)), (
+        "the marker centre must be squeezed about the camera focal point by "
+        "the per-axis MatRatio (clip-space offsets scale, so world offsets "
+        "from the focal must scale identically)."
+    )
+    rep.cleanup()
+
+
 def test_cleanup_detaches_the_marker_actor_from_the_renderer(
     rep_module, vtk_module
 ):

--- a/Testing/Python/unit/test_slice_contour_pipeline.py
+++ b/Testing/Python/unit/test_slice_contour_pipeline.py
@@ -180,3 +180,52 @@ def test_reslicing_recuts_the_contour(pipeline_module, surface_nodes):
         pipeline.cleanup()
     finally:
         scene.RemoveNode(slice_node)
+
+
+def test_reslicing_still_recuts_after_renderer_churn(
+    pipeline_module, surface_nodes
+):
+    """The slice-node observer must survive OnRendererRemoved/Added churn.
+
+    OnRendererRemoved -> cleanup() detaches EVERY observer (including the
+    slice node's); OnRendererAdded re-derives the display/data observers
+    but must also re-attach the slice-node observer, or reslicing after a
+    churn cycle silently stops recutting (the stale-trace bug, round two).
+    """
+    import slicer
+    import vtk
+
+    data, display = surface_nodes
+    scene = slicer.mrmlScene
+    slice_node = scene.AddNewNodeByClass("vtkMRMLSliceNode")
+    try:
+        pipeline = pipeline_module.SliceContourPipeline()
+        pipeline.SetViewNode(slice_node)
+        pipeline.SetDisplayNode(display)
+        _seed_flat_grid(data, z=10.0)
+        data.SetState(1)
+        slice_node.GetSliceToRAS().SetElement(2, 3, 10.0)
+        slice_node.Modified()
+        pipeline.UpdatePipeline()
+        assert pipeline.GetContourActor().GetVisibility() == 1, "precondition"
+
+        renderer = vtk.vtkRenderer()
+        pipeline.OnRendererRemoved(renderer)
+        pipeline.OnRendererAdded(renderer)
+
+        renders = []
+        pipeline.RequestRender = lambda: renders.append(1)
+        slice_node.GetSliceToRAS().SetElement(2, 3, 500.0)
+        slice_node.Modified()
+        assert renders, (
+            "after renderer churn a slice-pose change must STILL reach the "
+            "pipeline -- OnRendererAdded must re-attach the slice-node "
+            "observer that cleanup() detached."
+        )
+        assert pipeline.GetContourActor().GetVisibility() == 0, (
+            "the post-churn recut at the far plane must empty + hide the "
+            "contour."
+        )
+        pipeline.cleanup()
+    finally:
+        scene.RemoveNode(slice_node)

--- a/Testing/Python/unit/test_slice_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_slice_control_polygon_pipeline.py
@@ -391,3 +391,54 @@ def test_ring_respects_the_range_and_lone_points_keep_their_scaffold(
     )
     display.SetGrabbedControlPoint(-1)
     pipeline.cleanup()
+
+
+def test_reslicing_still_reprojects_after_renderer_churn(
+    pipeline_module, polygon_nodes
+):
+    """The slice-node observer must survive OnRendererRemoved/Added churn.
+
+    Mirrors the contour pipeline's churn pin: cleanup() (via
+    OnRendererRemoved) detaches every observer including the slice
+    node's; OnRendererAdded must re-attach it or reslicing after churn
+    stops updating the projected polygon.
+    """
+    import slicer
+    import vtk
+
+    data, display = polygon_nodes
+    scene = slicer.mrmlScene
+    slice_node = scene.AddNewNodeByClass("vtkMRMLSliceNode")
+    try:
+        pipeline = pipeline_module.SliceControlPolygonPipeline()
+        pipeline.SetViewNode(slice_node)
+        pipeline.SetDisplayNode(display)
+        for r in range(4):
+            for c in range(4):
+                data.SetControlPoint(r, c, float(c) * 40.0, float(r) * 40.0, 0.0)
+        data.SetState(1)
+        slice_node.Modified()
+        pipeline.UpdatePipeline()
+        assert pipeline._handles_actor.GetVisibility() == 1, "precondition"
+
+        renderer = vtk.vtkRenderer()
+        pipeline.OnRendererRemoved(renderer)
+        pipeline.OnRendererAdded(renderer)
+
+        renders = []
+        pipeline.RequestRender = lambda: renders.append(1)
+        slice_node.GetSliceToRAS().SetElement(2, 3, 500.0)  # far off the grid
+        slice_node.Modified()
+        assert renders, (
+            "after renderer churn a slice-pose change must STILL reach the "
+            "pipeline -- OnRendererAdded must re-attach the slice-node "
+            "observer that cleanup() detached."
+        )
+        handles = pipeline.GetHandlesPolyData()
+        assert handles.GetNumberOfPoints() == 0, (
+            "the post-churn reprojection at the far plane must empty the "
+            "scaffold (no points in range; presence is the cutoff)."
+        )
+        pipeline.cleanup()
+    finally:
+        scene.RemoveNode(slice_node)

--- a/Testing/Python/unit/test_slice_control_polygon_pipeline.py
+++ b/Testing/Python/unit/test_slice_control_polygon_pipeline.py
@@ -297,6 +297,40 @@ def test_edges_are_dashed_and_ring_marks_the_hover(pipeline_module, polygon_node
     pipeline.cleanup()
 
 
+def test_ring_hides_when_the_carrier_leaves_planning(
+    pipeline_module, polygon_nodes
+):
+    """Leaving Planning hides the hover ring with the rest of the scaffold.
+
+    The ring is driven by the hover channel, not the state gate: a hover
+    active at the moment the carrier transitions Planning -> Confirmed
+    left a stale ring floating in the slice with no handles under it.
+    """
+    import vtk
+
+    data, display = polygon_nodes
+    pipeline = pipeline_module.SliceControlPolygonPipeline()
+    pipeline._slice_node = _AxialSliceNodeAt(0.0)
+    pipeline.SetDisplayNode(display)
+    for r in range(4):
+        for c in range(4):
+            data.SetControlPoint(r, c, float(c) * 40.0, float(r) * 40.0, 0.0)
+    data.SetState(1)
+    pipeline.UpdatePipeline()
+    move = _TypedEvent(vtk.vtkCommand.MouseMoveEvent, (40.0, 40.0))
+    pipeline.CanProcessInteractionEvent(move)
+    pipeline.UpdatePipeline()
+    assert pipeline._ring_actor.GetVisibility() == 1, "precondition: hover ring up"
+
+    data.SetState(2)  # Planning -> Confirmed (the legal forward transition)
+    pipeline.UpdatePipeline()
+    assert pipeline._ring_actor.GetVisibility() == 0, (
+        "the hover ring must hide with the scaffold when the carrier "
+        "leaves Planning -- a stale ring floats over no handles."
+    )
+    pipeline.cleanup()
+
+
 def test_side_tint_tracks_the_signed_distance(pipeline_module, polygon_nodes):
     """Above-plane points tint lighter, below-plane darker (markups cue)."""
     data, display = polygon_nodes


### PR DESCRIPTION
Closes #560, closes #566.

## What

One conflict-free pass over the LayerDM pipelines bundling the getattr boundary-guard sweep (#560) with the slice-projection review follow-ups (#566), plus one demo-found fix.

### #560 — boundary guards instead of per-accessor getattr
- Every C++-called entry point (`UpdatePipeline`, `CanProcessInteractionEvent`, `ProcessInteractionEvent`, `OnRendererAdded`/`Removed`, `OnReferenceToDisplayNodeAdded`, observer callbacks, creator callbacks) now carries one never-raise try/except; plain attribute access inside.
- 79 per-accessor guards removed across the five pipelines + two Representations; unit-layer stubs enriched to implement the accessors the code needs (a stub missing one now fails its test loudly).
- Keep-list retained: the two-namespace `vtkBezierSurfaceSource` resolve, the injected-2D-mapper API probes (ADR-0014 §3 seam), Algorithm-class resolution, and the `_safe_get_*` helpers whose defaults cover a real None-node / unset-field state.

### #566 — review follow-ups
- **BUG**: slice-node observer re-attached after renderer churn in both slice pipelines (reslicing stopped recutting after a remove/add cycle) — pinned red→green in both suites.
- **BUG**: hover ring hides when the carrier leaves Planning — pinned red→green.
- **ENH**: picked (u, v) routed through `vtkMRMLLocatorNode.PickedUV` (transient, (-1,-1) sentinel, same persistence/CopyContent rule as `PickedPositionWorld`); the producer writes it beside the world point and the strip Representation reads it back — the direct `SetPickedUV` seam is gone (ADR-0025: the node is the locator-state carrier). CxxTest + producer + Representation pins.
- **ENH**: coverage pins for `EnsureLocatorNode`'s hidden-display invariant and the MatRatio marker squeeze at a non-unity aspect ratio.
- **STYLE**: `HANDLE_MIDTONE_FACTOR`, `HANDLE_GLYPH_SCALE_PX`/`RING_GLYPH_SCALE_PX`, `_MARKER_RADIUS_FACTOR` named beside `FADE_DISTANCE_MM`.

### Demo-found fix
- **BUG**: re-entering the module left the resectogram strip black until a manual redraw — `showEvent` now kicks one deferred render (pinned red→green).

## Validation

- Bare harness: 95 passed, 0 failed.
- Launched harness: 291 passed, 15 known skips, 1 known xfail, teardown-crash-free.
- CxxTests: 24/24 passed (including the new `PickedUV` pins).
- Interactive demo pass on real anatomy: strip marker gesture, control-point drag in 3D + slices (13.6 ms/event), reslice after drawer re-open, hover highlights, and module re-entry all verified.

---
_This PR was drafted with assistance from Claude (Anthropic Claude Fable 5)._
