### PR TITLE
ENH: Embedded Segment Editor under the segments table (#574 increment)

### DIFF
--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -33,6 +33,7 @@ import functools
 import logging
 import os
 
+import ctk
 import qt
 import slicer
 import vtk
@@ -114,6 +115,12 @@ STATUS_REVIEW = ("●", "Review")
 STATUS_CONFIRMED = ("✓", "Confirmed")
 STATUS_FLAGGED = ("⚑", "Flagged")
 STATUS_MARKED_ABSENT = ("∅", "Marked absent")
+
+#: Curated effect list for the embedded Segment Editor — the AI-mask-
+#: correction set (ADR-0034 §Amendments item 4).  Everything outside this
+#: order is hidden (``unorderedEffectsVisible`` off): the embedded editor
+#: corrects produced masks; it is not a from-scratch segmentation surface.
+EMBEDDED_EDITOR_EFFECTS = ("Paint", "Erase", "Scissors", "Islands", "Smoothing")
 
 
 #: Stage-1 / Stage-2 hand-off: Stage 2 segments the portal-venous-phase
@@ -218,6 +225,13 @@ def _segmentIsEmpty(segment):
     provenance), never on status: the status column is the surgeon's
     channel — an EMPTY ``Completed`` row is the absence attestation — so
     status cannot mark a row as a replaceable placeholder.
+
+    Emptiness is LABEL-AWARE: pre-seeded segments SHARE one binary-labelmap
+    layer (the stock ``AddEmptySegment`` shape), so a content write to one
+    segment through the Segment Editor funnel grows the shared image's
+    extent for every sharer.  A segment is empty iff NO voxel carries its
+    own label value — the object-level extent says nothing about a single
+    sharer.
     """
     if segment is None:
         return True
@@ -227,10 +241,17 @@ def _segmentIsEmpty(segment):
     labelmap = segment.GetRepresentation(name)
     if labelmap is None:
         return True
-    if hasattr(labelmap, "IsEmpty"):
-        return bool(labelmap.IsEmpty())
+    if hasattr(labelmap, "IsEmpty") and labelmap.IsEmpty():
+        return True
     extent = labelmap.GetExtent()
-    return extent[0] > extent[1] or extent[2] > extent[3] or extent[4] > extent[5]
+    if extent[0] > extent[1] or extent[2] > extent[3] or extent[4] > extent[5]:
+        return True
+    scalars = labelmap.GetPointData().GetScalars()
+    if scalars is None:
+        return True
+    from vtk.util.numpy_support import vtk_to_numpy
+
+    return not bool((vtk_to_numpy(scalars) == segment.GetLabelValue()).any())
 
 
 def _segmentTag(segment, tag):
@@ -306,8 +327,14 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
     on the SELECTED rows: Run TotalSegmentator (enqueues every selected
     structure into the §Decision 5 job queue; results land on the
     canonical node as native ``InProgress`` — no Accept/Reject machinery;
-    the surgeon's confirm is the status-cell click) and Edit in Segment
-    Editor (interim jump-to-module until the embedded-editor increment).
+    the surgeon's confirm is the status-cell click) and Edit (expands the
+    EMBEDDED ``qMRMLSegmentEditorWidget`` section under the toolbar and
+    syncs the selected row — ADR-0034 §Amendments item 4; the editor
+    drives its own non-singleton editor node with a curated effect list,
+    pinned to the canonical node + the Stage-1 PortalVenous volume).
+    Editing a ``Completed`` segment demotes it to ``InProgress`` (the
+    §Decision 2 staleness rule, hooked at segmentation level so stock-
+    module edits are covered too).
     Absence is attested through the table's own status gesture — an EMPTY
     row the surgeon sets ``Completed`` reads Marked absent — so the
     toolbar carries no dedicated affordance for it.  Each queued/running
@@ -338,6 +365,14 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         self._jobQueue = None
         self._pendingJobs = {}
         self._jobRows = {}
+        # Embedded Segment Editor (ADR-0034 §Amendments item 4): the stock
+        # qMRMLSegmentEditorWidget in a collapsible section, its OWN
+        # non-singleton editor node, and the vtkSegmentation currently
+        # observed for the demote-on-edit staleness rule.  Built in setup().
+        self._embeddedEditor = None
+        self._editorSection = None
+        self._editorNode = None
+        self._observedSegmentation = None
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)
 
@@ -349,6 +384,7 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
 
         self.layout.addWidget(self._buildSegmentsTable())
         self.layout.addWidget(self._buildSelectionToolbar())
+        self.layout.addWidget(self._buildEmbeddedEditor())
         self.layout.addWidget(self._buildLoadSegmentationSection())
         self.layout.addWidget(self._buildBackendStatusRow())
 
@@ -367,6 +403,8 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         # §Decision 1: the empty state teaches the goal).
         self.logic.getOrCreateCanonicalSegmentation()
         self._bindSegmentsTable()
+        self._bindEmbeddedEditor()
+        self._observeCanonicalSegmentation()
         self._refreshBackendStatus()
         self._updateRunButton()
 
@@ -464,20 +502,174 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             # Drop the stale reference; the observers go with cleanup().
             self._segmentsTable = None
 
+    def _buildEmbeddedEditor(self):
+        """Build the embedded Segment Editor section (ADR-0034 §Amendments 4).
+
+        A STOCK ``qMRMLSegmentEditorWidget`` inside a ``ctkCollapsibleButton``
+        directly under the table/toolbar, COLLAPSED by default (the table is
+        the primary surface; Edit is the opt-in gesture) — the MONAILabel /
+        SegmentationReview idiom replacing the jump-to-module path.  The
+        editor drives its OWN non-singleton ``vtkMRMLSegmentEditorNode`` so
+        embedded edits never clobber the stock Segment Editor module's
+        singleton state.  Its inputs are PINNED contracts, not user choices:
+        the node-selector rows and the switch-to-Segmentations button are
+        hidden; ``_bindEmbeddedEditor`` supplies the canonical node + the
+        Stage-1 PortalVenous volume.  Effects are the curated AI-mask-
+        correction set (``EMBEDDED_EDITOR_EFFECTS``), everything else hidden.
+        """
+        import qSlicerSegmentationsModuleWidgetsPythonQt
+
+        section = ctk.ctkCollapsibleButton()
+        section.text = "Edit selected segment"
+        section.setObjectName("EmbeddedEditorSection")
+        section.collapsed = True
+        column = qt.QVBoxLayout(section)
+
+        editor = qSlicerSegmentationsModuleWidgetsPythonQt.qMRMLSegmentEditorWidget()
+        editor.setObjectName("EmbeddedSegmentEditor")
+        editor.setMaximumNumberOfUndoStates(10)
+        editor.setEffectNameOrder(list(EMBEDDED_EDITOR_EFFECTS))
+        editor.unorderedEffectsVisible = False
+        editor.setSegmentationNodeSelectorVisible(False)
+        editor.setSourceVolumeNodeSelectorVisible(False)
+        editor.setSwitchToSegmentationsButtonVisible(False)
+        # Parameter node BEFORE the scene, so the automatic selections made
+        # when the scene lands are stored on OUR node (the stock module's
+        # setup order).
+        editor.setMRMLSegmentEditorNode(self._ensureEditorParameterNode())
+        editor.setMRMLScene(slicer.mrmlScene)
+        column.addWidget(editor)
+
+        self._embeddedEditor = editor
+        self._editorSection = section
+        return section
+
+    def embeddedEditor(self):  # noqa: N802 - Slicer/Qt verb convention
+        return getattr(self, "_embeddedEditor", None)
+
+    def embeddedEditorSection(self):  # noqa: N802 - Slicer/Qt verb convention
+        return getattr(self, "_editorSection", None)
+
+    def _ensureEditorParameterNode(self):
+        """Get-or-mint the embedded editor's OWN parameter node.
+
+        A plain (non-singleton) ``vtkMRMLSegmentEditorNode`` — deliberately
+        NOT the stock Segment Editor module's ``SegmentEditor`` singleton, so
+        the embedded editor's segmentation/volume/effect state stays private
+        (ADR-0034 §Amendments item 4).  Re-minted lazily when a scene close
+        reclaimed the previous one (the Edit gesture re-ensures it).
+        """
+        node = self._editorNode
+        if node is not None and node.GetScene() is not None:
+            return node
+        node = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLSegmentEditorNode", "LiverSegmentationEditor"
+        )
+        self._editorNode = node
+        return node
+
+    def _bindEmbeddedEditor(self):
+        """(Re-)pin the embedded editor's inputs from the scene state.
+
+        Pure READ path (the ``_bindSegmentsTable`` discipline): the
+        segmentation input is the canonical node when one exists (else
+        unbound), the source volume is the Stage-1 PortalVenous working
+        volume (``logic.selectInputVolume``) — re-resolved on every scene
+        change like the table bind, never minting anything.
+        """
+        editor = getattr(self, "_embeddedEditor", None)
+        if editor is None or self.logic is None:
+            return
+        try:
+            canonical = self.logic._findCanonicalSegmentation()
+            if editor.segmentationNode() is not canonical:
+                editor.setSegmentationNode(canonical)
+            source = self.logic.selectInputVolume()
+            if editor.sourceVolumeNode() is not source:
+                editor.setSourceVolumeNode(source)
+        except ValueError:
+            # PythonQt raises when the Qt widget was destroyed with a host
+            # parent tree while this Python widget is still alive (the
+            # _bindSegmentsTable case); drop the stale references.
+            self._embeddedEditor = None
+            self._editorSection = None
+
+    def _observeCanonicalSegmentation(self):
+        """(Re-)observe the canonical node's segmentation for content edits.
+
+        The demote-on-edit hook (ADR-0034 §Decision 2 staleness rule, as
+        amended) rides ``vtkSegmentation::SourceRepresentationModified`` —
+        the CONTENT-change event every Segment Editor effect apply funnels
+        through (``vtkSegmentationModifier`` invokes it with the segment id
+        as call data), covering the embedded editor AND stock-module edits.
+        Observing at segmentation level (not the editor) keeps the rule a
+        property of the canonical node's data, not of one editing surface.
+        Swapped, never stacked, when the canonical node changes.
+        """
+        node = (
+            self.logic._findCanonicalSegmentation() if self.logic is not None else None
+        )
+        segmentation = node.GetSegmentation() if node is not None else None
+        if segmentation is self._observedSegmentation:
+            return
+        if self._observedSegmentation is not None:
+            self.removeObserver(
+                self._observedSegmentation,
+                slicer.vtkSegmentation.SourceRepresentationModified,
+                self._onSegmentContentModified,
+            )
+        self._observedSegmentation = segmentation
+        if segmentation is not None:
+            self.addObserver(
+                segmentation,
+                slicer.vtkSegmentation.SourceRepresentationModified,
+                self._onSegmentContentModified,
+            )
+
+    def _onSegmentContentModified(self, caller, event, segmentId=None):
+        """Demote an edited ``Completed`` segment to ``InProgress``.
+
+        ADR-0034 §Decision 2 (as amended): an edited confirm is stale and
+        re-enters review.  ``SourceRepresentationModified`` arrives with the
+        modified segment's id as call data on the editor-apply funnel; other
+        emitters pass no usable id (a raw representation-object Modified
+        forwards null) — those are ignored rather than guessed at, so
+        nothing is ever demoted on attribution-free events.  Status-tag
+        writes (``SetSegmentStatus`` — including this demotion itself) fire
+        only ``SegmentModified``, never this event, so the hook cannot
+        recurse.
+        """
+        if not segmentId:
+            return
+        segment = caller.GetSegment(segmentId) if caller is not None else None
+        if segment is None:
+            return
+        segmentsLogic = slicer.vtkSlicerSegmentationsModuleLogic
+        if segmentsLogic.GetSegmentStatus(segment) != segmentsLogic.Completed:
+            return
+        segmentsLogic.SetSegmentStatus(segment, segmentsLogic.InProgress)
+
+    # VTK call-data plumbing for the observer above: vtkPythonCommand reads
+    # the callback's ``CallDataType`` attribute; ``"string0"`` is its
+    # null-terminated-string form (what ``vtk.calldata_type(vtk.VTK_STRING)``
+    # would declare).  Set as a plain attribute so module IMPORT stays pure —
+    # the import-purity probes stub ``vtk`` without the decorator helper.
+    _onSegmentContentModified.CallDataType = "string0"
+
     def _buildSelectionToolbar(self):
         """Build the selection-scoped toolbar + the per-job progress list.
 
         ADR-0034 §Amendments: gestures act on the SELECTED table rows, not
         on per-row button walls.  Run enqueues every selected structure
         (structures sharing a backend task coalesce into one child;
-        multi-select covers the run-everything gesture); Edit jumps to the
-        Segment Editor on the first selected row (interim until the
-        embedded-editor increment).  Absence is attested through the
-        table's own status gesture (empty row set ``Completed``), so no
-        dedicated button.  Under the buttons, one progress row PER
-        queued/running job — the job's text embedded IN its bar, a per-job
-        cancel (✕) beside it — plus one shared status label for
-        queue/backend lines.
+        multi-select covers the run-everything gesture); Edit expands the
+        embedded Segment Editor section and syncs the first selected row
+        into it (§Amendments item 4 — the jump-to-module path is retired).
+        Absence is attested through the table's own status gesture (empty
+        row set ``Completed``), so no dedicated button.  Under the buttons,
+        one progress row PER queued/running job — the job's text embedded
+        IN its bar, a per-job cancel (✕) beside it — plus one shared status
+        label for queue/backend lines.
         """
         box = qt.QWidget()
         column = qt.QVBoxLayout(box)
@@ -485,7 +677,7 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
 
         row = qt.QHBoxLayout()
         self._runButton = qt.QPushButton(self._RUN_LABEL_BASE)
-        self._editButton = qt.QPushButton("Edit in Segment Editor")
+        self._editButton = qt.QPushButton("Edit")
         row.addWidget(self._runButton)
         row.addWidget(self._editButton)
         row.addStretch(1)
@@ -500,7 +692,7 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         column.addWidget(self._statusLabel)
 
         self._runButton.connect("clicked()", self.onRunSelectedStructures)
-        self._editButton.connect("clicked()", self.onEditInSegmentEditor)
+        self._editButton.connect("clicked()", self.onEditSelectedSegment)
         return box
 
     #: Run-button label vocabulary (re-labelled live with the selection).
@@ -531,15 +723,42 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         return selections
 
     def _onTableSelectionChanged(self, *_args):
-        """Schedule a Run-button re-resolve AFTER the gesture settles.
+        """Schedule a selection re-resolve AFTER the gesture settles.
 
         The reporting signal (``clicked`` / ``currentChanged``) fires
         mid-gesture, before the selection model reflects a ctrl-click
         deselect; a zero-interval single-shot re-reads the REAL selection
-        once the event cascade completes, so the label never lags a
-        gesture behind.
+        once the event cascade completes, so neither the Run label nor the
+        embedded editor's current segment lags a gesture behind.
         """
-        qt.QTimer.singleShot(0, self._updateRunButton)
+        qt.QTimer.singleShot(0, self._onSelectionSettled)
+
+    def _onSelectionSettled(self):
+        """Fan the settled selection out to its consumers."""
+        self._updateRunButton()
+        self._syncEditorToSelection()
+
+    def _syncEditorToSelection(self):
+        """Set the embedded editor's current segment from the table selection.
+
+        The FIRST selected row becomes the editor's current segment
+        (ADR-0034 §Amendments item 4).  A no-op when nothing is selected
+        (the editor keeps its segment) or while the editor is unbound.
+        """
+        editor = getattr(self, "_embeddedEditor", None)
+        view = getattr(self, "_segmentsTable", None)
+        if editor is None or view is None:
+            return
+        try:
+            if editor.segmentationNode() is None:
+                return
+            selected = list(view.selectedSegmentIDs())
+            if selected:
+                editor.setCurrentSegmentID(selected[0])
+        except ValueError:
+            # The deferred re-resolve can outlive the Qt widgets (PythonQt
+            # raises on a deleted C++ object); nothing left to sync.
+            pass
 
     def _updateRunButton(self):
         """Re-label the Run button from the REAL current selection."""
@@ -925,25 +1144,32 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         except AttributeError:
             logging.debug("3D re-frame skipped: no layout manager (headless).")
 
-    def onEditInSegmentEditor(self):
-        """Open the stock Segment Editor on the canonical node.
+    def onEditSelectedSegment(self):
+        """Expand the embedded editor and sync the selected row into it.
 
-        Interim jump-to-module until the embedded ``qMRMLSegmentEditorWidget``
-        increment lands (ADR-0034 §Amendments).  With a table selection, the
-        FIRST selected row becomes the editor's current segment.  Kumar-Oram
-        effect pre-activation is out of scope here (ADR-0026 / future).
+        The toolbar's Edit gesture (ADR-0034 §Amendments item 4): re-ensure
+        the editor's parameter node + pinned inputs (a scene close may have
+        reclaimed them), open the collapsible section, and make the FIRST
+        selected row the editor's current segment.  Replaces the retired
+        jump-to-module path.  Effect pre-activation is out of scope here
+        (ADR-0026 / future).
         """
-        canonical = self.logic.getOrCreateCanonicalSegmentation()
-        view = getattr(self, "_segmentsTable", None)
-        selected = list(view.selectedSegmentIDs()) if view is not None else []
-        slicer.util.selectModule("SegmentEditor")
+        editor = getattr(self, "_embeddedEditor", None)
+        if editor is None:
+            return
+        self.logic.getOrCreateCanonicalSegmentation()
         try:
-            editorWidget = slicer.modules.segmenteditor.widgetRepresentation().self()
-            editorWidget.editor.setSegmentationNode(canonical)
-            if selected:
-                editorWidget.editor.setCurrentSegmentID(selected[0])
-        except Exception as exc:  # noqa: BLE001 — defensive across Slicer versions
-            logging.debug("Could not pre-select canonical node in editor: %s", exc)
+            editor.setMRMLSegmentEditorNode(self._ensureEditorParameterNode())
+        except ValueError:
+            self._embeddedEditor = None
+            self._editorSection = None
+            return
+        self._bindEmbeddedEditor()
+        self._observeCanonicalSegmentation()
+        section = getattr(self, "_editorSection", None)
+        if section is not None:
+            section.collapsed = False
+        self._syncEditorToSelection()
 
     def _buildBackendStatusRow(self):
         """Build the Stage-2-local backend-status + Pre-download row.
@@ -1036,8 +1262,11 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             return
         self.logic.importSegmentationAsCanonical(node, assignments)
         # The import promotes an EXISTING node (no NodeAdded/Removed event
-        # reaches _onSceneChanged), so re-bind the table explicitly.
+        # reaches _onSceneChanged), so re-bind the canonical consumers
+        # (table, embedded editor, demote-on-edit observer) explicitly.
         self._bindSegmentsTable()
+        self._bindEmbeddedEditor()
+        self._observeCanonicalSegmentation()
         # Same re-centre as the toolbar Run's landing: the imported anatomy's
         # surface model lands outside the default camera framing.
         self._reframeThreeDViews()
@@ -1064,12 +1293,37 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
 
     def _onSceneChanged(self, caller=None, event=None):
         self._bindSegmentsTable()
+        self._bindEmbeddedEditor()
+        self._observeCanonicalSegmentation()
 
     def cleanup(self):
         # No child process outlives the module: cancel the running job and
         # drop every pending one (ADR-0034 §Decision 5 teardown contract).
         if self._jobQueue is not None:
             self._jobQueue.shutdown()
+        # Embedded-editor teardown discipline: detach every MRML reference
+        # the editor holds BEFORE the Qt tree is disposed, and reclaim its
+        # private parameter node — a widget still holding scene nodes at
+        # shutdown is the launched-harness teardown-crash family.
+        editor = getattr(self, "_embeddedEditor", None)
+        if editor is not None:
+            try:
+                editor.setActiveEffect(None)
+                editor.removeViewObservations()
+                editor.setSegmentationNode(None)
+                editor.setSourceVolumeNode(None)
+                editor.setMRMLSegmentEditorNode(None)
+                editor.setMRMLScene(None)
+            except ValueError:
+                # The C++ widget already went down with a host parent tree.
+                pass
+        self._embeddedEditor = None
+        self._editorSection = None
+        editorNode = getattr(self, "_editorNode", None)
+        if editorNode is not None and editorNode.GetScene() is not None:
+            slicer.mrmlScene.RemoveNode(editorNode)
+        self._editorNode = None
+        self._observedSegmentation = None
         self.removeObservers()
 
 

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -533,6 +533,21 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         editor.setSegmentationNodeSelectorVisible(False)
         editor.setSourceVolumeNodeSelectorVisible(False)
         editor.setSwitchToSegmentationsButtonVisible(False)
+        # Row lifecycle belongs to the ANATOMY segments table above; the
+        # editor's own add/remove buttons would bypass the pre-seeded
+        # checklist contract (ADR-0034 §Amendments).
+        editor.setAddRemoveSegmentButtonsVisible(False)
+        # The editor embeds its OWN qMRMLSegmentsTableView -- redundant
+        # beside the anatomy table that already drives the selection
+        # (maintainer live-test finding).  No Q_PROPERTY exposes it, so
+        # hide the named child frame (the .ui wraps the view in
+        # SegmentsTableResizableFrame; falling back to the view itself
+        # keeps this resilient to upstream .ui reshuffles).
+        for childName in ("SegmentsTableResizableFrame", "SegmentsTableView"):
+            child = editor.findChild(qt.QWidget, childName)
+            if child is not None:
+                child.setVisible(False)
+                break
         # Parameter node BEFORE the scene, so the automatic selections made
         # when the scene lands are stored on OUR node (the stock module's
         # setup order).

--- a/LiverSegmentation/Testing/Python/CMakeLists.txt
+++ b/LiverSegmentation/Testing/Python/CMakeLists.txt
@@ -162,6 +162,16 @@ set(_liverseg_pytest_files
   # NO Segment-anatomy macro, multi-select Run subsumes it, ADR-0034
   # §Amendments).  Launched `pytest_launched` row; skips cleanly bare.
   test_liversegmentation_job_queue.py
+  # ADR-0034 §Amendments item 4 -- the embedded Segment Editor increment:
+  # a stock qMRMLSegmentEditorWidget in a collapsed ctkCollapsibleButton
+  # under the table (own non-singleton editor node, curated effects,
+  # selectors hidden, canonical + PortalVenous pinned); row-selection /
+  # Edit-button sync (the jump-to-module path is deleted); and the
+  # demote-on-edit staleness rule (content edit to a Completed segment ->
+  # InProgress via vtkSegmentation::SourceRepresentationModified; status-
+  # tag writes and the pre-seed/landing paths never spuriously demote).
+  # Widget-needing (launched `pytest_launched` row); skips cleanly bare.
+  test_liversegmentation_embedded_editor.py
   # Packaging parity for the LiverSegmentationLib sub-package: every source
   # .py appears in LiverSegmentationLib_PYTHON_SCRIPTS (and no stale
   # entries), or an omitted file silently vanishes from a fresh build and

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_embedded_editor.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_embedded_editor.py
@@ -1,0 +1,472 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0034 §Amendments item 4 — the embedded Segment Editor increment.
+
+Edit is an embedded ``qMRMLSegmentEditorWidget`` in a collapsible section
+directly under the anatomy segments table (the MONAILabel /
+SegmentationReview idiom), replacing the jump-to-module Edit button:
+
+  * The editor lives inside a ``ctkCollapsibleButton``, collapsed by
+    default, placed between the segments table and the import section.
+  * It drives its OWN non-singleton ``vtkMRMLSegmentEditorNode`` — never
+    the stock Segment Editor module's singleton — with a curated effect
+    list (the AI-mask-correction set) and the node-selector rows hidden:
+    the canonical node and the Stage-1 PortalVenous volume are pinned
+    inputs, not user choices.
+  * Selecting a table row syncs the editor's current segment; the
+    toolbar's Edit button expands the section and syncs the selection
+    (the module jump is deleted).
+  * Demote-on-edit (ADR-0034 §Decision 2 staleness, as amended): a
+    CONTENT modification to a ``Completed`` segment hosted on the
+    canonical node demotes it to ``InProgress`` — the hook rides
+    ``vtkSegmentation::SourceRepresentationModified`` (segment id as call
+    data on the editor-apply funnel), so stock-module edits are covered
+    too.  Writing the status TAG itself must never demote or recurse,
+    and the pre-seed / landing paths must not spuriously demote rows
+    they do not land.
+
+Needs the launched-Slicer harness (module + Qt + MRML); skips cleanly
+under bare pytest via the shared guards.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+MODULE_NAME = "liversegmentation"
+
+#: The curated AI-mask-correction effect set (ADR-0034 §Amendments item 4).
+CURATED_EFFECTS = ["Paint", "Erase", "Scissors", "Islands", "Smoothing"]
+
+
+def _slicer_or_skip():
+    from conftest import _import_slicer_or_skip, _require_mrml_scene
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _module_or_skip():
+    try:
+        import LiverSegmentation  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(f"LiverSegmentation not importable ({exc}).")
+    return LiverSegmentation
+
+
+def _widget_or_skip(slicer, registry):
+    from conftest import _require_qt_widget
+
+    _require_qt_widget()
+    if getattr(slicer.modules, MODULE_NAME, None) is None:
+        pytest.skip(
+            f"'{MODULE_NAME}' module not registered -- ADR-0024 surgeon-UI "
+            "deliverable absent."
+        )
+    module = _module_or_skip()
+    widget = module.LiverSegmentationWidget()
+    widget.setup()
+    registry.append(widget)
+    return widget
+
+
+def _segments_logic(slicer):
+    """The native per-segment status surface (enum + static accessors)."""
+    return slicer.vtkSlicerSegmentationsModuleLogic
+
+
+def _add_input_volume(slicer):
+    """A Stage-1 PortalVenous working volume (the editor's pinned source)."""
+    import numpy as np
+
+    volume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode")
+    slicer.util.updateVolumeFromArray(volume, np.zeros((8, 8, 8), dtype="int16"))
+    volume.SetAttribute("LiverRole", "PortalVenous")
+    return volume
+
+
+def _sct_segment_id(module, canonical, code):
+    """The single segment id on ``canonical`` terminology-tagged ``code``."""
+    import vtk
+
+    segmentation = canonical.GetSegmentation()
+    ids = []
+    for segment_id in list(segmentation.GetSegmentIDs()):
+        text = vtk.mutable("")
+        segmentation.GetSegment(segment_id).GetTag(
+            module.TERMINOLOGY_ENTRY_TAG, text
+        )
+        if f"^{code}^" in str(text):
+            ids.append(segment_id)
+    assert len(ids) == 1, f"expected exactly one segment tagged ^{code}^; got {ids!r}."
+    return ids[0]
+
+
+def _modify_segment_content(slicer, canonical, segment_id, dim=4):
+    """Write voxel CONTENT into a canonical segment via the editor funnel.
+
+    ``vtkSlicerSegmentationsModuleLogic.SetBinaryLabelmapToSegment`` is the
+    same ``vtkSegmentationModifier.ModifyBinaryLabelmap`` path every Segment
+    Editor effect apply routes through, and it fires
+    ``vtkSegmentation::SourceRepresentationModified`` with the segment id as
+    call data — exactly the event the demote-on-edit hook observes.
+    """
+    import vtk
+
+    labelmap = slicer.vtkOrientedImageData()
+    labelmap.SetDimensions(dim, dim, dim)
+    labelmap.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, 1)
+    labelmap.GetPointData().GetScalars().Fill(1)
+    assert slicer.vtkSlicerSegmentationsModuleLogic.SetBinaryLabelmapToSegment(
+        labelmap, canonical, segment_id
+    ), "the content write through the editor funnel must succeed."
+
+
+def _canonical_of(widget):
+    canonical = widget.segmentsTable().segmentationNode()
+    assert canonical is not None, "setup must have bound the canonical node."
+    return canonical
+
+
+# --------------------------------------------------------------------------- #
+# The embedded editor: shape, configuration, pinned inputs.
+# --------------------------------------------------------------------------- #
+
+
+def test_embedded_editor_exists_collapsed_and_configured(qt_widgets):
+    """The panel hosts a stock ``qMRMLSegmentEditorWidget`` inside a
+    collapsed ``ctkCollapsibleButton`` under the table (above the import
+    section), selectors hidden, curated effect list pinned, bound to the
+    canonical node + the Stage-1 PortalVenous source volume (ADR-0034
+    §Amendments item 4)."""
+    slicer = _slicer_or_skip()
+    _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    volume = _add_input_volume(slicer)
+    widget = _widget_or_skip(slicer, qt_widgets)
+
+    editor = widget.embeddedEditor()
+    assert editor is not None, (
+        "the Stage-2 panel must host the embedded Segment Editor "
+        "(ADR-0034 §Amendments item 4)."
+    )
+    assert editor.className() == "qMRMLSegmentEditorWidget", (
+        "Edit must be the STOCK qMRMLSegmentEditorWidget -- no bespoke "
+        "editor surface."
+    )
+
+    section = widget.embeddedEditorSection()
+    assert section is not None and section.className() == "ctkCollapsibleButton", (
+        "the editor must sit inside a ctkCollapsibleButton section."
+    )
+    assert section.collapsed, (
+        "the editor section must be COLLAPSED by default -- the table is "
+        "the primary surface; Edit is the opt-in gesture."
+    )
+    assert editor in section.findChildren("qMRMLSegmentEditorWidget"), (
+        "the editor widget must live INSIDE the collapsible section."
+    )
+
+    # Placement: directly under the table (with its toolbar), ABOVE the
+    # import section.
+    layout = widget.layout
+    load_section = slicer.util.findChild(widget.parent, "LoadSegmentationSection")
+    assert (
+        layout.indexOf(widget.segmentsTable())
+        < layout.indexOf(section)
+        < layout.indexOf(load_section)
+    ), (
+        "the editor section must sit under the segments table and above "
+        "the import section (ADR-0034 §Amendments item 4)."
+    )
+
+    # Pinned inputs: the node-selector rows are hidden -- the canonical
+    # node and the Stage-1 volume are contracts, not user choices.
+    assert not editor.segmentationNodeSelectorVisible, (
+        "the segmentation-node selector row must be hidden."
+    )
+    assert not editor.sourceVolumeNodeSelectorVisible, (
+        "the source-volume selector row must be hidden."
+    )
+    assert not editor.switchToSegmentationsButtonVisible, (
+        "the switch-to-Segmentations module button must be hidden -- the "
+        "jump-out path is retired."
+    )
+
+    # Curated effects: the AI-mask-correction set, nothing else.
+    assert list(editor.effectNameOrder()) == CURATED_EFFECTS, (
+        "the effect list must be the curated AI-mask-correction set; got "
+        f"{list(editor.effectNameOrder())!r}."
+    )
+    assert not editor.unorderedEffectsVisible, (
+        "effects outside the curated order must be hidden "
+        "(unorderedEffectsVisible False)."
+    )
+
+    # Bound inputs: the canonical node + the Stage-1 PortalVenous volume.
+    canonical = _canonical_of(widget)
+    bound = editor.segmentationNode()
+    assert bound is not None and bound.GetID() == canonical.GetID(), (
+        "the editor must be pinned to the canonical segmentation node."
+    )
+    source = editor.sourceVolumeNode()
+    assert source is not None and source.GetID() == volume.GetID(), (
+        "the editor's source volume must be the Stage-1 PortalVenous "
+        "volume (logic.selectInputVolume), like the table bind."
+    )
+
+
+def test_embedded_editor_node_is_not_the_stock_singleton(qt_widgets):
+    """The embedded editor drives its OWN non-singleton
+    ``vtkMRMLSegmentEditorNode`` -- never the stock Segment Editor
+    module's singleton, so embedded edits cannot clobber (or be
+    clobbered by) the stock module's state."""
+    slicer = _slicer_or_skip()
+    _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    editor_node = widget.embeddedEditor().mrmlSegmentEditorNode()
+    assert editor_node is not None, (
+        "the embedded editor must have its parameter node set on setup."
+    )
+    assert not editor_node.GetSingletonTag(), (
+        "the embedded editor's parameter node must be NON-singleton."
+    )
+
+    # Mint the stock module's singleton exactly the way SegmentEditor.py
+    # does and pin that the two are DIFFERENT nodes.
+    stock = slicer.mrmlScene.GetSingletonNode(
+        "SegmentEditor", "vtkMRMLSegmentEditorNode"
+    )
+    if stock is None:
+        stock = slicer.mrmlScene.CreateNodeByClass("vtkMRMLSegmentEditorNode")
+        stock.UnRegister(None)
+        stock.SetSingletonTag("SegmentEditor")
+        stock = slicer.mrmlScene.AddNode(stock)
+    assert stock.GetID() != editor_node.GetID(), (
+        "the embedded editor must NOT share the stock Segment Editor "
+        "module's singleton parameter node."
+    )
+    # Singleton nodes survive the fixture's scene Clear -- reclaim the
+    # minted stock node explicitly so the scene returns to baseline.
+    slicer.mrmlScene.RemoveNode(stock)
+
+
+# --------------------------------------------------------------------------- #
+# Selection sync + the rewired Edit button.
+# --------------------------------------------------------------------------- #
+
+
+def test_row_selection_syncs_editor_current_segment(qt_widgets):
+    """Selecting a table row sets the editor's current segment through the
+    existing deferred selection re-resolve (the same settle path the Run
+    re-label rides)."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    _add_input_volume(slicer)
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = _canonical_of(widget)
+    editor = widget.embeddedEditor()
+
+    liver_id = _sct_segment_id(module, canonical, module.SCT_LIVER_CODE)
+    widget.segmentsTable().setSelectedSegmentIDs([liver_id])
+    widget._onTableSelectionChanged()
+    slicer.app.processEvents()
+    assert editor.currentSegmentID() == liver_id, (
+        "selecting a table row must sync the editor's current segment."
+    )
+
+    portal_id = _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE)
+    widget.segmentsTable().setSelectedSegmentIDs([portal_id])
+    widget._onTableSelectionChanged()
+    slicer.app.processEvents()
+    assert editor.currentSegmentID() == portal_id, (
+        "a new row selection must re-sync the editor's current segment."
+    )
+
+
+def test_edit_button_expands_the_section_and_syncs_the_selection(qt_widgets):
+    """The toolbar's Edit button expands the collapsible and syncs the
+    FIRST selected row into the editor; the jump-to-module path is
+    deleted (ADR-0034 §Amendments item 4: the embedded editor replaces
+    the jump-to-module ✎ buttons)."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    _add_input_volume(slicer)
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = _canonical_of(widget)
+
+    assert widget._editButton.text == "Edit", (
+        "the toolbar button reads plain 'Edit' -- it no longer jumps to "
+        f"the Segment Editor module; got {widget._editButton.text!r}."
+    )
+    assert not hasattr(widget, "onEditInSegmentEditor"), (
+        "the module-jump handler must be deleted -- the embedded editor "
+        "REPLACES the jump-to-module path (ADR-0034 §Amendments item 4)."
+    )
+
+    section = widget.embeddedEditorSection()
+    assert section.collapsed, "precondition: the section starts collapsed."
+
+    portal_id = _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE)
+    widget.segmentsTable().setSelectedSegmentIDs([portal_id])
+    widget.onEditSelectedSegment()
+
+    assert not section.collapsed, (
+        "the Edit gesture must EXPAND the embedded-editor section."
+    )
+    assert widget.embeddedEditor().currentSegmentID() == portal_id, (
+        "the Edit gesture must sync the selected row into the editor."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Demote-on-edit (ADR-0034 §Decision 2 staleness rule, as amended).
+# --------------------------------------------------------------------------- #
+
+
+def test_content_edit_demotes_completed_segment_to_inprogress(qt_widgets):
+    """(a) A CONTENT modification to a ``Completed`` segment hosted on the
+    canonical node demotes it to ``InProgress`` -- an edited confirm is
+    stale and must re-enter review.  The hook is segmentation-level
+    (``SourceRepresentationModified``), so any editor-funnel write
+    (embedded OR stock module) is covered."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = _canonical_of(widget)
+    segments_logic = _segments_logic(slicer)
+
+    liver_id = _sct_segment_id(module, canonical, module.SCT_LIVER_CODE)
+    liver = canonical.GetSegmentation().GetSegment(liver_id)
+
+    # Land content (segment not yet confirmed -- the hook must not touch
+    # a non-Completed row on this write), then confirm.
+    _modify_segment_content(slicer, canonical, liver_id, dim=4)
+    assert (
+        segments_logic.GetSegmentStatus(liver) != segments_logic.Completed
+    ), "precondition: landing content must not read Completed."
+    segments_logic.SetSegmentStatus(liver, segments_logic.Completed)
+
+    # The edit: a second content write while Completed -> InProgress.
+    _modify_segment_content(slicer, canonical, liver_id, dim=6)
+    assert (
+        segments_logic.GetSegmentStatus(liver) == segments_logic.InProgress
+    ), (
+        "editing a Completed segment must demote it to InProgress "
+        "(ADR-0034 §Decision 2 staleness rule, as amended)."
+    )
+
+    # A further edit while already InProgress stays InProgress.
+    _modify_segment_content(slicer, canonical, liver_id, dim=8)
+    assert (
+        segments_logic.GetSegmentStatus(liver) == segments_logic.InProgress
+    ), "an edit to an InProgress segment must leave it InProgress."
+
+
+def test_status_tag_writes_do_not_demote_or_recurse(qt_widgets):
+    """(b) Writing the STATUS TAG itself (the surgeon's confirm gesture,
+    the demote itself) must neither demote nor recurse: the hook keys on
+    the CONTENT event (``SourceRepresentationModified``), which tag
+    writes never fire -- ``SetSegmentStatus`` only raises
+    ``SegmentModified``."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = _canonical_of(widget)
+    segments_logic = _segments_logic(slicer)
+
+    liver_id = _sct_segment_id(module, canonical, module.SCT_LIVER_CODE)
+    liver = canonical.GetSegmentation().GetSegment(liver_id)
+    _modify_segment_content(slicer, canonical, liver_id)
+    segments_logic.SetSegmentStatus(liver, segments_logic.Completed)
+
+    # Re-assert Completed (an idempotent tag write) -- must stay Completed.
+    segments_logic.SetSegmentStatus(liver, segments_logic.Completed)
+    assert (
+        segments_logic.GetSegmentStatus(liver) == segments_logic.Completed
+    ), "re-writing Completed must not demote (no loop on the status tag)."
+
+    # A status round-trip through Flagged -- every write must LAND as
+    # written; a demoting/recursing hook would corrupt the cycle.
+    segments_logic.SetSegmentStatus(liver, segments_logic.Flagged)
+    assert segments_logic.GetSegmentStatus(liver) == segments_logic.Flagged
+    segments_logic.SetSegmentStatus(liver, segments_logic.Completed)
+    assert (
+        segments_logic.GetSegmentStatus(liver) == segments_logic.Completed
+    ), "the status-cell cycle must land as written -- never demoted."
+
+    # Other segment-tag writes (provenance, terminology) are metadata,
+    # not content: no demote.
+    liver.SetTag(module.SOURCE_TAG, module.SOURCE_TOTALSEG)
+    assert (
+        segments_logic.GetSegmentStatus(liver) == segments_logic.Completed
+    ), "a segment-tag write must never demote a Completed segment."
+
+
+def test_preseed_and_landing_do_not_spuriously_demote(qt_widgets):
+    """(c) The pre-seed and landing paths must not spuriously demote rows
+    they do not land: re-running the checklist pre-seed keeps a
+    Completed confirm; landing a DIFFERENT structure's scratch keeps it
+    too (the same-code staleness demote is ``_landSegment``'s own,
+    already pinned in the segments-table suite)."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = _canonical_of(widget)
+    segments_logic = _segments_logic(slicer)
+    logic = widget.logic
+
+    liver_id = _sct_segment_id(module, canonical, module.SCT_LIVER_CODE)
+    liver = canonical.GetSegmentation().GetSegment(liver_id)
+    _modify_segment_content(slicer, canonical, liver_id)
+    segments_logic.SetSegmentStatus(liver, segments_logic.Completed)
+
+    # The pre-seed path (getOrCreate re-entry / scene self-heal).
+    logic.getOrCreateCanonicalSegmentation()
+    assert (
+        segments_logic.GetSegmentStatus(liver) == segments_logic.Completed
+    ), "re-running the checklist pre-seed must not demote a confirm."
+
+    # The landing path, for a DIFFERENT structure.
+    scratch = logic.createScratchSegmentation()
+    seg_id = scratch.GetSegmentation().AddEmptySegment("portal", "Portal vein")
+    logic.tagSegmentWithSct(
+        scratch, seg_id, module.SCT_PORTAL_VEIN_CODE, "Portal vein"
+    )
+    _modify_segment_content(slicer, scratch, seg_id)
+    logic.accept(scratch)
+
+    assert (
+        segments_logic.GetSegmentStatus(liver) == segments_logic.Completed
+    ), "landing another structure must not demote an unrelated confirm."
+    portal_id = _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE)
+    portal = canonical.GetSegmentation().GetSegment(portal_id)
+    assert (
+        segments_logic.GetSegmentStatus(portal) == segments_logic.InProgress
+    ), "the landed structure itself reads InProgress (produced, under review)."
+    # The untouched placeholders stay NotStarted -- nothing was demoted or
+    # spuriously started by the landing cascade.
+    for code in (module.SCT_HEPATIC_VEIN_CODE, module.SCT_MASS_CODE):
+        other_id = _sct_segment_id(module, canonical, code)
+        other = canonical.GetSegmentation().GetSegment(other_id)
+        assert (
+            segments_logic.GetSegmentStatus(other) == segments_logic.NotStarted
+        ), "rows the landing did not touch must stay NotStarted."
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_embedded_editor.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_embedded_editor.py
@@ -194,6 +194,29 @@ def test_embedded_editor_exists_collapsed_and_configured(qt_widgets):
         "the switch-to-Segmentations module button must be hidden -- the "
         "jump-out path is retired."
     )
+    assert not editor.addRemoveSegmentButtonsVisible, (
+        "the editor's add/remove segment buttons must be hidden -- row "
+        "lifecycle belongs to the anatomy table's pre-seeded checklist."
+    )
+    # The editor's OWN embedded segments table is redundant beside the
+    # anatomy table that drives the selection (maintainer live-test
+    # finding): the named child (frame, or the view as fallback) is
+    # hidden.
+    import qt
+
+    inner = None
+    for child_name in ("SegmentsTableResizableFrame", "SegmentsTableView"):
+        inner = editor.findChild(qt.QWidget, child_name)
+        if inner is not None:
+            break
+    assert inner is not None, (
+        "the stock editor no longer exposes its internal segments "
+        "table under a known child name -- update the hide fallback."
+    )
+    assert not inner.isVisibleTo(editor), (
+        "the editor's internal segments table must be hidden -- the "
+        "anatomy segments table above already fills that role."
+    )
 
     # Curated effects: the AI-mask-correction set, nothing else.
     assert list(editor.effectNameOrder()) == CURATED_EFFECTS, (

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_segments_table.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_segments_table.py
@@ -95,7 +95,13 @@ def _sct_segment_ids(module, canonical, code):
 
 
 def _fill_segment(slicer, segment):
-    """Give ``segment`` a tiny non-empty binary labelmap (a "landed" row)."""
+    """Give ``segment`` a tiny non-empty binary labelmap (a "landed" row).
+
+    Voxels carry the segment's OWN label value: emptiness is label-aware
+    (pre-seeded rows share one labelmap layer, so a foreign label value
+    would not count as this segment's content — the shape a real editor
+    write produces).
+    """
     import vtk
 
     name = (
@@ -104,7 +110,7 @@ def _fill_segment(slicer, segment):
     image = slicer.vtkOrientedImageData()
     image.SetDimensions(2, 2, 2)
     image.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, 1)
-    image.GetPointData().GetScalars().Fill(1)
+    image.GetPointData().GetScalars().Fill(segment.GetLabelValue())
     segment.AddRepresentation(name, image)
 
 


### PR DESCRIPTION
Implements the **embedded-Segment-Editor increment of #574** (ADR-0034 §Amendments item 4): Edit stops being a module jump.

## What

- A stock `qMRMLSegmentEditorWidget` in a collapsed section directly under the segments table — the MONAILabel/SegmentationReview idiom. Pinned to the canonical node + the Stage-1 PortalVenous source (node selectors hidden), its **own non-singleton** `vtkMRMLSegmentEditorNode`, and the curated AI-mask-correction effect set (Paint / Erase / Scissors / Islands / Smoothing). Full teardown discipline on cleanup.
- **Row-selection sync**: selecting a table row selects that segment in the editor; the toolbar **Edit** button expands the section and syncs (the jump-to-module handler is deleted).
- **Demote-on-edit** (the §Decision 2 staleness rule): a `Completed` segment demotes to `In progress` on content change. The hook is `vtkSegmentation::SourceRepresentationModified` — the content funnel every effect apply routes through (`SegmentModified` is documented metadata-only) — with string calldata carrying the segment id; segmentation-level, so edits made in the stock Segment Editor module are covered too. Recursion is structurally impossible (the status write fires only `SegmentModified`, never the observed event) and pinned.
- **Latent bug fixed en route**: placeholder emptiness keyed on the shared labelmap layer's *extent*, so any editor write made every pre-seeded placeholder read non-empty, silently breaking placeholder replacement at landing. Emptiness is now label-aware (no voxel carries the segment's own label value) — caught red by the new demote pins.

## Tests

New `test_liversegmentation_embedded_editor.py` (7 pins, red→green): configuration (collapsed, selectors hidden, curated effects, canonical+source binding), editor-node non-singleton isolation, row-sync + Edit gesture, demote-on-edit, status-write-never-recurses, pre-seed/landing never spuriously demote. Registered per-file; bare row skips cleanly.

## Verification

Full launched sweep, canonical four-root order: **494 passed / 16 skipped / 0 failed**, no crashes, no leak banner. ruff clean.

Remaining #574 increments after this: import-section unification, tool registry + Run ▾ split-button, validate-and-next explain API.

---
*Drafted by an AI assistant (Claude Fable 5); reviewed and submitted on behalf of the maintainer.*
