### PR TITLE
BUG: VascularTerritories post-merge review fixes (install gap + observer lifecycle + docs)

### DIFF
--- a/Docs/architecture/territories-class-hierarchy.md
+++ b/Docs/architecture/territories-class-hierarchy.md
@@ -42,16 +42,50 @@ classDiagram
     }
 
     class vtkMRMLCustomTerritoriesNode {
+        <<manual path — annotation carrier>>
         +CenterlineRefs vtkMRMLModelNode[]
-        +EndpointRefs vtkMRMLMarkupsFiducialNode[]
+        +AnnotationPoints map~territoryId, points[3]~
+        +TerritoryColor/Label/Visibility map~territoryId~
         +Groupings map~CenterlineId, SegmentId~
         +SegmentNames vtkStringArray
+    }
+
+    class vtkMRMLCustomTerritoriesStorageNode {
+        <<storage — .vta.json round-trip>>
+        annotationPoints + territoryDisplay
+    }
+
+    class vtkMRMLTerritoriesHighlightDisplayNode {
+        <<data-only display / interaction channel>>
+        +pickSurface → vtkMRMLSegmentationNode
+        +Armed / ActiveTerritory attrs
+        +carrier → vtkMRMLCustomTerritoriesNode
+        +Adhering / AdheringPointWorld
     }
 
     vtkMRMLAbstractTerritoriesNode <|-- vtkMRMLStdCouinaudTerritoriesNode
     vtkMRMLAbstractTerritoriesNode <|-- vtkMRMLCustomTerritoriesNode
     vtkMRMLAbstractTerritoriesNode --> vtkMRMLSegmentationNode : segments ref
+    vtkMRMLCustomTerritoriesNode --> vtkMRMLCustomTerritoriesStorageNode : storage
+    vtkMRMLTerritoriesHighlightDisplayNode --> vtkMRMLCustomTerritoriesNode : carrier ref
+    vtkMRMLTerritoriesHighlightDisplayNode --> vtkMRMLSegmentationNode : pickSurface ref
 ```
+
+Annotation moved **off Slicer markups** ([ADR-0037][adr-0037]): the
+manual path's endpoints are now an own ordered per-territory
+`AnnotationPoints` carrier on `vtkMRMLCustomTerritoriesNode` (with a
+per-territory colour/label/visibility display slot), round-tripped by
+`vtkMRMLCustomTerritoriesStorageNode` (`.vta.json`). Placement, edit, and
+the cross-view adhering highlight run through LayerDM scripted pipelines
+(`TerritoryPlacementPipeline` for 3D views, `TerritorySlicePipeline` for
+slice views) keyed on the data-only `vtkMRMLTerritoriesHighlightDisplayNode`,
+which also carries the shared arm/active/carrier interaction state
+([ADR-0013][adr-0013] one Pipeline per display-node type; [ADR-0032][adr-0032]
+interaction via the Pipeline seam).
+
+[adr-0037]: ../adr/0037-vascular-territories-off-markups.md
+[adr-0013]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md
+[adr-0032]: ../adr/0032-v2-interaction-via-layerdm-pipeline-seam.md
 
 The base class exposes only what downstream consumers need
 (Stage 4's classification overlay, Stage 5's per-segment volume

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.h
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.h
@@ -70,8 +70,8 @@ class vtkMRMLJsonElement;
  * {
  *   "schemaVersion": 1,
  *   "annotationPoints": {
- *     "SegmentVII":  [ [x, y, z], [x, y, z], ... ],
- *     "SegmentVIII": [ [x, y, z], ... ]
+ *     "SegmentVII":  [ { "xyz": [x, y, z] }, { "xyz": [x, y, z] }, ... ],
+ *     "SegmentVIII": [ { "xyz": [x, y, z] }, ... ]
  *   },
  *   "territoryDisplay": {
  *     "SegmentVII": { "color": [r, g, b], "label": "…", "visibility": true }

--- a/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
+++ b/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
@@ -2,28 +2,32 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
 #
-# VascularTerritories vessel-adhering-highlight — Python install rules
-# for the pure-Python pick core (and, in later increments, the LayerDM
-# highlight pipeline).
+# VascularTerritories annotation + vessel-adhering-highlight — Python
+# install rules for the pure-Python pick core, the shared interaction
+# state, the LayerDM placement/highlight/slice pipelines, and the
+# annotation table widget (ADR-0037).
 #
 # Mirrors the ``<Module>Lib`` convention used by ``LiverResectionsLib``
 # and Slicer-core's ``MarkupsLib``: a Python sub-package staged
 # alongside the scripted module so it is importable at runtime and from
 # the bare unit layer.
 #
-# Layout:
-#
-# * ``VascularTerritoriesLib/__init__.py`` — re-exports the public
-#   pick-core class.
-# * ``VascularTerritoriesLib/VesselSurfacePick.py`` — the pure-VTK pick
-#   core (ADR-0004 Python pick math, ADR-0025 locator pattern).
+# EVERY runtime module MUST be listed below: ctkMacroCompilePythonScript
+# stages ONLY the listed scripts into the build/install tree, and the
+# package ``__init__`` swallows a missing-module ImportError (degrading
+# the feature to silently disabled).  A file present on disk but absent
+# here works in the source tree yet vanishes in an installed build.
 #-----------------------------------------------------------------------------
 
 set(VascularTerritoriesLib_PYTHON_SCRIPTS
   __init__.py
   VesselSurfacePick.py
+  VesselHighlightWiring.py
   VesselHighlightPipeline.py
+  TerritoryInteractionState.py
   TerritoryPlacementPipeline.py
+  TerritorySliceProjection.py
+  TerritorySlicePipeline.py
   TerritoriesTableWidget.py
   )
 

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -226,13 +226,15 @@ class TerritoryPlacementPipeline(_PipelineBase):
         production the carrier is resolved from the display node's reference
         (``_get_carrier``); this direct bind is the unit seam that keeps the
         edit math GL- and scene-free.
+
+        Observation goes through ``_ensure_carrier_observed`` (the single
+        ``_observed_carrier`` dedupe key), NOT a direct attach here -- else a
+        later ``_ensure_carrier_observed`` resolving the same carrier would
+        add a SECOND ModifiedEvent observer (double rebuild per Modified).
         """
-        if self._carrier is not None:
-            self._detach_observer(self._carrier)
         self._carrier = carrier
         self._territory_id = territoryId
-        if carrier is not None:
-            self._attach_observer(carrier)
+        self._ensure_carrier_observed()
 
     def GetCarrier(self) -> Any | None:  # noqa: N802 - VTK verb
         return self._get_carrier()

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -269,12 +269,18 @@ class TerritorySlicePipeline(_PipelineBase):
                 renderer.AddActor2D(self._seed_actor)
                 renderer.AddActor2D(self._ring_actor)
                 renderer.AddActor2D(self._highlight_actor)
-            # Renderer churn cleared the display handle; re-derive it from the
-            # base's retained display node (the reattach precedent).
+            # Renderer churn cleared the handles (cleanup nulled them to force
+            # this re-derive); re-attach the display + slice observers from the
+            # base's retained nodes (the reattach precedent).
             if self._display_node is None:
                 display = self.GetDisplayNode()
                 if display is not None:
                     self.SetDisplayNode(display)
+            if self._slice_node is None:
+                getView = getattr(self, "GetViewNode", None)
+                view = getView() if getView is not None else None
+                if view is not None:
+                    self.SetViewNode(view)
             self._ensure_carrier_observed()
             self._reproject()
             self._reconcile_highlight()
@@ -319,6 +325,13 @@ class TerritorySlicePipeline(_PipelineBase):
     def cleanup(self) -> None:
         for node in list(self._observed_node_refs):
             self._detach_observer(node)
+        # Drop the display + slice handles too: cleanup detaches their
+        # observers, so leaving the handles set would make the OnRendererAdded
+        # re-derive guard (``if self._display_node is None``) skip re-attaching
+        # them after a renderer removal->re-add -> the cross-view adhering
+        # repaint would go unobserved on the re-added renderer.
+        self._display_node = None
+        self._slice_node = None
         self._observed_carrier = None
         self._drag_target = None
         self._hover_target = None


### PR DESCRIPTION
Follow-up to #593 addressing the `/slicer-review` findings (the feature itself is already merged; this is the fix pass).

## 🔴 Blocker (installed builds)
- `VascularTerritoriesLib/CMakeLists.txt` listed only some Python modules in `_PYTHON_SCRIPTS`, so `ctkMacroCompilePythonScript` never staged `TerritoryInteractionState`, `TerritorySliceProjection`, `TerritorySlicePipeline` (and the pre-existing `VesselHighlightWiring`). The package `__init__` swallows the resulting `ImportError`, so **an installed/packaged build silently disabled 2D slice placement + the arm-state seam**. The launched CTest runs from the source tree, masking it. Now lists every runtime module (+ a comment on why the list is load-bearing).

## 🟡 Observer lifecycle (correctness)
- `TerritoryPlacementPipeline.SetCarrier` double-observed the carrier (direct attach + `_ensure_carrier_observed` under a different dedupe key) on the bare/mixed path → two rebuilds per `Modified`. Routed through the single dedupe path.
- `TerritorySlicePipeline.cleanup` detached the display + slice observers but left the node handles set, so `OnRendererAdded`'s re-derive guard skipped re-attaching them after a renderer removal→re-add. Null the handles in cleanup and re-derive both (display + view) on renderer add.

## 🟠 Docs
- `territories-class-hierarchy.md` still showed the retired `EndpointRefs vtkMRMLMarkupsFiducialNode[]` slot (ADR-0037 promised the diagram would be extended). Replaced with the `AnnotationPoints` carrier + display slot, and added the storage node, the data-only highlight display node, and the LayerDM pipelines.
- Storage-node schema docstring aligned to the emitted `{ "xyz": [x,y,z] }` point encoding.

The uncovered interaction-seam tests remain deferred to the ADR-0038 (#594) unification — see #595, updated with the explicit seam checklist.

---
*Authored with the assistance of Claude (Anthropic Opus 4.8). Reviewed by the maintainer before merge.*