### PR TITLE
Stage 1: per-row role combo in the Case Setup table

### DIFF
--- a/Liver/Liver.py
+++ b/Liver/Liver.py
@@ -220,10 +220,8 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self._shellHost = None
     self._injectedStageCompletion = None
 
-    # Stage-1 Case Setup widgets (built in ``_buildStage1Page``); ``None``
+    # Stage-1 Case Setup table (built in ``_buildStage1Page``); ``None``
     # here so a pre-build ``_refreshCaseSetupTable`` short-circuits.
-    self._caseSetupVolumeCombo = None
-    self._caseSetupRoleCombo = None
     self._caseSetupTable = None
 
     # Stage-6 Export widgets (built in ``_buildStage6Page``).
@@ -413,16 +411,17 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """Shell-owned Case Setup UI (ADR-0023 §Stage 1 / ADR-0029; ADR-0004 Python).
 
     Load volume(s) via Slicer's Add Data, then tag each with its
-    acquisition-phase role.  A scalar-volume selector + a role dropdown whose
-    "Assign role" writes the shared ``LiverRole`` attribute via
-    ``LiverSegmentationLib.roles.set_volume_role`` — the SAME vocabulary Stage 2
-    reads to pick its working volume — plus a table of tagged volumes.  Tagging
-    flips the Stage-1 completion indicator (``_stage1IsComplete`` reads the
-    attribute).  Degrades to a hint label when the shared roles module is
-    unreachable (a build without ``LiverSegmentationLib``).
+    acquisition-phase role DIRECTLY in the volumes table: the Role
+    column hosts a per-row combo (default **None**) whose pick writes
+    the shared ``LiverRole`` attribute via
+    ``LiverSegmentationLib.roles.set_volume_role`` — the SAME vocabulary
+    Stage 2 reads to pick its working volume.  Tagging flips the Stage-1
+    completion indicator (``_stage1IsComplete`` reads the attribute).
+    Degrades to a hint label when the shared roles module is unreachable
+    (a build without ``LiverSegmentationLib``).
     """
     try:
-      from LiverSegmentationLib import roles
+      from LiverSegmentationLib import roles  # noqa: F401 — availability gate
     except Exception:  # pragma: no cover — surfaces only when the lib is absent
       page = qt.QWidget()
       layout = qt.QVBoxLayout(page)
@@ -439,24 +438,11 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     page.setMRMLScene(slicer.mrmlScene)
     ui = slicer.util.childWidgetVariables(page)
 
-    volumeCombo = ui.CaseSetupVolumeComboBox
-    # Bind the selector's scene explicitly -- the root qMRMLWidget's
-    # setMRMLScene does not reliably propagate to the child selector at
-    # build time (before the page is parented/shown).
-    volumeCombo.setMRMLScene(slicer.mrmlScene)
-    volumeCombo.connect("currentNodeChanged(vtkMRMLNode*)", self._onCaseSetupVolumeChanged)
-
-    roleCombo = ui.CaseSetupRoleComboBox
-    for value in roles.LIVER_ROLES:
-      roleCombo.addItem(self._caseSetupRoleLabel(value), value)
-
-    ui.CaseSetupAssignButton.connect("clicked()", self._onCaseSetupAssignRole)
-
+    # The role is picked DIRECTLY in the table (a per-row combo); the
+    # former select-volume + pick-role + Assign round-trip is retired.
     table = ui.CaseSetupRoleTable
     table.horizontalHeader().setStretchLastSection(True)
 
-    self._caseSetupVolumeCombo = volumeCombo
-    self._caseSetupRoleCombo = roleCombo
     self._caseSetupTable = table
 
     self._refreshCaseSetupTable()
@@ -466,48 +452,58 @@ class LiverWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """Human dropdown/table label for a stored ``LiverRole`` value."""
     return self._CASE_SETUP_ROLE_LABELS.get(value, value)
 
-  def _onCaseSetupVolumeChanged(self, node):
-    """Reflect the selected volume's current role in the dropdown, if tagged."""
-    combo = self._caseSetupRoleCombo
-    if combo is None or node is None:
-      return
-    current = node.GetAttribute("LiverRole")
-    if current is None:
-      return
-    index = combo.findData(current)
-    if index >= 0:
-      combo.setCurrentIndex(index)
+  def _onCaseSetupRolePicked(self, volume, combo):
+    """Write the row's picked role onto its volume; None clears the tag.
 
-  def _onCaseSetupAssignRole(self):
-    """Tag the selected volume with the chosen role, then refresh state."""
+    Qt-signal boundary: never raises (a combo pick must not throw into
+    the event loop).
+    """
+    try:
+      from LiverSegmentationLib import roles
+
+      role = combo.itemData(combo.currentIndex)
+      if role is None:
+        # The explicit None default: an untagged volume carries no tag.
+        volume.SetAttribute("LiverRole", None)
+      else:
+        roles.set_volume_role(volume, role)
+      self._refreshStageIndicators()
+    except Exception:  # pragma: no cover — Qt signal boundary must not raise
+      logging.exception("Case Setup role pick failed")
+
+  def _refreshCaseSetupTable(self):
+    """Rebuild the volumes x role table from the scene's scalar volumes.
+
+    The Role column hosts a QComboBox PER ROW: first entry is the
+    explicit **None** default (data ``None`` — a freshly loaded volume
+    is untagged until the surgeon chooses), then the shared role
+    vocabulary.  Picking writes ``LiverRole`` immediately.
+    """
+    table = self._caseSetupTable
+    if table is None:
+      return
     try:
       from LiverSegmentationLib import roles
     except Exception:  # pragma: no cover — surfaces only when the lib is absent
       return
-    volumeCombo = self._caseSetupVolumeCombo
-    roleCombo = self._caseSetupRoleCombo
-    if volumeCombo is None or roleCombo is None:
-      return
-    volume = volumeCombo.currentNode()
-    if volume is None:
-      return
-    role = roleCombo.itemData(roleCombo.currentIndex)
-    roles.set_volume_role(volume, role)
-    self._refreshCaseSetupTable()
-    self._refreshStageIndicators()
-
-  def _refreshCaseSetupTable(self):
-    """Rebuild the volumes x role table from the scene's scalar volumes."""
-    table = self._caseSetupTable
-    if table is None:
-      return
     volumes = list(slicer.util.getNodesByClass("vtkMRMLScalarVolumeNode"))
     table.setRowCount(len(volumes))
     for row, volume in enumerate(volumes):
-      role = volume.GetAttribute("LiverRole") or ""
       table.setItem(row, 0, qt.QTableWidgetItem(volume.GetName()))
-      table.setItem(row, 1, qt.QTableWidgetItem(
-        self._caseSetupRoleLabel(role) if role else ""))
+      combo = qt.QComboBox()
+      combo.addItem("None", None)
+      for value in roles.LIVER_ROLES:
+        combo.addItem(self._caseSetupRoleLabel(value), value)
+      current = volume.GetAttribute("LiverRole")
+      if current is not None:
+        index = combo.findData(current)
+        if index >= 0:
+          combo.setCurrentIndex(index)
+      combo.connect(
+        "currentIndexChanged(int)",
+        lambda _index, v=volume, c=combo: self._onCaseSetupRolePicked(v, c),
+      )
+      table.setCellWidget(row, 1, combo)
 
   def _buildResectionPlanningPage(self):
     """Return ``(page_widget, is_available)`` for the Stage-4 Python widget.

--- a/Liver/Resources/UI/StageCaseSetupWidget.ui
+++ b/Liver/Resources/UI/StageCaseSetupWidget.ui
@@ -22,58 +22,6 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="assignRow">
-     <item>
-      <widget class="QLabel" name="VolumeLabel">
-       <property name="text">
-        <string>Volume:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="qMRMLNodeComboBox" name="CaseSetupVolumeComboBox">
-       <property name="nodeTypes">
-        <stringlist>
-         <string>vtkMRMLScalarVolumeNode</string>
-        </stringlist>
-       </property>
-       <property name="addEnabled">
-        <bool>false</bool>
-       </property>
-       <property name="removeEnabled">
-        <bool>false</bool>
-       </property>
-       <property name="noneEnabled">
-        <bool>true</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="RoleLabel">
-       <property name="text">
-        <string>Role:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="CaseSetupRoleComboBox"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="CaseSetupAssignButton">
-       <property name="text">
-        <string>Assign role</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
     <widget class="QTableWidget" name="CaseSetupRoleTable">
      <property name="columnCount">
       <number>2</number>
@@ -104,11 +52,6 @@
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Liver/Testing/Python/test_case_setup_role_combo.py
+++ b/Liver/Testing/Python/test_case_setup_role_combo.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Stage-1 Case Setup: per-row role combo in the volumes table.
+
+Walkthrough finding (2026-07-09): the standalone role dropdown +
+"Assign role" button cost a selection round-trip per volume.  The Role
+column hosts a QComboBox PER ROW instead — pick the role directly in
+the row; the default is an explicit **None** entry, distinct from the
+acquisition-phase vocabulary, and selecting it clears the tag.  The
+combo writes the same shared ``LiverRole`` attribute downstream stages
+read (the Stage-1/Stage-2 hand-off).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _widget_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip,
+        register_widget_for_teardown,
+        require_mrml_scene,
+        require_qt_widget,
+    )
+
+    require_qt_widget()
+    slicer = import_slicer_or_skip()
+    require_mrml_scene()
+    try:
+        import Liver  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(f"Liver shell not importable ({exc}).")
+    widget = Liver.LiverWidget(None)
+    widget.setup()
+    return slicer, register_widget_for_teardown(widget)
+
+
+def _add_volume(slicer, name, role=None):
+    volume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", name)
+    if role is not None:
+        from LiverSegmentationLib.roles import set_volume_role
+
+        assert set_volume_role(volume, role)
+    return volume
+
+
+def test_role_table_hosts_a_per_row_combo_defaulting_to_none():
+    """Each table row carries a role QComboBox; untagged rows read None."""
+    import qt
+
+    slicer, widget = _widget_or_skip()
+    untagged = _add_volume(slicer, "CaseComboUntagged")
+    tagged = _add_volume(slicer, "CaseComboTagged", role="PortalVenous")
+    try:
+        widget._refreshCaseSetupTable()
+        table = widget._caseSetupTable
+        assert table is not None and table.rowCount >= 2
+
+        by_name = {}
+        for row in range(table.rowCount):
+            item = table.item(row, 0)
+            combo = table.cellWidget(row, 1)
+            assert isinstance(combo, qt.QComboBox), (
+                "the Role column must host a QComboBox per row (the "
+                "select-then-Assign round-trip is retired)."
+            )
+            by_name[item.text()] = combo
+
+        untagged_combo = by_name["CaseComboUntagged"]
+        assert untagged_combo.itemData(untagged_combo.currentIndex) is None, (
+            "an untagged volume's combo must sit on the explicit None entry."
+        )
+        tagged_combo = by_name["CaseComboTagged"]
+        assert tagged_combo.itemData(tagged_combo.currentIndex) == "PortalVenous", (
+            "a tagged volume's combo must reflect its stored LiverRole."
+        )
+    finally:
+        slicer.mrmlScene.RemoveNode(untagged)
+        slicer.mrmlScene.RemoveNode(tagged)
+
+
+def test_row_combo_writes_and_clears_the_role():
+    """Selecting a role tags the row's volume; selecting None clears it."""
+    slicer, widget = _widget_or_skip()
+    volume = _add_volume(slicer, "CaseComboWrite")
+    try:
+        widget._refreshCaseSetupTable()
+        table = widget._caseSetupTable
+        combo = None
+        for row in range(table.rowCount):
+            if table.item(row, 0).text() == "CaseComboWrite":
+                combo = table.cellWidget(row, 1)
+        assert combo is not None
+
+        index = combo.findData("PortalVenous")
+        assert index >= 0, "the role vocabulary must be offered in the combo"
+        combo.setCurrentIndex(index)
+        assert volume.GetAttribute("LiverRole") == "PortalVenous", (
+            "picking a role in the row must write the shared LiverRole "
+            "attribute (the Stage-1/Stage-2 hand-off)."
+        )
+
+        none_index = combo.findData(None)
+        combo.setCurrentIndex(none_index)
+        assert volume.GetAttribute("LiverRole") is None, (
+            "selecting the None entry must CLEAR the tag."
+        )
+    finally:
+        slicer.mrmlScene.RemoveNode(volume)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Closes #573 (E2E stabilization walkthrough finding #1).

The Stage-1 role tagging cost a selection round-trip: pick the volume in a selector, pick the role in a dropdown, click Assign. The Role column now hosts a **QComboBox per table row** — first entry an explicit **None** default (a freshly loaded volume is untagged until the surgeon chooses; selecting None clears the tag), then the shared role vocabulary — writing `LiverRole` immediately on pick. The standalone selector, dropdown, and Assign button leave the `.ui`.

The per-row combo writes through `LiverSegmentationLib.roles.set_volume_role` (the same Stage-1/Stage-2 hand-off vocabulary), refreshes the stage indicators, and never raises into the Qt event loop.

Validation: two new launched pins (per-row combo presence + stored-role reflection; write/clear-through to the attribute), full Liver shell suite 44 passed.

---
_This PR was drafted with assistance from Claude (Anthropic Claude Fable 5)._