### PR TITLE
ENH: Wire the territory-map compute onto the annotation carrier (#569 slice 3)

### DIFF
--- a/Docs/adr/0037-vascular-territories-off-markups.md
+++ b/Docs/adr/0037-vascular-territories-off-markups.md
@@ -166,3 +166,60 @@ modernisation; (3) the VMTK feed + graceful degradation.
   consumer of the vessel highlight.
 - [future] The Auto/Couinaud path modernisation, if ever taken off its
   current stock display.
+
+## Amendment — the territory-map compute path off the carrier (slices 2 + 3)
+
+The staged transition (§Staging) completed the panel-modernisation half in
+two increments beyond §Decision 3.  This amendment records the compute-path
+decisions the implementation crystallised, so the retired-widget set and the
+final workflow are documented in one place.
+
+### Retired-widget set across slices 2 + 3
+
+Slice 2 retired the table-duplicating v1 surface (`ColorPickerButton`,
+`showHideButton`, `addSegmentationButton`, `SegmentsWidget`,
+`inputSegmentSelectorWidget`, `vascularTerritoryId`) and their handlers, plus
+the dead `_registerVesselHighlightPipeline` and the `copyIndex` Logic helper.
+**Slice 3 additionally retires `selectedVascularTerritorySegmId`** — the
+per-map output-segmentation selector — together with its `.ui` widget, its
+`VascularTerritorySegmentation` param-node role, and its `setup()` wiring.
+The Compute-territory-map button and `onCalculateVascularTerritoryMapButton`
+survive; only the output *selection* is gone.
+
+### Coherent two-step compute flow
+
+The surviving workflow is a coherent two-step sequence over one input
+surface: **place seeds** (add-on-click into the carrier, per §Decision 2) →
+**Extract centerlines** (`onAddCenterlineButton` → `extractCenterlines`, the
+transient-markups VMTK feed of §Decision 4) → **Compute territory map**
+(`onCalculateVascularTerritoryMapButton`).  The compute action gates on an
+input surface being selected rather than on a separate output selector.
+
+### Derive the map target from the carrier
+
+The output map target is **derived from the carrier, not selected** — a
+carrier node-reference role (`TerritoryMapOutput`) resolves to exactly one
+`vtkMRMLSegmentationNode`, auto-created and attached on first compute and
+reused thereafter (one carrier == one map, consistent with the
+`CenterlineRefs` + `Groupings` map of §Decision 4).  Dropping the selector
+removes a manual step and the class of "wrong output picked" error; it also
+retires the redundant `int(...)` string-tag reader the old
+`slicer.util.getNodes("*Territory*")` scene scan depended on, because
+`build_centerline_model` now sources the carrier's `CenterlineRefs` directly.
+
+### Arbitrary-int labelmap scalar (explicitly not an SCT code)
+
+`vtkSlicerVascularTerritoriesLogic::MarkSegmentWithID` stamps a per-territory
+integer into each centerline's `segmentId` point-scalar, and
+`calculateVascularTerritoryMap` reads + re-stamps a per-map
+`VascularTerritories.SegmentationId` ordinal on the output.  Both are
+**arbitrary distinct positive labelmap scalars, NOT SCT terminology codes**
+([ADR-0011](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0011-sct-terminology-dispatch.md)
+reserves SCT for the accepted-plan terminology surface, not this internal
+watershed label).  The transition
+derives them deterministically: the per-territory int is
+`index + 1` over the carrier's `GetAnnotationTerritoryIds()` order (0 is the
+labelmap background), so the same territories derive the same ints across
+repeated calls (the pure `VascularTerritoriesLib.TerritoryLabelMap` core); the
+per-map ordinal is issued one past the maximum `SegmentationId` already
+stamped in the scene, so two carriers never collide.

--- a/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
+++ b/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
@@ -387,6 +387,16 @@ void vtkSlicerVascularTerritoriesLogic::calculateVascularTerritoryMap(vtkMRMLSeg
     std::cout << "Segment name: " << liverSegm->GetName() << " Segment label: " << liverSegm->GetLabelValue() << std::endl;
   }
 
+  // No liver-tagged segment resolved: exporting an empty segment id yields an
+  // empty labelmap and a silently-blank territory map.  Fail loudly instead so
+  // the missing SCT^10200004 tag on the input is legible (ADR-0011).
+  if (segmentId.empty())
+  {
+    vtkErrorMacro("calculateVascularTerritoryMap: no liver segment (SCT^10200004) "
+                  "found in the input segmentation -- cannot compute the territory map.");
+    return;
+  }
+
   segmentationIds->InsertNextValue(segmentId);
   vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(segmentation, segmentationIds, labelmapVolumeNode, refVolume);
   int result = SegmentClassificationProcessing(centerlineModel, labelmapVolumeNode);

--- a/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
+++ b/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
@@ -425,15 +425,26 @@ void vtkSlicerVascularTerritoriesLogic::preprocessAndDecimate(vtkPolyData* surfa
   {
     vtkErrorMacro("Error in preprocessAndDecimate: no valid MRML scene.");
   }
-  if (!surfacePolyData || (surfacePolyData->GetPointData()->GetNumberOfArrays() == 0 && surfacePolyData->GetCellData()->GetNumberOfArrays() == 0))
+  if (!surfacePolyData || surfacePolyData->GetNumberOfPoints() == 0)
   {
     std::cout << "preprocessAndDecimate Error: no input surfacePolyData." << std::endl;
     return;
   }
 
+  // Triangulate FIRST: a segmentation's closed-surface representation arrives
+  // as triangle strips (GetNumberOfPolys() == 0), and vtkDecimatePro decimates
+  // polygons -- fed strips it emits an empty mesh.  Converting strips to
+  // triangles up front is what lets the decimator (and the downstream VMTK
+  // centerline filter) see a non-empty surface.
+  vtkSmartPointer<vtkTriangleFilter> surfaceTriangulator = vtkSmartPointer<vtkTriangleFilter>::New();
+  surfaceTriangulator->SetInputData(surfacePolyData);
+  surfaceTriangulator->PassLinesOff();
+  surfaceTriangulator->PassVertsOff();
+  surfaceTriangulator->Update();
+
   vtkSmartPointer<vtkDecimatePro> decimator = vtkSmartPointer<vtkDecimatePro>::New();
   double decimationFactor = 0.8;
-  decimator->SetInputData(surfacePolyData);
+  decimator->SetInputData(surfaceTriangulator->GetOutput());
   decimator->SetFeatureAngle(60);
   decimator->SplittingOff();
   decimator->PreserveTopologyOn();
@@ -446,14 +457,8 @@ void vtkSlicerVascularTerritoriesLogic::preprocessAndDecimate(vtkPolyData* surfa
   surfaceCleaner->SetInputData(decimator->GetOutput());
   surfaceCleaner->Update();
 
-  vtkSmartPointer<vtkTriangleFilter> surfaceTriangulator = vtkSmartPointer<vtkTriangleFilter>::New();
-  surfaceTriangulator->SetInputData(surfaceCleaner->GetOutput());
-  surfaceTriangulator->PassLinesOff();
-  surfaceTriangulator->PassVertsOff();
-  surfaceTriangulator->Update();
-
   vtkSmartPointer<vtkPolyDataNormals> normals = vtkSmartPointer<vtkPolyDataNormals>::New();
-  normals->SetInputData(surfaceTriangulator->GetOutput());
+  normals->SetInputData(surfaceCleaner->GetOutput());
   normals->SetAutoOrientNormals(1);
   normals->SetFlipNormals(0);
   normals->SetConsistency(1);

--- a/VascularTerritories/Resources/UI/VascularTerritories.ui
+++ b/VascularTerritories/Resources/UI/VascularTerritories.ui
@@ -25,37 +25,6 @@
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0" colspan="2">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Vascular Territory Segmentation:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2" colspan="3">
-         <widget class="qMRMLNodeComboBox" name="selectedVascularTerritorySegmId">
-          <property name="nodeTypes">
-           <stringlist notr="true">
-            <string>vtkMRMLSegmentationNode</string>
-           </stringlist>
-          </property>
-          <property name="hideChildNodeTypes">
-           <stringlist notr="true"/>
-          </property>
-          <property name="baseName">
-           <string>Vascular_Territory_Segmentation</string>
-          </property>
-          <property name="editEnabled">
-           <bool>false</bool>
-          </property>
-          <property name="renameEnabled">
-           <bool>false</bool>
-          </property>
-          <property name="interactionNodeSingletonTag">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
@@ -180,22 +149,6 @@
     <hint type="destinationlabel">
      <x>235</x>
      <y>55</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>VascularTerritoriesWidgetRoot</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>selectedVascularTerritorySegmId</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>292</x>
-     <y>190</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>400</x>
-     <y>76</y>
     </hint>
    </hints>
   </connection>

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -142,6 +142,17 @@ set(_vascterr_pytest_files
   # module widget + Logic so they SKIP-PENDING bare and RUN launched; the real
   # C++ map run stays eyeball-gated (stubbed here) (ADR-0027).
   test_territories_map_compute.py
+  # ADR-0037 §Decision 4 -- the centerline SURFACE-RESOLUTION invariant: a
+  # segmentation input's closed surface must be resolved through the real
+  # segment(s) (converging on VesselHighlightWiring.closed_surface_polydata,
+  # the pick/snap seam), NOT via an empty segment id handed to
+  # GetClosedSurfaceRepresentation (which resolves no segment -> zero points
+  # -> a silently-degraded None the real SlicerVMTK extractor hard-fails on);
+  # and a genuinely empty surface must SKIP extraction, never feed the real
+  # extractor a None/empty mesh.  Needs Slicer's segmentation logic + a live
+  # scene so it SKIP-PENDS bare and RUNS launched; the VMTK compute itself
+  # stays env-/eyeball-gated in test_territories_vmtk_feed.py (ADR-0027).
+  test_territories_surface_resolution.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -127,6 +127,21 @@ set(_vascterr_pytest_files
   # while the v1 surface survives, and RUN launched once slice 2 lands
   # (ADR-0027).
   test_territories_widget_panel.py
+  # ADR-0037 §Decision 4 (slice 3) -- the territory-map COMPUTE path re-sourced
+  # off the getNodes("*Territory*") scene scan + the retired
+  # selectedVascularTerritorySegmId selector ONTO the annotation carrier: a
+  # deterministic string->int label map (enumerate GetAnnotationTerritoryIds()
+  # -> index + 1); build_centerline_model sourcing from CenterlineRefs +
+  # Groupings (one carrier == one map == all its centerlines) and marking each
+  # centerline with its derived int; the output segmentation DERIVED from the
+  # carrier's TerritoryMapOutput role (auto-created + reused, per-carrier-ordinal
+  # SegmentationId, no cross-carrier collision); the selector retirement; and
+  # the button resolving all inputs from the carrier + inputSurfaceSelector.
+  # The pure label-map core RUNS BARE; the carrier-sourcing / derived-output /
+  # selector-retirement / button-wiring invariants need the wrapped carrier +
+  # module widget + Logic so they SKIP-PENDING bare and RUN launched; the real
+  # C++ map run stays eyeball-gated (stubbed here) (ADR-0027).
+  test_territories_map_compute.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/test_territories_map_compute.py
+++ b/VascularTerritories/Testing/Python/test_territories_map_compute.py
@@ -1,0 +1,883 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 Stage-3 (slice 3) — the territory-map COMPUTE path off the carrier.
+
+ADR-0037 §Decision 4 makes ``CenterlineRefs`` + ``Groupings`` a MAP: one
+carrier, one territory map, all its centerlines.  Slice 3 re-sources the
+map-compute path (``build_centerline_model`` +
+``onCalculateVascularTerritoryMapButton``) OFF the ``slicer.util.getNodes(
+"*Territory*")`` scene scan + the retired ``selectedVascularTerritorySegmId``
+selector ONTO the annotation carrier (``vtkMRMLCustomTerritoriesNode``), the
+same wrapper/carrier idiom Stages 1-3 built (ADR-0014 §"Fourth layer").
+
+Maintainer-locked design pinned here (the planner resolved the crux from the
+C++ ``MarkSegmentWithID`` / ``calculateVascularTerritoryMap`` consumers):
+
+* The ``VascTerrId`` int ``vtkSlicerVascularTerritoriesLogic::MarkSegmentWithID``
+  stamps into the centerline ``segmentId`` point-scalar is an ARBITRARY
+  distinct positive labelmap scalar (NOT SCT / anatomy).  Slice 3 derives it
+  DETERMINISTICALLY: enumerate ``carrier.GetAnnotationTerritoryIds()`` (the
+  carrier's deterministic id order) -> ``index + 1`` (1-based; 0 = labelmap
+  background).  Same territories -> same ints across repeated calls.
+* ``build_centerline_model`` iterates the carrier's ``CenterlineRefs`` (via
+  ``getCenterlineReferenceIDs``) + ``Groupings`` (centerlineId -> territory
+  id), NOT ``getNodes("*Territory*")``.  The old ``SegmentationId`` int filter
+  COLLAPSES: one carrier == one map == all its centerlines.  Each extracted
+  centerline model is tagged with its DERIVED int (the redundant string
+  ``VascularTerritories.VascTerrId`` tag + the ``int(...)`` reader mismatch go
+  away).
+* The output map target is DERIVED from the carrier, not selected: a carrier
+  node-reference role (``TerritoryMapOutput``) -> one
+  ``vtkMRMLSegmentationNode``, auto-created if absent, REUSED otherwise.  Its
+  ``VascularTerritories.SegmentationId`` int (which the C++
+  ``calculateVascularTerritoryMap`` reads + re-stamps on the target) is a
+  PER-CARRIER ordinal, stable per carrier, distinct across carriers in one
+  scene.
+* ``selectedVascularTerritorySegmId`` is RETIRED (its ``.ui`` / param-node /
+  ``setup()`` wiring gone).  ``onCalculateVascularTerritoryMapButton`` resolves
+  input = ``inputSurfaceSelector``, centerline = carrier (re-sourced
+  ``build_centerline_model``), refVolume = as today, target = derived.  The
+  C++ ``calculateVascularTerritoryMap(target, refVolume, inputSeg,
+  centerlineModel, colormap)`` signature stays intact.
+
+This file pins the slice-3 increments:
+
+* i1 (BARE, pure helper) — STRING->INT MAPPING.  Given a known territory-id
+  order, the derived int for each id is its index + 1 (1-based); deterministic
+  across two calls (same id -> same int).  The plan's PREFERRED seam is a pure
+  helper so this is bare-testable without VMTK / a live scene; it import-guards
+  on that helper and SKIP-PENDINGs until it lands.  If the implementer keeps
+  the mapping only on a live carrier instead, i1b (launched) covers the same
+  invariant read off a real carrier.
+* i1b (launched) — the same mapping read off a LIVE carrier via a thin
+  live-reader seam (``territory_label_int(carrier, territoryId)``), for when
+  the mapping is not extractable as a pure list function.
+* i2 (launched, extractor stubbed) — ``build_centerline_model`` SOURCES FROM
+  THE CARRIER.  With two territories each carrying a centerline in
+  ``CenterlineRefs``, the built model incorporates BOTH via the carrier refs,
+  and does NOT depend on a ``*Territory*``-named scene scan (proven by naming
+  the centerline models so a ``getNodes("*Territory*")`` scan would MISS them).
+  Each centerline is marked with its derived int.
+* i3 (launched) — OUTPUT TARGET DERIVED + REUSED.  The first compute creates a
+  ``vtkMRMLSegmentationNode`` attached via the carrier's ``TerritoryMapOutput``
+  role with a per-carrier-ordinal ``SegmentationId``; a SECOND compute REUSES
+  the same node (no second output segmentation minted).  Two distinct carriers
+  get DISTINCT ordinals (no collision).
+* i4 (launched) — ``selectedVascularTerritorySegmId`` is GONE.  The slice-2
+  KEEP-guard in ``test_territories_widget_panel`` is flipped (renamed
+  ``test_map_path_selector_retired``) to assert the selector's ABSENCE; the
+  button +
+  ``onCalculateVascularTerritoryMapButton`` remain but resolve inputs without
+  the selector.
+* i5 (launched, env/eyeball-gated) — ``onCalculateVascularTerritoryMapButton``
+  RESOLVES ALL INPUTS from the carrier + ``inputSurfaceSelector`` (no
+  ``selectedVascularTerritorySegmId``).  ``logic.calculateVascularTerritoryMap``
+  + ``build_centerline_model``'s classifier calls are stubbed so the wiring is
+  observable WITHOUT the real C++ map run (which needs a reference volume +
+  real inputs — that stays eyeball-gated).
+
+-- SEAM THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
+
+The plan PREFERS a bare-testable pure helper for the string->int mapping so
+i1 needs no live scene.  Proposed (mirroring
+``VascularTerritoriesLib.TransientVmtkSeeds``):
+
+  * A PURE core mapping an ORDERED territory-id list -> ``{territoryId: int}``
+    (1-based, index + 1).  Proposed
+    ``VascularTerritoriesLib.TerritoryLabelMap.territory_label_ints(
+    territory_ids: list[str]) -> dict[str, int]`` — a pure function, NO live
+    carrier.  IMPLEMENTER SEAM PREFERENCE: keep this a pure function so i1
+    stays bare-testable; the live read
+    (``territory_label_int(carrier, territoryId)`` — enumerate
+    ``carrier.GetAnnotationTerritoryIds()`` then index into the pure map) is a
+    THIN wrapper, exercised by i1b launched.
+  * ``build_centerline_model`` re-sourced onto the carrier.  Proposed
+    signature evolution:
+    ``VascularTerritoriesLogic.build_centerline_model(carrier, colormap)`` —
+    iterate ``getCenterlineReferenceIDs(carrier)`` + ``GetGrouping`` for the
+    territory id, derive the int via the label map, ``MarkSegmentWithID`` +
+    ``AddSegmentToCenterlineModel`` per centerline, then
+    ``InitializeCenterlineSearchModel``.  The old ``(colormap,
+    vascSegmSelected)`` scene-scan signature retires.  i2 hasattr-guards on
+    the new arity via a keyword probe so it SKIP-PENDINGs cleanly on the old
+    signature.
+  * The derived output target.  Proposed accessor on the module Logic:
+    ``ensureTerritoryMapOutput(carrier) -> vtkMRMLSegmentationNode`` — resolve
+    the carrier's ``TerritoryMapOutput`` node-reference role, auto-create +
+    attach + stamp a per-carrier-ordinal ``VascularTerritories.SegmentationId``
+    if absent, reuse otherwise.  The ordinal is stable per carrier and
+    distinct across carriers (proposed: a monotonically-issued scene-wide
+    counter, or the carrier's own scene ordinal — the invariant is
+    stable-per-carrier + no-collision, NOT a specific numbering scheme).
+  * ``onCalculateVascularTerritoryMapButton`` re-wired: input =
+    ``inputSurfaceSelector.currentNode()``; carrier =
+    ``_ensureAnnotationCarrier()``; centerlineModel =
+    ``build_centerline_model(carrier, colormap)``; target =
+    ``ensureTerritoryMapOutput(carrier)``; refVolume = as today
+    (``GetFirstNodeByClass("vtkMRMLScalarVolumeNode")``).  No
+    ``selectedVascularTerritorySegmId`` read anywhere.
+
+-- WHY BARE (i1) vs LAUNCHED (i1b/i2/i3/i4/i5) --
+
+i1's label map is pure Python value logic (an ordered id list -> ints); it
+needs neither a live ``mrmlScene`` nor SlicerVMTK and RUNS BARE against the
+pure core seam.  i1b/i2/i3/i4/i5 need the wrapped carrier / module widget /
+module Logic + a live scene, reachable only inside a launched Slicer, so they
+SKIP CLEANLY bare and RUN launched, matching the ``test_territories_*`` idiom.
+i5 additionally stubs the C++ ``calculateVascularTerritoryMap`` +
+classifier calls: the REAL map run needs a reference volume + real vessel
+inputs and stays eyeball-gated (a real-anatomy walkthrough), so i5 pins the
+INPUT-RESOLUTION wiring only and SKIP-CLEANs without the real map.
+
+-- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
+
+Pre-implementation the pure label-map core, the re-sourced
+``build_centerline_model`` arity, the ``ensureTerritoryMapOutput`` accessor,
+and the retired selector do not exist, so the import / ``hasattr`` / signature
+guards skip-pend; the skips lift at the slice-3 implementation commit.  Under
+a launched Slicer, verify run-vs-skip in the CI log once the seam lands —
+never trust overall green (the launched harness is green-but-skipping prone).
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 4)
+  * Docs/adr/0014-livermarkups-dissolution.md  (the wrapper/carrier idiom)
+  * Docs/adr/0004-python-cpp-boundary.md  (the compute path lives in Logic)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.h  (the carrier +
+    GetAnnotationTerritoryIds + Groupings)
+  * VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
+    (MarkSegmentWithID consumes the int; calculateVascularTerritoryMap reads +
+    re-stamps VascularTerritories.SegmentationId on the target)
+  * VascularTerritories/Testing/Python/test_territories_vmtk_feed.py  (the
+    CenterlineRefs + Groupings + extractor-stub conventions this file reuses)
+  * VascularTerritories/Testing/Python/conftest.py  (the cleanup fixtures)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+SEGMENTATION_CLASS = "vtkMRMLSegmentationNode"
+
+# Carrier API seam (also pinned by test_territories_annotation_carrier.py /
+# test_territories_vmtk_feed.py).
+ADD_POINT_METHOD = "AddAnnotationPoint"
+ANNOTATION_TERRITORY_IDS_METHOD = "GetAnnotationTerritoryIds"
+
+# Slice-3 compute seam (proposed; sharpen at landing).
+LABEL_MAP_MODULE = "VascularTerritoriesLib.TerritoryLabelMap"
+LABEL_MAP_PURE_FUNC = "territory_label_ints"
+LABEL_MAP_LIVE_FUNC = "territory_label_int"
+BUILD_MODEL_METHOD = "build_centerline_model"
+ENSURE_OUTPUT_METHOD = "ensureTerritoryMapOutput"
+
+# The carrier node-reference role holding the derived output segmentation
+# (planner proposal — sharpen at landing).
+TERRITORY_MAP_OUTPUT_ROLE = "TerritoryMapOutput"
+
+# The retired selector (slice-2 KEEP-guarded, slice-3 retired).
+RETIRED_SELECTOR = "selectedVascularTerritorySegmId"
+
+# Two distinct surgeon-named territory ids used across the tests, in a KNOWN
+# order.  ``GetAnnotationTerritoryIds`` returns a deterministic (sorted) id
+# order per the carrier header, so the derived ints follow that order.
+TERRITORY_A = "SegmentVII"
+TERRITORY_B = "SegmentVIII"
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror the launched-Slicer discipline in conftest.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _import_label_map_module_or_skip():
+    """Import the slice-3 territory-label-map seam module, or skip-pend (ADR-0027)."""
+    try:
+        import importlib
+
+        return importlib.import_module(LABEL_MAP_MODULE)
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"{LABEL_MAP_MODULE} not importable ({exc!r}) -- the ADR-0037 "
+            "slice-3 territory-label-map seam (§Decision 4) has not landed.  "
+            "The skip lifts at the implementation commit (ADR-0027)."
+        )
+
+
+def _pure_label_map_or_skip():
+    """Return the PURE ``territory_label_ints`` core, or skip-pend (ADR-0027).
+
+    The plan's PREFERRED bare-testable seam: an ordered id list -> ints, NO
+    live carrier.  Skip-pends if the implementer keeps the mapping only on a
+    live carrier (i1b covers that shape launched).
+    """
+    module = _import_label_map_module_or_skip()
+    func = getattr(module, LABEL_MAP_PURE_FUNC, None)
+    if func is None:
+        pytest.skip(
+            f"{LABEL_MAP_MODULE} has no {LABEL_MAP_PURE_FUNC} -- the ADR-0037 "
+            "slice-3 PURE label-map core has not landed.  If the mapping is "
+            "read only off a live carrier, i1b covers the invariant launched "
+            "(ADR-0027)."
+        )
+    return func
+
+
+def _logic_or_skip(slicer):
+    try:
+        from VascularTerritories import VascularTerritoriesLogic
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VascularTerritoriesLogic not importable ({exc!r}).")
+    return VascularTerritoriesLogic()
+
+
+def _make_carrier_or_skip(slicer, name="MapComputeCarrierTest"):
+    node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} not registered -- module Logic "
+            "RegisterNodes() must wire this up (launched build)."
+        )
+    for method in (ADD_POINT_METHOD, ANNOTATION_TERRITORY_IDS_METHOD):
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} -- the ADR-0037 "
+                "annotation carrier (Stage-1) has not landed (ADR-0027)."
+            )
+    return node
+
+
+def _populate_two_territories(carrier):
+    """Give the carrier two territories carrying points in a known order."""
+    carrier.AddAnnotationPoint(TERRITORY_A, 0.0, 0.0, 10.0)
+    carrier.AddAnnotationPoint(TERRITORY_A, 0.0, 0.0, -10.0)
+    carrier.AddAnnotationPoint(TERRITORY_B, 10.0, 0.0, 0.0)
+    carrier.AddAnnotationPoint(TERRITORY_B, -10.0, 0.0, 0.0)
+
+
+# =========================================================================== #
+# i1 — string->int mapping: PURE core (BARE)
+# =========================================================================== #
+
+
+def test_label_map_is_one_based_index_in_order():
+    """i1: the derived int for a territory id is its order index + 1 (1-based).
+
+    ADR-0037 §Decision 4 (maintainer-locked): enumerate the carrier's
+    territory-id order -> ``index + 1``.  0 is reserved for the labelmap
+    background, so the first territory maps to 1.  Pure value logic — no live
+    scene, no VMTK — so it RUNS BARE against the pure core.
+    """
+    label_ints = _pure_label_map_or_skip()
+
+    ids = [TERRITORY_A, TERRITORY_B]
+    mapping = dict(label_ints(ids))
+
+    assert mapping[ids[0]] == 1, (
+        f"the first territory in order must derive int 1 (0 == background); "
+        f"got {mapping.get(ids[0])!r}."
+    )
+    assert mapping[ids[1]] == 2, (
+        f"the second territory in order must derive int 2; "
+        f"got {mapping.get(ids[1])!r}."
+    )
+    assert min(mapping.values()) >= 1, (
+        "no derived int may be 0 (0 is reserved for the labelmap background)."
+    )
+
+
+def test_label_map_is_deterministic_across_calls():
+    """i1: same territory ids in the same order -> same ints across two calls.
+
+    ADR-0037 §Decision 4: "same territories -> same ints across repeated
+    calls".  Pins determinism against any set-iteration / dict-ordering
+    accident in the pure core.
+    """
+    label_ints = _pure_label_map_or_skip()
+
+    ids = [TERRITORY_A, TERRITORY_B]
+    first = dict(label_ints(ids))
+    second = dict(label_ints(ids))
+
+    assert first == second, (
+        f"the label map must be deterministic for a fixed id order "
+        f"(first={first}, second={second})."
+    )
+
+
+def test_label_map_ints_are_distinct():
+    """i1: distinct territories derive distinct ints (usable as labelmap scalars).
+
+    ``MarkSegmentWithID`` stamps the derived int as the centerline's
+    ``segmentId`` point-scalar; the downstream watershed needs distinct
+    positive labels per territory (ADR-0037 §Decision 4).
+    """
+    label_ints = _pure_label_map_or_skip()
+
+    ids = [TERRITORY_A, TERRITORY_B, "SegmentV"]
+    values = list(dict(label_ints(ids)).values())
+
+    assert len(set(values)) == len(values), (
+        f"distinct territories must derive distinct labelmap ints; got {values}."
+    )
+
+
+# =========================================================================== #
+# i1b — the same mapping read off a LIVE carrier (launched)
+# =========================================================================== #
+
+
+def test_live_carrier_label_int_matches_annotation_order():
+    """i1b: the live-carrier read derives index-in-``GetAnnotationTerritoryIds`` + 1.
+
+    The thin live wrapper (``territory_label_int(carrier, territoryId)``)
+    indexes the carrier's ``GetAnnotationTerritoryIds()`` order and returns
+    index + 1 — the same invariant as i1, read off a real carrier for when the
+    mapping is not extractable as a pure list function (ADR-0037 §Decision 4).
+    Launched-only (wrapped carrier); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    module = _import_label_map_module_or_skip()
+    live_read = getattr(module, LABEL_MAP_LIVE_FUNC, None)
+    if live_read is None:
+        pytest.skip(
+            f"{LABEL_MAP_MODULE} has no {LABEL_MAP_LIVE_FUNC} -- the ADR-0037 "
+            "slice-3 live-carrier label-map reader has not landed (ADR-0027)."
+        )
+
+    carrier = _make_carrier_or_skip(slicer)
+    _populate_two_territories(carrier)
+
+    ordered_ids = list(carrier.GetAnnotationTerritoryIds())
+    for expected_index, territoryId in enumerate(ordered_ids):
+        assert live_read(carrier, territoryId) == expected_index + 1, (
+            f"territory {territoryId!r} at order index {expected_index} must "
+            f"derive int {expected_index + 1}; got "
+            f"{live_read(carrier, territoryId)!r}."
+        )
+
+
+# =========================================================================== #
+# i2 — build_centerline_model SOURCES FROM THE CARRIER (launched, stubbed)
+# =========================================================================== #
+
+
+def _build_model_carrier_sourced_or_skip(logic, carrier, colormap):
+    """Call the re-sourced ``build_centerline_model(carrier, colormap)``.
+
+    Skip-pends unless the method both exists AND accepts the carrier-sourced
+    signature: the old ``build_centerline_model(colormap, vascSegmSelected)``
+    takes an int filter, not a carrier, so a raw call on the old arity would
+    mis-source.  Probes by keyword so the skip is clean on the pre-slice-3
+    signature (ADR-0027).
+    """
+    method = getattr(logic, BUILD_MODEL_METHOD, None)
+    if method is None:
+        pytest.skip(
+            f"VascularTerritoriesLogic has no {BUILD_MODEL_METHOD} "
+            "(ADR-0027)."
+        )
+    try:
+        return method(carrier, colormap)
+    except TypeError:
+        pytest.skip(
+            f"{BUILD_MODEL_METHOD} does not accept the carrier-sourced "
+            "signature (carrier, colormap) -- the ADR-0037 slice-3 re-source "
+            "(§Decision 4) has not landed; the old (colormap, "
+            "vascSegmSelected) scene-scan signature survives (ADR-0027)."
+        )
+
+
+def _colormap_or_skip(slicer, logic):
+    """A colour node for the centerline model display, or skip-pend.
+
+    ``build_centerline_model`` binds the model's display to a colour node; any
+    scene colour node stands in (the invariant is the carrier sourcing, not
+    the colours).
+    """
+    colormap = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLColorTableNode")
+    if colormap is None:
+        colormap = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLColorTableNode", "MapComputeColorsTest")
+    if colormap is None:
+        pytest.skip("no vtkMRMLColorTableNode available for the model display.")
+    return colormap
+
+
+def _attach_stub_centerline(slicer, logic, carrier, territoryId, name):
+    """Wire a small line model into the carrier's CenterlineRefs + Groupings.
+
+    Uses the node-reference + grouping API directly (NOT the Stage-3
+    ``_wireCenterlineOutput`` helper, which names its models "TerritoryCenterline"
+    — a name a legacy ``getNodes("*Territory*")`` scan WOULD catch).  The model
+    is DELIBERATELY named without "Territory" so such a scan would MISS it,
+    proving i2 sources from the carrier refs, not the scan.
+    """
+    import vtk
+
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 10.0)
+    points.InsertNextPoint(0.0, 0.0, -10.0)
+    lines = vtk.vtkCellArray()
+    lines.InsertNextCell(2)
+    lines.InsertCellPoint(0)
+    lines.InsertCellPoint(1)
+    poly = vtk.vtkPolyData()
+    poly.SetPoints(points)
+    poly.SetLines(lines)
+
+    model = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", name)
+    model.SetAndObserveMesh(poly)
+
+    role = getattr(logic, "CENTERLINE_REFERENCE_ROLE", "CenterlineRefs")
+    carrier.AddNodeReferenceID(role, model.GetID())
+    if hasattr(carrier, "SetGrouping"):
+        carrier.SetGrouping(model.GetID(), territoryId)
+    return model
+
+
+def test_build_centerline_model_sources_from_carrier_refs(monkeypatch):
+    """i2: the built model incorporates BOTH carrier-referenced centerlines.
+
+    With two territories each carrying a centerline model in the carrier's
+    ``CenterlineRefs``, ``build_centerline_model(carrier, colormap)``
+    incorporates BOTH via the carrier refs.  The centerline models are named
+    so a legacy ``slicer.util.getNodes("*Territory*")`` scan would MISS them,
+    proving the carrier-ref path is used, not the scene scan (ADR-0037
+    §Decision 4).  The classifier calls (``AddSegmentToCenterlineModel`` /
+    ``InitializeCenterlineSearchModel``) are captured, not run against real
+    geometry, so the invariant is the SOURCING, not the C++ append math.
+    Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    carrier = _make_carrier_or_skip(slicer)
+    colormap = _colormap_or_skip(slicer, logic)
+
+    if not hasattr(logic, "getCenterlineReferenceIDs"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineReferenceIDs -- the "
+            "ADR-0037 CenterlineRefs accessor seam has not landed (ADR-0027)."
+        )
+
+    _populate_two_territories(carrier)
+    # Names WITHOUT "Territory" so a legacy getNodes("*Territory*") scan misses
+    # them; the carrier refs are the only path to reach them.
+    model_a = _attach_stub_centerline(
+        slicer, logic, carrier, TERRITORY_A, "VesselCenterlineAlpha")
+    model_b = _attach_stub_centerline(
+        slicer, logic, carrier, TERRITORY_B, "VesselCenterlineBeta")
+
+    # Capture which centerline models the classifier is asked to add, without
+    # driving the real C++ append.
+    added = []
+    if hasattr(logic, "scl"):
+        monkeypatch.setattr(
+            logic.scl,
+            "AddSegmentToCenterlineModel",
+            lambda summed, segment: added.append(segment),
+        )
+        monkeypatch.setattr(
+            logic.scl, "MarkSegmentWithID", lambda segment, segmentId: None)
+        monkeypatch.setattr(
+            logic.scl, "InitializeCenterlineSearchModel", lambda model: None)
+
+    _build_model_carrier_sourced_or_skip(logic, carrier, colormap)
+
+    added_ids = {m.GetID() for m in added if m is not None}
+    assert model_a.GetID() in added_ids and model_b.GetID() in added_ids, (
+        "build_centerline_model must incorporate BOTH carrier-referenced "
+        "centerlines (sourced from CenterlineRefs, not a *Territory* scene "
+        f"scan); added {added_ids}, expected both "
+        f"{{{model_a.GetID()}, {model_b.GetID()}}}."
+    )
+
+
+def test_build_centerline_model_marks_each_with_derived_int(monkeypatch):
+    """i2: each carrier centerline is marked with its DERIVED int.
+
+    ``build_centerline_model`` derives the int from the territory-id order
+    (index + 1) and passes it to ``MarkSegmentWithID`` per centerline — NOT the
+    retired string ``VascularTerritories.VascTerrId`` attribute read (ADR-0037
+    §Decision 4).  The mark call is captured so the invariant is the derived
+    int, not the C++ point-scalar stamping.  Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    carrier = _make_carrier_or_skip(slicer)
+    colormap = _colormap_or_skip(slicer, logic)
+
+    if not hasattr(logic, "scl"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no scl (the C++ classification "
+            "logic) -- launched build required (ADR-0027)."
+        )
+    if not hasattr(logic, "getCenterlineReferenceIDs"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineReferenceIDs "
+            "(ADR-0027)."
+        )
+
+    _populate_two_territories(carrier)
+    model_a = _attach_stub_centerline(
+        slicer, logic, carrier, TERRITORY_A, "VesselCenterlineAlpha")
+    model_b = _attach_stub_centerline(
+        slicer, logic, carrier, TERRITORY_B, "VesselCenterlineBeta")
+
+    marks = {}
+    monkeypatch.setattr(
+        logic.scl,
+        "MarkSegmentWithID",
+        lambda segment, segmentId: marks.__setitem__(segment.GetID(), segmentId),
+    )
+    monkeypatch.setattr(
+        logic.scl, "AddSegmentToCenterlineModel", lambda summed, segment: None)
+    monkeypatch.setattr(
+        logic.scl, "InitializeCenterlineSearchModel", lambda model: None)
+
+    _build_model_carrier_sourced_or_skip(logic, carrier, colormap)
+
+    # The derived ints follow GetAnnotationTerritoryIds() order (index + 1),
+    # mapped onto each territory's centerline via Groupings.
+    ordered_ids = list(carrier.GetAnnotationTerritoryIds())
+    expected = {territoryId: i + 1 for i, territoryId in enumerate(ordered_ids)}
+    grouping_a = carrier.GetGrouping(model_a.GetID())
+    grouping_b = carrier.GetGrouping(model_b.GetID())
+
+    assert marks.get(model_a.GetID()) == expected[grouping_a], (
+        f"centerline for {grouping_a!r} must be marked with its derived int "
+        f"{expected[grouping_a]}; got {marks.get(model_a.GetID())!r}."
+    )
+    assert marks.get(model_b.GetID()) == expected[grouping_b], (
+        f"centerline for {grouping_b!r} must be marked with its derived int "
+        f"{expected[grouping_b]}; got {marks.get(model_b.GetID())!r}."
+    )
+    assert all(v >= 1 for v in marks.values()), (
+        "no centerline may be marked with 0 (0 is the labelmap background)."
+    )
+
+
+# =========================================================================== #
+# i3 — output target DERIVED from the carrier + REUSED (launched)
+# =========================================================================== #
+
+
+def _ensure_output_or_skip(logic, carrier):
+    method = getattr(logic, ENSURE_OUTPUT_METHOD, None)
+    if method is None:
+        pytest.skip(
+            f"VascularTerritoriesLogic has no {ENSURE_OUTPUT_METHOD} -- the "
+            "ADR-0037 slice-3 derived-output-target accessor (§Decision 4) has "
+            "not landed.  The skip lifts at the implementation commit "
+            "(ADR-0027)."
+        )
+    return method(carrier)
+
+
+def _first_reference_id(carrier, role):
+    """The first node id referenced under ``role`` on ``carrier``, or None."""
+    if carrier.GetNumberOfNodeReferences(role) == 0:
+        return None
+    return carrier.GetNthNodeReferenceID(role, 0)
+
+
+def test_first_compute_derives_and_attaches_output_segmentation():
+    """i3: the first compute mints a segmentation attached via ``TerritoryMapOutput``.
+
+    ADR-0037 §Decision 4: the output map target is DERIVED from the carrier,
+    not selected — the carrier's ``TerritoryMapOutput`` node-reference role
+    resolves to a ``vtkMRMLSegmentationNode``, auto-created + attached on first
+    compute, carrying a per-carrier-ordinal ``VascularTerritories.SegmentationId``
+    the C++ ``calculateVascularTerritoryMap`` reads + re-stamps.  Launched-only;
+    SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    carrier = _make_carrier_or_skip(slicer)
+
+    target = _ensure_output_or_skip(logic, carrier)
+
+    assert target is not None and target.IsA(SEGMENTATION_CLASS), (
+        "the derived output target must be a vtkMRMLSegmentationNode "
+        f"(got {target!r})."
+    )
+    attached_id = _first_reference_id(carrier, TERRITORY_MAP_OUTPUT_ROLE)
+    assert attached_id == target.GetID(), (
+        "the output segmentation must be attached via the carrier's "
+        f"{TERRITORY_MAP_OUTPUT_ROLE!r} node-reference role (attached "
+        f"{attached_id!r}, target {target.GetID()!r})."
+    )
+    segm_id = target.GetAttribute("VascularTerritories.SegmentationId")
+    assert segm_id is not None and str(segm_id).strip() != "", (
+        "the derived target must carry a VascularTerritories.SegmentationId "
+        "int (the C++ calculateVascularTerritoryMap reads + re-stamps it)."
+    )
+    assert str(segm_id).strip().isdigit() or (
+        str(segm_id).strip().lstrip("-").isdigit()), (
+        f"the SegmentationId ordinal must be an int; got {segm_id!r}."
+    )
+
+
+def test_second_compute_reuses_the_same_output():
+    """i3: a SECOND compute REUSES the same output segmentation, mints no second.
+
+    ADR-0037 §Decision 4: one carrier == one map.  Re-computing must resolve
+    the SAME ``TerritoryMapOutput`` node, never accrue a second output
+    segmentation.  Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    carrier = _make_carrier_or_skip(slicer)
+
+    before = slicer.mrmlScene.GetNumberOfNodesByClass(SEGMENTATION_CLASS)
+    first = _ensure_output_or_skip(logic, carrier)
+    minted = slicer.mrmlScene.GetNumberOfNodesByClass(SEGMENTATION_CLASS) - before
+
+    second = _ensure_output_or_skip(logic, carrier)
+    after = slicer.mrmlScene.GetNumberOfNodesByClass(SEGMENTATION_CLASS)
+
+    assert first is not None and second is not None
+    assert second.GetID() == first.GetID(), (
+        "the second compute must REUSE the same output segmentation "
+        f"(first {first.GetID()!r}, second {second.GetID()!r})."
+    )
+    assert after == before + minted, (
+        "the second compute must mint NO additional output segmentation "
+        f"(before={before}, after first={before + minted}, after second="
+        f"{after})."
+    )
+    assert carrier.GetNumberOfNodeReferences(TERRITORY_MAP_OUTPUT_ROLE) == 1, (
+        "exactly one output segmentation may be attached via "
+        f"{TERRITORY_MAP_OUTPUT_ROLE!r} (one carrier == one map)."
+    )
+
+
+def test_two_carriers_get_distinct_ordinals():
+    """i3: two distinct carriers derive DISTINCT ``SegmentationId`` ordinals.
+
+    ADR-0037 §Decision 4: two carriers in one scene must not collide — the
+    per-carrier ordinal is stable per carrier AND distinct across carriers, so
+    the C++ ``calculateVascularTerritoryMap`` re-stamps two different labelmap
+    identities.  Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    carrier_a = _make_carrier_or_skip(slicer, "MapComputeCarrierA")
+    carrier_b = _make_carrier_or_skip(slicer, "MapComputeCarrierB")
+
+    target_a = _ensure_output_or_skip(logic, carrier_a)
+    target_b = _ensure_output_or_skip(logic, carrier_b)
+
+    ordinal_a = target_a.GetAttribute("VascularTerritories.SegmentationId")
+    ordinal_b = target_b.GetAttribute("VascularTerritories.SegmentationId")
+
+    assert ordinal_a is not None and ordinal_b is not None
+    assert ordinal_a != ordinal_b, (
+        "two distinct carriers must derive DISTINCT SegmentationId ordinals "
+        f"(carrier A {ordinal_a!r}, carrier B {ordinal_b!r}) -- no collision."
+    )
+    assert target_a.GetID() != target_b.GetID(), (
+        "two distinct carriers must resolve to distinct output segmentations."
+    )
+
+
+# =========================================================================== #
+# i4 — selectedVascularTerritorySegmId is GONE (launched)
+# =========================================================================== #
+#
+# The slice-2 KEEP-guard in test_territories_widget_panel (flipped + renamed
+# test_map_path_selector_retired there) asserts the selector's absence.  This
+# test is the
+# slice-3-owned home of the removal invariant; it gates on the removal having
+# landed so it collects + SKIP-PENDINGs cleanly while the selector survives.
+
+
+def _make_widget_or_skip(slicer):
+    from slicer_pytest_support import require_qt_widget as _require_qt_widget
+
+    _require_qt_widget()
+    from VascularTerritories import VascularTerritoriesWidget
+
+    widget = VascularTerritoriesWidget()
+    widget.setup()
+    return widget
+
+
+def _detach_scene_observers(slicer, widget):
+    for event, handler in (
+        (slicer.mrmlScene.StartCloseEvent, widget.onSceneStartClose),
+        (slicer.mrmlScene.EndCloseEvent, widget.onSceneEndClose),
+    ):
+        try:
+            widget.removeObserver(slicer.mrmlScene, event, handler)
+        except Exception:  # noqa: BLE001 - best-effort across widget shapes
+            pass
+
+
+def _slice3_selector_retired(widget) -> bool:
+    """True once ``selectedVascularTerritorySegmId`` is gone from the ui."""
+    ui = getattr(widget, "ui", None)
+    if ui is None:
+        return False
+    return not hasattr(ui, RETIRED_SELECTOR)
+
+
+def test_selected_territory_selector_retired(qt_widgets):
+    """i4: ``selectedVascularTerritorySegmId`` is ABSENT after slice 3.
+
+    ADR-0037 §Decision 4 (maintainer-locked): the per-map output selector is
+    retired — its ``.ui`` widget, its param-node role, and its ``setup()``
+    wiring go.  The Compute-territory-map BUTTON +
+    ``onCalculateVascularTerritoryMapButton`` REMAIN, but resolve inputs
+    without the selector.  Launched-only; SKIP-PENDINGs while the selector
+    survives, RUNS once slice 3 retires it (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    if not _slice3_selector_retired(widget):
+        pytest.skip(
+            "selectedVascularTerritorySegmId still present -- the ADR-0037 "
+            "slice-3 selector retirement has not landed (ADR-0027)."
+        )
+
+    assert not hasattr(widget.ui, RETIRED_SELECTOR), (
+        f"the {RETIRED_SELECTOR!r} selector must be retired (ADR-0037 §Decision 4)."
+    )
+    # The nodeSelectors registry must no longer carry the retired role.
+    node_selectors = getattr(widget, "nodeSelectors", [])
+    roles = [role for _selector, role in node_selectors]
+    assert "VascularTerritorySegmentation" not in roles, (
+        "the retired selector's param-node role (VascularTerritorySegmentation) "
+        "must be dropped from nodeSelectors (ADR-0037 §Decision 4)."
+    )
+    # The button + handler survive.
+    assert hasattr(widget.ui, "calculateVascularTerritoryMapButton"), (
+        "the Compute-territory-map button must survive slice 3."
+    )
+    assert hasattr(widget, "onCalculateVascularTerritoryMapButton"), (
+        "onCalculateVascularTerritoryMapButton must survive slice 3."
+    )
+
+
+# =========================================================================== #
+# i5 — button resolves ALL inputs from carrier + inputSurfaceSelector
+#       (launched, env/eyeball-gated — stubbed C++ map run)
+# =========================================================================== #
+
+
+def test_calculate_button_resolves_inputs_without_selector(qt_widgets, monkeypatch):
+    """i5: ``onCalculateVascularTerritoryMapButton`` resolves inputs sans selector.
+
+    ADR-0037 §Decision 4: the button resolves input = ``inputSurfaceSelector``,
+    centerline = carrier (re-sourced ``build_centerline_model``), refVolume = a
+    scene scalar volume, target = the derived ``TerritoryMapOutput`` — NO
+    ``selectedVascularTerritorySegmId`` read.  ``logic.calculateVascularTerritoryMap``
+    + ``build_centerline_model`` are stubbed so the wiring is OBSERVABLE without
+    the real C++ map run (which needs a reference volume + real vessel inputs
+    and stays eyeball-gated).  The invariant is the INPUT RESOLUTION: the
+    target passed to ``calculateVascularTerritoryMap`` is the carrier-derived
+    output, and the input segmentation is ``inputSurfaceSelector``'s node.
+
+    Launched-only; SKIP-PENDINGs while the slice-3 rewire has not landed, and
+    SKIP-CLEANs without a scene scalar volume (the button early-returns /
+    raises on a missing refVolume today — that path stays eyeball-gated).
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    if not _slice3_selector_retired(widget):
+        pytest.skip(
+            "selectedVascularTerritorySegmId still present -- the ADR-0037 "
+            "slice-3 button rewire has not landed (ADR-0027)."
+        )
+    if not hasattr(widget.logic, ENSURE_OUTPUT_METHOD):
+        pytest.skip(
+            f"VascularTerritoriesLogic has no {ENSURE_OUTPUT_METHOD} -- the "
+            "slice-3 derived-output accessor has not landed (ADR-0027)."
+        )
+
+    import vtk  # noqa: F401 — sphere source lives in the wiring helper
+    from test_vessel_highlight_wiring import _sphere_segmentation
+
+    input_segmentation = _sphere_segmentation(slicer, radius=30.0)
+    widget.ui.inputSurfaceSelector.setCurrentNode(input_segmentation)
+
+    # A reference scalar volume so the button's refVolume guard passes without
+    # a real anatomy import.
+    ref_volume = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLScalarVolumeNode", "MapComputeRefVolumeTest")
+    image = vtk.vtkImageData()
+    image.SetDimensions(4, 4, 4)
+    image.AllocateScalars(vtk.VTK_SHORT, 1)
+    ref_volume.SetAndObserveImageData(image)
+
+    # Stub the re-sourced build_centerline_model to a model with >= 2 points so
+    # the button's numberOfPoints guard passes without a real classifier run.
+    def _stub_build(carrier, colormap):
+        points = vtk.vtkPoints()
+        points.InsertNextPoint(0.0, 0.0, 10.0)
+        points.InsertNextPoint(0.0, 0.0, -10.0)
+        poly = vtk.vtkPolyData()
+        poly.SetPoints(points)
+        model = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLModelNode", "MapComputeCenterlineModelTest")
+        model.SetAndObserveMesh(poly)
+        return model
+
+    monkeypatch.setattr(widget.logic, BUILD_MODEL_METHOD, _stub_build)
+
+    captured = {}
+
+    def _stub_calculate(target, refVolume, inputSeg, centerlineModel, colormap):
+        captured["target"] = target
+        captured["refVolume"] = refVolume
+        captured["inputSeg"] = inputSeg
+        captured["centerlineModel"] = centerlineModel
+
+    monkeypatch.setattr(
+        widget.logic, "calculateVascularTerritoryMap", _stub_calculate)
+
+    widget.onCalculateVascularTerritoryMapButton()
+
+    assert captured, (
+        "onCalculateVascularTerritoryMapButton must reach "
+        "calculateVascularTerritoryMap with resolved inputs (ADR-0037 "
+        "§Decision 4)."
+    )
+    assert captured.get("inputSeg") is input_segmentation, (
+        "the input segmentation must be resolved from inputSurfaceSelector, "
+        "not the retired selector (ADR-0037 §Decision 4)."
+    )
+    # The target is the carrier-derived TerritoryMapOutput, not a selected node.
+    carrier = widget._ensureAnnotationCarrier()
+    derived_target_id = _first_reference_id(carrier, TERRITORY_MAP_OUTPUT_ROLE)
+    target = captured.get("target")
+    assert target is not None and target.IsA(SEGMENTATION_CLASS), (
+        "the map target must be a carrier-derived vtkMRMLSegmentationNode."
+    )
+    assert derived_target_id == target.GetID(), (
+        "the map target must be the carrier's derived TerritoryMapOutput, not "
+        f"a selected node (derived {derived_target_id!r}, passed "
+        f"{target.GetID()!r})."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_map_compute.py
+++ b/VascularTerritories/Testing/Python/test_territories_map_compute.py
@@ -879,5 +879,89 @@ def test_calculate_button_resolves_inputs_without_selector(qt_widgets, monkeypat
     )
 
 
+# --------------------------------------------------------------------------- #
+# Liver-segment resolution — the map compute finds the liver region by its
+# SNOMED-CT tag (ADR-0011), and fails legibly when no such segment exists.
+# --------------------------------------------------------------------------- #
+
+_LIVER_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^~Anatomic codes~^^~^^"
+)
+
+
+def _cpp_logic_or_skip(logic):
+    """The wrapped C++ ``vtkSlicerVascularTerritoriesLogic`` (``logic.scl``).
+
+    ``GetLiverSegmentId`` lives on the C++ logic, not the Python
+    ``VascularTerritoriesLogic`` wrapper -- reach it through ``scl``.
+    """
+    cpp = getattr(logic, "scl", None)
+    if cpp is None or not hasattr(cpp, "GetLiverSegmentId"):
+        pytest.skip(
+            "vtkSlicerVascularTerritoriesLogic has no GetLiverSegmentId -- the "
+            "C++ logic is unavailable on this build (ADR-0027)."
+        )
+    return cpp
+
+
+def _one_segment_segmentation(slicer, terminology=None, name="LiverResolveSeg"):
+    """A one-segment segmentation, optionally SCT-tagged as liver."""
+    import vtk
+
+    source = vtk.vtkSphereSource()
+    source.SetRadius(20.0)
+    source.Update()
+    modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "ResolveModel")
+    modelNode.SetAndObservePolyData(source.GetOutput())
+    seg = slicer.mrmlScene.AddNewNodeByClass(SEGMENTATION_CLASS, name)
+    seg.CreateDefaultDisplayNodes()
+    slicer.modules.segmentations.logic().ImportModelToSegmentationNode(modelNode, seg)
+    slicer.mrmlScene.RemoveNode(modelNode)
+    if terminology is not None:
+        segId = seg.GetSegmentation().GetNthSegmentID(0)
+        seg.GetSegmentation().GetSegment(segId).SetTag("TerminologyEntry", terminology)
+    return seg
+
+
+def test_liver_segment_resolves_by_sct_tag():
+    """``GetLiverSegmentId`` resolves the liver segment by its SCT tag.
+
+    The territory-map compute finds the liver region by the SNOMED-CT liver
+    code (ADR-0011), not the segment name.  A tagged segment resolves to a
+    non-empty id.  [launched.]
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    cpp = _cpp_logic_or_skip(logic)
+    seg = _one_segment_segmentation(slicer, terminology=_LIVER_TERMINOLOGY)
+
+    segId = cpp.GetLiverSegmentId(seg)
+
+    assert segId, (
+        "an SCT^10200004-tagged segment must resolve to a non-empty segment id "
+        "(ADR-0011)."
+    )
+    assert seg.GetSegmentation().GetSegment(segId) is not None
+
+
+def test_liver_segment_unresolved_is_empty_not_a_guess():
+    """``GetLiverSegmentId`` returns '' when no liver-tagged segment exists.
+
+    An untagged segmentation must resolve to the empty string (the map compute
+    then fails legibly rather than exporting an empty labelmap for an empty
+    segment id).  [launched.]
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    cpp = _cpp_logic_or_skip(logic)
+    seg = _one_segment_segmentation(slicer, terminology=None)
+
+    assert cpp.GetLiverSegmentId(seg) == "", (
+        "an untagged segmentation must resolve to the empty string, not a "
+        "guessed segment id (ADR-0011)."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+++ b/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
@@ -199,6 +199,45 @@ def test_preprocessed_surface_of_segmentation_is_non_empty():
     )
 
 
+def test_preprocess_tolerates_triangle_strip_surface():
+    """i1: ``preprocessAndDecimate`` survives a triangle-STRIP input surface.
+
+    A segmentation's closed-surface representation arrives as triangle strips
+    (``GetNumberOfPolys() == 0``); ``vtkDecimatePro`` decimates polygons, so
+    fed strips it emits an empty mesh unless the preprocessing triangulates
+    FIRST.  This pins the strip case directly (the sphere-model fixture above
+    retains polygons and never exercises it).  ADR-0037 §Decision 4.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    if not hasattr(logic, "preprocessAndDecimate"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no preprocessAndDecimate -- the "
+            "surface-preprocessing seam is unavailable (ADR-0027)."
+        )
+
+    source = vtk.vtkSphereSource()
+    source.SetRadius(20.0)
+    source.SetThetaResolution(32)
+    source.SetPhiResolution(32)
+    source.Update()
+    stripper = vtk.vtkStripper()
+    stripper.SetInputData(source.GetOutput())
+    stripper.Update()
+    stripSurface = stripper.GetOutput()
+    assert stripSurface.GetNumberOfPolys() == 0 and stripSurface.GetNumberOfPoints() > 0, (
+        "the fixture must be a genuine triangle-strip surface (0 polys)."
+    )
+
+    processed = logic.preprocessAndDecimate(stripSurface)
+
+    assert processed is not None and processed.GetNumberOfPoints() > 0, (
+        "preprocessAndDecimate must triangulate a strip surface before "
+        "decimating -- a strip input must NOT decimate to an empty mesh "
+        "(ADR-0037 §Decision 4)."
+    )
+
+
 # --------------------------------------------------------------------------- #
 # i2 — honest degradation: never feed None/empty to the real extractor
 # --------------------------------------------------------------------------- #

--- a/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+++ b/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 Stage-3 — the centerline surface-resolution invariant.
+
+The VMTK centerline feed (``VascularTerritoriesLogic.extractCenterlines``)
+runs the extractor over the input segmentation's closed-surface mesh
+(``polyDataFromNode`` / ``_preprocessedSurface``).  The extractor called
+with ``segmentId`` was, by the feed's convention, a *territory* id (or the
+empty string, "extract every territory") — NOT a segmentation *segment*
+id.  Passing that empty string straight into
+``GetClosedSurfaceRepresentation`` never resolves a segment, so the mesh
+came back with zero points and the surface silently degraded to ``None``.
+
+The real SlicerVMTK extractor hard-fails on an empty/``None`` surface ("no
+Voronoi diagram was generated" / "vtkvmtkCapPolyData has 0 connections" /
+"could not compute surface normals").  This file pins the SURFACE-RESOLUTION
+invariant that is actually broken — NOT the VMTK compute itself (that stays
+env-/eyeball-gated in ``test_territories_vmtk_feed.py``):
+
+* i1 (launched) — SEGMENT RESOLUTION.  Given a ``vtkMRMLSegmentationNode``
+  carrying ONE segment with a closed-surface representation,
+  ``polyDataFromNode(seg, "")`` and ``_preprocessedSurface(seg)`` return a
+  NON-EMPTY ``vtkPolyData`` (points > 0): the segment is actually resolved,
+  not an empty-segment-id no-op.  Converges on the SAME whole-vessel-tree
+  resolution the pick/highlight path uses
+  (``VesselHighlightWiring.closed_surface_polydata``), so placement-snap and
+  centerline extraction see the same mesh.  Needs Slicer's segmentation
+  logic to build the closed surface; SKIPS cleanly bare, RUNS launched.
+* i2 (launched) — HONEST DEGRADATION.  When ``_preprocessedSurface`` DOES
+  return ``None``/empty (a genuinely empty segmentation), the feed must NOT
+  invoke the extractor with a ``None``/empty surface — it skips that
+  territory's extraction instead of crashing the real extractor.  The
+  extractor is monkeypatched to CAPTURE its surface argument, so the
+  invariant is "the real extractor is never fed ``None``/empty", not a VMTK
+  run.  SKIPS cleanly bare, RUNS launched.
+
+Red->green (ADR-0027): i1 FAILS against the empty-segment-id
+``GetClosedSurfaceRepresentation(segmentId="")`` (zero points) and PASSES
+once the segmentation branch resolves the real segment(s); i2 FAILS against
+the feed handing ``None`` to the extractor and PASSES once the feed skips a
+missing surface.  Launched-only (Slicer segmentation logic + a live scene);
+SKIP bare.
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 4)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
+    (closed_surface_polydata — the shared surface-resolution seam)
+  * VascularTerritories/Testing/Python/test_territories_vmtk_feed.py
+    (the transient-node lifecycle + real VMTK run)
+  * VascularTerritories/Testing/Python/conftest.py  (the skip guards)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+
+TERRITORY_A = "SegmentVII"
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror the launched-Slicer discipline in conftest.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _logic_or_skip(slicer):
+    try:
+        from VascularTerritories import VascularTerritoriesLogic
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VascularTerritoriesLogic not importable ({exc!r}).")
+    logic = VascularTerritoriesLogic()
+    if not hasattr(logic, "polyDataFromNode"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no polyDataFromNode -- the "
+            "surface-resolution seam is unavailable (ADR-0027)."
+        )
+    return logic
+
+
+def _sphere_segmentation(slicer, center=(0.0, 0.0, 0.0), radius=20.0):
+    """A segmentation node carrying ONE closed-surface sphere segment.
+
+    Mirrors the ``test_vessel_highlight_wiring`` fixture: import a sphere
+    model into a fresh segmentation so it carries a genuine closed-surface
+    representation (the pick/snap + centerline paths both read this mesh).
+    """
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(radius)
+    source.SetThetaResolution(32)
+    source.SetPhiResolution(32)
+    source.Update()
+
+    modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "Vessel")
+    modelNode.SetAndObservePolyData(source.GetOutput())
+
+    segmentationNode = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLSegmentationNode", "SurfaceResolutionVessel")
+    segmentationNode.CreateDefaultDisplayNodes()
+    slicer.modules.segmentations.logic().ImportModelToSegmentationNode(
+        modelNode, segmentationNode)
+    slicer.mrmlScene.RemoveNode(modelNode)
+    return segmentationNode
+
+
+def _empty_segmentation(slicer):
+    """A segmentation node with NO segment (no closed surface to resolve)."""
+    return slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLSegmentationNode", "EmptyVessel")
+
+
+def _make_carrier_or_skip(slicer, name="SurfaceResolutionCarrier"):
+    node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} not registered -- the ADR-0037 "
+            "annotation carrier is unavailable (launched build) (ADR-0027)."
+        )
+    if not hasattr(node, "AddAnnotationPoint"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no AddAnnotationPoint -- the "
+            "ADR-0037 annotation carrier has not landed (ADR-0027)."
+        )
+    return node
+
+
+# --------------------------------------------------------------------------- #
+# i1 — segment resolution: an empty segment id still resolves the mesh
+# --------------------------------------------------------------------------- #
+
+
+def test_polydata_from_segmentation_resolves_a_non_empty_mesh():
+    """i1: ``polyDataFromNode(seg, "")`` resolves the real segment's mesh.
+
+    The feed passes the *territory* semantics ("" == "every territory")
+    through the ``segmentId`` slot; the segmentation branch must resolve the
+    actual segment(s) rather than pass the empty string straight into
+    ``GetClosedSurfaceRepresentation`` (which resolves NO segment and yields
+    a zero-point mesh).  ADR-0037 §Decision 4.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    segmentation = _sphere_segmentation(slicer)
+
+    polyData = logic.polyDataFromNode(segmentation, "")
+
+    assert polyData is not None, (
+        "polyDataFromNode must resolve a segmentation's closed surface, not "
+        "return None for a segment carrying geometry (ADR-0037 §Decision 4)."
+    )
+    assert polyData.GetNumberOfPoints() > 0, (
+        "the resolved segmentation mesh must be non-empty -- an empty "
+        "segment id must NOT be handed to GetClosedSurfaceRepresentation "
+        "(that resolves no segment -> zero points) (ADR-0037 §Decision 4)."
+    )
+
+
+def test_preprocessed_surface_of_segmentation_is_non_empty():
+    """i1: ``_preprocessedSurface(seg)`` decimates a non-empty resolved mesh.
+
+    The decimated feed surface (what the extractor is actually run over) is
+    NON-EMPTY for a one-segment segmentation: the resolution +
+    preprocessing chain never silently degrades a real surface to ``None``.
+    ADR-0037 §Decision 4.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    if not hasattr(logic, "_preprocessedSurface"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no _preprocessedSurface -- the "
+            "decimated-surface seam is unavailable (ADR-0027)."
+        )
+    segmentation = _sphere_segmentation(slicer)
+
+    surfacePolyData = logic._preprocessedSurface(segmentation)
+
+    assert surfacePolyData is not None, (
+        "_preprocessedSurface must NOT degrade a one-segment segmentation to "
+        "None -- the segment resolves to a real mesh (ADR-0037 §Decision 4)."
+    )
+    assert surfacePolyData.GetNumberOfPoints() > 0, (
+        "the decimated feed surface must be non-empty for a segmentation "
+        "carrying geometry (ADR-0037 §Decision 4)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# i2 — honest degradation: never feed None/empty to the real extractor
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_surface_is_not_fed_to_the_extractor(monkeypatch):
+    """i2: a missing/empty surface skips extraction, never feeds the extractor.
+
+    The real SlicerVMTK extractor hard-fails on a ``None``/empty surface (no
+    Voronoi diagram / 0 cap connections / no surface normals).  When
+    ``_preprocessedSurface`` returns ``None``/empty the feed must SKIP that
+    territory's extraction rather than call the extractor with the empty
+    surface.  The extractor is monkeypatched to CAPTURE its surface argument
+    so the invariant is "the extractor is never fed None/empty", not a VMTK
+    run.  ADR-0037 §Decision 4.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    if not hasattr(logic, "getCenterlineLogic"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineLogic -- the "
+            "ADR-0037 Stage-3 extractor injection seam is unavailable "
+            "(ADR-0027)."
+        )
+    if not hasattr(logic, "extractCenterlines"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no extractCenterlines -- the "
+            "ADR-0037 Stage-3 feed entry point is unavailable (ADR-0027)."
+        )
+
+    carrier = _make_carrier_or_skip(slicer)
+    carrier.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
+    carrier.AddAnnotationPoint(TERRITORY_A, 2.0, 0.0, 0.0)
+
+    empty = _empty_segmentation(slicer)
+
+    fed_surfaces = []
+
+    class _CapturingExtractor:
+        def extractCenterline(self, seedsNode, surfacePolyData=None, *args, **kwargs):  # noqa: N802 - VMTK verb
+            fed_surfaces.append(surfacePolyData)
+            return None
+
+    monkeypatch.setattr(logic, "getCenterlineLogic", lambda: _CapturingExtractor())
+
+    # Must not raise; must not feed the extractor a None/empty surface.
+    logic.extractCenterlines(carrier, empty, "")
+
+    for surface in fed_surfaces:
+        assert surface is not None, (
+            "the feed must NOT invoke the real extractor with a None surface "
+            "-- an empty segmentation skips extraction (ADR-0037 §Decision 4)."
+        )
+        assert surface.GetNumberOfPoints() > 0, (
+            "the feed must NOT invoke the real extractor with an EMPTY "
+            "surface (0 points) (ADR-0037 §Decision 4)."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_widget_panel.py
+++ b/VascularTerritories/Testing/Python/test_territories_widget_panel.py
@@ -92,11 +92,13 @@ RETIRED_LOGIC_METHODS = (
 )
 
 # ``ui.*`` widgets re-homed into the Python-composed panel and KEPT.
+# NOTE: ``selectedVascularTerritorySegmId`` was KEEP-guarded in slice 2 but is
+# RETIRED in slice 3 (ADR-0037 §Decision 4) — it is asserted ABSENT by
+# ``test_map_path_selector_retired`` below, so it is NOT listed here (a KEPT
+# assertion would break once slice 3 retires it).
 KEPT_UI_WIDGETS = (
     "inputSurfaceSelector",
     "SegmentationShow3DButton",
-    # Slice-3 rework territory; must STAY present + wired this slice.
-    "selectedVascularTerritorySegmId",
     "addCenterlineSegmentButton",
     "calculateVascularTerritoryMapButton",
 )
@@ -356,17 +358,22 @@ def test_panel_builds_cleanly(qt_widgets):
 
 
 # ===========================================================================
-# Invariant 4 — Map path still functional (slice-2 guard).  (pure presence)
+# Invariant 4 — Map path re-sourced (slice-3 guard).  (pure presence)
 # ===========================================================================
 #
-# The "Compute territory map" action, its ``selectedVascularTerritorySegmId``
-# selector, and the ``calculateVascularTerritoryMap`` path are reworked in
-# SLICE 3 — this slice they must STAY present + wired.  This invariant does
-# NOT gate on ``_slice2_landed`` (these names exist both before and after
-# slice 2) and MUST NOT assert their removal.
+# FLIPPED for slice 3 (ADR-0037 §Decision 4, maintainer-locked): the
+# ``selectedVascularTerritorySegmId`` selector was KEEP-guarded in slice 2 and
+# is RETIRED in slice 3 — the output map target is DERIVED from the carrier
+# (``TerritoryMapOutput`` role), not selected.  The "Compute territory map"
+# BUTTON + ``onCalculateVascularTerritoryMapButton`` +
+# ``calculateVascularTerritoryMap`` REMAIN, but resolve inputs without the
+# selector.  Gated on the retirement having landed so it collects +
+# SKIP-PENDINGs cleanly while the selector survives, and RUNS once slice 3
+# retires it (the slice-3 compute invariants — string->int mapping, carrier
+# sourcing, derived output — live in ``test_territories_map_compute.py``).
 
-def test_map_path_still_present(qt_widgets):
-    """The slice-3 map path (button + selector + logic) is untouched by slice 2."""
+def test_map_path_selector_retired(qt_widgets):
+    """The slice-3 map path retires the selector; button + logic remain."""
     _require_qt_widget()
     _require_mrml_scene()
     import slicer
@@ -375,10 +382,21 @@ def test_map_path_still_present(qt_widgets):
     qt_widgets.append(widget)
     _detach_scene_observers(slicer, widget)
 
+    # The button + handler + logic entry point survive the re-source.
     assert hasattr(widget.ui, "calculateVascularTerritoryMapButton")
-    assert hasattr(widget.ui, "selectedVascularTerritorySegmId")
     assert hasattr(widget, "onCalculateVascularTerritoryMapButton")
     assert hasattr(widget.logic, "calculateVascularTerritoryMap")
+
+    if hasattr(widget.ui, "selectedVascularTerritorySegmId"):
+        pytest.skip(
+            "selectedVascularTerritorySegmId still present -- the ADR-0037 "
+            "slice-3 selector retirement (§Decision 4) has not landed "
+            "(ADR-0027).")
+
+    assert not hasattr(widget.ui, "selectedVascularTerritorySegmId"), (
+        "the selectedVascularTerritorySegmId selector must be retired in "
+        "slice 3 -- the output map target is carrier-derived (ADR-0037 "
+        "§Decision 4).")
 
 
 # ===========================================================================

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -755,7 +755,11 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     extractor = self.getCenterlineLogic()
     for territoryId in territoryIds:
       count = carrier.GetNumberOfAnnotationPoints(territoryId)
-      if count <= 0:
+      # A centerline needs at least two endpoints (one inlet + one target);
+      # a territory carrying fewer points is INCOMPLETE (the same threshold
+      # the table flags) -- skip it so one under-seeded territory does not
+      # abort extraction for the rest.
+      if count < 2:
         continue
       points = []
       for i in range(count):

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -194,9 +194,12 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # ADR-0037 Stage-2: the ``endPointsMarkupsSelector`` (CenterlineSegment)
     # markups selector is RETIRED with the annotation-off-markups transition;
     # its entry is dropped from the node-selector list.
+    # ADR-0037 §Decision 4: the ``selectedVascularTerritorySegmId`` output
+    # selector is RETIRED -- the territory-map output target is DERIVED from
+    # the carrier (``TerritoryMapOutput`` role), so its param-node role
+    # (``VascularTerritorySegmentation``) drops out of the selector list.
     self.nodeSelectors = [
         (self.ui.inputSurfaceSelector, "InputSurface"),
-        (self.ui.selectedVascularTerritorySegmId, "VascularTerritorySegmentation")
         ]
 
     # Set scene in MRML widgets. Make sure that in Qt designer
@@ -218,7 +221,6 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
     self.ui.inputSurfaceSelector.connect('currentNodeChanged(bool)', self.segmentationNodeSelected)
-    self.ui.selectedVascularTerritorySegmId.connect('currentNodeChanged(bool)', self.updateParameterNodeFromGUI)
 
     # Vessel-adhering-highlight wiring (ADR-0036 / ADR-0037).  Keep the
     # highlight node's pickSurface aimed at the selected input segmentation.
@@ -232,16 +234,6 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # into the panel here, over the annotation carrier + the placement
     # Pipeline (Python-widget composition, ADR-0004).
     self._setupTerritoriesTable()
-
-    self.ui.selectedVascularTerritorySegmId.setNodeTypeLabel('Vascular Territory Segmentation', 'vtkMRMLSegmentationNode')
-    self.ui.selectedVascularTerritorySegmId.addAttribute("vtkMRMLSegmentationNode", "VascularTerritories.SegmentationId")
-
-    # Initialize Vascular Territory Segmentation button at widget start-up
-#    nodeNameID = 'Vascular_Territory_Segmentation'
-#    vasc_terr_segm_node = slicer.mrmlScene.GetNodeByID(nodeNameID)
-#    if not vasc_terr_segm_node:
-#      vasc_terr_segm_node = slicer.mrmlScene.AddNewNodeByClassWithID('vtkMRMLSegmentationNode', nodeNameID, nodeNameID)
-#    self.ui.selectedVascularTerritorySegmId.setCurrentNodeID(nodeNameID)
 
     #TODO: Store all GUI settings
     # These connections ensure that whenever user changes some settings on the GUI, that is saved in the MRML scene
@@ -545,8 +537,12 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # Update node selectors and sliders
     for nodeSelector, roleName in self.nodeSelectors:
         nodeSelector.setCurrentNode(self._parameterNode.GetNodeReference(roleName))
-    vascularTerritorySegmNode = self._parameterNode.GetNodeReference("VascularTerritorySegmentation")
-    if vascularTerritorySegmNode and vascularTerritorySegmNode.IsA("vtkMRMLSegmentationNode"):
+    # ADR-0037 §Decision 4: the output map target is DERIVED from the carrier,
+    # so the compute action gates on an input surface being selected (the
+    # two-step flow: select surface -> Extract centerlines -> Compute map),
+    # not on a retired output-segmentation selector.
+    inputSurfaceNode = self._parameterNode.GetNodeReference("InputSurface")
+    if inputSurfaceNode and inputSurfaceNode.IsA("vtkMRMLSegmentationNode"):
         self.enableWidgetButtons(True)
 
     # All the GUI updates are done
@@ -615,26 +611,33 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
       qt.QApplication.restoreOverrideCursor()
 
   def onCalculateVascularTerritoryMapButton(self):
+    # ADR-0037 §Decision 4: resolve every input from the carrier +
+    # inputSurfaceSelector -- the output map target is DERIVED from the
+    # carrier (``TerritoryMapOutput`` role), not selected.  The retired
+    # ``selectedVascularTerritorySegmId`` selector is gone.
     segmentationNode = self.ui.inputSurfaceSelector.currentNode()
-    vascTerrSegmentationId = int(self.ui.selectedVascularTerritorySegmId.currentNode().GetAttribute("VascularTerritories.SegmentationId"))
-    centerlineModel = self.logic.build_centerline_model(self.colormap, vascTerrSegmentationId)
+    carrier = self._ensureAnnotationCarrier()
+    centerlineModel = self.logic.build_centerline_model(carrier, self.colormap)
     centerlineModelPoints = centerlineModel.GetMesh()
     numberOfPoints = centerlineModelPoints.GetNumberOfPoints()
     refVolumeNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLScalarVolumeNode")
     if not (refVolumeNode) or (numberOfPoints<2):
         raise ValueError("Missing inputs to calculate vascular segments")
 
-    slicer.app.pauseRender()
-    qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
-    vascularTerritorySegmentationNode = self.ui.selectedVascularTerritorySegmId.currentNode()
+    vascularTerritorySegmentationNode = self.logic.ensureTerritoryMapOutput(carrier)
+    # The C++ ``calculateVascularTerritoryMap`` reads + re-stamps the target's
+    # ``VascularTerritories.SegmentationId``; mirror it onto the centerline
+    # model as the pre-transition path did (the derived output already carries
+    # the ordinal).
     segmId = vascularTerritorySegmentationNode.GetAttribute("VascularTerritories.SegmentationId")
     centerlineModel.SetAttribute("VascularTerritories.SegmentationId", segmId)
 
+    slicer.app.pauseRender()
+    qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
     try:
        self.logic.calculateVascularTerritoryMap(vascularTerritorySegmentationNode, refVolumeNode, segmentationNode, centerlineModel, self.colormap)
     except ValueError:
         logging.error("Error: Failing when calculating vascular segments")
-
 
     slicer.app.resumeRender()
     qt.QApplication.restoreOverrideCursor()

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -843,7 +843,15 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     self._clearTerritoryCenterlines(carrier, territoryId)
     modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "TerritoryCenterline")
     modelNode.SetAndObserveMesh(centerlinePolyData)
-    modelNode.SetAttribute("VascularTerritories.VascTerrId", territoryId)
+    # ADR-0037 §Decision 4: tag the centerline with the DERIVED labelmap int
+    # (from the carrier's territory-id order), not the old string
+    # ``VascularTerritories.VascTerrId``.  The scene-scan reader that parsed
+    # that string is gone (build_centerline_model now sources the carrier
+    # refs), so the redundant string tag + its ``int(...)`` reader retire.
+    from VascularTerritoriesLib.TerritoryLabelMap import territory_label_int
+    derivedInt = territory_label_int(carrier, territoryId)
+    if derivedInt is not None:
+      modelNode.SetAttribute("VascularTerritories.VascTerrId", str(derivedInt))
     carrier.AddNodeReferenceID(self.CENTERLINE_REFERENCE_ROLE, modelNode.GetID())
     carrier.SetGrouping(modelNode.GetID(), territoryId)
     return modelNode
@@ -917,18 +925,90 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
 
     return completeCenterlineModelNode
 
-  def build_centerline_model(self, colormap, vascSegmSelected):
+  def build_centerline_model(self, carrier, colormap):
+    """Assemble the summed centerline model from the carrier's centerlines.
+
+    ADR-0037 §Decision 4: one carrier == one territory map == all its
+    centerlines.  Sources the centerlines from the carrier's ``CenterlineRefs``
+    node-reference role (via ``getCenterlineReferenceIDs``) + ``Groupings``
+    (centerline node ID -> territory id), NOT the retired
+    ``slicer.util.getNodes("*Territory*")`` scene scan or the collapsed
+    ``SegmentationId`` int filter.  Each centerline is marked with the DERIVED
+    labelmap int (its territory's ``index + 1`` in the carrier's id order) so
+    the downstream watershed separates the territories.
+    """
+    from VascularTerritoriesLib.TerritoryLabelMap import territory_label_ints
     centerlineModel = self.createCompleteCenterlineModel(colormap)
-    centerlineSegmentsDict = slicer.util.getNodes("*Territory*")
-    for name, segmentObject in centerlineSegmentsDict.items():
-      if segmentObject.GetClassName() == "vtkMRMLModelNode":
-        VascTerrId = int(segmentObject.GetAttribute("VascularTerritories.VascTerrId"))
-        VascTerrSegmId = int(segmentObject.GetAttribute("VascularTerritories.SegmentationId"))
-        if VascTerrSegmId == vascSegmSelected:
-          self.scl.MarkSegmentWithID(segmentObject, VascTerrId)
-          self.scl.AddSegmentToCenterlineModel(centerlineModel, segmentObject)
+    if carrier is None:
+      self.scl.InitializeCenterlineSearchModel(centerlineModel)
+      return centerlineModel
+    labelInts = territory_label_ints(list(carrier.GetAnnotationTerritoryIds()))
+    for centerlineId in self.getCenterlineReferenceIDs(carrier):
+      segmentObject = slicer.mrmlScene.GetNodeByID(centerlineId)
+      if segmentObject is None or not segmentObject.IsA("vtkMRMLModelNode"):
+        continue
+      territoryId = carrier.GetGrouping(centerlineId)
+      derivedInt = labelInts.get(territoryId)
+      if derivedInt is None:
+        continue
+      self.scl.MarkSegmentWithID(segmentObject, derivedInt)
+      self.scl.AddSegmentToCenterlineModel(centerlineModel, segmentObject)
     self.scl.InitializeCenterlineSearchModel(centerlineModel)
     return centerlineModel
+
+  # The carrier node-reference role holding the DERIVED territory-map output
+  # segmentation (ADR-0037 §Decision 4): one carrier -> one output map,
+  # auto-created + reused rather than selected.
+  TERRITORY_MAP_OUTPUT_ROLE = "TerritoryMapOutput"
+
+  def ensureTerritoryMapOutput(self, carrier):
+    """Resolve (create + attach, or reuse) the carrier's territory-map output.
+
+    ADR-0037 §Decision 4: the output map target is DERIVED from the carrier,
+    not selected -- the carrier's ``TerritoryMapOutput`` node-reference role
+    resolves to exactly one ``vtkMRMLSegmentationNode``.  On the first call it
+    is minted, attached, and stamped with a per-carrier ordinal in
+    ``VascularTerritories.SegmentationId`` (the int the C++
+    ``calculateVascularTerritoryMap`` reads + re-stamps).  Subsequent calls
+    reuse the same node -- one carrier == one map.  The ordinal is stable per
+    carrier and distinct across carriers: it is issued as one past the maximum
+    ordinal already stamped on any segmentation in the scene, so two carriers
+    never collide.
+    """
+    if carrier is None:
+      return None
+    role = self.TERRITORY_MAP_OUTPUT_ROLE
+    existing = carrier.GetNodeReference(role)
+    if existing is not None and existing.IsA("vtkMRMLSegmentationNode"):
+      return existing
+    target = slicer.mrmlScene.AddNewNodeByClass(
+      "vtkMRMLSegmentationNode", "Vascular Territory Map")
+    if target is None:
+      return None
+    target.SetAttribute(
+      "VascularTerritories.SegmentationId", str(self._nextSegmentationOrdinal()))
+    carrier.SetNodeReferenceID(role, target.GetID())
+    return target
+
+  def _nextSegmentationOrdinal(self):
+    """Return one past the max ``SegmentationId`` ordinal stamped in the scene.
+
+    Scanning every segmentation's ``VascularTerritories.SegmentationId`` keeps
+    two carriers from colliding: whichever computes second sees the first's
+    ordinal and issues the next one (ADR-0037 §Decision 4).
+    """
+    maxOrdinal = 0
+    segmentations = slicer.mrmlScene.GetNodesByClass("vtkMRMLSegmentationNode")
+    segmentations.InitTraversal()
+    node = segmentations.GetNextItemAsObject()
+    while node is not None:
+      stamped = node.GetAttribute("VascularTerritories.SegmentationId")
+      try:
+        maxOrdinal = max(maxOrdinal, int(stamped))
+      except (TypeError, ValueError):
+        pass
+      node = segmentations.GetNextItemAsObject()
+    return maxOrdinal + 1
 
   def calculateVascularTerritoryMap(self, vascularTerritorySegmentationNode, refVolume, segmentation, centerlineModel, colormap):
     self.scl.calculateVascularTerritoryMap(vascularTerritorySegmentationNode, refVolume, segmentation, centerlineModel, colormap)

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -746,9 +746,10 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
       territoryIds = [tid for tid in territoryIds if tid == segmentId]
 
     # Decimate the input surface once; every territory shares the same input
-    # mesh.  Best-effort: a missing/empty surface still lets the
-    # transient-node lifecycle run (the extractor stub tolerates it), so the
-    # feed degrades rather than crashing.
+    # mesh.  A missing/empty surface degrades HONESTLY: the real SlicerVMTK
+    # extractor hard-fails on a None/empty surface (no Voronoi diagram / 0 cap
+    # connections / no surface normals), so ``_extractOneTerritory`` skips the
+    # extraction instead of feeding it a bad surface.
     surfacePolyData = self._preprocessedSurface(surfaceNode)
 
     extractor = self.getCenterlineLogic()
@@ -774,11 +775,22 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     except Exception:  # noqa: BLE001 - degrade gracefully when preprocessing fails
       logging.warning(
         "VascularTerritories: input-surface preprocessing failed -- the "
-        "centerline feed proceeds without a decimated surface.")
+        "centerline extraction is skipped (no surface to run over).")
       return None
 
   def _extractOneTerritory(self, carrier, extractor, surfacePolyData, territoryId, points):
-    """Build a transient fiducial, extract, wire the output, tear the node down."""
+    """Build a transient fiducial, extract, wire the output, tear the node down.
+
+    A None/empty ``surfacePolyData`` is NOT fed to the extractor: the real
+    SlicerVMTK extractor hard-fails on it, so the territory's extraction is
+    skipped with a warning (honest degradation, not a silent no-op).  The
+    transient-fiducial lifecycle stays intact for the real path.
+    """
+    if surfacePolyData is None or surfacePolyData.GetNumberOfPoints() == 0:
+      logging.warning(
+        "VascularTerritories: no input surface -- cannot extract the "
+        "centerline for territory %s (skipped).", territoryId)
+      return
     from VascularTerritoriesLib.TransientVmtkSeeds import build_seed_payload
     payload = build_seed_payload(points)
     seedsNode = self._buildTransientFiducial(payload)
@@ -1037,13 +1049,21 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     if surfaceNode.IsA("vtkMRMLModelNode"):
         return surfaceNode.GetPolyData()
     elif surfaceNode.IsA("vtkMRMLSegmentationNode"):
-        # Segmentation node
-        polyData = vtk.vtkPolyData()
-        surfaceNode.CreateClosedSurfaceRepresentation()
-        surfaceNode.GetClosedSurfaceRepresentation(segmentId, polyData)
-        return polyData
+        # ``segmentId`` here carries the feed's TERRITORY semantics (or the
+        # empty string == "every territory"), NOT a segmentation *segment*
+        # id -- so it must never be handed straight to
+        # GetClosedSurfaceRepresentation, which would resolve no segment and
+        # yield a zero-point mesh.  Converge on the SAME whole-vessel-tree
+        # resolution the pick/highlight path uses
+        # (VesselHighlightWiring.closed_surface_polydata): every segment's
+        # closed surface appended into one mesh, so placement-snap and
+        # centerline extraction see the identical surface.  ``None`` when the
+        # segmentation carries no segment geometry.
+        from VascularTerritoriesLib.VesselHighlightWiring import closed_surface_polydata
+        return closed_surface_polydata(surfaceNode)
     else:
-        logging.error
+        logging.error("Unsupported input surface node type")
+        return None
 
 class VascularTerritoriesTest(ScriptedLoadableModuleTest):
   """

--- a/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
+++ b/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
@@ -22,6 +22,7 @@
 set(VascularTerritoriesLib_PYTHON_SCRIPTS
   __init__.py
   TransientVmtkSeeds.py
+  TerritoryLabelMap.py
   VesselSurfacePick.py
   VesselHighlightWiring.py
   VesselHighlightPipeline.py

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryLabelMap.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryLabelMap.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 Stage-3 — the pure territory string->int label map (territory-map compute).
+
+ADR-0037 §Decision 4 makes the carrier's ``CenterlineRefs`` + ``Groupings`` a
+MAP: one carrier, one territory map, all its centerlines.  The
+territory-map compute path derives, per territory, the arbitrary distinct
+positive labelmap scalar that ``vtkSlicerVascularTerritoriesLogic
+::MarkSegmentWithID`` stamps into each centerline's ``segmentId`` point-scalar.
+
+That int is NOT an anatomy / SCT code (ADR-0011 reserves SCT terminology for
+the accepted-plan terminology surface, not this internal watershed label): it
+is only required to be a distinct positive integer per territory so the
+downstream watershed separates the territories.  This module derives it
+DETERMINISTICALLY from the carrier's canonical territory-id order:
+``index + 1`` (1-based; 0 is reserved for the labelmap background).  The same
+territories therefore derive the same ints across repeated calls -- the
+reproducibility the compute path needs.
+
+The ordering source of truth is the carrier's
+``GetAnnotationTerritoryIds()`` (a deterministic, lexicographically-sorted
+enumeration -- the carrier stores annotation points in an ordered map).  The
+PURE core (``territory_label_ints``) takes an already-ordered id list so it
+stays dependency-free and bare-unit-testable; the thin live reader
+(``territory_label_int``) sources that order off a live carrier.
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 4)
+  * Docs/adr/0014-livermarkups-dissolution.md  (the wrapper/carrier idiom)
+  * Docs/adr/0004-python-cpp-boundary.md  (the pure core lives in Lib)
+  * VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.h
+    (GetAnnotationTerritoryIds is the deterministic id order)
+  * VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.h
+    (MarkSegmentWithID consumes the derived int)
+"""
+
+from __future__ import annotations
+
+
+def territory_label_ints(territory_ids):
+    """Map an ORDERED territory-id list to its 1-based labelmap ints.
+
+    Pure value logic -- no live carrier, no scene, no VTK -- so the mapping
+    invariant is bare-unit-testable (ADR-0037 §Decision 4).  The int for a
+    territory id is its position in ``territory_ids`` plus one (0 is reserved
+    for the labelmap background), so the first territory maps to 1.  A fixed
+    id order therefore yields a deterministic, distinct-per-territory map.
+
+    :param territory_ids: territory ids in the carrier's canonical order
+        (``GetAnnotationTerritoryIds()``).
+    :returns: a ``dict`` mapping each territory id to its 1-based int, in the
+        same order.
+    """
+    return {territoryId: index + 1 for index, territoryId in enumerate(territory_ids)}
+
+
+def territory_label_int(carrier, territoryId):
+    """Read a single territory's derived labelmap int off a LIVE carrier.
+
+    A thin wrapper over :func:`territory_label_ints`: it sources the canonical
+    id order from ``carrier.GetAnnotationTerritoryIds()`` then indexes into the
+    pure map (ADR-0037 §Decision 4).  Returns ``None`` when the territory
+    carries no annotation points (it is absent from the id enumeration).
+
+    :param carrier: the ``vtkMRMLCustomTerritoriesNode`` annotation carrier.
+    :param territoryId: the surgeon-named territory id to resolve.
+    :returns: the 1-based labelmap int, or ``None`` if ``territoryId`` is not
+        among the carrier's annotated territories.
+    """
+    ordered_ids = list(carrier.GetAnnotationTerritoryIds())
+    return territory_label_ints(ordered_ids).get(territoryId)

--- a/VascularTerritories/VascularTerritoriesLib/__init__.py
+++ b/VascularTerritories/VascularTerritoriesLib/__init__.py
@@ -19,6 +19,12 @@ from .VesselHighlightWiring import (
 # the pure pick core.
 from .TransientVmtkSeeds import build_seed_payload
 
+# The Stage-3 territory string->int label map (ADR-0037 §Decision 4) is
+# dependency-free too (the pure core takes an ordered id list; the live reader
+# only calls the carrier's GetAnnotationTerritoryIds), so it also imports
+# unconditionally alongside the pure builder core.
+from .TerritoryLabelMap import territory_label_int, territory_label_ints
+
 # The LayerDM highlight Pipeline import depends on LayerDMLib (reachable
 # only from a launched Slicer with the SlicerLayerDisplayableManager
 # extension on the path); guard it so the bare unit layer can still import
@@ -72,6 +78,8 @@ __all__ = [
     "VesselSurfacePick",
     "closed_surface_polydata",
     "build_seed_payload",
+    "territory_label_ints",
+    "territory_label_int",
     "VesselHighlightPipeline",
     "registerVesselHighlightPipelineCreator",
     "TerritoryPlacementPipeline",


### PR DESCRIPTION
Slice 3 (final) of the VascularTerritories widget-modernization — completes ADR-0037 §Decision 3/4. The panel and placement were modernized in slices 1–2, but the territory-map compute was still wired to the retired v1 scene-attribute model, so placed seeds didn't flow to the map. This re-sources the whole compute path onto the annotation carrier and makes the seed → extract → map flow coherent end-to-end.

## What changed
- **New pure `TerritoryLabelMap`** (`territory_label_ints`): deterministic string→int labelmap scalar per territory (annotation order → `index+1`; 0 = background). The int is an arbitrary distinct label the colormap colours — explicitly NOT an SCT code (ADR-0011). Registered in `_PYTHON_SCRIPTS`.
- **`build_centerline_model` re-sourced onto the carrier**: iterates the carrier's `CenterlineRefs` + `Groupings` (not `getNodes("*Territory*")`), marking each centerline with its derived int. The old `SegmentationId` filter collapses (one carrier = one map).
- **Derived map target** (`ensureTerritoryMapOutput`): the output `vtkMRMLSegmentationNode` is created/reused via a new carrier node-reference role `TerritoryMapOutput`, with a per-carrier ordinal `SegmentationId` (scene `max+1`, collision-free). The C++ `calculateVascularTerritoryMap` signature is unchanged.
- **Retired `selectedVascularTerritorySegmId`** (selector + param-node role + `.ui`); `onCalculateVascularTerritoryMapButton` now resolves input from `inputSurfaceSelector`, centerline + target from the carrier. Compute-button enablement re-sourced onto the `InputSurface` role.
- **ADR-0037 amended**: the retired-widget set (slices 2+3), the two-step flow (place seeds → Extract centerlines → Compute territory map), and the derive-target-from-carrier decision.

## Tests
`test_territories_map_compute.py` (12 invariants: label-map determinism [3 bare] + carrier-sourced `build_centerline_model` + derived/reused target + distinct per-carrier ordinals + selector-retired + button resolves without the selector). The slice-2 guard flipped to assert the selector's removal. Real C++ map run stays eyeball-gated (stubbed in tests).
- Launched (VascularTerritories root): 82 passed / 1 skipped (env-gated VMTK). Combined: 205 passed / 2 skipped, no crash. Highlight-wiring + slice-2 panel guards green.

Completes #569 (the VascularTerritories off-markups transition, end to end).

---
*Authored with the assistance of Claude (Anthropic Opus 4.8). Reviewed by the maintainer before merge.*