### PR TITLE
DOC: v2.0.0 scope re-baseline (absorb the v2.1 feature plan)

### DIFF
--- a/Docs/adr/0012-layerdm-migration-v2-scope.md
+++ b/Docs/adr/0012-layerdm-migration-v2-scope.md
@@ -6,6 +6,22 @@
 - **Diagrams:** N/A
 - **PR:** _filled in on merge_
 
+## Amendments
+
+- **2026-07-09 — v2.0.0 absorbs the v2.1 feature plan.**  Maintainer
+  decision: v2.0.0 tags when the FULL planned feature set is usable
+  end-to-end, not before.  Everything this ADR's §"Out of v2.0.0
+  scope" deferred to v2.1.0 moves INTO v2.0.0 scope: the LiverSegments
+  / LiverVolumetry / Modeling LayerDM display-node migrations, the
+  cross-module locator unification, the feature issues previously
+  milestoned v2.1.0, and the ADR-0020 / ADR-0022 implementations
+  (their "target v2.1" annotations read "target v2.0" from this
+  date).  The §Context MINOR-vs-MAJOR reasoning is unaffected — the
+  absorbed work remains scene-compatible and additive; it simply
+  ships before the tag rather than after it.  The v2.0.0 release
+  tracker is the single work queue; the v2.1 tracker holds only
+  post-release carries.
+
 ## Context
 
 [ADR-0002](0002-migrate-to-slicerlayerdm.md) commits Slicer-Liver to

--- a/Docs/adr/0020-gpu-tessellation.md
+++ b/Docs/adr/0020-gpu-tessellation.md
@@ -1,10 +1,19 @@
 # 0020. GPU rendering of parametric surfaces and their widgets (v2.1 target)
 
-- **Status:** Accepted (target v2.1)
+- **Status:** Accepted (target v2.0 — re-baselined 2026-07-09; originally v2.1)
 - **Date:** 2026-05-18
 - **Deciders:** Rafael Palomar
 - **Diagrams:** N/A (deferred; class diagram lands with the ADR-0020 enabler PR)
 - **PR:** _filled in on merge_
+
+## Amendments
+
+- **2026-07-09 — retargeted to v2.0.**  The v2.0.0 scope re-baseline
+  ([ADR-0012's Amendments](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0012-layerdm-migration-v2-scope.md))
+  absorbs the v2.1 feature plan into v2.0.0; this ADR's
+  implementation ships before the v2.0.0 tag.  Every "v2.1" in the
+  body below reads as the pre-re-baseline target label, not a
+  schedule commitment.
 
 ## Context
 

--- a/Docs/adr/0022-nurbs-v2-1-design.md
+++ b/Docs/adr/0022-nurbs-v2-1-design.md
@@ -1,6 +1,6 @@
 # 0022. NURBS v2.1 design (data node, schema v3, fitter library, rendering integration)
 
-- **Status:** Accepted (target v2.1)
+- **Status:** Accepted (target v2.0 — re-baselined 2026-07-09; originally v2.1)
 - **Date:** 2026-05-19
 - **Deciders:** Rafael Palomar
 - **Diagrams:**
@@ -8,6 +8,15 @@
   - `Docs/architecture/surface-representation-taxonomy.md` (NURBS branch expanded with schema-v3 fields)
   - `Docs/architecture/rendering-pipeline.md` (NURBS evaluator in TES, paired with Bezier per [ADR-0020][adr-0020])
 - **PR:** _filled in on merge_
+
+## Amendments
+
+- **2026-07-09 — retargeted to v2.0.**  The v2.0.0 scope re-baseline
+  ([ADR-0012's Amendments](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0012-layerdm-migration-v2-scope.md))
+  absorbs the v2.1 feature plan into v2.0.0; this ADR's
+  implementation ships before the v2.0.0 tag.  The title's and
+  body's "v2.1" reads as the pre-re-baseline target label, not a
+  schedule commitment.
 
 ## Context
 

--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -44,7 +44,7 @@ Slicer-Liver extension.  Per ADR-0023 §"Shell composition (Option H)"
 it composes — but does not compute — six surgeon-facing stages on a
 vertical sidebar driving a content stack:
 
-  1. Case Setup            (shell-owned placeholder; ADR-0029)
+  1. Case Setup            (shell-owned page; ADR-0029)
   2. Anatomy Definition    (LiverSegmentation.widgetRepresentation();
                             degrades gracefully when the module is
                             absent from the build per Stage 2
@@ -52,7 +52,7 @@ vertical sidebar driving a content stack:
   3. Vascular Territories  (VascularTerritories.widgetRepresentation())
   4. Resection Planning    (LiverResections.widgetRepresentation())
   5. Volumetry             (LiverVolumetry.widgetRepresentation())
-  6. Export                (shell-owned placeholder)
+  6. Export                (shell-owned page)
 
 Per-stage completion is queried via ``IsStageComplete()`` on the C++
 logic of stages 3/4 and ``isStageComplete()`` on the Python logic of
@@ -236,8 +236,7 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     No domain logic; no per-module widget wiring beyond the
     composition step.  Stages 2-5 reach into their owning module's
     ``widgetRepresentation()`` cache; stages 1 and 6 ship shell-owned
-    placeholders (real UIs land in follow-up tasks — see ADR-0023
-    §Stage 1 / §Stage 6 + ADR-0029).
+    pages (Case Setup per ADR-0029; Export per ADR-0023 §Stage 6).
     """
     ScriptedLoadableModuleWidget.setup(self)
 
@@ -316,7 +315,7 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     Idempotent — calling twice replaces the previous widget cleanly.
     Stages 2-5 surface the cached widgetRepresentation() of their
-    owning Slicer module; stages 1 and 6 host shell-owned placeholders.
+    owning Slicer module; stages 1 and 6 host shell-owned pages.
     Stage 2 (LiverSegmentation) degrades gracefully when the module is
     absent from the build: tab disabled-greyed; predicate returns
     False.
@@ -361,7 +360,7 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def _resolveStagePage(self, index):
     """Return ``(page_widget, is_available)`` for stage ``index``.
 
-    Stages 1 and 6 return shell-owned placeholders; stages 2-5 return
+    Stages 1 and 6 return shell-owned pages; stages 2-5 return
     the cached ``widgetRepresentation()`` of the matching Slicer
     module, or a "module not available" placeholder when the module
     is not registered.


### PR DESCRIPTION
Docs-only. Records the maintainer's 2026-07-09 scope decision: **v2.0.0 absorbs the v2.1 feature plan** — the release tags when the full planned feature set is usable end-to-end.

- **ADR-0012** gains an Amendments section superseding its "Out of v2.0.0 scope" deferral list: the LiverSegments / LiverVolumetry / Modeling LayerDM display migrations, cross-module locator unification, the feature issues previously milestoned v2.1.0, and the ADR-0020 / ADR-0022 implementations all move into v2.0.0 scope. The MINOR-vs-MAJOR reasoning is unaffected (the work stays scene-compatible/additive).
- **ADR-0020 / ADR-0022** retarget from v2.1 to v2.0 (status line + amendment note each).
- **Liver.py** docstrings still called the Case Setup and Export pages "placeholders"; both are real implementations — reworded. The module-not-available fallback keeps its placeholder name.

Companion (already applied on GitHub): the thirteen v2.1-milestoned issues moved to the v2.0.0 milestone, #474 moved to v2.1 as a post-release infra carry, tracker #305's status section rewritten with the re-baselined checklist, and #373 annotated.

---
_This PR was drafted with assistance from Claude (Anthropic Claude Fable 5)._
