### PR TITLE
ENH: VascularTerritories annotation table + arming seam (ADR-0037 Stage 2)

### DIFF
--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.cxx
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.cxx
@@ -25,6 +25,7 @@
 // STD includes
 #include <cstring>
 #include <iomanip>
+#include <set>
 #include <sstream>
 #include <string>
 
@@ -155,6 +156,52 @@ void decodeAnnotationPoints(const std::string& encoded, std::map<std::string, st
                  });
 }
 
+// Compact encoding for the per-territory colour map: ``territoryId|r,g,b``
+// blocks separated by ``kPairDelimiter``.  Schema-internal (the .vta.json
+// storage surfaces the same data as JSON).
+std::string encodeColors(const std::map<std::string, std::array<double, 3>>& colors)
+{
+  std::ostringstream out;
+  out << std::setprecision(17);
+  bool first = true;
+  for (const auto& kv : colors)
+  {
+    if (!first)
+    {
+      out << kPairDelimiter;
+    }
+    first = false;
+    out << kv.first << kFieldDelimiter << kv.second[0] << kCoordDelimiter << kv.second[1] << kCoordDelimiter << kv.second[2];
+  }
+  return out.str();
+}
+
+void decodeColors(const std::string& encoded, std::map<std::string, std::array<double, 3>>& colors)
+{
+  colors.clear();
+  walkEncodedMap(encoded,
+                 [&colors](const std::string& territoryId, const std::string& rgb)
+                 {
+                   std::array<double, 3> value = { 1.0, 1.0, 1.0 };
+                   std::istringstream stream(rgb);
+                   std::string token;
+                   int c = 0;
+                   while (c < 3 && std::getline(stream, token, kCoordDelimiter))
+                   {
+                     try
+                     {
+                       value[c] = std::stod(token);
+                     }
+                     catch (const std::exception&)
+                     {
+                       // Malformed channel — keep the default.
+                     }
+                     ++c;
+                   }
+                   colors[territoryId] = value;
+                 });
+}
+
 } // namespace
 
 //------------------------------------------------------------------------------
@@ -186,6 +233,9 @@ void vtkMRMLCustomTerritoriesNode::PrintSelf(ostream& os, vtkIndent indent)
   {
     os << indent.GetNextIndent() << kv.first << ": " << kv.second.size() << " points\n";
   }
+  os << indent << "TerritoryColors: " << this->TerritoryColors.size() << " entries\n";
+  os << indent << "TerritoryLabels: " << this->TerritoryLabels.size() << " entries\n";
+  os << indent << "TerritoryVisibilities: " << this->TerritoryVisibilities.size() << " entries\n";
 }
 
 //------------------------------------------------------------------------------
@@ -224,6 +274,20 @@ void vtkMRMLCustomTerritoriesNode::ReadXMLAttributes(const char** atts)
     else if (!std::strcmp(attName, "annotationPoints"))
     {
       decodeAnnotationPoints(attValue, this->AnnotationPoints);
+    }
+    else if (!std::strcmp(attName, "territoryColors"))
+    {
+      decodeColors(attValue, this->TerritoryColors);
+    }
+    else if (!std::strcmp(attName, "territoryLabels"))
+    {
+      this->TerritoryLabels.clear();
+      walkEncodedMap(attValue, [this](std::string key, std::string value) { this->TerritoryLabels[std::move(key)] = std::move(value); });
+    }
+    else if (!std::strcmp(attName, "territoryVisibilities"))
+    {
+      this->TerritoryVisibilities.clear();
+      walkEncodedMap(attValue, [this](const std::string& key, const std::string& value) { this->TerritoryVisibilities[key] = (value != "0"); });
     }
     else if (!std::strcmp(attName, "segmentNames"))
     {
@@ -267,6 +331,23 @@ void vtkMRMLCustomTerritoriesNode::WriteXML(ostream& of, int nIndent)
   {
     of << " annotationPoints=\"" << this->XMLAttributeEncodeString(encodeAnnotationPoints(this->AnnotationPoints).c_str()) << "\"";
   }
+  if (!this->TerritoryColors.empty())
+  {
+    of << " territoryColors=\"" << this->XMLAttributeEncodeString(encodeColors(this->TerritoryColors).c_str()) << "\"";
+  }
+  if (!this->TerritoryLabels.empty())
+  {
+    of << " territoryLabels=\"" << this->XMLAttributeEncodeString(encodeMap(this->TerritoryLabels).c_str()) << "\"";
+  }
+  if (!this->TerritoryVisibilities.empty())
+  {
+    std::map<std::string, std::string> encodedVis;
+    for (const auto& kv : this->TerritoryVisibilities)
+    {
+      encodedVis[kv.first] = kv.second ? "1" : "0";
+    }
+    of << " territoryVisibilities=\"" << this->XMLAttributeEncodeString(encodeMap(encodedVis).c_str()) << "\"";
+  }
   if (this->SegmentNames && this->SegmentNames->GetNumberOfValues() > 0)
   {
     std::ostringstream names;
@@ -297,6 +378,9 @@ void vtkMRMLCustomTerritoriesNode::CopyContent(vtkMRMLNode* anode, bool deepCopy
   this->Groupings = other->Groupings;
   this->OptInSCTCodes = other->OptInSCTCodes;
   this->AnnotationPoints = other->AnnotationPoints;
+  this->TerritoryColors = other->TerritoryColors;
+  this->TerritoryLabels = other->TerritoryLabels;
+  this->TerritoryVisibilities = other->TerritoryVisibilities;
   if (other->SegmentNames)
   {
     this->SegmentNames->DeepCopy(other->SegmentNames);
@@ -472,6 +556,89 @@ std::vector<std::string> vtkMRMLCustomTerritoriesNode::GetAnnotationTerritoryIds
     }
   }
   return ids;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLCustomTerritoriesNode::SetTerritoryColor(const std::string& territoryId, double r, double g, double b)
+{
+  this->TerritoryColors[territoryId] = { r, g, b };
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+const double* vtkMRMLCustomTerritoriesNode::GetTerritoryColor(const std::string& territoryId)
+{
+  // Default for an unset territory: opaque white (the module's neutral
+  // swatch until the surgeon picks a colour).
+  this->TerritoryColorScratch[0] = 1.0;
+  this->TerritoryColorScratch[1] = 1.0;
+  this->TerritoryColorScratch[2] = 1.0;
+  auto it = this->TerritoryColors.find(territoryId);
+  if (it != this->TerritoryColors.end())
+  {
+    this->TerritoryColorScratch[0] = it->second[0];
+    this->TerritoryColorScratch[1] = it->second[1];
+    this->TerritoryColorScratch[2] = it->second[2];
+  }
+  return this->TerritoryColorScratch;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLCustomTerritoriesNode::SetTerritoryLabel(const std::string& territoryId, const std::string& label)
+{
+  this->TerritoryLabels[territoryId] = label;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+std::string vtkMRMLCustomTerritoriesNode::GetTerritoryLabel(const std::string& territoryId) const
+{
+  auto it = this->TerritoryLabels.find(territoryId);
+  if (it == this->TerritoryLabels.end())
+  {
+    return std::string();
+  }
+  return it->second;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLCustomTerritoriesNode::SetTerritoryVisibility(const std::string& territoryId, bool visible)
+{
+  this->TerritoryVisibilities[territoryId] = visible;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLCustomTerritoriesNode::GetTerritoryVisibility(const std::string& territoryId) const
+{
+  auto it = this->TerritoryVisibilities.find(territoryId);
+  if (it == this->TerritoryVisibilities.end())
+  {
+    // An unset territory defaults to visible.
+    return true;
+  }
+  return it->second;
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLCustomTerritoriesNode::GetDisplayTerritoryIds() const
+{
+  // Union of the three display maps' keys, deduplicated + deterministically
+  // ordered (std::set) so the storage node enumerates the slots stably.
+  std::set<std::string> ids;
+  for (const auto& kv : this->TerritoryColors)
+  {
+    ids.insert(kv.first);
+  }
+  for (const auto& kv : this->TerritoryLabels)
+  {
+    ids.insert(kv.first);
+  }
+  for (const auto& kv : this->TerritoryVisibilities)
+  {
+    ids.insert(kv.first);
+  }
+  return std::vector<std::string>(ids.begin(), ids.end());
 }
 
 //------------------------------------------------------------------------------

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.h
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.h
@@ -199,6 +199,48 @@ public:
   std::vector<std::string> GetAnnotationTerritoryIds() const;
 
   //--------------------------------------------------------------------------
+  // Per-territory display-attribute slot (ADR-0037 §Decision 3 / §3 table)
+  //--------------------------------------------------------------------------
+  //
+  // The table row carries a per-territory colour swatch, display label, and
+  // visibility toggle.  These live in an OWN per-territoryId slot on this
+  // carrier, mirroring the ``AnnotationPoints`` std::map idiom and keyed on
+  // the same surgeon-named territory id.  The display slot is INDEPENDENT of
+  // the geometry slot: a display write never touches ``AnnotationPoints``.
+  // Round-trips through MRML XML + the ``.vta.json`` storage node.  Each
+  // write fires ONE ModifiedEvent so the table's observer rebuilds.
+
+  /// Set territory ``territoryId``'s display colour (RGB in [0, 1]).  Fires
+  /// ONE ModifiedEvent.  Does NOT touch the annotation-point geometry.
+  void SetTerritoryColor(const std::string& territoryId, double r, double g, double b);
+
+  /// Territory ``territoryId``'s display colour as a 3-tuple in Python
+  /// (``VTK_SIZEHINT``).  An unset territory returns the module default
+  /// (opaque white).  The pointer aliases an internal scratch buffer valid
+  /// until the next call — copy before re-calling.
+  const double* GetTerritoryColor(const std::string& territoryId) VTK_SIZEHINT(3);
+
+  /// Set territory ``territoryId``'s display label.  Fires ONE
+  /// ModifiedEvent.  Does NOT touch the annotation-point geometry.
+  void SetTerritoryLabel(const std::string& territoryId, const std::string& label);
+
+  /// Territory ``territoryId``'s display label (empty string if unset).
+  std::string GetTerritoryLabel(const std::string& territoryId) const;
+
+  /// Set territory ``territoryId``'s display visibility.  Fires ONE
+  /// ModifiedEvent.  Does NOT touch the annotation-point geometry.
+  void SetTerritoryVisibility(const std::string& territoryId, bool visible);
+
+  /// Territory ``territoryId``'s display visibility (defaults to true for an
+  /// unset territory).
+  bool GetTerritoryVisibility(const std::string& territoryId) const;
+
+  /// The territory ids that currently carry a display attribute (colour,
+  /// label, or visibility), in a deterministic (sorted) order.  Used by the
+  /// storage node to enumerate the per-territory display slots.
+  std::vector<std::string> GetDisplayTerritoryIds() const;
+
+  //--------------------------------------------------------------------------
   // Storage
   //--------------------------------------------------------------------------
 
@@ -226,6 +268,19 @@ protected:
   /// return (the ``GetSlicingPlaneInitPoint`` idiom): a stable address to
   /// alias so the wrapped 3-tuple does not point at a temporary.
   double AnnotationPointScratch[3] = { 0.0, 0.0, 0.0 };
+
+  /// Per-territory display attributes (ADR-0037 §Decision 3).  Keyed on the
+  /// same surgeon-named territory id as ``AnnotationPoints`` but kept in
+  /// SEPARATE maps so a display write cannot perturb the geometry map.  A
+  /// territory with no entry falls back to the module defaults (opaque
+  /// white, empty label, visible).
+  std::map<std::string, std::array<double, 3>> TerritoryColors;
+  std::map<std::string, std::string> TerritoryLabels;
+  std::map<std::string, bool> TerritoryVisibilities;
+
+  /// Scratch buffer backing the ``GetTerritoryColor`` size-hinted return
+  /// (same idiom as ``AnnotationPointScratch``).
+  double TerritoryColorScratch[3] = { 1.0, 1.0, 1.0 };
 
   /// Surgeon-defined segment-label list.  Owned by the node; written
   /// to / read from MRML XML via the ``segmentNames`` attribute.

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.cxx
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.cxx
@@ -196,6 +196,26 @@ int vtkMRMLCustomTerritoriesStorageNode::WriteJson(const std::string& filePath, 
   }
   writer->WriteObjectPropertyEnd();
 
+  // territoryDisplay -- an object keyed by territory id carrying the
+  // per-territory display slot (colour / label / visibility) ADR-0037
+  // §Decision 3 adds alongside the ordered points.  Independent of the
+  // geometry: a territory may carry display attributes without points and
+  // vice versa.
+  writer->WriteObjectPropertyStart("territoryDisplay");
+  {
+    for (const std::string& territoryId : carrier->GetDisplayTerritoryIds())
+    {
+      writer->WriteObjectPropertyStart(territoryId);
+      const double* color = carrier->GetTerritoryColor(territoryId);
+      double rgb[3] = { color[0], color[1], color[2] };
+      writer->WriteVectorProperty("color", rgb, 3);
+      writer->WriteStringProperty("label", carrier->GetTerritoryLabel(territoryId));
+      writer->WriteBoolProperty("visibility", carrier->GetTerritoryVisibility(territoryId));
+      writer->WriteObjectPropertyEnd();
+    }
+  }
+  writer->WriteObjectPropertyEnd();
+
   if (!writer->WriteToFileEnd())
   {
     vtkErrorToMessageCollectionMacro(
@@ -242,47 +262,90 @@ int vtkMRMLCustomTerritoriesStorageNode::ReadJson(const std::string& filePath, v
     carrier->ClearAnnotationPoints(territoryId);
   }
 
-  if (!root->HasMember("annotationPoints"))
+  if (root->HasMember("annotationPoints"))
   {
-    // A carrier with no annotation points is a valid document.
-    return 1;
+    vtkSmartPointer<vtkMRMLJsonElement> pointsJson = vtkSmartPointer<vtkMRMLJsonElement>::Take(root->GetObjectProperty("annotationPoints"));
+    if (pointsJson == nullptr)
+    {
+      vtkWarningToMessageCollectionMacro(
+        this->GetUserMessages(), "vtkMRMLCustomTerritoriesStorageNode::ReadJson", "'annotationPoints' present but unreadable in '" << filePath << "'");
+    }
+    else
+    {
+      const int numberOfTerritories = pointsJson->GetObjectSize();
+      for (int t = 0; t < numberOfTerritories; ++t)
+      {
+        const std::string territoryId = pointsJson->GetObjectPropertyNameByIndex(t);
+        if (territoryId.empty())
+        {
+          continue;
+        }
+        vtkSmartPointer<vtkMRMLJsonElement> list = vtkSmartPointer<vtkMRMLJsonElement>::Take(pointsJson->GetArrayProperty(territoryId.c_str()));
+        if (list == nullptr)
+        {
+          continue;
+        }
+        const int nPoints = list->GetArraySize();
+        for (int i = 0; i < nPoints; ++i)
+        {
+          vtkSmartPointer<vtkMRMLJsonElement> item = vtkSmartPointer<vtkMRMLJsonElement>::Take(list->GetArrayItem(i));
+          if (item == nullptr)
+          {
+            continue;
+          }
+          double p[3] = { 0.0, 0.0, 0.0 };
+          if (item->GetVectorProperty("xyz", p, 3))
+          {
+            carrier->AddAnnotationPoint(territoryId, p[0], p[1], p[2]);
+          }
+        }
+      }
+    }
   }
 
-  vtkSmartPointer<vtkMRMLJsonElement> pointsJson = vtkSmartPointer<vtkMRMLJsonElement>::Take(root->GetObjectProperty("annotationPoints"));
-  if (pointsJson == nullptr)
+  this->ReadDisplay(root, carrier, filePath);
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLCustomTerritoriesStorageNode::ReadDisplay(vtkMRMLJsonElement* root, vtkMRMLCustomTerritoriesNode* carrier, const std::string& filePath)
+{
+  if (root == nullptr || !root->HasMember("territoryDisplay"))
+  {
+    return;
+  }
+  vtkSmartPointer<vtkMRMLJsonElement> displayJson = vtkSmartPointer<vtkMRMLJsonElement>::Take(root->GetObjectProperty("territoryDisplay"));
+  if (displayJson == nullptr)
   {
     vtkWarningToMessageCollectionMacro(
-      this->GetUserMessages(), "vtkMRMLCustomTerritoriesStorageNode::ReadJson", "'annotationPoints' present but unreadable in '" << filePath << "'");
-    return 1;
+      this->GetUserMessages(), "vtkMRMLCustomTerritoriesStorageNode::ReadDisplay", "'territoryDisplay' present but unreadable in '" << filePath << "'");
+    return;
   }
-
-  const int numberOfTerritories = pointsJson->GetObjectSize();
+  const int numberOfTerritories = displayJson->GetObjectSize();
   for (int t = 0; t < numberOfTerritories; ++t)
   {
-    const std::string territoryId = pointsJson->GetObjectPropertyNameByIndex(t);
+    const std::string territoryId = displayJson->GetObjectPropertyNameByIndex(t);
     if (territoryId.empty())
     {
       continue;
     }
-    vtkSmartPointer<vtkMRMLJsonElement> list = vtkSmartPointer<vtkMRMLJsonElement>::Take(pointsJson->GetArrayProperty(territoryId.c_str()));
-    if (list == nullptr)
+    vtkSmartPointer<vtkMRMLJsonElement> entry = vtkSmartPointer<vtkMRMLJsonElement>::Take(displayJson->GetObjectProperty(territoryId.c_str()));
+    if (entry == nullptr)
     {
       continue;
     }
-    const int nPoints = list->GetArraySize();
-    for (int i = 0; i < nPoints; ++i)
+    double rgb[3] = { 1.0, 1.0, 1.0 };
+    if (entry->GetVectorProperty("color", rgb, 3))
     {
-      vtkSmartPointer<vtkMRMLJsonElement> item = vtkSmartPointer<vtkMRMLJsonElement>::Take(list->GetArrayItem(i));
-      if (item == nullptr)
-      {
-        continue;
-      }
-      double p[3] = { 0.0, 0.0, 0.0 };
-      if (item->GetVectorProperty("xyz", p, 3))
-      {
-        carrier->AddAnnotationPoint(territoryId, p[0], p[1], p[2]);
-      }
+      carrier->SetTerritoryColor(territoryId, rgb[0], rgb[1], rgb[2]);
+    }
+    if (entry->HasMember("label"))
+    {
+      carrier->SetTerritoryLabel(territoryId, entry->GetStringProperty("label"));
+    }
+    if (entry->HasMember("visibility"))
+    {
+      carrier->SetTerritoryVisibility(territoryId, entry->GetBoolProperty("visibility"));
     }
   }
-  return 1;
 }

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.h
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.h
@@ -50,6 +50,7 @@
 #include <string>
 
 class vtkMRMLCustomTerritoriesNode;
+class vtkMRMLJsonElement;
 
 /**
  * \class vtkMRMLCustomTerritoriesStorageNode
@@ -71,9 +72,17 @@ class vtkMRMLCustomTerritoriesNode;
  *   "annotationPoints": {
  *     "SegmentVII":  [ [x, y, z], [x, y, z], ... ],
  *     "SegmentVIII": [ [x, y, z], ... ]
+ *   },
+ *   "territoryDisplay": {
+ *     "SegmentVII": { "color": [r, g, b], "label": "…", "visibility": true }
  *   }
  * }
  * \endcode
+ *
+ * The ``territoryDisplay`` object carries the per-territory display slot
+ * (colour / label / visibility) ADR-0037 §Decision 3 adds; it is optional
+ * and additive to the v1 schema (a document without it reads back with the
+ * carrier's display defaults).
  *
  * The per-territory arrays are ORDERED — placement order round-trips
  * identically (ADR-0037 §Conformance [test]).  The storage node is typed
@@ -128,6 +137,11 @@ private:
   /// Read the v1 ``.vta.json`` from ``filePath`` into ``carrier``.
   /// Returns 1 on success, 0 on failure.
   int ReadJson(const std::string& filePath, vtkMRMLCustomTerritoriesNode* carrier);
+
+  /// Read the per-territory display slot (colour / label / visibility) from
+  /// the parsed ``territoryDisplay`` object into ``carrier``.  A no-op when
+  /// the document carries no display slot.
+  void ReadDisplay(vtkMRMLJsonElement* root, vtkMRMLCustomTerritoriesNode* carrier, const std::string& filePath);
 };
 
 #endif // __vtkmrmlcustomterritoriesstoragenode_h_

--- a/VascularTerritories/Resources/UI/VascularTerritories.ui
+++ b/VascularTerritories/Resources/UI/VascularTerritories.ui
@@ -80,13 +80,6 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Vessel points:</string>
-          </property>
-         </widget>
-        </item>
         <item row="5" column="2" colspan="3">
          <widget class="QPushButton" name="addCenterlineSegmentButton">
           <property name="enabled">
@@ -127,30 +120,6 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1" colspan="3">
-         <widget class="qMRMLNodeComboBox" name="endPointsMarkupsSelector">
-          <property name="nodeTypes">
-           <stringlist>
-            <string>vtkMRMLMarkupsFiducialNode</string>
-           </stringlist>
-          </property>
-          <property name="showChildNodeTypes">
-           <bool>false</bool>
-          </property>
-          <property name="baseName">
-           <string>CenterlineSegment</string>
-          </property>
-          <property name="noneEnabled">
-           <bool>true</bool>
-          </property>
-          <property name="editEnabled">
-           <bool>true</bool>
-          </property>
-          <property name="renameEnabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
@@ -171,19 +140,6 @@
           </property>
           <property name="segmentationNodeSelectorVisible">
            <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="4">
-         <widget class="qSlicerMarkupsPlaceWidget" name="endPointsMarkupsPlaceWidget">
-          <property name="maximumSize">
-           <size>
-            <width>15000</width>
-            <height>40</height>
-           </size>
-          </property>
-          <property name="placeMultipleMarkups">
-           <enum>qSlicerMarkupsPlaceWidget::ForcePlaceMultipleMarkups</enum>
           </property>
          </widget>
         </item>
@@ -264,11 +220,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>qSlicerMarkupsPlaceWidget</class>
-   <extends>qSlicerWidget</extends>
-   <header>qSlicerMarkupsPlaceWidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>qMRMLSegmentSelectorWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLSegmentSelectorWidget.h</header>
@@ -302,38 +253,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>SegmentsWidget</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>endPointsMarkupsPlaceWidget</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>235</x>
-     <y>158</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>235</x>
-     <y>155</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>SegmentsWidget</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>endPointsMarkupsSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>235</x>
-     <y>158</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>235</x>
-     <y>55</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>SegmentsWidget</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
@@ -379,22 +298,6 @@
     <hint type="destinationlabel">
      <x>235</x>
      <y>95</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>endPointsMarkupsSelector</sender>
-   <signal>currentNodeChanged(vtkMRMLNode*)</signal>
-   <receiver>endPointsMarkupsPlaceWidget</receiver>
-   <slot>setCurrentNode(vtkMRMLNode*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>163</x>
-     <y>110</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>382</x>
-     <y>110</y>
     </hint>
    </hints>
   </connection>

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -86,6 +86,16 @@ set(_vascterr_pytest_files
   # TerritoryPlacementPipeline + LayerDMLib; SKIP bare, RUN launched,
   # mirroring the ControlPolygon/LiverBezier interaction suites (ADR-0027).
   test_territories_placement_pipeline.py
+  # ADR-0037 Stage-2 -- the annotation TABLE UI (§Decision 3 / §3 table):
+  # a Python-composed custom QTableWidget over the carrier, header row per
+  # territory + child row per seed; arm-through-the-Pipeline placement into
+  # the ACTIVE territory; delete-row/delete-pick convergence; glyph+text
+  # completeness (ADR-0010); selector retirement with the highlight wiring
+  # surviving and no persisted fiducial.  Needs Qt + the wrapped carrier +
+  # LayerDMLib; import-/hasattr-guarded on the not-yet-existing table widget
+  # + carrier display slot + Pipeline arm seam, they SKIP-PENDING bare and
+  # RUN launched once the seam lands (ADR-0027).
+  test_territories_table.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -96,6 +96,13 @@ set(_vascterr_pytest_files
   # + carrier display slot + Pipeline arm seam, they SKIP-PENDING bare and
   # RUN launched once the seam lands (ADR-0027).
   test_territories_table.py
+  # ADR-0037 §2D -- the slice-view territory placement + distance-faded viz
+  # (mirrors SliceControlPolygonPipeline, ADR-0033): the projection / signed
+  # distance / presence cutoff are pure math and RUN bare against the
+  # TerritorySliceProjection helper; the snap / arm-gate / bare-move-decline
+  # invariants need LayerDMLib so they SKIP bare and RUN launched, mirroring
+  # the 3D placement suite (ADR-0027).
+  test_territories_slice_pipeline.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/test_territories_annotation_carrier.py
+++ b/VascularTerritories/Testing/Python/test_territories_annotation_carrier.py
@@ -14,7 +14,8 @@ mirroring ``vtkMRMLResectionPlanStorageNode``.  No markups reference
 anywhere on the annotation path (ADR-0037 §Decision 1 + §Conformance
 [test], ADR-0014 §"Fourth layer").
 
-This file pins two Stage-1 increments:
+This file pins the Stage-1 increments and the Stage-2 display-attribute
+increment on the SAME carrier:
 
 * i1 — CARRIER STORAGE.  Ordered per-territory annotation points on the
   C++ ``vtkMRMLCustomTerritoriesNode``: add / get-Nth / count / clear;
@@ -23,6 +24,15 @@ This file pins two Stage-1 increments:
 * i2 — STORAGE ROUND-TRIP.  Writing the carrier's points to a storage
   node and reading them back yields identical ORDERED points per
   territory (mirrors ``vtkMRMLResectionPlanStorageNodeTest1``).
+* i5 (Stage 2) — DISPLAY-ATTRIBUTE SLOT.  ADR-0037 §Decision 3 / §3
+  table: the table row carries per-territory colour (RGB), display
+  label, and visibility.  Stage 2 ADDS these as a per-territoryId slot
+  on the SAME carrier, mirroring the ``AnnotationPoints``
+  ``std::map<std::string, ...>`` idiom, with XML + ``.vta.json``
+  round-trip.  These invariants pin that setting a display attribute
+  does NOT alter ``GetNumberOfAnnotationPoints`` or any point coord (the
+  display slot and the geometry slot are independent), and that the
+  attributes round-trip through storage.
 
 -- SEAM THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
 
@@ -85,6 +95,18 @@ ADD_POINT_METHOD = "AddAnnotationPoint"
 COUNT_METHOD = "GetNumberOfAnnotationPoints"
 GET_NTH_METHOD = "GetNthAnnotationPoint"
 CLEAR_METHOD = "ClearAnnotationPoints"
+
+# The per-territory DISPLAY-ATTRIBUTE slot ADR-0037 Stage-2 adds to the
+# carrier (colour / label / visibility), mirroring the AnnotationPoints
+# std::map idiom.  Tests skip-pending on absence (ADR-0027); the skip
+# lifts at the Stage-2 implementation commit.  Method names are PROPOSED;
+# sharpen at landing against the header's std::string-keyed idiom.
+SET_COLOR_METHOD = "SetTerritoryColor"
+GET_COLOR_METHOD = "GetTerritoryColor"
+SET_LABEL_METHOD = "SetTerritoryLabel"
+GET_LABEL_METHOD = "GetTerritoryLabel"
+SET_VISIBILITY_METHOD = "SetTerritoryVisibility"
+GET_VISIBILITY_METHOD = "GetTerritoryVisibility"
 
 # Two distinct surgeon-named territory ids used across the tests.
 TERRITORY_A = "SegmentVII"
@@ -296,6 +318,99 @@ def test_no_markups_fiducial_reference_role_on_the_carrier():
 
 
 # --------------------------------------------------------------------------- #
+# i5 (Stage 2) — per-territory display-attribute slot (launched)
+# --------------------------------------------------------------------------- #
+
+
+def _make_carrier_with_display_or_skip(slicer, name="DisplayAttrCarrierTest"):
+    """Mint a carrier exposing the Stage-2 display-attribute slot, or skip-pend.
+
+    Extends ``_make_custom_territories_or_skip`` with the per-territory
+    colour / label / visibility accessors ADR-0037 Stage-2 adds; skip-pends
+    (ADR-0027) when those accessors have not landed.
+    """
+    node = _make_custom_territories_or_skip(slicer, name)
+    for method in (
+        SET_COLOR_METHOD,
+        GET_COLOR_METHOD,
+        SET_LABEL_METHOD,
+        GET_LABEL_METHOD,
+        SET_VISIBILITY_METHOD,
+        GET_VISIBILITY_METHOD,
+    ):
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} -- the ADR-0037 "
+                "Stage-2 per-territory display-attribute slot (§Decision 3 / "
+                "§3 table) has not landed.  The skip lifts at the Stage-2 "
+                "implementation commit (ADR-0027)."
+            )
+    return node
+
+
+def test_display_attributes_store_and_read_back_per_territory():
+    """i5: colour / label / visibility store + read back, keyed per territory.
+
+    ADR-0037 §Decision 3 / §3 table: the header row carries a per-territory
+    colour swatch, display label, and visibility.  Two territories keep
+    INDEPENDENT display attributes (same std::map-keyed idiom as the point
+    carrier).
+    """
+    slicer = _slicer_or_skip()
+    node = _make_carrier_with_display_or_skip(slicer)
+
+    node.SetTerritoryColor(TERRITORY_A, 1.0, 0.0, 0.0)
+    node.SetTerritoryLabel(TERRITORY_A, "Right anterior")
+    node.SetTerritoryVisibility(TERRITORY_A, True)
+
+    node.SetTerritoryColor(TERRITORY_B, 0.0, 0.0, 1.0)
+    node.SetTerritoryLabel(TERRITORY_B, "Left lateral")
+    node.SetTerritoryVisibility(TERRITORY_B, False)
+
+    color_a = node.GetTerritoryColor(TERRITORY_A)
+    assert (color_a[0], color_a[1], color_a[2]) == pytest.approx((1.0, 0.0, 0.0), abs=1e-6)
+    assert node.GetTerritoryLabel(TERRITORY_A) == "Right anterior"
+    assert bool(node.GetTerritoryVisibility(TERRITORY_A)) is True
+
+    color_b = node.GetTerritoryColor(TERRITORY_B)
+    assert (color_b[0], color_b[1], color_b[2]) == pytest.approx((0.0, 0.0, 1.0), abs=1e-6)
+    assert node.GetTerritoryLabel(TERRITORY_B) == "Left lateral"
+    assert bool(node.GetTerritoryVisibility(TERRITORY_B)) is False
+
+
+def test_setting_a_display_attribute_does_not_touch_geometry():
+    """i5: a display-attribute write leaves point count + coords byte-identical.
+
+    ADR-0037 §Decision 3: the display slot and the geometry slot are
+    INDEPENDENT.  A colour / label / visibility edit is a "display slot
+    without touching geometry" write — no point added / moved / dropped
+    (the same invariant pinned launched by the table's colour/label/vis
+    edit test in ``test_territories_table.py``, pinned here at the carrier).
+    """
+    slicer = _slicer_or_skip()
+    node = _make_carrier_with_display_or_skip(slicer)
+
+    pts = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)]
+    for x, y, z in pts:
+        node.AddAnnotationPoint(TERRITORY_A, x, y, z)
+
+    before_count = node.GetNumberOfAnnotationPoints(TERRITORY_A)
+    before = [_nth(node, TERRITORY_A, i) for i in range(before_count)]
+
+    node.SetTerritoryColor(TERRITORY_A, 0.2, 0.4, 0.6)
+    node.SetTerritoryLabel(TERRITORY_A, "Renamed")
+    node.SetTerritoryVisibility(TERRITORY_A, False)
+
+    assert node.GetNumberOfAnnotationPoints(TERRITORY_A) == before_count, (
+        "a display-attribute write must NOT change the annotation-point count."
+    )
+    for i, expected in enumerate(before):
+        assert _nth(node, TERRITORY_A, i) == pytest.approx(expected, abs=1e-9), (
+            f"point {i} must not move on a display-attribute write."
+        )
+
+
+# --------------------------------------------------------------------------- #
 # i2 — storage round-trip (launched; needs scene + storage node)
 # --------------------------------------------------------------------------- #
 
@@ -373,6 +488,46 @@ def test_carrier_points_round_trip_through_storage():
             assert _nth(sink, TERRITORY_B, i) == pytest.approx(expected, abs=1e-6), (
                 f"territory B point {i} must round-trip in placement order."
             )
+    finally:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def test_display_attributes_round_trip_through_storage():
+    """i5: colour / label / visibility survive a ``.vta.json`` write+read.
+
+    ADR-0037 §Decision 3 adds the display slot "with XML + ``.vta.json``
+    round-trip" — the same storage node that persists the ordered points
+    also persists the per-territory colour, label, and visibility.  A
+    source carrier's display attributes read back identically on a fresh
+    sink carrier.
+    """
+    import os
+
+    slicer = _slicer_or_skip()
+    source = _make_carrier_with_display_or_skip(slicer, "DisplaySource")
+    storage = _make_storage_or_skip(slicer)
+
+    # At least one point so the territory is enumerable by the storage node.
+    source.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
+    source.SetTerritoryColor(TERRITORY_A, 0.1, 0.5, 0.9)
+    source.SetTerritoryLabel(TERRITORY_A, "Segment VII")
+    source.SetTerritoryVisibility(TERRITORY_A, False)
+
+    path = _temp_path(slicer, "json")
+    storage.SetFileName(path)
+    assert storage.WriteData(source) == 1, "storage WriteData must succeed."
+
+    try:
+        sink = _make_carrier_with_display_or_skip(slicer, "DisplaySink")
+        read_storage = _make_storage_or_skip(slicer)
+        read_storage.SetFileName(path)
+        assert read_storage.ReadData(sink) == 1, "storage ReadData must succeed."
+
+        color = sink.GetTerritoryColor(TERRITORY_A)
+        assert (color[0], color[1], color[2]) == pytest.approx((0.1, 0.5, 0.9), abs=1e-6)
+        assert sink.GetTerritoryLabel(TERRITORY_A) == "Segment VII"
+        assert bool(sink.GetTerritoryVisibility(TERRITORY_A)) is False
     finally:
         if os.path.exists(path):
             os.remove(path)

--- a/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+++ b/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
@@ -249,6 +249,12 @@ def test_click_adds_exactly_one_surface_snapped_point(monkeypatch):
     pipeline = TerritoryPlacementPipeline()
     carrier = _make_carrier_or_skip(slicer)
     _wire_pipeline_or_skip(slicer, pipeline, carrier, monkeypatch)
+    # ADR-0037 §Decision 3 arming model: add-on-click requires an armed
+    # pipeline (Stage-2 addition).  Arm into the wired territory before the
+    # click; the invariant pinned here (one surface-snapped point) is
+    # unchanged.
+    if hasattr(pipeline, "Arm"):
+        pipeline.Arm()
 
     before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
     click = _Event(vtk.vtkCommand.LeftButtonPressEvent)

--- a/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+++ b/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
@@ -19,10 +19,17 @@ delete-from-table is the whole lifecycle:
   * DELETE removes exactly one point;
   * an unrelated ``Modified`` causes no drift.
 
-This file pins two Stage-1 increments on the placement Pipeline:
+This file pins the Stage-1 increments + the Stage-2 shared-display-node
+routing on the placement Pipeline:
 
 * i3 — PLACEMENT click->add + bare-move decline.
 * i4 — EDIT (drag) + DELETE, and no-drift-on-unrelated-Modified.
+* i5 — SHARED DISPLAY-NODE routing (Stage 2 / the 3D-fix contract): with a
+  display node present, ``Arm()`` / ``SetActiveTerritory()`` publish onto it
+  and read back via ``IsArmed()`` / ``GetActiveTerritory()``, and a click
+  routes into the display-node-resolved carrier + ACTIVE territory.  The
+  bare-unit i3/i4 path (``SetPickCore`` + ``SetCarrier``, no display node)
+  keeps working via the instance-field fallback.
 
 The point storage lives on ``vtkMRMLCustomTerritoriesNode`` (the carrier
 pinned by ``test_territories_annotation_carrier.py``); this file pins the
@@ -83,7 +90,9 @@ import pytest
 vtk = pytest.importorskip("vtk")
 
 CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+HIGHLIGHT_DISPLAY_CLASS = "vtkMRMLTerritoriesHighlightDisplayNode"
 TERRITORY_A = "SegmentVII"
+TERRITORY_B = "SegmentVIII"
 
 # Carrier API seam (also pinned by test_territories_annotation_carrier.py).
 ADD_POINT_METHOD = "AddAnnotationPoint"
@@ -145,6 +154,29 @@ def _make_carrier_or_skip(slicer, name="PlacementCarrierTest"):
                 "lifts at the implementation commit (ADR-0027)."
             )
     return node
+
+
+def _make_display_node_or_skip(slicer, name="PlacementHighlightTest"):
+    """Mint the shared highlight display node, or skip-pend (ADR-0027)."""
+    node = slicer.mrmlScene.AddNewNodeByClass(HIGHLIGHT_DISPLAY_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{HIGHLIGHT_DISPLAY_CLASS} not registered -- the shared highlight "
+            "display node (ADR-0036/0037) is unavailable (launched build)."
+        )
+    return node
+
+
+def _import_interaction_state_or_skip():
+    """Import the shared interaction-state accessors, or skip-pend (ADR-0027)."""
+    try:
+        import TerritoryInteractionState as state
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoryInteractionState not importable ({exc!r}) -- the ADR-0037 "
+            "shared display-node state module has not landed (ADR-0027)."
+        )
+    return state
 
 
 def _unit_sphere():
@@ -444,6 +476,73 @@ def test_unrelated_modified_causes_no_point_drift(monkeypatch):
         assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, i)) == pytest.approx(
             expected, abs=1e-9
         ), f"point {i} must not drift on an unrelated Modified."
+
+
+# --------------------------------------------------------------------------- #
+# i5 — shared display-node routing (Stage 2 / the 3D-fix contract)
+# --------------------------------------------------------------------------- #
+
+
+def test_display_node_routes_arm_active_and_click(monkeypatch):
+    """i5: with a display node present, arm/active read back + a click routes there.
+
+    The 3D-fix contract: the widget/table cannot reach the manager-created
+    Pipeline instance, so arm state / active territory / carrier ride on the
+    SHARED highlight display node.  A Pipeline whose ``SetDisplayNode`` bound
+    that node must (a) publish ``Arm()`` / ``SetActiveTerritory()`` onto it
+    and read them back via ``IsArmed()`` / ``GetActiveTerritory()``, and (b)
+    route a click into the display-node-resolved carrier + ACTIVE territory —
+    NOT an instance-field carrier.  This is the integration the
+    detached-instance bug slipped through.
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+
+    VesselSurfacePick = _import_pick_or_skip()
+    if not hasattr(pipeline, "SetPickCore") or not hasattr(pipeline, "SetDisplayNode"):
+        pytest.skip(
+            "TerritoryPlacementPipeline lacks SetPickCore / SetDisplayNode -- "
+            "cannot bind the shared display-node state (Stage-2 not landed)."
+        )
+    for method in ("SetActiveTerritory", "GetActiveTerritory", "Arm", "IsArmed"):
+        if not hasattr(pipeline, method):
+            pytest.skip(
+                f"TerritoryPlacementPipeline has no {method} -- the shared "
+                "display-node arm seam has not landed (ADR-0027)."
+            )
+    monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
+    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
+
+    # Bind the carrier onto the SHARED display node (NOT via SetCarrier), then
+    # hand the display node to the pipeline: everything resolves from the node.
+    state.set_carrier(displayNode, carrier)
+    pipeline.SetDisplayNode(displayNode)
+
+    # (a) arm + active publish onto the node and read back through the seam.
+    pipeline.SetActiveTerritory(TERRITORY_B)
+    pipeline.Arm()
+    assert pipeline.IsArmed() is True
+    assert pipeline.GetActiveTerritory() == TERRITORY_B
+    assert state.is_armed(displayNode) is True
+    assert state.get_active_territory(displayNode) == TERRITORY_B
+
+    # (b) a click routes into the display-node-resolved carrier + ACTIVE
+    # territory (B), not the other one.
+    before_b = carrier.GetNumberOfAnnotationPoints(TERRITORY_B)
+    before_a = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    click = _Event(vtk.vtkCommand.LeftButtonPressEvent)
+    assert pipeline.ProcessInteractionEvent(click) is True
+
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_B) == before_b + 1, (
+        "an armed click must append ONE seed to the display-node ACTIVE territory."
+    )
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before_a, (
+        "the click must not leak into another territory."
+    )
 
 
 if __name__ == "__main__":

--- a/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+++ b/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
@@ -515,12 +515,15 @@ def test_display_node_routes_arm_active_and_click(monkeypatch):
                 "display-node arm seam has not landed (ADR-0027)."
             )
     monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
-    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
 
     # Bind the carrier onto the SHARED display node (NOT via SetCarrier), then
     # hand the display node to the pipeline: everything resolves from the node.
+    # SetDisplayNode resets the pick core to force a re-resolve from the node's
+    # pickSurface (production behaviour), so inject the unit-sphere pick AFTER
+    # the display node is bound.
     state.set_carrier(displayNode, carrier)
     pipeline.SetDisplayNode(displayNode)
+    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
 
     # (a) arm + active publish onto the node and read back through the seam.
     pipeline.SetActiveTerritory(TERRITORY_B)

--- a/VascularTerritories/Testing/Python/test_territories_slice_pipeline.py
+++ b/VascularTerritories/Testing/Python/test_territories_slice_pipeline.py
@@ -307,10 +307,16 @@ def _wire_slice_pipeline_or_skip(slicer, pipeline, displayNode, carrier, monkeyp
                 f"TerritorySlicePipeline has no {method} seam (ADR-0027)."
             )
     monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: object())
-    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
-    pipeline.SetViewNode(_FakeSliceNode(z0=0.0))
+    # The C++ base SetViewNode type-checks for a real vtkMRMLAbstractViewNode;
+    # the deterministic _FakeSliceNode drives the pure-Python projection/snap
+    # math, so set the internal slice-node field directly (avoids the C++
+    # marshalling that rejects a duck-typed node).
+    pipeline._slice_node = _FakeSliceNode(z0=0.0)
     state.set_carrier(displayNode, carrier)
     pipeline.SetDisplayNode(displayNode)
+    # SetDisplayNode resets the pick to force a re-resolve from the node's
+    # pickSurface (production behaviour), so inject the pick AFTER binding it.
+    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
 
 
 def test_armed_slice_press_adds_one_surface_snapped_seed(monkeypatch):
@@ -415,7 +421,10 @@ def test_reproject_projects_only_present_visible_seeds(monkeypatch):
     carrier.AddAnnotationPoint(TERRITORY_B, 1.0, 1.0, 0.0)  # invisible -> absent
 
     state.set_carrier(displayNode, carrier)
-    pipeline.SetViewNode(_FakeSliceNode(z0=0.0))
+    # Set the internal slice-node field directly: the C++ base SetViewNode
+    # type-checks for a real view node, while the deterministic _FakeSliceNode
+    # drives the pure-Python projection math under test.
+    pipeline._slice_node = _FakeSliceNode(z0=0.0)
     pipeline.SetDisplayNode(displayNode)
     pipeline._reproject()
 

--- a/VascularTerritories/Testing/Python/test_territories_slice_pipeline.py
+++ b/VascularTerritories/Testing/Python/test_territories_slice_pipeline.py
@@ -1,0 +1,430 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 §2D — the slice-view territory placement + distance-faded viz.
+
+ADR-0037 §Decision 2 routes vessel-annotation placement through a LayerDM
+scripted Pipeline; this file pins the SLICE-VIEW complement
+(``TerritorySlicePipeline``), which mirrors
+``LiverResectionsLib.SliceControlPolygonPipeline`` (ADR-0033):
+
+* PROJECTION (viz).  Every visible territory's carrier seeds project into
+  the slice view's XY space (``inverse(XYToRAS)``), faded by |signed
+  distance to the slice plane| over ``FADE_DISTANCE_MM``, with a signed
+  above/below SIDE TINT and a HARD presence cutoff at ``PICK_RANGE_MM``
+  (2D alpha is unreliable).  These are pure geometry given a slice node
+  exposing ``GetXYToRAS`` / ``GetSliceToRAS``, so they run BARE against the
+  ``TerritorySliceProjection`` helper module — no LayerDM, no GL, no scene.
+* SNAP (placement).  An armed LEFT-BUTTON PRESS resolves the slice pixel to
+  RAS on the plane (``XYToRAS``), casts a ray ALONG THE SLICE NORMAL, and
+  feeds it to ``VesselSurfacePick`` -> the surface-snapped seed lands in the
+  ACTIVE territory.  A bare MOVE is DECLINED (``(False, +inf)``, ADR-0033);
+  a disarmed press away from any seed leaves the gesture to the camera.
+* SHARED STATE.  Arm / active-territory / carrier live on the SAME shared
+  highlight display node the 3D placement uses
+  (``TerritoryInteractionState``), so 2D and 3D placement stay in lockstep.
+
+The projection math runs bare; the Pipeline itself needs LayerDMLib
+(reachable only inside a launched Slicer with the module loaded), so the
+snap / arm-gate / decline invariants SKIP bare and RUN launched, mirroring
+the 3D ``test_territories_placement_pipeline.py`` suite.
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (the decision)
+  * Docs/adr/0033-control-polygon-display-aspect.md  (slice-projection + hover)
+  * Docs/adr/0032-v2-interaction-via-layerdm-pipeline-seam.md  (the seam)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py  (mirror)
+  * VascularTerritories/VascularTerritoriesLib/TerritorySliceProjection.py
+  * VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+  * VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+HIGHLIGHT_DISPLAY_CLASS = "vtkMRMLTerritoriesHighlightDisplayNode"
+TERRITORY_A = "SegmentVII"
+TERRITORY_B = "SegmentVIII"
+
+# --------------------------------------------------------------------------- #
+# Repo geometry — the pure-math helper lives in the VascularTerritoriesLib
+# package alongside the pick core.  The path-insert lets the bare unit layer
+# import the projection module before the packaging follow-up lands (the
+# test_vessel_surface_pick.py precedent).
+# --------------------------------------------------------------------------- #
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "VascularTerritories" / "VascularTerritoriesLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Fake slice node — pure matrices, no MRML
+# --------------------------------------------------------------------------- #
+
+
+def _identity_scaled(fov_mm_per_px=1.0):
+    """A 4x4 mapping XY pixels to RAS with a uniform mm-per-pixel scale."""
+    m = vtk.vtkMatrix4x4()
+    m.Identity()
+    m.SetElement(0, 0, fov_mm_per_px)
+    m.SetElement(1, 1, fov_mm_per_px)
+    return m
+
+
+class _FakeSliceNode:
+    """An axial slice at ``z = z0``: normal +z, pixels 1 mm apart in x/y.
+
+    ``GetSliceToRAS`` origin is ``(0, 0, z0)`` with the standard axial
+    basis; ``GetXYToRAS`` maps pixel ``(ex, ey, 0)`` to RAS
+    ``(ex, ey, z0)`` — the in-plane landing point.
+    """
+
+    def __init__(self, z0=0.0, fov_mm_per_px=1.0):
+        self._slice_to_ras = vtk.vtkMatrix4x4()
+        self._slice_to_ras.Identity()
+        self._slice_to_ras.SetElement(2, 3, z0)
+        self._xy_to_ras = _identity_scaled(fov_mm_per_px)
+        self._xy_to_ras.SetElement(2, 3, z0)
+
+    def GetSliceToRAS(self):  # noqa: N802 - VTK verb
+        return self._slice_to_ras
+
+    def GetXYToRAS(self):  # noqa: N802 - VTK verb
+        return self._xy_to_ras
+
+    def IsA(self, cls):  # noqa: N802 - VTK verb
+        return cls == "vtkMRMLSliceNode"
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards for the launched-only Pipeline invariants
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _import_projection_or_skip():
+    """Import the pure-math projection helper, or skip-pend (ADR-0027)."""
+    try:
+        import TerritorySliceProjection as proj
+    except ImportError:
+        pytest.skip(
+            "TerritorySliceProjection not importable -- the ADR-0037 §2D slice "
+            "projection helper has not landed (ADR-0027 red->skip)."
+        )
+    return proj
+
+
+def _import_pipeline_or_skip():
+    try:
+        from VascularTerritoriesLib.TerritorySlicePipeline import (
+            TerritorySlicePipeline,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritorySlicePipeline not importable ({exc!r}) -- the ADR-0037 "
+            "§2D slice Pipeline has not landed OR LayerDMLib is not reachable "
+            "here.  The skip lifts at the implementation commit (ADR-0027)."
+        )
+    return TerritorySlicePipeline
+
+
+def _import_pick_or_skip():
+    try:
+        from VesselSurfacePick import VesselSurfacePick
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VesselSurfacePick not importable ({exc!r}).")
+    return VesselSurfacePick
+
+
+def _import_interaction_state_or_skip():
+    try:
+        import TerritoryInteractionState as state
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"TerritoryInteractionState not importable ({exc!r}).")
+    return state
+
+
+def _make_carrier_or_skip(slicer, name="SliceCarrierTest"):
+    node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} not registered -- the ADR-0037 "
+            "annotation carrier has not landed (launched build)."
+        )
+    if not hasattr(node, "AddAnnotationPoint"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no AddAnnotationPoint -- the "
+            "annotation carrier API has not landed (ADR-0027)."
+        )
+    return node
+
+
+def _make_display_node_or_skip(slicer, name="SliceHighlightTest"):
+    node = slicer.mrmlScene.AddNewNodeByClass(HIGHLIGHT_DISPLAY_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{HIGHLIGHT_DISPLAY_CLASS} not registered -- the shared highlight "
+            "display node is unavailable (launched build)."
+        )
+    return node
+
+
+def _unit_sphere():
+    source = vtk.vtkSphereSource()
+    source.SetRadius(1.0)
+    source.SetThetaResolution(64)
+    source.SetPhiResolution(64)
+    source.Update()
+    return source.GetOutput()
+
+
+class _Event:
+    """A minimal interaction event at a fixed display pixel + type."""
+
+    def __init__(self, etype, display_position=(0, 0)):
+        self._etype = etype
+        self._pos = display_position
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+# --------------------------------------------------------------------------- #
+# PURE MATH — projection / signed distance / presence cutoff (BARE)
+# --------------------------------------------------------------------------- #
+
+
+def test_project_ras_to_xy_round_trips_in_plane_point():
+    """A point ON the slice plane projects to its pixel via inverse(XYToRAS).
+
+    With a 1 mm/px axial slice at z=0, RAS ``(3, 4, 0)`` projects to XY
+    ``(3, 4)`` — the slice-view display coordinates coincide with this XY
+    space (the SliceControlPolygonPipeline convention).
+    """
+    proj = _import_projection_or_skip()
+    slice_node = _FakeSliceNode(z0=0.0, fov_mm_per_px=1.0)
+
+    xy = proj.project_ras_to_xy(slice_node, (3.0, 4.0, 0.0))
+
+    assert xy is not None
+    assert xy == pytest.approx((3.0, 4.0), abs=1e-6)
+
+
+def test_signed_distance_is_positive_above_negative_below():
+    """Signed distance is + above the plane (along +normal), - below.
+
+    An axial slice at z=0 has normal +z; RAS ``(0, 0, 5)`` is 5 mm above,
+    ``(0, 0, -5)`` is 5 mm below.
+    """
+    proj = _import_projection_or_skip()
+    slice_node = _FakeSliceNode(z0=0.0)
+
+    assert proj.signed_distance_to_slice(slice_node, (0.0, 0.0, 5.0)) == pytest.approx(5.0)
+    assert proj.signed_distance_to_slice(slice_node, (0.0, 0.0, -5.0)) == pytest.approx(-5.0)
+    assert proj.signed_distance_to_slice(slice_node, (2.0, 9.0, 0.0)) == pytest.approx(0.0)
+
+
+def test_presence_cutoff_is_hard_at_pick_range():
+    """Presence is a HARD cutoff at ``PICK_RANGE_MM`` (2D alpha unreliable).
+
+    A seed just inside the range is present; one at / beyond it is absent —
+    not merely faded to zero alpha (the ADR-0033 slice-polygon rule).
+    """
+    proj = _import_projection_or_skip()
+
+    assert proj.is_present(proj.PICK_RANGE_MM - 0.01) is True
+    assert proj.is_present(proj.PICK_RANGE_MM) is False
+    assert proj.is_present(proj.PICK_RANGE_MM + 5.0) is False
+    # The fade is monotone: nearer the plane => more opaque.
+    assert proj.fade_alpha(0.0) == pytest.approx(1.0)
+    assert proj.fade_alpha(proj.FADE_DISTANCE_MM) == pytest.approx(0.0)
+    assert 0.0 < proj.fade_alpha(proj.FADE_DISTANCE_MM / 2.0) < 1.0
+
+
+def test_side_tint_lightens_above_and_darkens_below():
+    """The signed side tint pulls a mid-grey toward white above / black below."""
+    proj = _import_projection_or_skip()
+    base = [128, 128, 128]
+
+    above = proj.side_tint(base, +proj.FADE_DISTANCE_MM)
+    below = proj.side_tint(base, -proj.FADE_DISTANCE_MM)
+
+    assert above[0] > base[0], "above the plane must lighten toward white."
+    assert below[0] < base[0], "below the plane must darken toward black."
+
+
+def test_normal_ray_runs_along_the_slice_normal_through_the_point():
+    """The snap ray straddles the RAS point ALONG the slice normal.
+
+    An axial slice's normal is +z, so the ray through ``(1, 2, 0)`` runs
+    from ``(1, 2, +extent)`` to ``(1, 2, -extent)`` — the x/y stay fixed.
+    """
+    proj = _import_projection_or_skip()
+    slice_node = _FakeSliceNode(z0=0.0)
+
+    ray = proj.normal_ray(slice_node, (1.0, 2.0, 0.0), extent_mm=50.0)
+
+    assert ray is not None
+    p1, p2 = ray
+    assert p1 == pytest.approx((1.0, 2.0, 50.0), abs=1e-6)
+    assert p2 == pytest.approx((1.0, 2.0, -50.0), abs=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# PIPELINE — snap / arm-gate / decline (LAUNCHED; SKIP bare)
+# --------------------------------------------------------------------------- #
+
+
+def _wire_slice_pipeline_or_skip(slicer, pipeline, displayNode, carrier, monkeypatch):
+    """Bind the pipeline to the shared display node + a slice view + pick core."""
+    VesselSurfacePick = _import_pick_or_skip()
+    state = _import_interaction_state_or_skip()
+    for method in ("SetPickCore", "SetDisplayNode", "SetViewNode"):
+        if not hasattr(pipeline, method):
+            pytest.skip(
+                f"TerritorySlicePipeline has no {method} seam (ADR-0027)."
+            )
+    monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: object())
+    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
+    pipeline.SetViewNode(_FakeSliceNode(z0=0.0))
+    state.set_carrier(displayNode, carrier)
+    pipeline.SetDisplayNode(displayNode)
+
+
+def test_armed_slice_press_adds_one_surface_snapped_seed(monkeypatch):
+    """An armed slice press snaps ONE seed onto the surface in the ACTIVE territory.
+
+    The pixel resolves to RAS on the plane, the normal ray hits the unit
+    sphere the injected pick core wraps, and the snapped seed lands in the
+    display-node ACTIVE territory (ADR-0037 §2D snap; the 2D/3D lockstep).
+    """
+    slicer = _slicer_or_skip()
+    TerritorySlicePipeline = _import_pipeline_or_skip()
+    pipeline = TerritorySlicePipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    _wire_slice_pipeline_or_skip(slicer, pipeline, displayNode, carrier, monkeypatch)
+
+    state.set_active_territory(displayNode, TERRITORY_A)
+    state.set_armed(displayNode, True)
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    # A pixel over the plane origin: the normal ray straddles the sphere.
+    press = _Event(vtk.vtkCommand.LeftButtonPressEvent, display_position=(0, 0))
+    assert pipeline.CanProcessInteractionEvent(press)[0] is True, (
+        "an armed press over the surface must be CLAIMED (add-on-click)."
+    )
+    assert pipeline.ProcessInteractionEvent(press) is True
+
+    after = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    assert after == before + 1, "an armed slice press must add EXACTLY ONE seed."
+
+
+def test_disarmed_slice_press_adds_nothing(monkeypatch):
+    """A disarmed slice press away from any seed adds no seed (ADR-0037 §Decision 3)."""
+    slicer = _slicer_or_skip()
+    TerritorySlicePipeline = _import_pipeline_or_skip()
+    pipeline = TerritorySlicePipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    _wire_slice_pipeline_or_skip(slicer, pipeline, displayNode, carrier, monkeypatch)
+
+    state.set_active_territory(displayNode, TERRITORY_A)
+    state.set_armed(displayNode, False)
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    press = _Event(vtk.vtkCommand.LeftButtonPressEvent, display_position=(0, 0))
+    can, _distance2 = pipeline.CanProcessInteractionEvent(press)
+
+    assert can is False, "a disarmed press away from any seed must be DECLINED."
+    pipeline.ProcessInteractionEvent(press)
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "a disarmed slice press must add no seed."
+    )
+
+
+def test_bare_slice_move_is_declined(monkeypatch):
+    """A bare slice move is DECLINED even while armed (ADR-0033 hover discipline)."""
+    import sys as _sys
+
+    slicer = _slicer_or_skip()
+    TerritorySlicePipeline = _import_pipeline_or_skip()
+    pipeline = TerritorySlicePipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    _wire_slice_pipeline_or_skip(slicer, pipeline, displayNode, carrier, monkeypatch)
+
+    state.set_active_territory(displayNode, TERRITORY_A)
+    state.set_armed(displayNode, True)
+
+    move = _Event(vtk.vtkCommand.MouseMoveEvent, display_position=(0, 0))
+    can, distance2 = pipeline.CanProcessInteractionEvent(move)
+
+    assert can is False, "a bare move must stay declined while armed (ADR-0033)."
+    assert distance2 == _sys.float_info.max
+
+
+def test_reproject_projects_only_present_visible_seeds(monkeypatch):
+    """The reproject drops seeds beyond the presence cutoff + invisible territories.
+
+    A seed on the plane is present; one far off the plane (beyond
+    ``PICK_RANGE_MM``) is dropped; an invisible territory contributes none.
+    The projected-key bookkeeping reflects exactly the surviving seeds.
+    """
+    slicer = _slicer_or_skip()
+    TerritorySlicePipeline = _import_pipeline_or_skip()
+    proj = _import_projection_or_skip()
+    pipeline = TerritorySlicePipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    if not hasattr(pipeline, "GetProjectedKeys") or not hasattr(pipeline, "SetViewNode"):
+        pytest.skip("TerritorySlicePipeline lacks GetProjectedKeys / SetViewNode (ADR-0027).")
+
+    carrier.SetTerritoryVisibility(TERRITORY_A, True)
+    carrier.SetTerritoryColor(TERRITORY_A, 0.9, 0.2, 0.2)
+    carrier.AddAnnotationPoint(TERRITORY_A, 3.0, 4.0, 0.0)  # on plane -> present
+    carrier.AddAnnotationPoint(TERRITORY_A, 0.0, 0.0, proj.PICK_RANGE_MM + 10.0)  # far -> absent
+    carrier.SetTerritoryVisibility(TERRITORY_B, False)
+    carrier.SetTerritoryColor(TERRITORY_B, 0.2, 0.2, 0.9)
+    carrier.AddAnnotationPoint(TERRITORY_B, 1.0, 1.0, 0.0)  # invisible -> absent
+
+    state.set_carrier(displayNode, carrier)
+    pipeline.SetViewNode(_FakeSliceNode(z0=0.0))
+    pipeline.SetDisplayNode(displayNode)
+    pipeline._reproject()
+
+    keys = pipeline.GetProjectedKeys()
+    assert keys == [(TERRITORY_A, 0)], (
+        "only the present, visible seed survives the projection (HARD presence "
+        "cutoff + territory visibility)."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -1,0 +1,839 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 Stage-2 — the VascularTerritories annotation table UI.
+
+ADR-0037 §Decision 3 (§3 table) replaces the legacy
+``inputSurfaceSelector`` / ``endPointsMarkupsSelector`` place-widget panel
+with a Python-composed custom ``QTableWidget`` (ADR-0004): a CUSTOM table,
+not a stock point-list view, because the surface-snap + territory-grouping
+contract has no stock fit (the same call ADR-0034 made against
+``qMRMLSegmentsTableView``).
+
+The confirmed Stage-2 design (maintainer-approved this session) that these
+invariants pin:
+
+* TABLE SHAPE.  Rows are PER-POINT, grouped under per-territory HEADER
+  rows.  Each territory has a header row (per-territory visibility, colour
+  swatch, label) and one CHILD row per seed point (on-surface status +
+  delete).
+* CARRIER IS THE MODEL.  The table reads/writes the Stage-1 annotation
+  carrier ``vtkMRMLCustomTerritoriesNode`` (points via ``AddAnnotationPoint``
+  / ``GetNumberOfAnnotationPoints`` / ``GetNthAnnotationPoint`` /
+  ``ClearAnnotationPoints``; the Stage-2 display slot via the per-territory
+  colour / label / visibility accessors).  It OBSERVES the carrier's
+  ``vtkCommand::ModifiedEvent`` and rebuilds; edits write back.
+* ARMING (pipeline-managed, NOT a Slicer mouse mode).  The arm state lives
+  on the ``TerritoryPlacementPipeline``; the interaction node is NOT
+  touched.  "Add Territory" mints a new empty territory on the carrier,
+  selects its row, makes it the pipeline's ACTIVE territory, and arms
+  placement; each surface click through the pipeline seam appends ONE seed
+  to the ACTIVE territory (sequential, unbounded).  "Done" / Esc disarms.
+  Selecting an existing row + "Add seeds" re-arms into THAT territory.
+* DELETE CONVERGENCE.  Delete-by-row (table) and delete-by-pick (pipeline)
+  route through ONE carrier deletion path — a single point-removal
+  implementation reached from both entry points.
+* SEED-COUNT COMPLETENESS.  A territory with < 2 seeds is flagged
+  incomplete via GLYPH + TEXT (ADR-0010, never colour alone) —
+  display-only in Stage 2 (extraction gating is Stage 3).
+* RETIREMENT.  The legacy markups-selector / place-widget wiring
+  (``endPointsMarkupsSelector`` / ``newEndpointsListCreated`` /
+  ``onSegmentChanged``) retires; ``inputSurfaceSelector`` +
+  ``updateHighlightPickSurface`` STAY (Stage-1 highlight-wiring invariant
+  survives); NO ``vtkMRMLMarkupsFiducialNode`` persisted by the annotation
+  path.
+
+-- SEAM THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
+
+A Python-widget-composed table, mirroring the Stage-2 segments-table
+paradigm (ADR-0034) but CUSTOM (ADR-0037 §Decision 3):
+
+  * module path ``VascularTerritoriesLib.TerritoriesTableWidget``, class
+    ``TerritoriesTableWidget`` (a ``qt.QTableWidget`` subclass or a
+    composed widget owning one), constructed over the carrier + the
+    placement Pipeline:
+      ``TerritoriesTableWidget(carrier=<vtkMRMLCustomTerritoriesNode>,
+                               pipeline=<TerritoryPlacementPipeline>)``.
+  * ``table()`` -> the underlying ``qt.QTableWidget``;
+  * row model helpers: ``isHeaderRow(row) -> bool``,
+    ``territoryOfRow(row) -> str``, ``pointIndexOfRow(row) -> int | None``
+    (``None`` for a header row);
+  * ``addTerritory(territoryId=None) -> str`` — mint an empty territory,
+    select its header row, arm the pipeline into it;
+  * ``armForSelectedTerritory()`` — re-arm placement into the selected
+    row's territory ("Add seeds");
+  * ``done()`` — disarm;
+  * ``deleteRow(row)`` — the delete-from-table entry point, converging on
+    the pipeline's ``DeleteAnnotationPoint``;
+  * status-cell readers for the completeness assertion:
+    ``rowStatusText(row) -> str`` and ``rowHasIncompleteGlyph(row) -> bool``.
+
+The arm state on the Pipeline (a Stage-2 addition to
+``TerritoryPlacementPipeline``): an ``IsArmed() -> bool`` plus an
+"active territory" the click appends into (the current ``SetCarrier``
+binds a single territory; Stage 2 needs "set active territory + arm" so a
+click appends to the ACTIVE territory, not an implicit one).  Proposed:
+``SetActiveTerritory(territoryId)`` / ``GetActiveTerritory()`` +
+``Arm()`` / ``Disarm()`` / ``IsArmed()``.
+
+-- WHY LAUNCHED-SLICER --
+
+The table needs Qt (``qt.QTableWidget``) + the wrapped
+``vtkMRMLCustomTerritoriesNode`` carrier + (for the arming tests) the
+LayerDM ``TerritoryPlacementPipeline``.  A bare ``PythonSlicer -m pytest``
+has ``slicer.mrmlScene is None``, no Qt, and LayerDMLib off the path, so
+every test here SKIPS CLEANLY via the shared ``slicer_pytest_support``
+guards.
+
+-- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
+
+Pre-implementation the table widget + the carrier display slot + the
+Pipeline arm seam do not exist, so the import / ``hasattr`` guards
+skip-pend; the skips lift at the Stage-2 implementation commit.  Under a
+launched Slicer, verify run-vs-skip in the CI log once the seam lands —
+never trust overall green (the launched harness is green-but-skipping
+prone).
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (the decision)
+  * Docs/adr/0034-stage2-segments-table.md  (the table paradigm)
+  * Docs/adr/0010-accessibility-and-i18n.md  (glyph + text, never colour)
+  * Docs/adr/0033-control-polygon-display-aspect.md  (hover-decline)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * VascularTerritories/Testing/Python/test_territories_annotation_carrier.py
+  * VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+  * VascularTerritories/Testing/Python/test_vessel_highlight_wiring.py
+  * VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+  * VascularTerritories/Testing/Python/conftest.py  (the cleanup fixtures)
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+TERRITORY_A = "SegmentVII"
+TERRITORY_B = "SegmentVIII"
+
+# Carrier point API (pinned by test_territories_annotation_carrier.py).
+ADD_POINT_METHOD = "AddAnnotationPoint"
+COUNT_METHOD = "GetNumberOfAnnotationPoints"
+GET_NTH_METHOD = "GetNthAnnotationPoint"
+
+# Carrier display-attribute slot (Stage-2; pinned bare-adjacent in the
+# carrier test's i5).  Proposed accessor names.
+DISPLAY_METHODS = (
+    "SetTerritoryColor",
+    "GetTerritoryColor",
+    "SetTerritoryLabel",
+    "GetTerritoryLabel",
+    "SetTerritoryVisibility",
+    "GetTerritoryVisibility",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror the launched-Slicer discipline in conftest.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from conftest import _import_slicer_or_skip, _require_mrml_scene
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _qt_or_skip():
+    from conftest import _require_qt_widget
+
+    _require_qt_widget()
+
+
+def _make_carrier_or_skip(slicer, name="TableCarrierTest"):
+    """Mint a carrier exposing the point + display-attribute API, or skip-pend."""
+    node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} not registered -- module Logic "
+            "RegisterNodes() must wire this up (launched build)."
+        )
+    for method in (ADD_POINT_METHOD, COUNT_METHOD, GET_NTH_METHOD):
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} -- the ADR-0037 "
+                "annotation carrier (Stage-1) has not landed (ADR-0027)."
+            )
+    for method in DISPLAY_METHODS:
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} -- the ADR-0037 "
+                "Stage-2 display-attribute slot has not landed (ADR-0027)."
+            )
+    return node
+
+
+def _import_table_or_skip():
+    """Import the Stage-2 table widget class or skip-pend (ADR-0027)."""
+    try:
+        from VascularTerritoriesLib.TerritoriesTableWidget import (
+            TerritoriesTableWidget,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoriesTableWidget not importable ({exc!r}) -- the ADR-0037 "
+            "Stage-2 table widget has not landed OR Qt/LayerDMLib is not "
+            "reachable here.  The skip lifts at the Stage-2 implementation "
+            "commit (ADR-0027)."
+        )
+    return TerritoriesTableWidget
+
+
+def _import_pipeline_or_skip():
+    try:
+        from VascularTerritoriesLib.TerritoryPlacementPipeline import (
+            TerritoryPlacementPipeline,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoryPlacementPipeline not importable ({exc!r}) -- ADR-0037 "
+            "placement Pipeline / LayerDMLib not reachable (ADR-0027)."
+        )
+    return TerritoryPlacementPipeline
+
+
+def _make_table_or_skip(slicer, carrier, pipeline=None):
+    """Construct the table over the carrier (+ pipeline), registering teardown.
+
+    Skip-pends when the table constructor does not yet accept the carrier +
+    pipeline seam (Stage-2 not landed).
+    """
+    TerritoriesTableWidget = _import_table_or_skip()
+    try:
+        table = TerritoriesTableWidget(carrier=carrier, pipeline=pipeline)
+    except TypeError as exc:
+        pytest.skip(
+            f"TerritoriesTableWidget(carrier=, pipeline=) seam absent ({exc!r}) "
+            "-- the ADR-0037 Stage-2 table constructor has not landed (ADR-0027)."
+        )
+    return table
+
+
+def _require_table_row_model(table):
+    """Skip-pend unless the table exposes the row-model reader seams."""
+    for method in ("table", "isHeaderRow", "territoryOfRow", "pointIndexOfRow"):
+        if not hasattr(table, method):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {method} row-model seam -- "
+                "the ADR-0037 Stage-2 table has not landed (ADR-0027)."
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Fake interaction plumbing (reused from the placement-pipeline suite shape)
+# --------------------------------------------------------------------------- #
+
+
+def _unit_sphere():
+    source = vtk.vtkSphereSource()
+    source.SetRadius(1.0)
+    source.SetThetaResolution(64)
+    source.SetPhiResolution(64)
+    source.Update()
+    return source.GetOutput()
+
+
+class _FakeRenderer:
+    """Display->world unprojects any pixel to the +z ray a unit sphere is hit by."""
+
+    def __init__(self):
+        self._display = [0.0, 0.0, 0.0]
+
+    def SetDisplayPoint(self, x, y, z):  # noqa: N802 - VTK verb
+        self._display = [x, y, z]
+
+    def DisplayToWorld(self):  # noqa: N802 - VTK verb
+        pass
+
+    def GetWorldPoint(self):  # noqa: N802 - VTK verb
+        if self._display[2] <= 0.0:
+            return (0.0, 0.0, 5.0, 1.0)
+        return (0.0, 0.0, -5.0, 1.0)
+
+
+class _Event:
+    """A minimal interaction event at a fixed display pixel + type."""
+
+    def __init__(self, etype, display_position=(100, 100)):
+        self._etype = etype
+        self._pos = display_position
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+def _wire_pipeline_or_skip(pipeline, carrier, monkeypatch):
+    """Attach a stub renderer + pick core so a click resolves to the surface."""
+    try:
+        from VesselSurfacePick import VesselSurfacePick
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VesselSurfacePick not importable ({exc!r}).")
+    if not hasattr(pipeline, "SetPickCore") or not hasattr(pipeline, "SetCarrier"):
+        pytest.skip(
+            "TerritoryPlacementPipeline lacks SetPickCore / SetCarrier -- "
+            "cannot drive a click (Stage-1 not landed; ADR-0027)."
+        )
+    monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
+    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
+    pipeline.SetCarrier(carrier, TERRITORY_A)
+
+
+def _require_arm_seam(pipeline):
+    """Skip-pend unless the Pipeline exposes the Stage-2 active-territory + arm seam."""
+    for method in ("SetActiveTerritory", "GetActiveTerritory", "Arm", "Disarm", "IsArmed"):
+        if not hasattr(pipeline, method):
+            pytest.skip(
+                f"TerritoryPlacementPipeline has no {method} -- the ADR-0037 "
+                "Stage-2 active-territory + arm seam has not landed.  A click "
+                "must append to the ACTIVE territory, not an implicit one "
+                "(§Decision 3 arming model; ADR-0027)."
+            )
+
+
+# --------------------------------------------------------------------------- #
+# TABLE SHAPE — header row per territory + child row per seed
+# --------------------------------------------------------------------------- #
+
+
+def test_table_builds_header_row_per_territory_and_child_row_per_point(qt_widgets):
+    """The table has one header row per territory + one child row per seed.
+
+    ADR-0037 §Decision 3 / §3 table: rows are per-point, grouped under
+    per-territory header rows.  A carrier with two territories (2 + 3 seeds)
+    yields 2 header rows + 5 child rows, in territory order.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+
+    for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]:
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    for x, y, z in [(0.0, 1.0, 0.0), (0.0, 2.0, 0.0), (0.0, 3.0, 0.0)]:
+        carrier.AddAnnotationPoint(TERRITORY_B, x, y, z)
+    carrier.Modified()
+
+    widget = table.table()
+    header_rows = [r for r in range(widget.rowCount) if table.isHeaderRow(r)]
+    child_rows = [r for r in range(widget.rowCount) if not table.isHeaderRow(r)]
+
+    assert len(header_rows) == 2, "one header row per territory."
+    assert len(child_rows) == 5, "one child row per seed point across both territories."
+    # Every child row resolves to a real point index within its territory.
+    for r in child_rows:
+        territory = table.territoryOfRow(r)
+        idx = table.pointIndexOfRow(r)
+        assert idx is not None and 0 <= idx < carrier.GetNumberOfAnnotationPoints(territory)
+
+
+def test_carrier_modified_event_rebuilds_the_table(qt_widgets):
+    """A carrier ``ModifiedEvent`` triggers a table rebuild (the carrier is the model).
+
+    ADR-0037 §Decision 3: the table OBSERVES the carrier's
+    ``vtkCommand::ModifiedEvent`` and rebuilds.  Adding a point to the
+    carrier (outside the table) grows the child-row count without an
+    explicit table refresh call.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+
+    carrier.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
+    before = sum(1 for r in range(table.table().rowCount) if not table.isHeaderRow(r))
+
+    carrier.AddAnnotationPoint(TERRITORY_A, 2.0, 0.0, 0.0)  # fires ModifiedEvent
+
+    after = sum(1 for r in range(table.table().rowCount) if not table.isHeaderRow(r))
+    assert after == before + 1, (
+        "a carrier ModifiedEvent must rebuild the table (child-row count grows "
+        "with the seed count) -- the carrier is the model, no manual refresh."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ARMING — click appends to the ACTIVE territory
+# --------------------------------------------------------------------------- #
+
+
+def test_arm_then_click_appends_one_seed_to_active_territory(qt_widgets, monkeypatch):
+    """Arm + a surface click appends EXACTLY ONE seed to the ACTIVE territory.
+
+    ADR-0037 §Decision 3 arming model: "Add Territory" makes a territory
+    the pipeline's ACTIVE one and arms placement; a surface click through
+    the pipeline seam appends one seed to THAT territory, not another.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    pipeline = _import_pipeline_or_skip()()
+    _wire_pipeline_or_skip(pipeline, carrier, monkeypatch)
+    _require_arm_seam(pipeline)
+    table = _make_table_or_skip(slicer, carrier, pipeline)
+    qt_widgets.append(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    active = table.addTerritory()  # mints + selects + arms into a new territory
+    assert pipeline.IsArmed() is True, "Add Territory must arm placement."
+    assert pipeline.GetActiveTerritory() == active
+
+    before_active = carrier.GetNumberOfAnnotationPoints(active)
+    before_other = carrier.GetNumberOfAnnotationPoints(TERRITORY_B)
+
+    click = _Event(vtk.vtkCommand.LeftButtonPressEvent)
+    assert pipeline.ProcessInteractionEvent(click) is True
+
+    assert carrier.GetNumberOfAnnotationPoints(active) == before_active + 1, (
+        "an armed click must append EXACTLY ONE seed to the ACTIVE territory."
+    )
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_B) == before_other, (
+        "the click must NOT leak into another territory."
+    )
+
+
+def test_click_with_nothing_armed_appends_nothing(qt_widgets, monkeypatch):
+    """A click with placement NOT armed appends no seed (ADR-0037 §Decision 3).
+
+    Disarmed ("Done" / Esc), the pipeline is idle: a click adds nothing to
+    any territory.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    pipeline = _import_pipeline_or_skip()()
+    _wire_pipeline_or_skip(pipeline, carrier, monkeypatch)
+    _require_arm_seam(pipeline)
+    table = _make_table_or_skip(slicer, carrier, pipeline)
+    qt_widgets.append(table)
+
+    pipeline.Disarm()
+    assert pipeline.IsArmed() is False
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    click = _Event(vtk.vtkCommand.LeftButtonPressEvent)
+    pipeline.ProcessInteractionEvent(click)
+
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "a click with nothing armed must append no seed."
+    )
+
+
+def test_bare_move_stays_declined_while_armed(qt_widgets, monkeypatch):
+    """A bare hover/move stays DECLINED even while armed (ADR-0033).
+
+    Arming enables add-on-click; it does NOT make a bare move claim the
+    gesture.  ``CanProcessInteractionEvent`` on a move returns
+    ``(False, +inf)`` so the camera is untouched (ADR-0033 hover discipline,
+    carried into ADR-0037).
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    pipeline = _import_pipeline_or_skip()()
+    _wire_pipeline_or_skip(pipeline, carrier, monkeypatch)
+    _require_arm_seam(pipeline)
+    pipeline.Arm()
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    move = _Event(vtk.vtkCommand.MouseMoveEvent)
+    can, distance2 = pipeline.CanProcessInteractionEvent(move)
+
+    assert can is False, "a bare move must stay declined while armed (ADR-0033)."
+    assert distance2 == sys.float_info.max
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "a bare move must append no seed."
+    )
+
+
+def test_switching_active_territory_redirects_subsequent_clicks(qt_widgets, monkeypatch):
+    """Selecting a row + Add seeds redirects clicks to the newly ACTIVE territory.
+
+    ADR-0037 §Decision 3: "Selecting an existing row + 'Add seeds' re-arms
+    into that territory."  After re-arming into territory B, a click lands in
+    B — not the previously active A.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    pipeline = _import_pipeline_or_skip()()
+    _wire_pipeline_or_skip(pipeline, carrier, monkeypatch)
+    _require_arm_seam(pipeline)
+    table = _make_table_or_skip(slicer, carrier, pipeline)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    for seam in ("addTerritory", "armForSelectedTerritory", "selectTerritoryRow"):
+        if not hasattr(table, seam):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {seam} seam -- cannot pin "
+                "active-territory switching (ADR-0037 Stage-2; ADR-0027)."
+            )
+
+    territory_a = table.addTerritory()
+    territory_b = table.addTerritory()
+    # Re-arm into A first, then switch back to B via the row selection.
+    table.selectTerritoryRow(territory_a)
+    table.armForSelectedTerritory()
+    assert pipeline.GetActiveTerritory() == territory_a
+
+    table.selectTerritoryRow(territory_b)
+    table.armForSelectedTerritory()
+    assert pipeline.GetActiveTerritory() == territory_b
+
+    before_b = carrier.GetNumberOfAnnotationPoints(territory_b)
+    before_a = carrier.GetNumberOfAnnotationPoints(territory_a)
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent))
+
+    assert carrier.GetNumberOfAnnotationPoints(territory_b) == before_b + 1, (
+        "after re-arming into B, a click must land in B."
+    )
+    assert carrier.GetNumberOfAnnotationPoints(territory_a) == before_a, (
+        "the previously active territory A must not receive the click."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# DELETE convergence — table + pipeline share one carrier deletion path
+# --------------------------------------------------------------------------- #
+
+
+def test_delete_row_removes_exactly_one_point(qt_widgets):
+    """Delete-by-row removes EXACTLY ONE carrier point (§Decision 3 / §Decision 2).
+
+    Deleting a child row drops that one seed from the carrier; the count
+    falls by one and the survivors keep their order.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    if not hasattr(table, "deleteRow"):
+        pytest.skip("TerritoriesTableWidget has no deleteRow seam (ADR-0027).")
+
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    for x, y, z in pts:
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    carrier.Modified()
+
+    # The child row for territory A, point index 1.
+    target_row = next(
+        r
+        for r in range(table.table().rowCount)
+        if not table.isHeaderRow(r)
+        and table.territoryOfRow(r) == TERRITORY_A
+        and table.pointIndexOfRow(r) == 1
+    )
+    table.deleteRow(target_row)
+
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == len(pts) - 1, (
+        "delete-by-row must remove EXACTLY ONE carrier point."
+    )
+    assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, 0)) == pytest.approx(pts[0], abs=1e-6)
+    assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, 1)) == pytest.approx(pts[2], abs=1e-6)
+
+
+def test_delete_by_row_and_by_pick_share_one_carrier_path(qt_widgets):
+    """Delete-by-row and the pipeline's ``DeleteAnnotationPoint`` converge.
+
+    ADR-0037 §Decision 3 delete convergence: BOTH entry points route through
+    ONE carrier deletion path.  Deleting index 1 via each entry point removes
+    the same point and drops the count by one identically — no divergent
+    routes.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    pipeline = _import_pipeline_or_skip()()
+    if not hasattr(pipeline, "SetCarrier") or not hasattr(pipeline, "DeleteAnnotationPoint"):
+        pytest.skip(
+            "TerritoryPlacementPipeline lacks SetCarrier / DeleteAnnotationPoint "
+            "-- cannot pin delete convergence (ADR-0027)."
+        )
+    pipeline.SetCarrier(carrier, TERRITORY_A)
+    table = _make_table_or_skip(slicer, carrier, pipeline)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    if not hasattr(table, "deleteRow"):
+        pytest.skip("TerritoriesTableWidget has no deleteRow seam (ADR-0027).")
+
+    # Seed two identical-shaped territories to delete-index-1 from each way.
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    for x, y, z in pts:
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    for x, y, z in pts:
+        carrier.AddAnnotationPoint(TERRITORY_B, x, y, z)
+    carrier.Modified()
+
+    # Route 1: pipeline delete-by-pick on territory B, index 1.
+    assert pipeline.DeleteAnnotationPoint(TERRITORY_B, 1) is True
+    b_after = [
+        tuple(carrier.GetNthAnnotationPoint(TERRITORY_B, i))
+        for i in range(carrier.GetNumberOfAnnotationPoints(TERRITORY_B))
+    ]
+
+    # Route 2: table delete-by-row on territory A, index 1.
+    target_row = next(
+        r
+        for r in range(table.table().rowCount)
+        if not table.isHeaderRow(r)
+        and table.territoryOfRow(r) == TERRITORY_A
+        and table.pointIndexOfRow(r) == 1
+    )
+    table.deleteRow(target_row)
+    a_after = [
+        tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, i))
+        for i in range(carrier.GetNumberOfAnnotationPoints(TERRITORY_A))
+    ]
+
+    # Both routes must yield the SAME surviving set (points 0 and 2).
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == len(pts) - 1
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_B) == len(pts) - 1
+    assert a_after == pytest.approx(b_after, abs=1e-6), (
+        "delete-by-row and delete-by-pick must converge on one carrier path "
+        "(identical survivors) -- no divergent deletion routes."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# DISPLAY EDITS — write the carrier display slot without touching geometry
+# --------------------------------------------------------------------------- #
+
+
+def test_visibility_colour_label_edits_leave_geometry_unchanged(qt_widgets):
+    """Header-row visibility / colour / label edits write the display slot only.
+
+    ADR-0037 §Decision 3: the header row carries per-territory visibility,
+    colour swatch, and label; editing them writes the carrier's display slot
+    "without touching geometry" — the annotation-point count + coords stay
+    byte-identical.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    for seam in ("setTerritoryVisibility", "setTerritoryColor", "setTerritoryLabel"):
+        if not hasattr(table, seam):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {seam} edit seam (ADR-0027)."
+            )
+
+    pts = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)]
+    for x, y, z in pts:
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    carrier.Modified()
+
+    before_count = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    before = [
+        tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, i)) for i in range(before_count)
+    ]
+
+    table.setTerritoryVisibility(TERRITORY_A, False)
+    table.setTerritoryColor(TERRITORY_A, 0.3, 0.6, 0.9)
+    table.setTerritoryLabel(TERRITORY_A, "Renamed via table")
+
+    # The display slot took the edit ...
+    assert bool(carrier.GetTerritoryVisibility(TERRITORY_A)) is False
+    assert carrier.GetTerritoryLabel(TERRITORY_A) == "Renamed via table"
+    color = carrier.GetTerritoryColor(TERRITORY_A)
+    assert (color[0], color[1], color[2]) == pytest.approx((0.3, 0.6, 0.9), abs=1e-6)
+
+    # ... and the geometry did not move.
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before_count, (
+        "a display edit must NOT change the annotation-point count."
+    )
+    for i, expected in enumerate(before):
+        assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, i)) == pytest.approx(
+            expected, abs=1e-9
+        ), f"point {i} must not move on a display edit."
+
+
+# --------------------------------------------------------------------------- #
+# COMPLETENESS — < 2 seeds flagged via glyph + text (ADR-0010, not colour)
+# --------------------------------------------------------------------------- #
+
+
+def test_territory_with_fewer_than_two_seeds_is_flagged_incomplete(qt_widgets):
+    """A territory with < 2 seeds shows an incomplete indicator as GLYPH + TEXT.
+
+    ADR-0037 §Decision 3 + §Conformance [review] (ADR-0010): status is
+    rendered as glyph + text, NEVER colour alone.  A one-seed territory reads
+    incomplete (glyph present + a non-empty status text); a two-seed one does
+    not.  Display-only in Stage 2 — extraction gating is Stage 3.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    for seam in ("rowStatusText", "rowHasIncompleteGlyph"):
+        if not hasattr(table, seam):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {seam} status seam -- cannot "
+                "assert the glyph+text completeness indicator (ADR-0010; ADR-0027)."
+            )
+
+    carrier.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)  # one seed -> incomplete
+    for x, y, z in [(0.0, 1.0, 0.0), (0.0, 2.0, 0.0)]:
+        carrier.AddAnnotationPoint(TERRITORY_B, x, y, z)  # two seeds -> complete
+    carrier.Modified()
+
+    header_a = next(
+        r for r in range(table.table().rowCount)
+        if table.isHeaderRow(r) and table.territoryOfRow(r) == TERRITORY_A
+    )
+    header_b = next(
+        r for r in range(table.table().rowCount)
+        if table.isHeaderRow(r) and table.territoryOfRow(r) == TERRITORY_B
+    )
+
+    # Assert the GLYPH + TEXT indicator, never a colour.
+    assert table.rowHasIncompleteGlyph(header_a) is True, (
+        "a < 2-seed territory must carry an incomplete GLYPH (ADR-0010)."
+    )
+    assert table.rowStatusText(header_a).strip() != "", (
+        "the incomplete state must also carry TEXT (ADR-0010, never colour alone)."
+    )
+    assert table.rowHasIncompleteGlyph(header_b) is False, (
+        "a >= 2-seed territory must NOT be flagged incomplete."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# RETIREMENT — selector gone; highlight wiring survives; no persisted markups
+# --------------------------------------------------------------------------- #
+
+
+def test_highlight_picksurface_wiring_survives_selector_retirement(qt_widgets):
+    """The Stage-1 highlight-wiring invariant survives the selector retirement.
+
+    ADR-0037 §Consequences: ``inputSurfaceSelector`` + ``updateHighlightPickSurface``
+    STAY.  After the legacy ``endPointsMarkupsSelector`` retires, selecting an
+    input segmentation must still aim the highlight's ``pickSurface`` at it
+    (the ``test_vessel_highlight_wiring.py`` invariant, re-pinned here so the
+    Stage-2 panel rewrite does not regress it).
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+
+    from VascularTerritories import VascularTerritoriesWidget
+
+    widget = VascularTerritoriesWidget()
+    widget.setup()
+    qt_widgets.append(widget)
+
+    source = vtk.vtkSphereSource()
+    source.SetRadius(30.0)
+    source.SetThetaResolution(48)
+    source.SetPhiResolution(48)
+    source.Update()
+    model = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "Vessel")
+    model.SetAndObservePolyData(source.GetOutput())
+    segmentation = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode", "TestVessel")
+    segmentation.CreateDefaultDisplayNodes()
+    slicer.modules.segmentations.logic().ImportModelToSegmentationNode(model, segmentation)
+    slicer.mrmlScene.RemoveNode(model)
+
+    if not hasattr(widget, "updateHighlightPickSurface"):
+        pytest.skip(
+            "VascularTerritoriesWidget has no updateHighlightPickSurface -- the "
+            "surviving Stage-1 highlight wiring is absent (regression!)."
+        )
+    widget.ui.inputSurfaceSelector.blockSignals(True)
+    widget.ui.inputSurfaceSelector.setCurrentNode(segmentation)
+    widget.ui.inputSurfaceSelector.blockSignals(False)
+    widget.updateHighlightPickSurface()
+
+    highlight = widget._highlightDisplayNode
+    assert highlight is not None
+    assert highlight.GetPickSurfaceNode() is segmentation, (
+        "updateHighlightPickSurface must still aim pickSurface at the selected "
+        "input segmentation after the selector retirement (ADR-0037 §Consequences)."
+    )
+
+    # Drop the widget's scene observers before the autouse scene-clear fires.
+    for event, handler in (
+        (slicer.mrmlScene.StartCloseEvent, widget.onSceneStartClose),
+        (slicer.mrmlScene.EndCloseEvent, widget.onSceneEndClose),
+    ):
+        widget.removeObserver(slicer.mrmlScene, event, handler)
+    widget.cleanup()
+
+
+def test_no_endpoints_selector_and_no_persisted_fiducial(qt_widgets):
+    """``endPointsMarkupsSelector`` is gone AND no fiducial is persisted.
+
+    ADR-0037 §Consequences + §Conformance [review]: the markups-selector /
+    place-widget wiring retires, and the annotation/table path persists NO
+    ``vtkMRMLMarkupsFiducialNode``.  Both have a credible creep-in path (a
+    left-in selector; a fallback fiducial), so per the no-colour-of-the-sky
+    discipline this narrow absence stays pinned.
+
+    Pins: (1) the widget no longer exposes ``ui.endPointsMarkupsSelector``;
+    (2) after arming + a surface click through the placement path, no
+    ``vtkMRMLMarkupsFiducialNode`` is present in the scene.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+
+    from VascularTerritories import VascularTerritoriesWidget
+
+    widget = VascularTerritoriesWidget()
+    widget.setup()
+    qt_widgets.append(widget)
+
+    # (1) the legacy selector is retired from the UI.
+    ui = getattr(widget, "ui", None)
+    assert ui is not None
+    if hasattr(ui, "endPointsMarkupsSelector"):
+        # Skip-pend rather than fail while the Stage-2 panel rewrite is in
+        # flight: the retirement is the deliverable this test drives RED for.
+        pytest.skip(
+            "widget.ui still exposes endPointsMarkupsSelector -- the ADR-0037 "
+            "Stage-2 selector retirement has not landed.  The skip lifts at the "
+            "retirement commit (ADR-0027)."
+        )
+
+    # (2) no fiducial persisted by the annotation/table path.
+    fiducials = slicer.mrmlScene.GetNodesByClass("vtkMRMLMarkupsFiducialNode")
+    count = fiducials.GetNumberOfItems() if fiducials is not None else 0
+    assert count == 0, (
+        "the annotation/table path must persist NO vtkMRMLMarkupsFiducialNode "
+        "(ADR-0037 §Conformance [review])."
+    )
+
+    for event, handler in (
+        (slicer.mrmlScene.StartCloseEvent, widget.onSceneStartClose),
+        (slicer.mrmlScene.EndCloseEvent, widget.onSceneEndClose),
+    ):
+        widget.removeObserver(slicer.mrmlScene, event, handler)
+    widget.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -24,12 +24,19 @@ invariants pin:
   colour / label / visibility accessors).  It OBSERVES the carrier's
   ``vtkCommand::ModifiedEvent`` and rebuilds; edits write back.
 * ARMING (pipeline-managed, NOT a Slicer mouse mode).  The arm state lives
-  on the ``TerritoryPlacementPipeline``; the interaction node is NOT
-  touched.  "Add Territory" mints a new empty territory on the carrier,
-  selects its row, makes it the pipeline's ACTIVE territory, and arms
-  placement; each surface click through the pipeline seam appends ONE seed
-  to the ACTIVE territory (sequential, unbounded).  "Done" / Esc disarms.
-  Selecting an existing row + "Add seeds" re-arms into THAT territory.
+  on the SHARED highlight DISPLAY NODE (``TerritoryInteractionState``): the
+  table WRITES arm / active-territory / carrier onto it, and the
+  manager-driven placement Pipeline READS them back at event time — the
+  widget cannot reach the manager-owned Pipeline instance directly, so the
+  display node is the shared handle (the 3D-fix contract).  "Add Territory"
+  mints a new empty territory on the carrier, selects its row, makes it the
+  ACTIVE territory, and arms placement; each surface click through the
+  pipeline seam appends ONE seed to the ACTIVE territory (sequential,
+  unbounded).  "Done" / Esc disarms.  Selecting an existing row + "Add
+  seeds" re-arms into THAT territory.  The integration these tests pin: a
+  REAL ``TerritoryPlacementPipeline`` whose ``SetDisplayNode`` was called
+  with the SAME display node the table writes to routes the click into the
+  ACTIVE territory — the gap that let the detached-instance bug through.
 * DELETE CONVERGENCE.  Delete-by-row (table) and delete-by-pick (pipeline)
   route through ONE carrier deletion path — a single point-removal
   implementation reached from both entry points.
@@ -49,11 +56,11 @@ A Python-widget-composed table, mirroring the Stage-2 segments-table
 paradigm (ADR-0034) but CUSTOM (ADR-0037 §Decision 3):
 
   * module path ``VascularTerritoriesLib.TerritoriesTableWidget``, class
-    ``TerritoriesTableWidget`` (a ``qt.QTableWidget`` subclass or a
-    composed widget owning one), constructed over the carrier + the
-    placement Pipeline:
+    ``TerritoriesTableWidget`` (a composed ``qt.QWidget`` owning a
+    ``qt.QTableWidget``), constructed over the carrier + the SHARED
+    highlight display node:
       ``TerritoriesTableWidget(carrier=<vtkMRMLCustomTerritoriesNode>,
-                               pipeline=<TerritoryPlacementPipeline>)``.
+                               displayNode=<vtkMRMLTerritoriesHighlightDisplayNode>)``.
   * ``table()`` -> the underlying ``qt.QTableWidget``;
   * row model helpers: ``isHeaderRow(row) -> bool``,
     ``territoryOfRow(row) -> str``, ``pointIndexOfRow(row) -> int | None``
@@ -64,17 +71,19 @@ paradigm (ADR-0034) but CUSTOM (ADR-0037 §Decision 3):
     row's territory ("Add seeds");
   * ``done()`` — disarm;
   * ``deleteRow(row)`` — the delete-from-table entry point, converging on
-    the pipeline's ``DeleteAnnotationPoint``;
+    the carrier's ``RemoveNthAnnotationPoint`` (the SAME method the
+    pipeline's ``DeleteAnnotationPoint`` reaches);
   * status-cell readers for the completeness assertion:
     ``rowStatusText(row) -> str`` and ``rowHasIncompleteGlyph(row) -> bool``.
 
-The arm state on the Pipeline (a Stage-2 addition to
-``TerritoryPlacementPipeline``): an ``IsArmed() -> bool`` plus an
-"active territory" the click appends into (the current ``SetCarrier``
-binds a single territory; Stage 2 needs "set active territory + arm" so a
-click appends to the ACTIVE territory, not an implicit one).  Proposed:
-``SetActiveTerritory(territoryId)`` / ``GetActiveTerritory()`` +
-``Arm()`` / ``Disarm()`` / ``IsArmed()``.
+The arm state rides on the SHARED highlight DISPLAY NODE
+(``TerritoryInteractionState``: ``set_armed`` / ``is_armed`` /
+``set_active_territory`` / ``get_active_territory`` / ``set_carrier`` /
+``get_carrier``), the handle both the table and the manager-driven Pipeline
+hold.  The Pipeline reads them back via its ``IsArmed()`` /
+``GetActiveTerritory()`` seam once ``SetDisplayNode`` binds the SAME node.
+"Add Territory" writes active-territory + armed onto the display node so a
+click appends to the ACTIVE territory, not an implicit one.
 
 -- WHY LAUNCHED-SLICER --
 
@@ -116,6 +125,7 @@ import pytest
 vtk = pytest.importorskip("vtk")
 
 CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+HIGHLIGHT_DISPLAY_CLASS = "vtkMRMLTerritoriesHighlightDisplayNode"
 TERRITORY_A = "SegmentVII"
 TERRITORY_B = "SegmentVIII"
 
@@ -177,6 +187,34 @@ def _make_carrier_or_skip(slicer, name="TableCarrierTest"):
     return node
 
 
+def _make_display_node_or_skip(slicer, name="TableHighlightTest"):
+    """Mint the shared highlight display node, or skip-pend (ADR-0027).
+
+    The display node is the shared handle both the table and the
+    manager-driven placement Pipeline hold: the table writes arm /
+    active-territory / carrier onto it, the Pipeline reads them back.
+    """
+    node = slicer.mrmlScene.AddNewNodeByClass(HIGHLIGHT_DISPLAY_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{HIGHLIGHT_DISPLAY_CLASS} not registered -- the shared highlight "
+            "display node (ADR-0036/0037) is unavailable (launched build)."
+        )
+    return node
+
+
+def _import_interaction_state_or_skip():
+    """Import the shared interaction-state accessors, or skip-pend (ADR-0027)."""
+    try:
+        import TerritoryInteractionState as state
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoryInteractionState not importable ({exc!r}) -- the ADR-0037 "
+            "shared display-node state module has not landed (ADR-0027)."
+        )
+    return state
+
+
 def _import_table_or_skip():
     """Import the Stage-2 table widget class or skip-pend (ADR-0027)."""
     try:
@@ -206,18 +244,19 @@ def _import_pipeline_or_skip():
     return TerritoryPlacementPipeline
 
 
-def _make_table_or_skip(slicer, carrier, pipeline=None):
-    """Construct the table over the carrier (+ pipeline), registering teardown.
+def _make_table_or_skip(slicer, carrier, displayNode):
+    """Construct the table over the carrier + shared display node.
 
-    Skip-pends when the table constructor does not yet accept the carrier +
-    pipeline seam (Stage-2 not landed).
+    Skip-pends when the table constructor does not yet accept the
+    ``(carrier=, displayNode=)`` seam (the 3D-fix contract; Stage-2 not
+    landed).
     """
     TerritoriesTableWidget = _import_table_or_skip()
     try:
-        table = TerritoriesTableWidget(carrier=carrier, pipeline=pipeline)
+        table = TerritoriesTableWidget(carrier=carrier, displayNode=displayNode)
     except TypeError as exc:
         pytest.skip(
-            f"TerritoriesTableWidget(carrier=, pipeline=) seam absent ({exc!r}) "
+            f"TerritoriesTableWidget(carrier=, displayNode=) seam absent ({exc!r}) "
             "-- the ADR-0037 Stage-2 table constructor has not landed (ADR-0027)."
         )
     return table
@@ -279,20 +318,34 @@ class _Event:
         return self._pos
 
 
-def _wire_pipeline_or_skip(pipeline, carrier, monkeypatch):
-    """Attach a stub renderer + pick core so a click resolves to the surface."""
+def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch):
+    """Bind a REAL pipeline to the SHARED display node so it reads live state.
+
+    This is the integration the detached-instance bug slipped through: the
+    pipeline resolves its carrier / active territory / arm flag from the
+    display node the TABLE writes to (``SetDisplayNode`` + the carrier bound
+    onto the display node via ``TerritoryInteractionState``), NOT from a
+    hand-armed detached instance.  A stub renderer + injected pick core keep
+    the click GL-free.
+    """
     try:
         from VesselSurfacePick import VesselSurfacePick
     except Exception as exc:  # pragma: no cover - import-environment dependent
         pytest.skip(f"VesselSurfacePick not importable ({exc!r}).")
-    if not hasattr(pipeline, "SetPickCore") or not hasattr(pipeline, "SetCarrier"):
+    if not hasattr(pipeline, "SetPickCore") or not hasattr(pipeline, "SetDisplayNode"):
         pytest.skip(
-            "TerritoryPlacementPipeline lacks SetPickCore / SetCarrier -- "
-            "cannot drive a click (Stage-1 not landed; ADR-0027)."
+            "TerritoryPlacementPipeline lacks SetPickCore / SetDisplayNode -- "
+            "cannot bind the shared display-node state (Stage-1 not landed; "
+            "ADR-0027)."
         )
+    state = _import_interaction_state_or_skip()
     monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
     pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
-    pipeline.SetCarrier(carrier, TERRITORY_A)
+    # Bind the carrier onto the SHARED display node, then hand the display
+    # node to the pipeline: it now reads the SAME carrier + arm state the
+    # table writes.
+    state.set_carrier(displayNode, carrier)
+    pipeline.SetDisplayNode(displayNode)
 
 
 def _require_arm_seam(pipeline):
@@ -322,7 +375,8 @@ def test_table_builds_header_row_per_territory_and_child_row_per_point(qt_widget
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
-    table = _make_table_or_skip(slicer, carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_table_row_model(table)
 
@@ -356,7 +410,8 @@ def test_carrier_modified_event_rebuilds_the_table(qt_widgets):
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
-    table = _make_table_or_skip(slicer, carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_table_row_model(table)
 
@@ -387,16 +442,22 @@ def test_arm_then_click_appends_one_seed_to_active_territory(qt_widgets, monkeyp
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
     pipeline = _import_pipeline_or_skip()()
-    _wire_pipeline_or_skip(pipeline, carrier, monkeypatch)
+    _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
     _require_arm_seam(pipeline)
-    table = _make_table_or_skip(slicer, carrier, pipeline)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     active = table.addTerritory()  # mints + selects + arms into a new territory
-    assert pipeline.IsArmed() is True, "Add Territory must arm placement."
+    # The table wrote arm + active onto the SHARED display node; the pipeline
+    # (bound to that SAME node via SetDisplayNode) reads them back — the
+    # integration the detached-instance bug slipped through.
+    assert pipeline.IsArmed() is True, (
+        "Add Territory must arm placement via the shared display node."
+    )
     assert pipeline.GetActiveTerritory() == active
 
     before_active = carrier.GetNumberOfAnnotationPoints(active)
@@ -422,13 +483,18 @@ def test_click_with_nothing_armed_appends_nothing(qt_widgets, monkeypatch):
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
     pipeline = _import_pipeline_or_skip()()
-    _wire_pipeline_or_skip(pipeline, carrier, monkeypatch)
+    _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
     _require_arm_seam(pipeline)
-    table = _make_table_or_skip(slicer, carrier, pipeline)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
 
-    pipeline.Disarm()
+    # An ACTIVE territory is set (so the gate under test is the ARM flag, not a
+    # missing active territory); then the table's "Done" disarms via the
+    # shared display node.
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    table.done()
     assert pipeline.IsArmed() is False
 
     before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
@@ -451,9 +517,11 @@ def test_bare_move_stays_declined_while_armed(qt_widgets, monkeypatch):
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
     pipeline = _import_pipeline_or_skip()()
-    _wire_pipeline_or_skip(pipeline, carrier, monkeypatch)
+    _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
     _require_arm_seam(pipeline)
+    pipeline.SetActiveTerritory(TERRITORY_A)
     pipeline.Arm()
 
     before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
@@ -477,10 +545,11 @@ def test_switching_active_territory_redirects_subsequent_clicks(qt_widgets, monk
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
     pipeline = _import_pipeline_or_skip()()
-    _wire_pipeline_or_skip(pipeline, carrier, monkeypatch)
+    _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
     _require_arm_seam(pipeline)
-    table = _make_table_or_skip(slicer, carrier, pipeline)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_table_row_model(table)
     for seam in ("addTerritory", "armForSelectedTerritory", "selectTerritoryRow"):
@@ -527,7 +596,8 @@ def test_delete_row_removes_exactly_one_point(qt_widgets):
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
-    table = _make_table_or_skip(slicer, carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_table_row_model(table)
     if not hasattr(table, "deleteRow"):
@@ -566,14 +636,19 @@ def test_delete_by_row_and_by_pick_share_one_carrier_path(qt_widgets):
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
     pipeline = _import_pipeline_or_skip()()
-    if not hasattr(pipeline, "SetCarrier") or not hasattr(pipeline, "DeleteAnnotationPoint"):
+    if not hasattr(pipeline, "SetDisplayNode") or not hasattr(pipeline, "DeleteAnnotationPoint"):
         pytest.skip(
-            "TerritoryPlacementPipeline lacks SetCarrier / DeleteAnnotationPoint "
+            "TerritoryPlacementPipeline lacks SetDisplayNode / DeleteAnnotationPoint "
             "-- cannot pin delete convergence (ADR-0027)."
         )
-    pipeline.SetCarrier(carrier, TERRITORY_A)
-    table = _make_table_or_skip(slicer, carrier, pipeline)
+    # The pipeline resolves its carrier from the SHARED display node (the same
+    # handle the table binds), so both delete entry points reach one carrier.
+    state = _import_interaction_state_or_skip()
+    state.set_carrier(displayNode, carrier)
+    pipeline.SetDisplayNode(displayNode)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_table_row_model(table)
     if not hasattr(table, "deleteRow"):
@@ -633,7 +708,8 @@ def test_visibility_colour_label_edits_leave_geometry_unchanged(qt_widgets):
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
-    table = _make_table_or_skip(slicer, carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_table_row_model(table)
     for seam in ("setTerritoryVisibility", "setTerritoryColor", "setTerritoryLabel"):
@@ -688,7 +764,8 @@ def test_territory_with_fewer_than_two_seeds_is_flagged_incomplete(qt_widgets):
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
-    table = _make_table_or_skip(slicer, carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_table_row_model(table)
     for seam in ("rowStatusText", "rowHasIncompleteGlyph"):

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -340,12 +340,14 @@ def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monke
         )
     state = _import_interaction_state_or_skip()
     monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
-    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
     # Bind the carrier onto the SHARED display node, then hand the display
     # node to the pipeline: it now reads the SAME carrier + arm state the
-    # table writes.
+    # table writes.  SetDisplayNode resets the pick to force a re-resolve from
+    # the node's pickSurface (production behaviour), so inject the unit-sphere
+    # pick AFTER binding the display node.
     state.set_carrier(displayNode, carrier)
     pipeline.SetDisplayNode(displayNode)
+    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
 
 
 def _require_arm_seam(pipeline):

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -180,6 +180,7 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # hard runtime dependency) but let the rest of setup continue.
     self._registerVesselHighlightPipeline()
     self._registerTerritoryPlacementPipeline()
+    self._registerTerritorySlicePipeline()
 
     # Load widget from .ui file (created by Qt Designer)
     uiWidget = slicer.util.loadUI(self.resourcePath('UI/VascularTerritories.ui'))
@@ -298,6 +299,27 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         "not registered (%s) -- annotation placement is disabled in this "
         "session.  Loading the SlicerLayerDisplayableManager extension is "
         "required for the Pipeline path (ADR-0013/0037).", exc)
+
+  def _registerTerritorySlicePipeline(self):
+    """Register the slice-view annotation LayerDM Pipeline creator.
+
+    ADR-0037 §2D placement (ADR-0013 §5 call 3): the slice complement of the
+    3D placement Pipeline, reusing the SAME shared display-node state so 2D
+    and 3D placement stay in lockstep.  Idempotent; a missing LayerDMLib is a
+    real configuration error under ADR-0002 so it logs at ``critical``, but
+    the rest of widget setup continues.
+    """
+    try:
+      from VascularTerritoriesLib import registerTerritorySlicePipelineCreator
+      if registerTerritorySlicePipelineCreator is None:
+        raise ImportError("registerTerritorySlicePipelineCreator unavailable")
+      registerTerritorySlicePipelineCreator()
+    except ImportError as exc:
+      logging.critical(
+        "VascularTerritories: slice-view annotation LayerDM Pipeline creator "
+        "not registered (%s) -- slice-view annotation placement is disabled "
+        "in this session.  Loading the SlicerLayerDisplayableManager "
+        "extension is required for the Pipeline path (ADR-0013/0037).", exc)
 
   # ------------------------------------------------------------------ #
   # Vessel-adhering-highlight wiring (ADR-0036)

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -368,8 +368,15 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     if TerritoriesTableWidget is None:
       return
     carrier = self._ensureAnnotationCarrier()
-    pipeline = self._territoryPlacementPipeline()
-    self._territoriesTable = TerritoriesTableWidget(carrier=carrier, pipeline=pipeline)
+    # The highlight display node is the SHARED handle: the table writes the
+    # arm state / active territory / carrier binding onto it, and the
+    # LayerDM-driven placement Pipeline reads them back (the widget cannot
+    # reach the manager-owned Pipeline instance directly).  Aim its
+    # pickSurface at the current input segmentation so the click-snap + the
+    # adhering highlight resolve against the vessel mesh.
+    displayNode = self._ensureHighlightDisplayNode()
+    self.updateHighlightPickSurface()
+    self._territoriesTable = TerritoriesTableWidget(carrier=carrier, displayNode=displayNode)
     self.layout.addWidget(self._territoriesTable)
 
   def _ensureAnnotationCarrier(self):
@@ -391,24 +398,6 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
       return None
     self._annotationCarrier = node
     return node
-
-  def _territoryPlacementPipeline(self):
-    """The placement Pipeline instance bound to the annotation carrier.
-
-    ``None`` when LayerDMLib is unreachable; the table still works
-    read-only + delete-by-row against the carrier alone.
-    """
-    pipeline = getattr(self, "_placementPipeline", None)
-    if pipeline is not None:
-      return pipeline
-    try:
-      from VascularTerritoriesLib import TerritoryPlacementPipeline
-    except ImportError:
-      return None
-    if TerritoryPlacementPipeline is None:
-      return None
-    self._placementPipeline = TerritoryPlacementPipeline()
-    return self._placementPipeline
 
   def enableWidgetButtons(self, state):
     self.ui.addSegmentationButton.setEnabled(state)

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -170,15 +170,15 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     """
     ScriptedLoadableModuleWidget.setup(self)
 
-    # ADR-0013 §5 call 3 — register the LayerDM Pipeline creator for the
-    # vessel-adhering highlight (``vtkMRMLTerritoriesHighlightDisplayNode``).
-    # The Pipeline class is Python (ADR-0004 §1); one Pipeline per
-    # display-node type (ADR-0013 §1).  Registration is idempotent (a
-    # module-level flag inside the creator).  Guarded: in a launch without
-    # the SlicerLayerDisplayableManager extension on the module path,
-    # ``LayerDMLib`` is unreachable — log loudly (ADR-0002 makes LayerDM a
-    # hard runtime dependency) but let the rest of setup continue.
-    self._registerVesselHighlightPipeline()
+    # Register the LayerDM Pipeline creators (ADR-0013 §5 call 3).  ONE
+    # Pipeline per display-node type (ADR-0013 §1): the highlight display node
+    # gets exactly ONE 3D pipeline -- ``TerritoryPlacementPipeline``, which
+    # renders the placed seeds AND the hover-adhering marker AND handles
+    # placement/edit -- plus ONE slice pipeline (``TerritorySlicePipeline``)
+    # for the 2D views.  ``VesselHighlightPipeline`` is NOT registered: a
+    # second pipeline on the same (view, display) type is never created by
+    # LayerDM, which previously shadowed placement (only the marker showed).
+    # Registration is idempotent; guarded against an unreachable LayerDMLib.
     self._registerTerritoryPlacementPipeline()
     self._registerTerritorySlicePipeline()
 
@@ -349,8 +349,7 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     if node is not None and slicer.mrmlScene.IsNodePresent(node):
       return node
     try:
-      node = slicer.mrmlScene.AddNewNodeByClass(
-        "vtkMRMLTerritoriesHighlightDisplayNode", "Vessel Highlight")
+      node = slicer.mrmlScene.CreateNodeByClass("vtkMRMLTerritoriesHighlightDisplayNode")
     except Exception:  # noqa: BLE001 - node class not registered in this launch
       logging.warning(
         "VascularTerritories: vtkMRMLTerritoriesHighlightDisplayNode "
@@ -358,7 +357,24 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
       return None
     if node is None:
       return None
-    node.SetVisibility(False)  # off until place mode turns it on
+    node.UnRegister(None)
+    node.SetName("Vessel Highlight")
+    node.SetVisibility(False)  # off until arming turns it on
+    # Configure BEFORE AddNode: LayerDM consults the pipeline creators the
+    # moment the node enters the scene, and each created pipeline (3D + every
+    # slice) resolves + OBSERVES the annotation carrier at creation.  So the
+    # carrier reference (and the pickSurface) must already be on the node --
+    # bind them here, pre-add, or a seed placed in one view never repaints the
+    # others until they are individually resliced (the ResectogramViewManager
+    # "configure before AddNode" precedent).
+    carrier = getattr(self, "_annotationCarrier", None)
+    if carrier is not None:
+      from VascularTerritoriesLib import TerritoryInteractionState as _territoryState
+      _territoryState.set_carrier(node, carrier)
+    segmentation = self.ui.inputSurfaceSelector.currentNode()
+    if segmentation is not None:
+      node.SetAndObservePickSurfaceNodeID(segmentation.GetID())
+    node = slicer.mrmlScene.AddNode(node)
     self._highlightDisplayNode = node
     return node
 

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -191,9 +191,11 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
     self.ui = slicer.util.childWidgetVariables(uiWidget)
 
+    # ADR-0037 Stage-2: the ``endPointsMarkupsSelector`` (CenterlineSegment)
+    # markups selector is RETIRED with the annotation-off-markups transition;
+    # its entry is dropped from the node-selector list.
     self.nodeSelectors = [
         (self.ui.inputSurfaceSelector, "InputSurface"),
-        (self.ui.endPointsMarkupsSelector, "CenterlineSegment"),
         (self.ui.selectedVascularTerritorySegmId, "VascularTerritorySegmentation")
         ]
 
@@ -214,29 +216,27 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # Connections
     self.ui.inputSurfaceSelector.connect('currentNodeChanged(bool)', self.updateParameterNodeFromGUI)
     self.ui.inputSegmentSelectorWidget.connect('currentSegmentChanged(QString)', self.updateParameterNodeFromGUI)
-    self.ui.inputSegmentSelectorWidget.connect('currentSegmentChanged(QString)', self.onSegmentChanged)
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
-    self.ui.endPointsMarkupsSelector.connect('nodeAddedByUser(vtkMRMLNode*)', self.newEndpointsListCreated)
-    #self.ui.endPointsMarkupsSelector.connect('nodeAdded(vtkMRMLNode*)', self.newEndpointsListCreated)
     self.ui.inputSurfaceSelector.connect('currentNodeChanged(bool)', self.segmentationNodeSelected)
-    self.ui.vascularTerritoryId.connect('currentIndexChanged(int)', self.onVascularTerritoryIdChanged)
     self.ui.selectedVascularTerritorySegmId.connect('currentNodeChanged(bool)', self.updateParameterNodeFromGUI)
     self.ui.selectedVascularTerritorySegmId.connect('currentNodeChanged(bool)', self.vascular_territory_segmentationNodeSelected)
 
-    # Vessel-adhering-highlight wiring (ADR-0036).  Keep the highlight
-    # node's pickSurface aimed at the selected input segmentation, keep the
-    # snap observer attached to the current endpoints markup, and gate the
-    # highlight's visibility on place mode (see ``_updateHighlightWiring``).
+    # Vessel-adhering-highlight wiring (ADR-0036 / ADR-0037).  Keep the
+    # highlight node's pickSurface aimed at the selected input segmentation.
+    # ADR-0037 Stage-2 retires the markups selector + place widget that used
+    # to also gate the highlight's visibility on place mode; the surviving
+    # invariant is ``updateHighlightPickSurface`` tracking the input
+    # segmentation.
     self.ui.inputSurfaceSelector.connect('currentNodeChanged(bool)', self.updateHighlightPickSurface)
-    self.ui.endPointsMarkupsSelector.connect('currentNodeChanged(vtkMRMLNode*)', self.updateHighlightWiring)
-    self.ui.endPointsMarkupsPlaceWidget.connect('placeModeChanged()', self.updateHighlightVisibility)
+
+    # ADR-0037 Stage-2 table (§Decision 3): the annotation table is composed
+    # into the panel here, over the annotation carrier + the placement
+    # Pipeline (Python-widget composition, ADR-0004).
+    self._setupTerritoriesTable()
 
     self.ui.selectedVascularTerritorySegmId.setNodeTypeLabel('Vascular Territory Segmentation', 'vtkMRMLSegmentationNode')
     self.ui.selectedVascularTerritorySegmId.addAttribute("vtkMRMLSegmentationNode", "VascularTerritories.SegmentationId")
-
-    #self.onVascularTerritoryIdChanged()
-    #self.ui.endPointsMarkupsSelector.setEnabled(False)#Disable selector for now, as the lists are automatically managed
 
     # Initialize Vascular Territory Segmentation button at widget start-up
 #    nodeNameID = 'Vascular_Territory_Segmentation'
@@ -349,25 +349,66 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     segmentationId = segmentation.GetID() if segmentation is not None else None
     node.SetAndObservePickSurfaceNodeID(segmentationId)
 
-  def updateHighlightVisibility(self, *args):
-    """Show the highlight only while the endpoints markup is in place mode."""
-    node = self._ensureHighlightDisplayNode()
-    if node is None:
-      return
-    placing = self.ui.endPointsMarkupsPlaceWidget.placeModeEnabled
-    node.SetVisibility(bool(placing))
+  def _setupTerritoriesTable(self):
+    """Compose the ADR-0037 Stage-2 annotation table into the panel.
 
-  def updateHighlightWiring(self, *args):
-    """Sync the hover highlight's pickSurface + visibility.
-
-    Transitional scaffolding (ADR-0037): placement + snap now live on the
-    LayerDM ``TerritoryPlacementPipeline`` against the annotation carrier,
-    not a markup observer.  Stage 2 (the table UI) retires the markups
-    selector this keys off; until then a selector change keeps the hover
-    highlight fully wired in one call.
+    The table is a Python-composed custom widget (ADR-0004 / ADR-0037
+    §Decision 3) over the annotation carrier + the placement Pipeline.  A
+    launch without the module's MRML library or LayerDMLib on the path
+    degrades gracefully: the panel loads without the table.
     """
-    self.updateHighlightPickSurface()
-    self.updateHighlightVisibility()
+    self._territoriesTable = None
+    try:
+      from VascularTerritoriesLib import TerritoriesTableWidget
+    except ImportError as exc:
+      logging.warning(
+        "VascularTerritories: annotation table widget unavailable (%s) -- "
+        "the Stage-2 table is disabled this session.", exc)
+      return
+    if TerritoriesTableWidget is None:
+      return
+    carrier = self._ensureAnnotationCarrier()
+    pipeline = self._territoryPlacementPipeline()
+    self._territoriesTable = TerritoriesTableWidget(carrier=carrier, pipeline=pipeline)
+    self.layout.addWidget(self._territoriesTable)
+
+  def _ensureAnnotationCarrier(self):
+    """Return the scene-resident annotation carrier, creating it once.
+
+    ``None`` when the C++ node class is unavailable (a launch without the
+    module's MRML library on the path) -- the caller degrades gracefully.
+    """
+    node = getattr(self, "_annotationCarrier", None)
+    if node is not None and slicer.mrmlScene.IsNodePresent(node):
+      return node
+    try:
+      node = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLCustomTerritoriesNode", "Vascular Territories Annotation")
+    except Exception:  # noqa: BLE001 - node class not registered in this launch
+      logging.warning(
+        "VascularTerritories: vtkMRMLCustomTerritoriesNode unavailable -- "
+        "annotation table disabled this session.")
+      return None
+    self._annotationCarrier = node
+    return node
+
+  def _territoryPlacementPipeline(self):
+    """The placement Pipeline instance bound to the annotation carrier.
+
+    ``None`` when LayerDMLib is unreachable; the table still works
+    read-only + delete-by-row against the carrier alone.
+    """
+    pipeline = getattr(self, "_placementPipeline", None)
+    if pipeline is not None:
+      return pipeline
+    try:
+      from VascularTerritoriesLib import TerritoryPlacementPipeline
+    except ImportError:
+      return None
+    if TerritoryPlacementPipeline is None:
+      return None
+    self._placementPipeline = TerritoryPlacementPipeline()
+    return self._placementPipeline
 
   def enableWidgetButtons(self, state):
     self.ui.addSegmentationButton.setEnabled(state)
@@ -375,7 +416,6 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     self.ui.calculateVascularTerritoryMapButton.setEnabled(state)
     self.ui.inputSurfaceSelector.setEnabled(state)
     self.ui.vascularTerritoryId.setEnabled(state)
-    self.ui.endPointsMarkupsSelector.setEnabled(state)
     self.ui.showHideButton.setEnabled(state)
 
   def segmentationNodeSelected(self):
@@ -388,41 +428,6 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     displayNode = segmentationNode.GetDisplayNode()
     displayNode.SetOpacity3D(0.3)
     self.updateShowHideButtonText()
-
-  #Auto create if name/id don't exist. Auto switch if it exists
-  def onSegmentChanged(self):
-    endPointsMarkupsNode = self.ui.endPointsMarkupsSelector.currentNode()
-    if endPointsMarkupsNode is not None:
-      endPointsMarkupsNode.SetDisplayVisibility(False)#Hide previous markup points
-    if self.ui.inputSurfaceSelector.currentNode() is None:
-      return
-    if not self.ui.inputSegmentSelectorWidget.currentSegmentID():
-      return
-    #Check if this is a Vascular Territory Segmentation node
-    segmentationNodeAttribute = self.ui.inputSurfaceSelector.currentNode().GetAttribute("VascularTerritories.SegmentationId")
-    if segmentationNodeAttribute is not None:
-      return
-
-    VascSegmIdno = self.ui.selectedVascularTerritorySegmId.currentNode().GetAttribute("VascularTerritories.SegmentationId")
-    VascTerrIdno = self.ui.vascularTerritoryId.currentIndex
-    vesselPointsSelector = self.ui.endPointsMarkupsSelector
-    vesselPointsSelector.blockSignals(True)
-    vesselPointsSelector.addAttribute("vtkMRMLMarkupsFiducialNode", "VascularTerritories.VascTerrId", str(VascTerrIdno))
-    vesselPointsSelector.addAttribute("vtkMRMLMarkupsFiducialNode", "VascularTerritories.SegmentationId", str(VascSegmIdno))
-    vesselPointsSelector.blockSignals(False)
-
-    endPointsMarkupsNode = self.getVesselSegmentfromName()
-    if endPointsMarkupsNode is None:
-      endPointsMarkupsNode = self.ui.endPointsMarkupsSelector.addNode()
-      self.ui.endPointsMarkupsSelector.setCurrentNode(endPointsMarkupsNode)
-#    else:
-    endPointsMarkupsNode.SetAttribute("VascularTerritories.SegmentationId",str(VascSegmIdno))
-    endPointsMarkupsNode.SetAttribute("VascularTerritories.VascTerrId",str(VascTerrIdno))
-#    endPointsMarkupsNode.addAttribute("vtkMRMLMarkupsFiducialNode", "VascularTerritories.SegmentationId",str(Idno))
-
-    self.ui.endPointsMarkupsSelector.baseName = self.getVesselSegmentName()
-    self.refreshShowHideButton()
-    endPointsMarkupsNode.SetDisplayVisibility(True)#Show current markup points
 
   def onShowHideButton(self):
     displayNode, segmentId = self.getDisplayNodeAndSegmentId()
@@ -514,7 +519,6 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
       if attribute is not None:
         if node.GetDisplayNode():
           node.GetDisplayNode().SetAllSegmentsVisibility(False)
-    self.ui.endPointsMarkupsPlaceWidget.setPlaceModeEnabled(False)
 
 
   def updateVascTerrList(self, vasc_terr_ID_list, vascular_territory_segm_node):
@@ -539,19 +543,8 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
       vasc_terr_ID_list.addItem(nameString)
       self.colormap.SetColorName(index, nameString)
       vasc_terr_ID_list.setCurrentIndex(index)
-      self.onSegmentChanged()
     vasc_terr_ID_list.setCurrentIndex(1)
     vasc_terr_ID_list.blockSignals(False)
-
-  def getVesselSegmentfromName(self):
-    segmentName = self.getVesselSegmentName()
-    for i in range(self.ui.endPointsMarkupsSelector.nodeCount()):
-      node = self.ui.endPointsMarkupsSelector.nodeFromIndex(i)
-      if segmentName == node.GetName():
-        self.ui.endPointsMarkupsSelector.setCurrentNode(node)
-        return self.ui.endPointsMarkupsSelector.currentNode()
-    logging.info('Found no node called: ' + segmentName)
-    return None
 
   def createColorMap(self):
 #    colorTableNodes = slicer.util.getNodes("SlicerLiverColorMap*")
@@ -568,6 +561,9 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     """
     Called when the application closes and the module widget is destroyed.
     """
+    table = getattr(self, "_territoriesTable", None)
+    if table is not None and hasattr(table, "cleanup"):
+      table.cleanup()
     self.removeObservers()
 
   def enter(self):
@@ -595,9 +591,11 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     """
     Called just after the scene is closed.
     """
-    # The highlight display node was cleared with the scene; drop the stale
-    # handle so the next placement re-creates a fresh one.
+    # The highlight display node + annotation carrier were cleared with the
+    # scene; drop the stale handles so the next placement re-creates fresh
+    # ones.
     self._highlightDisplayNode = None
+    self._annotationCarrier = None
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
     self.initializeParameterNode()
 
@@ -719,31 +717,6 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     self.logic.copyIndex(endPointsMarkupsNode, centerlineModelNode)
     return centerlineModelNode
 
-  def getVesselSegmentName(self):
-    segmentation = self.ui.inputSegmentSelectorWidget.currentNode().GetSegmentation()
-    segmId = self.ui.inputSegmentSelectorWidget.currentSegmentID()
-    segment = segmentation.GetSegment(segmId)
-    name = 'Segment_' + self.ui.selectedVascularTerritorySegmId.currentNode().GetAttribute("VascularTerritories.SegmentationId") \
-      + '_Territory_' + str(self.ui.vascularTerritoryId.currentIndex) + '_' + segment.GetName()
-    return name
-
-  def newEndpointsListCreated(self):
-    #Set baseName, and use this to create new unique names if endPointsMarkupsNode with this name already exist
-    newName = self.getVesselSegmentName()
-    self.updateSelectorColor()
-    if(self.ui.endPointsMarkupsSelector.baseName == newName):
-      return
-    self.ui.endPointsMarkupsSelector.baseName = newName
-
-    endPointsMarkupsNode = self.ui.endPointsMarkupsSelector.currentNode()
-    endPointsMarkupsNode.SetName(newName)
-    self.ui.endPointsMarkupsPlaceWidget.setPlaceModeEnabled(True)
-
-  def updateSelectorColor(self):
-    color = self.getCurrentColor()
-    color255 = [int(i * 255) for i in color]
-    self.ui.endPointsMarkupsPlaceWidget.ColorButton.setColor(qt.QColor(color255[0], color255[1], color255[2]))
-
   def getCurrentColor(self):
     color = [1, 1, 1, 1]
     index = self.ui.vascularTerritoryId.currentIndex
@@ -762,42 +735,6 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     inputColor = self.getCurrentColorQt()
     centerlineModelNode.GetDisplayNode().SetColor(inputColor.redF(), inputColor.greenF(), inputColor.blueF())
 
-  def onVascularTerritoryIdChanged(self):
-    index = self.ui.vascularTerritoryId.currentIndex
-    vascularTerrSegmNode = self.ui.selectedVascularTerritorySegmId.currentNode()
-    VascSegmIdno = vascularTerrSegmNode.GetAttribute("VascularTerritories.SegmentationId")
-    # If the GUI is updating - No action
-    if  self._updatingGUIFromSegmentationNode:
-      return
-    #Add new vascular territory ID
-    if(index == 0):
-      numItems = self.ui.vascularTerritoryId.count
-      idString = "Vascular Territory ID " + str(numItems)
-      self.ui.vascularTerritoryId.addItem(idString)
-      self.ui.vascularTerritoryId.setCurrentIndex(numItems)
-      self.ui.endPointsMarkupsPlaceWidget.setPlaceModeEnabled(True)
-    else:
-      self.ui.endPointsMarkupsPlaceWidget.setPlaceModeEnabled(False)
-    #Add new Vascular Territory Segmentation
-    segmentName = self.ui.vascularTerritoryId.currentText
-    vascularTerrSegm = vascularTerrSegmNode.GetSegmentation()
-    numberOfSegments = vascularTerrSegm.GetNumberOfSegments()
-    if numberOfSegments < index:
-      vascularTerrSegm.AddEmptySegment(segmentName, segmentName)
-
-    #Update color in selector
-    self.ui.ColorPickerButton.setColor(self.getCurrentColorQt())
-    if(index > 0):
-      self.colormap.SetColorName(index, self.ui.vascularTerritoryId.currentText)
-      self.onSegmentChanged()#Also generate new vessel segment point lists when changing territory id
-
-    index = self.ui.vascularTerritoryId.currentIndex
-    vesselPointsSelector = self.ui.endPointsMarkupsSelector
-    vesselPointsSelector.blockSignals(True)
-    vesselPointsSelector.addAttribute("vtkMRMLMarkupsFiducialNode", "VascularTerritories.VascTerrId", str(index))
-    vesselPointsSelector.addAttribute("vtkMRMLMarkupsFiducialNode", "VascularTerritories.SegmentationId", str(VascSegmIdno))
-    vesselPointsSelector.blockSignals(False)
-
   def onColorChanged(self):
     colorIndex = self.ui.vascularTerritoryId.currentIndex
     color = self.ui.ColorPickerButton.color
@@ -811,55 +748,16 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     self.onAddCenterlineSegment(addSegmentationInsteadOfLine = True)
 
   def onAddCenterlineSegment(self, addSegmentationInsteadOfLine = False):
-    if not (self.logic.check_module_Extract_Centerline_installed()):
-      self.ui.endPointsMarkupsPlaceWidget.setPlaceModeEnabled(False)
-      slicer.util.errorDisplay("SlicerVMTK Extension not installed")
-      return
-    endPointsMarkupsNode = self.ui.endPointsMarkupsSelector.currentNode()
-    self.ui.endPointsMarkupsPlaceWidget.setPlaceModeEnabled(False)
-    endPointsMarkupsNode.SetAttribute("VascularTerritories.VascTerrId", str(self.ui.vascularTerritoryId.currentIndex))
-    vascularTerritorySegm = self.ui.selectedVascularTerritorySegmId.currentNode()
-    vascularTerritorySegmId = vascularTerritorySegm.GetAttribute("VascularTerritories.SegmentationId")
-    endPointsMarkupsNode.SetAttribute("VascularTerritories.SegmentationId", str(vascularTerritorySegmId))
-
-    slicer.app.pauseRender()
-    qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
-
-    try:
-        preprocessedPolyData = self.getPreprocessedPolyData()
-    except ValueError:
-        logging.error("Error: Preprocessing of polydata fails")
-        slicer.app.resumeRender()
-        qt.QApplication.restoreOverrideCursor()
-        raise
-
-    try:
-        centerlineModelNode = self.createCenterlineNode(endPointsMarkupsNode)
-    except ValueError:
-        logging.error("Error: Failed to generate centerline model")
-
-    try:
-      if(addSegmentationInsteadOfLine):
-        mergedLines = self.mergePolydata(centerlineModelNode.GetMesh(), preprocessedPolyData)
-      else:
-        centerlineProcessingLogic = self.logic.getCenterlineLogic()
-        centerlinePolyData, voronoiDiagramPolyData = centerlineProcessingLogic.extractCenterline(preprocessedPolyData, endPointsMarkupsNode)
-        decimatedCenterlinePolyData = self.logic.decimateLine(centerlinePolyData)
-        mergedLines = self.mergePolydata(centerlineModelNode.GetMesh(), decimatedCenterlinePolyData)
-
-      centerlineModelNode.SetAndObserveMesh(mergedLines)
-      centerlineModelNode.SetAttribute("VascularTerritories.SegmentationId", str(vascularTerritorySegmId))
-      centerlineModelNode.SetAttribute("VascularTerritories.VascTerrId", str(self.ui.vascularTerritoryId.currentIndex))
-
-      centerlineModelNode.CreateDefaultDisplayNodes()
-      self.useColorFromSelector(centerlineModelNode)
-      centerlineModelNode.GetDisplayNode().SetLineWidth(3)
-      endPointsMarkupsNode.SetDisplayVisibility(False)
-    except ValueError:
-      logging.error("Error: Failed to extract centerline")
-
-    slicer.app.resumeRender()
-    qt.QApplication.restoreOverrideCursor()
+    # ADR-0037 §Decision 4: the VMTK centerline feed is rewired off Slicer
+    # markups onto the annotation carrier in Stage 3 -- the extraction call
+    # builds a TRANSIENT fiducial node from the carrier's points inside the
+    # call and discards it.  With the Stage-2 markups-selector retirement the
+    # legacy markups-sourced feed is gone; the extraction action is inert
+    # until the Stage-3 carrier feed lands.
+    del addSegmentationInsteadOfLine
+    slicer.util.errorDisplay(
+      "Centerline extraction from the annotation carrier is not available "
+      "yet -- it lands with the VMTK feed transition (ADR-0037 Stage 3).")
 
   def mergePolydata(self, existingPolyData, newPolyData):
     combinedPolyData = vtk.vtkAppendPolyData()

--- a/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
+++ b/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
@@ -24,6 +24,7 @@ set(VascularTerritoriesLib_PYTHON_SCRIPTS
   VesselSurfacePick.py
   VesselHighlightPipeline.py
   TerritoryPlacementPipeline.py
+  TerritoriesTableWidget.py
   )
 
 set(VascularTerritoriesLib_PYTHON_RESOURCES

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -38,6 +38,22 @@ from typing import Any
 import qt
 import vtk
 
+try:  # pragma: no cover - exercised once per import path
+    from . import TerritoryInteractionState as _state
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    import TerritoryInteractionState as _state  # type: ignore[no-redef]
+
+#: A small distinct palette so minted territories read apart in both the
+#: swatch and the 3D seed glyphs (RGB in 0..1).  Cycled by mint order.
+_TERRITORY_PALETTE = (
+    (0.90, 0.30, 0.24),  # red
+    (0.20, 0.60, 0.86),  # blue
+    (0.18, 0.80, 0.44),  # green
+    (0.95, 0.77, 0.06),  # amber
+    (0.61, 0.35, 0.71),  # purple
+    (0.90, 0.49, 0.13),  # orange
+)
+
 #: Column layout of the custom table.  A HEADER row uses columns as
 #: [visibility | colour | label | status]; a CHILD row uses
 #: [<blank> | <blank> | status text | delete].
@@ -67,21 +83,29 @@ _ROLE_IS_HEADER = qt.Qt.UserRole + 3
 class TerritoriesTableWidget(qt.QWidget):
     """Custom table view + editor over the annotation carrier (ADR-0037).
 
-    Constructed over the Stage-1 carrier and (optionally) the Stage-2
-    placement Pipeline:
+    Constructed over the Stage-1 carrier and the shared highlight display
+    node:
 
         ``TerritoriesTableWidget(carrier=<vtkMRMLCustomTerritoriesNode>,
-                                 pipeline=<TerritoryPlacementPipeline>)``.
+                                 displayNode=<vtkMRMLTerritoriesHighlightDisplayNode>)``.
 
-    The carrier is the model; the pipeline (when present) carries the arm
-    state and the shared point-removal path.
+    The carrier is the model.  Arm state / active territory are written onto
+    the DISPLAY NODE (``TerritoryInteractionState``) — the shared handle the
+    LayerDM-driven placement Pipeline reads at event time, since the widget
+    cannot reach the manager-owned Pipeline instance directly.  Delete goes
+    straight to the carrier (the same ``RemoveNthAnnotationPoint`` the
+    Pipeline's pick-delete uses — one carrier method, ADR-0037 §Decision 3).
     """
 
-    def __init__(self, carrier: Any = None, pipeline: Any = None, parent: Any = None) -> None:
+    def __init__(self, carrier: Any = None, displayNode: Any = None, parent: Any = None) -> None:
         super().__init__(parent)
 
         self._carrier = carrier
-        self._pipeline = pipeline
+        self._displayNode = displayNode
+        # Bind the carrier onto the shared display node so the LayerDM-driven
+        # placement Pipeline (which the widget cannot reach directly) resolves
+        # the same carrier the table edits.
+        _state.set_carrier(displayNode, carrier)
         self._carrier_observer_tag: int | None = None
         # Guards against the write-back edits re-triggering a rebuild mid-edit.
         self._rebuilding = False
@@ -199,12 +223,19 @@ class TerritoriesTableWidget(qt.QWidget):
         """
         if territoryId is None:
             territoryId = self._mintTerritoryId()
-        if territoryId not in self._territory_order:
+        newTerritory = territoryId not in self._territory_order
+        if newTerritory:
             self._territory_order.append(territoryId)
         # Give the territory a display slot so its header row survives before
-        # any seed lands (an empty minted territory is enumerable).
+        # any seed lands (an empty minted territory is enumerable), and a
+        # distinct palette colour so it reads apart in the swatch + 3D seeds.
         if self._carrier is not None:
             self._carrier.SetTerritoryVisibility(territoryId, True)
+            if newTerritory:
+                r, g, b = _TERRITORY_PALETTE[
+                    (len(self._territory_order) - 1) % len(_TERRITORY_PALETTE)
+                ]
+                self._carrier.SetTerritoryColor(territoryId, r, g, b)
         self._rebuild()
         self.selectTerritoryRow(territoryId)
         self._armInto(territoryId)
@@ -224,9 +255,10 @@ class TerritoriesTableWidget(qt.QWidget):
         return self.territoryOfRow(self._table.currentRow)
 
     def done(self) -> None:
-        """Disarm placement ("Done" / Esc)."""
-        if self._pipeline is not None and hasattr(self._pipeline, "Disarm"):
-            self._pipeline.Disarm()
+        """Disarm placement ("Done" / Esc) and hide the adhering highlight."""
+        _state.set_armed(self._displayNode, False)
+        if self._displayNode is not None and hasattr(self._displayNode, "SetVisibility"):
+            self._displayNode.SetVisibility(False)
 
     def selectTerritoryRow(self, territoryId: str) -> None:
         """Select the header row of ``territoryId`` (a no-op if absent)."""
@@ -237,13 +269,17 @@ class TerritoriesTableWidget(qt.QWidget):
                 return
 
     def _armInto(self, territoryId: str) -> None:
-        pipeline = self._pipeline
-        if pipeline is None:
-            return
-        if hasattr(pipeline, "SetActiveTerritory"):
-            pipeline.SetActiveTerritory(territoryId)
-        if hasattr(pipeline, "Arm"):
-            pipeline.Arm()
+        """Arm placement into ``territoryId`` via the shared display node.
+
+        Writes the active territory + armed flag onto the highlight display
+        node the LayerDM-driven Pipeline reads, and makes the node visible so
+        the adhering highlight is live during placement (the retired place-mode
+        visibility gate, re-homed to the arm state — ADR-0037 §Decision 2).
+        """
+        _state.set_active_territory(self._displayNode, territoryId)
+        _state.set_armed(self._displayNode, True)
+        if self._displayNode is not None and hasattr(self._displayNode, "SetVisibility"):
+            self._displayNode.SetVisibility(True)
 
     def _mintTerritoryId(self) -> str:
         while True:
@@ -271,11 +307,10 @@ class TerritoriesTableWidget(qt.QWidget):
     def deleteRow(self, row: int) -> None:
         """Delete-from-table entry point — converges on the shared removal path.
 
-        Routes through the placement Pipeline's ``DeleteAnnotationPoint`` when
-        a pipeline is present (so delete-by-row and delete-by-pick share one
-        path); falls back to the carrier's ``RemoveNthAnnotationPoint``
-        directly when no pipeline is wired.  Both reach the SAME carrier
-        method (ADR-0037 §Decision 3 delete convergence).
+        Routes through ``_removePoint`` to the carrier's
+        ``RemoveNthAnnotationPoint`` — the SAME carrier method the placement
+        Pipeline's pick-delete reaches, so delete-by-row and delete-by-pick
+        converge on one deletion path (ADR-0037 §Decision 3).
         """
         if self.isHeaderRow(row):
             return
@@ -408,15 +443,12 @@ class TerritoriesTableWidget(qt.QWidget):
     def _removePoint(self, territoryId: str, pointIndex: int) -> None:
         """The ONE point-removal path shared by delete-by-row + delete-by-cell.
 
-        Routes through the placement Pipeline's ``DeleteAnnotationPoint`` when
-        a pipeline is present (so delete-by-row and delete-by-pick converge on
-        one carrier deletion path, ADR-0037 §Decision 3); falls back to the
-        carrier's ``RemoveNthAnnotationPoint`` directly when no pipeline is
-        wired.  Both reach the SAME carrier method.
+        Calls the carrier's ``RemoveNthAnnotationPoint`` directly — the SAME
+        carrier method the placement Pipeline's pick-delete
+        (``DeleteAnnotationPoint``) reaches, so delete-by-row and
+        delete-by-pick converge on one deletion path (ADR-0037 §Decision 3).
         """
-        if self._pipeline is not None and hasattr(self._pipeline, "DeleteAnnotationPoint"):
-            self._pipeline.DeleteAnnotationPoint(territoryId, pointIndex)
-        elif self._carrier is not None:
+        if self._carrier is not None:
             self._carrier.RemoveNthAnnotationPoint(territoryId, pointIndex)
 
     def _pickColour(self, territoryId: str) -> None:

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -1,0 +1,439 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0037 Stage-2 — the VascularTerritories annotation table widget.
+
+ADR-0037 §Decision 3 replaces the legacy markups-selector / place-widget
+panel with a Python-composed CUSTOM ``qt.QTableWidget`` (ADR-0004): the
+surface-snap + territory-grouping contract has no stock point-list fit (the
+same call ADR-0034 made against ``qMRMLSegmentsTableView``).
+
+The table is a VIEW over the Stage-1 annotation carrier
+(``vtkMRMLCustomTerritoriesNode``): it OBSERVES the carrier's
+``vtkCommand::ModifiedEvent`` and rebuilds, and its edits write BACK to the
+carrier (geometry via the point carrier + the placement Pipeline's shared
+removal path, display via the per-territory display slot).  The arm state
+lives on the ``TerritoryPlacementPipeline`` (pipeline-managed, not a Slicer
+mouse mode); "Add Territory" mints an empty territory + arms into it, and a
+surface click through the pipeline seam appends one seed to the ACTIVE
+territory.
+
+Rows are PER-POINT, grouped under per-territory HEADER rows:
+
+* HEADER row (one per territory): per-territory visibility toggle, colour
+  swatch, editable label, and a completeness indicator rendered as GLYPH +
+  TEXT (ADR-0010, never colour alone) — display-only in Stage 2 (extraction
+  gating is Stage 3).
+* CHILD row (one per seed point): on-surface status + a delete affordance.
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (the decision)
+  * Docs/adr/0034-stage2-segments-table.md  (the table paradigm)
+  * Docs/adr/0010-accessibility-and-i18n.md  (glyph + text, never colour)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import qt
+import vtk
+
+#: Column layout of the custom table.  A HEADER row uses columns as
+#: [visibility | colour | label | status]; a CHILD row uses
+#: [<blank> | <blank> | status text | delete].
+_COL_VISIBILITY = 0
+_COL_COLOUR = 1
+_COL_LABEL = 2
+_COL_STATUS = 3
+_COLUMN_COUNT = 4
+
+#: A territory needs at least this many seeds to be complete (a centerline
+#: needs a start + an end); fewer reads incomplete (display-only, Stage 2).
+_MIN_SEEDS_FOR_COMPLETE = 2
+
+#: The incomplete indicator, rendered as GLYPH + TEXT (ADR-0010): the glyph
+#: is a leading warning sign, the text spells the state out.
+_INCOMPLETE_GLYPH = "⚠"  # WARNING SIGN
+_INCOMPLETE_TEXT = "Incomplete — needs at least two seeds"
+_COMPLETE_TEXT = "Ready"
+
+#: The Qt item-data role carrying a header row's territory id / a child row's
+#: (territory id, point index).  Used by the row-model reader seams.
+_ROLE_TERRITORY = qt.Qt.UserRole + 1
+_ROLE_POINT_INDEX = qt.Qt.UserRole + 2
+_ROLE_IS_HEADER = qt.Qt.UserRole + 3
+
+
+class TerritoriesTableWidget(qt.QWidget):
+    """Custom table view + editor over the annotation carrier (ADR-0037).
+
+    Constructed over the Stage-1 carrier and (optionally) the Stage-2
+    placement Pipeline:
+
+        ``TerritoriesTableWidget(carrier=<vtkMRMLCustomTerritoriesNode>,
+                                 pipeline=<TerritoryPlacementPipeline>)``.
+
+    The carrier is the model; the pipeline (when present) carries the arm
+    state and the shared point-removal path.
+    """
+
+    def __init__(self, carrier: Any = None, pipeline: Any = None, parent: Any = None) -> None:
+        super().__init__(parent)
+
+        self._carrier = carrier
+        self._pipeline = pipeline
+        self._carrier_observer_tag: int | None = None
+        # Guards against the write-back edits re-triggering a rebuild mid-edit.
+        self._rebuilding = False
+        # Deterministic territory order: minted / points-bearing / display
+        # territories in first-seen order (so an EMPTY minted territory keeps
+        # its header row).
+        self._territory_order: list[str] = []
+        # Row -> (territoryId, pointIndex | None); rebuilt on every repaint.
+        self._row_info: list[tuple[str, int | None]] = []
+        # Auto-mint counter for "Add Territory".
+        self._mint_counter = 0
+        # The territory the surgeon last selected (drives "Add seeds"); the
+        # explicit selection survives an offscreen ``currentRow`` of -1.
+        self._selected_territory: str = ""
+
+        layout = qt.QVBoxLayout(self)
+
+        self._table = qt.QTableWidget()
+        self._table.setColumnCount(_COLUMN_COUNT)
+        self._table.setHorizontalHeaderLabels(["Visible", "Colour", "Territory / label", "Status"])
+        self._table.horizontalHeader().setStretchLastSection(True)
+        self._table.verticalHeader().setVisible(False)
+        self._table.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
+        self._table.setSelectionMode(qt.QAbstractItemView.SingleSelection)
+        layout.addWidget(self._table)
+
+        buttons = qt.QHBoxLayout()
+        self._addTerritoryButton = qt.QPushButton("Add Territory")
+        self._addSeedsButton = qt.QPushButton("Add seeds")
+        self._doneButton = qt.QPushButton("Done")
+        buttons.addWidget(self._addTerritoryButton)
+        buttons.addWidget(self._addSeedsButton)
+        buttons.addWidget(self._doneButton)
+        buttons.addStretch(1)
+        layout.addLayout(buttons)
+
+        self._addTerritoryButton.connect("clicked(bool)", lambda _checked: self.addTerritory())
+        self._addSeedsButton.connect("clicked(bool)", lambda _checked: self.armForSelectedTerritory())
+        self._doneButton.connect("clicked(bool)", lambda _checked: self.done())
+        self._table.connect("itemChanged(QTableWidgetItem*)", self._onItemChanged)
+
+        self._attachCarrierObserver()
+        self._rebuild()
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def cleanup(self) -> None:
+        """Drop the carrier observer (called by the test teardown fixture)."""
+        self._detachCarrierObserver()
+
+    def _attachCarrierObserver(self) -> None:
+        if self._carrier is None or not hasattr(self._carrier, "AddObserver"):
+            return
+        self._carrier_observer_tag = self._carrier.AddObserver(
+            vtk.vtkCommand.ModifiedEvent, self._onCarrierModified
+        )
+
+    def _detachCarrierObserver(self) -> None:
+        if self._carrier is None or self._carrier_observer_tag is None:
+            return
+        try:
+            self._carrier.RemoveObserver(self._carrier_observer_tag)
+        except Exception:  # noqa: BLE001 - teardown is best-effort
+            pass
+        self._carrier_observer_tag = None
+
+    def _onCarrierModified(self, caller: Any, event: str) -> None:
+        del caller, event
+        if self._rebuilding:
+            return
+        self._rebuild()
+
+    # ------------------------------------------------------------------ #
+    # Row-model reader seams
+    # ------------------------------------------------------------------ #
+
+    def table(self) -> Any:
+        """The underlying ``qt.QTableWidget``."""
+        return self._table
+
+    def isHeaderRow(self, row: int) -> bool:
+        if row < 0 or row >= len(self._row_info):
+            return False
+        _territory, pointIndex = self._row_info[row]
+        return pointIndex is None
+
+    def territoryOfRow(self, row: int) -> str:
+        if row < 0 or row >= len(self._row_info):
+            return ""
+        return self._row_info[row][0]
+
+    def pointIndexOfRow(self, row: int):
+        if row < 0 or row >= len(self._row_info):
+            return None
+        return self._row_info[row][1]
+
+    def rowStatusText(self, row: int) -> str:
+        item = self._table.item(row, _COL_STATUS)
+        return item.text() if item is not None else ""
+
+    def rowHasIncompleteGlyph(self, row: int) -> bool:
+        return _INCOMPLETE_GLYPH in self.rowStatusText(row)
+
+    # ------------------------------------------------------------------ #
+    # Territory lifecycle (arming)
+    # ------------------------------------------------------------------ #
+
+    def addTerritory(self, territoryId: str | None = None) -> str:
+        """Mint an empty territory, select its header row, arm the pipeline.
+
+        Returns the (possibly auto-generated) territory id.  Auto-generated
+        ids avoid colliding with an existing territory.
+        """
+        if territoryId is None:
+            territoryId = self._mintTerritoryId()
+        if territoryId not in self._territory_order:
+            self._territory_order.append(territoryId)
+        # Give the territory a display slot so its header row survives before
+        # any seed lands (an empty minted territory is enumerable).
+        if self._carrier is not None:
+            self._carrier.SetTerritoryVisibility(territoryId, True)
+        self._rebuild()
+        self.selectTerritoryRow(territoryId)
+        self._armInto(territoryId)
+        return territoryId
+
+    def armForSelectedTerritory(self) -> None:
+        """Re-arm placement into the selected row's territory ("Add seeds")."""
+        territory = self._selectedTerritory()
+        if not territory:
+            return
+        self._armInto(territory)
+
+    def _selectedTerritory(self) -> str:
+        """The selected row's territory (explicit selection wins over the row)."""
+        if self._selected_territory:
+            return self._selected_territory
+        return self.territoryOfRow(self._table.currentRow)
+
+    def done(self) -> None:
+        """Disarm placement ("Done" / Esc)."""
+        if self._pipeline is not None and hasattr(self._pipeline, "Disarm"):
+            self._pipeline.Disarm()
+
+    def selectTerritoryRow(self, territoryId: str) -> None:
+        """Select the header row of ``territoryId`` (a no-op if absent)."""
+        self._selected_territory = territoryId
+        for row, (territory, pointIndex) in enumerate(self._row_info):
+            if pointIndex is None and territory == territoryId:
+                self._table.setCurrentCell(row, _COL_LABEL)
+                return
+
+    def _armInto(self, territoryId: str) -> None:
+        pipeline = self._pipeline
+        if pipeline is None:
+            return
+        if hasattr(pipeline, "SetActiveTerritory"):
+            pipeline.SetActiveTerritory(territoryId)
+        if hasattr(pipeline, "Arm"):
+            pipeline.Arm()
+
+    def _mintTerritoryId(self) -> str:
+        while True:
+            self._mint_counter += 1
+            candidate = f"Territory {self._mint_counter}"
+            if candidate not in self._territory_order:
+                return candidate
+
+    # ------------------------------------------------------------------ #
+    # Display + delete edits (write back to the carrier)
+    # ------------------------------------------------------------------ #
+
+    def setTerritoryVisibility(self, territoryId: str, visible: bool) -> None:
+        if self._carrier is not None:
+            self._carrier.SetTerritoryVisibility(territoryId, bool(visible))
+
+    def setTerritoryColor(self, territoryId: str, r: float, g: float, b: float) -> None:
+        if self._carrier is not None:
+            self._carrier.SetTerritoryColor(territoryId, float(r), float(g), float(b))
+
+    def setTerritoryLabel(self, territoryId: str, label: str) -> None:
+        if self._carrier is not None:
+            self._carrier.SetTerritoryLabel(territoryId, str(label))
+
+    def deleteRow(self, row: int) -> None:
+        """Delete-from-table entry point — converges on the shared removal path.
+
+        Routes through the placement Pipeline's ``DeleteAnnotationPoint`` when
+        a pipeline is present (so delete-by-row and delete-by-pick share one
+        path); falls back to the carrier's ``RemoveNthAnnotationPoint``
+        directly when no pipeline is wired.  Both reach the SAME carrier
+        method (ADR-0037 §Decision 3 delete convergence).
+        """
+        if self.isHeaderRow(row):
+            return
+        territory = self.territoryOfRow(row)
+        pointIndex = self.pointIndexOfRow(row)
+        if not territory or pointIndex is None:
+            return
+        self._removePoint(territory, pointIndex)
+
+    # ------------------------------------------------------------------ #
+    # Repaint
+    # ------------------------------------------------------------------ #
+
+    def _territories(self) -> list[str]:
+        """The territories to render, in a stable order.
+
+        Union of the first-seen minted order, the carrier's points-bearing
+        territories, and its display-slot territories — so a points-bearing
+        territory added outside the table (a pipeline click) still gets a
+        header row, and an empty minted territory keeps its header row.
+        """
+        order = list(self._territory_order)
+        seen = set(order)
+        if self._carrier is not None:
+            for territory in list(self._carrier.GetAnnotationTerritoryIds()) + list(
+                self._carrier.GetDisplayTerritoryIds()
+            ):
+                if territory not in seen:
+                    seen.add(territory)
+                    order.append(territory)
+        # Keep the local order list in sync so a later addTerritory sees them.
+        self._territory_order = order
+        return order
+
+    def _rebuild(self) -> None:
+        self._rebuilding = True
+        try:
+            self._table.blockSignals(True)
+            self._table.setRowCount(0)
+            self._row_info = []
+            for territory in self._territories():
+                self._appendHeaderRow(territory)
+                count = (
+                    self._carrier.GetNumberOfAnnotationPoints(territory)
+                    if self._carrier is not None
+                    else 0
+                )
+                for pointIndex in range(count):
+                    self._appendChildRow(territory, pointIndex)
+        finally:
+            self._table.blockSignals(False)
+            self._rebuilding = False
+
+    def _appendHeaderRow(self, territoryId: str) -> None:
+        row = self._table.rowCount
+        self._table.insertRow(row)
+        self._row_info.append((territoryId, None))
+
+        seedCount = (
+            self._carrier.GetNumberOfAnnotationPoints(territoryId)
+            if self._carrier is not None
+            else 0
+        )
+        visible = (
+            bool(self._carrier.GetTerritoryVisibility(territoryId))
+            if self._carrier is not None
+            else True
+        )
+        label = ""
+        color = (1.0, 1.0, 1.0)
+        if self._carrier is not None:
+            label = self._carrier.GetTerritoryLabel(territoryId) or territoryId
+            rgb = self._carrier.GetTerritoryColor(territoryId)
+            color = (rgb[0], rgb[1], rgb[2])
+
+        # Visibility toggle.
+        visibilityBox = qt.QCheckBox()
+        visibilityBox.setChecked(visible)
+        visibilityBox.connect(
+            "toggled(bool)",
+            lambda checked, t=territoryId: self.setTerritoryVisibility(t, checked),
+        )
+        self._table.setCellWidget(row, _COL_VISIBILITY, visibilityBox)
+
+        # Colour swatch (a button whose background carries the RGB; a click
+        # opens the colour picker).
+        colourButton = qt.QPushButton()
+        colourButton.setFlat(True)
+        colourButton.setAutoFillBackground(True)
+        qcolor = qt.QColor(int(color[0] * 255), int(color[1] * 255), int(color[2] * 255))
+        colourButton.setStyleSheet(f"background-color: {qcolor.name()};")
+        colourButton.connect("clicked(bool)", lambda _checked, t=territoryId: self._pickColour(t))
+        self._table.setCellWidget(row, _COL_COLOUR, colourButton)
+
+        # Editable label; header rows carry the territory id / point index on
+        # the label item's data roles for the row-model readers.
+        labelItem = qt.QTableWidgetItem(label)
+        labelItem.setData(_ROLE_TERRITORY, territoryId)
+        labelItem.setData(_ROLE_IS_HEADER, True)
+        labelItem.setFlags(qt.Qt.ItemIsEnabled | qt.Qt.ItemIsSelectable | qt.Qt.ItemIsEditable)
+        self._table.setItem(row, _COL_LABEL, labelItem)
+
+        # Completeness indicator: GLYPH + TEXT (ADR-0010, never colour alone).
+        incomplete = seedCount < _MIN_SEEDS_FOR_COMPLETE
+        statusText = f"{_INCOMPLETE_GLYPH} {_INCOMPLETE_TEXT}" if incomplete else _COMPLETE_TEXT
+        statusItem = qt.QTableWidgetItem(statusText)
+        statusItem.setFlags(qt.Qt.ItemIsEnabled)
+        self._table.setItem(row, _COL_STATUS, statusItem)
+
+    def _appendChildRow(self, territoryId: str, pointIndex: int) -> None:
+        row = self._table.rowCount
+        self._table.insertRow(row)
+        self._row_info.append((territoryId, pointIndex))
+
+        # On-surface status text for the seed (surface-snapped on placement).
+        statusItem = qt.QTableWidgetItem(f"Seed {pointIndex + 1} — on surface")
+        statusItem.setData(_ROLE_TERRITORY, territoryId)
+        statusItem.setData(_ROLE_POINT_INDEX, pointIndex)
+        statusItem.setData(_ROLE_IS_HEADER, False)
+        statusItem.setFlags(qt.Qt.ItemIsEnabled | qt.Qt.ItemIsSelectable)
+        self._table.setItem(row, _COL_LABEL, statusItem)
+
+        deleteButton = qt.QPushButton("Delete")
+        deleteButton.connect(
+            "clicked(bool)",
+            lambda _checked, t=territoryId, i=pointIndex: self._removePoint(t, i),
+        )
+        self._table.setCellWidget(row, _COL_STATUS, deleteButton)
+
+    def _removePoint(self, territoryId: str, pointIndex: int) -> None:
+        """The ONE point-removal path shared by delete-by-row + delete-by-cell.
+
+        Routes through the placement Pipeline's ``DeleteAnnotationPoint`` when
+        a pipeline is present (so delete-by-row and delete-by-pick converge on
+        one carrier deletion path, ADR-0037 §Decision 3); falls back to the
+        carrier's ``RemoveNthAnnotationPoint`` directly when no pipeline is
+        wired.  Both reach the SAME carrier method.
+        """
+        if self._pipeline is not None and hasattr(self._pipeline, "DeleteAnnotationPoint"):
+            self._pipeline.DeleteAnnotationPoint(territoryId, pointIndex)
+        elif self._carrier is not None:
+            self._carrier.RemoveNthAnnotationPoint(territoryId, pointIndex)
+
+    def _pickColour(self, territoryId: str) -> None:
+        current = qt.QColor(255, 255, 255)
+        if self._carrier is not None:
+            rgb = self._carrier.GetTerritoryColor(territoryId)
+            current = qt.QColor(int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255))
+        chosen = qt.QColorDialog.getColor(current, self)
+        if chosen.isValid():
+            self.setTerritoryColor(territoryId, chosen.redF(), chosen.greenF(), chosen.blueF())
+
+    def _onItemChanged(self, item: Any) -> None:
+        """Write an edited header label back to the carrier's display slot."""
+        if item is None or self._rebuilding:
+            return
+        if not bool(item.data(_ROLE_IS_HEADER)):
+            return
+        territory = item.data(_ROLE_TERRITORY)
+        if territory:
+            self.setTerritoryLabel(territory, item.text())

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Shared annotation-interaction state on the highlight display node (ADR-0037).
+
+The Stage-2 placement is *pipeline-managed* (ADR-0037 §Decision 2), not a
+Slicer interaction node / mouse mode.  But LayerDM owns the placement
+Pipeline instance's lifecycle — it creates its own per view — so the widget
+and its table cannot reach that instance directly.  The two sides meet on
+the shared ``vtkMRMLTerritoriesHighlightDisplayNode``: the table WRITES the
+arm state / active territory / carrier binding onto the display node, and the
+manager-driven Pipeline READS them back at event time.
+
+These are the accessors both sides use.  The module imports nothing heavy
+(no LayerDMLib, no Qt) so the table can depend on it without dragging in the
+Pipeline's LayerDM dependency.
+
+* armed + active territory ride as string attributes (cheap, XML-transient).
+* the carrier rides as a typed node-reference role.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Display-node attribute keys / reference role for the interaction state.
+ARMED_ATTR = "VascularTerritories.Armed"
+ACTIVE_TERRITORY_ATTR = "VascularTerritories.ActiveTerritory"
+CARRIER_REFERENCE_ROLE = "VascularTerritories.carrier"
+
+
+def set_armed(displayNode: Any, armed: bool) -> None:
+    """Publish the arm state onto the shared highlight display node."""
+    if displayNode is not None:
+        displayNode.SetAttribute(ARMED_ATTR, "1" if armed else "0")
+
+
+def is_armed(displayNode: Any) -> bool:
+    return displayNode is not None and displayNode.GetAttribute(ARMED_ATTR) == "1"
+
+
+def set_active_territory(displayNode: Any, territoryId: str | None) -> None:
+    """Publish the active territory onto the shared highlight display node."""
+    if displayNode is not None:
+        displayNode.SetAttribute(ACTIVE_TERRITORY_ATTR, territoryId or "")
+
+
+def get_active_territory(displayNode: Any) -> str | None:
+    if displayNode is None:
+        return None
+    value = displayNode.GetAttribute(ACTIVE_TERRITORY_ATTR)
+    return value or None
+
+
+def set_carrier(displayNode: Any, carrier: Any) -> None:
+    """Bind the annotation carrier onto the display node (typed node ref)."""
+    if displayNode is None:
+        return
+    carrierId = carrier.GetID() if carrier is not None else None
+    displayNode.SetNodeReferenceID(CARRIER_REFERENCE_ROLE, carrierId)
+
+
+def get_carrier(displayNode: Any) -> Any | None:
+    if displayNode is None:
+        return None
+    return displayNode.GetNodeReference(CARRIER_REFERENCE_ROLE)

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
@@ -52,11 +52,19 @@ def get_active_territory(displayNode: Any) -> str | None:
 
 
 def set_carrier(displayNode: Any, carrier: Any) -> None:
-    """Bind the annotation carrier onto the display node (typed node ref)."""
+    """Bind the annotation carrier onto the display node (typed node ref).
+
+    Fires an explicit ``Modified()``: LayerDM creates the view pipelines when
+    the display node enters the scene, which is BEFORE this bind, and a node-
+    reference change does not reliably emit ``ModifiedEvent``.  The explicit
+    Modified drives LayerDM's ``UpdatePipeline`` on every view so each
+    pipeline (re)attaches its carrier observer and starts tracking seeds.
+    """
     if displayNode is None:
         return
     carrierId = carrier.GetID() if carrier is not None else None
     displayNode.SetNodeReferenceID(CARRIER_REFERENCE_ROLE, carrierId)
+    displayNode.Modified()
 
 
 def get_carrier(displayNode: Any) -> Any | None:

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -40,14 +40,29 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
+    from .VesselHighlightWiring import closed_surface_polydata
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
+    from VesselHighlightWiring import closed_surface_polydata  # type: ignore[no-redef]
 
 #: Display-space pick radius for grabbing an existing point, in pixels
 #: (mirrors ``ControlPolygonPipeline.CONTROL_POINT_PICK_RADIUS_PX``).  A
 #: press within this radius of a placed point grabs it for a drag; a press
 #: outside it (but over the surface) adds a new point.
 POINT_PICK_RADIUS_PX = 20.0
+
+#: Interaction state lives on the shared highlight DISPLAY NODE, not on the
+#: Pipeline instance: LayerDM owns the Pipeline instance lifecycle (it creates
+#: its own per view), so the widget/table can only reach the Pipeline the
+#: manager drives THROUGH the display node both sides hold.  This is still
+#: "pipeline-managed" (ADR-0037 §Decision 2) — the state is read by the
+#: Pipeline, not by a Slicer interaction node / mouse mode.  The accessors
+#: live in the dependency-free ``TerritoryInteractionState`` module so the
+#: table can share them without the LayerDMLib import.
+try:  # pragma: no cover - exercised once per import path
+    from . import TerritoryInteractionState as _state
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    import TerritoryInteractionState as _state  # type: ignore[no-redef]
 
 _REGISTERED = False
 
@@ -75,30 +90,95 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._territory_id: str | None = None
 
         # Stage-2 arming (ADR-0037 §Decision 3).  An armed click appends one
-        # seed to the ACTIVE territory; a disarmed click adds nothing.  The
-        # arm state lives HERE (pipeline-managed), not on the interaction
-        # node -- there is no Slicer mouse mode.  The active territory
-        # overrides the ``SetCarrier`` binding for placement.
+        # seed to the ACTIVE territory; a disarmed click adds nothing.  In
+        # production the arm state + active territory + carrier all live on the
+        # shared highlight DISPLAY NODE (read by ``GetActiveTerritory`` /
+        # ``IsArmed`` / ``_get_carrier``) so the widget/table reach the
+        # manager-driven Pipeline; these instance fields are the BARE-unit
+        # fallback (no display node).  It is still pipeline-managed, not a
+        # Slicer interaction node / mouse mode.
         self._active_territory: str | None = None
         self._armed: bool = False
 
-        # Injectable pick core (bare unit layer feeds a known surface).
+        # Injectable pick core (bare unit layer feeds a known surface); in
+        # production ``_ensure_pick`` builds it from the display node's
+        # pickSurface.
         self._pick: VesselSurfacePick | None = None
 
         # (territory id, in-territory index) of the point currently GRABBED
         # by a press/move/release drag -- None when no drag is in flight.
         self._drag_target: tuple[str, int] | None = None
 
+        # Carrier currently observed for the seed-glyph rebuild (production
+        # resolves it from the display node, so the bare ``SetCarrier`` bind is
+        # not the only path); tracked to avoid double-observing.
+        self._observed_carrier: Any | None = None
+
+        # -- placed-seed rendering (ADR-0037 §Decision 2): the persistent
+        # markers for the carrier's annotation points, glyphed as spheres and
+        # coloured per territory from the carrier's display slot.  One actor
+        # for the whole point set; rebuilt on any carrier Modified.
+        self._seed_points = vtk.vtkPoints()
+        self._seed_colors = vtk.vtkUnsignedCharArray()
+        self._seed_colors.SetNumberOfComponents(3)
+        self._seed_colors.SetName("SeedColors")
+        self._seed_polydata = vtk.vtkPolyData()
+        self._seed_polydata.SetPoints(self._seed_points)
+        self._seed_polydata.GetPointData().SetScalars(self._seed_colors)
+        self._seed_sphere = vtk.vtkSphereSource()
+        self._seed_sphere.SetPhiResolution(12)
+        self._seed_sphere.SetThetaResolution(12)
+        self._seed_sphere.SetRadius(2.2)
+        self._seed_glyph = vtk.vtkGlyph3D()
+        self._seed_glyph.SetInputData(self._seed_polydata)
+        self._seed_glyph.SetSourceConnection(self._seed_sphere.GetOutputPort())
+        self._seed_glyph.SetScaleModeToDataScalingOff()
+        self._seed_glyph.SetColorModeToColorByScalar()
+        self._seed_mapper = vtk.vtkPolyDataMapper()
+        self._seed_mapper.SetInputConnection(self._seed_glyph.GetOutputPort())
+        self._seed_mapper.SetColorModeToDirectScalars()
+        self._seed_actor = vtk.vtkActor()
+        self._seed_actor.SetMapper(self._seed_mapper)
+
     # ------------------------------------------------------------------ #
     # Wiring seams (unit + production)
     # ------------------------------------------------------------------ #
 
     def SetPickCore(self, pick: VesselSurfacePick | None) -> None:  # noqa: N802 - VTK verb
-        """Inject the ``VesselSurfacePick`` over the target surface."""
+        """Inject the ``VesselSurfacePick`` over the target surface (unit seam)."""
         self._pick = pick
 
+    def _ensure_pick(self) -> VesselSurfacePick | None:
+        """Build the pick core against the display node's ``pickSurface`` mesh.
+
+        Production (LayerDM-created) instances resolve the surface from the
+        shared display node exactly as ``VesselHighlightPipeline`` does, so
+        the click-snap and the hover marker adhere to the same mesh with no
+        injection.  A test-injected ``self._pick`` short-circuits this for the
+        bare unit layer.
+        """
+        if self._pick is not None:
+            return self._pick
+        display = self._display_node
+        if display is None:
+            return None
+        segmentation = display.GetPickSurfaceNode()
+        if segmentation is None:
+            return None
+        polydata = closed_surface_polydata(segmentation)
+        if polydata is None:
+            return None
+        self._pick = VesselSurfacePick(polydata)
+        return self._pick
+
     def SetCarrier(self, carrier: Any, territoryId: str) -> None:  # noqa: N802 - VTK verb
-        """Bind the ``vtkMRMLCustomTerritoriesNode`` carrier + active territory."""
+        """Bind the ``vtkMRMLCustomTerritoriesNode`` carrier + active territory.
+
+        Instance-field binding for the BARE unit layer (no display node).  In
+        production the carrier is resolved from the display node's reference
+        (``_get_carrier``); this direct bind is the unit seam that keeps the
+        edit math GL- and scene-free.
+        """
         if self._carrier is not None:
             self._detach_observer(self._carrier)
         self._carrier = carrier
@@ -107,6 +187,19 @@ class TerritoryPlacementPipeline(_PipelineBase):
             self._attach_observer(carrier)
 
     def GetCarrier(self) -> Any | None:  # noqa: N802 - VTK verb
+        return self._get_carrier()
+
+    def _get_carrier(self) -> Any | None:
+        """The carrier in effect: the display node's reference, else the bound one.
+
+        Production (LayerDM-created) instances resolve the carrier from the
+        shared display node so the widget/table and the manager-driven
+        Pipeline agree; the bare unit layer (no display node) falls back to
+        the directly-bound ``SetCarrier`` carrier.
+        """
+        carrier = _state.get_carrier(self._display_node)
+        if carrier is not None:
+            return carrier
         return self._carrier
 
     # ------------------------------------------------------------------ #
@@ -115,26 +208,37 @@ class TerritoryPlacementPipeline(_PipelineBase):
 
     def SetActiveTerritory(self, territoryId: str | None) -> None:  # noqa: N802 - VTK verb
         """Set the territory an armed click appends into (the ACTIVE one)."""
+        if self._display_node is not None:
+            _state.set_active_territory(self._display_node, territoryId)
         self._active_territory = territoryId
 
     def GetActiveTerritory(self) -> str | None:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            return _state.get_active_territory(self._display_node)
         return self._active_territory
 
     def Arm(self) -> None:  # noqa: N802 - VTK verb
         """Enable add-on-click into the active territory ("Add Territory" / "Add seeds")."""
+        if self._display_node is not None:
+            _state.set_armed(self._display_node, True)
         self._armed = True
 
     def Disarm(self) -> None:  # noqa: N802 - VTK verb
         """Disable add-on-click ("Done" / Esc).  A click then adds nothing."""
+        if self._display_node is not None:
+            _state.set_armed(self._display_node, False)
         self._armed = False
 
     def IsArmed(self) -> bool:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            return _state.is_armed(self._display_node)
         return self._armed
 
     def _placement_territory(self) -> str | None:
         """The territory a click appends into: the active one, else the bound one."""
-        if self._active_territory is not None:
-            return self._active_territory
+        active = self.GetActiveTerritory()
+        if active is not None:
+            return active
         return self._territory_id
 
     def _safe_get_renderer(self) -> Any | None:
@@ -147,16 +251,32 @@ class TerritoryPlacementPipeline(_PipelineBase):
     def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
         super().SetDisplayNode(displayNode)
         self._display_node = displayNode
+        # A (re)attached display node can carry a different pickSurface /
+        # carrier: force both to re-resolve (the highlight-Pipeline precedent).
+        self._pick = None
+        self._ensure_carrier_observed()
 
     def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
         try:
             self._renderer = renderer
+            if renderer is not None:
+                renderer.AddActor(self._seed_actor)
+            # Renderer churn cleared the display handle; re-derive it from the
+            # base's retained display node (the ControlPolygonPipeline
+            # re-attach precedent) so the carrier + seed glyphs come back.
+            if self._display_node is None:
+                display = self.GetDisplayNode()
+                if display is not None:
+                    self.SetDisplayNode(display)
+            self._ensure_carrier_observed()
+            self._rebuild_seed_actor()
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass
 
     def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        del renderer
         try:
+            if renderer is not None:
+                renderer.RemoveActor(self._seed_actor)
             self._renderer = None
             self.cleanup()
         except Exception:  # pragma: no cover - C++ boundary must never raise
@@ -166,7 +286,24 @@ class TerritoryPlacementPipeline(_PipelineBase):
         for node in list(self._observed_node_refs):
             self._detach_observer(node)
         self._carrier = None
+        self._observed_carrier = None
         self._drag_target = None
+
+    def _ensure_carrier_observed(self) -> None:
+        """Observe the in-effect carrier so seed glyphs track its edits.
+
+        Production resolves the carrier from the display node (never via
+        ``SetCarrier``), so the seed-glyph rebuild needs its own observer
+        attach; re-attaches when the resolved carrier changes.
+        """
+        carrier = self._get_carrier()
+        if carrier is self._observed_carrier:
+            return
+        if self._observed_carrier is not None:
+            self._detach_observer(self._observed_carrier)
+        self._observed_carrier = carrier
+        if carrier is not None:
+            self._attach_observer(carrier)
 
     # ------------------------------------------------------------------ #
     # Interaction — placement / edit (ADR-0032 / ADR-0033)
@@ -280,7 +417,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
         ADR-0037 §Decision 2 "delete removes one point"; the tail shifts up
         in order.  Returns True iff a point was removed.
         """
-        carrier = self._carrier
+        carrier = self._get_carrier()
         if carrier is None:
             return False
         return bool(carrier.RemoveNthAnnotationPoint(territoryId, int(index)))
@@ -290,14 +427,14 @@ class TerritoryPlacementPipeline(_PipelineBase):
     # ------------------------------------------------------------------ #
 
     def _add_point(self, world: Any) -> None:
-        carrier = self._carrier
+        carrier = self._get_carrier()
         territory = self._placement_territory()
         if carrier is None or territory is None:
             return
         carrier.AddAnnotationPoint(territory, float(world[0]), float(world[1]), float(world[2]))
 
     def _relocate_grabbed_point(self, world: Any) -> None:
-        carrier = self._carrier
+        carrier = self._get_carrier()
         target = self._drag_target
         if carrier is None or target is None:
             return
@@ -317,7 +454,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
         The unit layer injects the result directly, keeping the edit math
         GL-free.
         """
-        pick = self._pick
+        pick = self._ensure_pick()
         if pick is None:
             return None
         ray = self._cursor_ray(renderer, eventData)
@@ -334,7 +471,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
         distance (LayerDM arbitration).  ``(None, None, +inf)`` when there
         is no carrier / territory / point.
         """
-        carrier = self._carrier
+        carrier = self._get_carrier()
         territory = self._placement_territory()
         if carrier is None or territory is None:
             return None, None, sys.float_info.max
@@ -448,9 +585,43 @@ class TerritoryPlacementPipeline(_PipelineBase):
         """
         del caller, event
         try:
+            self._rebuild_seed_actor()
             self.RequestRender()
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass
+
+    # ------------------------------------------------------------------ #
+    # Placed-seed rendering (ADR-0037 §Decision 2)
+    # ------------------------------------------------------------------ #
+
+    def _rebuild_seed_actor(self) -> None:
+        """Rebuild the seed-glyph point set from the carrier, coloured per territory.
+
+        The carrier is the source of truth: read every visible territory's
+        points, glyph each as a sphere tinted with the territory's display
+        colour (ADR-0037 §Decision 1 display slot).  A no-op-safe rebuild — an
+        empty carrier clears the glyphs.
+        """
+        self._seed_points.Reset()
+        self._seed_colors.Reset()
+        self._seed_colors.SetNumberOfComponents(3)
+        carrier = self._get_carrier()
+        if carrier is not None:
+            for territory in carrier.GetAnnotationTerritoryIds():
+                if not bool(carrier.GetTerritoryVisibility(territory)):
+                    continue
+                rgb = carrier.GetTerritoryColor(territory)
+                r = int(max(0.0, min(1.0, rgb[0])) * 255)
+                g = int(max(0.0, min(1.0, rgb[1])) * 255)
+                b = int(max(0.0, min(1.0, rgb[2])) * 255)
+                count = carrier.GetNumberOfAnnotationPoints(territory)
+                for i in range(count):
+                    point = carrier.GetNthAnnotationPoint(territory, i)
+                    self._seed_points.InsertNextPoint(point[0], point[1], point[2])
+                    self._seed_colors.InsertNextTuple3(r, g, b)
+        self._seed_points.Modified()
+        self._seed_colors.Modified()
+        self._seed_polydata.Modified()
 
 
 def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -74,6 +74,14 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._carrier: Any | None = None
         self._territory_id: str | None = None
 
+        # Stage-2 arming (ADR-0037 §Decision 3).  An armed click appends one
+        # seed to the ACTIVE territory; a disarmed click adds nothing.  The
+        # arm state lives HERE (pipeline-managed), not on the interaction
+        # node -- there is no Slicer mouse mode.  The active territory
+        # overrides the ``SetCarrier`` binding for placement.
+        self._active_territory: str | None = None
+        self._armed: bool = False
+
         # Injectable pick core (bare unit layer feeds a known surface).
         self._pick: VesselSurfacePick | None = None
 
@@ -100,6 +108,34 @@ class TerritoryPlacementPipeline(_PipelineBase):
 
     def GetCarrier(self) -> Any | None:  # noqa: N802 - VTK verb
         return self._carrier
+
+    # ------------------------------------------------------------------ #
+    # Active-territory + arm seam (Stage 2, ADR-0037 §Decision 3)
+    # ------------------------------------------------------------------ #
+
+    def SetActiveTerritory(self, territoryId: str | None) -> None:  # noqa: N802 - VTK verb
+        """Set the territory an armed click appends into (the ACTIVE one)."""
+        self._active_territory = territoryId
+
+    def GetActiveTerritory(self) -> str | None:  # noqa: N802 - VTK verb
+        return self._active_territory
+
+    def Arm(self) -> None:  # noqa: N802 - VTK verb
+        """Enable add-on-click into the active territory ("Add Territory" / "Add seeds")."""
+        self._armed = True
+
+    def Disarm(self) -> None:  # noqa: N802 - VTK verb
+        """Disable add-on-click ("Done" / Esc).  A click then adds nothing."""
+        self._armed = False
+
+    def IsArmed(self) -> bool:  # noqa: N802 - VTK verb
+        return self._armed
+
+    def _placement_territory(self) -> str | None:
+        """The territory a click appends into: the active one, else the bound one."""
+        if self._active_territory is not None:
+            return self._active_territory
+        return self._territory_id
 
     def _safe_get_renderer(self) -> Any | None:
         return self._renderer
@@ -176,8 +212,15 @@ class TerritoryPlacementPipeline(_PipelineBase):
 
             _territory, _index, distance2 = self._nearest_point_in_display(renderer, eventData)
             if distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
-                # Press near an existing point -> grab it for a drag.
+                # Press near an existing point -> grab it for a drag (an edit
+                # gesture; independent of the arm state).
                 return True, distance2
+
+            # Add-on-click requires an armed pipeline (ADR-0037 §Decision 3):
+            # a disarmed press away from any point leaves the gesture to the
+            # camera.
+            if not self._armed:
+                return False, sys.float_info.max
 
             # Press away from any point: claim only when the ray hits the
             # surface (add-on-click); otherwise leave the press to the camera.
@@ -201,10 +244,15 @@ class TerritoryPlacementPipeline(_PipelineBase):
                     return False
                 territory, index, distance2 = self._nearest_point_in_display(renderer, eventData)
                 if territory is not None and index is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
-                    # Grab the existing point for a drag.
+                    # Grab the existing point for a drag (edit gesture).
                     self._drag_target = (territory, index)
                     return True
-                # Add-on-click: snap to the surface and add exactly one point.
+                # Add-on-click requires an armed pipeline (ADR-0037
+                # §Decision 3): a disarmed click adds nothing.
+                if not self._armed:
+                    return False
+                # Snap to the surface and add exactly one point to the active
+                # territory.
                 world = self._event_world_on_surface(renderer, eventData)
                 if world is None:
                     return False
@@ -243,9 +291,10 @@ class TerritoryPlacementPipeline(_PipelineBase):
 
     def _add_point(self, world: Any) -> None:
         carrier = self._carrier
-        if carrier is None or self._territory_id is None:
+        territory = self._placement_territory()
+        if carrier is None or territory is None:
             return
-        carrier.AddAnnotationPoint(self._territory_id, float(world[0]), float(world[1]), float(world[2]))
+        carrier.AddAnnotationPoint(territory, float(world[0]), float(world[1]), float(world[2]))
 
     def _relocate_grabbed_point(self, world: Any) -> None:
         carrier = self._carrier
@@ -286,7 +335,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
         is no carrier / territory / point.
         """
         carrier = self._carrier
-        territory = self._territory_id
+        territory = self._placement_territory()
         if carrier is None or territory is None:
             return None, None, sys.float_info.max
         count = carrier.GetNumberOfAnnotationPoints(territory)

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -51,6 +51,13 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
 #: outside it (but over the surface) adds a new point.
 POINT_PICK_RADIUS_PX = 20.0
 
+#: Hover/grab cue colours + halo scale, shared with the resection surface
+#: control points (ControlPolygonPipeline): hover = yellow, grab = green, and
+#: the glow halo is a slightly larger sphere (blurred by vtkOutlineGlowPass).
+HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
+HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
+HALO_HOVER_SCALE = 1.6
+
 #: Interaction state lives on the shared highlight DISPLAY NODE, not on the
 #: Pipeline instance: LayerDM owns the Pipeline instance lifecycle (it creates
 #: its own per view), so the widget/table can only reach the Pipeline the
@@ -136,9 +143,50 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._seed_glyph.SetColorModeToColorByScalar()
         self._seed_mapper = vtk.vtkPolyDataMapper()
         self._seed_mapper.SetInputConnection(self._seed_glyph.GetOutputPort())
+        # Interpret the per-glyph uchar[3] scalars as RGB directly.  Without
+        # ScalarVisibilityOn + UsePointData the mapper falls back to the LUT
+        # (which maps the 3-component array to near-black) -- the spheres then
+        # render invisible against the dark 3D background.
+        self._seed_mapper.SetScalarModeToUsePointData()
+        self._seed_mapper.ScalarVisibilityOn()
         self._seed_mapper.SetColorModeToDirectScalars()
         self._seed_actor = vtk.vtkActor()
         self._seed_actor.SetMapper(self._seed_mapper)
+
+        # -- hover-adhering MARKER: the sphere that clings to the surface under
+        # the cursor.  This pipeline is the SINGLE 3D pipeline for the
+        # highlight display-node type (ADR-0013 §1, one Pipeline per type), so
+        # it renders the hover marker ITSELF rather than relying on a second
+        # pipeline on the same type (which LayerDM would not create).
+        self._marker_sphere = vtk.vtkSphereSource()
+        self._marker_sphere.SetPhiResolution(16)
+        self._marker_sphere.SetThetaResolution(16)
+        self._marker_sphere.SetRadius(3.0)
+        self._marker_mapper = vtk.vtkPolyDataMapper()
+        self._marker_mapper.SetInputConnection(self._marker_sphere.GetOutputPort())
+        self._marker_actor = vtk.vtkActor()
+        self._marker_actor.SetMapper(self._marker_mapper)
+        self._marker_actor.GetProperty().SetColor(1.0, 0.6, 0.1)
+        self._marker_actor.SetVisibility(False)
+
+        # -- edit hover GLOW halo: a blurred glow around the seed under the
+        # cursor (yellow), swapping to green while grabbed, so the surgeon
+        # knows a marker is about to move -- the ControlPolygonPipeline glow
+        # cue.  Rendered in a private overlay renderer carrying a
+        # vtkOutlineGlowPass (the blur-to-halo pass); degrades to a plain
+        # sphere when the pass class is unavailable.
+        self._hover_target: tuple[str, int] | None = None
+        self._halo_renderer: Any | None = None
+        self._halo_sphere = vtk.vtkSphereSource()
+        self._halo_sphere.SetPhiResolution(16)
+        self._halo_sphere.SetThetaResolution(16)
+        self._halo_sphere.SetRadius(self._seed_sphere.GetRadius() * HALO_HOVER_SCALE)
+        self._halo_mapper = vtk.vtkPolyDataMapper()
+        self._halo_mapper.SetInputConnection(self._halo_sphere.GetOutputPort())
+        self._halo_actor = vtk.vtkActor()
+        self._halo_actor.SetMapper(self._halo_mapper)
+        self._halo_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
+        self._halo_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
     # Wiring seams (unit + production)
@@ -261,6 +309,8 @@ class TerritoryPlacementPipeline(_PipelineBase):
             self._renderer = renderer
             if renderer is not None:
                 renderer.AddActor(self._seed_actor)
+                renderer.AddActor(self._marker_actor)
+            self._attach_halo_renderer(renderer)
             # Renderer churn cleared the display handle; re-derive it from the
             # base's retained display node (the ControlPolygonPipeline
             # re-attach precedent) so the carrier + seed glyphs come back.
@@ -270,6 +320,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
                     self.SetDisplayNode(display)
             self._ensure_carrier_observed()
             self._rebuild_seed_actor()
+            self._reconcile_highlight()
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass
 
@@ -277,9 +328,55 @@ class TerritoryPlacementPipeline(_PipelineBase):
         try:
             if renderer is not None:
                 renderer.RemoveActor(self._seed_actor)
+                renderer.RemoveActor(self._marker_actor)
+            self._detach_halo_renderer()
             self._renderer = None
             self.cleanup()
         except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _attach_halo_renderer(self, renderer: Any) -> None:
+        """Build the private glow overlay on ``renderer``'s window.
+
+        A dedicated overlay ``vtkRenderer`` (camera shared with the view
+        renderer) carries the halo actor and a ``vtkOutlineGlowPass`` -- the
+        blur-to-halo pass -- so qMRMLThreeDView's SetPass(nullptr) reset on the
+        VIEW renderer never clobbers it (the ControlPolygonPipeline
+        precedent).  Degrades to the plain halo sphere when the pass class or
+        the render window is unavailable (bare unit layer).
+        """
+        window = getattr(renderer, "GetRenderWindow", None)
+        window = window() if window is not None else None
+        if window is None or self._halo_renderer is not None:
+            return
+        try:
+            overlay = vtk.vtkRenderer()
+            overlay.SetLayer(max(1, window.GetNumberOfLayers()))
+            window.SetNumberOfLayers(overlay.GetLayer() + 1)
+            overlay.InteractiveOff()
+            overlay.SetActiveCamera(renderer.GetActiveCamera())
+            overlay.AddActor(self._halo_actor)
+            glow = getattr(vtk, "vtkOutlineGlowPass", None)
+            steps = getattr(vtk, "vtkRenderStepsPass", None)
+            if glow is not None and steps is not None:
+                glow_pass = glow()
+                glow_pass.SetDelegatePass(steps())
+                overlay.SetPass(glow_pass)
+            window.AddRenderer(overlay)
+            self._halo_renderer = overlay
+        except Exception:  # pragma: no cover - defensive (fake renderers)
+            self._halo_renderer = None
+
+    def _detach_halo_renderer(self) -> None:
+        overlay = self._halo_renderer
+        self._halo_renderer = None
+        if overlay is None:
+            return
+        try:
+            window = overlay.GetRenderWindow()
+            if window is not None:
+                window.RemoveRenderer(overlay)
+        except Exception:  # pragma: no cover - defensive
             pass
 
     def cleanup(self) -> None:
@@ -288,6 +385,8 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._carrier = None
         self._observed_carrier = None
         self._drag_target = None
+        self._hover_target = None
+        self._halo_actor.SetVisibility(False)
 
     def _ensure_carrier_observed(self) -> None:
         """Observe the in-effect carrier so seed glyphs track its edits.
@@ -304,6 +403,48 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._observed_carrier = carrier
         if carrier is not None:
             self._attach_observer(carrier)
+
+    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        """LayerDM's re-sync hook (display-node Modified).
+
+        The display node is added to the scene (LayerDM creates this pipeline)
+        BEFORE the table binds the carrier reference onto it, so the carrier is
+        not resolvable at creation.  This hook fires when the reference IS set,
+        so it is where the seed-glyph observer finally attaches -- without it a
+        seed placed from a SLICE view never repaints the 3D glyphs.
+        """
+        try:
+            self._ensure_carrier_observed()
+            self._rebuild_seed_actor()
+            self._reconcile_highlight()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _reconcile_highlight(self) -> None:
+        """Sync the hover-marker sphere to the shared display node's adhering state.
+
+        The single 3D pipeline renders the cross-view hover marker: shown at
+        ``AdheringPointWorld`` when the display node is adhering + visible
+        (published by a hover in ANY view), hidden otherwise.
+        """
+        display = self._display_node
+        if display is None or not hasattr(display, "GetAdhering"):
+            self._marker_actor.SetVisibility(False)
+            return
+        try:
+            self._marker_sphere.SetRadius(float(display.GetRadius()))
+        except Exception:  # pragma: no cover - defensive
+            pass
+        try:
+            color = display.GetColor()
+            self._marker_actor.GetProperty().SetColor(color[0], color[1], color[2])
+        except Exception:  # pragma: no cover - defensive
+            pass
+        adhering = bool(display.GetAdhering()) and bool(display.GetVisibility())
+        self._marker_actor.SetVisibility(adhering)
+        if adhering:
+            point = display.GetAdheringPointWorld()
+            self._marker_actor.SetPosition(point[0], point[1], point[2])
 
     # ------------------------------------------------------------------ #
     # Interaction — placement / edit (ADR-0032 / ADR-0033)
@@ -339,9 +480,23 @@ class TerritoryPlacementPipeline(_PipelineBase):
                 return False, sys.float_info.max
 
             if etype == vtk.vtkCommand.MouseMoveEvent:
-                # Bare hover: raise the highlight as a SIDE EFFECT and
-                # DECLINE -- camera moves stay unclaimed (ADR-0033).
-                self._raise_highlight(renderer, eventData)
+                # Bare hover (ADR-0033: side-effect repaint, DECLINE so the
+                # camera is untouched).  Over an existing seed -> glow halo on
+                # it (about-to-move cue) + suppress the placement preview; over
+                # empty surface -> raise the adhering placement preview.
+                territory, index, distance2 = self._nearest_point_in_display(renderer, eventData)
+                if (
+                    territory is not None
+                    and index is not None
+                    and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
+                ):
+                    self._set_hover((territory, index))
+                    self._clear_adhering()
+                else:
+                    self._set_hover(None)
+                    self._raise_highlight(renderer, eventData)
+                self._reconcile_highlight()
+                self.RequestRender()
                 return False, sys.float_info.max
 
             if etype != vtk.vtkCommand.LeftButtonPressEvent:
@@ -356,7 +511,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
             # Add-on-click requires an armed pipeline (ADR-0037 §Decision 3):
             # a disarmed press away from any point leaves the gesture to the
             # camera.
-            if not self._armed:
+            if not self.IsArmed():
                 return False, sys.float_info.max
 
             # Press away from any point: claim only when the ray hits the
@@ -381,12 +536,18 @@ class TerritoryPlacementPipeline(_PipelineBase):
                     return False
                 territory, index, distance2 = self._nearest_point_in_display(renderer, eventData)
                 if territory is not None and index is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
-                    # Grab the existing point for a drag (edit gesture).
+                    # Grab the existing point for a drag (edit gesture): swap the
+                    # glow halo + the seed to the grab colour (green).
                     self._drag_target = (territory, index)
+                    self._position_halo()
+                    self._rebuild_seed_actor()
+                    self.RequestRender()
                     return True
                 # Add-on-click requires an armed pipeline (ADR-0037
-                # §Decision 3): a disarmed click adds nothing.
-                if not self._armed:
+                # §Decision 3): a disarmed click adds nothing.  Read the
+                # display-node-backed arm state (the table writes it there),
+                # NOT the instance flag.
+                if not self.IsArmed():
                     return False
                 # Snap to the surface and add exactly one point to the active
                 # territory.
@@ -394,17 +555,29 @@ class TerritoryPlacementPipeline(_PipelineBase):
                 if world is None:
                     return False
                 self._add_point(world)
+                # Repaint immediately: the carrier observer's RequestRender does
+                # not flush a frame mid-interaction (the slice-pipeline lesson).
+                self._rebuild_seed_actor()
+                self.RequestRender()
                 return True
 
             if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
                 self._drag_target = None
-                return False  # gesture over -- release the focus
+                # Gesture over: drop the grab colour (fall back to hover/none).
+                self._position_halo()
+                self._rebuild_seed_actor()
+                self.RequestRender()
+                return False  # release the focus
 
             if etype == vtk.vtkCommand.MouseMoveEvent:
                 world = self._event_world_on_surface(renderer, eventData)
                 if world is None:
                     return True  # keep the grab; this move just didn't resolve
                 self._relocate_grabbed_point(world)
+                # Track the grabbed seed under the drag + repaint immediately.
+                self._position_halo()
+                self._rebuild_seed_actor()
+                self.RequestRender()
                 return True
 
             return False
@@ -549,6 +722,38 @@ class TerritoryPlacementPipeline(_PipelineBase):
         if changed:
             display.Modified()
 
+    def _clear_adhering(self) -> None:
+        """Retire the placement preview (cursor is over a seed, not empty surface)."""
+        display = self._display_node
+        if display is None or not hasattr(display, "SetAdhering"):
+            return
+        if bool(display.GetAdhering()):
+            display.SetAdhering(False)
+            display.Modified()
+
+    def _set_hover(self, target: tuple[str, int] | None) -> None:
+        """Glow-halo the seed under the cursor (``None`` clears the hover)."""
+        if target == self._hover_target:
+            return
+        self._hover_target = target
+        self._position_halo()
+        self._rebuild_seed_actor()
+
+    def _position_halo(self) -> None:
+        """Place the glow halo on the grabbed (green) or hovered (yellow) seed."""
+        target = self._drag_target or self._hover_target
+        carrier = self._get_carrier()
+        show = False
+        if target is not None and carrier is not None:
+            territory, index = target
+            if 0 <= index < carrier.GetNumberOfAnnotationPoints(territory):
+                point = carrier.GetNthAnnotationPoint(territory, index)
+                self._halo_actor.SetPosition(point[0], point[1], point[2])
+                colour = HALO_GRAB_COLOR if self._drag_target is not None else HALO_HOVER_COLOR
+                self._halo_actor.GetProperty().SetColor(*colour)
+                show = True
+        self._halo_actor.SetVisibility(show)
+
     # ------------------------------------------------------------------ #
     # Observers (reconcile) + plumbing
     # ------------------------------------------------------------------ #
@@ -605,20 +810,30 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._seed_points.Reset()
         self._seed_colors.Reset()
         self._seed_colors.SetNumberOfComponents(3)
+        grab_rgb = tuple(int(c * 255) for c in HALO_GRAB_COLOR)
+        hover_rgb = tuple(int(c * 255) for c in HALO_HOVER_COLOR)
         carrier = self._get_carrier()
         if carrier is not None:
             for territory in carrier.GetAnnotationTerritoryIds():
                 if not bool(carrier.GetTerritoryVisibility(territory)):
                     continue
                 rgb = carrier.GetTerritoryColor(territory)
-                r = int(max(0.0, min(1.0, rgb[0])) * 255)
-                g = int(max(0.0, min(1.0, rgb[1])) * 255)
-                b = int(max(0.0, min(1.0, rgb[2])) * 255)
+                base = (
+                    int(max(0.0, min(1.0, rgb[0])) * 255),
+                    int(max(0.0, min(1.0, rgb[1])) * 255),
+                    int(max(0.0, min(1.0, rgb[2])) * 255),
+                )
                 count = carrier.GetNumberOfAnnotationPoints(territory)
                 for i in range(count):
                     point = carrier.GetNthAnnotationPoint(territory, i)
                     self._seed_points.InsertNextPoint(point[0], point[1], point[2])
-                    self._seed_colors.InsertNextTuple3(r, g, b)
+                    key = (territory, i)
+                    if key == self._drag_target:
+                        self._seed_colors.InsertNextTuple3(*grab_rgb)  # grabbed: green
+                    elif key == self._hover_target:
+                        self._seed_colors.InsertNextTuple3(*hover_rgb)  # hovered: yellow
+                    else:
+                        self._seed_colors.InsertNextTuple3(*base)
         self._seed_points.Modified()
         self._seed_colors.Modified()
         self._seed_polydata.Modified()

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -1,0 +1,565 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Slice-view LayerDM Pipeline for vessel-annotation placement + viz (ADR-0037).
+
+The 2D-slice complement of ``TerritoryPlacementPipeline``: the SAME arm
+state / active territory / carrier live on the shared highlight display
+node (``TerritoryInteractionState``), so 2D and 3D placement stay in
+lockstep -- an armed click in a slice view appends one surface-snapped seed
+to the ACTIVE territory, exactly as an armed click in a 3D view does.
+
+Mirrors ``LiverResectionsLib.SliceControlPolygonPipeline`` (ADR-0033): the
+carrier's annotation points are projected into the slice view's XY space
+(``inverse(XYToRAS)``) with DISTANCE FADING, a signed above/below SIDE
+TINT, and a HARD presence cutoff (2D alpha is unreliable).  Rendering
+rebuilds on a carrier ``Modified`` and on slice reslice (the slice node is
+observed).
+
+Placement (ADR-0037 §2D snap):
+
+* a BARE MOVE is DECLINED (``(False, +inf)``, ADR-0033) -- the camera is
+  untouched;
+* an armed LEFT-BUTTON PRESS over the slice resolves the pixel to RAS ON
+  the plane (``XYToRAS``), casts a ray ALONG THE SLICE NORMAL (both
+  directions), feeds it to ``VesselSurfacePick`` -> the surface-snapped
+  seed is added to the ACTIVE territory;
+* a press near an existing PROJECTED seed within the pick radius grabs it
+  for a drag; the drag relocates along the slice-normal snap;
+* a disarmed press away from any seed leaves the gesture to the camera;
+* DELETE converges on the carrier's ``RemoveNthAnnotationPoint`` (the one
+  deletion path the table + the 3D pick-delete share).
+
+Keyed on ``(vtkMRMLSliceNode, vtkMRMLTerritoriesHighlightDisplayNode)`` --
+the slice-view half of the annotation placement (the 3D creator accepts
+only ``vtkMRMLViewNode``).  ADR-0013 §5 keeps the (view-type, display-type)
+keying disjoint per pair; rendering + interaction route through this
+scripted Pipeline + its creator, never a custom displayable manager.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import vtk
+
+from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+
+try:  # pragma: no cover - exercised once per import path
+    from .VesselSurfacePick import VesselSurfacePick
+    from .VesselHighlightWiring import closed_surface_polydata
+    from . import TerritoryInteractionState as _state
+    from . import TerritorySliceProjection as _proj
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
+    from VesselHighlightWiring import closed_surface_polydata  # type: ignore[no-redef]
+    import TerritoryInteractionState as _state  # type: ignore[no-redef]
+    import TerritorySliceProjection as _proj  # type: ignore[no-redef]
+
+_REGISTERED = False
+
+#: Display-space pick radius (XY pixels) for grabbing an existing projected
+#: seed (mirrors ``TerritoryPlacementPipeline.POINT_PICK_RADIUS_PX``).
+POINT_PICK_RADIUS_PX = 20.0
+
+#: Seed glyph diameter (XY pixels) -- a grab target larger than a default
+#: markups glyph (the slice-control-polygon convention).
+SEED_GLYPH_SCALE_PX = 12.0
+
+
+def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
+    """True iff ``viewNode`` is a slice view (this pipeline's home).
+
+    Part of the creator callback: LayerDM invokes it for every
+    ``(view, node)`` pair, so it must never raise.
+    """
+    try:
+        return viewNode is not None and bool(viewNode.IsA("vtkMRMLSliceNode"))
+    except Exception:  # pragma: no cover - C++ boundary must never raise
+        return False
+
+
+class TerritorySlicePipeline(_PipelineBase):
+    """Projected, fading, slice-editable territory annotation seeds."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.SetPythonObject(self)
+
+        self._display_node: Any | None = None
+        self._slice_node: Any | None = None
+        self._renderer: Any | None = None
+        self._observer_tags: dict = {}
+        self._observed_node_refs: list = []
+        self._observed_carrier: Any | None = None
+
+        # Injectable pick core (bare unit layer feeds a known surface); in
+        # production ``_ensure_pick`` builds it from the display node's
+        # pickSurface (the ``TerritoryPlacementPipeline`` precedent).
+        self._pick: VesselSurfacePick | None = None
+
+        # Projected-seed bookkeeping (pick arbitration): parallel lists of
+        # (territoryId, index) keys, their XY positions, and |distance| to
+        # the slice plane -- rebuilt on every reproject.
+        self._projected_keys: list = []
+        self._projected_xy: list = []
+        self._plane_distances: list = []
+
+        # (territory id, in-territory index) of the projected seed currently
+        # GRABBED by a press/move/release drag -- None when no drag.
+        self._drag_target: tuple[str, int] | None = None
+
+        # Seed glyphs: projected points as 2D circle glyphs with RGBA fading.
+        self._seed_polydata = vtk.vtkPolyData()
+        self._seed_polydata.SetPoints(vtk.vtkPoints())
+        self._seed_glyph_source = vtk.vtkGlyphSource2D()
+        self._seed_glyph_source.SetGlyphTypeToCircle()
+        self._seed_glyph_source.FilledOn()
+        self._seed_glyph_source.SetScale(SEED_GLYPH_SCALE_PX)
+        self._seed_glyph = vtk.vtkGlyph2D()
+        self._seed_glyph.SetInputData(self._seed_polydata)
+        self._seed_glyph.SetSourceConnection(self._seed_glyph_source.GetOutputPort())
+        self._seed_glyph.SetColorModeToColorByScalar()
+        self._seed_glyph.ScalingOff()
+        self._seed_mapper = vtk.vtkPolyDataMapper2D()
+        self._seed_mapper.SetInputConnection(self._seed_glyph.GetOutputPort())
+        self._seed_actor = vtk.vtkActor2D()
+        self._seed_actor.SetMapper(self._seed_mapper)
+        self._seed_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # Wiring seams (unit + production)
+    # ------------------------------------------------------------------ #
+
+    def SetPickCore(self, pick: VesselSurfacePick | None) -> None:  # noqa: N802 - VTK verb
+        """Inject the ``VesselSurfacePick`` over the target surface (unit seam)."""
+        self._pick = pick
+
+    def _ensure_pick(self) -> VesselSurfacePick | None:
+        """Build the pick core against the display node's ``pickSurface`` mesh.
+
+        Production instances resolve the surface from the shared display node
+        exactly as ``TerritoryPlacementPipeline`` does, so the 2D and 3D snaps
+        adhere to the SAME mesh.  A test-injected ``self._pick`` short-circuits
+        this for the bare unit layer.
+        """
+        if self._pick is not None:
+            return self._pick
+        display = self._display_node
+        if display is None:
+            return None
+        segmentation = display.GetPickSurfaceNode()
+        if segmentation is None:
+            return None
+        polydata = closed_surface_polydata(segmentation)
+        if polydata is None:
+            return None
+        self._pick = VesselSurfacePick(polydata)
+        return self._pick
+
+    def _get_carrier(self) -> Any | None:
+        """The carrier the shared display node binds (the 3D-pipeline seam)."""
+        return _state.get_carrier(self._display_node)
+
+    def _placement_territory(self) -> str | None:
+        """The territory an armed click appends into (the ACTIVE one)."""
+        return _state.get_active_territory(self._display_node)
+
+    def _is_armed(self) -> bool:
+        return _state.is_armed(self._display_node)
+
+    def _safe_get_renderer(self) -> Any | None:
+        return self._renderer
+
+    # ------------------------------------------------------------------ #
+    # LayerDM lifecycle
+    # ------------------------------------------------------------------ #
+
+    def SetViewNode(self, viewNode: Any) -> None:  # noqa: N802 - VTK verb
+        super().SetViewNode(viewNode)
+        # Observe the slice node OURSELVES: reslicing must re-project + re-fade
+        # (the SliceControlPolygonPipeline stale-trace lesson).
+        if self._slice_node is not None:
+            self._detach_observer(self._slice_node)
+        self._slice_node = viewNode
+        if viewNode is not None:
+            self._attach_observer(viewNode)
+
+    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
+        super().SetDisplayNode(displayNode)
+        self._display_node = displayNode
+        # A (re)attached display node can carry a different pickSurface /
+        # carrier: force both to re-resolve (the highlight-Pipeline precedent).
+        self._pick = None
+        self._ensure_carrier_observed()
+
+    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        try:
+            self._renderer = renderer
+            if renderer is not None:
+                renderer.AddActor2D(self._seed_actor)
+            # Renderer churn cleared the display handle; re-derive it from the
+            # base's retained display node (the reattach precedent).
+            if self._display_node is None:
+                display = self.GetDisplayNode()
+                if display is not None:
+                    self.SetDisplayNode(display)
+            self._ensure_carrier_observed()
+            self._reproject()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        try:
+            if renderer is not None:
+                renderer.RemoveActor2D(self._seed_actor)
+            self._renderer = None
+            self.cleanup()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def cleanup(self) -> None:
+        for node in list(self._observed_node_refs):
+            self._detach_observer(node)
+        self._observed_carrier = None
+        self._drag_target = None
+        self._seed_actor.SetVisibility(False)
+
+    def _ensure_carrier_observed(self) -> None:
+        """Observe the in-effect carrier so seed glyphs track its edits."""
+        carrier = self._get_carrier()
+        if carrier is self._observed_carrier:
+            return
+        if self._observed_carrier is not None:
+            self._detach_observer(self._observed_carrier)
+        self._observed_carrier = carrier
+        if carrier is not None:
+            self._attach_observer(carrier)
+
+    # ------------------------------------------------------------------ #
+    # Rendering (viz) -- fading projection into the slice XY
+    # ------------------------------------------------------------------ #
+
+    def _reproject(self) -> bool:
+        """Project every visible territory's seeds into XY with distance fading.
+
+        Reads the carrier (the source of truth), projects each seed via
+        ``inverse(XYToRAS)``, fades alpha by its |distance| to the slice
+        plane, applies the signed above/below side tint over the
+        per-territory colour, and drops seeds beyond the HARD presence cutoff
+        (2D alpha unreliable).  Populates the pick-arbitration bookkeeping.
+        """
+        self._projected_keys = []
+        self._projected_xy = []
+        self._plane_distances = []
+        carrier = self._get_carrier()
+        slice_node = self._slice_node
+        if carrier is None or slice_node is None:
+            self._seed_actor.SetVisibility(False)
+            return False
+
+        # Hoist the slice frame + the inverse XYToRAS out of the per-seed loop
+        # (the SliceControlPolygonPipeline convention): resolving them once
+        # keeps the reproject O(seeds), not O(seeds) matrix inversions.
+        frame = _proj.slice_frame(slice_node)
+        ras_to_xy = _proj.inverse_xy_to_ras(slice_node)
+        if frame is None or ras_to_xy is None:
+            self._seed_actor.SetVisibility(False)
+            return False
+        origin, normal = frame
+
+        points = vtk.vtkPoints()
+        rgba = vtk.vtkUnsignedCharArray()
+        rgba.SetNumberOfComponents(4)
+        rgba.SetName("SeedColors")
+        try:
+            for territory in carrier.GetAnnotationTerritoryIds():
+                if not bool(carrier.GetTerritoryVisibility(territory)):
+                    continue
+                base = self._territory_rgb(carrier, territory)
+                count = carrier.GetNumberOfAnnotationPoints(territory)
+                for i in range(count):
+                    point = carrier.GetNthAnnotationPoint(territory, i)
+                    signed = _proj.signed_distance(origin, normal, point)
+                    if not _proj.is_present(signed):
+                        continue  # HARD presence cutoff
+                    xy = _proj.apply_matrix_xy(ras_to_xy, point)
+                    tint = _proj.side_tint(base, signed)
+                    alpha = int(_proj.fade_alpha(signed) * 255)
+                    points.InsertNextPoint(xy[0], xy[1], 0.0)
+                    rgba.InsertNextTuple4(tint[0], tint[1], tint[2], alpha)
+                    self._projected_keys.append((territory, i))
+                    self._projected_xy.append((xy[0], xy[1]))
+                    self._plane_distances.append(abs(signed))
+        except Exception:  # pragma: no cover - defensive
+            self._seed_actor.SetVisibility(False)
+            return False
+
+        self._seed_polydata.SetPoints(points)
+        self._seed_polydata.GetPointData().SetScalars(rgba)
+        self._seed_polydata.Modified()
+        self._seed_actor.SetVisibility(points.GetNumberOfPoints() > 0)
+        return True
+
+    @staticmethod
+    def _territory_rgb(carrier: Any, territory: str) -> list:
+        """The territory's base display colour as an ``[r, g, b]`` 0..255 list."""
+        try:
+            rgb = carrier.GetTerritoryColor(territory)
+            return [int(max(0.0, min(1.0, c)) * 255) for c in (rgb[0], rgb[1], rgb[2])]
+        except Exception:  # pragma: no cover - defensive
+            return [255, 255, 255]
+
+    # ------------------------------------------------------------------ #
+    # Interaction -- placement / slice-side edit (ADR-0032 / ADR-0033)
+    # ------------------------------------------------------------------ #
+
+    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
+        """Return ``(canProcess, distance2)`` for the LayerDM focus logic.
+
+        Mirrors ``TerritoryPlacementPipeline`` on the slice: a press near a
+        projected seed grabs it (real squared distance); an armed press over
+        the slice claims add-on-click (pick-radius squared); a grabbed
+        move/release is claimed unconditionally; a bare move is DECLINED
+        (``(False, +inf)``) so the camera is untouched (ADR-0033).
+        """
+        try:
+            if self._safe_get_renderer() is None:
+                return False, sys.float_info.max
+            etype = _event_type(eventData)
+
+            if self._drag_target is not None:
+                if etype in (
+                    vtk.vtkCommand.MouseMoveEvent,
+                    vtk.vtkCommand.LeftButtonReleaseEvent,
+                ):
+                    return True, 0.0
+                return False, sys.float_info.max
+
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                return False, sys.float_info.max  # bare hover: camera untouched
+
+            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                return False, sys.float_info.max
+
+            _key, distance2 = self._nearest_seed_in_display(eventData)
+            if distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
+                return True, distance2  # grab a seed for a drag (edit gesture)
+
+            # Add-on-click requires an armed pipeline (ADR-0037 §Decision 3):
+            # a disarmed press away from any seed leaves it to the camera.
+            if not self._is_armed():
+                return False, sys.float_info.max
+            if self._snap_event_to_surface(eventData) is None:
+                return False, sys.float_info.max
+            return True, POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False, sys.float_info.max
+
+    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
+        """Drive add-on-click / drag-to-edit from a slice view (ADR-0037 §2D)."""
+        try:
+            if self._safe_get_renderer() is None:
+                self._drag_target = None
+                return False
+            etype = _event_type(eventData)
+
+            if self._drag_target is None:
+                if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                    return False
+                key, distance2 = self._nearest_seed_in_display(eventData)
+                if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
+                    self._drag_target = key  # grab for a drag (edit gesture)
+                    return True
+                if not self._is_armed():
+                    return False  # a disarmed click adds nothing
+                world = self._snap_event_to_surface(eventData)
+                if world is None:
+                    return False
+                self._add_point(world)
+                return True
+
+            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
+                self._drag_target = None
+                return False  # gesture over -- release the focus
+
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                world = self._snap_event_to_surface(eventData)
+                if world is None:
+                    return True  # keep the grab; this move just didn't resolve
+                self._relocate_grabbed_point(world)
+                return True
+
+            return False
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False
+
+    def DeleteAnnotationPoint(self, territoryId: str, index: int) -> bool:  # noqa: N802 - VTK verb
+        """Remove EXACTLY ONE seed via the carrier (the shared deletion path)."""
+        carrier = self._get_carrier()
+        if carrier is None:
+            return False
+        return bool(carrier.RemoveNthAnnotationPoint(territoryId, int(index)))
+
+    # ------------------------------------------------------------------ #
+    # Snap + carrier writes
+    # ------------------------------------------------------------------ #
+
+    def _snap_event_to_surface(self, eventData: Any):
+        """Snap a slice-view pixel onto the vessel surface along the normal.
+
+        Resolves the pixel to RAS ON the slice plane (``XYToRAS``), casts a
+        ray ALONG THE SLICE NORMAL through it, and feeds it to
+        ``VesselSurfacePick`` -> the surface-snapped world point (``None`` on
+        a miss / no surface).  Kept GL-free (the unit layer injects the pick
+        result), unlike the 3D pipeline's camera-ray unprojection.
+        """
+        pick = self._ensure_pick()
+        if pick is None:
+            return None
+        try:
+            ex, ey = eventData.GetDisplayPosition()
+        except Exception:  # pragma: no cover - defensive (fake events)
+            return None
+        ras = _proj.xy_to_ras_on_plane(self._slice_node, ex, ey)
+        if ras is None:
+            return None
+        ray = _proj.normal_ray(self._slice_node, ras)
+        if ray is None:
+            return None
+        p1, p2 = ray
+        # Fall back to the in-plane RAS point when the normal ray misses the
+        # surface, so an armed click still lands a seed on the plane.
+        return pick.pick(p1, p2, fallback_point=ras)
+
+    def _add_point(self, world: Any) -> None:
+        carrier = self._get_carrier()
+        territory = self._placement_territory()
+        if carrier is None or territory is None:
+            return
+        carrier.AddAnnotationPoint(territory, float(world[0]), float(world[1]), float(world[2]))
+
+    def _relocate_grabbed_point(self, world: Any) -> None:
+        carrier = self._get_carrier()
+        target = self._drag_target
+        if carrier is None or target is None:
+            return
+        territory, index = target
+        carrier.SetNthAnnotationPoint(territory, int(index), float(world[0]), float(world[1]), float(world[2]))
+
+    def _nearest_seed_in_display(self, eventData: Any):
+        """``((territoryId, index) | None, distance2)`` of the nearest projected seed.
+
+        Slice-view display coordinates coincide with the XY projection space
+        (the slice renderer convention), so the arbitration compares the
+        event pixel against ``_projected_xy``.  A seed at / beyond the
+        presence cutoff is not projected, so it is inherently unpickable.
+        """
+        try:
+            ex, ey = eventData.GetDisplayPosition()
+        except Exception:  # pragma: no cover - defensive (fake events)
+            return None, sys.float_info.max
+        best_key = None
+        best_d2 = sys.float_info.max
+        for key, (px, py) in zip(self._projected_keys, self._projected_xy):
+            d2 = (px - ex) ** 2 + (py - ey) ** 2
+            if d2 < best_d2:
+                best_d2 = d2
+                best_key = key
+        return best_key, best_d2
+
+    # ------------------------------------------------------------------ #
+    # Introspection (unit seams)
+    # ------------------------------------------------------------------ #
+
+    def GetSeedActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._seed_actor
+
+    def GetSeedPolyData(self) -> Any:  # noqa: N802 - VTK verb
+        return self._seed_polydata
+
+    def GetProjectedKeys(self) -> list:  # noqa: N802 - VTK verb
+        return list(self._projected_keys)
+
+    # ------------------------------------------------------------------ #
+    # Observers
+    # ------------------------------------------------------------------ #
+
+    def _attach_observer(self, node: Any) -> None:
+        if node is None or not hasattr(node, "AddObserver"):
+            return
+        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
+        self._observer_tags.setdefault(id(node), []).append(tag)
+        if node not in self._observed_node_refs:
+            self._observed_node_refs.append(node)
+
+    def _detach_observer(self, node: Any) -> None:
+        if node is None:
+            return
+        for tag in self._observer_tags.pop(id(node), []):
+            try:
+                node.RemoveObserver(tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        try:
+            self._observed_node_refs.remove(node)
+        except ValueError:
+            pass
+
+    def _on_node_modified(self, caller: Any, event: str) -> None:
+        """Reconcile on a carrier / slice ``Modified`` -- reproject + render.
+
+        The Pipeline holds no shadow copy of the seed set: the carrier IS the
+        source of truth, so a reconcile driven by an unrelated ``Modified``
+        (a table repaint, a colour change) reprojects without adding / moving
+        / dropping any seed (ADR-0037 §Conformance no-drift).
+        """
+        del caller, event
+        try:
+            self._reproject()
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+
+def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name
+    """The VTK event-type id off ``eventData``."""
+    return int(eventData.GetType())
+
+
+def registerTerritorySlicePipelineCreator() -> None:  # noqa: N802 - project convention
+    """Register the ``TerritorySlicePipeline`` creator with LayerDM.
+
+    Idempotent (module-level flag), mirroring
+    ``registerTerritoryPlacementPipelineCreator``.  The creator matches
+    ``(vtkMRMLSliceNode, vtkMRMLTerritoriesHighlightDisplayNode)`` -- the
+    slice views only; the 3D placement creator accepts only
+    ``vtkMRMLViewNode``, so the (view-type, display-type) keying stays
+    disjoint (ADR-0013 §1).  Rendering + interaction route through this
+    scripted Pipeline + its creator, never a custom displayable manager
+    (ADR-0013 §5).
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return
+
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLLayerDMPipelineFactory,
+        vtkMRMLLayerDMPipelineScriptedCreator,
+        vtkMRMLTerritoriesHighlightDisplayNode,
+    )
+
+    def tryCreate(viewNode, node):
+        try:
+            if not _creator_accepts_view(viewNode):
+                return None
+            if not isinstance(node, vtkMRMLTerritoriesHighlightDisplayNode):
+                return None
+            return TerritorySlicePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return None
+
+    creator = vtkMRMLLayerDMPipelineScriptedCreator()
+    creator.SetPythonCallback(tryCreate)
+    vtkMRMLLayerDMPipelineFactory.GetInstance().AddPipelineCreator(creator)
+    _REGISTERED = True

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -62,9 +62,22 @@ _REGISTERED = False
 #: seed (mirrors ``TerritoryPlacementPipeline.POINT_PICK_RADIUS_PX``).
 POINT_PICK_RADIUS_PX = 20.0
 
-#: Seed glyph diameter (XY pixels) -- a grab target larger than a default
-#: markups glyph (the slice-control-polygon convention).
-SEED_GLYPH_SCALE_PX = 12.0
+#: Handle / hover-ring glyph diameters (XY pixels), mirroring
+#: ``SliceControlPolygonPipeline``: seeds render as hollow-circle HANDLES
+#: (grab targets), and the ring is a larger hollow circle AROUND the
+#: hovered/grabbed handle.
+HANDLE_GLYPH_SCALE_PX = 13.0
+RING_GLYPH_SCALE_PX = 20.0
+
+#: Interaction colours shared with the resection surface interaction
+#: (``ControlPolygonPipeline``): hover = yellow, grab = green.
+HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
+HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
+
+#: Pull the per-territory base colour toward mid-tone before the signed-
+#: distance side tint, so BOTH the lighter-above and darker-below cues have
+#: headroom (the ``SliceControlPolygonPipeline`` HANDLE_MIDTONE_FACTOR).
+HANDLE_MIDTONE_FACTOR = 0.78
 
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
@@ -108,14 +121,19 @@ class TerritorySlicePipeline(_PipelineBase):
         # (territory id, in-territory index) of the projected seed currently
         # GRABBED by a press/move/release drag -- None when no drag.
         self._drag_target: tuple[str, int] | None = None
+        # (territory id, in-territory index) of the seed under the cursor (the
+        # hover grab affordance), None when the cursor is over none.
+        self._hover_target: tuple[str, int] | None = None
 
-        # Seed glyphs: projected points as 2D circle glyphs with RGBA fading.
+        # Seed HANDLES: projected points as hollow-circle 2D glyphs with RGBA
+        # side-tint + distance fade -- the SliceControlPolygonPipeline handle
+        # style (a grab target you can see is a grab target you can move).
         self._seed_polydata = vtk.vtkPolyData()
         self._seed_polydata.SetPoints(vtk.vtkPoints())
         self._seed_glyph_source = vtk.vtkGlyphSource2D()
         self._seed_glyph_source.SetGlyphTypeToCircle()
-        self._seed_glyph_source.FilledOn()
-        self._seed_glyph_source.SetScale(SEED_GLYPH_SCALE_PX)
+        self._seed_glyph_source.FilledOff()
+        self._seed_glyph_source.SetScale(HANDLE_GLYPH_SCALE_PX)
         self._seed_glyph = vtk.vtkGlyph2D()
         self._seed_glyph.SetInputData(self._seed_polydata)
         self._seed_glyph.SetSourceConnection(self._seed_glyph_source.GetOutputPort())
@@ -124,8 +142,52 @@ class TerritorySlicePipeline(_PipelineBase):
         self._seed_mapper = vtk.vtkPolyDataMapper2D()
         self._seed_mapper.SetInputConnection(self._seed_glyph.GetOutputPort())
         self._seed_actor = vtk.vtkActor2D()
+        self._seed_actor.GetProperty().SetLineWidth(2.0)
         self._seed_actor.SetMapper(self._seed_mapper)
         self._seed_actor.SetVisibility(False)
+
+        # Hover / grab RING: a larger hollow circle on the hovered (yellow) or
+        # grabbed (green) handle -- the 2D analogue of the 3D glow halo, the
+        # SliceControlPolygonPipeline ring.
+        self._ring_polydata = vtk.vtkPolyData()
+        self._ring_polydata.SetPoints(vtk.vtkPoints())
+        self._ring_glyph_source = vtk.vtkGlyphSource2D()
+        self._ring_glyph_source.SetGlyphTypeToCircle()
+        self._ring_glyph_source.FilledOff()
+        self._ring_glyph_source.SetScale(RING_GLYPH_SCALE_PX)
+        self._ring_glyph = vtk.vtkGlyph2D()
+        self._ring_glyph.SetInputData(self._ring_polydata)
+        self._ring_glyph.SetSourceConnection(self._ring_glyph_source.GetOutputPort())
+        self._ring_glyph.ScalingOff()
+        self._ring_mapper = vtk.vtkPolyDataMapper2D()
+        self._ring_mapper.SetInputConnection(self._ring_glyph.GetOutputPort())
+        self._ring_actor = vtk.vtkActor2D()
+        self._ring_actor.GetProperty().SetLineWidth(2.0)
+        self._ring_actor.SetVisibility(False)
+
+        # Adhering-placement PREVIEW: a hollow-circle handle (yellow, the hover
+        # colour) at the shared display node's AdheringPointWorld projected
+        # into THIS slice -- where an armed click would drop a seed.  Published
+        # by whichever view the cursor is in, so it shows in every view at once
+        # (ADR-0033 cross-view cue).  Styled as a handle preview, not a
+        # crosshair, so it reads like the surface interaction.
+        self._highlight_polydata = vtk.vtkPolyData()
+        self._highlight_polydata.SetPoints(vtk.vtkPoints())
+        self._highlight_glyph_source = vtk.vtkGlyphSource2D()
+        self._highlight_glyph_source.SetGlyphTypeToCircle()
+        self._highlight_glyph_source.FilledOff()
+        self._highlight_glyph_source.SetScale(HANDLE_GLYPH_SCALE_PX)
+        self._highlight_glyph = vtk.vtkGlyph2D()
+        self._highlight_glyph.SetInputData(self._highlight_polydata)
+        self._highlight_glyph.SetSourceConnection(self._highlight_glyph_source.GetOutputPort())
+        self._highlight_glyph.ScalingOff()
+        self._highlight_mapper = vtk.vtkPolyDataMapper2D()
+        self._highlight_mapper.SetInputConnection(self._highlight_glyph.GetOutputPort())
+        self._highlight_actor = vtk.vtkActor2D()
+        self._highlight_actor.GetProperty().SetLineWidth(2.0)
+        self._highlight_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
+        self._highlight_actor.SetMapper(self._highlight_mapper)
+        self._highlight_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
     # Wiring seams (unit + production)
@@ -187,10 +249,17 @@ class TerritorySlicePipeline(_PipelineBase):
 
     def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
         super().SetDisplayNode(displayNode)
+        if self._display_node is not None and self._display_node is not displayNode:
+            self._detach_observer(self._display_node)
         self._display_node = displayNode
         # A (re)attached display node can carry a different pickSurface /
         # carrier: force both to re-resolve (the highlight-Pipeline precedent).
         self._pick = None
+        # Observe the display node so a cross-view adhering-point change
+        # (published by whichever view the cursor is in) repaints this slice's
+        # hover marker.
+        if displayNode is not None:
+            self._attach_observer(displayNode)
         self._ensure_carrier_observed()
 
     def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
@@ -198,6 +267,8 @@ class TerritorySlicePipeline(_PipelineBase):
             self._renderer = renderer
             if renderer is not None:
                 renderer.AddActor2D(self._seed_actor)
+                renderer.AddActor2D(self._ring_actor)
+                renderer.AddActor2D(self._highlight_actor)
             # Renderer churn cleared the display handle; re-derive it from the
             # base's retained display node (the reattach precedent).
             if self._display_node is None:
@@ -206,6 +277,31 @@ class TerritorySlicePipeline(_PipelineBase):
                     self.SetDisplayNode(display)
             self._ensure_carrier_observed()
             self._reproject()
+            self._reconcile_highlight()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        """LayerDM's re-sync hook: reproject the seeds + repaint the highlight.
+
+        LayerDM's manager owns the display-node observation and calls this when
+        the pipeline's display node is Modified (a hover-published adhering
+        point from ANY view, an arm/visibility change) -- the same hook
+        ``VesselHighlightPipeline`` / ``SliceControlPolygonPipeline`` reconcile
+        in.  This is the channel the cross-view highlight rides, not the raw
+        display-node observer (which LayerDM intercepts).
+
+        Also (re)attaches the carrier observer: the display node is added to
+        the scene (LayerDM creates this pipeline) BEFORE the table binds the
+        carrier reference onto it, so the carrier is not resolvable at
+        creation.  This hook fires when the reference IS set (a display-node
+        Modified), so it is where the seed-tracking observer finally attaches
+        -- without it a passive slice never repaints a seed placed elsewhere.
+        """
+        try:
+            self._ensure_carrier_observed()
+            self._reproject()
+            self._reconcile_highlight()
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass
 
@@ -213,6 +309,8 @@ class TerritorySlicePipeline(_PipelineBase):
         try:
             if renderer is not None:
                 renderer.RemoveActor2D(self._seed_actor)
+                renderer.RemoveActor2D(self._ring_actor)
+                renderer.RemoveActor2D(self._highlight_actor)
             self._renderer = None
             self.cleanup()
         except Exception:  # pragma: no cover - C++ boundary must never raise
@@ -223,7 +321,10 @@ class TerritorySlicePipeline(_PipelineBase):
             self._detach_observer(node)
         self._observed_carrier = None
         self._drag_target = None
+        self._hover_target = None
         self._seed_actor.SetVisibility(False)
+        self._ring_actor.SetVisibility(False)
+        self._highlight_actor.SetVisibility(False)
 
     def _ensure_carrier_observed(self) -> None:
         """Observe the in-effect carrier so seed glyphs track its edits."""
@@ -268,6 +369,8 @@ class TerritorySlicePipeline(_PipelineBase):
             return False
         origin, normal = frame
 
+        hover_rgb = [int(c * 255) for c in HALO_HOVER_COLOR]
+        grab_rgb = [int(c * 255) for c in HALO_GRAB_COLOR]
         points = vtk.vtkPoints()
         rgba = vtk.vtkUnsignedCharArray()
         rgba.SetNumberOfComponents(4)
@@ -284,11 +387,21 @@ class TerritorySlicePipeline(_PipelineBase):
                     if not _proj.is_present(signed):
                         continue  # HARD presence cutoff
                     xy = _proj.apply_matrix_xy(ras_to_xy, point)
-                    tint = _proj.side_tint(base, signed)
-                    alpha = int(_proj.fade_alpha(signed) * 255)
+                    key = (territory, i)
+                    if key == self._drag_target:
+                        # Grabbed handle: full-alpha grab colour (green).
+                        rgba.InsertNextTuple4(grab_rgb[0], grab_rgb[1], grab_rgb[2], 255)
+                    elif key == self._hover_target:
+                        # Hovered handle: full-alpha hover colour (yellow).
+                        rgba.InsertNextTuple4(hover_rgb[0], hover_rgb[1], hover_rgb[2], 255)
+                    else:
+                        # The markups signed-distance cue: mid-toned base tinted
+                        # toward white (above) / black (below), alpha by distance.
+                        tint = _proj.side_tint(base, signed)
+                        alpha = int(_proj.fade_alpha(signed) * 255)
+                        rgba.InsertNextTuple4(tint[0], tint[1], tint[2], alpha)
                     points.InsertNextPoint(xy[0], xy[1], 0.0)
-                    rgba.InsertNextTuple4(tint[0], tint[1], tint[2], alpha)
-                    self._projected_keys.append((territory, i))
+                    self._projected_keys.append(key)
                     self._projected_xy.append((xy[0], xy[1]))
                     self._plane_distances.append(abs(signed))
         except Exception:  # pragma: no cover - defensive
@@ -299,16 +412,40 @@ class TerritorySlicePipeline(_PipelineBase):
         self._seed_polydata.GetPointData().SetScalars(rgba)
         self._seed_polydata.Modified()
         self._seed_actor.SetVisibility(points.GetNumberOfPoints() > 0)
+        self._update_ring()
         return True
 
-    @staticmethod
-    def _territory_rgb(carrier: Any, territory: str) -> list:
-        """The territory's base display colour as an ``[r, g, b]`` 0..255 list."""
+    def _territory_rgb(self, carrier: Any, territory: str) -> list:
+        """The territory's mid-toned base colour as an ``[r, g, b]`` 0..255 list.
+
+        Pulled toward mid-tone (``HANDLE_MIDTONE_FACTOR``) so the signed-distance
+        side tint has headroom in BOTH directions (the SliceControlPolygonPipeline
+        convention).
+        """
         try:
             rgb = carrier.GetTerritoryColor(territory)
-            return [int(max(0.0, min(1.0, c)) * 255) for c in (rgb[0], rgb[1], rgb[2])]
+            return [
+                int(max(0.0, min(1.0, c)) * 255 * HANDLE_MIDTONE_FACTOR)
+                for c in (rgb[0], rgb[1], rgb[2])
+            ]
         except Exception:  # pragma: no cover - defensive
-            return [255, 255, 255]
+            return [int(255 * HANDLE_MIDTONE_FACTOR)] * 3
+
+    def _update_ring(self) -> None:
+        """Show the hover/grab ring on the grabbed (green) or hovered (yellow) seed."""
+        target = self._drag_target or self._hover_target
+        pts = vtk.vtkPoints()
+        show = False
+        if target is not None and target in self._projected_keys:
+            idx = self._projected_keys.index(target)
+            px, py = self._projected_xy[idx]
+            pts.InsertNextPoint(px, py, 0.0)
+            colour = HALO_GRAB_COLOR if self._drag_target is not None else HALO_HOVER_COLOR
+            self._ring_actor.GetProperty().SetColor(*colour)
+            show = True
+        self._ring_polydata.SetPoints(pts)
+        self._ring_polydata.Modified()
+        self._ring_actor.SetVisibility(show)
 
     # ------------------------------------------------------------------ #
     # Interaction -- placement / slice-side edit (ADR-0032 / ADR-0033)
@@ -337,7 +474,24 @@ class TerritorySlicePipeline(_PipelineBase):
                 return False, sys.float_info.max
 
             if etype == vtk.vtkCommand.MouseMoveEvent:
-                return False, sys.float_info.max  # bare hover: camera untouched
+                # Bare hover (ADR-0033: repaint as a side effect, DECLINE so the
+                # camera is untouched).  Over an existing handle -> mark it the
+                # hover target (yellow ring, grab affordance) and clear the
+                # placement preview; over empty surface -> publish the adhering
+                # point so the placement preview follows the cursor in every
+                # view.  Repaint THIS slice directly -- it must not wait on the
+                # cross-view update path.
+                key, distance2 = self._nearest_seed_in_display(eventData)
+                if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
+                    self._hover_target = key
+                    self._clear_highlight()
+                else:
+                    self._hover_target = None
+                    self._publish_highlight(eventData)
+                self._reproject()
+                self._reconcile_highlight()
+                self.RequestRender()
+                return False, sys.float_info.max
 
             if etype != vtk.vtkCommand.LeftButtonPressEvent:
                 return False, sys.float_info.max
@@ -370,6 +524,8 @@ class TerritorySlicePipeline(_PipelineBase):
                 key, distance2 = self._nearest_seed_in_display(eventData)
                 if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
                     self._drag_target = key  # grab for a drag (edit gesture)
+                    self._reproject()  # recolour the grabbed handle green + ring
+                    self.RequestRender()
                     return True
                 if not self._is_armed():
                     return False  # a disarmed click adds nothing
@@ -377,10 +533,17 @@ class TerritorySlicePipeline(_PipelineBase):
                 if world is None:
                     return False
                 self._add_point(world)
+                # Repaint THIS slice immediately: a RequestRender from the
+                # carrier observer does not flush a frame mid-interaction (the
+                # seed would otherwise only appear on the next reslice).
+                self._reproject()
+                self.RequestRender()
                 return True
 
             if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
                 self._drag_target = None
+                self._reproject()  # drop the grab colour + ring
+                self.RequestRender()
                 return False  # gesture over -- release the focus
 
             if etype == vtk.vtkCommand.MouseMoveEvent:
@@ -388,6 +551,8 @@ class TerritorySlicePipeline(_PipelineBase):
                 if world is None:
                     return True  # keep the grab; this move just didn't resolve
                 self._relocate_grabbed_point(world)
+                self._reproject()
+                self.RequestRender()
                 return True
 
             return False
@@ -405,7 +570,7 @@ class TerritorySlicePipeline(_PipelineBase):
     # Snap + carrier writes
     # ------------------------------------------------------------------ #
 
-    def _snap_event_to_surface(self, eventData: Any):
+    def _snap_event_to_surface(self, eventData: Any, use_fallback: bool = True):
         """Snap a slice-view pixel onto the vessel surface along the normal.
 
         Resolves the pixel to RAS ON the slice plane (``XYToRAS``), casts a
@@ -413,6 +578,11 @@ class TerritorySlicePipeline(_PipelineBase):
         ``VesselSurfacePick`` -> the surface-snapped world point (``None`` on
         a miss / no surface).  Kept GL-free (the unit layer injects the pick
         result), unlike the 3D pipeline's camera-ray unprojection.
+
+        ``use_fallback`` (placement) lands the in-plane RAS point when the
+        normal ray misses, so an armed click still drops a seed on the plane;
+        the hover highlight passes ``use_fallback=False`` so it hides
+        off-surface (the 3D ``VesselHighlightPipeline`` honest-cue convention).
         """
         pick = self._ensure_pick()
         if pick is None:
@@ -428,9 +598,7 @@ class TerritorySlicePipeline(_PipelineBase):
         if ray is None:
             return None
         p1, p2 = ray
-        # Fall back to the in-plane RAS point when the normal ray misses the
-        # surface, so an armed click still lands a seed on the plane.
-        return pick.pick(p1, p2, fallback_point=ras)
+        return pick.pick(p1, p2, fallback_point=(ras if use_fallback else None))
 
     def _add_point(self, world: Any) -> None:
         carrier = self._get_carrier()
@@ -446,6 +614,85 @@ class TerritorySlicePipeline(_PipelineBase):
             return
         territory, index = target
         carrier.SetNthAnnotationPoint(territory, int(index), float(world[0]), float(world[1]), float(world[2]))
+
+    # ------------------------------------------------------------------ #
+    # Cross-view adhering highlight (publish on hover / render the marker)
+    # ------------------------------------------------------------------ #
+
+    def _publish_highlight(self, eventData: Any) -> None:
+        """Publish the cursor's surface point onto the shared display node.
+
+        A bare hover in this slice resolves the vessel-surface point under the
+        cursor (along the slice normal, no in-plane fallback) and writes it
+        onto the data-only highlight display node, so EVERY view's Pipeline
+        paints the adhering marker there (the cross-view hover cue).
+        Change-gated so the hover does not storm ``Modified``.
+        """
+        display = self._display_node
+        if display is None or not hasattr(display, "SetAdhering"):
+            return
+        world = self._snap_event_to_surface(eventData, use_fallback=False)
+        adhering = world is not None
+        changed = False
+        if bool(display.GetAdhering()) != adhering:
+            display.SetAdhering(adhering)
+            changed = True
+        if adhering:
+            current = display.GetAdheringPointWorld()
+            if tuple(current) != (world[0], world[1], world[2]):
+                display.SetAdheringPointWorld(world[0], world[1], world[2])
+                changed = True
+        if changed:
+            display.Modified()
+
+    def _clear_highlight(self) -> None:
+        """Clear the shared adhering point (cursor is over a handle, not empty surface).
+
+        Publishing ``adhering=False`` retires the placement preview in EVERY
+        view so it does not compete with the grab ring on the hovered handle.
+        """
+        display = self._display_node
+        if display is None or not hasattr(display, "SetAdhering"):
+            return
+        if bool(display.GetAdhering()):
+            display.SetAdhering(False)
+            display.Modified()
+
+    def _reconcile_highlight(self) -> None:
+        """Project the shared adhering point into this slice as the hover marker.
+
+        Reads the data-only display node (the adhering point + flags any view
+        published) and shows a hollow-circle handle PREVIEW (solid yellow, the
+        hover colour, set on the actor) at its projection.  Unlike the seeds,
+        the preview is a TRANSIENT cue and is NOT distance-culled: the surface
+        point under the cursor sits at the vessel's depth (a radius OFF the
+        slice plane along the normal), so a presence cutoff would hide it in
+        the very slice being hovered.  It shows in every slice whenever
+        adhering, so the cue is present in 2D and 3D regardless of where the
+        cursor is.
+        """
+        display = self._display_node
+        slice_node = self._slice_node
+        points = vtk.vtkPoints()
+        show = False
+        try:
+            if (
+                display is not None
+                and slice_node is not None
+                and bool(display.GetAdhering())
+                and bool(display.GetVisibility())
+            ):
+                ras_to_xy = _proj.inverse_xy_to_ras(slice_node)
+                if ras_to_xy is not None:
+                    world = display.GetAdheringPointWorld()
+                    xy = _proj.apply_matrix_xy(ras_to_xy, world)
+                    points.InsertNextPoint(xy[0], xy[1], 0.0)
+                    show = True
+        except Exception:  # pragma: no cover - defensive
+            show = False
+        self._highlight_polydata.SetPoints(points)
+        self._highlight_polydata.Modified()
+        self._highlight_actor.SetVisibility(show)
 
     def _nearest_seed_in_display(self, eventData: Any):
         """``((territoryId, index) | None, distance2)`` of the nearest projected seed.
@@ -514,9 +761,15 @@ class TerritorySlicePipeline(_PipelineBase):
         (a table repaint, a colour change) reprojects without adding / moving
         / dropping any seed (ADR-0037 §Conformance no-drift).
         """
-        del caller, event
+        del event
         try:
-            self._reproject()
+            # A display-node Modified is (almost always) an adhering-point /
+            # visibility change from a hover in SOME view: repaint the marker
+            # only, keeping the per-hover cost off the full seed reprojection.
+            # A carrier / slice Modified reprojects the seeds too.
+            if caller is not self._display_node:
+                self._reproject()
+            self._reconcile_highlight()
             self.RequestRender()
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySliceProjection.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySliceProjection.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Pure-math slice projection for territory annotation seeds (ADR-0037).
+
+The 2D-slice territory placement (``TerritorySlicePipeline``) projects the
+carrier's annotation points into a slice view's XY space, fades them by
+their distance to the slice plane, and casts a snap ray along the slice
+normal.  Those operations are pure geometry given a slice node exposing
+``GetXYToRAS`` / ``GetSliceToRAS`` (4x4 ``vtkMatrix4x4``) -- no LayerDM, no
+GL, no Slicer scene -- so they live here as module-level functions the
+bare unit layer can exercise directly (the ``VesselSurfacePick`` /
+``VesselHighlightWiring`` pure-VTK-helper split precedent).
+
+The fade / side-tint / presence-cutoff constants MIRROR the slice control
+polygon (``LiverResectionsLib.SliceControlPolygonPipeline``, ADR-0033) so
+the two slice-projected annotation surfaces read consistently: short fade
+distance (only points NEAR the plane are present), a signed above/below
+side tint, and a HARD presence cutoff because 2D alpha is unreliable.
+
+Imports ``vtk`` only (for the matrix arithmetic); the slice node is passed
+in and duck-typed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Distance (mm) over which the projection fades to fully transparent --
+#: the above/below-the-plane cue.  Short by design: only annotation seeds
+#: NEAR the plane are present in a slice at all (mirrors
+#: ``SliceControlPolygonPipeline.FADE_DISTANCE_MM``).
+FADE_DISTANCE_MM = 15.0
+
+#: Presence == visibility: a seed at / beyond ``FADE_DISTANCE_MM`` is
+#: absent (2D alpha is unreliable, so presence is a HARD cutoff, not a
+#: faded-to-zero alpha -- the ADR-0033 slice-polygon rule).
+PICK_RANGE_MM = FADE_DISTANCE_MM
+
+#: Maximum lightness shift for the above/below-plane cue: seeds ABOVE the
+#: plane tint toward white, below toward black, graded by distance.
+#: Sign-neutral, so it composes with any per-territory colour and stays
+#: colourblind-legible (mirrors ``SliceControlPolygonPipeline.SIDE_TINT_MAX``).
+SIDE_TINT_MAX = 0.55
+
+
+def slice_frame(slice_node: Any):
+    """``(origin, unit_normal)`` of the slice plane in RAS, or ``None``.
+
+    Reads the slice-to-RAS matrix's translation (origin) + normalized
+    third column (plane normal).  ``None`` when no slice node / matrix.
+    """
+    if slice_node is None:
+        return None
+    try:
+        to_ras = slice_node.GetSliceToRAS()
+    except Exception:  # pragma: no cover - defensive (fake nodes)
+        return None
+    if to_ras is None:
+        return None
+    origin = [to_ras.GetElement(r, 3) for r in range(3)]
+    normal = [to_ras.GetElement(r, 2) for r in range(3)]
+    norm = sum(n * n for n in normal) ** 0.5 or 1.0
+    normal = [n / norm for n in normal]
+    return origin, normal
+
+
+def signed_distance(origin, normal, point) -> float:
+    """Signed distance (mm) from ``point`` to a plane ``(origin, unit normal)``.
+
+    Positive on the ``+normal`` side, negative on the other.  The per-seed
+    primitive the reproject loop calls after resolving the frame ONCE.
+    """
+    return sum(n * (p - o) for n, p, o in zip(normal, point, origin))
+
+
+def signed_distance_to_slice(slice_node: Any, point) -> float:
+    """Signed distance (mm) from ``point`` (RAS) to the slice plane.
+
+    Positive ABOVE the plane (along the slice normal), negative below.
+    ``+inf`` when the slice frame cannot be resolved.  Convenience wrapper
+    resolving the frame per call -- for a loop, resolve ``slice_frame`` once
+    and call :func:`signed_distance`.
+    """
+    frame = slice_frame(slice_node)
+    if frame is None:
+        return float("inf")
+    return signed_distance(frame[0], frame[1], point)
+
+
+def inverse_xy_to_ras(slice_node: Any):
+    """The slice's ``inverse(XYToRAS)`` as a ``vtkMatrix4x4``, or ``None``.
+
+    Resolved ONCE per reproject and reused for every seed (the
+    ``SliceControlPolygonPipeline`` convention).
+    """
+    if slice_node is None:
+        return None
+    try:
+        import vtk
+
+        ras_to_xy = vtk.vtkMatrix4x4()
+        ras_to_xy.DeepCopy(slice_node.GetXYToRAS())
+        ras_to_xy.Invert()
+    except Exception:  # pragma: no cover - defensive (fake nodes)
+        return None
+    return ras_to_xy
+
+
+def apply_matrix_xy(ras_to_xy, point):
+    """Map an RAS ``point`` through a pre-built ``inverse(XYToRAS)`` to XY."""
+    xy = ras_to_xy.MultiplyPoint((point[0], point[1], point[2], 1.0))
+    w = xy[3] or 1.0
+    return xy[0] / w, xy[1] / w
+
+
+def project_ras_to_xy(slice_node: Any, point):
+    """Project an RAS ``point`` into the slice view's XY space, or ``None``.
+
+    Uses ``inverse(XYToRAS)`` -- the slice-view display coordinates coincide
+    with this XY space (the slice renderer convention, shared with
+    ``SliceControlPolygonPipeline``).  Convenience wrapper building the
+    inverse per call -- for a loop, build it once via
+    :func:`inverse_xy_to_ras` and call :func:`apply_matrix_xy`.
+    """
+    ras_to_xy = inverse_xy_to_ras(slice_node)
+    if ras_to_xy is None:
+        return None
+    return apply_matrix_xy(ras_to_xy, point)
+
+
+def xy_to_ras_on_plane(slice_node: Any, ex: float, ey: float):
+    """Resolve a slice-view pixel ``(ex, ey)`` to its RAS point ON the plane.
+
+    ``XYToRAS`` maps the in-plane pixel (z=0) straight onto the slice
+    plane, so this is the click's landing point before the normal-ray snap.
+    ``None`` when the matrix cannot be read.
+    """
+    if slice_node is None:
+        return None
+    try:
+        xy_to_ras = slice_node.GetXYToRAS()
+        ras = xy_to_ras.MultiplyPoint((float(ex), float(ey), 0.0, 1.0))
+    except Exception:  # pragma: no cover - defensive (fake nodes)
+        return None
+    w = ras[3] or 1.0
+    return ras[0] / w, ras[1] / w, ras[2] / w
+
+
+def normal_ray(slice_node: Any, ras_point, extent_mm: float = 1000.0):
+    """A world ray ``(p1, p2)`` through ``ras_point`` ALONG the slice normal.
+
+    Casts from ``ras_point + extent * normal`` to ``ras_point - extent *
+    normal`` so ``VesselSurfacePick`` can snap the seed onto the vessel
+    surface the slice cuts (ADR-0037 §2D snap).  ``None`` when the slice
+    frame cannot be resolved.
+    """
+    frame = slice_frame(slice_node)
+    if frame is None:
+        return None
+    _origin, normal = frame
+    p1 = tuple(ras_point[i] + normal[i] * extent_mm for i in range(3))
+    p2 = tuple(ras_point[i] - normal[i] * extent_mm for i in range(3))
+    return p1, p2
+
+
+def is_present(distance_mm: float) -> bool:
+    """True iff a seed at ``|distance_mm|`` is present in the slice.
+
+    The HARD presence cutoff (2D alpha unreliable): a seed at / beyond
+    ``PICK_RANGE_MM`` is absent -- not faded-to-zero (ADR-0033).
+    """
+    return abs(distance_mm) < PICK_RANGE_MM
+
+
+def fade_alpha(distance_mm: float) -> float:
+    """Linear fade [0, 1] of a seed by ``|distance_mm|`` to the plane."""
+    return max(0.0, 1.0 - abs(distance_mm) / FADE_DISTANCE_MM)
+
+
+def side_tint(rgb, signed_distance: float):
+    """Blend ``rgb`` toward white (above the plane) or black (below).
+
+    Mirrors ``SliceControlPolygonPipeline._side_tint`` so the two
+    slice-projected surfaces share the signed above/below cue.
+    """
+    fraction = min(1.0, abs(signed_distance) / FADE_DISTANCE_MM) * SIDE_TINT_MAX
+    target = 255 if signed_distance > 0 else 0
+    return [int(c + (target - c) * fraction) for c in rgb]

--- a/VascularTerritories/VascularTerritoriesLib/__init__.py
+++ b/VascularTerritories/VascularTerritoriesLib/__init__.py
@@ -39,6 +39,18 @@ except ImportError:  # pragma: no cover - LayerDMLib unreachable bare
     TerritoryPlacementPipeline = None
     registerTerritoryPlacementPipelineCreator = None
 
+# The slice-view annotation Pipeline (ADR-0037 §2D placement) is the slice
+# complement of the placement Pipeline; same LayerDMLib dependency, guarded
+# the same way.
+try:
+    from .TerritorySlicePipeline import (
+        TerritorySlicePipeline,
+        registerTerritorySlicePipelineCreator,
+    )
+except ImportError:  # pragma: no cover - LayerDMLib unreachable bare
+    TerritorySlicePipeline = None
+    registerTerritorySlicePipelineCreator = None
+
 # The Stage-2 annotation table widget (ADR-0037 §Decision 3) needs Qt
 # (``qt.QTableWidget``); guard it so the bare unit layer can still import the
 # package for the pure-VTK pick core alone.
@@ -54,5 +66,7 @@ __all__ = [
     "registerVesselHighlightPipelineCreator",
     "TerritoryPlacementPipeline",
     "registerTerritoryPlacementPipelineCreator",
+    "TerritorySlicePipeline",
+    "registerTerritorySlicePipelineCreator",
     "TerritoriesTableWidget",
 ]

--- a/VascularTerritories/VascularTerritoriesLib/__init__.py
+++ b/VascularTerritories/VascularTerritoriesLib/__init__.py
@@ -39,6 +39,14 @@ except ImportError:  # pragma: no cover - LayerDMLib unreachable bare
     TerritoryPlacementPipeline = None
     registerTerritoryPlacementPipelineCreator = None
 
+# The Stage-2 annotation table widget (ADR-0037 §Decision 3) needs Qt
+# (``qt.QTableWidget``); guard it so the bare unit layer can still import the
+# package for the pure-VTK pick core alone.
+try:
+    from .TerritoriesTableWidget import TerritoriesTableWidget
+except ImportError:  # pragma: no cover - Qt unreachable bare
+    TerritoriesTableWidget = None
+
 __all__ = [
     "VesselSurfacePick",
     "closed_surface_polydata",
@@ -46,4 +54,5 @@ __all__ = [
     "registerVesselHighlightPipelineCreator",
     "TerritoryPlacementPipeline",
     "registerTerritoryPlacementPipelineCreator",
+    "TerritoriesTableWidget",
 ]


### PR DESCRIPTION
## Summary — VascularTerritories off markups (ADR-0037), Stage 2 + interaction

Transitions VascularTerritories annotation off Slicer markups onto the v2
LayerDM architecture: a carrier on `vtkMRMLCustomTerritoriesNode` (+ display
slot + `.vta.json` storage), a custom table UI, and a full **placement +
edit interaction** across the 3D view and the slice views — no markups.

### What landed

- **Annotation carrier + storage** (per-territory ordered points; colour /
  label / visibility display slot; `.vta.json` round-trip).
- **Custom table UI** (ADR-0034 paradigm): per-point rows grouped under
  per-territory headers; visibility / colour / label; glyph+text `<2-seed`
  completeness (ADR-0010); Add Territory / Add seeds / Done arming.
- **Placement + edit interaction** through the LayerDM Pipeline seam
  (ADR-0032 / ADR-0033), in **3D and the slice views**:
  - click on the vessel surface adds a surface-snapped seed to the active
    territory (2D snaps along the slice normal); armed/active/carrier state
    lives on the shared highlight display node so the manager-driven
    pipeline and the widget agree;
  - **drag** a marker to reposition (re-snaps to the surface);
  - **delete** via the table row;
  - **cross-view adhering highlight** published from whichever view the
    cursor is in and painted in every view;
  - **edit affordance** parity: hover glows a marker yellow (blurred via
    `vtkOutlineGlowPass`), grab swaps it green — matching the resection
    surface control points;
  - slice viz: hollow-circle handles, per-territory base with signed side
    tint + distance alpha + hard presence cutoff (the
    `SliceControlPolygonPipeline` convention).
- One 3D pipeline per display-node type (ADR-0013 §1): the placement
  pipeline renders seeds + hover marker + handles interaction; the separate
  highlight pipeline is retired.

### Tests

- Launched: **51 passed / 0 failed / 0 skipped** (VascularTerritories root).
- Bare: **11 passed / 40 clean launched-only skips**.
- The GL glow / rendered appearance is eyeball-gated (maintainer-verified live).

### Follow-up

The control-point visualization + interaction is now duplicated with the
resection surface pipelines; **ADR-0038** (#594) + issue **#595** track
unifying them onto a shared base, and the interaction-seam tests are
deferred to land once against that base.

---
*Authored with the assistance of Claude (Anthropic Opus 4.8). Reviewed by the maintainer before merge.*