### PR TITLE
BUG: VascularTerritories slice-1 fixes — ring-actor mapper + re-extraction idempotency

### DIFF
--- a/VascularTerritories/Testing/Python/test_territories_slice_pipeline.py
+++ b/VascularTerritories/Testing/Python/test_territories_slice_pipeline.py
@@ -23,6 +23,11 @@ scripted Pipeline; this file pins the SLICE-VIEW complement
 * SHARED STATE.  Arm / active-territory / carrier live on the SAME shared
   highlight display node the 3D placement uses
   (``TerritoryInteractionState``), so 2D and 3D placement stay in lockstep.
+* CONSTRUCTION.  Every ``vtkActor2D`` the pipeline adds to the renderer (the
+  seed handles, the hover/grab ring, the adhering-placement preview) is
+  built WITH its ``vtkPolyDataMapper2D`` -- a mapperless 2D actor emits
+  ``vtkActor2D: No mapper set`` on every render and can crash the app under
+  GL, a defect invisible to headless tests + review.
 
 The projection math runs bare; the Pipeline itself needs LayerDMLib
 (reachable only inside a launched Slicer with the module loaded), so the
@@ -433,6 +438,48 @@ def test_reproject_projects_only_present_visible_seeds(monkeypatch):
         "only the present, visible seed survives the projection (HARD presence "
         "cutoff + territory visibility)."
     )
+
+
+# --------------------------------------------------------------------------- #
+# CONSTRUCTION — every 2D actor carries a mapper (LAUNCHED; SKIP bare)
+# --------------------------------------------------------------------------- #
+
+
+def test_every_slice_actor_has_a_mapper():
+    """A freshly built pipeline's 2D actors ALL carry a non-None mapper.
+
+    Each ``vtkActor2D`` the slice pipeline adds to the renderer -- the seed
+    HANDLES, the hover/grab RING, and the adhering-placement PREVIEW -- must
+    be constructed WITH its ``vtkPolyDataMapper2D`` set.  An actor added to a
+    renderer without a mapper emits ``vtkActor2D: No mapper set`` on every
+    render and can crash the app under GL -- a defect invisible to headless
+    tests and review (no mapper, no crash without a live GL context).  Pins
+    the construction contract so a dropped ``SetMapper`` on ANY of the three
+    actors regresses here rather than in the field (ADR-0037 §Decision 2 the
+    LayerDM Pipeline renders the annotation; ADR-0033 the slice handle/ring
+    mirror).
+
+    Launched-only: ``TerritorySlicePipeline`` imports ``LayerDMLib`` at module
+    top, so this SKIPS bare and RUNS launched (the module-load skip idiom).
+    """
+    _slicer_or_skip()
+    TerritorySlicePipeline = _import_pipeline_or_skip()
+    pipeline = TerritorySlicePipeline()
+
+    actors = {
+        "_seed_actor": getattr(pipeline, "_seed_actor", None),
+        "_ring_actor": getattr(pipeline, "_ring_actor", None),
+        "_highlight_actor": getattr(pipeline, "_highlight_actor", None),
+    }
+    for name, actor in actors.items():
+        assert actor is not None, (
+            f"the slice pipeline must construct its {name} 2D actor."
+        )
+        assert actor.GetMapper() is not None, (
+            f"{name} must be constructed WITH a mapper -- a mapperless "
+            "vtkActor2D emits 'No mapper set' on every render and can crash "
+            "the app under GL (ADR-0037 §Decision 2 / ADR-0033)."
+        )
 
 
 if __name__ == "__main__":

--- a/VascularTerritories/Testing/Python/test_territories_vmtk_feed.py
+++ b/VascularTerritories/Testing/Python/test_territories_vmtk_feed.py
@@ -50,6 +50,18 @@ This file pins the Stage-3 increments:
   down), never one merged node — mirroring the legacy per-``VascTerrId``
   grouping.  Asserted by monkeypatching the extraction logic to COUNT
   calls + CAPTURE the fed node, without a real VMTK run.
+* i6 (launched) — RE-EXTRACTION IDEMPOTENCY.  Extracting a territory, then
+  RE-EXTRACTING the SAME carrier/territory, leaves EXACTLY ONE
+  ``CenterlineRefs`` entry, ONE ``TerritoryCenterline`` model, and a STABLE
+  ``Groupings`` count for that territory — the second run REPLACES the
+  first, never appends.  The prior centerline model is not orphaned in the
+  scene.  ADR-0037 §Decision 4 (the Stage-4 territory-map contract is a
+  MAP: one centerline per territory) + §Conformance no-drift.  The
+  extractor is stubbed to a small line polydata (via ``getCenterlineLogic``)
+  so a model is minted + wired without a real VMTK run.  This is the
+  red->green invariant: it FAILS against an append-only
+  ``_wireCenterlineOutput`` and PASSES once re-extraction clears the
+  territory's prior refs + models before wiring (ADR-0027).
 
 -- SEAM THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
 
@@ -95,7 +107,10 @@ only inside a launched Slicer, so they SKIP CLEANLY bare and RUN launched.
 i4 additionally needs SlicerVMTK's ``ExtractCenterline`` module present, so
 it SKIPS CLEANLY when the extractor is absent — CI's bare path has no
 SlicerVMTK; the launched self-test image (ALive-Docker layers 5a-5c, see
-the CMakeLists comment) does.
+the CMakeLists comment) does.  i6 needs the module Logic + a live scene (the
+carrier's ``CenterlineRefs`` + ``Groupings`` map, the minted-model
+lifecycle) but NOT SlicerVMTK — the extractor is stubbed via
+``getCenterlineLogic`` — so it SKIPS CLEANLY bare and RUNS launched.
 
 -- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
 
@@ -577,6 +592,130 @@ def test_each_territory_drives_its_own_extraction_invocation(monkeypatch):
         f"(expected per-call counts {sorted([len(a_pts), len(b_pts)])}, got "
         f"{sorted(c for c in captured_counts if c is not None)}) -- the "
         "transient nodes are per-territory, not merged."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# i6 — re-extraction idempotency: one centerline per territory (launched)
+# --------------------------------------------------------------------------- #
+
+
+def _line_polydata():
+    """A tiny 2-point line standing in for an extracted centerline.
+
+    Enough geometry that ``_wireCenterlineOutput`` mints + wires a
+    ``TerritoryCenterline`` model (a ``None`` result wires nothing), without
+    a real VMTK run.
+    """
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 10.0)
+    points.InsertNextPoint(0.0, 0.0, -10.0)
+    line = vtk.vtkCellArray()
+    line.InsertNextCell(2)
+    line.InsertCellPoint(0)
+    line.InsertCellPoint(1)
+    poly = vtk.vtkPolyData()
+    poly.SetPoints(points)
+    poly.SetLines(line)
+    return poly
+
+
+def _count_centerline_models(slicer):
+    """Number of ``TerritoryCenterline`` model nodes currently in the scene."""
+    count = 0
+    nodes = slicer.mrmlScene.GetNodesByClass("vtkMRMLModelNode")
+    nodes.InitTraversal()
+    node = nodes.GetNextItemAsObject()
+    while node is not None:
+        if node.GetName() == "TerritoryCenterline":
+            count += 1
+        node = nodes.GetNextItemAsObject()
+    return count
+
+
+def test_re_extraction_replaces_the_territorys_centerline(monkeypatch):
+    """i6: re-extracting the SAME territory leaves ONE ref / ONE model / stable grouping.
+
+    ADR-0037 §Decision 4 makes ``CenterlineRefs`` + ``Groupings`` a MAP: one
+    centerline per territory.  A first extraction wires one model; a SECOND
+    extraction of the SAME carrier/territory must REPLACE it, not append --
+    else the carrier accrues duplicate ``CenterlineRefs`` entries, an
+    inconsistent ``Groupings`` count, and orphaned prior
+    ``TerritoryCenterline`` models linger in the scene (ADR-0037 §Conformance
+    no-drift; the Stage-4 territory-map contract).  The extractor is stubbed
+    to a small line polydata so a model is minted + wired WITHOUT a real VMTK
+    run -- the invariant is the ref/model/grouping bookkeeping, not the
+    geometry.
+
+    Red->green (ADR-0027): FAILS against an append-only
+    ``_wireCenterlineOutput`` and PASSES once re-extraction clears the
+    territory's prior refs + removes its prior model before wiring the new
+    one.  Launched-only (module Logic + a live scene); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    carrier = _make_carrier_or_skip(slicer)
+    surface = _closed_surface_model(slicer)
+
+    if not hasattr(logic, "getCenterlineLogic"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineLogic -- the "
+            "ADR-0037 Stage-3 extractor injection seam has not landed."
+        )
+    if not hasattr(logic, "getCenterlineReferenceIDs"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineReferenceIDs -- the "
+            "ADR-0037 Stage-3 CenterlineRefs accessor seam has not landed "
+            "(ADR-0027)."
+        )
+    if not hasattr(carrier, "GetGrouping") or not hasattr(carrier, "GetNumberOfGroupings"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no Groupings API -- the Stage-4 "
+            "territory-map contract accessor is unavailable (ADR-0027)."
+        )
+
+    carrier.AddAnnotationPoint(TERRITORY_A, 0.0, 0.0, 10.0)
+    carrier.AddAnnotationPoint(TERRITORY_A, 0.0, 0.0, -10.0)
+
+    # Stub the extractor so a fresh small line is wired per call (no VMTK).
+    class _LineExtractor:
+        def extractCenterline(self, *args, **kwargs):  # noqa: N802 - VMTK verb
+            return _line_polydata()
+
+    monkeypatch.setattr(logic, "getCenterlineLogic", lambda: _LineExtractor())
+
+    # First extraction: one ref, one model, one grouping for the territory.
+    logic.extractCenterlines(carrier, surface, "")
+    first_ids = logic.getCenterlineReferenceIDs(carrier)
+    assert len(first_ids) == 1, (
+        f"the first extraction must register exactly one centerline "
+        f"(got {first_ids})."
+    )
+    first_groupings = carrier.GetNumberOfGroupings()
+
+    # Second extraction of the SAME carrier/territory must REPLACE, not append.
+    logic.extractCenterlines(carrier, surface, "")
+    second_ids = logic.getCenterlineReferenceIDs(carrier)
+
+    assert len(second_ids) == 1, (
+        f"re-extracting the same territory must leave EXACTLY ONE "
+        f"CenterlineRefs entry, not append (got {second_ids}) -- the "
+        "territory-map contract is one centerline per territory (ADR-0037 "
+        "§Decision 4)."
+    )
+    assert carrier.GetGrouping(second_ids[0]) == TERRITORY_A, (
+        "the surviving centerline must stay grouped under its territory id "
+        f"({TERRITORY_A}); got {carrier.GetGrouping(second_ids[0])!r}."
+    )
+    assert carrier.GetNumberOfGroupings() == first_groupings, (
+        f"the Groupings count for the territory must be STABLE across a "
+        f"re-extraction (was {first_groupings}, now "
+        f"{carrier.GetNumberOfGroupings()}) -- no duplicate/orphan grouping."
+    )
+    assert _count_centerline_models(slicer) == 1, (
+        "the prior TerritoryCenterline model must be removed on "
+        "re-extraction, not orphaned in the scene (ADR-0037 §Conformance "
+        f"no-drift); found {_count_centerline_models(slicer)} models."
     )
 
 

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -1042,16 +1042,58 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     ``Groupings`` (centerline node ID -> territory id) so the downstream
     watershed scan resolves it.  A ``None`` result (the extractor stubbed to
     a no-op) wires nothing -- the transient-node lifecycle is unaffected.
+
+    Re-extraction is IDEMPOTENT (ADR-0037 §Decision 4 -- the territory map is
+    one centerline per territory): the territory's PRIOR centerline state is
+    cleared BEFORE the new output is wired, so any number of re-extractions
+    leaves exactly one ``CenterlineRefs`` entry, one ``TerritoryCenterline``
+    model, and a stable ``Groupings`` count for that territory.  The prior
+    model is removed from the scene, not orphaned.
     """
     centerlinePolyData = self._centerlinePolyDataFromResult(result)
     if centerlinePolyData is None:
       return
+    # Clear this territory's prior centerline(s) before wiring the new one so
+    # re-extraction REPLACES rather than APPENDS (no duplicate refs, no orphan
+    # models, stable Groupings count).  The carrier's grouping map is keyed on
+    # the centerline node ID and exposes no per-key removal, so the map is
+    # rebuilt from the surviving references after the prior model is dropped.
+    self._clearTerritoryCenterlines(carrier, territoryId)
     modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "TerritoryCenterline")
     modelNode.SetAndObserveMesh(centerlinePolyData)
     modelNode.SetAttribute("VascularTerritories.VascTerrId", territoryId)
     carrier.AddNodeReferenceID(self.CENTERLINE_REFERENCE_ROLE, modelNode.GetID())
     carrier.SetGrouping(modelNode.GetID(), territoryId)
     return modelNode
+
+  def _clearTerritoryCenterlines(self, carrier, territoryId):
+    """Drop ``territoryId``'s prior centerline refs + models + grouping entries.
+
+    Removes every ``CenterlineRefs`` reference grouped under ``territoryId``,
+    deletes the referenced model node from the scene, and rebuilds the
+    ``Groupings`` map from the surviving references.  ``vtkMRMLCustomTerritories
+    Node`` exposes only ``SetGrouping`` / ``ClearGroupings`` (no per-key
+    removal), so the map is cleared and repopulated from the references that
+    remain -- keeping the ID-keyed grouping map consistent with the refs.
+    """
+    role = self.CENTERLINE_REFERENCE_ROLE
+    # Partition the existing refs in one pass: this territory's prior models
+    # are removed from the scene; every other (id -> territory) grouping is
+    # snapshotted so the rebuilt map re-uses the ids the cleared map held.
+    survivors = []
+    for centerlineId in self.getCenterlineReferenceIDs(carrier):
+      groupTerritoryId = carrier.GetGrouping(centerlineId)
+      if groupTerritoryId == territoryId:
+        priorModel = slicer.mrmlScene.GetNodeByID(centerlineId)
+        if priorModel is not None:
+          slicer.mrmlScene.RemoveNode(priorModel)
+      else:
+        survivors.append((centerlineId, groupTerritoryId))
+    carrier.RemoveNodeReferenceIDs(role)
+    carrier.ClearGroupings()
+    for centerlineId, groupTerritoryId in survivors:
+      carrier.AddNodeReferenceID(role, centerlineId)
+      carrier.SetGrouping(centerlineId, groupTerritoryId)
 
   def _centerlinePolyDataFromResult(self, result):
     """Extract the centerline polydata from an extractor return value.

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -162,6 +162,7 @@ class TerritorySlicePipeline(_PipelineBase):
         self._ring_mapper = vtk.vtkPolyDataMapper2D()
         self._ring_mapper.SetInputConnection(self._ring_glyph.GetOutputPort())
         self._ring_actor = vtk.vtkActor2D()
+        self._ring_actor.SetMapper(self._ring_mapper)
         self._ring_actor.GetProperty().SetLineWidth(2.0)
         self._ring_actor.SetVisibility(False)
 


### PR DESCRIPTION
Slice 1 of the VascularTerritories widget-modernization (ADR-0037 §Decision 3 completion): two isolated bug fixes, test-first, ahead of the widget-retirement slices.

## Fixes
- **Ring-actor mapper (GL crash).** In `TerritorySlicePipeline`, the hover/grab ring `vtkActor2D` was constructed without `SetMapper`, so every slice render emitted `vtkActor2D: No mapper set` and eventually segfaulted the app. A GL-only failure that headless tests + review couldn't see (surfaced in an interactive eyeball). One line; now pinned by a construction invariant asserting all three slice 2D actors (seed / ring / highlight) carry a mapper.
- **Re-extraction idempotency (#598).** `extractCenterlines`/`_wireCenterlineOutput` only appended, so re-extracting a territory duplicated `CenterlineRefs` + `Groupings` and orphaned the prior centerline model. New `_clearTerritoryCenterlines` clears the territory's prior refs/models before wiring the new output (partition-in-one-pass; the carrier exposes `SetGrouping`/`ClearGroupings` only, so groupings are cleared + repopulated from surviving references). Net: exactly one ref + one model per territory after any number of re-extractions.

## Tests
- `test_every_slice_actor_has_a_mapper` — launched; green (regression guard).
- `test_re_extraction_replaces_the_territorys_centerline` (i6) — launched, extractor stubbed (no SlicerVMTK needed); proven red→green (stripping the fix fails exactly this test).
- Sweeps: bare 5 passed / 14 skipped; launched 60 passed / 1 skipped (only the env-gated real-VMTK test), no crash.

Closes #598.

---
*Authored with the assistance of Claude (Anthropic Opus 4.8). Reviewed by the maintainer before merge.*