### PR TITLE
Resection init slice 2: derive the slicing plane from the init points

### DIFF
--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -714,7 +714,44 @@ class LiverBezierSurfacePipeline(_PipelineBase):
         if placed is False:  # the node's Init-only guard rejected it
             return None
         self._slicing_plane_points_placed += 1
+        # Both points down -> the plane is now defined; derive it (and
+        # re-derive on every subsequent placement-kernel call, the drag
+        # path's re-entry).
+        if self._slicing_plane_points_placed >= 2:
+            self._derive_slicing_plane()
         return index
+
+    def _derive_slicing_plane(self) -> bool:
+        """Write the carrier's slicing plane from its two init points.
+
+        v1 parity (the NorMIT-Plan bisector): ``origin = midpoint(p1, p2)``,
+        ``normal = unit(p2 - p1)`` — the perpendicular-bisector plane of the
+        two handles.  The camera does NOT enter the plane math; it only
+        orients the auto-seeded initial placement.  A no-op returning
+        ``False`` when fewer than two points are placed or the points are
+        coincident (a degenerate normal must not overwrite the stored
+        plane).
+        """
+        carrier = self._data_node
+        if carrier is None or self._slicing_plane_points_placed < 2:
+            return False
+        p1 = carrier.GetSlicingPlaneInitPoint(0)
+        p2 = carrier.GetSlicingPlaneInitPoint(1)
+        if p1 is None or p2 is None:
+            return False
+        delta = [float(p2[i]) - float(p1[i]) for i in range(3)]
+        length = (delta[0] ** 2 + delta[1] ** 2 + delta[2] ** 2) ** 0.5
+        if length <= 0.0:
+            return False
+        carrier.SetSlicingPlaneOrigin(
+            (float(p1[0]) + float(p2[0])) / 2.0,
+            (float(p1[1]) + float(p2[1])) / 2.0,
+            (float(p1[2]) + float(p2[2])) / 2.0,
+        )
+        carrier.SetSlicingPlaneNormal(
+            delta[0] / length, delta[1] / length, delta[2] / length
+        )
+        return True
 
     def _place_distance_spheroid_init_point(self, world: Any) -> int | None:
         """Place the next distance-spheroid init point at RAS ``world``.

--- a/LiverResections/Testing/Python/test_pipeline_slicing_plane_init_placement.py
+++ b/LiverResections/Testing/Python/test_pipeline_slicing_plane_init_placement.py
@@ -514,3 +514,67 @@ def test_process_interaction_event_routes_placement_through_override():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+def test_second_placement_derives_the_slicing_plane():
+    """Placing both points writes origin=midpoint, normal=unit(p2-p1).
+
+    v1 parity (the NorMIT-Plan bisector): the slicing plane is the
+    perpendicular bisector of the two init points -- origin at their
+    midpoint, normal along their difference (normalized here so
+    downstream consumers -- the shader band, the ring extractor -- get a
+    unit normal).  The camera does NOT enter the plane math (the v1
+    study correction); it only orients the auto-seed placement.
+    """
+    slicer = _slicer_or_skip()
+    pipeline, carrier = _make_init_slicing_plane_carrier_or_skip(slicer)
+    _require_place_kernel_or_skip(pipeline)
+
+    first = pipeline._place_slicing_plane_init_point((10.0, 0.0, 0.0))
+    assert first == 0
+    second = pipeline._place_slicing_plane_init_point((40.0, 40.0, 0.0))
+    assert second == 1
+
+    origin = tuple(carrier.GetSlicingPlaneOrigin())
+    assert origin == pytest.approx((25.0, 20.0, 0.0)), (
+        "the slicing-plane origin must be the MIDPOINT of the two init "
+        "points (the v1 bisector plane)."
+    )
+    normal = tuple(carrier.GetSlicingPlaneNormal())
+    assert normal == pytest.approx((0.6, 0.8, 0.0)), (
+        "the slicing-plane normal must be the UNIT vector along p2 - p1."
+    )
+
+
+def test_rederive_follows_a_moved_init_point():
+    """Re-running the derivation after a point moves updates the plane."""
+    slicer = _slicer_or_skip()
+    pipeline, carrier = _make_init_slicing_plane_carrier_or_skip(slicer)
+    _require_place_kernel_or_skip(pipeline)
+
+    pipeline._place_slicing_plane_init_point((0.0, 0.0, 0.0))
+    pipeline._place_slicing_plane_init_point((10.0, 0.0, 0.0))
+
+    carrier.SetSlicingPlaneInitPoint(1, [0.0, 0.0, 8.0])
+    pipeline._derive_slicing_plane()
+
+    assert tuple(carrier.GetSlicingPlaneOrigin()) == pytest.approx(
+        (0.0, 0.0, 4.0)
+    )
+    assert tuple(carrier.GetSlicingPlaneNormal()) == pytest.approx(
+        (0.0, 0.0, 1.0)
+    )
+
+
+def test_derivation_is_a_noop_before_both_points():
+    """One placed point must not fabricate a plane (degenerate normal)."""
+    slicer = _slicer_or_skip()
+    pipeline, carrier = _make_init_slicing_plane_carrier_or_skip(slicer)
+    _require_place_kernel_or_skip(pipeline)
+
+    before_origin = tuple(carrier.GetSlicingPlaneOrigin())
+    before_normal = tuple(carrier.GetSlicingPlaneNormal())
+    pipeline._place_slicing_plane_init_point((10.0, 20.0, 30.0))
+
+    assert tuple(carrier.GetSlicingPlaneOrigin()) == before_origin
+    assert tuple(carrier.GetSlicingPlaneNormal()) == before_normal


### PR DESCRIPTION
Second slice of #578.

The carrier's `SlicingPlaneOrigin`/`SlicingPlaneNormal` setters had no callers — the Init representation rendered whatever stale plane the node stored. The placement kernel now derives the plane the moment the second init point lands (and on every kernel re-entry, which slice 3's drag path reuses): **origin = midpoint, normal = unit(p2 − p1)** — the v1 NorMIT-Plan perpendicular-bisector plane, deliberately camera-free per the v1 source study (the camera's role is confined to orienting the auto-seeded initial placement, coming in slice 3). Coincident points refuse to overwrite the stored plane.

Three new pins (derivation on second placement; re-derivation after a moved point; no-plane-before-both guard); slicing-plane + pipeline suites 30 passed.

Sibling of #580 (slice 1, target-model wire); the two are file-disjoint and independently mergeable.

---
_This PR was drafted with assistance from Claude (Anthropic Claude Fable 5)._