### PR TITLE
ENH: Validate-and-next seam for Stage 2 (#574 increment)

### DIFF
--- a/Docs/adr/0034-stage2-segments-table.md
+++ b/Docs/adr/0034-stage2-segments-table.md
@@ -370,9 +370,12 @@ Qt.  See References.
   re-run covers its uses, so there is no Discard behaviour to pin.)
 - [test] Completion predicate: all rows Confirmed/Marked-absent ⇒
   complete; any other status ⇒ incomplete.
-- [future] The explain API naming the offending rows — a later
-  increment alongside the shell's "Validate and next" wiring
-  (Decision 6).
+- [test] The explain API naming the offending rows
+  (`explainStageIncomplete()` → the unsatisfied structures with title +
+  status text), derived through the same `structureStatus` the completion
+  predicate reads so the two cannot drift (`isStageComplete()` iff the
+  explanation is empty).  The shell's "Validate and next" wiring that
+  consumes it stays [future] (Decision 6).
 - [test] Re-run/edit of a confirmed row demotes it to `● Review`.
 - [future] The registry covers every seeded structure; each entry
   names wrapper, labels, modality, and preferred input role — arrives

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -1464,7 +1464,7 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         if label is None:
             return
         if not offenders:
-            label.setText(
+            text = (
                 f"Anatomy complete — all {len(STRUCTURE_TABS)} structures "
                 "confirmed."
             )
@@ -1473,7 +1473,14 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
                 f"{title} ({statusText})"
                 for _code, title, statusText in offenders
             )
-            label.setText(f"Unresolved: {summary}")
+            text = f"Unresolved: {summary}"
+        try:
+            label.setText(text)
+        except (ValueError, RuntimeError):
+            # The status label went down with a host parent tree while the
+            # mark observers were still live (the teardown-ordering window);
+            # drop the stale reference rather than swarm setText errors.
+            self._statusLabel = None
 
     def clearUnresolvedMarks(self):
         """Drop the validation row-tints (ADR-0034 §Decision 6).
@@ -1881,6 +1888,10 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             slicer.mrmlScene.RemoveNode(editorNode)
         self._editorNode = None
         self._observedSegmentation = None
+        # Gate the validation-mark refresh OFF before dropping observers, so
+        # any event still in flight during teardown is a no-op instead of a
+        # write into a disposed status label / view.
+        self._marksActive = False
         # Drop the tint-delegate references (parented to the inner view, so
         # the Qt tree owns their lifetime — this only releases the Python
         # handles that outlive it).

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -125,6 +125,16 @@ STATUS_CONFIRMED = ("✓", "Confirmed")
 STATUS_FLAGGED = ("⚑", "Flagged")
 STATUS_MARKED_ABSENT = ("∅", "Marked absent")
 
+#: Validation-tint palette (ADR-0034 §Decision 6; ADR-0010 reinforcement).
+#: Light, desaturated row backgrounds so the status GLYPH stays legible over
+#: them and dark cell text keeps its contrast — the tint REINFORCES the
+#: glyph+text status column, it never carries the meaning on hue alone.  The
+#: green/red pair is the conventional validated/unresolved reading; because
+#: the status column already reproduces the state as glyph+text, the hue is
+#: pure reinforcement (a red-green-blind reader loses nothing).
+TINT_VALIDATED = "#e6f4ea"  # accessible light green (validated rows)
+TINT_UNRESOLVED = "#fce8e6"  # accessible light red (not-validated rows)
+
 #: Curated effect list for the embedded Segment Editor — the AI-mask-
 #: correction set (ADR-0034 §Amendments item 4).  Everything outside this
 #: order is hidden (``unorderedEffectsVisible`` off): the embedded editor
@@ -349,6 +359,37 @@ def structureStatus(canonicalNode, sctCode):
     return STATUS_MARKED_ABSENT if markedAbsent else STATUS_MISSING
 
 
+def _makeRowTintDelegate(baseDelegateClass, tintForRow):
+    """Build a row-background tint delegate SUBCLASSING an existing one.
+
+    ADR-0034 §Decision 6 (tint mechanism).  The stock
+    ``qMRMLSegmentsTableView`` installs functional per-column item delegates
+    (``qSlicerTerminologyItemDelegate`` on the name column, ``qMRMLItemDelegate``
+    on opacity), and its status/visibility icons are painted by the default
+    delegate via the decoration role.  Whole-view ``setItemDelegate`` would
+    clobber those; the status-cell click-to-cycle review gesture MUST survive.
+    So the tint is injected by SUBCLASSING whatever delegate already sits on a
+    column and overriding ONLY ``initStyleOption`` to set
+    ``option.backgroundBrush`` — every inherited behaviour (terminology
+    editing, opacity spinbox, status icon, click-to-cycle) is untouched
+    because none of those delegates override ``paint``, so the base
+    ``QStyledItemDelegate::paint`` still honours the background brush.
+
+    ``tintForRow(row) -> QColor | None`` is the widget-held state the delegate
+    consults per paint (NOT model data — so nothing fights the model's
+    per-update item regeneration).  ``None`` leaves the cell neutral.
+    """
+
+    class _RowTintDelegate(baseDelegateClass):
+        def initStyleOption(self, option, index):  # noqa: N802 - Qt override
+            baseDelegateClass.initStyleOption(self, option, index)
+            colour = tintForRow(index.row())
+            if colour is not None:
+                option.backgroundBrush = qt.QBrush(colour)
+
+    return _RowTintDelegate
+
+
 class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """Stage-2 surgeon panel — the anatomy segments table + selection toolbar.
 
@@ -403,11 +444,16 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         self._editorNode = None
         self._observedSegmentation = None
         # Validate-and-next seam (ADR-0034 §Decision 6): whether the
-        # unresolved-row marks are currently up, plus a digest of the last
-        # marked offender set so the live re-evaluation only touches the view
-        # on an ACTUAL change (no per-event selection storm).
+        # validation row-tints are currently up, plus the per-segment tint
+        # state the tint delegate consults (segmentId -> "validated" |
+        # "unresolved").  Empty + inactive == neutral (no tint), so the tint
+        # delegate is a no-op outside an active validation and a normal edit
+        # never colours a row.  A digest of the last painted state gates the
+        # live re-evaluation so it only repaints on an ACTUAL change.
         self._marksActive = False
-        self._markedOffendersDigest = None
+        self._rowTintState = {}
+        self._markedTintDigest = None
+        self._tintDelegates = []
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)
 
@@ -505,7 +551,66 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         except Exception as exc:  # noqa: BLE001 — defensive across versions
             logging.debug("segments-table selection signal unavailable: %s", exc)
         self._segmentsTable = view
+        self._installRowTintDelegates(view)
         return view
+
+    #: Columns the tint delegate paints — the stock model's fixed layout.  The
+    #: tint SUBCLASSES each column's existing delegate (name = terminology,
+    #: opacity = qMRMLItemDelegate) so no functional delegate is clobbered and
+    #: the status-cell click-to-cycle keeps working (ADR-0034 §Decision 6).
+    _TINT_COLUMNS = (0, 1, 2, 3, 5)  # visibility, colour, opacity, name, status
+
+    def _installRowTintDelegates(self, view):
+        """Install the per-column row-tint delegates on the inner table view.
+
+        One tint delegate per visible column, each SUBCLASSING that column's
+        current delegate (or ``QStyledItemDelegate`` where none is set) so the
+        whole row tints together while every column keeps its own behaviour.
+        The delegates read :meth:`_rowTintColour`, a widget-held state, per
+        paint — so the model's per-update item regeneration never erases the
+        tint.  Delegates are parented to the inner view and retained on ``self``
+        for their connections' lifetime (the PythonQt discipline).
+        """
+        try:
+            inner = view.tableWidget()
+        except Exception as exc:  # noqa: BLE001 — defensive across versions
+            logging.debug("segments-table inner view unavailable: %s", exc)
+            return
+        self._tintDelegates = []
+        for column in self._TINT_COLUMNS:
+            existing = inner.itemDelegateForColumn(column)
+            baseClass = type(existing) if existing is not None else qt.QStyledItemDelegate
+            delegateClass = _makeRowTintDelegate(baseClass, self._rowTintColour)
+            delegate = delegateClass(inner)
+            inner.setItemDelegateForColumn(column, delegate)
+            self._tintDelegates.append(delegate)
+
+    def _rowTintColour(self, row):
+        """The ``QColor`` (or None) the tint delegate paints for ``row``.
+
+        Maps the table row to its segment id and looks the id up in the
+        widget-held :attr:`_rowTintState`; returns the palette green for a
+        "validated" row, the palette red for an "unresolved" row, and None
+        (neutral) otherwise — so a row with no validation state, and every row
+        while no validation is active, stays untinted.
+        """
+        view = getattr(self, "_segmentsTable", None)
+        if view is None:
+            return None
+        try:
+            segmentId = view.segmentIDForRow(row)
+        except (ValueError, RuntimeError):
+            return None
+        return self._rowTintColourForSegment(segmentId)
+
+    def _rowTintColourForSegment(self, segmentId):
+        """The palette ``QColor`` for a segment id's tint state, or None."""
+        state = self._rowValidationTint(segmentId)
+        if state == "validated":
+            return qt.QColor(TINT_VALIDATED)
+        if state == "unresolved":
+            return qt.QColor(TINT_UNRESOLVED)
+        return None
 
     def segmentsTable(self):  # noqa: N802 - Slicer/Qt verb convention
         return getattr(self, "_segmentsTable", None)
@@ -1281,122 +1386,153 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
     # drive, plus a Stage-2-LOCAL "Validate anatomy" affordance so the stage
     # can be checked in isolation.
     #
-    # Marking mechanism: the stock qMRMLSegmentsTableView exposes no
-    # Python-writable per-row background/decoration role that survives the
-    # qMRMLSegmentsModel's per-update item regeneration, and the name/colour
-    # data must not be repurposed — so an unresolved row is marked by
-    # SELECTING it (setSelectedSegmentIDs) and listing it (glyph+text) on the
-    # shared status label, never colour alone (ADR-0010).
+    # Marking mechanism: the stock qMRMLSegmentsTableView installs functional
+    # per-column item delegates (terminology on the name column, an item
+    # delegate on opacity) and paints the status/visibility icons through the
+    # default delegate's decoration role.  So Validate tints each row by
+    # SUBCLASSING every column's delegate and setting option.backgroundBrush
+    # from a widget-held per-segment state (_installRowTintDelegates /
+    # _rowValidationTint) — no delegate is clobbered (status-cell click-to-
+    # cycle keeps working) and nothing fights the model's item regeneration.
+    # The tint is REINFORCEMENT: the status column's glyph+text stays the
+    # primary carrier and a shared status-label summary line accompanies it,
+    # never colour alone (ADR-0010).
     #
 
-    def _unresolvedOffenderIds(self):
-        """The canonical segment ids of the structures Validate would flag.
+    def _rowValidationTint(self, segmentId):
+        """The tint state a delegate consults for ``segmentId``.
 
-        The SAME derivation the logic's explain API uses (both route through
-        ``structureStatus``): every structure-vocabulary code the explain API
-        reports, resolved to its canonical segment id.  Missing structures
-        with no segment yet contribute nothing to SELECT (there is no row to
-        mark); they still count as unresolved in the summary text.
+        ``"validated"`` (native ``Completed``, incl. the empty-``Completed``
+        absence attestation), ``"unresolved"`` (Missing / Review / Flagged),
+        or ``None`` — neutral, meaning no tint.  Reads the widget-held
+        :attr:`_rowTintState`, which is empty while no validation is active, so
+        this is ``None`` for every row outside an active validation (a normal
+        edit never tints a row).
+        """
+        if not self._marksActive:
+            return None
+        return self._rowTintState.get(segmentId)
+
+    def _computeRowTintState(self):
+        """The per-segment ``{id: "validated"|"unresolved"}`` for every row.
+
+        The SAME derivation the explain API / completion predicate use (both
+        route through :func:`structureStatus` via
+        :meth:`explainStageIncomplete`): a structure whose SCT code is in the
+        unresolved explanation is ``"unresolved"``; every other pre-seeded
+        structure row is ``"validated"``.  A missing canonical node yields an
+        empty map (there are no rows to tint).
         """
         canonical = (
             self.logic._findCanonicalSegmentation() if self.logic else None
         )
         if canonical is None:
-            return []
-        ids = []
-        for sctCode, _title, _statusText in self.logic.explainStageIncomplete():
+            return {}
+        unresolvedCodes = {
+            code for code, _title, _status in self.logic.explainStageIncomplete()
+        }
+        state = {}
+        for _title, sctCode in STRUCTURE_TABS:
             segmentId = _findSctSegmentId(canonical, sctCode)
-            if segmentId is not None:
-                ids.append(segmentId)
-        return ids
+            if segmentId is None:
+                continue
+            state[segmentId] = (
+                "unresolved" if sctCode in unresolvedCodes else "validated"
+            )
+        return state
 
-    def markUnresolvedRows(self):
-        """Mark the unresolved anatomy rows (ADR-0034 §Decision 6).
+    def markValidationRows(self):
+        """Tint every anatomy row by its validation state (ADR-0034 §Decision 6).
 
-        Selects exactly the offending rows in the stock view and puts a
-        glyph+text summary line on the shared status label listing them.  A
-        no-op-clean when the stage is complete (clears any prior marks).
-        Idempotent: re-marking the same offender set does not re-churn the
-        selection (the digest discipline the widget already uses).
+        Paints all rows — green for validated (native ``Completed``, incl. the
+        empty-``Completed`` absence attestation), red for not-validated
+        (Missing / Review / Flagged) — and puts a glyph+text summary line on
+        the shared status label listing the unresolved structures.  A complete
+        anatomy tints every row green and reports completeness.  Idempotent:
+        re-marking an unchanged state does not repaint the view (the digest
+        discipline the widget already uses).
         """
-        offenders = self.logic.explainStageIncomplete() if self.logic else []
-        if not offenders:
-            self.clearUnresolvedMarks()
-            return
-        ids = self._unresolvedOffenderIds()
-        digest = tuple(ids)
         self._marksActive = True
-        if digest != self._markedOffendersDigest:
-            self._markedOffendersDigest = digest
-            view = getattr(self, "_segmentsTable", None)
-            if view is not None:
-                try:
-                    view.setSelectedSegmentIDs(ids)
-                except ValueError:
-                    # The Qt view went down with a host parent tree while the
-                    # observers are still alive (the _bindSegmentsTable case).
-                    self._segmentsTable = None
-        summary = ", ".join(
-            f"{title} ({statusText})" for _code, title, statusText in offenders
-        )
+        state = self._computeRowTintState()
+        digest = tuple(sorted(state.items()))
+        if digest != self._markedTintDigest:
+            self._markedTintDigest = digest
+            self._rowTintState = state
+            self._repaintTintedRows()
+        offenders = self.logic.explainStageIncomplete() if self.logic else []
         label = getattr(self, "_statusLabel", None)
-        if label is not None:
+        if label is None:
+            return
+        if not offenders:
+            label.setText(
+                f"Anatomy complete — all {len(STRUCTURE_TABS)} structures "
+                "confirmed."
+            )
+        else:
+            summary = ", ".join(
+                f"{title} ({statusText})"
+                for _code, title, statusText in offenders
+            )
             label.setText(f"Unresolved: {summary}")
 
     def clearUnresolvedMarks(self):
-        """Drop the unresolved-row marks (ADR-0034 §Decision 6).
+        """Drop the validation row-tints (ADR-0034 §Decision 6).
 
-        Clears the view selection and forgets the marked-offender digest.  A
-        no-op when no marks are up (the digest discipline: never churn the
-        view or the label on a change that leaves the marks already clear).
+        Returns every row to neutral (no tint) and forgets the painted state.
+        A no-op when no tints are up (the digest discipline: never repaint on a
+        change that leaves the rows already neutral).
         """
         if not self._marksActive:
             return
         self._marksActive = False
-        self._markedOffendersDigest = None
+        self._markedTintDigest = None
+        self._rowTintState = {}
+        self._repaintTintedRows()
+
+    def _repaintTintedRows(self):
+        """Ask the inner table view to repaint (the tint delegates re-read state).
+
+        The tint delegates paint from :attr:`_rowTintState`, not model data, so
+        a model update never triggers a repaint on its own; nudge the view's
+        viewport after the state changes.  Best-effort — a torn-down view
+        (host parent disposed while observers live) just drops the reference.
+        """
         view = getattr(self, "_segmentsTable", None)
-        if view is not None:
-            try:
-                view.setSelectedSegmentIDs([])
-            except ValueError:
-                self._segmentsTable = None
+        if view is None:
+            return
+        try:
+            view.tableWidget().viewport().update()
+        except (ValueError, RuntimeError, AttributeError):
+            self._segmentsTable = None
 
     def _refreshUnresolvedMarks(self):
-        """Live-re-evaluate the marks after a row resolves (ADR-0034 §Decision 6).
+        """Live-re-evaluate the tints after a row resolves (ADR-0034 §Decision 6).
 
         Ridden by the canonical-segmentation observation / ``_onSceneChanged``
-        (the same surfaces the table bind uses): while the marks are up, a
-        status flip to ``Completed`` (or a landing) that resolves a row drops
-        ITS mark and re-summarises the remainder; the last resolution clears
-        every mark.  A no-op while no marks are up — so a normal edit outside
-        a validation never touches the selection.
+        (the same surfaces the table bind uses): while the tints are up, a
+        status flip to ``Completed`` (or a landing) that resolves a row flips
+        ITS tint red -> green and re-summarises the remainder.  A no-op while
+        no tints are up — so a normal edit outside a validation never tints a
+        row.
         """
         if not self._marksActive:
             return
-        self.markUnresolvedRows()
+        self.markValidationRows()
 
     def onValidateAnatomy(self):
         """The Stage-2-local "Validate anatomy" gesture (ADR-0034 §Decision 6).
 
-        Complete: clear any marks and report completeness ("Anatomy complete
-        — all N structures confirmed.").  Incomplete: mark the offending rows
-        (:meth:`markUnresolvedRows`) and list them on the status label.  The
+        Tints every row by its validation state (green validated / red
+        not-validated) and puts a glyph+text summary line on the status label —
+        a complete anatomy tints all rows green and reports completeness.  The
         SHELL-level "Validate and next" button and its Next wiring are OUT of
         scope here — they stay with the phase-contracts work (#440); this
-        module only exposes the explain API + the marking that button drives.
+        module only exposes the explain API + the row tinting that button
+        drives.
         """
         if self.logic is None:
             return
-        if self.logic.isStageComplete():
-            self.clearUnresolvedMarks()
-            label = getattr(self, "_statusLabel", None)
-            if label is not None:
-                label.setText(
-                    f"Anatomy complete — all {len(STRUCTURE_TABS)} structures "
-                    "confirmed."
-                )
-            return
-        self.markUnresolvedRows()
+        self.markValidationRows()
 
     def _buildBackendStatusRow(self):
         """Build the Stage-2-local backend-status + Pre-download row.
@@ -1745,6 +1881,10 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             slicer.mrmlScene.RemoveNode(editorNode)
         self._editorNode = None
         self._observedSegmentation = None
+        # Drop the tint-delegate references (parented to the inner view, so
+        # the Qt tree owns their lifetime — this only releases the Python
+        # handles that outlive it).
+        self._tintDelegates = []
         self.removeObservers()
 
 

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -402,6 +402,12 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         self._editorSection = None
         self._editorNode = None
         self._observedSegmentation = None
+        # Validate-and-next seam (ADR-0034 §Decision 6): whether the
+        # unresolved-row marks are currently up, plus a digest of the last
+        # marked offender set so the live re-evaluation only touches the view
+        # on an ACTUAL change (no per-event selection storm).
+        self._marksActive = False
+        self._markedOffendersDigest = None
         ScriptedLoadableModuleWidget.__init__(self, parent)
         VTKObservationMixin.__init__(self)
 
@@ -661,12 +667,28 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
                 slicer.vtkSegmentation.SourceRepresentationModified,
                 self._onSegmentContentModified,
             )
+        if self._observedSegmentation is not None:
+            self.removeObserver(
+                self._observedSegmentation,
+                slicer.vtkSegmentation.SegmentModified,
+                self._onSegmentStatusMaybeChanged,
+            )
         self._observedSegmentation = segmentation
         if segmentation is not None:
             self.addObserver(
                 segmentation,
                 slicer.vtkSegmentation.SourceRepresentationModified,
                 self._onSegmentContentModified,
+            )
+            # The demote-on-edit hook above rides the CONTENT-change event;
+            # the validate-seam live-clear (ADR-0034 §Decision 6) needs the
+            # STATUS-change surface too, which a SetSegmentStatus write fires
+            # (SegmentModified, never SourceRepresentationModified).  Guarded
+            # by _marksActive so it is a no-op outside a validation.
+            self.addObserver(
+                segmentation,
+                slicer.vtkSegmentation.SegmentModified,
+                self._onSegmentStatusMaybeChanged,
             )
 
     def _onSegmentContentModified(self, caller, event, segmentId=None):
@@ -699,6 +721,20 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
     # the import-purity probes stub ``vtk`` without the decorator helper.
     _onSegmentContentModified.CallDataType = "string0"
 
+    def _onSegmentStatusMaybeChanged(self, caller=None, event=None, segmentId=None):
+        """Re-evaluate the validate-seam marks after a segment changes.
+
+        ADR-0034 §Decision 6 live-clear: a status flip to ``Completed`` (or a
+        landing) that resolves a row must drop its mark WITHOUT re-clicking
+        Validate.  ``SegmentModified`` fires on every ``SetSegmentStatus``
+        write; ``_refreshUnresolvedMarks`` is a no-op unless the marks are up
+        AND the offender set actually changed (the digest discipline), so
+        this rides the existing observation without a per-event storm.
+        """
+        self._refreshUnresolvedMarks()
+
+    _onSegmentStatusMaybeChanged.CallDataType = "string0"
+
     def _buildSelectionToolbar(self):
         """Build the selection-scoped toolbar + the per-job progress list.
 
@@ -730,9 +766,20 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             "Import a loaded segmentation's segments into the anatomy "
             "table (they land under review)."
         )
+        # The Stage-2-LOCAL validate affordance (ADR-0034 §Decision 6): the
+        # shell-level "Validate and next" button stays with the
+        # phase-contracts work (#440); this gives Stage 2 its own gesture to
+        # check completeness and mark the offending rows.
+        self._validateButton = qt.QPushButton("Validate anatomy")
+        self._validateButton.setObjectName("ValidateAnatomyButton")
+        self._validateButton.setToolTip(
+            "Check every anatomy structure is confirmed or attested absent; "
+            "the unresolved rows are selected and listed."
+        )
         row.addWidget(self._runButton)
         row.addWidget(self._editButton)
         row.addWidget(self._importButton)
+        row.addWidget(self._validateButton)
         row.addStretch(1)
         column.addLayout(row)
 
@@ -747,6 +794,7 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         self._runButton.connect("clicked()", self.onRunSelectedStructures)
         self._editButton.connect("clicked()", self.onEditSelectedSegment)
         self._importButton.connect("clicked()", self.onImportSegmentation)
+        self._validateButton.connect("clicked()", self.onValidateAnatomy)
         return box
 
     #: Run-button label vocabulary (re-labelled live with the selection).
@@ -1225,6 +1273,131 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             section.collapsed = False
         self._syncEditorToSelection()
 
+    #
+    # Validate-and-next seam (ADR-0034 §Decision 6).  The shell owns the
+    # actual "Validate and next" stage-footer button and its Next wiring —
+    # that stays with the phase-contracts work (#440); this module exposes
+    # the explain API (on the logic) and the row marking that button will
+    # drive, plus a Stage-2-LOCAL "Validate anatomy" affordance so the stage
+    # can be checked in isolation.
+    #
+    # Marking mechanism: the stock qMRMLSegmentsTableView exposes no
+    # Python-writable per-row background/decoration role that survives the
+    # qMRMLSegmentsModel's per-update item regeneration, and the name/colour
+    # data must not be repurposed — so an unresolved row is marked by
+    # SELECTING it (setSelectedSegmentIDs) and listing it (glyph+text) on the
+    # shared status label, never colour alone (ADR-0010).
+    #
+
+    def _unresolvedOffenderIds(self):
+        """The canonical segment ids of the structures Validate would flag.
+
+        The SAME derivation the logic's explain API uses (both route through
+        ``structureStatus``): every structure-vocabulary code the explain API
+        reports, resolved to its canonical segment id.  Missing structures
+        with no segment yet contribute nothing to SELECT (there is no row to
+        mark); they still count as unresolved in the summary text.
+        """
+        canonical = (
+            self.logic._findCanonicalSegmentation() if self.logic else None
+        )
+        if canonical is None:
+            return []
+        ids = []
+        for sctCode, _title, _statusText in self.logic.explainStageIncomplete():
+            segmentId = _findSctSegmentId(canonical, sctCode)
+            if segmentId is not None:
+                ids.append(segmentId)
+        return ids
+
+    def markUnresolvedRows(self):
+        """Mark the unresolved anatomy rows (ADR-0034 §Decision 6).
+
+        Selects exactly the offending rows in the stock view and puts a
+        glyph+text summary line on the shared status label listing them.  A
+        no-op-clean when the stage is complete (clears any prior marks).
+        Idempotent: re-marking the same offender set does not re-churn the
+        selection (the digest discipline the widget already uses).
+        """
+        offenders = self.logic.explainStageIncomplete() if self.logic else []
+        if not offenders:
+            self.clearUnresolvedMarks()
+            return
+        ids = self._unresolvedOffenderIds()
+        digest = tuple(ids)
+        self._marksActive = True
+        if digest != self._markedOffendersDigest:
+            self._markedOffendersDigest = digest
+            view = getattr(self, "_segmentsTable", None)
+            if view is not None:
+                try:
+                    view.setSelectedSegmentIDs(ids)
+                except ValueError:
+                    # The Qt view went down with a host parent tree while the
+                    # observers are still alive (the _bindSegmentsTable case).
+                    self._segmentsTable = None
+        summary = ", ".join(
+            f"{title} ({statusText})" for _code, title, statusText in offenders
+        )
+        label = getattr(self, "_statusLabel", None)
+        if label is not None:
+            label.setText(f"Unresolved: {summary}")
+
+    def clearUnresolvedMarks(self):
+        """Drop the unresolved-row marks (ADR-0034 §Decision 6).
+
+        Clears the view selection and forgets the marked-offender digest.  A
+        no-op when no marks are up (the digest discipline: never churn the
+        view or the label on a change that leaves the marks already clear).
+        """
+        if not self._marksActive:
+            return
+        self._marksActive = False
+        self._markedOffendersDigest = None
+        view = getattr(self, "_segmentsTable", None)
+        if view is not None:
+            try:
+                view.setSelectedSegmentIDs([])
+            except ValueError:
+                self._segmentsTable = None
+
+    def _refreshUnresolvedMarks(self):
+        """Live-re-evaluate the marks after a row resolves (ADR-0034 §Decision 6).
+
+        Ridden by the canonical-segmentation observation / ``_onSceneChanged``
+        (the same surfaces the table bind uses): while the marks are up, a
+        status flip to ``Completed`` (or a landing) that resolves a row drops
+        ITS mark and re-summarises the remainder; the last resolution clears
+        every mark.  A no-op while no marks are up — so a normal edit outside
+        a validation never touches the selection.
+        """
+        if not self._marksActive:
+            return
+        self.markUnresolvedRows()
+
+    def onValidateAnatomy(self):
+        """The Stage-2-local "Validate anatomy" gesture (ADR-0034 §Decision 6).
+
+        Complete: clear any marks and report completeness ("Anatomy complete
+        — all N structures confirmed.").  Incomplete: mark the offending rows
+        (:meth:`markUnresolvedRows`) and list them on the status label.  The
+        SHELL-level "Validate and next" button and its Next wiring are OUT of
+        scope here — they stay with the phase-contracts work (#440); this
+        module only exposes the explain API + the marking that button drives.
+        """
+        if self.logic is None:
+            return
+        if self.logic.isStageComplete():
+            self.clearUnresolvedMarks()
+            label = getattr(self, "_statusLabel", None)
+            if label is not None:
+                label.setText(
+                    f"Anatomy complete — all {len(STRUCTURE_TABS)} structures "
+                    "confirmed."
+                )
+            return
+        self.markUnresolvedRows()
+
     def _buildBackendStatusRow(self):
         """Build the Stage-2-local backend-status + Pre-download row.
 
@@ -1539,6 +1712,10 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         self._bindSegmentsTable()
         self._bindEmbeddedEditor()
         self._observeCanonicalSegmentation()
+        # A landing that grows/replaces the canonical node can resolve a
+        # marked row (ADR-0034 §Decision 6 live-clear); no-op unless marks
+        # are up (the digest discipline).
+        self._refreshUnresolvedMarks()
 
     def cleanup(self):
         # No child process outlives the module: cancel the running job and
@@ -1588,6 +1765,14 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
     # semantics"; LiverVolumetryLogic.isStageComplete() precedent).
     #
 
+    #: The row statuses that SATISFY the completion predicate — the surgeon's
+    #: data-carrying confirm (``STATUS_CONFIRMED``) and the empty-``Completed``
+    #: absence attestation (``STATUS_MARKED_ABSENT``); both are native
+    #: ``Completed``.  Every other status (Missing / Review / Flagged) leaves
+    #: the row unresolved.  The single source both the predicate and the
+    #: explain API read, so they cannot drift (ADR-0034 §Decision 6).
+    _SATISFIED_STATUSES = (STATUS_CONFIRMED, STATUS_MARKED_ABSENT)
+
     def isStageComplete(self) -> bool:
         """Return True iff Stage 2 is done: every expected structure Completed.
 
@@ -1598,18 +1783,36 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
         attestation and counts — absence is stated through the same status
         gesture, never inferred from a forgotten row.  Scratch nodes never
         flip the predicate true (canonical-only read).
+
+        Routed through :meth:`explainStageIncomplete` so the predicate and
+        the explanation are ONE derivation and cannot drift (ADR-0034
+        §Decision 6): the stage is complete iff nothing is unresolved.
+        """
+        return not self.explainStageIncomplete()
+
+    def explainStageIncomplete(self):
+        """The unresolved structures as ``[(sctCode, title, statusText), ...]``.
+
+        ADR-0034 §Decision 6: the explain API the shell's "Validate and
+        next" seam needs (the button itself stays with the phase-contracts
+        work, #440).  Every structure-vocabulary entry whose derived
+        :func:`structureStatus` is NOT one of ``_SATISFIED_STATUSES``
+        (native ``Completed`` — a data-carrying confirm or the empty-
+        ``Completed`` absence attestation) is listed, in vocabulary order,
+        with its glyph-vocabulary status TEXT.  An EMPTY list means the
+        stage is complete — and :meth:`isStageComplete` is exactly this
+        emptiness, so the predicate and the explanation share one source of
+        truth (``structureStatus``) and cannot drift.  A missing canonical
+        node reports every structure Missing.
         """
         canonical = self._findCanonicalSegmentation()
-        if canonical is None:
-            return False
-        segmentsLogic = slicer.vtkSlicerSegmentationsModuleLogic
-        for _title, sctCode in STRUCTURE_TABS:
-            segment = _findSctSegment(canonical, sctCode)
-            if segment is None:
-                return False
-            if segmentsLogic.GetSegmentStatus(segment) != segmentsLogic.Completed:
-                return False
-        return True
+        unresolved = []
+        for title, sctCode in STRUCTURE_TABS:
+            status = structureStatus(canonical, sctCode)
+            if status in self._SATISFIED_STATUSES:
+                continue
+            unresolved.append((sctCode, title, status[1]))
+        return unresolved
 
     def isStructureAccepted(self, sctCode) -> bool:
         """Return True iff the CANONICAL node holds a LANDED ``sctCode`` segment.

--- a/LiverSegmentation/Testing/Python/CMakeLists.txt
+++ b/LiverSegmentation/Testing/Python/CMakeLists.txt
@@ -184,14 +184,16 @@ set(_liverseg_pytest_files
   # naming the unsatisfied structures (title + status text), derived
   # through the SAME structureStatus the completion predicate reads so they
   # cannot drift (isStageComplete() iff the explanation is empty); the
-  # widget's markUnresolvedRows()/clearUnresolvedMarks() marking mechanism
-  # (SELECT the offenders + a glyph+text summary line, never colour alone,
-  # ADR-0010 -- the stock model exposes no safe per-row background role);
-  # the local "Validate anatomy" affordance; and the LIVE clear (a status
-  # flip to Completed / a landing drops the row's mark without re-clicking
-  # Validate, riding the existing canonical-segmentation observation with
-  # the digest discipline).  Widget-needing (launched `pytest_launched`
-  # row); skips cleanly bare.
+  # widget's markValidationRows()/clearUnresolvedMarks() tint mechanism
+  # (each row tinted green validated / red not-validated + a glyph+text
+  # summary line, the tint reinforcing, never colour alone, ADR-0010 -- a
+  # per-column delegate SUBCLASSING each column's own delegate so the
+  # status-cell click-to-cycle survives, reading a widget-held tint state);
+  # the local "Validate anatomy" affordance; and the LIVE update (a status
+  # flip to Completed / a landing flips the row's tint to green without
+  # re-clicking Validate, riding the existing canonical-segmentation
+  # observation with the digest discipline).  Widget-needing (launched
+  # `pytest_launched` row); skips cleanly bare.
   test_liversegmentation_validate_seam.py
   # Packaging parity for the LiverSegmentationLib sub-package: every source
   # .py appears in LiverSegmentationLib_PYTHON_SCRIPTS (and no stale

--- a/LiverSegmentation/Testing/Python/CMakeLists.txt
+++ b/LiverSegmentation/Testing/Python/CMakeLists.txt
@@ -178,6 +178,21 @@ set(_liverseg_pytest_files
   # tag writes and the pre-seed/landing paths never spuriously demote).
   # Widget-needing (launched `pytest_launched` row); skips cleanly bare.
   test_liversegmentation_embedded_editor.py
+  # ADR-0034 §Decision 6 -- the validate-and-next SEAM (the shell's
+  # "Validate and next" button itself stays with the phase-contracts work
+  # #440; this ships what it needs): the logic's explainStageIncomplete()
+  # naming the unsatisfied structures (title + status text), derived
+  # through the SAME structureStatus the completion predicate reads so they
+  # cannot drift (isStageComplete() iff the explanation is empty); the
+  # widget's markUnresolvedRows()/clearUnresolvedMarks() marking mechanism
+  # (SELECT the offenders + a glyph+text summary line, never colour alone,
+  # ADR-0010 -- the stock model exposes no safe per-row background role);
+  # the local "Validate anatomy" affordance; and the LIVE clear (a status
+  # flip to Completed / a landing drops the row's mark without re-clicking
+  # Validate, riding the existing canonical-segmentation observation with
+  # the digest discipline).  Widget-needing (launched `pytest_launched`
+  # row); skips cleanly bare.
+  test_liversegmentation_validate_seam.py
   # Packaging parity for the LiverSegmentationLib sub-package: every source
   # .py appears in LiverSegmentationLib_PYTHON_SCRIPTS (and no stale
   # entries), or an omitted file silently vanishes from a fresh build and

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_validate_seam.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_validate_seam.py
@@ -14,18 +14,25 @@ Stage-2-local "Validate anatomy" affordance:
     complete.  The predicate and the explanation are the SAME derivation
     (both route through ``structureStatus``), pinned equivalent here:
     ``isStageComplete()`` iff ``explainStageIncomplete() == []``.
-  * ``LiverSegmentationWidget.markUnresolvedRows()`` /
-    ``clearUnresolvedMarks()`` mark/unmark the offending rows.  Mechanism:
-    the stock ``qMRMLSegmentsTableView`` offers no Python-writable
-    background/decoration role that survives the model's per-update item
-    regeneration (and the name/colour data must not be abused, per the
-    brief), so marking is realised as SELECTING the offending rows
-    (``setSelectedSegmentIDs``) plus a glyph+text summary line on the shared
-    status label ("Unresolved: Portal vein (Missing), Tumors (Review)"),
-    never colour alone (ADR-0010).
-  * The marks CLEAR LIVE: resolving a row (native status flip to
-    ``Completed``, or a landing) re-evaluates and unmarks, riding the
-    existing canonical-segmentation observation / ``_onSceneChanged``.
+  * ``LiverSegmentationWidget.markValidationRows()`` /
+    ``clearUnresolvedMarks()`` tint/untint every anatomy row by its
+    validation state.  Mechanism: the stock ``qMRMLSegmentsTableView``
+    installs functional per-column item delegates (terminology on the name
+    column, an item delegate on opacity) and paints the status/visibility
+    icons through the default delegate's decoration role, so a whole-view
+    delegate would clobber them; instead each column's delegate is
+    SUBCLASSED to set ``option.backgroundBrush`` from a widget-held
+    per-segment tint state (``_rowValidationTint``), leaving the status-cell
+    click-to-cycle review gesture intact.  Green for validated (native
+    ``Completed``, incl. the empty-``Completed`` absence attestation), red
+    for not-validated (Missing / Review / Flagged), plus a glyph+text summary
+    line on the shared status label — the tint REINFORCES the status column,
+    never colour alone (ADR-0010).  Delegate paint is not unit-testable
+    headless, so these tests pin the STATE the delegate consults
+    (``_rowValidationTint``), not pixels.
+  * The tints UPDATE LIVE: resolving a row (native status flip to
+    ``Completed``, or a landing) re-evaluates and flips its tint red -> green,
+    riding the existing canonical-segmentation observation / ``_onSceneChanged``.
 
 Needs the launched-Slicer harness (module + Qt + MRML); skips cleanly under
 bare pytest via the shared guards.
@@ -230,11 +237,17 @@ def test_isstagecomplete_is_exactly_the_empty_explanation():
 # --------------------------------------------------------------------------- #
 
 
-def test_validate_on_incomplete_marks_offenders_and_summarises(qt_widgets):
-    """The local Validate gesture on an incomplete stage marks the offending
-    rows (SELECTED in the stock view) and puts a glyph+text summary line
-    listing them on the shared status label (ADR-0034 §Decision 6; ADR-0010
-    never colour alone)."""
+def _tint(widget, module, canonical, code):
+    """The tint state (`'validated'|'unresolved'|None`) of a structure's row."""
+    return widget._rowValidationTint(_sct_segment_id(module, canonical, code))
+
+
+def test_validate_on_incomplete_tints_rows_by_state_and_summarises(qt_widgets):
+    """The local Validate gesture on an incomplete stage tints each row by its
+    validation state — green validated, red not-validated — and puts a
+    glyph+text summary line naming the unresolved structures on the shared
+    status label (ADR-0034 §Decision 6; the tint reinforces, ADR-0010 never
+    colour alone)."""
     slicer = _slicer_or_skip()
     module = _module_or_skip()
     slicer.mrmlScene.Clear(0)
@@ -245,6 +258,7 @@ def test_validate_on_incomplete_marks_offenders_and_summarises(qt_widgets):
     # Confirm two structures; leave Portal vein (Missing) and Tumors (Review)
     # unresolved.
     _confirm(slicer, module, canonical, module.SCT_LIVER_CODE)
+    _confirm(slicer, module, canonical, module.SCT_HEPATIC_VEIN_CODE)
     segments_logic = _segments_logic(slicer)
     tumors = canonical.GetSegmentation().GetSegment(
         _sct_segment_id(module, canonical, module.SCT_MASS_CODE)
@@ -253,37 +267,35 @@ def test_validate_on_incomplete_marks_offenders_and_summarises(qt_widgets):
 
     widget.onValidateAnatomy()
 
-    table = widget.segmentsTable()
-    selected = set(table.selectedSegmentIDs())
-    offenders = {
-        _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE),
-        _sct_segment_id(module, canonical, module.SCT_HEPATIC_VEIN_CODE),
-        _sct_segment_id(module, canonical, module.SCT_MASS_CODE),
-    }
-    assert selected == offenders, (
-        "Validate must SELECT exactly the unresolved rows (the marking "
-        f"mechanism); got {selected!r} vs {offenders!r}."
+    # Validated rows read 'validated'; unresolved rows read 'unresolved'.
+    assert _tint(widget, module, canonical, module.SCT_LIVER_CODE) == "validated"
+    assert (
+        _tint(widget, module, canonical, module.SCT_HEPATIC_VEIN_CODE)
+        == "validated"
     )
+    assert (
+        _tint(widget, module, canonical, module.SCT_PORTAL_VEIN_CODE)
+        == "unresolved"
+    ), "a Missing row must tint 'unresolved'."
+    assert _tint(widget, module, canonical, module.SCT_MASS_CODE) == "unresolved", (
+        "a Review (InProgress) row must tint 'unresolved'."
+    )
+
     summary = widget._statusLabel.text
     assert "Unresolved" in summary
-    for token in (
-        "Portal vein",
-        module.STATUS_MISSING[1],
-        "Hepatic vein",
-        "Tumors",
-        module.STATUS_REVIEW[1],
-    ):
+    for token in ("Portal vein", module.STATUS_MISSING[1], "Tumors", module.STATUS_REVIEW[1]):
         assert token in summary, (
             f"the summary line must name every offender with its status "
-            f"text (glyph+text, never colour alone); {token!r} missing from "
+            f"text (glyph+text, the primary carrier); {token!r} missing from "
             f"{summary!r}."
         )
 
 
-def test_resolving_one_row_clears_its_mark_live_without_re_validating(qt_widgets):
-    """Resolving ONE structure (native status flip to ``Completed``) clears
-    ITS mark live — no second Validate click — and resolving ALL clears every
-    mark (ADR-0034 §Decision 6: marks clear live)."""
+def test_resolving_one_row_flips_its_tint_live_without_re_validating(qt_widgets):
+    """Resolving ONE structure (native status flip to ``Completed``) flips ITS
+    tint 'unresolved' -> 'validated' live — no second Validate click — and
+    resolving ALL leaves every row 'validated' (ADR-0034 §Decision 6: tints
+    update live)."""
     slicer = _slicer_or_skip()
     module = _module_or_skip()
     slicer.mrmlScene.Clear(0)
@@ -301,32 +313,33 @@ def test_resolving_one_row_clears_its_mark_live_without_re_validating(qt_widgets
         segments_logic.SetSegmentStatus(seg, segments_logic.InProgress)
 
     widget.onValidateAnatomy()
-    table = widget.segmentsTable()
-    assert len(table.selectedSegmentIDs()) == len(module.STRUCTURE_TABS), (
-        "all four rows unresolved before any confirm."
-    )
+    # Every one of the four rows is unresolved before any confirm.
+    for _title, code in module.STRUCTURE_TABS:
+        assert _tint(widget, module, canonical, code) == "unresolved"
 
     # Confirm the portal vein via its status cell -- the content edit +
     # status flip funnels through the canonical-segmentation observer the
-    # widget already rides; the portal-vein mark must drop WITHOUT a second
-    # Validate click.
+    # widget already rides; the portal-vein tint must flip to green WITHOUT a
+    # second Validate click.
     pv = canonical.GetSegmentation().GetSegment(
         _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE)
     )
     segments_logic.SetSegmentStatus(pv, segments_logic.Completed)
 
-    pv_id = _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE)
-    assert pv_id not in set(table.selectedSegmentIDs()), (
-        "resolving the portal-vein row must clear ITS mark live, without "
-        "re-clicking Validate (ADR-0034 §Decision 6)."
+    assert (
+        _tint(widget, module, canonical, module.SCT_PORTAL_VEIN_CODE)
+        == "validated"
+    ), (
+        "resolving the portal-vein row must flip ITS tint to 'validated' "
+        "live, without re-clicking Validate (ADR-0034 §Decision 6)."
     )
-    # Its still-unresolved siblings stay marked.
-    hv_id = _sct_segment_id(module, canonical, module.SCT_HEPATIC_VEIN_CODE)
-    assert hv_id in set(table.selectedSegmentIDs()), (
-        "a still-unresolved sibling row must keep its mark."
-    )
+    # Its still-unresolved sibling stays red.
+    assert (
+        _tint(widget, module, canonical, module.SCT_HEPATIC_VEIN_CODE)
+        == "unresolved"
+    ), "a still-unresolved sibling row must keep its 'unresolved' tint."
 
-    # Resolve the rest -> every mark gone.
+    # Resolve the rest -> every row 'validated'.
     for title, code in module.STRUCTURE_TABS:
         if code == module.SCT_PORTAL_VEIN_CODE:
             continue
@@ -336,15 +349,16 @@ def test_resolving_one_row_clears_its_mark_live_without_re_validating(qt_widgets
         _fill_segment(slicer, seg)
         segments_logic.SetSegmentStatus(seg, segments_logic.Completed)
 
-    assert list(table.selectedSegmentIDs()) == [], (
-        "resolving every structure must clear all marks live (ADR-0034 "
-        "§Decision 6)."
-    )
+    for _title, code in module.STRUCTURE_TABS:
+        assert _tint(widget, module, canonical, code) == "validated", (
+            "resolving every structure must leave all rows 'validated' live "
+            "(ADR-0034 §Decision 6)."
+        )
 
 
-def test_validate_on_complete_reports_complete_with_no_marks(qt_widgets):
-    """Validate on a complete stage clears marks and reports completeness on
-    the status label — no rows selected (ADR-0034 §Decision 6)."""
+def test_validate_on_complete_tints_all_green_and_reports_complete(qt_widgets):
+    """Validate on a complete stage tints every row 'validated' and reports
+    completeness on the status label (ADR-0034 §Decision 6)."""
     slicer = _slicer_or_skip()
     module = _module_or_skip()
     slicer.mrmlScene.Clear(0)
@@ -357,10 +371,10 @@ def test_validate_on_complete_reports_complete_with_no_marks(qt_widgets):
 
     widget.onValidateAnatomy()
 
-    table = widget.segmentsTable()
-    assert list(table.selectedSegmentIDs()) == [], (
-        "a complete stage must leave no offending rows marked."
-    )
+    for _title, code in module.STRUCTURE_TABS:
+        assert _tint(widget, module, canonical, code) == "validated", (
+            "a complete stage must tint every row 'validated' (green)."
+        )
     summary = widget._statusLabel.text
     assert "complete" in summary.lower(), (
         f"Validate on a complete stage must report completeness; got "
@@ -372,36 +386,72 @@ def test_validate_on_complete_reports_complete_with_no_marks(qt_widgets):
     )
 
 
-def test_marking_mechanism_selects_exactly_the_offenders(qt_widgets):
-    """The marking mechanism's own shape pin: ``markUnresolvedRows()`` SELECTS
-    exactly the offending segment ids and ``clearUnresolvedMarks()`` clears
-    the selection (the committed fallback — no background-role abuse; the
-    stock model exposes none that survives item regeneration)."""
+def test_tint_state_neutral_outside_active_validation(qt_widgets):
+    """The tint state the delegate consults is None for every row while no
+    validation is active, and ``clearUnresolvedMarks`` returns all rows to
+    None (ADR-0034 §Decision 6: a normal edit never tints a row)."""
     slicer = _slicer_or_skip()
     module = _module_or_skip()
     slicer.mrmlScene.Clear(0)
 
     widget = _widget_or_skip(slicer, qt_widgets)
     canonical = widget.logic.getOrCreateCanonicalSegmentation()
-
-    # Confirm liver only; the other three are the offenders.
     _confirm(slicer, module, canonical, module.SCT_LIVER_CODE)
 
-    widget.markUnresolvedRows()
-    table = widget.segmentsTable()
-    offenders = {
-        _sct_segment_id(module, canonical, code)
-        for _title, code in module.STRUCTURE_TABS
-        if code != module.SCT_LIVER_CODE
-    }
-    assert set(table.selectedSegmentIDs()) == offenders, (
-        "markUnresolvedRows must set the view's selection to EXACTLY the "
-        "offending rows (the committed marking mechanism)."
+    # Before any Validate: every row neutral (None).
+    for _title, code in module.STRUCTURE_TABS:
+        assert _tint(widget, module, canonical, code) is None, (
+            "no row may be tinted before Validate is invoked."
+        )
+
+    widget.markValidationRows()
+    assert _tint(widget, module, canonical, module.SCT_LIVER_CODE) == "validated"
+    assert (
+        _tint(widget, module, canonical, module.SCT_PORTAL_VEIN_CODE)
+        == "unresolved"
     )
 
     widget.clearUnresolvedMarks()
-    assert list(table.selectedSegmentIDs()) == [], (
-        "clearUnresolvedMarks must clear the selection."
+    for _title, code in module.STRUCTURE_TABS:
+        assert _tint(widget, module, canonical, code) is None, (
+            "clearUnresolvedMarks must return every row to neutral (None)."
+        )
+
+
+def test_tint_delegate_installed_on_name_column_status_column_delegate_intact(
+    qt_widgets,
+):
+    """The tint delegate is installed on the name column (and the other tinted
+    columns) while the status column keeps a functional item delegate — the
+    tint SUBCLASSES each column's delegate rather than clobbering it, so the
+    status-cell click-to-cycle review gesture survives (ADR-0034 §Decision 6)."""
+    slicer = _slicer_or_skip()
+    _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    inner = widget.segmentsTable().tableWidget()
+
+    # Stock column layout: name = 3, status = 5.  The tint delegate on the name
+    # column must still be a terminology delegate (subclassed, not replaced) so
+    # name/terminology editing survives.
+    from qSlicerTerminologiesModuleWidgetsPythonQt import (
+        qSlicerTerminologyItemDelegate,
+    )
+
+    name_delegate = inner.itemDelegateForColumn(3)
+    assert isinstance(name_delegate, qSlicerTerminologyItemDelegate), (
+        "the name-column tint delegate must SUBCLASS the terminology delegate "
+        "so terminology editing is preserved."
+    )
+    assert name_delegate in widget._tintDelegates, (
+        "the name column must carry one of the widget's tint delegates."
+    )
+
+    # The tint delegate must be scoped per column, not installed whole-view
+    # (a whole-view setItemDelegate would clobber the icon columns).
+    assert inner.itemDelegate() not in widget._tintDelegates, (
+        "the tint must be column-scoped, never a whole-view delegate."
     )
 
 

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_validate_seam.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_validate_seam.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0034 §Decision 6 — the validate-and-next SEAM (explain API + row marking).
+
+This increment ships everything the shell's "Validate and next" button
+(which itself stays with the phase-contracts work, #440) will need, plus a
+Stage-2-local "Validate anatomy" affordance:
+
+  * ``LiverSegmentationLogic.explainStageIncomplete()`` returns the list of
+    ``(sctCode, title, statusText)`` for every expected structure NOT
+    satisfying the completion predicate (native ``Completed`` — incl. the
+    empty-``Completed`` absence attestation).  An empty list == stage
+    complete.  The predicate and the explanation are the SAME derivation
+    (both route through ``structureStatus``), pinned equivalent here:
+    ``isStageComplete()`` iff ``explainStageIncomplete() == []``.
+  * ``LiverSegmentationWidget.markUnresolvedRows()`` /
+    ``clearUnresolvedMarks()`` mark/unmark the offending rows.  Mechanism:
+    the stock ``qMRMLSegmentsTableView`` offers no Python-writable
+    background/decoration role that survives the model's per-update item
+    regeneration (and the name/colour data must not be abused, per the
+    brief), so marking is realised as SELECTING the offending rows
+    (``setSelectedSegmentIDs``) plus a glyph+text summary line on the shared
+    status label ("Unresolved: Portal vein (Missing), Tumors (Review)"),
+    never colour alone (ADR-0010).
+  * The marks CLEAR LIVE: resolving a row (native status flip to
+    ``Completed``, or a landing) re-evaluates and unmarks, riding the
+    existing canonical-segmentation observation / ``_onSceneChanged``.
+
+Needs the launched-Slicer harness (module + Qt + MRML); skips cleanly under
+bare pytest via the shared guards.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+MODULE_NAME = "liversegmentation"
+
+
+def _slicer_or_skip():
+    from conftest import _import_slicer_or_skip, _require_mrml_scene
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _module_or_skip():
+    try:
+        import LiverSegmentation  # type: ignore[import-not-found]
+    except ImportError as exc:
+        pytest.skip(f"LiverSegmentation not importable ({exc}).")
+    return LiverSegmentation
+
+
+def _widget_or_skip(slicer, registry):
+    from conftest import _require_qt_widget
+
+    _require_qt_widget()
+    if getattr(slicer.modules, MODULE_NAME, None) is None:
+        pytest.skip(
+            f"'{MODULE_NAME}' module not registered -- ADR-0024 surgeon-UI "
+            "deliverable absent."
+        )
+    module = _module_or_skip()
+    widget = module.LiverSegmentationWidget()
+    widget.setup()
+    registry.append(widget)
+    return widget
+
+
+def _segments_logic(slicer):
+    """The native per-segment status surface (enum + static accessors)."""
+    return slicer.vtkSlicerSegmentationsModuleLogic
+
+
+def _sct_segment_id(module, canonical, code):
+    """The (first) segment id on ``canonical`` whose terminology tag has ``code``."""
+    import vtk
+
+    segmentation = canonical.GetSegmentation()
+    for segment_id in list(segmentation.GetSegmentIDs()):
+        text = vtk.mutable("")
+        segmentation.GetSegment(segment_id).GetTag(
+            module.TERMINOLOGY_ENTRY_TAG, text
+        )
+        if f"^{code}^" in str(text):
+            return segment_id
+    return None
+
+
+def _fill_segment(slicer, segment):
+    """Give ``segment`` a tiny non-empty binary labelmap (a "landed" row)."""
+    import vtk
+
+    name = (
+        slicer.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName()
+    )
+    image = slicer.vtkOrientedImageData()
+    image.SetDimensions(2, 2, 2)
+    image.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, 1)
+    image.GetPointData().GetScalars().Fill(segment.GetLabelValue())
+    segment.AddRepresentation(name, image)
+
+
+def _confirm(slicer, module, canonical, code):
+    """Simulate the surgeon's status-cell confirm of a structure row.
+
+    A data-carrying ``Completed`` row (a real segmentation the surgeon
+    accepts); the empty-``Completed`` absence attestation is exercised
+    separately.
+    """
+    segments_logic = _segments_logic(slicer)
+    segment = canonical.GetSegmentation().GetSegment(
+        _sct_segment_id(module, canonical, code)
+    )
+    _fill_segment(slicer, segment)
+    segments_logic.SetSegmentStatus(segment, segments_logic.Completed)
+    return segment
+
+
+# --------------------------------------------------------------------------- #
+# Explain API (logic).
+# --------------------------------------------------------------------------- #
+
+
+def test_explain_lists_every_unsatisfied_structure_with_title_and_status():
+    """``explainStageIncomplete`` names every structure NOT satisfying the
+    completion predicate as ``(sctCode, title, statusText)`` (ADR-0034
+    §Decision 6).  On a fresh pre-seeded checklist that is all four
+    structures, each carrying its Missing status text."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    logic = module.LiverSegmentationLogic()
+    canonical = logic.getOrCreateCanonicalSegmentation()
+
+    explanation = logic.explainStageIncomplete()
+    # Every pre-seeded row is NotStarted -> Missing -> unresolved.
+    expected = [
+        (code, title, module.STATUS_MISSING[1])
+        for title, code in module.STRUCTURE_TABS
+    ]
+    assert explanation == expected, (
+        "explainStageIncomplete must list every unsatisfied structure as "
+        "(sctCode, title, statusText), in vocabulary order; got "
+        f"{explanation!r}."
+    )
+
+    # Resolve one (Portal vein -> Review): it stays unresolved, now carrying
+    # its Review status text; the others are unchanged.
+    segments_logic = _segments_logic(slicer)
+    pv = canonical.GetSegmentation().GetSegment(
+        _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE)
+    )
+    segments_logic.SetSegmentStatus(pv, segments_logic.InProgress)
+    explanation = logic.explainStageIncomplete()
+    pv_entry = next(
+        e for e in explanation if e[0] == module.SCT_PORTAL_VEIN_CODE
+    )
+    assert pv_entry == (
+        module.SCT_PORTAL_VEIN_CODE,
+        "Portal vein",
+        module.STATUS_REVIEW[1],
+    ), "an InProgress row must be explained as unresolved with 'Review' text."
+
+
+def test_explain_empty_on_all_completed_incl_marked_absent_empty():
+    """``explainStageIncomplete`` is empty when every structure is satisfied,
+    counting the empty-``Completed`` absence attestation (ADR-0034
+    §Amendments) exactly like a data-carrying confirm."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    logic = module.LiverSegmentationLogic()
+    canonical = logic.getOrCreateCanonicalSegmentation()
+    segments_logic = _segments_logic(slicer)
+
+    for title, code in module.STRUCTURE_TABS:
+        if code == module.SCT_MASS_CODE:
+            # The multifocal Tumors row: an EMPTY Completed segment is the
+            # explicit absence attestation ("no tumor in this case").
+            segment = canonical.GetSegmentation().GetSegment(
+                _sct_segment_id(module, canonical, code)
+            )
+            segments_logic.SetSegmentStatus(segment, segments_logic.Completed)
+        else:
+            _confirm(slicer, module, canonical, code)
+
+    assert logic.explainStageIncomplete() == [], (
+        "with every structure Completed (incl. the empty-Completed absence "
+        "attestation) the explanation must be empty."
+    )
+
+
+def test_isstagecomplete_is_exactly_the_empty_explanation():
+    """The predicate and the explanation are the SAME derivation: for every
+    scene state, ``isStageComplete()`` iff ``explainStageIncomplete() == []``
+    (ADR-0034 §Decision 6 — they must not drift)."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    logic = module.LiverSegmentationLogic()
+
+    # No canonical: incomplete, and explained as every structure missing.
+    assert logic.isStageComplete() is (logic.explainStageIncomplete() == [])
+
+    canonical = logic.getOrCreateCanonicalSegmentation()
+
+    # Confirm the structures one at a time; the equivalence holds at each step.
+    for title, code in module.STRUCTURE_TABS:
+        assert logic.isStageComplete() is (
+            logic.explainStageIncomplete() == []
+        ), (
+            "isStageComplete() must be exactly equivalent to an empty "
+            f"explanation at every step (before confirming {title!r})."
+        )
+        _confirm(slicer, module, canonical, code)
+
+    assert logic.isStageComplete() is True
+    assert logic.explainStageIncomplete() == []
+    assert logic.isStageComplete() is (logic.explainStageIncomplete() == [])
+
+
+# --------------------------------------------------------------------------- #
+# Row marking + the local "Validate anatomy" affordance (widget).
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_on_incomplete_marks_offenders_and_summarises(qt_widgets):
+    """The local Validate gesture on an incomplete stage marks the offending
+    rows (SELECTED in the stock view) and puts a glyph+text summary line
+    listing them on the shared status label (ADR-0034 §Decision 6; ADR-0010
+    never colour alone)."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = widget.logic.getOrCreateCanonicalSegmentation()
+
+    # Confirm two structures; leave Portal vein (Missing) and Tumors (Review)
+    # unresolved.
+    _confirm(slicer, module, canonical, module.SCT_LIVER_CODE)
+    segments_logic = _segments_logic(slicer)
+    tumors = canonical.GetSegmentation().GetSegment(
+        _sct_segment_id(module, canonical, module.SCT_MASS_CODE)
+    )
+    segments_logic.SetSegmentStatus(tumors, segments_logic.InProgress)
+
+    widget.onValidateAnatomy()
+
+    table = widget.segmentsTable()
+    selected = set(table.selectedSegmentIDs())
+    offenders = {
+        _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE),
+        _sct_segment_id(module, canonical, module.SCT_HEPATIC_VEIN_CODE),
+        _sct_segment_id(module, canonical, module.SCT_MASS_CODE),
+    }
+    assert selected == offenders, (
+        "Validate must SELECT exactly the unresolved rows (the marking "
+        f"mechanism); got {selected!r} vs {offenders!r}."
+    )
+    summary = widget._statusLabel.text
+    assert "Unresolved" in summary
+    for token in (
+        "Portal vein",
+        module.STATUS_MISSING[1],
+        "Hepatic vein",
+        "Tumors",
+        module.STATUS_REVIEW[1],
+    ):
+        assert token in summary, (
+            f"the summary line must name every offender with its status "
+            f"text (glyph+text, never colour alone); {token!r} missing from "
+            f"{summary!r}."
+        )
+
+
+def test_resolving_one_row_clears_its_mark_live_without_re_validating(qt_widgets):
+    """Resolving ONE structure (native status flip to ``Completed``) clears
+    ITS mark live — no second Validate click — and resolving ALL clears every
+    mark (ADR-0034 §Decision 6: marks clear live)."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = widget.logic.getOrCreateCanonicalSegmentation()
+    segments_logic = _segments_logic(slicer)
+
+    # Land Portal vein + Hepatic vein under review, leave the rest Missing.
+    for code in (module.SCT_PORTAL_VEIN_CODE, module.SCT_HEPATIC_VEIN_CODE):
+        seg = canonical.GetSegmentation().GetSegment(
+            _sct_segment_id(module, canonical, code)
+        )
+        _fill_segment(slicer, seg)
+        segments_logic.SetSegmentStatus(seg, segments_logic.InProgress)
+
+    widget.onValidateAnatomy()
+    table = widget.segmentsTable()
+    assert len(table.selectedSegmentIDs()) == len(module.STRUCTURE_TABS), (
+        "all four rows unresolved before any confirm."
+    )
+
+    # Confirm the portal vein via its status cell -- the content edit +
+    # status flip funnels through the canonical-segmentation observer the
+    # widget already rides; the portal-vein mark must drop WITHOUT a second
+    # Validate click.
+    pv = canonical.GetSegmentation().GetSegment(
+        _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE)
+    )
+    segments_logic.SetSegmentStatus(pv, segments_logic.Completed)
+
+    pv_id = _sct_segment_id(module, canonical, module.SCT_PORTAL_VEIN_CODE)
+    assert pv_id not in set(table.selectedSegmentIDs()), (
+        "resolving the portal-vein row must clear ITS mark live, without "
+        "re-clicking Validate (ADR-0034 §Decision 6)."
+    )
+    # Its still-unresolved siblings stay marked.
+    hv_id = _sct_segment_id(module, canonical, module.SCT_HEPATIC_VEIN_CODE)
+    assert hv_id in set(table.selectedSegmentIDs()), (
+        "a still-unresolved sibling row must keep its mark."
+    )
+
+    # Resolve the rest -> every mark gone.
+    for title, code in module.STRUCTURE_TABS:
+        if code == module.SCT_PORTAL_VEIN_CODE:
+            continue
+        seg = canonical.GetSegmentation().GetSegment(
+            _sct_segment_id(module, canonical, code)
+        )
+        _fill_segment(slicer, seg)
+        segments_logic.SetSegmentStatus(seg, segments_logic.Completed)
+
+    assert list(table.selectedSegmentIDs()) == [], (
+        "resolving every structure must clear all marks live (ADR-0034 "
+        "§Decision 6)."
+    )
+
+
+def test_validate_on_complete_reports_complete_with_no_marks(qt_widgets):
+    """Validate on a complete stage clears marks and reports completeness on
+    the status label — no rows selected (ADR-0034 §Decision 6)."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = widget.logic.getOrCreateCanonicalSegmentation()
+
+    for _title, code in module.STRUCTURE_TABS:
+        _confirm(slicer, module, canonical, code)
+
+    widget.onValidateAnatomy()
+
+    table = widget.segmentsTable()
+    assert list(table.selectedSegmentIDs()) == [], (
+        "a complete stage must leave no offending rows marked."
+    )
+    summary = widget._statusLabel.text
+    assert "complete" in summary.lower(), (
+        f"Validate on a complete stage must report completeness; got "
+        f"{summary!r}."
+    )
+    assert str(len(module.STRUCTURE_TABS)) in summary, (
+        "the complete message names the count of confirmed structures "
+        f"(N={len(module.STRUCTURE_TABS)}); got {summary!r}."
+    )
+
+
+def test_marking_mechanism_selects_exactly_the_offenders(qt_widgets):
+    """The marking mechanism's own shape pin: ``markUnresolvedRows()`` SELECTS
+    exactly the offending segment ids and ``clearUnresolvedMarks()`` clears
+    the selection (the committed fallback — no background-role abuse; the
+    stock model exposes none that survives item regeneration)."""
+    slicer = _slicer_or_skip()
+    module = _module_or_skip()
+    slicer.mrmlScene.Clear(0)
+
+    widget = _widget_or_skip(slicer, qt_widgets)
+    canonical = widget.logic.getOrCreateCanonicalSegmentation()
+
+    # Confirm liver only; the other three are the offenders.
+    _confirm(slicer, module, canonical, module.SCT_LIVER_CODE)
+
+    widget.markUnresolvedRows()
+    table = widget.segmentsTable()
+    offenders = {
+        _sct_segment_id(module, canonical, code)
+        for _title, code in module.STRUCTURE_TABS
+        if code != module.SCT_LIVER_CODE
+    }
+    assert set(table.selectedSegmentIDs()) == offenders, (
+        "markUnresolvedRows must set the view's selection to EXACTLY the "
+        "offending rows (the committed marking mechanism)."
+    )
+
+    widget.clearUnresolvedMarks()
+    assert list(table.selectedSegmentIDs()) == [], (
+        "clearUnresolvedMarks must clear the selection."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_validate_seam.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_validate_seam.py
@@ -432,28 +432,41 @@ def test_tint_delegate_installed_on_name_column_status_column_delegate_intact(
     widget = _widget_or_skip(slicer, qt_widgets)
     inner = widget.segmentsTable().tableWidget()
 
-    # Stock column layout: name = 3, status = 5.  The tint delegate on the name
-    # column must still be a terminology delegate (subclassed, not replaced) so
-    # name/terminology editing survives.  Assert the subclass relationship via
-    # the Python MRO rather than importing the base class by name -- the
-    # terminology delegate's Python-importable location is build-specific, but
-    # the implementation subclasses whatever delegate the column already had
-    # (type(existing)), so its name is on our tint delegate's MRO regardless.
+    # Stock column layout: name = 3, status = 5.  The tint delegate must
+    # SUBCLASS whatever delegate the column already had (the implementation
+    # uses type(existing)) rather than replace it -- so any editor behaviour
+    # the build installed on the column survives.  WHICH base that is, is
+    # build-specific: the terminology delegate is present only where the
+    # Terminologies module widgets are wrapped (absent in some CI builds,
+    # where the base is plain QStyledItemDelegate).  So pin the two
+    # build-agnostic invariants, not the specific base class:
     name_delegate = inner.itemDelegateForColumn(3)
-    mro_names = [base.__name__ for base in type(name_delegate).__mro__]
-    assert "qSlicerTerminologyItemDelegate" in mro_names, (
-        "the name-column tint delegate must SUBCLASS the terminology delegate "
-        f"so terminology editing is preserved; MRO was {mro_names!r}."
-    )
     assert name_delegate in widget._tintDelegates, (
         "the name column must carry one of the widget's tint delegates."
     )
+    # PythonQt flattens C++ inheritance -- a wrapped delegate's Python MRO
+    # sits directly on PythonQtInstanceWrapper, never chaining through a
+    # Python QStyledItemDelegate -- and the base class is the build-specific
+    # delegate the column already had (terminology where the module widgets
+    # are wrapped, plain QStyledItemDelegate otherwise).  The build-agnostic
+    # fact is that our subclass wraps a REAL Qt delegate (not a bare Python
+    # object): PythonQtInstanceWrapper on the MRO.
+    mro_names = [base.__name__ for base in type(name_delegate).__mro__]
+    assert "PythonQtInstanceWrapper" in mro_names, (
+        "the tint delegate must subclass the column's real (wrapped) item "
+        f"delegate so its editor behaviour is preserved; MRO was {mro_names!r}."
+    )
 
-    # The tint delegate must be scoped per column, not installed whole-view
-    # (a whole-view setItemDelegate would clobber the icon columns).
+    # Column-scoped, never a whole-view setItemDelegate -- THE anti-clobber
+    # invariant: a whole-view delegate would replace the icon/editor columns'
+    # delegates wholesale (status click-to-cycle, terminology, opacity).
     assert inner.itemDelegate() not in widget._tintDelegates, (
         "the tint must be column-scoped, never a whole-view delegate."
     )
+    for column in (0, 1, 2, 3, 5):
+        assert inner.itemDelegateForColumn(column) in widget._tintDelegates, (
+            f"column {column} must carry a column-scoped tint delegate."
+        )
 
 
 if __name__ == "__main__":

--- a/LiverSegmentation/Testing/Python/test_liversegmentation_validate_seam.py
+++ b/LiverSegmentation/Testing/Python/test_liversegmentation_validate_seam.py
@@ -434,15 +434,16 @@ def test_tint_delegate_installed_on_name_column_status_column_delegate_intact(
 
     # Stock column layout: name = 3, status = 5.  The tint delegate on the name
     # column must still be a terminology delegate (subclassed, not replaced) so
-    # name/terminology editing survives.
-    from qSlicerTerminologiesModuleWidgetsPythonQt import (
-        qSlicerTerminologyItemDelegate,
-    )
-
+    # name/terminology editing survives.  Assert the subclass relationship via
+    # the Python MRO rather than importing the base class by name -- the
+    # terminology delegate's Python-importable location is build-specific, but
+    # the implementation subclasses whatever delegate the column already had
+    # (type(existing)), so its name is on our tint delegate's MRO regardless.
     name_delegate = inner.itemDelegateForColumn(3)
-    assert isinstance(name_delegate, qSlicerTerminologyItemDelegate), (
+    mro_names = [base.__name__ for base in type(name_delegate).__mro__]
+    assert "qSlicerTerminologyItemDelegate" in mro_names, (
         "the name-column tint delegate must SUBCLASS the terminology delegate "
-        "so terminology editing is preserved."
+        f"so terminology editing is preserved; MRO was {mro_names!r}."
     )
     assert name_delegate in widget._tintDelegates, (
         "the name column must carry one of the widget's tint delegates."


### PR DESCRIPTION
Implements the **validate-and-next seam increment of #574** (ADR-0034 §Decision 6): Stage 2 exposes the completion contract the shell-level "Validate and next" button (#440) will consume, plus a local Validate affordance with green/red row tinting.

## What

- **`explainStageIncomplete()`** on the logic — lists `(sctCode, title, statusText)` for every expected structure not satisfying the completion predicate (native Completed, incl. the empty-Completed absence attestation). `isStageComplete()` is rewritten as `not explainStageIncomplete()`, so predicate and explanation share one derivation through `structureStatus` and cannot drift (pinned by an equivalence test).
- **"Validate anatomy" toolbar button** — tints each table row by state: validated (Completed / Marked-absent) light **green**, not-validated (Missing / Review / Flagged) light **red**, with a glyph+text summary line as the text companion. Complete anatomy → all green + "Anatomy complete — all N structures confirmed." Tint updates **live** as rows resolve (red→green on confirm), without re-clicking Validate.
- ADR-0010: the status column's glyph+text stays the primary carrier; the desaturated tint is reinforcement, not sole meaning.
- The shell-level Next wiring stays with #440 (deferred in the docstring).

This is the mechanism behind the earlier "Place button does nothing" episode — downstream gates can now *say why* a stage is incomplete instead of failing silently.

## Tint mechanism (stock-widget-safe)

The inner `QTableView` already installs per-column editor delegates (terminology on the name column, opacity on its column) whose paint falls through to `QStyledItemDelegate`, and the status column's click-to-cycle is view/model-driven, not delegate-driven. So per column we **subclass that column's current delegate** and override only `initStyleOption` to set `option.backgroundBrush` from a widget-held per-segment state — installed via `setItemDelegateForColumn`, never a whole-view `setItemDelegate` (which would clobber the editors). The delegate reads widget state, not model data, so model item regeneration never erases the tint. Status-cell cycling, terminology, and opacity editing all stay intact.

## Verification

Full launched sweep, canonical four-root order: **520 passed / 16 skipped / 0 failed**, no crashes; bare row skips cleanly; ruff clean. Row tint pinned by consulted STATE (not pixels): per-row validated/unresolved/neutral, live flip on status change, neutral outside an active validation, and the name-column terminology delegate preserved.

Remaining #574 increment: the tool registry + Run ▾ split-button (its UI value is gated on a second backend existing — worth discussing scope before building).

---
*Drafted by an AI assistant (Claude Fable 5); reviewed and submitted on behalf of the maintainer.*