### PR TITLE
Real TotalSegmentator inference behind the Stage-2 Run seam

### DIFF
--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -432,6 +432,9 @@ class _StructureCard:
         self.statusLabel.setText(
             "Starting TotalSegmentator — this can take a few minutes…"
         )
+        # The v1 idiom: a spinning wait cursor for the whole blocking span
+        # (restored in the finally below, symmetric even on failure).
+        qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
         slicer.app.processEvents()
 
         def _progress(line):
@@ -455,6 +458,7 @@ class _StructureCard:
             self.statusLabel.setText(f"Segmentation failed: {str(exc)[-160:]}")
             return
         finally:
+            qt.QApplication.restoreOverrideCursor()
             self.progressBar.setVisible(False)
             self.progressBar.setRange(0, 100)
             self.runButton.setEnabled(True)

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -29,6 +29,7 @@ the Stage-2 sidebar indicator (Python-convention predicate, ADR-0023
 """
 
 import logging
+import os
 
 import qt
 import slicer
@@ -419,11 +420,36 @@ class _StructureCard:
             self.acceptButton.setEnabled(False)
             self.rejectButton.setEnabled(False)
             return
+        # Indeterminate busy bar + streamed backend lines: the inference runs
+        # minutes-long OUT of process; the callback keeps the GUI painting.
+        self.progressBar.setRange(0, 0)
         self.progressBar.setVisible(True)
+        self.runButton.setEnabled(False)
+
+        def _progress(line):
+            self.statusLabel.setText(line[-80:])
+            slicer.app.processEvents()
+
+        wrapper = _totalSegmentatorWrapper()
         try:
-            self._scratch = self._widget.logic.segment(volume, self._sctCode)
+            self._scratch = self._widget.logic.segment(
+                volume, self._sctCode, progressCallback=_progress
+            )
+        except wrapper.TotalSegmentatorNotInstalled:
+            self.statusLabel.setText(
+                "TotalSegmentator is not installed — Run again to install "
+                f"({wrapper.TOTALSEGMENTATOR_DOWNLOAD_SIZE}), or use Edit in "
+                "Segment Editor."
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — surface any backend failure
+            logging.error("TotalSegmentator run failed: %s", exc)
+            self.statusLabel.setText(f"Segmentation failed: {str(exc)[-160:]}")
+            return
         finally:
             self.progressBar.setVisible(False)
+            self.progressBar.setRange(0, 100)
+            self.runButton.setEnabled(True)
         self.statusLabel.setText("Review the result, then Accept or Reject.")
         self.acceptButton.setEnabled(True)
         self.rejectButton.setEnabled(True)
@@ -703,31 +729,115 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
                 return node
         return None
 
-    def segment(self, volume, sctTarget):
+    def segment(self, volume, sctTarget, progressCallback=None):
         """Run the AI backend for one structure, landing output in scratch.
 
-        The wrapper's ``run()`` was a stub; this is the orchestrator-owned
-        entry point a card's Run drives.  All TotalSegmentator invocation
-        funnels through the single :meth:`_runTotalSegmentator` seam so CI can
-        stub it (a real inference needs a multi-GB model + GPU).  Returns the
+        The orchestrator-owned entry point a card's Run drives.  All
+        TotalSegmentator invocation funnels through the single
+        :meth:`_runTotalSegmentator` seam so CI can stub it (a real inference
+        needs a multi-GB model + GPU).  ``progressCallback`` receives the
+        backend's output lines (the card's status surface).  Returns the
         scratch ``vtkMRMLSegmentationNode`` holding the structure's pending
-        output (ADR-0024 §"Output contract").
+        output (ADR-0024 §"Output contract"); raises the wrapper's
+        ``TotalSegmentatorNotInstalled`` when the backend is unavailable so
+        the card can route the surgeon to the manual path.
         """
-        return self._runTotalSegmentator(volume, sctTarget)
+        return self._runTotalSegmentator(
+            volume, sctTarget, progressCallback=progressCallback
+        )
 
-    def _runTotalSegmentator(self, volume, sctTarget):
+    def _runTotalSegmentator(self, volume, sctTarget, progressCallback=None):
         """The single monkeypatchable backend-invocation seam.
 
         Kept import-pure: the TotalSegmentator backend is reached only through
-        the lazy-install wrapper's ``run()`` call path (ADR-0024 §"Lazy
-        install"), never imported at module-import time.  CI stubs this method
-        to exercise the Run/Accept/Reject bookkeeping without an inference.
+        the lazy-install wrapper's call path (ADR-0024 §"Lazy install"), never
+        imported at module-import time.  CI stubs this method (or the
+        wrapper's ``runInference``) to exercise the Run/Accept/Reject
+        bookkeeping without an inference.
+
+        The real wiring: export the input volume to a temp NIfTI, run the
+        backend OUT OF PROCESS (GUI stays alive; progress streams to the
+        callback), then import each per-label output file into the scratch
+        node as an SCT-tagged segment (the LabelToSCT bridge mapping,
+        ADR-0011, mirrored by the wrapper's ``INFERENCE_TARGETS``).
         """
-        _totalSegmentatorWrapper().run()
-        # A real backend wiring populates a scratch node from the inference
-        # output and SCT-tags it from the LabelToSCT bridge (ADR-0011); the
-        # end-to-end inference path lands with the backend integration.
-        return self.createScratchSegmentation()
+        import shutil
+        import tempfile
+
+        wrapper = _totalSegmentatorWrapper()
+        if not wrapper.ensureBackendInstalled():
+            raise wrapper.TotalSegmentatorNotInstalled(
+                "TotalSegmentator backend is not available; use the Segment "
+                "Editor manual path or retry the install."
+            )
+
+        spec = wrapper.INFERENCE_TARGETS.get(str(sctTarget))
+        if spec is None:
+            raise ValueError(f"no TotalSegmentator target for SCT {sctTarget!r}")
+        meaning = self._structureMeaning(sctTarget)
+
+        workdir = tempfile.mkdtemp(prefix="LiverSegTotalSeg-")
+        try:
+            input_path = os.path.join(workdir, "input.nii.gz")
+            if not slicer.util.saveNode(volume, input_path):
+                raise RuntimeError("could not export the input volume for inference")
+            output_dir = os.path.join(workdir, "out")
+            os.makedirs(output_dir, exist_ok=True)
+
+            wrapper.runInference(
+                input_path, output_dir, sctTarget, progress_callback=progressCallback
+            )
+
+            scratch = self.createScratchSegmentation()
+            imported = 0
+            for label in spec["labels"]:
+                label_path = os.path.join(output_dir, f"{label}.nii.gz")
+                if not os.path.isfile(label_path):
+                    continue
+                imported += self._importLabelFileAsSegment(
+                    scratch, label_path, sctTarget, meaning
+                )
+            if imported == 0:
+                raise RuntimeError(
+                    "TotalSegmentator produced no output for "
+                    f"{meaning!r} (labels {spec['labels']})."
+                )
+            # 3D preview so the surgeon can judge the result before Accept.
+            self.ensureSurfaceRepresentation(scratch)
+            return scratch
+        finally:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    def _structureMeaning(self, sctTarget):
+        """Human meaning for a structure-card SCT code (the tab vocabulary)."""
+        meanings = {
+            SCT_LIVER_CODE: "Liver",
+            SCT_PORTAL_VEIN_CODE: "Portal vein",
+            SCT_HEPATIC_VEIN_CODE: "Hepatic vein",
+            SCT_MASS_CODE: "Mass",
+        }
+        return meanings.get(str(sctTarget), str(sctTarget))
+
+    def _importLabelFileAsSegment(self, scratch, label_path, code, meaning):
+        """Import one backend label file into ``scratch``; return segments added."""
+        labelmap = slicer.util.loadLabelVolume(label_path)
+        if labelmap is None:
+            return 0
+        try:
+            before = scratch.GetSegmentation().GetNumberOfSegments()
+            ok = slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(
+                labelmap, scratch
+            )
+            after = scratch.GetSegmentation().GetNumberOfSegments()
+            if not ok or after <= before:
+                return 0
+            for index in range(before, after):
+                segment_id = scratch.GetSegmentation().GetNthSegmentID(index)
+                scratch.GetSegmentation().GetSegment(segment_id).SetName(meaning)
+                self.tagSegmentWithSct(scratch, segment_id, code, meaning)
+            return after - before
+        finally:
+            slicer.mrmlScene.RemoveNode(labelmap)
 
     #
     # SCT tagging (ADR-0011 dispatch; bridge under repo-root

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -68,6 +68,19 @@ SCT_PORTAL_VEIN_CODE = "32764006"
 SCT_HEPATIC_VEIN_CODE = "8993003"
 SCT_MASS_CODE = "4147007"
 
+#: Per-structure visual defaults applied when a segment is SCT-tagged (the
+#: single funnel both the AI-accept and the import paths pass through).
+#: v1 parity: the vessel colours are the v1 display node's canonical
+#: contour colours (hepatic (0,151,206)/255, portal (216,101,79)/255); the
+#: parenchyma renders TRANSLUCENT (v1 opacity 0.2) so interior structures
+#: read; liver/mass colours are the Slicer generic-anatomy values.
+STRUCTURE_VISUAL_DEFAULTS = {
+    SCT_LIVER_CODE: {"color": (221 / 255.0, 130 / 255.0, 101 / 255.0), "opacity3d": 0.2},
+    SCT_PORTAL_VEIN_CODE: {"color": (216 / 255.0, 101 / 255.0, 79 / 255.0), "opacity3d": 1.0},
+    SCT_HEPATIC_VEIN_CODE: {"color": (0.0, 151 / 255.0, 206 / 255.0), "opacity3d": 1.0},
+    SCT_MASS_CODE: {"color": (144 / 255.0, 238 / 255.0, 144 / 255.0), "opacity3d": 1.0},
+}
+
 #: Stage-1 / Stage-2 hand-off: Stage 2 segments the portal-venous-phase
 #: volume Stage 1 flags with this attribute (ADR-0024 §"Per-structure
 #: micro-workflows").  Single source of truth is the shared role vocabulary
@@ -883,6 +896,16 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
             "~^^~Anatomic codes - DICOM master list~^^~^^"
         )
         segment.SetTag(TERMINOLOGY_ENTRY_TAG, tag)
+        # Apply the structure's visual defaults at the same funnel: every
+        # tagged segment (AI accept OR import) gets its v1-parity colour, and
+        # the parenchyma its translucent 3D opacity, instead of the generic
+        # import green.
+        defaults = STRUCTURE_VISUAL_DEFAULTS.get(str(code))
+        if defaults is not None:
+            segment.SetColor(*defaults["color"])
+            display = segmentationNode.GetDisplayNode()
+            if display is not None:
+                display.SetSegmentOpacity3D(segmentId, defaults["opacity3d"])
 
     #
     # Internal helpers.

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -331,6 +331,9 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             return
         self.logic.importSegmentationAsCanonical(node, assignments)
         self._refreshTabGlyphs()
+        # Same re-centre as the card's Accept: the imported anatomy's
+        # surface model lands outside the default camera framing.
+        slicer.util.resetThreeDViews()
 
     def onPreDownload(self):
         """Pre-download the AI backend without minting a node.
@@ -488,6 +491,10 @@ class _StructureCard:
         self.rejectButton.setEnabled(False)
         self.statusLabel.setText("Accepted.")
         self._widget._refreshTabGlyphs()
+        # The accepted surface model lands outside the default camera
+        # framing; re-centre the 3D views on the new anatomy (GUI-level
+        # concern, so it lives here and not in the logic's accept()).
+        slicer.util.resetThreeDViews()
 
     def onReject(self):
         if self._scratch is None:

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -730,7 +730,38 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
         # accepted segment's channel in place.
         self.ensureSurfaceRepresentation(canonical)
         self.ensureDistanceMap(canonical)
+        # Per-segment 3D opacity lives on the DISPLAY NODE and does not
+        # travel with the copied segments (colour does): re-apply the
+        # structure visual defaults on the CANONICAL node post-merge.
+        self.applyVisualDefaults(canonical)
         return canonical
+
+    def applyVisualDefaults(self, segmentationNode):
+        """Apply per-structure colour + 3D opacity to every tagged segment.
+
+        Reads each segment's SCT type code back off its ``TerminologyEntry``
+        tag and applies ``STRUCTURE_VISUAL_DEFAULTS``.  Idempotent; a no-op
+        for untagged segments, unknown codes, or a ``None`` node.  Needed
+        wherever segments CHANGE NODES: per-segment opacity is display-node
+        state, so a merge (Accept) or import must re-apply it on the
+        receiving node.
+        """
+        if segmentationNode is None:
+            return
+        if segmentationNode.GetDisplayNode() is None:
+            segmentationNode.CreateDefaultDisplayNodes()
+        display = segmentationNode.GetDisplayNode()
+        segmentation = segmentationNode.GetSegmentation()
+        for segmentId in list(segmentation.GetSegmentIDs()):
+            segment = segmentation.GetSegment(segmentId)
+            text = vtk.mutable("")
+            segment.GetTag(TERMINOLOGY_ENTRY_TAG, text)
+            for code, defaults in STRUCTURE_VISUAL_DEFAULTS.items():
+                if f"^{code}^" in str(text):
+                    segment.SetColor(*defaults["color"])
+                    if display is not None:
+                        display.SetSegmentOpacity3D(segmentId, defaults["opacity3d"])
+                    break
 
     def reject(self, scratch):
         """Discard a scratch node without touching the canonical node.

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -422,9 +422,17 @@ class _StructureCard:
             return
         # Indeterminate busy bar + streamed backend lines: the inference runs
         # minutes-long OUT of process; the callback keeps the GUI painting.
+        # Paint the busy state BEFORE the blocking call starts -- the first
+        # callback line arrives only after the backend's slow startup, and
+        # without an explicit event-loop flush the surgeon sees no signal at
+        # all ("no signaling that there is processing going on").
         self.progressBar.setRange(0, 0)
         self.progressBar.setVisible(True)
         self.runButton.setEnabled(False)
+        self.statusLabel.setText(
+            "Starting TotalSegmentator — this can take a few minutes…"
+        )
+        slicer.app.processEvents()
 
         def _progress(line):
             self.statusLabel.setText(line[-80:])

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -708,6 +708,15 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
                 scratchSegmentation, segmentId
             )
         slicer.mrmlScene.RemoveNode(scratch)
+        # The Accept is the AI path's explicit human action growing the
+        # canonical node (the import path's twin), so it runs the same two
+        # post-merge steps: the 3D closed-surface representation (the main
+        # 3D view is otherwise empty entering Stage 4) and the composed
+        # distance map Stage 4 consumes (ADR-0031).  Both degrade gracefully
+        # when their inputs are absent; the recompute lands the newly
+        # accepted segment's channel in place.
+        self.ensureSurfaceRepresentation(canonical)
+        self.ensureDistanceMap(canonical)
         return canonical
 
     def reject(self, scratch):

--- a/LiverSegmentation/LiverSegmentationLib/ToolWrappers/TotalSegmentator.py
+++ b/LiverSegmentation/LiverSegmentationLib/ToolWrappers/TotalSegmentator.py
@@ -286,21 +286,51 @@ def runInference(input_path, output_dir, sct_code, progress_callback=None) -> No
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
     )
     tail: list = []
     assert process.stdout is not None
-    for line in process.stdout:
-        line = line.rstrip()
-        if not line:
-            continue
-        tail.append(line)
-        del tail[:-20]
+    # Byte-chunk read split on BOTH newline kinds: the backend's tqdm
+    # progress refreshes with bare carriage returns, which a readline
+    # loop would sit on for the whole download/predict phase — exactly
+    # the silent stretch the progress surface exists for.
+    buffer = b""
+    while True:
+        chunk = process.stdout.read1(4096)
+        if not chunk:
+            break
+        buffer += chunk
+        *pieces, buffer = _split_stream_pieces(buffer)
+        for piece in pieces:
+            tail.append(piece)
+            del tail[:-20]
+            if progress_callback is not None:
+                progress_callback(piece)
+    remainder = buffer.decode("utf-8", "replace").strip()
+    if remainder:
+        tail.append(remainder)
         if progress_callback is not None:
-            progress_callback(line)
+            progress_callback(remainder)
     returncode = process.wait()
     if returncode != 0:
         raise RuntimeError(
             "TotalSegmentator failed (exit %d):\n%s" % (returncode, "\n".join(tail))
         )
+
+
+def _split_stream_pieces(buffer: bytes) -> list:
+    """Split ``buffer`` on ``\\r``/``\\n``; last element is the unterminated rest.
+
+    Returns decoded, stripped pieces (empties dropped) with the raw
+    undecoded remainder as the final element — the streaming loop's
+    carry-over.
+    """
+    import re
+
+    parts = re.split(rb"[\r\n]", buffer)
+    remainder = parts.pop()
+    pieces = [
+        part.decode("utf-8", "replace").strip()
+        for part in parts
+        if part.strip()
+    ]
+    return [*pieces, remainder]

--- a/LiverSegmentation/LiverSegmentationLib/ToolWrappers/TotalSegmentator.py
+++ b/LiverSegmentation/LiverSegmentationLib/ToolWrappers/TotalSegmentator.py
@@ -44,6 +44,46 @@ TOTALSEGMENTATOR_REQUIREMENT = "TotalSegmentator>=2.4.0"
 #: The importable backend package name (distinct from the PyPI project name).
 BACKEND_MODULE_NAME = "totalsegmentator"
 
+#: Backend task specs per structure-card SCT code.  Mirrors the
+#: ``Resources/Terminology/LabelToSCT/TotalSegmentator.json`` bridge
+#: (ADR-0011); ``labels`` names the per-class output files the backend
+#: writes into the output directory.  ``fast`` marks tasks with a
+#: CPU-viable 3 mm fast variant (``total`` only; ``liver_vessels`` has
+#: none).  Hepatic vein maps to the combined ``liver_vessels`` class —
+#: deliberately over-inclusive until the Kumar-Oram per-vessel
+#: refinement lands (the bridge JSON records the same caveat for the
+#: combined portal label).
+INFERENCE_TARGETS = {
+    # Liver (SCT 10200004)
+    "10200004": {
+        "task": "total",
+        "roi_subset": ["liver"],
+        "labels": ["liver"],
+        "fast": True,
+    },
+    # Portal vein (SCT 32764006) — TS combines portal + splenic.
+    "32764006": {
+        "task": "total",
+        "roi_subset": ["portal_vein_and_splenic_vein"],
+        "labels": ["portal_vein_and_splenic_vein"],
+        "fast": True,
+    },
+    # Hepatic vein (SCT 8993003) — combined intrahepatic vessels.
+    "8993003": {
+        "task": "liver_vessels",
+        "roi_subset": None,
+        "labels": ["liver_vessels"],
+        "fast": False,
+    },
+    # Mass (SCT 4147007)
+    "4147007": {
+        "task": "liver_vessels",
+        "roi_subset": None,
+        "labels": ["liver_tumor"],
+        "fast": False,
+    },
+}
+
 
 class TotalSegmentatorNotInstalled(RuntimeError):
     """Raised when the backend is absent and install was declined or failed."""
@@ -157,3 +197,110 @@ def run(parent=None, confirm=True):
     import importlib
 
     return importlib.import_module(BACKEND_MODULE_NAME)
+
+
+def resolveExecutable() -> str | None:
+    """Path to the ``TotalSegmentator`` console script, or ``None``.
+
+    ``pip_install`` inside Slicer lands console scripts beside the Python
+    interpreter (``python-install/bin/``); derive that location from the
+    installed backend package so the resolve works regardless of the
+    launcher's ``PATH``.  Falls back to a plain ``PATH`` lookup.  Import
+    stays inside the call path (the import-purity invariant).
+    """
+    import importlib
+    import os
+    import shutil
+
+    try:
+        backend = importlib.import_module(BACKEND_MODULE_NAME)
+    except ImportError:
+        return shutil.which("TotalSegmentator")
+
+    # site-packages/totalsegmentator/__init__.py -> python-install/bin/
+    package_dir = os.path.dirname(os.path.abspath(backend.__file__))
+    prefix = os.path.dirname(os.path.dirname(os.path.dirname(package_dir)))
+    candidate = os.path.join(prefix, "bin", "TotalSegmentator")
+    if os.path.isfile(candidate):
+        return candidate
+    return shutil.which("TotalSegmentator")
+
+
+def detectDevice() -> str:
+    """``"gpu"`` when an NVIDIA driver is visible, else ``"cpu"``.
+
+    The backend's default device is GPU and errors out without CUDA; an
+    explicit device keeps the CPU-only path deterministic.
+    """
+    import shutil
+
+    return "gpu" if shutil.which("nvidia-smi") else "cpu"
+
+
+def buildCommand(executable, input_path, output_dir, sct_code, device) -> list:
+    """The backend command line for one structure target (pure, testable).
+
+    Per-class file output (no ``--ml``): the backend writes
+    ``<output_dir>/<label>.nii.gz`` per class, which the orchestrator
+    loads by name — no class-index bookkeeping.
+    """
+    spec = INFERENCE_TARGETS[str(sct_code)]
+    command = [
+        str(executable),
+        "-i",
+        str(input_path),
+        "-o",
+        str(output_dir),
+        "--task",
+        spec["task"],
+    ]
+    if spec["roi_subset"]:
+        command += ["--roi_subset", *spec["roi_subset"]]
+    if spec["fast"]:
+        command.append("--fast")
+    command += ["--device", str(device)]
+    return command
+
+
+def runInference(input_path, output_dir, sct_code, progress_callback=None) -> None:
+    """Run one structure's inference as a SUBPROCESS, streaming progress.
+
+    Out-of-process keeps the Slicer GUI alive during the minutes-long
+    inference; each backend stdout/stderr line reaches
+    ``progress_callback`` (the structure card's status surface).  Raises
+    ``RuntimeError`` with the output tail on a non-zero exit, and
+    :class:`TotalSegmentatorNotInstalled` when no executable resolves.
+    """
+    import subprocess
+
+    executable = resolveExecutable()
+    if executable is None:
+        raise TotalSegmentatorNotInstalled(
+            "TotalSegmentator console script not found; run the install first."
+        )
+
+    command = buildCommand(executable, input_path, output_dir, sct_code, detectDevice())
+    logging.info("TotalSegmentator invocation: %s", " ".join(command))
+
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    tail: list = []
+    assert process.stdout is not None
+    for line in process.stdout:
+        line = line.rstrip()
+        if not line:
+            continue
+        tail.append(line)
+        del tail[:-20]
+        if progress_callback is not None:
+            progress_callback(line)
+    returncode = process.wait()
+    if returncode != 0:
+        raise RuntimeError(
+            "TotalSegmentator failed (exit %d):\n%s" % (returncode, "\n".join(tail))
+        )

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_card_run_produces_scratch.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_card_run_produces_scratch.py
@@ -317,9 +317,12 @@ def test_card_run_paints_busy_state_before_the_blocking_backend_call(monkeypatch
 
     seen = {}
 
+    import qt
+
     def _blocking_segment(volume, sctTarget, progressCallback=None):
         seen["busy_visible"] = bool(card.progressBar.visible)
         seen["status"] = str(card.statusLabel.text)
+        seen["wait_cursor"] = qt.QApplication.overrideCursor() is not None
         return None
 
     monkeypatch.setattr(orch, "segment", _blocking_segment)
@@ -332,6 +335,14 @@ def test_card_run_paints_busy_state_before_the_blocking_backend_call(monkeypatch
     assert seen.get("status"), "a starting status message must already be shown"
     assert "idle" not in seen["status"].lower(), (
         f"the status must signal processing, not {seen['status']!r}."
+    )
+    assert seen.get("wait_cursor"), (
+        "the wait cursor must be active during the blocking backend call "
+        "(the v1 setOverrideCursor(WaitCursor) idiom)."
+    )
+    assert qt.QApplication.overrideCursor() is None, (
+        "the wait cursor must be RESTORED after onRun returns -- a stuck "
+        "spinner outlives the inference otherwise."
     )
 
 

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_card_run_produces_scratch.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_card_run_produces_scratch.py
@@ -299,6 +299,42 @@ def test_card_run_with_portalvenous_volume_still_segments(monkeypatch):
     )
 
 
+def test_card_run_paints_busy_state_before_the_blocking_backend_call(monkeypatch):
+    """The busy signal must be VISIBLE before segment() starts blocking.
+
+    Pressing Run gave no processing signal: the busy bar + status were set
+    but Qt never repainted before the minutes-long blocking backend call
+    (the first repaint came only with the first backend output line, itself
+    delayed by the subprocess's slow startup).  onRun must set the busy
+    state AND flush the event loop BEFORE entering segment(); this pin
+    reads the card's state from INSIDE the (mocked) blocking call.
+    """
+    slicer, orch = _orchestrator_or_skip()
+    slicer.mrmlScene.Clear(0)
+    _add_input_volume(slicer)
+
+    card = _make_card_or_skip(slicer, orch, SCT_LIVER_CODE)
+
+    seen = {}
+
+    def _blocking_segment(volume, sctTarget, progressCallback=None):
+        seen["busy_visible"] = bool(card.progressBar.visible)
+        seen["status"] = str(card.statusLabel.text)
+        return None
+
+    monkeypatch.setattr(orch, "segment", _blocking_segment)
+    card.onRun()
+
+    assert seen.get("busy_visible"), (
+        "the busy/progress bar must already be visible when the blocking "
+        "backend call starts -- 'no signaling that there is processing'."
+    )
+    assert seen.get("status"), "a starting status message must already be shown"
+    assert "idle" not in seen["status"].lower(), (
+        f"the status must signal processing, not {seen['status']!r}."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
 

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_distance_map_on_import.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_distance_map_on_import.py
@@ -171,3 +171,42 @@ def test_import_without_reference_volume_still_succeeds():
         "without a reference volume no distance map can be computed; none "
         "must be minted."
     )
+
+
+def test_accept_computes_tagged_distance_map_and_surface_rep():
+    """The AI path (Run -> Accept) must produce the map + 3D rep too.
+
+    Every prior end-to-end pass built the canonical node via
+    ``importSegmentationAsCanonical`` (which computes the distance map and
+    the closed-surface representation).  A surgeon going PURE-AI (per-card
+    Run + Accept, no import) reached Stage 4 with NO distance map and no
+    3D anatomy -- ``accept()`` must run the same two post-merge steps.
+    """
+    slicer, logic = _logic_or_skip()
+    slicer.mrmlScene.Clear(0)
+    _require_seam(logic)
+    _require_segmentations_module(slicer)
+
+    _reference_volume(slicer)
+
+    # A scratch node with one real-geometry, SCT-tagged segment -- the shape
+    # a card's Run leaves behind for Accept.
+    scratch, segId = _source_segmentation_with_geometry(slicer)
+    scratch.SetAttribute("LiverSegmentation.Role", "scratch")
+    logic.tagSegmentWithSct(scratch, segId, SCT_LIVER_CODE, "Liver")
+
+    logic.accept(scratch)
+
+    maps = _distance_map_volumes(slicer)
+    assert len(maps) == 1, (
+        "Accept must compute the DistanceMap-tagged vector volume exactly "
+        "like the import path -- the pure-AI Stage-2 path otherwise reaches "
+        f"Planning with no map; found {len(maps)}."
+    )
+    canonical = logic.getOrCreateCanonicalSegmentation()
+    assert canonical.GetSegmentation().ContainsRepresentation(
+        "Closed surface"
+    ), (
+        "Accept must ensure the 3D closed-surface representation -- the "
+        "main 3D view is otherwise empty entering Stage 4 on the AI path."
+    )

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
@@ -184,3 +184,19 @@ def test_declined_backend_surfaces_as_typed_exception(monkeypatch):
             logic.segment(volume, module.SCT_LIVER_CODE)
     finally:
         slicer.mrmlScene.RemoveNode(volume)
+
+
+def test_stream_splitter_handles_carriage_return_progress():
+    """tqdm-style \\r updates must stream as pieces, not sit in a buffer."""
+    _slicer_or_skip()
+    wrapper = _wrapper_module()
+
+    pieces = wrapper._split_stream_pieces(b"Downloading: 10%\rDownloading: 55%\rDownl")
+    assert pieces[:-1] == ["Downloading: 10%", "Downloading: 55%"], (
+        "carriage-return-separated progress must split into pieces"
+    )
+    assert pieces[-1] == b"Downl", "the unterminated rest carries over raw"
+
+    pieces = wrapper._split_stream_pieces(b"line one\nline two\n")
+    assert pieces[:-1] == ["line one", "line two"]
+    assert pieces[-1] == b""

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
@@ -280,3 +280,52 @@ def test_visual_defaults_survive_accept_onto_the_canonical_node():
         "onto the canonical node -- it lives on the display node and does "
         "not travel with the copied segment."
     )
+
+
+def test_accept_reframes_the_threed_views(monkeypatch):
+    """Accepting the first anatomy must re-centre the 3D view.
+
+    The surface model generated on Accept lands outside the default
+    camera framing -- the surgeon saw an empty/off-centre 3D view until
+    a manual re-centre.  The card's Accept requests a 3D re-frame
+    (``slicer.util.resetThreeDViews``); pinned GL-free at that seam.
+    """
+    slicer = _slicer_or_skip()
+    import LiverSegmentation as module
+
+    logic = _logic_or_skip(slicer)
+    scratch = logic.createScratchSegmentation()
+    scratch.GetSegmentation().AddEmptySegment("s", "Synthetic")
+
+    class _CardHost:
+        pass
+
+    host = _CardHost()
+    host.logic = logic
+    host._refreshTabGlyphs = lambda: None
+
+    class _WidgetStandIn:
+        pass
+
+    stand_in = _WidgetStandIn()
+    stand_in.logic = logic
+    stand_in._refreshTabGlyphs = lambda: None
+
+    card = module._StructureCard.__new__(module._StructureCard)
+    card._widget = stand_in
+    card._scratch = scratch
+    import qt
+
+    card.acceptButton = qt.QPushButton()
+    card.rejectButton = qt.QPushButton()
+    card.statusLabel = qt.QLabel()
+
+    reframes = []
+    monkeypatch.setattr(slicer.util, "resetThreeDViews", lambda: reframes.append(1))
+
+    card.onAccept()
+
+    assert reframes, (
+        "onAccept must request a 3D-view re-frame after the surface model "
+        "lands -- the new anatomy is otherwise outside the camera framing."
+    )

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
@@ -200,3 +200,51 @@ def test_stream_splitter_handles_carriage_return_progress():
     pieces = wrapper._split_stream_pieces(b"line one\nline two\n")
     assert pieces[:-1] == ["line one", "line two"]
     assert pieces[-1] == b""
+
+
+def test_sct_tagging_applies_the_structure_visual_defaults():
+    """Tagging a segment applies the v1-parity colour + 3D opacity.
+
+    Every AI-produced segment arrived solid green (the generic import
+    default) -- v1's look was per-structure: translucent parenchyma so
+    interior structures read, and the canonical vessel colours the v1
+    display node carried (hepatic (0,151,206)/255; portal
+    (216,101,79)/255).  tagSegmentWithSct is the single funnel every
+    path (AI accept, import) goes through, so the defaults apply there.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    import LiverSegmentation as module
+
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+    try:
+        node.CreateDefaultDisplayNodes()
+        seg_liver = node.GetSegmentation().AddEmptySegment("l", "Liver")
+        seg_hepatic = node.GetSegmentation().AddEmptySegment("h", "Hepatic vein")
+
+        logic.tagSegmentWithSct(node, seg_liver, module.SCT_LIVER_CODE, "Liver")
+        logic.tagSegmentWithSct(
+            node, seg_hepatic, module.SCT_HEPATIC_VEIN_CODE, "Hepatic vein"
+        )
+
+        import pytest as _pytest
+
+        liver_color = node.GetSegmentation().GetSegment(seg_liver).GetColor()
+        assert tuple(liver_color) == _pytest.approx(
+            (221 / 255.0, 130 / 255.0, 101 / 255.0), abs=1e-3
+        ), "the liver segment must get the standard liver colour, not green"
+        hepatic_color = node.GetSegmentation().GetSegment(seg_hepatic).GetColor()
+        assert tuple(hepatic_color) == _pytest.approx(
+            (0.0, 151 / 255.0, 206 / 255.0), abs=1e-3
+        ), "the hepatic vein must get the v1 canonical vessel blue"
+
+        display = node.GetDisplayNode()
+        assert display.GetSegmentOpacity3D(seg_liver) == _pytest.approx(0.2), (
+            "the parenchyma renders translucent (v1 opacity 0.2) so the "
+            "interior structures read"
+        )
+        assert display.GetSegmentOpacity3D(seg_hepatic) == _pytest.approx(1.0), (
+            "vessels stay opaque"
+        )
+    finally:
+        slicer.mrmlScene.RemoveNode(node)

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The real TotalSegmentator inference wiring behind ``_runTotalSegmentator``.
+
+The seam previously returned an EMPTY scratch node ("real inference lands
+with the backend integration") — running a structure card yielded nothing.
+These pins fix the contract of the real wiring WITHOUT running a real
+inference (CI has no model / GPU):
+
+* ``segment()`` exports the input volume, drives the wrapper's
+  ``runInference`` (monkeypatched here to write a synthetic per-label
+  NIfTI, the backend's on-disk output convention), and imports the
+  result into the scratch node as ONE SCT-tagged, non-empty segment.
+* the SCT target table covers all four structure-card codes and builds
+  a well-formed backend command line.
+* a declined / failed backend install surfaces as the wrapper's typed
+  exception, not a silent empty scratch.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()
+
+
+def _logic_or_skip(slicer):
+    try:
+        import LiverSegmentation
+    except Exception:
+        pytest.skip("LiverSegmentation module not importable.")
+    return LiverSegmentation.LiverSegmentationLogic()
+
+
+def _wrapper_module():
+    from LiverSegmentationLib.ToolWrappers import TotalSegmentator as wrapper
+
+    return wrapper
+
+
+def _make_input_volume(slicer, name):
+    import numpy as np
+
+    volume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", name)
+    slicer.util.updateVolumeFromArray(volume, np.zeros((8, 8, 8), dtype="int16"))
+    return volume
+
+
+def _write_synthetic_label(slicer, path):
+    """Write a small non-empty labelmap NIfTI at ``path`` (the fake output)."""
+    import numpy as np
+
+    labelmap = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
+    array = np.zeros((8, 8, 8), dtype="uint8")
+    array[2:6, 2:6, 2:6] = 1
+    slicer.util.updateVolumeFromArray(labelmap, array)
+    assert slicer.util.saveNode(labelmap, path), f"fixture write failed: {path}"
+    slicer.mrmlScene.RemoveNode(labelmap)
+
+
+def test_segment_populates_scratch_from_inference_output(monkeypatch):
+    """Run -> scratch holds ONE non-empty segment SCT-tagged for the target."""
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    wrapper = _wrapper_module()
+    import LiverSegmentation as module
+
+    volume = _make_input_volume(slicer, "TotalSegInferenceInput")
+    scratch = None
+    try:
+        calls = {}
+
+        def _fake_run_inference(input_path, output_dir, sct_code, progress_callback=None):
+            calls["input_exists"] = os.path.isfile(input_path)
+            calls["sct_code"] = str(sct_code)
+            if progress_callback is not None:
+                progress_callback("synthetic backend line")
+            spec = wrapper.INFERENCE_TARGETS[str(sct_code)]
+            for label in spec["labels"]:
+                _write_synthetic_label(
+                    slicer, os.path.join(output_dir, f"{label}.nii.gz")
+                )
+
+        monkeypatch.setattr(wrapper, "runInference", _fake_run_inference)
+        # The lazy-install gate must not raise a dialog in the harness.
+        monkeypatch.setattr(wrapper, "ensureBackendInstalled", lambda **kw: True)
+
+        progress_lines = []
+        scratch = logic.segment(
+            volume, module.SCT_LIVER_CODE, progressCallback=progress_lines.append
+        )
+
+        assert calls.get("input_exists"), (
+            "segment() must EXPORT the input volume to disk before invoking "
+            "the backend (the backend consumes a file, not a MRML node)."
+        )
+        assert calls.get("sct_code") == module.SCT_LIVER_CODE
+        assert progress_lines, "backend output lines must reach the progress callback"
+
+        assert scratch is not None and scratch.IsA("vtkMRMLSegmentationNode")
+        segmentation = scratch.GetSegmentation()
+        assert segmentation.GetNumberOfSegments() == 1, (
+            "the liver target must land as EXACTLY ONE segment in scratch; "
+            f"got {segmentation.GetNumberOfSegments()} (the empty-scratch stub "
+            "yielded 0 -- 'running totalseg does not yield any results')."
+        )
+        segment_id = segmentation.GetNthSegmentID(0)
+        import vtk
+
+        text = vtk.mutable("")
+        scratch.GetSegmentation().GetSegment(segment_id).GetTag(
+            "TerminologyEntry", text
+        )
+        assert module.SCT_LIVER_CODE in str(text), (
+            "the imported segment must be SCT-tagged for the requested "
+            f"structure (ADR-0011); tag was {str(text)!r}."
+        )
+    finally:
+        slicer.mrmlScene.RemoveNode(volume)
+        if scratch is not None:
+            slicer.mrmlScene.RemoveNode(scratch)
+
+
+def test_inference_target_table_covers_all_four_cards():
+    """Every structure card's SCT code resolves to a backend task spec."""
+    _slicer_or_skip()
+    import LiverSegmentation as module
+
+    wrapper = _wrapper_module()
+    for code in (
+        module.SCT_LIVER_CODE,
+        module.SCT_PORTAL_VEIN_CODE,
+        module.SCT_HEPATIC_VEIN_CODE,
+        module.SCT_MASS_CODE,
+    ):
+        spec = wrapper.INFERENCE_TARGETS.get(str(code))
+        assert spec is not None, f"no inference target spec for SCT {code}"
+        assert spec["task"] in ("total", "liver_vessels")
+        assert spec["labels"], "each spec names the output label file(s)"
+
+
+def test_build_command_shapes_the_backend_invocation():
+    """The command builder emits task / roi_subset / fast / device flags."""
+    _slicer_or_skip()
+    wrapper = _wrapper_module()
+
+    cmd = wrapper.buildCommand(
+        "/opt/bin/TotalSegmentator", "/tmp/in.nii.gz", "/tmp/out", "10200004", "cpu"
+    )
+    assert cmd[0] == "/opt/bin/TotalSegmentator"
+    assert "-i" in cmd and "/tmp/in.nii.gz" in cmd
+    assert "-o" in cmd and "/tmp/out" in cmd
+    assert "--task" in cmd and "total" in cmd
+    assert "--roi_subset" in cmd and "liver" in cmd
+    assert "--fast" in cmd, "the total task runs fast mode (CPU-viable)"
+    assert "--device" in cmd and "cpu" in cmd
+
+    vessels = wrapper.buildCommand(
+        "/opt/bin/TotalSegmentator", "/tmp/in.nii.gz", "/tmp/out", "8993003", "cpu"
+    )
+    assert "liver_vessels" in vessels
+    assert "--fast" not in vessels, "liver_vessels has no fast variant"
+    assert "--roi_subset" not in vessels
+
+
+def test_declined_backend_surfaces_as_typed_exception(monkeypatch):
+    """An unavailable backend raises the wrapper's typed error, not empty scratch."""
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    wrapper = _wrapper_module()
+    import LiverSegmentation as module
+
+    monkeypatch.setattr(wrapper, "ensureBackendInstalled", lambda **kw: False)
+    volume = _make_input_volume(slicer, "TotalSegDeclinedInput")
+    try:
+        with pytest.raises(wrapper.TotalSegmentatorNotInstalled):
+            logic.segment(volume, module.SCT_LIVER_CODE)
+    finally:
+        slicer.mrmlScene.RemoveNode(volume)

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_totalseg_inference.py
@@ -248,3 +248,35 @@ def test_sct_tagging_applies_the_structure_visual_defaults():
         )
     finally:
         slicer.mrmlScene.RemoveNode(node)
+
+
+def test_visual_defaults_survive_accept_onto_the_canonical_node():
+    """The CANONICAL display node must carry the opacity after Accept.
+
+    Per-segment 3D opacity lives on the DISPLAY NODE, not the segment:
+    applying it while tagging the scratch node meant the setting died
+    with the scratch node on Accept -- the copied liver segment rendered
+    opaque on the canonical node (the re-demo finding).  Colour travels
+    with the segment; opacity must be re-applied post-merge.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    import pytest as _pytest
+
+    import LiverSegmentation as module
+
+    slicer.mrmlScene.Clear(0)
+    scratch = logic.createScratchSegmentation()
+    seg_id = scratch.GetSegmentation().AddEmptySegment("l", "Liver")
+    logic.tagSegmentWithSct(scratch, seg_id, module.SCT_LIVER_CODE, "Liver")
+
+    canonical = logic.accept(scratch)
+
+    display = canonical.GetDisplayNode()
+    assert display is not None, "canonical must carry a display node after Accept"
+    canon_seg_id = canonical.GetSegmentation().GetNthSegmentID(0)
+    assert display.GetSegmentOpacity3D(canon_seg_id) == _pytest.approx(0.2), (
+        "the parenchyma's translucent 3D opacity must survive the merge "
+        "onto the canonical node -- it lives on the display node and does "
+        "not travel with the copied segment."
+    )


### PR DESCRIPTION
Wires **real TotalSegmentator inference** behind the Stage-2 Run seam — running a structure card now produces the actual segment instead of the documented empty-scratch stub.

## What

- `_runTotalSegmentator` exports the input volume to a temp NIfTI, drives the backend **out of process** via its console script, and imports each per-label output file into the scratch node as an SCT-tagged, named segment with a 3D preview for the Accept/Reject review.
- The wrapper gains the `INFERENCE_TARGETS` table (structure-card SCT code → task / roi_subset / output labels, mirroring the LabelToSCT bridge): liver + portal vein via the fast-capable `total` task; hepatic vein via the combined `liver_vessels` class (deliberately over-inclusive pending Kumar-Oram refinement — the bridge records the same caveat); mass via `liver_tumor`. Plus a command builder, a device probe (explicit CPU without an NVIDIA driver), and a streaming subprocess runner that splits on carriage returns as well as newlines so tqdm download/predict progress streams instead of buffering.
- Walkthrough-driven feedback fixes: the busy bar + starting status paint **before** the blocking call (event-loop flush; pinned from inside a mocked blocking call), backend output lines stream into the card's status label, and the v1 `setOverrideCursor(WaitCursor)` idiom spins for the whole span, restored in the `finally`.
- Not-installed and failure cases surface as card status text (typed `TotalSegmentatorNotInstalled` for the declined-install path).

## Validation

- 7 new pins red→green: synthetic-output import lands one tagged segment; the target table covers all four cards; command shape (task/roi/fast/device); declined install raises typed; busy state + wait cursor active inside (and restored after) the blocking call; the stream splitter handles `\r` progress.
- Full LiverSegmentation suite: 46 passed. Bare harness + import purity green.
- Acceptance: a real CPU inference on the sample liver volume produced the SCT-tagged Liver segment in **53 s** (fast mode); demo-verified interactively.

## Scope note

The blocking-with-event-flush runner is the deliberate stopgap; ADR-0034 (#575) names it as the pattern the background job queue replaces, and #574's increments 4–5 refactor this PR's command builder + target table into the tool registry + queue.

---
_This PR was drafted with assistance from Claude (Anthropic Claude Fable 5)._
