### PR TITLE
Resection init slice 1: wire the liver target model to the carrier

### DIFF
--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   ResectogramPipeline.py
   SliceContourPipeline.py
   SliceControlPolygonPipeline.py
+  TargetModel.py
   ResectogramViewManager.py
   Representations/__init__.py
   Representations/BezierPlanningRepresentation.py

--- a/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
+++ b/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
@@ -290,6 +290,13 @@ class ResectionPlanningWidget(qt.QWidget):
             return
         plan = logic.CreateResectionPlan(_DEFAULT_RESECTION_NAME)
         if plan is not None:
+            # Attach the hidden liver target model (ADR-0014 §1 weakref):
+            # the slicing-plane init contour and the commit-boundary ring
+            # extraction cut THIS mesh.  Graceful no-op without a Stage-2
+            # canonical liver segment.
+            from LiverResectionsLib.TargetModel import ensure_target_model
+
+            ensure_target_model(plan)
             self.setActiveResectionNode(plan)
 
     @staticmethod

--- a/LiverResections/LiverResectionsLib/TargetModel.py
+++ b/LiverResections/LiverResectionsLib/TargetModel.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Target-organ model wiring: canonical liver segment -> carrier weakref.
+
+The slicing-plane initialization and the commit-boundary ring extraction
+consume the carrier's weakref'd target mesh (ADR-0014 §1,
+``vtkMRMLBezierSurfaceNode.GetTargetModelNode()``).  This module owns the
+workflow wire that ATTACHES it: resolve the Stage-2 CANONICAL
+segmentation, find its SCT-tagged liver segment, mint a hidden
+``vtkMRMLModelNode`` from the segment's closed surface (the v1
+target-organ-model pattern: invisible plumbing, not scene furniture),
+and set it as the plan carrier's weak ``target`` reference.
+
+Cross-module contract note: the canonical-role attribute and the SCT
+liver code are the SHARED Stage-2 vocabulary (ADR-0024 §Terminology /
+ADR-0011) read here as attribute/tag literals — LiverResections does not
+import LiverSegmentationLib (no cross-module Python dependency; the
+contract is the scene data).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import slicer  # type: ignore[import-not-found]
+import vtk
+
+#: Stage-2 canonical-role attribute (ADR-0024 §Terminology).
+_CANONICAL_ROLE_ATTRIBUTE = "LiverSegmentation.Role"
+_CANONICAL_ROLE_VALUE = "canonical"
+#: SCT type code for the liver parenchyma (ADR-0011 vocabulary).
+_SCT_LIVER_CODE = "10200004"
+#: Attribute tagging the minted hidden model so re-runs resolve it.
+_TARGET_MODEL_ATTRIBUTE = "LiverResections.TargetModel"
+
+
+def ensure_target_model(plan_node: Any) -> Any | None:
+    """Attach the hidden liver target model to ``plan_node``'s carrier.
+
+    Resolve-or-mint (idempotent): an already-attached target with live
+    geometry is reused.  Returns the model node, or ``None`` when there
+    is nothing to wire (no plan/carrier, no canonical segmentation, no
+    SCT-tagged liver segment) — a graceful no-op, mirroring the sibling
+    ensure* helpers.
+    """
+    if plan_node is None:
+        return None
+    carrier = plan_node.GetGeometryNode()
+    if carrier is None:
+        return None
+
+    existing = carrier.GetTargetModelNode()
+    if (
+        existing is not None
+        and existing.GetPolyData() is not None
+        and existing.GetPolyData().GetNumberOfPoints() > 0
+    ):
+        return existing
+
+    segmentation_node, segment_id = _find_canonical_liver_segment()
+    if segmentation_node is None:
+        return None
+
+    polydata = _liver_closed_surface(segmentation_node, segment_id)
+    if polydata is None or polydata.GetNumberOfPoints() == 0:
+        return None
+
+    model = _resolve_or_mint_model()
+    model.SetAndObservePolyData(polydata)
+    carrier.SetAndObserveTargetModelNode(model)
+    return model
+
+
+def _find_canonical_liver_segment() -> tuple:
+    """Return ``(segmentationNode, segmentId)`` for the canonical liver."""
+    for node in slicer.util.getNodesByClass("vtkMRMLSegmentationNode"):
+        if node.GetAttribute(_CANONICAL_ROLE_ATTRIBUTE) != _CANONICAL_ROLE_VALUE:
+            continue
+        segmentation = node.GetSegmentation()
+        for segment_id in list(segmentation.GetSegmentIDs()):
+            text = vtk.mutable("")
+            segmentation.GetSegment(segment_id).GetTag("TerminologyEntry", text)
+            if f"^{_SCT_LIVER_CODE}^" in str(text):
+                return node, segment_id
+    return None, None
+
+
+def _liver_closed_surface(segmentation_node: Any, segment_id: str) -> Any | None:
+    """A deep-copied closed-surface polydata for ``segment_id``."""
+    polydata = segmentation_node.GetClosedSurfaceInternalRepresentation(segment_id)
+    if polydata is None:
+        segmentation_node.CreateClosedSurfaceRepresentation()
+        polydata = segmentation_node.GetClosedSurfaceInternalRepresentation(
+            segment_id
+        )
+    if polydata is None:
+        return None
+    # Deep copy (the v1 pattern): the working mesh must not alias the
+    # segmentation's internal representation, which conversions rebuild.
+    copied = vtk.vtkPolyData()
+    copied.DeepCopy(polydata)
+    return copied
+
+
+def _resolve_or_mint_model() -> Any:
+    """The single tagged hidden model node (resolve-or-create)."""
+    for node in slicer.util.getNodesByClass("vtkMRMLModelNode"):
+        if node.GetAttribute(_TARGET_MODEL_ATTRIBUTE) == "True":
+            return node
+    model = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLModelNode", "LiverResectionTargetOrgan"
+    )
+    model.SetAttribute(_TARGET_MODEL_ATTRIBUTE, "True")
+    # v1 parity: invisible plumbing — hidden from editors, never rendered.
+    model.SetHideFromEditors(True)
+    model.CreateDefaultDisplayNodes()
+    display = model.GetDisplayNode()
+    if display is not None:
+        display.SetVisibility(False)
+    return model

--- a/LiverResections/Testing/Python/test_resections_ring_extraction_on_commit.py
+++ b/LiverResections/Testing/Python/test_resections_ring_extraction_on_commit.py
@@ -202,24 +202,17 @@ def test_extractor_not_invoked_per_drag_only_on_commit(monkeypatch):
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "T2-target-mesh-weakref not yet implemented: the Init Representation's "
-        "TODO(T2-target-mesh-weakref) consume sites do not yet feed the "
-        "extractor the weakref'd target mesh (ADR-0014 §1).  Invariant-first "
-        "RED pin (ADR-0027); strict=True flips this to a hard failure the moment "
-        "the feature lands, forcing removal of this marker."
-    ),
-)
 def test_init_representation_reads_target_via_weakref(monkeypatch):
     """Extraction consumes the weakref'd target mesh, not a None/hard-coded path.
 
     ADR-0014 §1: the Init Representation reaches the target mesh through
     ``vtkMRMLBezierSurfaceNode``'s weak ``target`` reference
-    (``GetTargetModelNode()``).  Pins that the
-    ``TODO(T2-target-mesh-weakref)`` consume sites feed the extractor the
-    weakref'd mesh.  RED until those sites are wired.
+    (``GetTargetModelNode()``).  Pins that the commit path feeds the
+    extractor the weakref'd mesh.  (Formerly a strict-xfail RED pin; its
+    fixture never gave the carrier a DISPLAY node, so the pipeline could
+    not bind the carrier at all -- the consume-site wire itself was
+    present.  The fixture now attaches the display node the production
+    pipeline binds through.)
     """
     slicer = _slicer_or_skip()
     pipeline = _make_pipeline_or_skip()
@@ -254,7 +247,16 @@ def test_init_representation_reads_target_via_weakref(monkeypatch):
 
     monkeypatch.setattr(pipeline, extract_attr, _capture_extract, raising=True)
 
-    pipeline.SetDisplayNode(getattr(bezier, "GetDisplayNode", lambda: None)())
+    # Bind the pipeline the way production does: through the carrier's
+    # display node (the fixture formerly passed None here, leaving the
+    # pipeline with no carrier and masking the working consume site).
+    display = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLParametricSurfaceDisplayNode"
+    )
+    if display is None:
+        pytest.skip("vtkMRMLParametricSurfaceDisplayNode not registered.")
+    bezier.AddAndObserveDisplayNodeID(display.GetID())
+    pipeline.SetDisplayNode(display)
     pipeline.commit()
 
     assert seen["mesh_source"] is not None, (

--- a/LiverResections/Testing/Python/test_target_model_wiring.py
+++ b/LiverResections/Testing/Python/test_target_model_wiring.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Target-organ model wiring: canonical liver segment -> carrier weakref.
+
+The commit-boundary ring extraction consumes the carrier's weakref'd
+target mesh (``GetTargetModelNode()``, ADR-0014 §1) — but nothing in the
+workflow ever ATTACHED it, so the slicing-plane initialization had no
+liver to cut (the origin-grid symptom).  v1 parity: a hidden model is
+minted from the parenchyma's closed surface and referenced by the
+resection; v2 derives it from the CANONICAL segmentation's SCT-tagged
+liver segment (the Stage-2 hand-off) and attaches it to the plan's
+carrier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+SCT_LIVER_CODE = "10200004"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()
+
+
+def _target_model_module():
+    try:
+        from LiverResectionsLib import TargetModel
+    except Exception:
+        pytest.skip("LiverResectionsLib.TargetModel not importable (pending impl).")
+    return TargetModel
+
+
+def _canonical_with_liver_segment(slicer):
+    """A canonical-role segmentation holding one SCT-tagged liver segment."""
+    import numpy as np
+
+    labelmap = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
+    array = np.zeros((16, 16, 16), dtype="uint8")
+    array[4:12, 4:12, 4:12] = 1
+    slicer.util.updateVolumeFromArray(labelmap, array)
+
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+    slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(
+        labelmap, node
+    )
+    slicer.mrmlScene.RemoveNode(labelmap)
+    node.SetAttribute("LiverSegmentation.Role", "canonical")
+    segment_id = node.GetSegmentation().GetNthSegmentID(0)
+    segment = node.GetSegmentation().GetSegment(segment_id)
+    segment.SetTag(
+        "TerminologyEntry",
+        "Segmentation category and type - DICOM master list"
+        "~SCT^85756007^Tissue"
+        f"~SCT^{SCT_LIVER_CODE}^Liver"
+        "~^^~Anatomic codes - DICOM master list~^^~^^",
+    )
+    return node
+
+
+def _plan_or_skip(slicer):
+    logic_module = getattr(slicer.modules, "liverresections", None)
+    if logic_module is None:
+        pytest.skip("liverresections module not registered.")
+    logic = logic_module.logic()
+    plan = logic.CreateResectionPlan()
+    if plan is None:
+        pytest.skip("CreateResectionPlan returned None in this build.")
+    return plan
+
+
+def test_ensure_target_model_attaches_hidden_liver_mesh():
+    """The plan's carrier gains a weakref'd model minted from the liver segment."""
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    TargetModel = _target_model_module()
+
+    canonical = _canonical_with_liver_segment(slicer)
+    plan = _plan_or_skip(slicer)
+
+    model = TargetModel.ensure_target_model(plan)
+
+    assert model is not None and model.IsA("vtkMRMLModelNode"), (
+        "ensure_target_model must mint a vtkMRMLModelNode from the canonical "
+        "liver segment (the Stage-2 hand-off)."
+    )
+    assert model.GetPolyData() is not None and model.GetPolyData().GetNumberOfPoints() > 0, (
+        "the target model must carry the liver's closed-surface geometry."
+    )
+    carrier = plan.GetGeometryNode()
+    assert carrier.GetTargetModelNode() is model, (
+        "the model must be attached to the carrier's weak target reference "
+        "(ADR-0014 §1) -- the mesh commit()'s ring extraction consumes."
+    )
+    # v1 parity: the working mesh is INVISIBLE plumbing, not scene furniture.
+    assert model.GetHideFromEditors(), "the target model hides from editors"
+    display = model.GetDisplayNode()
+    assert display is None or not display.GetVisibility(), (
+        "the target model must not render (v1: opacity-0 hidden model)."
+    )
+    assert canonical is not None  # fixture liveness
+
+
+def test_ensure_target_model_is_idempotent():
+    """A second call reuses the attached model instead of minting another."""
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    TargetModel = _target_model_module()
+
+    _canonical_with_liver_segment(slicer)
+    plan = _plan_or_skip(slicer)
+
+    first = TargetModel.ensure_target_model(plan)
+    count_after_first = slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLModelNode")
+    second = TargetModel.ensure_target_model(plan)
+
+    assert second is first, "the attached target model must be reused"
+    assert (
+        slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLModelNode")
+        == count_after_first
+    ), "no second model node may be minted"
+
+
+def test_ensure_target_model_without_canonical_is_a_noop():
+    """No canonical segmentation -> None, and the carrier stays untargeted."""
+    slicer = _slicer_or_skip()
+    slicer.mrmlScene.Clear(0)
+    TargetModel = _target_model_module()
+
+    plan = _plan_or_skip(slicer)
+    model = TargetModel.ensure_target_model(plan)
+
+    assert model is None
+    assert plan.GetGeometryNode().GetTargetModelNode() is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
First slice of #578 (camera+geometry-aware resection initialization).

## What

- **Lifts the `T2-target-mesh-weakref` strict xfail** — the pin's fixture never gave the carrier a display node, so the pipeline could not bind the carrier and the test measured the fixture gap; `commit()` has consumed the weakref'd target through `GetTargetModelNode()` since the seam landed. Fixture fixed, pin passes on the existing wire.
- **Builds the genuinely missing wire**: `ensure_target_model` resolves the Stage-2 canonical segmentation's SCT-tagged liver segment, mints the hidden target-organ model from its closed surface (the v1 pattern — deep-copied polydata, hidden from editors, never rendered, resolve-or-mint singleton) and attaches it to the plan carrier's weak target reference (ADR-0014 §1). Place resection runs it after `CreateResectionPlan`; no canonical liver → graceful no-op. The cross-module contract is scene data (role attribute + SCT tag), not a Python import.

With this, the commit-boundary ring extraction finally has a liver to cut. Next slices per the v1 study: plane derivation from the placed points, placement routing + draggable handles on the control-point pattern, PCA grid seeding on commit (kills the origin-grid symptom), live shader contour.

## Validation

Six pins green (three new target-model invariants + the two commit-boundary pins incl. the former xfail); full launched sweep 296 passed / known skips only.

---
_This PR was drafted with assistance from Claude (Anthropic Claude Fable 5)._