### PR TITLE
ENH: VascularTerritories per-territory Place mode + composite-row tree panel

### DIFF
--- a/Docs/adr/0037-vascular-territories-off-markups.md
+++ b/Docs/adr/0037-vascular-territories-off-markups.md
@@ -223,3 +223,44 @@ labelmap background), so the same territories derive the same ints across
 repeated calls (the pure `VascularTerritoriesLib.TerritoryLabelMap` core); the
 per-map ordinal is issued one past the maximum `SegmentationId` already
 stamped in the scene, so two carriers never collide.
+
+## Amendment — per-territory Place mode + module-active gate (slice 4)
+
+§Decision 2 said placement "adds one point per click" but left the *arming*
+implicit ("Add Territory" armed and never disarmed, a panel "Add seeds" /
+"Done" pair the only re-arm/disarm).  In use this leaked an armed view across
+module switches (a click in another module could still land a seed) and the
+panel buttons duplicated per-territory intent.  Slice 4 makes arming an
+explicit, per-territory, exclusive toggle and gates it on the module being
+active.
+
+### Per-territory exclusive Place toggle (extends §Decision 2)
+
+The table grows a leftmost **Place** column, so the layout becomes
+`Place | Visibility | Colour | Label | Status`.  Each territory header row
+carries a checkable Place button.  Toggling it ON arms placement into THAT
+territory — `set_active_territory` + `set_armed(True)` on the shared display
+node, highlight made visible — and un-checks every other row's toggle
+(**exclusive**: one territory armed at a time).  Toggling OFF disarms through
+the shared `done()` body.  The checked state is **re-derived** from the
+display node on every rebuild (`is_armed(dn) and get_active_territory(dn) ==
+territoryId`), never stored in a Python field, so it survives the
+carrier-`Modified` rebuild.  `Add Territory` still mints a territory and arms
+it (its toggle then re-derives checked); the panel `Add seeds` + `Done`
+buttons **retire** — only the `done()` disarm logic survives, as the shared
+body reused by a toggle-OFF and by the module-active gate below.
+
+### Module-active gate (extends §Decision 2)
+
+The widget's `exit()` disarms placement (the table's shared `disarm()`/`done()`
+body, then a rebuild so the toggles re-derive un-checked), so no view claims an
+add-on-click while VascularTerritories is inactive.  `enter()` auto-arms
+nothing.  Edits (grab/drag/delete of existing seeds) stay **independent** of
+arm state — intended, not gated.
+
+### Eye-icon visibility (extends §Decision 3)
+
+The visibility column becomes a Slicer-idiomatic eye-on / eye-off
+`qt.QToolButton` (the segmentation convention), not a `QCheckBox`; toggling it
+flips `SetTerritoryVisibility` and its checked state is derived from
+`GetTerritoryVisibility` on rebuild.

--- a/Docs/adr/0037-vascular-territories-off-markups.md
+++ b/Docs/adr/0037-vascular-territories-off-markups.md
@@ -234,10 +234,27 @@ panel buttons duplicated per-territory intent.  Slice 4 makes arming an
 explicit, per-territory, exclusive toggle and gates it on the module being
 active.
 
+### Tree UX — a two-level hierarchy (extends §Decision 3)
+
+The panel composes a `qt.QTreeWidget`, not a flat `qt.QTableWidget`:
+territories are TOP-LEVEL items and seed points are CHILD items nested under
+them (disclosure triangle + indentation).  This diverges from the flat
+[ADR-0034](0034-stage2-segments-table.md) segments-table paradigm because
+territories have a genuine parent/child structure — seeds belong *to* a
+territory — that a flat table cannot express without dead cells (the seed
+sub-rows leave the Place / Visibility / Colour columns blank).  The tree makes
+the hierarchy structural: the indentation in the Place column conveys the
+grouping, so a seed child item carries only its on-surface status (in the
+Label column, aligning under the territory label) and a delete affordance (in
+the Status column).  The 5-column layout is otherwise **unchanged** — a
+`QTreeWidget` has columns too — so the column contract below carries over
+verbatim; only navigation changes (flat rows become tree items, addressed via
+`tree()` / `territoryIds()` / `territoryItem()` / `seedItems()`).
+
 ### Per-territory exclusive Place toggle (extends §Decision 2)
 
-The table grows a leftmost **Place** column, so the layout becomes
-`Place | Visibility | Colour | Label | Status`.  Each territory header row
+The tree grows a leftmost **Place** column, so the layout becomes
+`Place | Visibility | Colour | Label | Status`.  Each territory top-level item
 carries a checkable Place button.  Toggling it ON arms placement into THAT
 territory — `set_active_territory` + `set_armed(True)` on the shared display
 node, highlight made visible — and un-checks every other row's toggle

--- a/Docs/adr/0037-vascular-territories-off-markups.md
+++ b/Docs/adr/0037-vascular-territories-off-markups.md
@@ -234,28 +234,35 @@ panel buttons duplicated per-territory intent.  Slice 4 makes arming an
 explicit, per-territory, exclusive toggle and gates it on the module being
 active.
 
-### Tree UX — a two-level hierarchy (extends §Decision 3)
+### Tree UX — a single-column, header-less tree of composite row widgets (extends §Decision 3)
 
 The panel composes a `qt.QTreeWidget`, not a flat `qt.QTableWidget`:
 territories are TOP-LEVEL items and seed points are CHILD items nested under
 them (disclosure triangle + indentation).  This diverges from the flat
 [ADR-0034](0034-stage2-segments-table.md) segments-table paradigm because
 territories have a genuine parent/child structure — seeds belong *to* a
-territory — that a flat table cannot express without dead cells (the seed
-sub-rows leave the Place / Visibility / Colour columns blank).  The tree makes
-the hierarchy structural: the indentation in the Place column conveys the
-grouping, so a seed child item carries only its on-surface status (in the
-Label column, aligning under the territory label) and a delete affordance (in
-the Status column).  The 5-column layout is otherwise **unchanged** — a
-`QTreeWidget` has columns too — so the column contract below carries over
-verbatim; only navigation changes (flat rows become tree items, addressed via
-`tree()` / `territoryIds()` / `territoryItem()` / `seedItems()`).
+territory — that a flat table cannot express.
+
+The tree drops the column grid and the header entirely: it is **single-column**
+(`columnCount == 1`) with a **hidden header** (`header().isHidden()`), and each
+item — territory top-level AND seed child — carries ONE composite `QWidget` on
+column 0 (`tree.itemWidget(item, 0)`) whose `QHBoxLayout` holds the row's
+controls as a **horizontal strip**.  There is no per-column cell layout and no
+dead cells under a seed row; the two-level territory→seeds hierarchy is
+conveyed structurally by the disclosure triangle + indentation.  The controls
+are addressed by NAME (`territoryRowWidget` / `placeButton` /
+`visibilityButton` / `colourButton` / `territoryLabelEdit` / `seedRowWidget` /
+`seedDeleteButton` / `seedStatusText`), never by column index — the columns no
+longer exist.  A **territory** row strip carries, in order, the Place toggle,
+the eye-icon visibility toggle, the colour button, an editable label
+`QLineEdit`, and a completeness status label; a **seed** row strip carries the
+on-surface status label + a delete button.  Navigation stays via `tree()` /
+`territoryIds()` / `territoryItem()` / `seedItems()`.
 
 ### Per-territory exclusive Place toggle (extends §Decision 2)
 
-The tree grows a leftmost **Place** column, so the layout becomes
-`Place | Visibility | Colour | Label | Status`.  Each territory top-level item
-carries a checkable Place button.  Toggling it ON arms placement into THAT
+Each territory row strip leads with a checkable **Place** `QToolButton`.
+Toggling it ON arms placement into THAT
 territory — `set_active_territory` + `set_armed(True)` on the shared display
 node, highlight made visible — and un-checks every other row's toggle
 (**exclusive**: one territory armed at a time).  Toggling OFF disarms through
@@ -277,7 +284,14 @@ arm state — intended, not gated.
 
 ### Eye-icon visibility (extends §Decision 3)
 
-The visibility column becomes a Slicer-idiomatic eye-on / eye-off
+The visibility control is a Slicer-idiomatic eye-on / eye-off
 `qt.QToolButton` (the segmentation convention), not a `QCheckBox`; toggling it
 flips `SetTerritoryVisibility` and its checked state is derived from
 `GetTerritoryVisibility` on rebuild.
+
+### Editable label moves to a `QLineEdit` (extends §Decision 3)
+
+With the column grid gone, the territory label is an editable `qt.QLineEdit`
+in the row strip whose `editingFinished` routes through `setTerritoryLabel` to
+the carrier's display slot — the composite-row replacement for the retired
+in-item editable text (and its tree `itemChanged` label handler).

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -154,20 +154,21 @@ set(_vascterr_pytest_files
   # stays env-/eyeball-gated in test_territories_vmtk_feed.py (ADR-0027).
   test_territories_surface_resolution.py
   # ADR-0037 §Decision 2/3 (slice 4) -- per-territory Place mode + module-active
-  # gate + table-UX polish.  Placement becomes an EXPLICIT, exclusive, per-
-  # territory arm toggle in a NEW leftmost Place column (Place | Visibility |
-  # Colour | Label | Status): toggling ON arms THAT territory on the shared
-  # display node and un-checks every other row; toggling OFF disarms; the
-  # armed row's checked state is re-derived from the display node on each
-  # rebuild.  The widget's exit() disarms so no view claims an add-on-click
-  # while the module is inactive; enter() auto-arms nothing.  The visibility
-  # cell becomes an eye-icon QToolButton (not QCheckBox); Add seeds / Done
-  # panel buttons retire (done() disarm body survives); an armed click adds one
-  # child row under the header.  The exclusivity / re-derivation logic drives
-  # via the table + display node; the exit-disarm + click-adds-a-child-row
-  # invariants need a REAL pipeline bound to the SAME display node -- all
-  # SKIP-PENDING bare / while the 4-column layout survives, and RUN launched
-  # once the slice-4 Place column + eye toggle land (ADR-0027).
+  # gate + composite-row panel polish.  Placement becomes an EXPLICIT,
+  # exclusive, per-territory arm toggle: toggling ON arms THAT territory on the
+  # shared display node and un-checks every other territory; toggling OFF
+  # disarms; the armed territory's checked state is re-derived from the display
+  # node on each rebuild.  The widget's exit() disarms so no view claims an
+  # add-on-click while the module is inactive; enter() auto-arms nothing.  The
+  # visibility control is an eye-icon QToolButton (not QCheckBox); Add seeds /
+  # Done panel buttons retire (done() disarm body survives); an armed click
+  # adds one seed child item under the territory.  The panel is a header-less,
+  # single-column tree of composite row widgets (a per-row Place / eye / colour
+  # / label / status strip; no column grid).  The exclusivity / re-derivation
+  # logic drives via the tree + display node; the exit-disarm + click-adds-a-
+  # child invariants need a REAL pipeline bound to the SAME display node -- all
+  # SKIP-PENDING bare / while the composite-row seam is absent, and RUN launched
+  # once the composite-row tree + eye toggle land (ADR-0027).
   test_territories_placemode.py
 )
 

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -153,6 +153,22 @@ set(_vascterr_pytest_files
   # scene so it SKIP-PENDS bare and RUNS launched; the VMTK compute itself
   # stays env-/eyeball-gated in test_territories_vmtk_feed.py (ADR-0027).
   test_territories_surface_resolution.py
+  # ADR-0037 §Decision 2/3 (slice 4) -- per-territory Place mode + module-active
+  # gate + table-UX polish.  Placement becomes an EXPLICIT, exclusive, per-
+  # territory arm toggle in a NEW leftmost Place column (Place | Visibility |
+  # Colour | Label | Status): toggling ON arms THAT territory on the shared
+  # display node and un-checks every other row; toggling OFF disarms; the
+  # armed row's checked state is re-derived from the display node on each
+  # rebuild.  The widget's exit() disarms so no view claims an add-on-click
+  # while the module is inactive; enter() auto-arms nothing.  The visibility
+  # cell becomes an eye-icon QToolButton (not QCheckBox); Add seeds / Done
+  # panel buttons retire (done() disarm body survives); an armed click adds one
+  # child row under the header.  The exclusivity / re-derivation logic drives
+  # via the table + display node; the exit-disarm + click-adds-a-child-row
+  # invariants need a REAL pipeline bound to the SAME display node -- all
+  # SKIP-PENDING bare / while the 4-column layout survives, and RUN launched
+  # once the slice-4 Place column + eye toggle land (ADR-0027).
+  test_territories_placemode.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/test_territories_placemode.py
+++ b/VascularTerritories/Testing/Python/test_territories_placemode.py
@@ -13,14 +13,14 @@ the Slicer-idiomatic eye-icon visibility toggle.
 The confirmed slice-4 design (maintainer-LOCKED this session), each pinned
 below:
 
-1.  PER-TERRITORY EXCLUSIVE PLACE TOGGLE.  Each territory TOP-LEVEL item gets a
-    checkable "Place" button in the leftmost column.  The 5-column layout is
-    ``Place | Visibility | Colour | Label | Status``.  Toggling ON arms
-    placement into THAT territory (``set_active_territory`` +
-    ``set_armed(True)`` + the highlight visible via ``TerritoryInteractionState``)
-    and un-checks EVERY other territory's toggle (EXCLUSIVE — one territory
-    armed at a time); toggling OFF disarms.  The armed item's checked state is
-    RE-DERIVED from the display node on each rebuild
+1.  PER-TERRITORY EXCLUSIVE PLACE TOGGLE.  Each territory row is ONE composite
+    ``QWidget`` (a horizontal STRIP of controls, not a column grid) carrying a
+    checkable "Place" ``qt.QToolButton``.  Toggling ON arms placement into THAT
+    territory (``set_active_territory`` + ``set_armed(True)`` + the highlight
+    visible via ``TerritoryInteractionState``) and un-checks EVERY other
+    territory's toggle (EXCLUSIVE — one territory armed at a time); toggling OFF
+    disarms.  The armed item's checked state is RE-DERIVED from the display node
+    on each rebuild
     (``checked = is_armed(dn) and get_active_territory(dn) == territoryId``),
     NOT stored in a Python field, so it survives the carrier-Modified rebuild.
 
@@ -30,44 +30,49 @@ below:
     ``enter()`` auto-arms NOTHING.  Edits (grab/drag/delete of existing seeds)
     stay INDEPENDENT of arm state — intended, not gated.
 
-3.  EYE-ICON VISIBILITY.  The visibility column is a Slicer-idiomatic
+3.  EYE-ICON VISIBILITY.  The visibility control is a Slicer-idiomatic
     eye-on / eye-off toggle (the segmentation convention): a checkable
     ``qt.QToolButton`` (NOT a ``QCheckBox``) toggling
     ``carrier.SetTerritoryVisibility``.
 
 4.  HIERARCHICAL CHILD ITEMS ON PLACEMENT.  Placing a seed into the armed
     territory (carrier ``AddAnnotationPoint`` / a click through the
-    display-node-wired pipeline) adds EXACTLY ONE child item under that
-    territory's top-level item on the next rebuild, in the right columns of the
-    5-column layout.
+    display-node-wired pipeline) adds EXACTLY ONE child item — thus one seed
+    composite-row ``QWidget`` — under that territory's top-level item on the
+    next rebuild.
 
 5.  PANEL BUTTONS.  ``Add Territory`` mints a new empty territory item AND arms
     it (its Place toggle reads checked after rebuild).  ``Add seeds`` + ``Done``
     panel buttons are RETIRED (absent).  The ``done()`` disarm logic survives
     as the shared body reused by ``exit()`` + toggle-OFF.
 
-6.  COLOUR CELL guard.  The colour cell is a ``ctkColorPickerButton``
+6.  COLOUR CONTROL guard.  The colour control is a ``ctkColorPickerButton``
     (committed in slice 2/3); a light guard that the tree rewrite does not
     regress it (``colorChanged`` -> ``setTerritoryColor``).
 
--- THE TREE (two-level hierarchy) --
+-- THE TREE (composite-row, two-level hierarchy) --
 
-The panel composes a ``qt.QTreeWidget``: territories are TOP-LEVEL items,
-seed points are CHILD items nested under their territory (disclosure triangle
-+ indentation, a genuine two-level hierarchy — unlike the flat ADR-0034
-segments table).  The 5-column layout is UNCHANGED
-(``Place | Visibility | Colour | Label | Status``, ``columnCount == 5``); what
-changes from the retired flat table is navigation — flat rows become tree
-items, addressed via the item-based reader seams below.
+The panel composes a SINGLE-COLUMN ``qt.QTreeWidget`` with NO header row and
+NO visible column grid (``columnCount == 1``, ``header().isHidden()``):
+territories are TOP-LEVEL items, seed points are CHILD items nested under
+their territory (disclosure triangle + indentation, a genuine two-level
+hierarchy — unlike the flat ADR-0034 segments table).  Each item carries a
+COMPOSITE ``QWidget`` on column 0 (``tree.itemWidget(item, 0)``) whose layout
+holds the row's controls as a horizontal STRIP.  Controls are addressed by
+NAME through the composite sub-widget getters, never by column index — the
+columns no longer exist.
 
-* TERRITORY (top-level) item: the Place / Visibility / Colour cell widgets in
-  cols 0/1/2 (``tree.itemWidget(item, col)``), the editable label text in col 3
-  (``item.text(3)``), and the status glyph+text in col 4.
-* SEED (child) item: nested under its territory's top-level item.  The seed
-  status TEXT lives in the Label column (``item.text(3)``, aligning under the
-  territory label); the DELETE affordance is a cell widget in col 4
-  (``tree.itemWidget(item, 4)``); cols 0/1/2 carry NO widget and NO text (the
-  tree indentation in col 0 conveys the hierarchy).
+* TERRITORY (top-level) row widget: in order — the Place toggle
+  (``qt.QToolButton``, checkable), the eye-icon visibility toggle
+  (``qt.QToolButton``, checkable), the colour button (``ctk.ctkColorPickerButton``),
+  an editable label (``qt.QLineEdit``), and a status label (``qt.QLabel``,
+  glyph+text).  Reached via ``territoryRowWidget`` / ``placeButton`` /
+  ``visibilityButton`` / ``colourButton`` / ``territoryLabelEdit`` /
+  ``territoryStatusText``.
+* SEED (child) row widget: a status label (``qt.QLabel``, e.g.
+  "Seed N — on surface") and a delete button (``qt.QToolButton``), nested under
+  its territory's top-level item.  Reached via ``seedRowWidget`` /
+  ``seedStatusText`` / ``seedDeleteButton``.
 
 -- BARE vs LAUNCHED --
 
@@ -82,12 +87,13 @@ via the shared ``conftest`` guards.
 
 -- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
 
-Pre-implementation the tree seam / Place column / eye-icon toggle /
+Pre-implementation the composite-row seam / Place toggle / eye-icon toggle /
 exit-disarm / child-item-on-placement do not exist, so the ``tree()`` /
-column-shape / ``hasattr`` guards skip-pend; the skips lift at the slice-4
-tree rewrite commit.  Under a launched Slicer, verify run-vs-skip in the CI
-log once the seam lands — never trust overall green (the launched harness is
-green-but-skipping prone).
+single-column-shape / ``territoryRowWidget`` / ``placeButton`` /  ``hasattr``
+guards skip-pend; the skips lift at the slice-4 composite-row rewrite commit.
+Under a launched Slicer, verify run-vs-skip in the CI log once the seam lands
+— never trust overall green (the launched harness is green-but-skipping
+prone).
 
 See also:
   * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 2 / §3)
@@ -126,27 +132,23 @@ DISPLAY_METHODS = (
 )
 
 # ---------------------------------------------------------------------------
-# THE 5-COLUMN CONTRACT the implementer MUST honour (slice 4).
+# THE COMPOSITE-ROW CONTRACT the implementer MUST honour (slice 4).
 #
-# The 5-column layout is UNCHANGED from the retired flat table; the tree
-# rewrite changes only navigation (flat rows -> tree items).  A QTreeWidget
-# has columns too:
-#     [Place=0 | Visibility=1 | Colour=2 | Label=3 | Status=4]  (columnCount == 5)
+# The columns + header row are DROPPED.  The tree is SINGLE-COLUMN
+# (``columnCount == 1``) with a hidden header (``header().isHidden()``) and no
+# visible column grid.  Each item — territory top-level AND seed child —
+# carries ONE composite ``QWidget`` on column 0 (``tree.itemWidget(item, 0)``)
+# whose layout holds the row's controls as a horizontal STRIP.  Controls are
+# addressed by NAME through the composite sub-widget getters below, NEVER by
+# column index.
 #
-# A TERRITORY (top-level) item carries the Place / Visibility / Colour cell
-# widgets in cols 0/1/2, the editable label text in col 3, the status text in
-# col 4.  A SEED (child) item carries its status TEXT in the Label column (3)
-# — aligning under the territory label — and the DELETE affordance as a cell
-# widget in the Status column (4); cols 0/1/2 stay blank (no widget, no text)
-# because the tree indentation in col 0 conveys the hierarchy.  These offsets
-# are asserted below so the implementer's ``_COL_*`` constants match.
+# TERRITORY row widget, in order: Place toggle (checkable QToolButton),
+# eye-icon visibility toggle (checkable QToolButton), colour button
+# (ctkColorPickerButton), editable label (QLineEdit), status label (QLabel).
+# SEED row widget: status label (QLabel) + delete button (QToolButton).
 # ---------------------------------------------------------------------------
-EXPECTED_COLUMN_COUNT = 5
-EXPECTED_COL_PLACE = 0
-EXPECTED_COL_VISIBILITY = 1
-EXPECTED_COL_COLOUR = 2
-EXPECTED_COL_LABEL = 3
-EXPECTED_COL_STATUS = 4
+EXPECTED_COLUMN_COUNT = 1  # single-column tree; the composite row lives on col 0
+COMPOSITE_COLUMN = 0
 
 
 # --------------------------------------------------------------------------- #
@@ -265,48 +267,55 @@ def _require_tree_model(table):
             )
 
 
-def _require_tree_layout_or_skip(table):
-    """Skip-pend unless the widget adopted the slice-4 QTreeWidget 5-column layout.
+def _require_composite_rows_or_skip(table):
+    """Skip-pend unless the widget adopted the slice-4 composite-row layout.
 
-    The gate for every slice-4 tree assertion: while the ``tree()`` seam is
-    absent OR the column count is not the 5-column
-    (``Place | Visibility | Colour | Label | Status``) layout, the tests
-    collect + SKIP-PENDING and RUN once the tree rewrite lands (ADR-0037
-    §Decision 2 slice-4 amendment; ADR-0027).
+    The gate for every slice-4 assertion: while the ``tree()`` seam is absent,
+    OR the tree is not single-column (``columnCount != 1``), OR its header is
+    not hidden, OR the ``territoryRowWidget`` / ``placeButton`` composite
+    getters are absent, the tests collect + SKIP-PENDING and RUN once the
+    composite-row rewrite lands (ADR-0037 §Decision 2 slice-4 amendment;
+    ADR-0027).
     """
     if not hasattr(table, "tree"):
         pytest.skip(
             "TerritoriesTableWidget has no tree() seam -- the ADR-0037 slice-4 "
-            "QTreeWidget rewrite has not landed (ADR-0027)."
+            "composite-row rewrite has not landed (ADR-0027)."
         )
     tree = table.tree()
     if tree.columnCount != EXPECTED_COLUMN_COUNT:
         pytest.skip(
-            f"tree has {tree.columnCount} columns, not the slice-4 "
-            f"{EXPECTED_COLUMN_COUNT} (Place | Visibility | Colour | Label | "
-            "Status) -- the per-territory Place column has not landed (ADR-0027)."
+            f"tree has {tree.columnCount} columns, not the slice-4 single-column "
+            "(composite-row) layout -- the column-drop rewrite has not landed "
+            "(ADR-0027)."
         )
+    header = tree.header()
+    if header is None or not header.isHidden():
+        pytest.skip(
+            "tree header is not hidden -- the slice-4 header-drop has not landed "
+            "(ADR-0027)."
+        )
+    for method in ("territoryRowWidget", "placeButton"):
+        if not hasattr(table, method):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {method} composite getter -- the "
+                "ADR-0037 slice-4 composite-row rewrite has not landed (ADR-0027)."
+            )
 
 
-def _place_cell_or_skip(table, territoryId):
-    """Return the territory item's Place toggle widget, or skip-pend.
+def _place_button_or_skip(table, territoryId):
+    """Return the territory row's Place toggle button, or skip-pend.
 
-    Skips while the Place column is absent so the toggle-behaviour tests
-    remain collectible pre-implementation.
+    Skips while the composite Place toggle is absent so the toggle-behaviour
+    tests remain collectible pre-implementation.
     """
-    item = table.territoryItem(territoryId)
-    if item is None:
+    button = table.placeButton(territoryId)
+    if button is None:
         pytest.skip(
-            f"no top-level tree item for {territoryId!r} -- the ADR-0037 slice-4 "
-            "QTreeWidget rewrite has not landed (ADR-0027)."
-        )
-    cell = table.tree().itemWidget(item, EXPECTED_COL_PLACE)
-    if cell is None:
-        pytest.skip(
-            "no Place-toggle cell widget on the territory item -- the ADR-0037 "
+            "no Place-toggle button on the territory row widget -- the ADR-0037 "
             "slice-4 per-territory Place toggle has not landed (ADR-0027)."
         )
-    return cell
+    return button
 
 
 # --------------------------------------------------------------------------- #
@@ -381,17 +390,17 @@ def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monke
 
 
 # ===========================================================================
-# Invariant 1 — the 5-column layout with the leftmost Place column.
+# Invariant 1 — single-column, header-hidden tree; per-item composite row.
 # ===========================================================================
 
 
-def test_tree_has_five_columns_with_place_leftmost(qt_widgets):
-    """The tree adopts the slice-4 5-column layout, Place leftmost.
+def test_tree_is_single_column_with_header_hidden(qt_widgets):
+    """The tree drops columns + header: single-column with a hidden header.
 
-    ADR-0037 §Decision 2 (slice-4 amendment): the columns are
-    ``Place | Visibility | Colour | Label | Status`` on the ``QTreeWidget``.
-    The Place column is the leftmost (index 0); the layout is unchanged from
-    the retired flat table save for the flat-rows -> tree-items navigation.
+    ADR-0037 §Decision 2 (slice-4 amendment): the column grid + header row are
+    retired.  The ``QTreeWidget`` is single-column (``columnCount == 1``) with
+    its header hidden (``header().isHidden()``); each row's controls live in a
+    composite ``QWidget`` on column 0, not in per-column cells.
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -400,25 +409,81 @@ def test_tree_has_five_columns_with_place_leftmost(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
 
-    # TODO(slice-4 implementer): the invariant body below is authoritative once
-    # the tree rewrite lands; it is unreachable while the guard skip-pends.
-    assert table.tree().columnCount == EXPECTED_COLUMN_COUNT
+    tree = table.tree()
+    assert tree.columnCount == EXPECTED_COLUMN_COUNT, (
+        "the tree must be single-column (columns dropped) after the slice-4 "
+        "composite-row rewrite."
+    )
+    assert tree.header().isHidden(), (
+        "the tree header row must be hidden (no visible column grid)."
+    )
 
 
-def test_seed_child_item_carries_status_at_label_and_delete_at_status(qt_widgets):
-    """A seed CHILD item renders in the shifted 5-column offsets (the column contract).
+def test_territory_row_widget_holds_the_named_controls_strip(qt_widgets):
+    """A territory row is ONE composite QWidget holding the named controls strip.
+
+    ADR-0037 §Decision 2 (slice-4): each territory item carries a composite
+    ``QWidget`` via ``tree.itemWidget(item, 0)`` whose layout holds — in order —
+    the Place toggle (checkable ``QToolButton``), the eye-icon visibility toggle
+    (checkable ``QToolButton``), the colour button (``ctkColorPickerButton``),
+    an editable label (``QLineEdit``), and a status label (``QLabel``).  The
+    controls are reached by NAME through the composite getters, never by column.
+    """
+    import ctk
+    import qt
+
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+    for getter in (
+        "colourButton",
+        "visibilityButton",
+        "territoryLabelEdit",
+    ):
+        if not hasattr(table, getter):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {getter} composite getter -- the "
+                "ADR-0037 slice-4 composite-row rewrite has not landed (ADR-0027)."
+            )
+
+    territory = table.addTerritory()
+
+    # The composite row widget lives on column 0 of the top-level item.
+    item = table.territoryItem(territory)
+    assert item is not None, "the minted territory must have a top-level tree item."
+    row = table.territoryRowWidget(territory)
+    assert row is not None, "the territory item must carry a composite row widget."
+    assert row is table.tree().itemWidget(item, COMPOSITE_COLUMN), (
+        "territoryRowWidget must be the composite widget on column 0."
+    )
+
+    # The named controls resolve to their expected widget types.
+    assert isinstance(table.placeButton(territory), qt.QToolButton)
+    assert isinstance(table.visibilityButton(territory), qt.QToolButton)
+    assert isinstance(table.colourButton(territory), ctk.ctkColorPickerButton)
+    assert isinstance(table.territoryLabelEdit(territory), qt.QLineEdit)
+
+
+def test_seed_row_widget_holds_status_label_and_delete_button(qt_widgets):
+    """A seed CHILD item is ONE composite QWidget: status label + delete button.
 
     ADR-0037 §Decision 2 (slice-4): a seed is a CHILD item nested under its
-    territory's top-level item.  Its status TEXT lives in the Label column
-    (index ``EXPECTED_COL_LABEL == 3``, aligning under the territory label) and
-    its DELETE affordance is a cell widget in the Status column (index
-    ``EXPECTED_COL_STATUS == 4``); cols 0/1/2 (Place / Visibility / Colour) stay
-    blank — no widget and no text — because the tree indentation in col 0
-    conveys the hierarchy.  This pins the exact offsets the implementer's seed
-    child-item construction must honour.
+    territory's top-level item.  Its composite row widget (on column 0) holds a
+    status label (``QLabel``, non-empty text, e.g. "Seed N — on surface") and a
+    delete button (``QToolButton``).  Reached via ``seedRowWidget`` /
+    ``seedStatusText`` / ``seedDeleteButton`` — never by column index.
     """
+    import qt
+
     slicer = _slicer_or_skip()
     _qt_or_skip()
     carrier = _make_carrier_or_skip(slicer)
@@ -426,7 +491,13 @@ def test_seed_child_item_carries_status_at_label_and_delete_at_status(qt_widgets
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
+    for getter in ("seedRowWidget", "seedStatusText", "seedDeleteButton"):
+        if not hasattr(table, getter):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {getter} composite getter -- the "
+                "ADR-0037 slice-4 composite-row rewrite has not landed (ADR-0027)."
+            )
 
     for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]:
         carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
@@ -444,22 +515,22 @@ def test_seed_child_item_carries_status_at_label_and_delete_at_status(qt_widgets
         "a seed must be a CHILD item nested under its territory's top-level item."
     )
 
-    # Status TEXT lives in the Label column (index 3).
-    assert seed.text(EXPECTED_COL_LABEL).strip() != "", (
-        "the seed's status text must live in the Label column "
-        f"(index {EXPECTED_COL_LABEL})."
+    # The seed's composite row widget lives on column 0.
+    row = table.seedRowWidget(TERRITORY_A, 0)
+    assert row is not None, "the seed item must carry a composite row widget."
+    assert row is tree.itemWidget(seed, COMPOSITE_COLUMN), (
+        "seedRowWidget must be the composite widget on column 0."
     )
-    # Delete affordance lives in the Status column (index 4) — a cell widget.
-    delete_cell = tree.itemWidget(seed, EXPECTED_COL_STATUS)
-    assert delete_cell is not None, (
-        "the seed's delete affordance must live in the Status column "
-        f"(index {EXPECTED_COL_STATUS})."
+
+    # Status TEXT is non-empty (glyph+text status label).
+    assert table.seedStatusText(TERRITORY_A, 0).strip() != "", (
+        "the seed row's status label must carry non-empty text."
     )
-    # Place / Visibility / Colour stay blank on a seed child item.
-    for col in (EXPECTED_COL_PLACE, EXPECTED_COL_VISIBILITY, EXPECTED_COL_COLOUR):
-        assert tree.itemWidget(seed, col) is None and seed.text(col) == "", (
-            f"seed child column {col} must be blank in the 5-column tree layout."
-        )
+    # The delete affordance is a QToolButton on the seed row.
+    delete = table.seedDeleteButton(TERRITORY_A, 0)
+    assert isinstance(delete, qt.QToolButton), (
+        "the seed row's delete affordance must be a QToolButton."
+    )
 
 
 # ===========================================================================
@@ -484,12 +555,12 @@ def test_place_toggle_arms_its_territory_on_the_display_node(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory = table.addTerritory()
-    place = _place_cell_or_skip(table, territory)
+    place = _place_button_or_skip(table, territory)
 
     place.setChecked(True)
 
@@ -519,18 +590,18 @@ def test_place_toggle_is_exclusive_arm_b_unchecks_a(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory_a = table.addTerritory()
     territory_b = table.addTerritory()
 
-    place_a = _place_cell_or_skip(table, territory_a)
+    place_a = _place_button_or_skip(table, territory_a)
     place_a.setChecked(True)
     assert state.get_active_territory(displayNode) == territory_a
 
-    place_b = _place_cell_or_skip(table, territory_b)
+    place_b = _place_button_or_skip(table, territory_b)
     place_b.setChecked(True)
 
     assert state.get_active_territory(displayNode) == territory_b, (
@@ -538,7 +609,7 @@ def test_place_toggle_is_exclusive_arm_b_unchecks_a(qt_widgets):
     )
     # A's toggle must have been un-checked (exclusivity) — re-read from the
     # rebuilt item (the checked state is display-node-derived, not stored).
-    place_a_after = _place_cell_or_skip(table, territory_a)
+    place_a_after = _place_button_or_skip(table, territory_a)
     assert place_a_after.isChecked() is False, (
         "arming B must un-check A's Place toggle (EXCLUSIVE arming)."
     )
@@ -559,16 +630,16 @@ def test_place_toggle_off_disarms(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory = table.addTerritory()
-    place = _place_cell_or_skip(table, territory)
+    place = _place_button_or_skip(table, territory)
     place.setChecked(True)
     assert state.is_armed(displayNode) is True
 
-    place_after = _place_cell_or_skip(table, territory)
+    place_after = _place_button_or_skip(table, territory)
     place_after.setChecked(False)
 
     assert state.is_armed(displayNode) is False, (
@@ -593,21 +664,21 @@ def test_checked_state_rederived_from_display_node_on_rebuild(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory_a = table.addTerritory()
     territory_b = table.addTerritory()
-    place_a = _place_cell_or_skip(table, territory_a)
+    place_a = _place_button_or_skip(table, territory_a)
     place_a.setChecked(True)
 
     # Force a full rebuild by adding a seed to the OTHER territory.
     carrier.AddAnnotationPoint(territory_b, 1.0, 0.0, 0.0)
     carrier.Modified()
 
-    place_a_after = _place_cell_or_skip(table, territory_a)
-    place_b_after = _place_cell_or_skip(table, territory_b)
+    place_a_after = _place_button_or_skip(table, territory_a)
+    place_b_after = _place_button_or_skip(table, territory_b)
     assert place_a_after.isChecked() is True, (
         "the armed territory's Place toggle must stay checked across a rebuild "
         "(checked state re-derived from the display node, not stored)."
@@ -622,13 +693,14 @@ def test_checked_state_rederived_from_display_node_on_rebuild(qt_widgets):
 # ===========================================================================
 
 
-def test_visibility_cell_is_eye_icon_tool_button_not_checkbox(qt_widgets):
-    """The visibility cell is a Slicer-idiomatic eye-icon ``QToolButton``.
+def test_visibility_control_is_eye_icon_tool_button_not_checkbox(qt_widgets):
+    """The visibility control is a Slicer-idiomatic eye-icon ``QToolButton``.
 
-    ADR-0037 §Decision 3 (slice-4 UX polish): the visibility column becomes a
+    ADR-0037 §Decision 3 (slice-4 UX polish): the visibility control is a
     checkable ``qt.QToolButton`` (eye-on / eye-off, the segmentation
     convention), NOT a ``QCheckBox``.  Toggling it flips
-    ``carrier.SetTerritoryVisibility``.  [launched.]
+    ``carrier.SetTerritoryVisibility``.  Reached via ``visibilityButton``.
+    [launched.]
     """
     import qt
 
@@ -639,18 +711,19 @@ def test_visibility_cell_is_eye_icon_tool_button_not_checkbox(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
-    if not hasattr(table, "addTerritory"):
-        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "addTerritory") or not hasattr(table, "visibilityButton"):
+        pytest.skip(
+            "TerritoriesTableWidget has no addTerritory / visibilityButton seam "
+            "(ADR-0027)."
+        )
 
     territory = table.addTerritory()
-    item = table.territoryItem(territory)
-    assert item is not None, "the armed territory must have a top-level tree item."
-    cell = table.tree().itemWidget(item, EXPECTED_COL_VISIBILITY)
-    assert cell is not None, "the territory item must carry a visibility cell widget."
+    cell = table.visibilityButton(territory)
+    assert cell is not None, "the territory row must carry a visibility control."
 
     assert isinstance(cell, qt.QToolButton), (
-        "the visibility cell must be an eye-icon QToolButton (segmentation "
+        "the visibility control must be an eye-icon QToolButton (segmentation "
         "convention), not a QCheckBox (ADR-0037 slice-4 UX polish)."
     )
     assert cell.isCheckable(), "the eye-icon toggle must be checkable."
@@ -668,17 +741,18 @@ def test_visibility_cell_is_eye_icon_tool_button_not_checkbox(qt_widgets):
 
 
 # ===========================================================================
-# Invariant 6 — colour cell stays a ctkColorPickerButton (regression guard).
+# Invariant 6 — colour control stays a ctkColorPickerButton (regression guard).
 # ===========================================================================
 
 
-def test_colour_cell_stays_ctk_color_picker_button(qt_widgets):
-    """The colour cell survives the tree rewrite as a ``ctkColorPickerButton``.
+def test_colour_control_stays_ctk_color_picker_button(qt_widgets):
+    """The colour control survives the rewrite as a ``ctkColorPickerButton``.
 
     ADR-0037 §Decision 3 (already committed): the colour swatch is a
     ``ctkColorPickerButton`` emitting ``colorChanged`` -> ``setTerritoryColor``.
-    A light regression guard that the flat-table -> tree rewrite does not turn
-    it back into a bare swatch.  [launched.]
+    A light regression guard that the flat-table -> composite-row rewrite does
+    not turn it back into a bare swatch.  Reached via ``colourButton``.
+    [launched.]
     """
     import ctk
 
@@ -689,18 +763,19 @@ def test_colour_cell_stays_ctk_color_picker_button(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
-    if not hasattr(table, "addTerritory"):
-        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "addTerritory") or not hasattr(table, "colourButton"):
+        pytest.skip(
+            "TerritoriesTableWidget has no addTerritory / colourButton seam "
+            "(ADR-0027)."
+        )
 
     territory = table.addTerritory()
-    item = table.territoryItem(territory)
-    assert item is not None, "the armed territory must have a top-level tree item."
-    cell = table.tree().itemWidget(item, EXPECTED_COL_COLOUR)
-    assert cell is not None, "the territory item must carry a colour cell widget."
+    cell = table.colourButton(territory)
+    assert cell is not None, "the territory row must carry a colour control."
     assert isinstance(cell, ctk.ctkColorPickerButton), (
-        "the colour cell must stay a ctkColorPickerButton after the tree "
-        "rewrite (ADR-0037 §Decision 3)."
+        "the colour control must stay a ctkColorPickerButton after the "
+        "composite-row rewrite (ADR-0037 §Decision 3)."
     )
 
     # colorChanged -> setTerritoryColor: the emitted signal writes the carrier.
@@ -735,7 +810,7 @@ def test_add_territory_mints_and_arms_its_toggle_reads_checked_after_rebuild(qt_
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
@@ -743,7 +818,7 @@ def test_add_territory_mints_and_arms_its_toggle_reads_checked_after_rebuild(qt_
 
     assert state.is_armed(displayNode) is True, "Add Territory must arm placement."
     assert state.get_active_territory(displayNode) == territory
-    place = _place_cell_or_skip(table, territory)
+    place = _place_button_or_skip(table, territory)
     assert place.isChecked() is True, (
         "the minted territory's Place toggle must read checked after rebuild."
     )
@@ -765,7 +840,7 @@ def test_add_seeds_and_done_panel_buttons_retired(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
 
     # The retired panel buttons must not survive as private attributes ...
     for attr in ("_addSeedsButton", "_doneButton"):
@@ -815,12 +890,12 @@ def test_click_while_armed_places_into_territory_and_adds_one_child_item(qt_widg
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory = table.addTerritory()
-    place = _place_cell_or_skip(table, territory)
+    place = _place_button_or_skip(table, territory)
     place.setChecked(True)  # arm via the Place toggle (writes the display node)
 
     before_children = len(table.seedItems(territory))
@@ -836,19 +911,17 @@ def test_click_while_armed_places_into_territory_and_adds_one_child_item(qt_widg
         "an armed click must add EXACTLY ONE child item under the armed "
         "territory's top-level item (ADR-0037 slice-4 invariant 4)."
     )
-    # The new child item renders in the shifted 5-column offsets.
+    # The new child item carries a composite seed-row widget (col 0).
     seed = after_children[-1]
-    tree = table.tree()
+    new_index = len(after_children) - 1
     assert seed.parent() is table.territoryItem(territory), (
         "the new seed must be a child of the armed territory's top-level item."
     )
-    assert seed.text(EXPECTED_COL_LABEL).strip() != "", (
-        "the new seed's status text must land in the Label column (index 3)."
-    )
-    assert tree.itemWidget(seed, EXPECTED_COL_STATUS) is not None, (
-        "the new seed's delete affordance must land in the Status column "
-        "(index 4)."
-    )
+    if hasattr(table, "seedRowWidget"):
+        assert table.seedRowWidget(territory, new_index) is not None, (
+            "the new seed must carry a composite row widget on column 0 "
+            "(ADR-0037 slice-4)."
+        )
 
 
 # ===========================================================================
@@ -892,7 +965,7 @@ def test_exit_disarms_and_a_later_click_places_nothing(qt_widgets, monkeypatch):
             "carrier is off the launched path (ADR-0027)."
         )
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
     displayNode = getattr(widget, "_highlightDisplayNode", None)
     carrier = getattr(widget, "_annotationCarrier", None)
     if displayNode is None or carrier is None:
@@ -907,7 +980,7 @@ def test_exit_disarms_and_a_later_click_places_nothing(qt_widgets, monkeypatch):
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
     territory = table.addTerritory()
-    place = _place_cell_or_skip(table, territory)
+    place = _place_button_or_skip(table, territory)
     place.setChecked(True)
     assert state.is_armed(displayNode) is True
 
@@ -966,7 +1039,7 @@ def test_enter_auto_arms_nothing(qt_widgets):
     table = getattr(widget, "_territoriesTable", None)
     if table is None:
         pytest.skip("composed TerritoriesTableWidget absent (ADR-0027).")
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
     state = _import_interaction_state_or_skip()
 
     widget.enter()

--- a/VascularTerritories/Testing/Python/test_territories_placemode.py
+++ b/VascularTerritories/Testing/Python/test_territories_placemode.py
@@ -1,0 +1,953 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 slice 4 — per-territory Place mode + module-active gate + table-UX polish.
+
+ADR-0037 §Decision 2 (placement/edit via the Pipeline seam) + §Decision 3
+(the table UI) — sharpened by the slice-4 amendment recording the place-mode
+UX.  Slice 4 makes placement an EXPLICIT, per-territory, exclusive arm toggle
+driven from the table (not an implicit "Add Territory arms it and never
+disarms"), gates arming on the module being active, and polishes the table to
+the Slicer-idiomatic eye-icon visibility toggle.
+
+The confirmed slice-4 design (maintainer-LOCKED this session), each pinned
+below:
+
+1.  PER-TERRITORY EXCLUSIVE PLACE TOGGLE.  Each territory HEADER row gets a
+    checkable "Place" button in a NEW leftmost column.  The 5-column layout
+    becomes ``Place | Visibility | Colour | Label | Status``.  Toggling ON
+    arms placement into THAT territory (``set_active_territory`` +
+    ``set_armed(True)`` + the highlight visible via ``TerritoryInteractionState``)
+    and un-checks EVERY other row's toggle (EXCLUSIVE — one territory armed at
+    a time); toggling OFF disarms.  The armed row's checked state is
+    RE-DERIVED from the display node on each rebuild
+    (``checked = is_armed(dn) and get_active_territory(dn) == territoryId``),
+    NOT stored in a Python field, so it survives the carrier-Modified rebuild.
+
+2.  MODULE-ACTIVE GATE.  ``exit()`` disarms placement (clears the display
+    node's armed/active, hides the highlight, un-checks the active toggle) so
+    no view claims an add-on-click when VascularTerritories is inactive.
+    ``enter()`` auto-arms NOTHING.  Edits (grab/drag/delete of existing seeds)
+    stay INDEPENDENT of arm state — intended, not gated.
+
+3.  EYE-ICON VISIBILITY.  The visibility column is a Slicer-idiomatic
+    eye-on / eye-off toggle (the segmentation convention): a checkable
+    ``qt.QToolButton`` (NOT a ``QCheckBox``) toggling
+    ``carrier.SetTerritoryVisibility``.
+
+4.  HIERARCHICAL CHILD ROWS ON PLACEMENT.  Placing a seed into the armed
+    territory (carrier ``AddAnnotationPoint`` / a click through the
+    display-node-wired pipeline) adds EXACTLY ONE child row under that
+    territory's header on the next rebuild, in the right columns of the
+    5-column layout.
+
+5.  PANEL BUTTONS.  ``Add Territory`` mints a new empty territory row AND arms
+    it (its Place toggle reads checked after rebuild).  ``Add seeds`` + ``Done``
+    panel buttons are RETIRED (absent).  The ``done()`` disarm logic survives
+    as the shared body reused by ``exit()`` + toggle-OFF.
+
+6.  COLOUR CELL guard.  The colour cell is a ``ctkColorPickerButton``
+    (committed in slice 2/3); a light guard that the 5-column shift does not
+    regress it (``colorChanged`` -> ``setTerritoryColor``).
+
+-- BARE vs LAUNCHED --
+
+The Place-toggle EXCLUSIVITY / re-derivation logic can be driven purely
+through the table + a display node (no GL, no pipeline event dispatch), so
+those RUN launched where the wrapped display node is reachable, and SKIP
+cleanly bare (no Qt, no wrapped node).  The exit()-disarms-a-click and
+click-adds-a-child-row invariants need a REAL pipeline bound to the SAME
+display node the table writes (the detached-instance contract), so they are
+LAUNCHED, pipeline wired via the display node.  Every test SKIPS cleanly bare
+via the shared ``conftest`` guards.
+
+-- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
+
+Pre-implementation the Place column / eye-icon toggle / exit-disarm /
+child-row-on-placement do not exist, so the ``hasattr`` / column-shape guards
+skip-pend; the skips lift at the slice-4 implementation commit.  Under a
+launched Slicer, verify run-vs-skip in the CI log once the seam lands — never
+trust overall green (the launched harness is green-but-skipping prone).
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 2 / §3)
+  * Docs/adr/0034-stage2-segments-table.md  (the table paradigm)
+  * Docs/adr/0033-control-polygon-display-aspect.md  (hover-decline)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * VascularTerritories/Testing/Python/test_territories_table.py  (shared idiom)
+  * VascularTerritories/Testing/Python/test_territories_widget_panel.py
+  * VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+HIGHLIGHT_DISPLAY_CLASS = "vtkMRMLTerritoriesHighlightDisplayNode"
+TERRITORY_A = "SegmentVII"
+TERRITORY_B = "SegmentVIII"
+
+# Carrier point API (pinned by test_territories_annotation_carrier.py).
+ADD_POINT_METHOD = "AddAnnotationPoint"
+COUNT_METHOD = "GetNumberOfAnnotationPoints"
+GET_NTH_METHOD = "GetNthAnnotationPoint"
+
+# Carrier display-attribute slot (Stage-2).
+DISPLAY_METHODS = (
+    "SetTerritoryColor",
+    "GetTerritoryColor",
+    "SetTerritoryLabel",
+    "GetTerritoryLabel",
+    "SetTerritoryVisibility",
+    "GetTerritoryVisibility",
+)
+
+# ---------------------------------------------------------------------------
+# THE 5-COLUMN CONTRACT the implementer MUST honour (slice 4).
+#
+# The Place column is inserted LEFTMOST; every downstream column shifts right
+# by one.  The old 4-column layout was:
+#     [Visibility=0 | Colour=1 | Label=2 | Status=3]  (_COLUMN_COUNT == 4)
+# The slice-4 layout is:
+#     [Place=0 | Visibility=1 | Colour=2 | Label=3 | Status=4]  (== 5)
+#
+# ``_appendChildRow`` must move with the shift: the child-row STATUS TEXT
+# (formerly in _COL_LABEL == 2) moves to the new label column (3), and the
+# child-row DELETE affordance (formerly in _COL_STATUS == 3) moves to the new
+# status column (4).  The Place + Visibility + Colour cells stay blank on a
+# child row.  These offsets are asserted below so the implementer's
+# ``_COL_*`` constants + ``_appendHeaderRow`` / ``_appendChildRow`` matches.
+# ---------------------------------------------------------------------------
+EXPECTED_COLUMN_COUNT = 5
+EXPECTED_COL_PLACE = 0
+EXPECTED_COL_VISIBILITY = 1
+EXPECTED_COL_COLOUR = 2
+EXPECTED_COL_LABEL = 3
+EXPECTED_COL_STATUS = 4
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror the launched-Slicer discipline in conftest.py + the
+# shared idiom in test_territories_table.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from conftest import _import_slicer_or_skip, _require_mrml_scene
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _qt_or_skip():
+    from conftest import _require_qt_widget
+
+    _require_qt_widget()
+
+
+def _make_carrier_or_skip(slicer, name="PlaceModeCarrierTest"):
+    """Mint a carrier exposing the point + display-attribute API, or skip-pend."""
+    node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} not registered -- module Logic "
+            "RegisterNodes() must wire this up (launched build)."
+        )
+    for method in (ADD_POINT_METHOD, COUNT_METHOD, GET_NTH_METHOD):
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} -- the ADR-0037 "
+                "annotation carrier (Stage-1) has not landed (ADR-0027)."
+            )
+    for method in DISPLAY_METHODS:
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} -- the ADR-0037 "
+                "Stage-2 display-attribute slot has not landed (ADR-0027)."
+            )
+    return node
+
+
+def _make_display_node_or_skip(slicer, name="PlaceModeHighlightTest"):
+    """Mint the shared highlight display node, or skip-pend (ADR-0027)."""
+    node = slicer.mrmlScene.AddNewNodeByClass(HIGHLIGHT_DISPLAY_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{HIGHLIGHT_DISPLAY_CLASS} not registered -- the shared highlight "
+            "display node (ADR-0036/0037) is unavailable (launched build)."
+        )
+    return node
+
+
+def _import_interaction_state_or_skip():
+    """Import the shared interaction-state accessors, or skip-pend (ADR-0027)."""
+    try:
+        import TerritoryInteractionState as state
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoryInteractionState not importable ({exc!r}) -- the ADR-0037 "
+            "shared display-node state module has not landed (ADR-0027)."
+        )
+    return state
+
+
+def _import_table_or_skip():
+    """Import the Stage-2 table widget class or skip-pend (ADR-0027)."""
+    try:
+        from VascularTerritoriesLib.TerritoriesTableWidget import (
+            TerritoriesTableWidget,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoriesTableWidget not importable ({exc!r}) -- the ADR-0037 "
+            "table widget has not landed OR Qt/LayerDMLib is not reachable here "
+            "(ADR-0027)."
+        )
+    return TerritoriesTableWidget
+
+
+def _import_pipeline_or_skip():
+    try:
+        from VascularTerritoriesLib.TerritoryPlacementPipeline import (
+            TerritoryPlacementPipeline,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoryPlacementPipeline not importable ({exc!r}) -- ADR-0037 "
+            "placement Pipeline / LayerDMLib not reachable (ADR-0027)."
+        )
+    return TerritoryPlacementPipeline
+
+
+def _make_table_or_skip(slicer, carrier, displayNode):
+    """Construct the table over the carrier + shared display node, or skip-pend."""
+    TerritoriesTableWidget = _import_table_or_skip()
+    try:
+        table = TerritoriesTableWidget(carrier=carrier, displayNode=displayNode)
+    except TypeError as exc:
+        pytest.skip(
+            f"TerritoriesTableWidget(carrier=, displayNode=) seam absent ({exc!r}) "
+            "-- the ADR-0037 table constructor has not landed (ADR-0027)."
+        )
+    return table
+
+
+def _require_table_row_model(table):
+    """Skip-pend unless the table exposes the row-model reader seams."""
+    for method in ("table", "isHeaderRow", "territoryOfRow", "pointIndexOfRow"):
+        if not hasattr(table, method):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {method} row-model seam -- "
+                "the ADR-0037 table has not landed (ADR-0027)."
+            )
+
+
+def _require_five_column_layout_or_skip(table):
+    """Skip-pend unless the table adopted the slice-4 5-column Place layout.
+
+    The gate for every slice-4-shape assertion: while the pre-slice-4
+    4-column layout survives, the table has no Place column, so the tests
+    collect + SKIP-PENDING and RUN once the leftmost Place column lands
+    (ADR-0037 §Decision 2 slice-4 amendment; ADR-0027).
+    """
+    widget = table.table()
+    if widget.columnCount != EXPECTED_COLUMN_COUNT:
+        pytest.skip(
+            f"table has {widget.columnCount} columns, not the slice-4 "
+            f"{EXPECTED_COLUMN_COUNT} (Place | Visibility | Colour | Label | "
+            "Status) -- the per-territory Place column has not landed (ADR-0027)."
+        )
+
+
+def _place_cell_or_skip(table, row):
+    """Return the header row's Place toggle widget, or skip-pend.
+
+    Skips while the Place column is absent so the toggle-behaviour tests
+    remain collectible pre-implementation.
+    """
+    widget = table.table()
+    cell = widget.cellWidget(row, EXPECTED_COL_PLACE)
+    if cell is None:
+        pytest.skip(
+            "no Place-toggle cell widget on the header row -- the ADR-0037 "
+            "slice-4 per-territory Place toggle has not landed (ADR-0027)."
+        )
+    return cell
+
+
+def _header_row_for(table, territoryId):
+    """The header-row index for ``territoryId`` (raises if absent)."""
+    return next(
+        r
+        for r in range(table.table().rowCount)
+        if table.isHeaderRow(r) and table.territoryOfRow(r) == territoryId
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fake interaction plumbing (reused from the placement-pipeline / table suites)
+# --------------------------------------------------------------------------- #
+
+
+def _unit_sphere():
+    source = vtk.vtkSphereSource()
+    source.SetRadius(1.0)
+    source.SetThetaResolution(64)
+    source.SetPhiResolution(64)
+    source.Update()
+    return source.GetOutput()
+
+
+class _FakeRenderer:
+    """Display->world unprojects any pixel to the +z ray a unit sphere is hit by."""
+
+    def __init__(self):
+        self._display = [0.0, 0.0, 0.0]
+
+    def SetDisplayPoint(self, x, y, z):  # noqa: N802 - VTK verb
+        self._display = [x, y, z]
+
+    def DisplayToWorld(self):  # noqa: N802 - VTK verb
+        pass
+
+    def GetWorldPoint(self):  # noqa: N802 - VTK verb
+        if self._display[2] <= 0.0:
+            return (0.0, 0.0, 5.0, 1.0)
+        return (0.0, 0.0, -5.0, 1.0)
+
+
+class _Event:
+    """A minimal interaction event at a fixed display pixel + type."""
+
+    def __init__(self, etype, display_position=(100, 100)):
+        self._etype = etype
+        self._pos = display_position
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch):
+    """Bind a REAL pipeline to the SHARED display node so it reads live state.
+
+    The detached-instance contract: the pipeline resolves its carrier / active
+    territory / arm flag from the display node the TABLE writes to, NOT from a
+    hand-armed detached instance.  A stub renderer + injected pick core keep
+    the click GL-free.  (Same helper shape as test_territories_table.py.)
+    """
+    try:
+        from VesselSurfacePick import VesselSurfacePick
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VesselSurfacePick not importable ({exc!r}).")
+    if not hasattr(pipeline, "SetPickCore") or not hasattr(pipeline, "SetDisplayNode"):
+        pytest.skip(
+            "TerritoryPlacementPipeline lacks SetPickCore / SetDisplayNode -- "
+            "cannot bind the shared display-node state (Stage-1 not landed; "
+            "ADR-0027)."
+        )
+    state = _import_interaction_state_or_skip()
+    monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
+    state.set_carrier(displayNode, carrier)
+    pipeline.SetDisplayNode(displayNode)
+    pipeline.SetPickCore(VesselSurfacePick(_unit_sphere()))
+
+
+# ===========================================================================
+# Invariant 1 — the 5-column layout with the leftmost Place column.
+# ===========================================================================
+
+
+def test_table_has_five_columns_with_place_leftmost(qt_widgets):
+    """The table adopts the slice-4 5-column layout, Place leftmost.
+
+    ADR-0037 §Decision 2 (slice-4 amendment): the columns become
+    ``Place | Visibility | Colour | Label | Status``.  The Place column is
+    inserted LEFTMOST (index 0); the downstream columns shift right by one.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+
+    # TODO(slice-4 implementer): the invariant body below is authoritative once
+    # the Place column lands; it is unreachable while the guard skip-pends.
+    assert table.table().columnCount == EXPECTED_COLUMN_COUNT
+
+
+def test_child_row_status_and_delete_shift_into_the_five_column_offsets(qt_widgets):
+    """Child rows render in the shifted 5-column offsets (the column contract).
+
+    ADR-0037 §Decision 2 (slice-4): with the leftmost Place column inserted,
+    ``_appendChildRow`` must move — the seed STATUS TEXT into the label column
+    (index ``EXPECTED_COL_LABEL == 3``) and the DELETE affordance into the
+    status column (index ``EXPECTED_COL_STATUS == 4``); Place / Visibility /
+    Colour stay blank on a child row.  This pins the exact offsets the
+    implementer's ``_appendChildRow`` must honour.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+
+    for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]:
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    carrier.Modified()
+
+    widget = table.table()
+    child_row = next(r for r in range(widget.rowCount) if not table.isHeaderRow(r))
+
+    # Status TEXT lives in the label column (index 3) — a QTableWidgetItem.
+    label_item = widget.item(child_row, EXPECTED_COL_LABEL)
+    assert label_item is not None and label_item.text().strip() != "", (
+        "child-row status text must live in the shifted label column "
+        f"(index {EXPECTED_COL_LABEL})."
+    )
+    # Delete affordance lives in the status column (index 4) — a cell widget.
+    delete_cell = widget.cellWidget(child_row, EXPECTED_COL_STATUS)
+    assert delete_cell is not None, (
+        "child-row delete affordance must live in the shifted status column "
+        f"(index {EXPECTED_COL_STATUS})."
+    )
+    # Place / Visibility / Colour stay blank on a child row.
+    for col in (EXPECTED_COL_PLACE, EXPECTED_COL_VISIBILITY, EXPECTED_COL_COLOUR):
+        assert widget.cellWidget(child_row, col) is None and widget.item(child_row, col) is None, (
+            f"child-row column {col} must be blank in the 5-column layout."
+        )
+
+
+# ===========================================================================
+# Invariant 1 — per-territory EXCLUSIVE Place toggle.
+# ===========================================================================
+
+
+def test_place_toggle_arms_its_territory_on_the_display_node(qt_widgets):
+    """Toggling a Place button ON arms THAT territory on the display node.
+
+    ADR-0037 §Decision 2 (slice-4): the header's Place toggle writes
+    ``set_active_territory`` + ``set_armed(True)`` onto the SHARED display node
+    (``TerritoryInteractionState``) and makes the highlight visible.  [launched
+    where the wrapped display node is reachable; the toggle logic is driven via
+    the table + display node, no pipeline dispatch needed.]
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    territory = table.addTerritory()
+    header = _header_row_for(table, territory)
+    place = _place_cell_or_skip(table, header)
+
+    place.setChecked(True)
+
+    assert state.is_armed(displayNode) is True, (
+        "a checked Place toggle must arm placement via the shared display node."
+    )
+    assert state.get_active_territory(displayNode) == territory, (
+        "a checked Place toggle must make its territory the ACTIVE one."
+    )
+    assert bool(displayNode.GetVisibility()) is True, (
+        "arming must make the adhering highlight visible (ADR-0037 §Decision 2)."
+    )
+
+
+def test_place_toggle_is_exclusive_arm_b_unchecks_a(qt_widgets):
+    """Arming territory B un-arms A (EXCLUSIVE — one territory armed at a time).
+
+    ADR-0037 §Decision 2 (slice-4): toggling one Place button ON un-checks
+    every other row's toggle and re-points the display node's ACTIVE territory
+    at B.  [launched; toggle logic driven via the table + display node.]
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    territory_a = table.addTerritory()
+    territory_b = table.addTerritory()
+
+    place_a = _place_cell_or_skip(table, _header_row_for(table, territory_a))
+    place_a.setChecked(True)
+    assert state.get_active_territory(displayNode) == territory_a
+
+    place_b = _place_cell_or_skip(table, _header_row_for(table, territory_b))
+    place_b.setChecked(True)
+
+    assert state.get_active_territory(displayNode) == territory_b, (
+        "arming B must re-point the ACTIVE territory at B."
+    )
+    # A's toggle must have been un-checked (exclusivity) — re-read from the
+    # rebuilt row (the checked state is display-node-derived, not stored).
+    place_a_after = _place_cell_or_skip(table, _header_row_for(table, territory_a))
+    assert place_a_after.isChecked() is False, (
+        "arming B must un-check A's Place toggle (EXCLUSIVE arming)."
+    )
+
+
+def test_place_toggle_off_disarms(qt_widgets):
+    """Toggling the armed Place button OFF disarms placement.
+
+    ADR-0037 §Decision 2 (slice-4): toggling OFF clears the display node's
+    armed flag (reusing the shared ``done()`` disarm body).  [launched; toggle
+    logic driven via the table + display node.]
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    territory = table.addTerritory()
+    place = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place.setChecked(True)
+    assert state.is_armed(displayNode) is True
+
+    place_after = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place_after.setChecked(False)
+
+    assert state.is_armed(displayNode) is False, (
+        "toggling the Place button OFF must disarm placement."
+    )
+
+
+def test_checked_state_rederived_from_display_node_on_rebuild(qt_widgets):
+    """The armed row's checked state survives a carrier-Modified rebuild.
+
+    ADR-0037 §Decision 2 (slice-4): ``checked = is_armed(dn) and
+    get_active_territory(dn) == territoryId`` is RE-DERIVED on each rebuild,
+    NOT stored in a Python field.  Arming a territory, then forcing a rebuild
+    (a carrier ``Modified()``), leaves that territory's Place toggle STILL
+    checked and the others un-checked.  [launched or bare where the display
+    node is reachable.]
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    territory_a = table.addTerritory()
+    territory_b = table.addTerritory()
+    place_a = _place_cell_or_skip(table, _header_row_for(table, territory_a))
+    place_a.setChecked(True)
+
+    # Force a full rebuild by adding a seed to the OTHER territory.
+    carrier.AddAnnotationPoint(territory_b, 1.0, 0.0, 0.0)
+    carrier.Modified()
+
+    place_a_after = _place_cell_or_skip(table, _header_row_for(table, territory_a))
+    place_b_after = _place_cell_or_skip(table, _header_row_for(table, territory_b))
+    assert place_a_after.isChecked() is True, (
+        "the armed territory's Place toggle must stay checked across a rebuild "
+        "(checked state re-derived from the display node, not stored)."
+    )
+    assert place_b_after.isChecked() is False, (
+        "a non-armed territory's Place toggle must read un-checked after rebuild."
+    )
+
+
+# ===========================================================================
+# Invariant 3 — eye-icon visibility toggle (QToolButton, not QCheckBox).
+# ===========================================================================
+
+
+def test_visibility_cell_is_eye_icon_tool_button_not_checkbox(qt_widgets):
+    """The visibility cell is a Slicer-idiomatic eye-icon ``QToolButton``.
+
+    ADR-0037 §Decision 3 (slice-4 UX polish): the visibility column becomes a
+    checkable ``qt.QToolButton`` (eye-on / eye-off, the segmentation
+    convention), NOT a ``QCheckBox``.  Toggling it flips
+    ``carrier.SetTerritoryVisibility``.  [launched.]
+    """
+    import qt
+
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    territory = table.addTerritory()
+    header = _header_row_for(table, territory)
+    cell = table.table().cellWidget(header, EXPECTED_COL_VISIBILITY)
+    assert cell is not None, "the header row must carry a visibility cell widget."
+
+    assert isinstance(cell, qt.QToolButton), (
+        "the visibility cell must be an eye-icon QToolButton (segmentation "
+        "convention), not a QCheckBox (ADR-0037 slice-4 UX polish)."
+    )
+    assert cell.isCheckable(), "the eye-icon toggle must be checkable."
+
+    # Toggling flips the carrier's per-territory visibility.
+    carrier.SetTerritoryVisibility(territory, True)
+    cell.setChecked(False)
+    assert bool(carrier.GetTerritoryVisibility(territory)) is False, (
+        "un-checking the eye toggle must hide the territory on the carrier."
+    )
+    cell.setChecked(True)
+    assert bool(carrier.GetTerritoryVisibility(territory)) is True, (
+        "checking the eye toggle must show the territory on the carrier."
+    )
+
+
+# ===========================================================================
+# Invariant 6 — colour cell stays a ctkColorPickerButton (regression guard).
+# ===========================================================================
+
+
+def test_colour_cell_stays_ctk_color_picker_button(qt_widgets):
+    """The colour cell survives the 5-column shift as a ``ctkColorPickerButton``.
+
+    ADR-0037 §Decision 3 (already committed): the colour swatch is a
+    ``ctkColorPickerButton`` emitting ``colorChanged`` -> ``setTerritoryColor``.
+    A light regression guard that the leftmost-Place-column shift does not turn
+    it back into a bare swatch.  [launched.]
+    """
+    import ctk
+
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    territory = table.addTerritory()
+    header = _header_row_for(table, territory)
+    cell = table.table().cellWidget(header, EXPECTED_COL_COLOUR)
+    assert cell is not None, "the header row must carry a colour cell widget."
+    assert isinstance(cell, ctk.ctkColorPickerButton), (
+        "the colour cell must stay a ctkColorPickerButton after the 5-column "
+        "shift (ADR-0037 §Decision 3)."
+    )
+
+    # colorChanged -> setTerritoryColor: the emitted signal writes the carrier.
+    import qt
+
+    cell.setColor(qt.QColor(int(0.3 * 255), int(0.6 * 255), int(0.9 * 255)))
+    color = carrier.GetTerritoryColor(territory)
+    assert (color[0], color[1], color[2]) == pytest.approx((0.3, 0.6, 0.9), abs=2e-3), (
+        "the colour picker's colorChanged must write the carrier's territory "
+        "colour (setTerritoryColor)."
+    )
+
+
+# ===========================================================================
+# Invariant 5 — Add Territory mints + arms; Add seeds / Done buttons retired.
+# ===========================================================================
+
+
+def test_add_territory_mints_and_arms_its_toggle_reads_checked_after_rebuild(qt_widgets):
+    """``Add Territory`` mints a territory AND arms it; its Place toggle checks.
+
+    ADR-0037 §Decision 2 (slice-4): "Add Territory" mints a new empty territory
+    row and arms it — after the rebuild that follows, that row's Place toggle
+    reads checked (the checked state re-derived from the display node).
+    [launched or bare where the display node is reachable.]
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    territory = table.addTerritory()
+
+    assert state.is_armed(displayNode) is True, "Add Territory must arm placement."
+    assert state.get_active_territory(displayNode) == territory
+    place = _place_cell_or_skip(table, _header_row_for(table, territory))
+    assert place.isChecked() is True, (
+        "the minted territory's Place toggle must read checked after rebuild."
+    )
+
+
+def test_add_seeds_and_done_panel_buttons_retired(qt_widgets):
+    """The ``Add seeds`` + ``Done`` panel buttons are absent (slice-4 retirement).
+
+    ADR-0037 §Decision 2 (slice-4): with per-territory Place toggles the panel
+    ``Add seeds`` + ``Done`` buttons retire; the ``done()`` disarm LOGIC
+    survives (reused by ``exit()`` + toggle-OFF), but the panel buttons are
+    gone.  Both have a credible creep-in path (a left-in button), so this
+    narrow absence stays pinned.  [launched.]
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+
+    # The retired panel buttons must not survive as private attributes ...
+    for attr in ("_addSeedsButton", "_doneButton"):
+        assert not hasattr(table, attr), (
+            f"the retired panel button {attr!r} must be absent (ADR-0037 slice-4)."
+        )
+    # ... nor as any QPushButton bearing their label text.
+    import qt
+
+    labels = {
+        b.text
+        for b in table.findChildren(qt.QPushButton)
+        if b.text
+    }
+    assert "Add seeds" not in labels, "the 'Add seeds' panel button must be retired."
+    assert "Done" not in labels, "the 'Done' panel button must be retired."
+
+    # The shared disarm BODY survives (reused by exit + toggle-OFF).
+    assert hasattr(table, "done"), (
+        "the done() disarm logic must survive as the shared disarm body "
+        "(ADR-0037 slice-4)."
+    )
+
+
+# ===========================================================================
+# Invariant 4 — a click while armed places into THAT territory + adds one child
+# row.  [launched, pipeline wired via the display node.]
+# ===========================================================================
+
+
+def test_click_while_armed_places_into_territory_and_adds_one_child_row(qt_widgets, monkeypatch):
+    """An armed click appends one seed AND yields exactly one new child row.
+
+    ADR-0037 §Decision 2/3 (slice-4 invariant 4): with a territory armed via
+    its Place toggle, a click through the display-node-wired pipeline adds one
+    surface-snapped point to the carrier AND — on the carrier-Modified rebuild
+    — exactly one CHILD ROW appears under that territory's header (the
+    maintainer-reported "no child rows" symptom, pinned).  [launched, pipeline
+    wired via the display node.]
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    pipeline = _import_pipeline_or_skip()()
+    _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+
+    territory = table.addTerritory()
+    place = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place.setChecked(True)  # arm via the Place toggle (writes the display node)
+
+    def _child_rows_for(territoryId):
+        w = table.table()
+        return [
+            r
+            for r in range(w.rowCount)
+            if not table.isHeaderRow(r) and table.territoryOfRow(r) == territoryId
+        ]
+
+    before_rows = len(_child_rows_for(territory))
+    before_points = carrier.GetNumberOfAnnotationPoints(territory)
+
+    assert pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent)) is True
+
+    assert carrier.GetNumberOfAnnotationPoints(territory) == before_points + 1, (
+        "an armed click must append EXACTLY ONE seed to the ACTIVE territory."
+    )
+    after_rows = _child_rows_for(territory)
+    assert len(after_rows) == before_rows + 1, (
+        "an armed click must add EXACTLY ONE child row under the armed "
+        "territory's header (ADR-0037 slice-4 invariant 4)."
+    )
+    # The new child row renders in the shifted 5-column offsets.
+    child_row = after_rows[-1]
+    widget = table.table()
+    assert widget.item(child_row, EXPECTED_COL_LABEL) is not None, (
+        "the new child row's status text must land in the label column (index 3)."
+    )
+    assert widget.cellWidget(child_row, EXPECTED_COL_STATUS) is not None, (
+        "the new child row's delete affordance must land in the status column "
+        "(index 4)."
+    )
+
+
+# ===========================================================================
+# Invariant 2 — module-active gate: exit() disarms; a later click places nothing.
+# ===========================================================================
+
+
+def test_exit_disarms_and_a_later_click_places_nothing(qt_widgets, monkeypatch):
+    """``exit()`` disarms placement so a subsequent click adds no seed.
+
+    ADR-0037 §Decision 2 (slice-4 module-active gate): the widget's ``exit()``
+    disarms placement (clears the display node's armed/active + hides the
+    highlight) so no view claims an add-on-click while VascularTerritories is
+    inactive.  After ``exit()``, a click through the display-node-wired
+    pipeline places nothing and the display node reads dis-armed + hidden.
+    [launched, pipeline wired via the display node.]
+    """
+    _slicer_or_skip()
+    _qt_or_skip()
+    import slicer as _slicer  # noqa: F811 — the widget lives on the launched module
+
+    from VascularTerritories import VascularTerritoriesWidget
+
+    widget = VascularTerritoriesWidget()
+    widget.setup()
+    qt_widgets.append(widget)
+    # Drop the widget's scene observers before the autouse scene-clear fires.
+    for event, handler in (
+        (_slicer.mrmlScene.StartCloseEvent, widget.onSceneStartClose),
+        (_slicer.mrmlScene.EndCloseEvent, widget.onSceneEndClose),
+    ):
+        try:
+            widget.removeObserver(_slicer.mrmlScene, event, handler)
+        except Exception:  # noqa: BLE001 — best-effort across widget shapes
+            pass
+
+    table = getattr(widget, "_territoriesTable", None)
+    if table is None:
+        pytest.skip(
+            "composed TerritoriesTableWidget absent -- LayerDMLib / the wrapped "
+            "carrier is off the launched path (ADR-0027)."
+        )
+    _require_table_row_model(table)
+    _require_five_column_layout_or_skip(table)
+    displayNode = getattr(widget, "_highlightDisplayNode", None)
+    carrier = getattr(widget, "_annotationCarrier", None)
+    if displayNode is None or carrier is None:
+        pytest.skip(
+            "widget did not expose the shared display node + carrier handles "
+            "(ADR-0027)."
+        )
+    state = _import_interaction_state_or_skip()
+
+    # Arm via the table's Place toggle, then bind a REAL pipeline to the SAME
+    # display node the widget/table write.
+    if not hasattr(table, "addTerritory"):
+        pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
+    territory = table.addTerritory()
+    place = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place.setChecked(True)
+    assert state.is_armed(displayNode) is True
+
+    pipeline = _import_pipeline_or_skip()()
+    _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
+
+    # The module-active gate: exit() disarms.
+    widget.exit()
+    assert state.is_armed(displayNode) is False, (
+        "exit() must disarm placement (ADR-0037 slice-4 module-active gate)."
+    )
+    assert bool(displayNode.GetVisibility()) is False, (
+        "exit() must hide the adhering highlight."
+    )
+
+    before = carrier.GetNumberOfAnnotationPoints(territory)
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent))
+    assert carrier.GetNumberOfAnnotationPoints(territory) == before, (
+        "a click after exit() must place nothing (no view claims an add-on-"
+        "click while the module is inactive)."
+    )
+
+    widget.cleanup()
+
+
+def test_enter_auto_arms_nothing(qt_widgets):
+    """``enter()`` arms NOTHING (no view claims a click just from entering).
+
+    ADR-0037 §Decision 2 (slice-4): ``enter()`` auto-arms nothing — placement
+    is an EXPLICIT per-territory Place toggle.  After ``enter()`` the display
+    node reads dis-armed.  [launched.]
+    """
+    _slicer_or_skip()
+    _qt_or_skip()
+    import slicer as _slicer  # noqa: F811
+
+    from VascularTerritories import VascularTerritoriesWidget
+
+    widget = VascularTerritoriesWidget()
+    widget.setup()
+    qt_widgets.append(widget)
+    for event, handler in (
+        (_slicer.mrmlScene.StartCloseEvent, widget.onSceneStartClose),
+        (_slicer.mrmlScene.EndCloseEvent, widget.onSceneEndClose),
+    ):
+        try:
+            widget.removeObserver(_slicer.mrmlScene, event, handler)
+        except Exception:  # noqa: BLE001 — best-effort across widget shapes
+            pass
+
+    displayNode = getattr(widget, "_highlightDisplayNode", None)
+    if displayNode is None:
+        pytest.skip(
+            "widget did not expose the shared display node handle (ADR-0027)."
+        )
+    table = getattr(widget, "_territoriesTable", None)
+    if table is None:
+        pytest.skip("composed TerritoriesTableWidget absent (ADR-0027).")
+    _require_five_column_layout_or_skip(table)
+    state = _import_interaction_state_or_skip()
+
+    widget.enter()
+
+    assert state.is_armed(displayNode) is False, (
+        "enter() must auto-arm nothing (ADR-0037 slice-4 module-active gate)."
+    )
+
+    widget.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_placemode.py
+++ b/VascularTerritories/Testing/Python/test_territories_placemode.py
@@ -1,25 +1,25 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
 
-"""ADR-0037 slice 4 — per-territory Place mode + module-active gate + table-UX polish.
+"""ADR-0037 slice 4 — per-territory Place mode + module-active gate + tree-UX polish.
 
 ADR-0037 §Decision 2 (placement/edit via the Pipeline seam) + §Decision 3
 (the table UI) — sharpened by the slice-4 amendment recording the place-mode
 UX.  Slice 4 makes placement an EXPLICIT, per-territory, exclusive arm toggle
-driven from the table (not an implicit "Add Territory arms it and never
-disarms"), gates arming on the module being active, and polishes the table to
+driven from the tree (not an implicit "Add Territory arms it and never
+disarms"), gates arming on the module being active, and polishes the panel to
 the Slicer-idiomatic eye-icon visibility toggle.
 
 The confirmed slice-4 design (maintainer-LOCKED this session), each pinned
 below:
 
-1.  PER-TERRITORY EXCLUSIVE PLACE TOGGLE.  Each territory HEADER row gets a
-    checkable "Place" button in a NEW leftmost column.  The 5-column layout
-    becomes ``Place | Visibility | Colour | Label | Status``.  Toggling ON
-    arms placement into THAT territory (``set_active_territory`` +
+1.  PER-TERRITORY EXCLUSIVE PLACE TOGGLE.  Each territory TOP-LEVEL item gets a
+    checkable "Place" button in the leftmost column.  The 5-column layout is
+    ``Place | Visibility | Colour | Label | Status``.  Toggling ON arms
+    placement into THAT territory (``set_active_territory`` +
     ``set_armed(True)`` + the highlight visible via ``TerritoryInteractionState``)
-    and un-checks EVERY other row's toggle (EXCLUSIVE — one territory armed at
-    a time); toggling OFF disarms.  The armed row's checked state is
+    and un-checks EVERY other territory's toggle (EXCLUSIVE — one territory
+    armed at a time); toggling OFF disarms.  The armed item's checked state is
     RE-DERIVED from the display node on each rebuild
     (``checked = is_armed(dn) and get_active_territory(dn) == territoryId``),
     NOT stored in a Python field, so it survives the carrier-Modified rebuild.
@@ -35,39 +35,59 @@ below:
     ``qt.QToolButton`` (NOT a ``QCheckBox``) toggling
     ``carrier.SetTerritoryVisibility``.
 
-4.  HIERARCHICAL CHILD ROWS ON PLACEMENT.  Placing a seed into the armed
+4.  HIERARCHICAL CHILD ITEMS ON PLACEMENT.  Placing a seed into the armed
     territory (carrier ``AddAnnotationPoint`` / a click through the
-    display-node-wired pipeline) adds EXACTLY ONE child row under that
-    territory's header on the next rebuild, in the right columns of the
+    display-node-wired pipeline) adds EXACTLY ONE child item under that
+    territory's top-level item on the next rebuild, in the right columns of the
     5-column layout.
 
-5.  PANEL BUTTONS.  ``Add Territory`` mints a new empty territory row AND arms
+5.  PANEL BUTTONS.  ``Add Territory`` mints a new empty territory item AND arms
     it (its Place toggle reads checked after rebuild).  ``Add seeds`` + ``Done``
     panel buttons are RETIRED (absent).  The ``done()`` disarm logic survives
     as the shared body reused by ``exit()`` + toggle-OFF.
 
 6.  COLOUR CELL guard.  The colour cell is a ``ctkColorPickerButton``
-    (committed in slice 2/3); a light guard that the 5-column shift does not
+    (committed in slice 2/3); a light guard that the tree rewrite does not
     regress it (``colorChanged`` -> ``setTerritoryColor``).
+
+-- THE TREE (two-level hierarchy) --
+
+The panel composes a ``qt.QTreeWidget``: territories are TOP-LEVEL items,
+seed points are CHILD items nested under their territory (disclosure triangle
++ indentation, a genuine two-level hierarchy — unlike the flat ADR-0034
+segments table).  The 5-column layout is UNCHANGED
+(``Place | Visibility | Colour | Label | Status``, ``columnCount == 5``); what
+changes from the retired flat table is navigation — flat rows become tree
+items, addressed via the item-based reader seams below.
+
+* TERRITORY (top-level) item: the Place / Visibility / Colour cell widgets in
+  cols 0/1/2 (``tree.itemWidget(item, col)``), the editable label text in col 3
+  (``item.text(3)``), and the status glyph+text in col 4.
+* SEED (child) item: nested under its territory's top-level item.  The seed
+  status TEXT lives in the Label column (``item.text(3)``, aligning under the
+  territory label); the DELETE affordance is a cell widget in col 4
+  (``tree.itemWidget(item, 4)``); cols 0/1/2 carry NO widget and NO text (the
+  tree indentation in col 0 conveys the hierarchy).
 
 -- BARE vs LAUNCHED --
 
 The Place-toggle EXCLUSIVITY / re-derivation logic can be driven purely
-through the table + a display node (no GL, no pipeline event dispatch), so
+through the tree + a display node (no GL, no pipeline event dispatch), so
 those RUN launched where the wrapped display node is reachable, and SKIP
 cleanly bare (no Qt, no wrapped node).  The exit()-disarms-a-click and
-click-adds-a-child-row invariants need a REAL pipeline bound to the SAME
-display node the table writes (the detached-instance contract), so they are
+click-adds-a-child-item invariants need a REAL pipeline bound to the SAME
+display node the tree writes (the detached-instance contract), so they are
 LAUNCHED, pipeline wired via the display node.  Every test SKIPS cleanly bare
 via the shared ``conftest`` guards.
 
 -- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
 
-Pre-implementation the Place column / eye-icon toggle / exit-disarm /
-child-row-on-placement do not exist, so the ``hasattr`` / column-shape guards
-skip-pend; the skips lift at the slice-4 implementation commit.  Under a
-launched Slicer, verify run-vs-skip in the CI log once the seam lands — never
-trust overall green (the launched harness is green-but-skipping prone).
+Pre-implementation the tree seam / Place column / eye-icon toggle /
+exit-disarm / child-item-on-placement do not exist, so the ``tree()`` /
+column-shape / ``hasattr`` guards skip-pend; the skips lift at the slice-4
+tree rewrite commit.  Under a launched Slicer, verify run-vs-skip in the CI
+log once the seam lands — never trust overall green (the launched harness is
+green-but-skipping prone).
 
 See also:
   * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 2 / §3)
@@ -108,18 +128,18 @@ DISPLAY_METHODS = (
 # ---------------------------------------------------------------------------
 # THE 5-COLUMN CONTRACT the implementer MUST honour (slice 4).
 #
-# The Place column is inserted LEFTMOST; every downstream column shifts right
-# by one.  The old 4-column layout was:
-#     [Visibility=0 | Colour=1 | Label=2 | Status=3]  (_COLUMN_COUNT == 4)
-# The slice-4 layout is:
-#     [Place=0 | Visibility=1 | Colour=2 | Label=3 | Status=4]  (== 5)
+# The 5-column layout is UNCHANGED from the retired flat table; the tree
+# rewrite changes only navigation (flat rows -> tree items).  A QTreeWidget
+# has columns too:
+#     [Place=0 | Visibility=1 | Colour=2 | Label=3 | Status=4]  (columnCount == 5)
 #
-# ``_appendChildRow`` must move with the shift: the child-row STATUS TEXT
-# (formerly in _COL_LABEL == 2) moves to the new label column (3), and the
-# child-row DELETE affordance (formerly in _COL_STATUS == 3) moves to the new
-# status column (4).  The Place + Visibility + Colour cells stay blank on a
-# child row.  These offsets are asserted below so the implementer's
-# ``_COL_*`` constants + ``_appendHeaderRow`` / ``_appendChildRow`` matches.
+# A TERRITORY (top-level) item carries the Place / Visibility / Colour cell
+# widgets in cols 0/1/2, the editable label text in col 3, the status text in
+# col 4.  A SEED (child) item carries its status TEXT in the Label column (3)
+# — aligning under the territory label — and the DELETE affordance as a cell
+# widget in the Status column (4); cols 0/1/2 stay blank (no widget, no text)
+# because the tree indentation in col 0 conveys the hierarchy.  These offsets
+# are asserted below so the implementer's ``_COL_*`` constants match.
 # ---------------------------------------------------------------------------
 EXPECTED_COLUMN_COUNT = 5
 EXPECTED_COL_PLACE = 0
@@ -195,7 +215,7 @@ def _import_interaction_state_or_skip():
 
 
 def _import_table_or_skip():
-    """Import the Stage-2 table widget class or skip-pend (ADR-0027)."""
+    """Import the tree widget class or skip-pend (ADR-0027)."""
     try:
         from VascularTerritoriesLib.TerritoriesTableWidget import (
             TerritoriesTableWidget,
@@ -203,8 +223,8 @@ def _import_table_or_skip():
     except Exception as exc:  # pragma: no cover - import-environment dependent
         pytest.skip(
             f"TerritoriesTableWidget not importable ({exc!r}) -- the ADR-0037 "
-            "table widget has not landed OR Qt/LayerDMLib is not reachable here "
-            "(ADR-0027)."
+            "territories widget has not landed OR Qt/LayerDMLib is not reachable "
+            "here (ADR-0027)."
         )
     return TerritoriesTableWidget
 
@@ -223,68 +243,70 @@ def _import_pipeline_or_skip():
 
 
 def _make_table_or_skip(slicer, carrier, displayNode):
-    """Construct the table over the carrier + shared display node, or skip-pend."""
+    """Construct the widget over the carrier + shared display node, or skip-pend."""
     TerritoriesTableWidget = _import_table_or_skip()
     try:
         table = TerritoriesTableWidget(carrier=carrier, displayNode=displayNode)
     except TypeError as exc:
         pytest.skip(
             f"TerritoriesTableWidget(carrier=, displayNode=) seam absent ({exc!r}) "
-            "-- the ADR-0037 table constructor has not landed (ADR-0027)."
+            "-- the ADR-0037 widget constructor has not landed (ADR-0027)."
         )
     return table
 
 
-def _require_table_row_model(table):
-    """Skip-pend unless the table exposes the row-model reader seams."""
-    for method in ("table", "isHeaderRow", "territoryOfRow", "pointIndexOfRow"):
+def _require_tree_model(table):
+    """Skip-pend unless the widget exposes the item-based tree reader seams."""
+    for method in ("tree", "territoryIds", "territoryItem", "seedItems"):
         if not hasattr(table, method):
             pytest.skip(
-                f"TerritoriesTableWidget has no {method} row-model seam -- "
-                "the ADR-0037 table has not landed (ADR-0027)."
+                f"TerritoriesTableWidget has no {method} tree seam -- the "
+                "ADR-0037 slice-4 QTreeWidget rewrite has not landed (ADR-0027)."
             )
 
 
-def _require_five_column_layout_or_skip(table):
-    """Skip-pend unless the table adopted the slice-4 5-column Place layout.
+def _require_tree_layout_or_skip(table):
+    """Skip-pend unless the widget adopted the slice-4 QTreeWidget 5-column layout.
 
-    The gate for every slice-4-shape assertion: while the pre-slice-4
-    4-column layout survives, the table has no Place column, so the tests
-    collect + SKIP-PENDING and RUN once the leftmost Place column lands
-    (ADR-0037 §Decision 2 slice-4 amendment; ADR-0027).
+    The gate for every slice-4 tree assertion: while the ``tree()`` seam is
+    absent OR the column count is not the 5-column
+    (``Place | Visibility | Colour | Label | Status``) layout, the tests
+    collect + SKIP-PENDING and RUN once the tree rewrite lands (ADR-0037
+    §Decision 2 slice-4 amendment; ADR-0027).
     """
-    widget = table.table()
-    if widget.columnCount != EXPECTED_COLUMN_COUNT:
+    if not hasattr(table, "tree"):
         pytest.skip(
-            f"table has {widget.columnCount} columns, not the slice-4 "
+            "TerritoriesTableWidget has no tree() seam -- the ADR-0037 slice-4 "
+            "QTreeWidget rewrite has not landed (ADR-0027)."
+        )
+    tree = table.tree()
+    if tree.columnCount != EXPECTED_COLUMN_COUNT:
+        pytest.skip(
+            f"tree has {tree.columnCount} columns, not the slice-4 "
             f"{EXPECTED_COLUMN_COUNT} (Place | Visibility | Colour | Label | "
             "Status) -- the per-territory Place column has not landed (ADR-0027)."
         )
 
 
-def _place_cell_or_skip(table, row):
-    """Return the header row's Place toggle widget, or skip-pend.
+def _place_cell_or_skip(table, territoryId):
+    """Return the territory item's Place toggle widget, or skip-pend.
 
     Skips while the Place column is absent so the toggle-behaviour tests
     remain collectible pre-implementation.
     """
-    widget = table.table()
-    cell = widget.cellWidget(row, EXPECTED_COL_PLACE)
+    item = table.territoryItem(territoryId)
+    if item is None:
+        pytest.skip(
+            f"no top-level tree item for {territoryId!r} -- the ADR-0037 slice-4 "
+            "QTreeWidget rewrite has not landed (ADR-0027)."
+        )
+    cell = table.tree().itemWidget(item, EXPECTED_COL_PLACE)
     if cell is None:
         pytest.skip(
-            "no Place-toggle cell widget on the header row -- the ADR-0037 "
+            "no Place-toggle cell widget on the territory item -- the ADR-0037 "
             "slice-4 per-territory Place toggle has not landed (ADR-0027)."
         )
     return cell
-
-
-def _header_row_for(table, territoryId):
-    """The header-row index for ``territoryId`` (raises if absent)."""
-    return next(
-        r
-        for r in range(table.table().rowCount)
-        if table.isHeaderRow(r) and table.territoryOfRow(r) == territoryId
-    )
 
 
 # --------------------------------------------------------------------------- #
@@ -337,7 +359,7 @@ def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monke
     """Bind a REAL pipeline to the SHARED display node so it reads live state.
 
     The detached-instance contract: the pipeline resolves its carrier / active
-    territory / arm flag from the display node the TABLE writes to, NOT from a
+    territory / arm flag from the display node the TREE writes to, NOT from a
     hand-armed detached instance.  A stub renderer + injected pick core keep
     the click GL-free.  (Same helper shape as test_territories_table.py.)
     """
@@ -363,12 +385,13 @@ def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monke
 # ===========================================================================
 
 
-def test_table_has_five_columns_with_place_leftmost(qt_widgets):
-    """The table adopts the slice-4 5-column layout, Place leftmost.
+def test_tree_has_five_columns_with_place_leftmost(qt_widgets):
+    """The tree adopts the slice-4 5-column layout, Place leftmost.
 
-    ADR-0037 §Decision 2 (slice-4 amendment): the columns become
-    ``Place | Visibility | Colour | Label | Status``.  The Place column is
-    inserted LEFTMOST (index 0); the downstream columns shift right by one.
+    ADR-0037 §Decision 2 (slice-4 amendment): the columns are
+    ``Place | Visibility | Colour | Label | Status`` on the ``QTreeWidget``.
+    The Place column is the leftmost (index 0); the layout is unchanged from
+    the retired flat table save for the flat-rows -> tree-items navigation.
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -376,23 +399,25 @@ def test_table_has_five_columns_with_place_leftmost(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
 
     # TODO(slice-4 implementer): the invariant body below is authoritative once
-    # the Place column lands; it is unreachable while the guard skip-pends.
-    assert table.table().columnCount == EXPECTED_COLUMN_COUNT
+    # the tree rewrite lands; it is unreachable while the guard skip-pends.
+    assert table.tree().columnCount == EXPECTED_COLUMN_COUNT
 
 
-def test_child_row_status_and_delete_shift_into_the_five_column_offsets(qt_widgets):
-    """Child rows render in the shifted 5-column offsets (the column contract).
+def test_seed_child_item_carries_status_at_label_and_delete_at_status(qt_widgets):
+    """A seed CHILD item renders in the shifted 5-column offsets (the column contract).
 
-    ADR-0037 §Decision 2 (slice-4): with the leftmost Place column inserted,
-    ``_appendChildRow`` must move — the seed STATUS TEXT into the label column
-    (index ``EXPECTED_COL_LABEL == 3``) and the DELETE affordance into the
-    status column (index ``EXPECTED_COL_STATUS == 4``); Place / Visibility /
-    Colour stay blank on a child row.  This pins the exact offsets the
-    implementer's ``_appendChildRow`` must honour.
+    ADR-0037 §Decision 2 (slice-4): a seed is a CHILD item nested under its
+    territory's top-level item.  Its status TEXT lives in the Label column
+    (index ``EXPECTED_COL_LABEL == 3``, aligning under the territory label) and
+    its DELETE affordance is a cell widget in the Status column (index
+    ``EXPECTED_COL_STATUS == 4``); cols 0/1/2 (Place / Visibility / Colour) stay
+    blank — no widget and no text — because the tree indentation in col 0
+    conveys the hierarchy.  This pins the exact offsets the implementer's seed
+    child-item construction must honour.
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -400,32 +425,40 @@ def test_child_row_status_and_delete_shift_into_the_five_column_offsets(qt_widge
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
 
     for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]:
         carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
     carrier.Modified()
 
-    widget = table.table()
-    child_row = next(r for r in range(widget.rowCount) if not table.isHeaderRow(r))
+    tree = table.tree()
+    seeds = table.seedItems(TERRITORY_A)
+    assert len(seeds) >= 1, "the armed territory must carry at least one seed child item."
+    seed = seeds[0]
 
-    # Status TEXT lives in the label column (index 3) — a QTableWidgetItem.
-    label_item = widget.item(child_row, EXPECTED_COL_LABEL)
-    assert label_item is not None and label_item.text().strip() != "", (
-        "child-row status text must live in the shifted label column "
+    # The seed is genuinely a CHILD of its territory's top-level item.
+    territory_item = table.territoryItem(TERRITORY_A)
+    assert territory_item is not None
+    assert seed.parent() is territory_item, (
+        "a seed must be a CHILD item nested under its territory's top-level item."
+    )
+
+    # Status TEXT lives in the Label column (index 3).
+    assert seed.text(EXPECTED_COL_LABEL).strip() != "", (
+        "the seed's status text must live in the Label column "
         f"(index {EXPECTED_COL_LABEL})."
     )
-    # Delete affordance lives in the status column (index 4) — a cell widget.
-    delete_cell = widget.cellWidget(child_row, EXPECTED_COL_STATUS)
+    # Delete affordance lives in the Status column (index 4) — a cell widget.
+    delete_cell = tree.itemWidget(seed, EXPECTED_COL_STATUS)
     assert delete_cell is not None, (
-        "child-row delete affordance must live in the shifted status column "
+        "the seed's delete affordance must live in the Status column "
         f"(index {EXPECTED_COL_STATUS})."
     )
-    # Place / Visibility / Colour stay blank on a child row.
+    # Place / Visibility / Colour stay blank on a seed child item.
     for col in (EXPECTED_COL_PLACE, EXPECTED_COL_VISIBILITY, EXPECTED_COL_COLOUR):
-        assert widget.cellWidget(child_row, col) is None and widget.item(child_row, col) is None, (
-            f"child-row column {col} must be blank in the 5-column layout."
+        assert tree.itemWidget(seed, col) is None and seed.text(col) == "", (
+            f"seed child column {col} must be blank in the 5-column tree layout."
         )
 
 
@@ -437,11 +470,11 @@ def test_child_row_status_and_delete_shift_into_the_five_column_offsets(qt_widge
 def test_place_toggle_arms_its_territory_on_the_display_node(qt_widgets):
     """Toggling a Place button ON arms THAT territory on the display node.
 
-    ADR-0037 §Decision 2 (slice-4): the header's Place toggle writes
+    ADR-0037 §Decision 2 (slice-4): the territory item's Place toggle writes
     ``set_active_territory`` + ``set_armed(True)`` onto the SHARED display node
     (``TerritoryInteractionState``) and makes the highlight visible.  [launched
     where the wrapped display node is reachable; the toggle logic is driven via
-    the table + display node, no pipeline dispatch needed.]
+    the tree + display node, no pipeline dispatch needed.]
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -450,14 +483,13 @@ def test_place_toggle_arms_its_territory_on_the_display_node(qt_widgets):
     state = _import_interaction_state_or_skip()
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory = table.addTerritory()
-    header = _header_row_for(table, territory)
-    place = _place_cell_or_skip(table, header)
+    place = _place_cell_or_skip(table, territory)
 
     place.setChecked(True)
 
@@ -476,8 +508,8 @@ def test_place_toggle_is_exclusive_arm_b_unchecks_a(qt_widgets):
     """Arming territory B un-arms A (EXCLUSIVE — one territory armed at a time).
 
     ADR-0037 §Decision 2 (slice-4): toggling one Place button ON un-checks
-    every other row's toggle and re-points the display node's ACTIVE territory
-    at B.  [launched; toggle logic driven via the table + display node.]
+    every other territory's toggle and re-points the display node's ACTIVE
+    territory at B.  [launched; toggle logic driven via the tree + display node.]
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -486,27 +518,27 @@ def test_place_toggle_is_exclusive_arm_b_unchecks_a(qt_widgets):
     state = _import_interaction_state_or_skip()
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory_a = table.addTerritory()
     territory_b = table.addTerritory()
 
-    place_a = _place_cell_or_skip(table, _header_row_for(table, territory_a))
+    place_a = _place_cell_or_skip(table, territory_a)
     place_a.setChecked(True)
     assert state.get_active_territory(displayNode) == territory_a
 
-    place_b = _place_cell_or_skip(table, _header_row_for(table, territory_b))
+    place_b = _place_cell_or_skip(table, territory_b)
     place_b.setChecked(True)
 
     assert state.get_active_territory(displayNode) == territory_b, (
         "arming B must re-point the ACTIVE territory at B."
     )
     # A's toggle must have been un-checked (exclusivity) — re-read from the
-    # rebuilt row (the checked state is display-node-derived, not stored).
-    place_a_after = _place_cell_or_skip(table, _header_row_for(table, territory_a))
+    # rebuilt item (the checked state is display-node-derived, not stored).
+    place_a_after = _place_cell_or_skip(table, territory_a)
     assert place_a_after.isChecked() is False, (
         "arming B must un-check A's Place toggle (EXCLUSIVE arming)."
     )
@@ -517,7 +549,7 @@ def test_place_toggle_off_disarms(qt_widgets):
 
     ADR-0037 §Decision 2 (slice-4): toggling OFF clears the display node's
     armed flag (reusing the shared ``done()`` disarm body).  [launched; toggle
-    logic driven via the table + display node.]
+    logic driven via the tree + display node.]
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -526,17 +558,17 @@ def test_place_toggle_off_disarms(qt_widgets):
     state = _import_interaction_state_or_skip()
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory = table.addTerritory()
-    place = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place = _place_cell_or_skip(table, territory)
     place.setChecked(True)
     assert state.is_armed(displayNode) is True
 
-    place_after = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place_after = _place_cell_or_skip(table, territory)
     place_after.setChecked(False)
 
     assert state.is_armed(displayNode) is False, (
@@ -545,7 +577,7 @@ def test_place_toggle_off_disarms(qt_widgets):
 
 
 def test_checked_state_rederived_from_display_node_on_rebuild(qt_widgets):
-    """The armed row's checked state survives a carrier-Modified rebuild.
+    """The armed item's checked state survives a carrier-Modified rebuild.
 
     ADR-0037 §Decision 2 (slice-4): ``checked = is_armed(dn) and
     get_active_territory(dn) == territoryId`` is RE-DERIVED on each rebuild,
@@ -560,22 +592,22 @@ def test_checked_state_rederived_from_display_node_on_rebuild(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory_a = table.addTerritory()
     territory_b = table.addTerritory()
-    place_a = _place_cell_or_skip(table, _header_row_for(table, territory_a))
+    place_a = _place_cell_or_skip(table, territory_a)
     place_a.setChecked(True)
 
     # Force a full rebuild by adding a seed to the OTHER territory.
     carrier.AddAnnotationPoint(territory_b, 1.0, 0.0, 0.0)
     carrier.Modified()
 
-    place_a_after = _place_cell_or_skip(table, _header_row_for(table, territory_a))
-    place_b_after = _place_cell_or_skip(table, _header_row_for(table, territory_b))
+    place_a_after = _place_cell_or_skip(table, territory_a)
+    place_b_after = _place_cell_or_skip(table, territory_b)
     assert place_a_after.isChecked() is True, (
         "the armed territory's Place toggle must stay checked across a rebuild "
         "(checked state re-derived from the display node, not stored)."
@@ -606,15 +638,16 @@ def test_visibility_cell_is_eye_icon_tool_button_not_checkbox(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory = table.addTerritory()
-    header = _header_row_for(table, territory)
-    cell = table.table().cellWidget(header, EXPECTED_COL_VISIBILITY)
-    assert cell is not None, "the header row must carry a visibility cell widget."
+    item = table.territoryItem(territory)
+    assert item is not None, "the armed territory must have a top-level tree item."
+    cell = table.tree().itemWidget(item, EXPECTED_COL_VISIBILITY)
+    assert cell is not None, "the territory item must carry a visibility cell widget."
 
     assert isinstance(cell, qt.QToolButton), (
         "the visibility cell must be an eye-icon QToolButton (segmentation "
@@ -640,11 +673,11 @@ def test_visibility_cell_is_eye_icon_tool_button_not_checkbox(qt_widgets):
 
 
 def test_colour_cell_stays_ctk_color_picker_button(qt_widgets):
-    """The colour cell survives the 5-column shift as a ``ctkColorPickerButton``.
+    """The colour cell survives the tree rewrite as a ``ctkColorPickerButton``.
 
     ADR-0037 §Decision 3 (already committed): the colour swatch is a
     ``ctkColorPickerButton`` emitting ``colorChanged`` -> ``setTerritoryColor``.
-    A light regression guard that the leftmost-Place-column shift does not turn
+    A light regression guard that the flat-table -> tree rewrite does not turn
     it back into a bare swatch.  [launched.]
     """
     import ctk
@@ -655,18 +688,19 @@ def test_colour_cell_stays_ctk_color_picker_button(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory = table.addTerritory()
-    header = _header_row_for(table, territory)
-    cell = table.table().cellWidget(header, EXPECTED_COL_COLOUR)
-    assert cell is not None, "the header row must carry a colour cell widget."
+    item = table.territoryItem(territory)
+    assert item is not None, "the armed territory must have a top-level tree item."
+    cell = table.tree().itemWidget(item, EXPECTED_COL_COLOUR)
+    assert cell is not None, "the territory item must carry a colour cell widget."
     assert isinstance(cell, ctk.ctkColorPickerButton), (
-        "the colour cell must stay a ctkColorPickerButton after the 5-column "
-        "shift (ADR-0037 §Decision 3)."
+        "the colour cell must stay a ctkColorPickerButton after the tree "
+        "rewrite (ADR-0037 §Decision 3)."
     )
 
     # colorChanged -> setTerritoryColor: the emitted signal writes the carrier.
@@ -689,9 +723,9 @@ def test_add_territory_mints_and_arms_its_toggle_reads_checked_after_rebuild(qt_
     """``Add Territory`` mints a territory AND arms it; its Place toggle checks.
 
     ADR-0037 §Decision 2 (slice-4): "Add Territory" mints a new empty territory
-    row and arms it — after the rebuild that follows, that row's Place toggle
-    reads checked (the checked state re-derived from the display node).
-    [launched or bare where the display node is reachable.]
+    top-level item and arms it — after the rebuild that follows, that item's
+    Place toggle reads checked (the checked state re-derived from the display
+    node).  [launched or bare where the display node is reachable.]
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -700,8 +734,8 @@ def test_add_territory_mints_and_arms_its_toggle_reads_checked_after_rebuild(qt_
     state = _import_interaction_state_or_skip()
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
@@ -709,7 +743,7 @@ def test_add_territory_mints_and_arms_its_toggle_reads_checked_after_rebuild(qt_
 
     assert state.is_armed(displayNode) is True, "Add Territory must arm placement."
     assert state.get_active_territory(displayNode) == territory
-    place = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place = _place_cell_or_skip(table, territory)
     assert place.isChecked() is True, (
         "the minted territory's Place toggle must read checked after rebuild."
     )
@@ -730,8 +764,8 @@ def test_add_seeds_and_done_panel_buttons_retired(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
 
     # The retired panel buttons must not survive as private attributes ...
     for attr in ("_addSeedsButton", "_doneButton"):
@@ -758,17 +792,17 @@ def test_add_seeds_and_done_panel_buttons_retired(qt_widgets):
 
 # ===========================================================================
 # Invariant 4 — a click while armed places into THAT territory + adds one child
-# row.  [launched, pipeline wired via the display node.]
+# item.  [launched, pipeline wired via the display node.]
 # ===========================================================================
 
 
-def test_click_while_armed_places_into_territory_and_adds_one_child_row(qt_widgets, monkeypatch):
-    """An armed click appends one seed AND yields exactly one new child row.
+def test_click_while_armed_places_into_territory_and_adds_one_child_item(qt_widgets, monkeypatch):
+    """An armed click appends one seed AND yields exactly one new child item.
 
     ADR-0037 §Decision 2/3 (slice-4 invariant 4): with a territory armed via
     its Place toggle, a click through the display-node-wired pipeline adds one
     surface-snapped point to the carrier AND — on the carrier-Modified rebuild
-    — exactly one CHILD ROW appears under that territory's header (the
+    — exactly one CHILD ITEM appears under that territory's top-level item (the
     maintainer-reported "no child rows" symptom, pinned).  [launched, pipeline
     wired via the display node.]
     """
@@ -780,24 +814,16 @@ def test_click_while_armed_places_into_territory_and_adds_one_child_row(qt_widge
     _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     territory = table.addTerritory()
-    place = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place = _place_cell_or_skip(table, territory)
     place.setChecked(True)  # arm via the Place toggle (writes the display node)
 
-    def _child_rows_for(territoryId):
-        w = table.table()
-        return [
-            r
-            for r in range(w.rowCount)
-            if not table.isHeaderRow(r) and table.territoryOfRow(r) == territoryId
-        ]
-
-    before_rows = len(_child_rows_for(territory))
+    before_children = len(table.seedItems(territory))
     before_points = carrier.GetNumberOfAnnotationPoints(territory)
 
     assert pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent)) is True
@@ -805,19 +831,22 @@ def test_click_while_armed_places_into_territory_and_adds_one_child_row(qt_widge
     assert carrier.GetNumberOfAnnotationPoints(territory) == before_points + 1, (
         "an armed click must append EXACTLY ONE seed to the ACTIVE territory."
     )
-    after_rows = _child_rows_for(territory)
-    assert len(after_rows) == before_rows + 1, (
-        "an armed click must add EXACTLY ONE child row under the armed "
-        "territory's header (ADR-0037 slice-4 invariant 4)."
+    after_children = table.seedItems(territory)
+    assert len(after_children) == before_children + 1, (
+        "an armed click must add EXACTLY ONE child item under the armed "
+        "territory's top-level item (ADR-0037 slice-4 invariant 4)."
     )
-    # The new child row renders in the shifted 5-column offsets.
-    child_row = after_rows[-1]
-    widget = table.table()
-    assert widget.item(child_row, EXPECTED_COL_LABEL) is not None, (
-        "the new child row's status text must land in the label column (index 3)."
+    # The new child item renders in the shifted 5-column offsets.
+    seed = after_children[-1]
+    tree = table.tree()
+    assert seed.parent() is table.territoryItem(territory), (
+        "the new seed must be a child of the armed territory's top-level item."
     )
-    assert widget.cellWidget(child_row, EXPECTED_COL_STATUS) is not None, (
-        "the new child row's delete affordance must land in the status column "
+    assert seed.text(EXPECTED_COL_LABEL).strip() != "", (
+        "the new seed's status text must land in the Label column (index 3)."
+    )
+    assert tree.itemWidget(seed, EXPECTED_COL_STATUS) is not None, (
+        "the new seed's delete affordance must land in the Status column "
         "(index 4)."
     )
 
@@ -862,8 +891,8 @@ def test_exit_disarms_and_a_later_click_places_nothing(qt_widgets, monkeypatch):
             "composed TerritoriesTableWidget absent -- LayerDMLib / the wrapped "
             "carrier is off the launched path (ADR-0027)."
         )
-    _require_table_row_model(table)
-    _require_five_column_layout_or_skip(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
     displayNode = getattr(widget, "_highlightDisplayNode", None)
     carrier = getattr(widget, "_annotationCarrier", None)
     if displayNode is None or carrier is None:
@@ -873,12 +902,12 @@ def test_exit_disarms_and_a_later_click_places_nothing(qt_widgets, monkeypatch):
         )
     state = _import_interaction_state_or_skip()
 
-    # Arm via the table's Place toggle, then bind a REAL pipeline to the SAME
-    # display node the widget/table write.
+    # Arm via the tree's Place toggle, then bind a REAL pipeline to the SAME
+    # display node the widget/tree write.
     if not hasattr(table, "addTerritory"):
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
     territory = table.addTerritory()
-    place = _place_cell_or_skip(table, _header_row_for(table, territory))
+    place = _place_cell_or_skip(table, territory)
     place.setChecked(True)
     assert state.is_armed(displayNode) is True
 
@@ -937,7 +966,7 @@ def test_enter_auto_arms_nothing(qt_widgets):
     table = getattr(widget, "_territoriesTable", None)
     if table is None:
         pytest.skip("composed TerritoriesTableWidget absent (ADR-0027).")
-    _require_five_column_layout_or_skip(table)
+    _require_tree_layout_or_skip(table)
     state = _import_interaction_state_or_skip()
 
     widget.enter()

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -1,23 +1,25 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
 
-"""ADR-0037 Stage-2 — the VascularTerritories annotation table UI.
+"""ADR-0037 Stage-2 — the VascularTerritories annotation tree UI.
 
 ADR-0037 §Decision 3 (§3 table) replaces the legacy
 ``inputSurfaceSelector`` / ``endPointsMarkupsSelector`` place-widget panel
-with a Python-composed custom ``QTableWidget`` (ADR-0004): a CUSTOM table,
-not a stock point-list view, because the surface-snap + territory-grouping
-contract has no stock fit (the same call ADR-0034 made against
+with a Python-composed custom tree (ADR-0004): a CUSTOM view, not a stock
+point-list view, because the surface-snap + territory-grouping contract has
+no stock fit (the same call ADR-0034 made against
 ``qMRMLSegmentsTableView``).
 
-The confirmed Stage-2 design (maintainer-approved this session) that these
+The confirmed design (maintainer-approved this session) that these
 invariants pin:
 
-* TABLE SHAPE.  Rows are PER-POINT, grouped under per-territory HEADER
-  rows.  Each territory has a header row (per-territory visibility, colour
-  swatch, label) and one CHILD row per seed point (on-surface status +
-  delete).
-* CARRIER IS THE MODEL.  The table reads/writes the Stage-1 annotation
+* TREE SHAPE (two-level hierarchy).  Territories are TOP-LEVEL items; seed
+  points are CHILD items nested under their territory (disclosure triangle +
+  indentation) — a genuine parent/child hierarchy, unlike the flat ADR-0034
+  segments table.  Each territory item carries per-territory visibility, a
+  colour swatch, and an editable label; each seed child item carries an
+  on-surface status + a delete affordance.
+* CARRIER IS THE MODEL.  The tree reads/writes the Stage-1 annotation
   carrier ``vtkMRMLCustomTerritoriesNode`` (points via ``AddAnnotationPoint``
   / ``GetNumberOfAnnotationPoints`` / ``GetNthAnnotationPoint`` /
   ``ClearAnnotationPoints``; the Stage-2 display slot via the per-territory
@@ -25,19 +27,19 @@ invariants pin:
   ``vtkCommand::ModifiedEvent`` and rebuilds; edits write back.
 * ARMING (pipeline-managed, NOT a Slicer mouse mode).  The arm state lives
   on the SHARED highlight DISPLAY NODE (``TerritoryInteractionState``): the
-  table WRITES arm / active-territory / carrier onto it, and the
+  tree WRITES arm / active-territory / carrier onto it, and the
   manager-driven placement Pipeline READS them back at event time — the
   widget cannot reach the manager-owned Pipeline instance directly, so the
   display node is the shared handle (the 3D-fix contract).  "Add Territory"
-  mints a new empty territory on the carrier, selects its row, makes it the
+  mints a new empty territory on the carrier, selects its item, makes it the
   ACTIVE territory, and arms placement; each surface click through the
   pipeline seam appends ONE seed to the ACTIVE territory (sequential,
-  unbounded).  "Done" / Esc disarms.  Selecting an existing row + "Add
-  seeds" re-arms into THAT territory.  The integration these tests pin: a
-  REAL ``TerritoryPlacementPipeline`` whose ``SetDisplayNode`` was called
-  with the SAME display node the table writes to routes the click into the
+  unbounded).  "Done" / Esc disarms.  Selecting an existing territory +
+  "Add seeds" re-arms into THAT territory.  The integration these tests pin:
+  a REAL ``TerritoryPlacementPipeline`` whose ``SetDisplayNode`` was called
+  with the SAME display node the tree writes to routes the click into the
   ACTIVE territory — the gap that let the detached-instance bug through.
-* DELETE CONVERGENCE.  Delete-by-row (table) and delete-by-pick (pipeline)
+* DELETE CONVERGENCE.  Delete-by-seed (tree) and delete-by-pick (pipeline)
   route through ONE carrier deletion path — a single point-removal
   implementation reached from both entry points.
 * SEED-COUNT COMPLETENESS.  A territory with < 2 seeds is flagged
@@ -52,34 +54,38 @@ invariants pin:
 
 -- SEAM THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
 
-A Python-widget-composed table, mirroring the Stage-2 segments-table
-paradigm (ADR-0034) but CUSTOM (ADR-0037 §Decision 3):
+A Python-widget-composed tree, mirroring the Stage-2 table paradigm
+(ADR-0034) but CUSTOM and HIERARCHICAL (ADR-0037 §Decision 3):
 
   * module path ``VascularTerritoriesLib.TerritoriesTableWidget``, class
     ``TerritoriesTableWidget`` (a composed ``qt.QWidget`` owning a
-    ``qt.QTableWidget``), constructed over the carrier + the SHARED
-    highlight display node:
+    ``qt.QTreeWidget``), constructed over the carrier + the SHARED highlight
+    display node:
       ``TerritoriesTableWidget(carrier=<vtkMRMLCustomTerritoriesNode>,
                                displayNode=<vtkMRMLTerritoriesHighlightDisplayNode>)``.
-  * ``table()`` -> the underlying ``qt.QTableWidget``;
-  * row model helpers: ``isHeaderRow(row) -> bool``,
-    ``territoryOfRow(row) -> str``, ``pointIndexOfRow(row) -> int | None``
-    (``None`` for a header row);
+  * ``tree()`` -> the underlying ``qt.QTreeWidget``;
+  * item-model helpers:
+      ``territoryIds() -> list[str]`` (top-level items, in order),
+      ``territoryItem(territoryId) -> QTreeWidgetItem`` (the top-level item),
+      ``seedItems(territoryId) -> list[QTreeWidgetItem]`` (child items, in
+      order);
   * ``addTerritory(territoryId=None) -> str`` — mint an empty territory,
-    select its header row, arm the pipeline into it;
+    select its item, arm the pipeline into it;
   * ``armForSelectedTerritory()`` — re-arm placement into the selected
-    row's territory ("Add seeds");
+    territory ("Add seeds");
+  * ``selectTerritoryRow(territoryId)`` — select a territory's top-level item;
   * ``done()`` — disarm;
-  * ``deleteRow(row)`` — the delete-from-table entry point, converging on
-    the carrier's ``RemoveNthAnnotationPoint`` (the SAME method the
-    pipeline's ``DeleteAnnotationPoint`` reaches);
-  * status-cell readers for the completeness assertion:
-    ``rowStatusText(row) -> str`` and ``rowHasIncompleteGlyph(row) -> bool``.
+  * ``deleteSeed(territoryId, pointIndex)`` — the delete-from-tree entry
+    point, converging on the carrier's ``RemoveNthAnnotationPoint`` (the SAME
+    method the pipeline's ``DeleteAnnotationPoint`` reaches);
+  * completeness readers on the territory item:
+    ``territoryStatusText(territoryId) -> str`` and
+    ``territoryHasIncompleteGlyph(territoryId) -> bool``.
 
 The arm state rides on the SHARED highlight DISPLAY NODE
 (``TerritoryInteractionState``: ``set_armed`` / ``is_armed`` /
 ``set_active_territory`` / ``get_active_territory`` / ``set_carrier`` /
-``get_carrier``), the handle both the table and the manager-driven Pipeline
+``get_carrier``), the handle both the tree and the manager-driven Pipeline
 hold.  The Pipeline reads them back via its ``IsArmed()`` /
 ``GetActiveTerritory()`` seam once ``SetDisplayNode`` binds the SAME node.
 "Add Territory" writes active-territory + armed onto the display node so a
@@ -87,7 +93,7 @@ click appends to the ACTIVE territory, not an implicit one.
 
 -- WHY LAUNCHED-SLICER --
 
-The table needs Qt (``qt.QTableWidget``) + the wrapped
+The tree needs Qt (``qt.QTreeWidget``) + the wrapped
 ``vtkMRMLCustomTerritoriesNode`` carrier + (for the arming tests) the
 LayerDM ``TerritoryPlacementPipeline``.  A bare ``PythonSlicer -m pytest``
 has ``slicer.mrmlScene is None``, no Qt, and LayerDMLib off the path, so
@@ -96,12 +102,12 @@ guards.
 
 -- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
 
-Pre-implementation the table widget + the carrier display slot + the
-Pipeline arm seam do not exist, so the import / ``hasattr`` guards
-skip-pend; the skips lift at the Stage-2 implementation commit.  Under a
-launched Slicer, verify run-vs-skip in the CI log once the seam lands —
-never trust overall green (the launched harness is green-but-skipping
-prone).
+Pre-implementation the tree widget + the carrier display slot + the
+Pipeline arm seam do not exist, so the import / ``tree()`` / ``hasattr``
+guards skip-pend; the skips lift at the tree-rewrite implementation commit.
+Under a launched Slicer, verify run-vs-skip in the CI log once the seam
+lands — never trust overall green (the launched harness is
+green-but-skipping prone).
 
 See also:
   * Docs/adr/0037-vascular-territories-off-markups.md  (the decision)
@@ -144,6 +150,15 @@ DISPLAY_METHODS = (
     "SetTerritoryVisibility",
     "GetTerritoryVisibility",
 )
+
+# The 5-column layout is UNCHANGED across the flat-table -> tree rewrite
+# (ADR-0037 §Decision 2 slice-4 amendment): a QTreeWidget has columns too.
+EXPECTED_COLUMN_COUNT = 5
+EXPECTED_COL_PLACE = 0
+EXPECTED_COL_VISIBILITY = 1
+EXPECTED_COL_COLOUR = 2
+EXPECTED_COL_LABEL = 3
+EXPECTED_COL_STATUS = 4
 
 
 # --------------------------------------------------------------------------- #
@@ -190,8 +205,8 @@ def _make_carrier_or_skip(slicer, name="TableCarrierTest"):
 def _make_display_node_or_skip(slicer, name="TableHighlightTest"):
     """Mint the shared highlight display node, or skip-pend (ADR-0027).
 
-    The display node is the shared handle both the table and the
-    manager-driven placement Pipeline hold: the table writes arm /
+    The display node is the shared handle both the tree and the
+    manager-driven placement Pipeline hold: the tree writes arm /
     active-territory / carrier onto it, the Pipeline reads them back.
     """
     node = slicer.mrmlScene.AddNewNodeByClass(HIGHLIGHT_DISPLAY_CLASS, name)
@@ -216,7 +231,7 @@ def _import_interaction_state_or_skip():
 
 
 def _import_table_or_skip():
-    """Import the Stage-2 table widget class or skip-pend (ADR-0027)."""
+    """Import the tree widget class or skip-pend (ADR-0027)."""
     try:
         from VascularTerritoriesLib.TerritoriesTableWidget import (
             TerritoriesTableWidget,
@@ -224,8 +239,8 @@ def _import_table_or_skip():
     except Exception as exc:  # pragma: no cover - import-environment dependent
         pytest.skip(
             f"TerritoriesTableWidget not importable ({exc!r}) -- the ADR-0037 "
-            "Stage-2 table widget has not landed OR Qt/LayerDMLib is not "
-            "reachable here.  The skip lifts at the Stage-2 implementation "
+            "territories widget has not landed OR Qt/LayerDMLib is not "
+            "reachable here.  The skip lifts at the tree-rewrite implementation "
             "commit (ADR-0027)."
         )
     return TerritoriesTableWidget
@@ -245,10 +260,10 @@ def _import_pipeline_or_skip():
 
 
 def _make_table_or_skip(slicer, carrier, displayNode):
-    """Construct the table over the carrier + shared display node.
+    """Construct the tree over the carrier + shared display node.
 
-    Skip-pends when the table constructor does not yet accept the
-    ``(carrier=, displayNode=)`` seam (the 3D-fix contract; Stage-2 not
+    Skip-pends when the widget constructor does not yet accept the
+    ``(carrier=, displayNode=)`` seam (the 3D-fix contract; tree rewrite not
     landed).
     """
     TerritoriesTableWidget = _import_table_or_skip()
@@ -257,19 +272,42 @@ def _make_table_or_skip(slicer, carrier, displayNode):
     except TypeError as exc:
         pytest.skip(
             f"TerritoriesTableWidget(carrier=, displayNode=) seam absent ({exc!r}) "
-            "-- the ADR-0037 Stage-2 table constructor has not landed (ADR-0027)."
+            "-- the ADR-0037 widget constructor has not landed (ADR-0027)."
         )
     return table
 
 
-def _require_table_row_model(table):
-    """Skip-pend unless the table exposes the row-model reader seams."""
-    for method in ("table", "isHeaderRow", "territoryOfRow", "pointIndexOfRow"):
+def _require_tree_model(table):
+    """Skip-pend unless the widget exposes the item-based tree reader seams."""
+    for method in ("tree", "territoryIds", "territoryItem", "seedItems"):
         if not hasattr(table, method):
             pytest.skip(
-                f"TerritoriesTableWidget has no {method} row-model seam -- "
-                "the ADR-0037 Stage-2 table has not landed (ADR-0027)."
+                f"TerritoriesTableWidget has no {method} tree seam -- the "
+                "ADR-0037 QTreeWidget rewrite has not landed (ADR-0027)."
             )
+
+
+def _require_tree_layout_or_skip(table):
+    """Skip-pend unless the widget adopted the QTreeWidget 5-column layout.
+
+    The gate for the tree-shape assertions: while the ``tree()`` seam is
+    absent OR the column count is not the 5-column
+    (``Place | Visibility | Colour | Label | Status``) layout, the tests
+    collect + SKIP-PENDING and RUN once the tree rewrite lands (ADR-0037
+    §Decision 2 slice-4 amendment; ADR-0027).
+    """
+    if not hasattr(table, "tree"):
+        pytest.skip(
+            "TerritoriesTableWidget has no tree() seam -- the ADR-0037 "
+            "QTreeWidget rewrite has not landed (ADR-0027)."
+        )
+    tree = table.tree()
+    if tree.columnCount != EXPECTED_COLUMN_COUNT:
+        pytest.skip(
+            f"tree has {tree.columnCount} columns, not the "
+            f"{EXPECTED_COLUMN_COUNT} (Place | Visibility | Colour | Label | "
+            "Status) -- the tree rewrite has not landed (ADR-0027)."
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -323,7 +361,7 @@ def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monke
 
     This is the integration the detached-instance bug slipped through: the
     pipeline resolves its carrier / active territory / arm flag from the
-    display node the TABLE writes to (``SetDisplayNode`` + the carrier bound
+    display node the TREE writes to (``SetDisplayNode`` + the carrier bound
     onto the display node via ``TerritoryInteractionState``), NOT from a
     hand-armed detached instance.  A stub renderer + injected pick core keep
     the click GL-free.
@@ -342,7 +380,7 @@ def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monke
     monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
     # Bind the carrier onto the SHARED display node, then hand the display
     # node to the pipeline: it now reads the SAME carrier + arm state the
-    # table writes.  SetDisplayNode resets the pick to force a re-resolve from
+    # tree writes.  SetDisplayNode resets the pick to force a re-resolve from
     # the node's pickSurface (production behaviour), so inject the unit-sphere
     # pick AFTER binding the display node.
     state.set_carrier(displayNode, carrier)
@@ -351,28 +389,29 @@ def _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monke
 
 
 def _require_arm_seam(pipeline):
-    """Skip-pend unless the Pipeline exposes the Stage-2 active-territory + arm seam."""
+    """Skip-pend unless the Pipeline exposes the active-territory + arm seam."""
     for method in ("SetActiveTerritory", "GetActiveTerritory", "Arm", "Disarm", "IsArmed"):
         if not hasattr(pipeline, method):
             pytest.skip(
                 f"TerritoryPlacementPipeline has no {method} -- the ADR-0037 "
-                "Stage-2 active-territory + arm seam has not landed.  A click "
-                "must append to the ACTIVE territory, not an implicit one "
+                "active-territory + arm seam has not landed.  A click must "
+                "append to the ACTIVE territory, not an implicit one "
                 "(§Decision 3 arming model; ADR-0027)."
             )
 
 
 # --------------------------------------------------------------------------- #
-# TABLE SHAPE — header row per territory + child row per seed
+# TREE SHAPE — top-level item per territory + child item per seed
 # --------------------------------------------------------------------------- #
 
 
-def test_table_builds_header_row_per_territory_and_child_row_per_point(qt_widgets):
-    """The table has one header row per territory + one child row per seed.
+def test_tree_builds_top_level_item_per_territory_and_child_item_per_point(qt_widgets):
+    """The tree has one top-level item per territory + one child item per seed.
 
-    ADR-0037 §Decision 3 / §3 table: rows are per-point, grouped under
-    per-territory header rows.  A carrier with two territories (2 + 3 seeds)
-    yields 2 header rows + 5 child rows, in territory order.
+    ADR-0037 §Decision 3 / §3 table: territories are TOP-LEVEL items, seed
+    points CHILD items nested under them.  A carrier with two territories
+    (2 + 3 seeds) yields 2 top-level items with 2 + 3 child items, in
+    territory order.
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -380,7 +419,8 @@ def test_table_builds_header_row_per_territory_and_child_row_per_point(qt_widget
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
 
     for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]:
         carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
@@ -388,26 +428,32 @@ def test_table_builds_header_row_per_territory_and_child_row_per_point(qt_widget
         carrier.AddAnnotationPoint(TERRITORY_B, x, y, z)
     carrier.Modified()
 
-    widget = table.table()
-    header_rows = [r for r in range(widget.rowCount) if table.isHeaderRow(r)]
-    child_rows = [r for r in range(widget.rowCount) if not table.isHeaderRow(r)]
+    tree = table.tree()
+    assert tree.topLevelItemCount == 2, "one top-level item per territory."
+    assert TERRITORY_A in table.territoryIds()
+    assert TERRITORY_B in table.territoryIds()
 
-    assert len(header_rows) == 2, "one header row per territory."
-    assert len(child_rows) == 5, "one child row per seed point across both territories."
-    # Every child row resolves to a real point index within its territory.
-    for r in child_rows:
-        territory = table.territoryOfRow(r)
-        idx = table.pointIndexOfRow(r)
-        assert idx is not None and 0 <= idx < carrier.GetNumberOfAnnotationPoints(territory)
+    # Each territory's child-item count matches its seed count, and each child
+    # is genuinely nested under its territory's top-level item.
+    for territory, expected in ((TERRITORY_A, 2), (TERRITORY_B, 3)):
+        parent = table.territoryItem(territory)
+        assert parent is not None
+        seeds = table.seedItems(territory)
+        assert len(seeds) == expected, f"one child item per seed for {territory}."
+        assert parent.childCount() == expected
+        for j, seed in enumerate(seeds):
+            assert seed.parent() is parent, "each seed must nest under its territory."
+            assert parent.child(j) is seed, "seedItems order must match child() order."
+        assert expected == carrier.GetNumberOfAnnotationPoints(territory)
 
 
-def test_carrier_modified_event_rebuilds_the_table(qt_widgets):
-    """A carrier ``ModifiedEvent`` triggers a table rebuild (the carrier is the model).
+def test_carrier_modified_event_rebuilds_the_tree(qt_widgets):
+    """A carrier ``ModifiedEvent`` triggers a tree rebuild (the carrier is the model).
 
-    ADR-0037 §Decision 3: the table OBSERVES the carrier's
+    ADR-0037 §Decision 3: the tree OBSERVES the carrier's
     ``vtkCommand::ModifiedEvent`` and rebuilds.  Adding a point to the
-    carrier (outside the table) grows the child-row count without an
-    explicit table refresh call.
+    carrier (outside the tree) grows the child-item count without an
+    explicit tree refresh call.
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -415,16 +461,17 @@ def test_carrier_modified_event_rebuilds_the_table(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
+    _require_tree_model(table)
+    _require_tree_layout_or_skip(table)
 
     carrier.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
-    before = sum(1 for r in range(table.table().rowCount) if not table.isHeaderRow(r))
+    before = len(table.seedItems(TERRITORY_A))
 
     carrier.AddAnnotationPoint(TERRITORY_A, 2.0, 0.0, 0.0)  # fires ModifiedEvent
 
-    after = sum(1 for r in range(table.table().rowCount) if not table.isHeaderRow(r))
+    after = len(table.seedItems(TERRITORY_A))
     assert after == before + 1, (
-        "a carrier ModifiedEvent must rebuild the table (child-row count grows "
+        "a carrier ModifiedEvent must rebuild the tree (child-item count grows "
         "with the seed count) -- the carrier is the model, no manual refresh."
     )
 
@@ -454,7 +501,7 @@ def test_arm_then_click_appends_one_seed_to_active_territory(qt_widgets, monkeyp
         pytest.skip("TerritoriesTableWidget has no addTerritory seam (ADR-0027).")
 
     active = table.addTerritory()  # mints + selects + arms into a new territory
-    # The table wrote arm + active onto the SHARED display node; the pipeline
+    # The tree wrote arm + active onto the SHARED display node; the pipeline
     # (bound to that SAME node via SetDisplayNode) reads them back — the
     # integration the detached-instance bug slipped through.
     assert pipeline.IsArmed() is True, (
@@ -493,7 +540,7 @@ def test_click_with_nothing_armed_appends_nothing(qt_widgets, monkeypatch):
     qt_widgets.append(table)
 
     # An ACTIVE territory is set (so the gate under test is the ARM flag, not a
-    # missing active territory); then the table's "Done" disarms via the
+    # missing active territory); then the tree's "Done" disarms via the
     # shared display node.
     pipeline.SetActiveTerritory(TERRITORY_A)
     table.done()
@@ -538,11 +585,11 @@ def test_bare_move_stays_declined_while_armed(qt_widgets, monkeypatch):
 
 
 def test_switching_active_territory_redirects_subsequent_clicks(qt_widgets, monkeypatch):
-    """Selecting a row + Add seeds redirects clicks to the newly ACTIVE territory.
+    """Selecting a territory + Add seeds redirects clicks to the newly ACTIVE one.
 
-    ADR-0037 §Decision 3: "Selecting an existing row + 'Add seeds' re-arms
-    into that territory."  After re-arming into territory B, a click lands in
-    B — not the previously active A.
+    ADR-0037 §Decision 3: "Selecting an existing territory + 'Add seeds'
+    re-arms into that territory."  After re-arming into territory B, a click
+    lands in B — not the previously active A.
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -553,7 +600,7 @@ def test_switching_active_territory_redirects_subsequent_clicks(qt_widgets, monk
     _require_arm_seam(pipeline)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
+    _require_tree_model(table)
     for seam in ("addTerritory", "armForSelectedTerritory", "selectTerritoryRow"):
         if not hasattr(table, seam):
             pytest.skip(
@@ -563,7 +610,7 @@ def test_switching_active_territory_redirects_subsequent_clicks(qt_widgets, monk
 
     territory_a = table.addTerritory()
     territory_b = table.addTerritory()
-    # Re-arm into A first, then switch back to B via the row selection.
+    # Re-arm into A first, then switch back to B via the item selection.
     table.selectTerritoryRow(territory_a)
     table.armForSelectedTerritory()
     assert pipeline.GetActiveTerritory() == territory_a
@@ -585,15 +632,15 @@ def test_switching_active_territory_redirects_subsequent_clicks(qt_widgets, monk
 
 
 # --------------------------------------------------------------------------- #
-# DELETE convergence — table + pipeline share one carrier deletion path
+# DELETE convergence — tree + pipeline share one carrier deletion path
 # --------------------------------------------------------------------------- #
 
 
-def test_delete_row_removes_exactly_one_point(qt_widgets):
-    """Delete-by-row removes EXACTLY ONE carrier point (§Decision 3 / §Decision 2).
+def test_delete_seed_removes_exactly_one_point(qt_widgets):
+    """Delete-by-seed removes EXACTLY ONE carrier point (§Decision 3 / §Decision 2).
 
-    Deleting a child row drops that one seed from the carrier; the count
-    falls by one and the survivors keep their order.
+    Deleting a seed child item drops that one seed from the carrier; the
+    count falls by one and the survivors keep their order.
     """
     slicer = _slicer_or_skip()
     _qt_or_skip()
@@ -601,34 +648,27 @@ def test_delete_row_removes_exactly_one_point(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    if not hasattr(table, "deleteRow"):
-        pytest.skip("TerritoriesTableWidget has no deleteRow seam (ADR-0027).")
+    _require_tree_model(table)
+    if not hasattr(table, "deleteSeed"):
+        pytest.skip("TerritoriesTableWidget has no deleteSeed seam (ADR-0027).")
 
     pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
     for x, y, z in pts:
         carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
     carrier.Modified()
 
-    # The child row for territory A, point index 1.
-    target_row = next(
-        r
-        for r in range(table.table().rowCount)
-        if not table.isHeaderRow(r)
-        and table.territoryOfRow(r) == TERRITORY_A
-        and table.pointIndexOfRow(r) == 1
-    )
-    table.deleteRow(target_row)
+    # Delete territory A, point index 1.
+    table.deleteSeed(TERRITORY_A, 1)
 
     assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == len(pts) - 1, (
-        "delete-by-row must remove EXACTLY ONE carrier point."
+        "delete-by-seed must remove EXACTLY ONE carrier point."
     )
     assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, 0)) == pytest.approx(pts[0], abs=1e-6)
     assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, 1)) == pytest.approx(pts[2], abs=1e-6)
 
 
-def test_delete_by_row_and_by_pick_share_one_carrier_path(qt_widgets):
-    """Delete-by-row and the pipeline's ``DeleteAnnotationPoint`` converge.
+def test_delete_by_seed_and_by_pick_share_one_carrier_path(qt_widgets):
+    """Delete-by-seed and the pipeline's ``DeleteAnnotationPoint`` converge.
 
     ADR-0037 §Decision 3 delete convergence: BOTH entry points route through
     ONE carrier deletion path.  Deleting index 1 via each entry point removes
@@ -646,15 +686,15 @@ def test_delete_by_row_and_by_pick_share_one_carrier_path(qt_widgets):
             "-- cannot pin delete convergence (ADR-0027)."
         )
     # The pipeline resolves its carrier from the SHARED display node (the same
-    # handle the table binds), so both delete entry points reach one carrier.
+    # handle the tree binds), so both delete entry points reach one carrier.
     state = _import_interaction_state_or_skip()
     state.set_carrier(displayNode, carrier)
     pipeline.SetDisplayNode(displayNode)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    if not hasattr(table, "deleteRow"):
-        pytest.skip("TerritoriesTableWidget has no deleteRow seam (ADR-0027).")
+    _require_tree_model(table)
+    if not hasattr(table, "deleteSeed"):
+        pytest.skip("TerritoriesTableWidget has no deleteSeed seam (ADR-0027).")
 
     # Seed two identical-shaped territories to delete-index-1 from each way.
     pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
@@ -671,15 +711,8 @@ def test_delete_by_row_and_by_pick_share_one_carrier_path(qt_widgets):
         for i in range(carrier.GetNumberOfAnnotationPoints(TERRITORY_B))
     ]
 
-    # Route 2: table delete-by-row on territory A, index 1.
-    target_row = next(
-        r
-        for r in range(table.table().rowCount)
-        if not table.isHeaderRow(r)
-        and table.territoryOfRow(r) == TERRITORY_A
-        and table.pointIndexOfRow(r) == 1
-    )
-    table.deleteRow(target_row)
+    # Route 2: tree delete-by-seed on territory A, index 1.
+    table.deleteSeed(TERRITORY_A, 1)
     a_after = [
         tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, i))
         for i in range(carrier.GetNumberOfAnnotationPoints(TERRITORY_A))
@@ -689,7 +722,7 @@ def test_delete_by_row_and_by_pick_share_one_carrier_path(qt_widgets):
     assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == len(pts) - 1
     assert carrier.GetNumberOfAnnotationPoints(TERRITORY_B) == len(pts) - 1
     assert a_after == pytest.approx(b_after, abs=1e-6), (
-        "delete-by-row and delete-by-pick must converge on one carrier path "
+        "delete-by-seed and delete-by-pick must converge on one carrier path "
         "(identical survivors) -- no divergent deletion routes."
     )
 
@@ -700,9 +733,9 @@ def test_delete_by_row_and_by_pick_share_one_carrier_path(qt_widgets):
 
 
 def test_visibility_colour_label_edits_leave_geometry_unchanged(qt_widgets):
-    """Header-row visibility / colour / label edits write the display slot only.
+    """Territory visibility / colour / label edits write the display slot only.
 
-    ADR-0037 §Decision 3: the header row carries per-territory visibility,
+    ADR-0037 §Decision 3: the territory item carries per-territory visibility,
     colour swatch, and label; editing them writes the carrier's display slot
     "without touching geometry" — the annotation-point count + coords stay
     byte-identical.
@@ -713,7 +746,7 @@ def test_visibility_colour_label_edits_leave_geometry_unchanged(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
+    _require_tree_model(table)
     for seam in ("setTerritoryVisibility", "setTerritoryColor", "setTerritoryLabel"):
         if not hasattr(table, seam):
             pytest.skip(
@@ -732,11 +765,11 @@ def test_visibility_colour_label_edits_leave_geometry_unchanged(qt_widgets):
 
     table.setTerritoryVisibility(TERRITORY_A, False)
     table.setTerritoryColor(TERRITORY_A, 0.3, 0.6, 0.9)
-    table.setTerritoryLabel(TERRITORY_A, "Renamed via table")
+    table.setTerritoryLabel(TERRITORY_A, "Renamed via tree")
 
     # The display slot took the edit ...
     assert bool(carrier.GetTerritoryVisibility(TERRITORY_A)) is False
-    assert carrier.GetTerritoryLabel(TERRITORY_A) == "Renamed via table"
+    assert carrier.GetTerritoryLabel(TERRITORY_A) == "Renamed via tree"
     color = carrier.GetTerritoryColor(TERRITORY_A)
     assert (color[0], color[1], color[2]) == pytest.approx((0.3, 0.6, 0.9), abs=1e-6)
 
@@ -769,8 +802,8 @@ def test_territory_with_fewer_than_two_seeds_is_flagged_incomplete(qt_widgets):
     displayNode = _make_display_node_or_skip(slicer)
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
-    _require_table_row_model(table)
-    for seam in ("rowStatusText", "rowHasIncompleteGlyph"):
+    _require_tree_model(table)
+    for seam in ("territoryStatusText", "territoryHasIncompleteGlyph"):
         if not hasattr(table, seam):
             pytest.skip(
                 f"TerritoriesTableWidget has no {seam} status seam -- cannot "
@@ -782,23 +815,14 @@ def test_territory_with_fewer_than_two_seeds_is_flagged_incomplete(qt_widgets):
         carrier.AddAnnotationPoint(TERRITORY_B, x, y, z)  # two seeds -> complete
     carrier.Modified()
 
-    header_a = next(
-        r for r in range(table.table().rowCount)
-        if table.isHeaderRow(r) and table.territoryOfRow(r) == TERRITORY_A
-    )
-    header_b = next(
-        r for r in range(table.table().rowCount)
-        if table.isHeaderRow(r) and table.territoryOfRow(r) == TERRITORY_B
-    )
-
     # Assert the GLYPH + TEXT indicator, never a colour.
-    assert table.rowHasIncompleteGlyph(header_a) is True, (
+    assert table.territoryHasIncompleteGlyph(TERRITORY_A) is True, (
         "a < 2-seed territory must carry an incomplete GLYPH (ADR-0010)."
     )
-    assert table.rowStatusText(header_a).strip() != "", (
+    assert table.territoryStatusText(TERRITORY_A).strip() != "", (
         "the incomplete state must also carry TEXT (ADR-0010, never colour alone)."
     )
-    assert table.rowHasIncompleteGlyph(header_b) is False, (
+    assert table.territoryHasIncompleteGlyph(TERRITORY_B) is False, (
         "a >= 2-seed territory must NOT be flagged incomplete."
     )
 
@@ -868,7 +892,7 @@ def test_no_endpoints_selector_and_no_persisted_fiducial(qt_widgets):
     """``endPointsMarkupsSelector`` is gone AND no fiducial is persisted.
 
     ADR-0037 §Consequences + §Conformance [review]: the markups-selector /
-    place-widget wiring retires, and the annotation/table path persists NO
+    place-widget wiring retires, and the annotation/tree path persists NO
     ``vtkMRMLMarkupsFiducialNode``.  Both have a credible creep-in path (a
     left-in selector; a fallback fiducial), so per the no-colour-of-the-sky
     discipline this narrow absence stays pinned.
@@ -898,11 +922,11 @@ def test_no_endpoints_selector_and_no_persisted_fiducial(qt_widgets):
             "retirement commit (ADR-0027)."
         )
 
-    # (2) no fiducial persisted by the annotation/table path.
+    # (2) no fiducial persisted by the annotation/tree path.
     fiducials = slicer.mrmlScene.GetNodesByClass("vtkMRMLMarkupsFiducialNode")
     count = fiducials.GetNumberOfItems() if fiducials is not None else 0
     assert count == 0, (
-        "the annotation/table path must persist NO vtkMRMLMarkupsFiducialNode "
+        "the annotation/tree path must persist NO vtkMRMLMarkupsFiducialNode "
         "(ADR-0037 §Conformance [review])."
     )
 

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -13,12 +13,17 @@ no stock fit (the same call ADR-0034 made against
 The confirmed design (maintainer-approved this session) that these
 invariants pin:
 
-* TREE SHAPE (two-level hierarchy).  Territories are TOP-LEVEL items; seed
-  points are CHILD items nested under their territory (disclosure triangle +
-  indentation) — a genuine parent/child hierarchy, unlike the flat ADR-0034
-  segments table.  Each territory item carries per-territory visibility, a
-  colour swatch, and an editable label; each seed child item carries an
-  on-surface status + a delete affordance.
+* TREE SHAPE (composite-row, two-level hierarchy).  The tree is SINGLE-COLUMN
+  with NO header row and NO visible column grid (``columnCount == 1``,
+  ``header().isHidden()``).  Territories are TOP-LEVEL items; seed points are
+  CHILD items nested under their territory (disclosure triangle + indentation)
+  — a genuine parent/child hierarchy, unlike the flat ADR-0034 segments table.
+  Each item carries ONE composite ``QWidget`` on column 0
+  (``tree.itemWidget(item, 0)``) holding the row's controls as a horizontal
+  STRIP, addressed by NAME (never by column).  A territory row carries a Place
+  toggle, an eye-icon visibility toggle, a colour button, an editable label,
+  and a status label; each seed child row carries an on-surface status label +
+  a delete button.
 * CARRIER IS THE MODEL.  The tree reads/writes the Stage-1 annotation
   carrier ``vtkMRMLCustomTerritoriesNode`` (points via ``AddAnnotationPoint``
   / ``GetNumberOfAnnotationPoints`` / ``GetNthAnnotationPoint`` /
@@ -69,6 +74,16 @@ A Python-widget-composed tree, mirroring the Stage-2 table paradigm
       ``territoryItem(territoryId) -> QTreeWidgetItem`` (the top-level item),
       ``seedItems(territoryId) -> list[QTreeWidgetItem]`` (child items, in
       order);
+  * composite sub-widget getters (controls addressed by NAME, never column):
+      ``territoryRowWidget(territoryId) -> QWidget``,
+      ``placeButton(territoryId) -> QToolButton`` (checkable),
+      ``visibilityButton(territoryId) -> QToolButton`` (checkable eye),
+      ``colourButton(territoryId) -> ctkColorPickerButton``,
+      ``territoryLabelEdit(territoryId) -> QLineEdit`` (editing writes
+      ``setTerritoryLabel``),
+      ``seedRowWidget(territoryId, pointIndex) -> QWidget``,
+      ``seedDeleteButton(territoryId, pointIndex) -> QToolButton``,
+      ``seedStatusText(territoryId, pointIndex) -> str``;
   * ``addTerritory(territoryId=None) -> str`` — mint an empty territory,
     select its item, arm the pipeline into it;
   * ``armForSelectedTerritory()`` — re-arm placement into the selected
@@ -102,12 +117,12 @@ guards.
 
 -- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
 
-Pre-implementation the tree widget + the carrier display slot + the
-Pipeline arm seam do not exist, so the import / ``tree()`` / ``hasattr``
-guards skip-pend; the skips lift at the tree-rewrite implementation commit.
-Under a launched Slicer, verify run-vs-skip in the CI log once the seam
-lands — never trust overall green (the launched harness is
-green-but-skipping prone).
+Pre-implementation the composite-row widget + the carrier display slot + the
+Pipeline arm seam do not exist, so the import / ``tree()`` / single-column /
+header-hidden / ``territoryRowWidget`` / ``placeButton`` / ``hasattr`` guards
+skip-pend; the skips lift at the composite-row implementation commit.  Under a
+launched Slicer, verify run-vs-skip in the CI log once the seam lands — never
+trust overall green (the launched harness is green-but-skipping prone).
 
 See also:
   * Docs/adr/0037-vascular-territories-off-markups.md  (the decision)
@@ -151,14 +166,12 @@ DISPLAY_METHODS = (
     "GetTerritoryVisibility",
 )
 
-# The 5-column layout is UNCHANGED across the flat-table -> tree rewrite
-# (ADR-0037 §Decision 2 slice-4 amendment): a QTreeWidget has columns too.
-EXPECTED_COLUMN_COUNT = 5
-EXPECTED_COL_PLACE = 0
-EXPECTED_COL_VISIBILITY = 1
-EXPECTED_COL_COLOUR = 2
-EXPECTED_COL_LABEL = 3
-EXPECTED_COL_STATUS = 4
+# The columns + header row are DROPPED (ADR-0037 §Decision 2 slice-4
+# amendment): the tree is SINGLE-COLUMN with a hidden header, each item
+# carrying ONE composite QWidget on column 0.  Controls are addressed by NAME
+# through the composite getters, never by column index.
+EXPECTED_COLUMN_COUNT = 1  # single-column tree; the composite row lives on col 0
+COMPOSITE_COLUMN = 0
 
 
 # --------------------------------------------------------------------------- #
@@ -287,27 +300,40 @@ def _require_tree_model(table):
             )
 
 
-def _require_tree_layout_or_skip(table):
-    """Skip-pend unless the widget adopted the QTreeWidget 5-column layout.
+def _require_composite_rows_or_skip(table):
+    """Skip-pend unless the widget adopted the composite-row layout.
 
     The gate for the tree-shape assertions: while the ``tree()`` seam is
-    absent OR the column count is not the 5-column
-    (``Place | Visibility | Colour | Label | Status``) layout, the tests
-    collect + SKIP-PENDING and RUN once the tree rewrite lands (ADR-0037
-    §Decision 2 slice-4 amendment; ADR-0027).
+    absent, OR the tree is not single-column (``columnCount != 1``), OR its
+    header is not hidden, OR the ``territoryRowWidget`` / ``placeButton``
+    composite getters are absent, the tests collect + SKIP-PENDING and RUN
+    once the composite-row rewrite lands (ADR-0037 §Decision 2 slice-4
+    amendment; ADR-0027).
     """
     if not hasattr(table, "tree"):
         pytest.skip(
             "TerritoriesTableWidget has no tree() seam -- the ADR-0037 "
-            "QTreeWidget rewrite has not landed (ADR-0027)."
+            "composite-row rewrite has not landed (ADR-0027)."
         )
     tree = table.tree()
     if tree.columnCount != EXPECTED_COLUMN_COUNT:
         pytest.skip(
-            f"tree has {tree.columnCount} columns, not the "
-            f"{EXPECTED_COLUMN_COUNT} (Place | Visibility | Colour | Label | "
-            "Status) -- the tree rewrite has not landed (ADR-0027)."
+            f"tree has {tree.columnCount} columns, not the slice-4 single-column "
+            "(composite-row) layout -- the column-drop rewrite has not landed "
+            "(ADR-0027)."
         )
+    header = tree.header()
+    if header is None or not header.isHidden():
+        pytest.skip(
+            "tree header is not hidden -- the slice-4 header-drop has not landed "
+            "(ADR-0027)."
+        )
+    for method in ("territoryRowWidget", "placeButton"):
+        if not hasattr(table, method):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {method} composite getter -- the "
+                "ADR-0037 slice-4 composite-row rewrite has not landed (ADR-0027)."
+            )
 
 
 # --------------------------------------------------------------------------- #
@@ -420,7 +446,7 @@ def test_tree_builds_top_level_item_per_territory_and_child_item_per_point(qt_wi
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
 
     for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]:
         carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
@@ -462,7 +488,7 @@ def test_carrier_modified_event_rebuilds_the_tree(qt_widgets):
     table = _make_table_or_skip(slicer, carrier, displayNode)
     qt_widgets.append(table)
     _require_tree_model(table)
-    _require_tree_layout_or_skip(table)
+    _require_composite_rows_or_skip(table)
 
     carrier.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
     before = len(table.seedItems(TERRITORY_A))
@@ -781,6 +807,76 @@ def test_visibility_colour_label_edits_leave_geometry_unchanged(qt_widgets):
         assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, i)) == pytest.approx(
             expected, abs=1e-9
         ), f"point {i} must not move on a display edit."
+
+
+def test_editing_the_label_line_edit_writes_set_territory_label(qt_widgets):
+    """Editing the row's ``QLineEdit`` writes ``setTerritoryLabel`` on the carrier.
+
+    ADR-0037 §Decision 3 (slice-4 composite-row): the editable label is a
+    ``qt.QLineEdit`` in the territory row widget (``territoryLabelEdit``).
+    Committing an edit (setting the text + emitting ``editingFinished``) routes
+    through the tree's ``setTerritoryLabel`` and writes the carrier's display
+    slot — the composite-row replacement for the retired in-item editable text.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "addTerritory") or not hasattr(table, "territoryLabelEdit"):
+        pytest.skip(
+            "TerritoriesTableWidget has no addTerritory / territoryLabelEdit seam "
+            "(ADR-0027)."
+        )
+
+    territory = table.addTerritory()
+    edit = table.territoryLabelEdit(territory)
+    assert edit is not None, "the territory row must carry an editable label QLineEdit."
+
+    edit.setText("Renamed via line edit")
+    edit.editingFinished()  # commit the edit
+
+    assert carrier.GetTerritoryLabel(territory) == "Renamed via line edit", (
+        "committing the label QLineEdit must write setTerritoryLabel on the "
+        "carrier (ADR-0037 §Decision 3 composite-row)."
+    )
+
+
+def test_seed_delete_button_removes_exactly_that_seed(qt_widgets):
+    """Clicking a seed's delete button removes exactly that seed via the carrier.
+
+    ADR-0037 §Decision 3 delete convergence (slice-4 composite-row): each seed
+    row's delete affordance (``seedDeleteButton``) drives the SAME carrier
+    removal path as ``deleteSeed``; clicking it drops exactly that one seed.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "seedDeleteButton"):
+        pytest.skip("TerritoriesTableWidget has no seedDeleteButton seam (ADR-0027).")
+
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    for x, y, z in pts:
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    carrier.Modified()
+
+    delete = table.seedDeleteButton(TERRITORY_A, 1)
+    assert delete is not None, "the seed row must carry a delete button."
+    delete.click()
+
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == len(pts) - 1, (
+        "clicking a seed's delete button must remove EXACTLY ONE carrier point."
+    )
+    assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, 0)) == pytest.approx(pts[0], abs=1e-6)
+    assert tuple(carrier.GetNthAnnotationPoint(TERRITORY_A, 1)) == pytest.approx(pts[2], abs=1e-6)
 
 
 # --------------------------------------------------------------------------- #

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -452,6 +452,9 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     """
     Called each time the user opens this module.
     """
+    # ADR-0037 §Decision 2 slice-4 module-active gate: entering auto-arms
+    # NOTHING.  Placement is an explicit per-territory Place toggle in the
+    # table, so no view claims an add-on-click merely from opening the module.
     # Make sure parameter node exists and observed
     self.initializeParameterNode()
 
@@ -459,6 +462,14 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     """
     Called each time the user opens a different module.
     """
+    # ADR-0037 §Decision 2 slice-4 module-active gate: disarm placement on the
+    # way out so no view claims an add-on-click while VascularTerritories is
+    # inactive.  Reuse the table's shared disarm body (clears the display
+    # node's armed/active + hides the highlight); the follow-up rebuild
+    # re-derives every Place toggle un-checked.
+    table = getattr(self, "_territoriesTable", None)
+    if table is not None and hasattr(table, "disarm"):
+      table.disarm()
     # Do not react to parameter node changes (GUI wlil be updated when the user enters into the module)
     self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
 

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -11,9 +11,7 @@ Unlike the flat ADR-0034 segments table, territories have a genuine
 parent/child structure — seed points nest under their territory — so the
 panel composes a two-level ``qt.QTreeWidget`` (territories as TOP-LEVEL
 items, seed points as CHILD items with a disclosure triangle + indentation)
-rather than a flat ``qt.QTableWidget`` whose seed sub-rows leave dead cells
-under the Place / Visibility / Colour columns (§Decision 2 slice-4
-amendment).
+rather than a flat ``qt.QTableWidget`` (§Decision 2 slice-4 amendment).
 
 The tree is a VIEW over the Stage-1 annotation carrier
 (``vtkMRMLCustomTerritoriesNode``): it OBSERVES the carrier's
@@ -25,20 +23,22 @@ not a Slicer mouse mode); "Add Territory" mints an empty territory + arms
 into it, and a surface click through the pipeline seam appends one seed to
 the ACTIVE territory.
 
-The 5-column layout (``Place | Visibility | Colour | Label | Status``) is
-UNCHANGED across the flat-table -> tree rewrite; a ``QTreeWidget`` has
-columns too:
+The panel is a SINGLE-COLUMN, HEADER-LESS tree of composite row widgets
+(ADR-0037 §Decision 2 slice-4 amendment): the column grid + header row are
+dropped.  ``columnCount == 1`` and ``header().isHidden()``; each item —
+territory top-level AND seed child — carries ONE composite ``QWidget`` on
+column 0 (``tree.itemWidget(item, 0)``) whose ``QHBoxLayout`` holds the row's
+controls as a horizontal STRIP, addressed by NAME (never by column index):
 
-* TERRITORY (top-level) item: per-territory Place toggle / eye-icon
-  visibility toggle / colour swatch in cols 0/1/2, an editable label in
-  col 3, and a completeness indicator rendered as GLYPH + TEXT (ADR-0010,
-  never colour alone) in col 4 — display-only in Stage 2 (extraction gating
-  is Stage 3).
-* SEED (child) item: nested under its territory's top-level item; the
-  on-surface status text lives in the Label column (col 3, aligning under
-  the territory label) and the delete affordance is a cell widget in the
-  Status column (col 4); cols 0/1/2 stay blank because the tree indentation
-  conveys the hierarchy.
+* TERRITORY (top-level) row widget, in order: a per-territory Place toggle
+  (``qt.QToolButton``, checkable), an eye-icon visibility toggle
+  (``qt.QToolButton``, checkable), a colour button (``ctk.ctkColorPickerButton``),
+  an editable label (``qt.QLineEdit``, stretch), and a completeness status
+  label (``qt.QLabel``) rendered as GLYPH + TEXT (ADR-0010, never colour
+  alone) — display-only in Stage 2 (extraction gating is Stage 3).
+* SEED (child) row widget: an on-surface status label (``qt.QLabel``,
+  stretch) + a delete button (``qt.QToolButton``), nested under its
+  territory's top-level item (the tree indentation conveys the hierarchy).
 
 See also:
   * Docs/adr/0037-vascular-territories-off-markups.md  (the decision)
@@ -70,22 +70,11 @@ _TERRITORY_PALETTE = (
     (0.90, 0.49, 0.13),  # orange
 )
 
-#: Column layout of the custom tree (ADR-0037 §Decision 2 slice-4 amendment).
-#: A leftmost per-territory Place toggle drives explicit, exclusive arming.  A
-#: TERRITORY (top-level) item uses columns as
-#: [place | visibility | colour | label | status]; a SEED (child) item uses
-#: [<blank> | <blank> | <blank> | status text | delete].
-_COL_PLACE = 0
-_COL_VISIBILITY = 1
-_COL_COLOUR = 2
-_COL_LABEL = 3
-_COL_STATUS = 4
-_COLUMN_COUNT = 5
-
-#: The tree column the top-level territory id is stashed on (item data is
-#: per-column on a ``QTreeWidgetItem``); the Label column doubles as the id
-#: carrier so the itemChanged / reader seams read it back off one column.
-_COL_TERRITORY_DATA_COL = _COL_LABEL
+#: The single column the composite row widget lives on (ADR-0037 §Decision 2
+#: slice-4 amendment): the column grid + header row are dropped, so every item
+#: carries ONE composite ``QWidget`` on column 0.
+_COMPOSITE_COLUMN = 0
+_COLUMN_COUNT = 1
 
 #: A territory needs at least this many seeds to be complete (a centerline
 #: needs a start + an end); fewer reads incomplete (display-only, Stage 2).
@@ -97,17 +86,15 @@ _INCOMPLETE_GLYPH = "⚠"  # WARNING SIGN
 _INCOMPLETE_TEXT = "Incomplete — needs at least two seeds"
 _COMPLETE_TEXT = "Ready"
 
-#: The Qt item-data role carrying a top-level item's territory id.  Used by
-#: the itemChanged label write-back to identify which territory was renamed.
-_ROLE_TERRITORY = qt.Qt.UserRole + 1
-
 
 class TerritoriesTableWidget(qt.QWidget):
-    """Custom tree view + editor over the annotation carrier (ADR-0037).
+    """Custom composite-row tree over the annotation carrier (ADR-0037).
 
-    Composes a two-level ``qt.QTreeWidget`` — territories are TOP-LEVEL
-    items, seed points CHILD items nested under them — constructed over the
-    Stage-1 carrier and the shared highlight display node:
+    Composes a SINGLE-COLUMN, HEADER-LESS two-level ``qt.QTreeWidget`` —
+    territories are TOP-LEVEL items, seed points CHILD items nested under
+    them — where each item carries ONE composite ``QWidget`` (a horizontal
+    STRIP of controls) on column 0.  Constructed over the Stage-1 carrier and
+    the shared highlight display node:
 
         ``TerritoriesTableWidget(carrier=<vtkMRMLCustomTerritoriesNode>,
                                  displayNode=<vtkMRMLTerritoriesHighlightDisplayNode>)``.
@@ -118,6 +105,11 @@ class TerritoriesTableWidget(qt.QWidget):
     cannot reach the manager-owned Pipeline instance directly.  Delete goes
     straight to the carrier (the same ``RemoveNthAnnotationPoint`` the
     Pipeline's pick-delete uses — one carrier method, ADR-0037 §Decision 3).
+
+    Controls are addressed by NAME through the composite sub-widget getters
+    (``placeButton`` / ``visibilityButton`` / ``colourButton`` /
+    ``territoryLabelEdit`` / ``seedDeleteButton`` ...), never by column index —
+    the columns no longer exist.
     """
 
     def __init__(self, carrier: Any = None, displayNode: Any = None, parent: Any = None) -> None:
@@ -138,6 +130,12 @@ class TerritoriesTableWidget(qt.QWidget):
         self._territory_order: list[str] = []
         # territoryId -> its top-level QTreeWidgetItem; rebuilt every repaint.
         self._territory_items: dict[str, Any] = {}
+        # territoryId -> the composite row QWidget on the top-level item, and
+        # the named controls parsed out of it (rebuilt every repaint).
+        self._territory_rows: dict[str, dict[str, Any]] = {}
+        # (territoryId, pointIndex) -> the seed composite row QWidget + its
+        # named controls (rebuilt every repaint).
+        self._seed_rows: dict[tuple[str, int], dict[str, Any]] = {}
         # Auto-mint counter for "Add Territory".
         self._mint_counter = 0
         # The territory the surgeon last selected (drives "Add seeds"); the
@@ -146,19 +144,21 @@ class TerritoriesTableWidget(qt.QWidget):
 
         layout = qt.QVBoxLayout(self)
 
+        # Single-column, header-less tree (ADR-0037 §Decision 2 slice-4
+        # amendment): each item carries a composite row widget on column 0, so
+        # there is no column grid and no header row.  The disclosure triangle
+        # (setRootIsDecorated) stays so seeds expand/collapse under a territory.
         self._tree = qt.QTreeWidget()
         self._tree.setColumnCount(_COLUMN_COUNT)
-        self._tree.setHeaderLabels(
-            ["Place", "Visible", "Colour", "Territory / label", "Status"]
-        )
-        self._tree.header().setStretchLastSection(True)
+        self._tree.setHeaderHidden(True)
+        self._tree.setRootIsDecorated(True)
         self._tree.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
         self._tree.setSelectionMode(qt.QAbstractItemView.SingleSelection)
         layout.addWidget(self._tree)
 
         buttons = qt.QHBoxLayout()
         # ADR-0037 §Decision 2 slice-4: placement is an explicit per-territory
-        # Place toggle in the leftmost column, so the "Add seeds" + "Done" panel
+        # Place toggle in each territory row, so the "Add seeds" + "Done" panel
         # buttons retire; the shared disarm body survives as ``done()``.
         self._addTerritoryButton = qt.QPushButton("Add Territory")
         buttons.addWidget(self._addTerritoryButton)
@@ -166,7 +166,6 @@ class TerritoriesTableWidget(qt.QWidget):
         layout.addLayout(buttons)
 
         self._addTerritoryButton.connect("clicked(bool)", lambda _checked: self.addTerritory())
-        self._tree.connect("itemChanged(QTreeWidgetItem*,int)", self._onItemChanged)
 
         self._attachCarrierObserver()
         self._rebuild()
@@ -230,13 +229,60 @@ class TerritoriesTableWidget(qt.QWidget):
         return [parent.child(j) for j in range(parent.childCount())]
 
     def territoryStatusText(self, territoryId: str) -> str:
-        """The completeness status TEXT shown on the territory's top-level item."""
-        item = self._territory_items.get(territoryId)
-        return item.text(_COL_STATUS) if item is not None else ""
+        """The completeness status TEXT shown on the territory's row widget."""
+        status = self._territoryControl(territoryId, "status")
+        return status.text if status is not None else ""
 
     def territoryHasIncompleteGlyph(self, territoryId: str) -> bool:
         """Whether the territory carries the incomplete GLYPH (ADR-0010)."""
         return _INCOMPLETE_GLYPH in self.territoryStatusText(territoryId)
+
+    # ------------------------------------------------------------------ #
+    # Composite sub-widget getters (controls addressed by NAME, never column)
+    # ------------------------------------------------------------------ #
+
+    def _territoryControl(self, territoryId: str, key: str) -> Any:
+        """The named control from a territory's composite row (or ``None``)."""
+        row = self._territory_rows.get(territoryId)
+        return row[key] if row is not None else None
+
+    def _seedControl(self, territoryId: str, pointIndex: int, key: str) -> Any:
+        """The named control from a seed's composite row (or ``None``)."""
+        row = self._seed_rows.get((territoryId, int(pointIndex)))
+        return row[key] if row is not None else None
+
+    def territoryRowWidget(self, territoryId: str) -> Any:
+        """The composite ``QWidget`` on the territory's top-level item (col 0)."""
+        return self._territoryControl(territoryId, "widget")
+
+    def placeButton(self, territoryId: str) -> Any:
+        """The checkable Place ``qt.QToolButton`` on the territory row."""
+        return self._territoryControl(territoryId, "place")
+
+    def visibilityButton(self, territoryId: str) -> Any:
+        """The checkable eye-icon ``qt.QToolButton`` on the territory row."""
+        return self._territoryControl(territoryId, "visibility")
+
+    def colourButton(self, territoryId: str) -> Any:
+        """The ``ctk.ctkColorPickerButton`` on the territory row."""
+        return self._territoryControl(territoryId, "colour")
+
+    def territoryLabelEdit(self, territoryId: str) -> Any:
+        """The editable label ``qt.QLineEdit`` on the territory row."""
+        return self._territoryControl(territoryId, "label")
+
+    def seedRowWidget(self, territoryId: str, pointIndex: int) -> Any:
+        """The composite ``QWidget`` on the seed child item (col 0)."""
+        return self._seedControl(territoryId, pointIndex, "widget")
+
+    def seedDeleteButton(self, territoryId: str, pointIndex: int) -> Any:
+        """The delete ``qt.QToolButton`` on the seed row."""
+        return self._seedControl(territoryId, pointIndex, "delete")
+
+    def seedStatusText(self, territoryId: str, pointIndex: int) -> str:
+        """The on-surface status label text on the seed row."""
+        status = self._seedControl(territoryId, pointIndex, "status")
+        return status.text if status is not None else ""
 
     # ------------------------------------------------------------------ #
     # Territory lifecycle (arming)
@@ -346,6 +392,17 @@ class TerritoriesTableWidget(qt.QWidget):
         self.setTerritoryVisibility(territoryId, checked)
         self._applyEyeIcon(button, checked)
 
+    def _onLabelEdited(self, territoryId: str, edit: Any) -> None:
+        """Write an edited label ``QLineEdit`` back to the carrier's display slot.
+
+        The composite-row replacement for the retired in-item editable text
+        (ADR-0037 §Decision 3 slice-4): the ``QLineEdit``'s ``editingFinished``
+        routes through ``setTerritoryLabel``.
+        """
+        if self._rebuilding:
+            return
+        self.setTerritoryLabel(territoryId, edit.text)
+
     def _applyEyeIcon(self, button: Any, visible: bool) -> None:
         """Paint the eye-on / eye-off affordance on a visibility toggle.
 
@@ -425,14 +482,14 @@ class TerritoriesTableWidget(qt.QWidget):
     def _rebuild(self) -> None:
         self._rebuilding = True
         try:
-            self._tree.blockSignals(True)
             self._tree.clear()
             self._territory_items = {}
+            self._territory_rows = {}
+            self._seed_rows = {}
             for territory in self._territories():
                 self._appendTerritoryItem(territory)
             self._tree.expandAll()
         finally:
-            self._tree.blockSignals(False)
             self._rebuilding = False
 
     def _appendTerritoryItem(self, territoryId: str) -> None:
@@ -446,7 +503,7 @@ class TerritoriesTableWidget(qt.QWidget):
             if self._carrier is not None
             else True
         )
-        label = ""
+        label = territoryId
         color = (1.0, 1.0, 1.0)
         if self._carrier is not None:
             label = self._carrier.GetTerritoryLabel(territoryId) or territoryId
@@ -454,17 +511,40 @@ class TerritoriesTableWidget(qt.QWidget):
             color = (rgb[0], rgb[1], rgb[2])
 
         item = qt.QTreeWidgetItem(self._tree)
-        item.setData(_COL_TERRITORY_DATA_COL, _ROLE_TERRITORY, territoryId)
-        # The Label column carries the editable territory label.
-        item.setText(_COL_LABEL, label)
-        item.setFlags(item.flags() | qt.Qt.ItemIsEditable)
         self._territory_items[territoryId] = item
 
-        # Place toggle (ADR-0037 §Decision 2 slice-4): a checkable button that
-        # arms placement into THIS territory, exclusively.  Its checked state is
-        # RE-DERIVED from the shared display node on every rebuild, never stored
-        # in a Python field, so it survives the carrier-Modified rebuild.
+        rowWidget = self._buildTerritoryRow(territoryId, label, color, visible, seedCount)
+        self._tree.setItemWidget(item, _COMPOSITE_COLUMN, rowWidget)
+
+        for pointIndex in range(seedCount):
+            self._appendSeedItem(item, territoryId, pointIndex)
+
+    def _buildTerritoryRow(
+        self,
+        territoryId: str,
+        label: str,
+        color: tuple[float, float, float],
+        visible: bool,
+        seedCount: int,
+    ) -> Any:
+        """Compose a territory row's horizontal control STRIP (ADR-0037 slice-4).
+
+        Order: Place toggle -> eye-icon visibility toggle -> colour button ->
+        label QLineEdit (stretch) -> completeness status label.  Controls are
+        registered by NAME in ``_territory_rows`` so the getters resolve them
+        without any column index.
+        """
+        rowWidget = qt.QWidget()
+        rowLayout = qt.QHBoxLayout(rowWidget)
+        rowLayout.setContentsMargins(2, 1, 2, 1)
+        rowLayout.setSpacing(4)
+
+        # Place toggle: a checkable button that arms placement into THIS
+        # territory, exclusively.  Its checked state is RE-DERIVED from the
+        # shared display node on every rebuild, never stored in a Python field,
+        # so it survives the carrier-Modified rebuild.
         placeButton = qt.QToolButton()
+        placeButton.setAutoRaise(True)
         placeButton.setCheckable(True)
         placeButton.setText("Place")
         placeButton.setToolTip("Arm placement into this territory (exclusive)")
@@ -476,12 +556,13 @@ class TerritoriesTableWidget(qt.QWidget):
             "toggled(bool)",
             lambda checked, t=territoryId: self._onPlaceToggled(t, checked),
         )
-        self._tree.setItemWidget(item, _COL_PLACE, placeButton)
+        rowLayout.addWidget(placeButton)
 
         # Visibility: a Slicer-idiomatic eye-on / eye-off ``QToolButton`` (the
         # segmentation convention, ADR-0037 §Decision 3 slice-4 UX polish), NOT
         # a bare QCheckBox.  Checked state is derived from the carrier.
         visibilityButton = qt.QToolButton()
+        visibilityButton.setAutoRaise(True)
         visibilityButton.setCheckable(True)
         visibilityButton.setChecked(visible)
         self._applyEyeIcon(visibilityButton, visible)
@@ -489,7 +570,7 @@ class TerritoriesTableWidget(qt.QWidget):
             "toggled(bool)",
             lambda checked, t=territoryId, b=visibilityButton: self._onVisibilityToggled(t, b, checked),
         )
-        self._tree.setItemWidget(item, _COL_VISIBILITY, visibilityButton)
+        rowLayout.addWidget(visibilityButton)
 
         # Colour swatch: the Slicer-idiomatic ``ctkColorPickerButton`` (the
         # segmentation / resection convention) -- it renders its own colour
@@ -507,29 +588,71 @@ class TerritoriesTableWidget(qt.QWidget):
                 t, c.redF(), c.greenF(), c.blueF()
             ),
         )
-        self._tree.setItemWidget(item, _COL_COLOUR, colourButton)
+        rowLayout.addWidget(colourButton)
+
+        # Editable label: a ``QLineEdit`` (the composite-row replacement for the
+        # retired in-item editable text); ``editingFinished`` writes the
+        # carrier's display slot.  It takes the row's slack (stretch=1).
+        labelEdit = qt.QLineEdit()
+        labelEdit.setText(label)
+        labelEdit.connect(
+            "editingFinished()",
+            lambda t=territoryId, e=labelEdit: self._onLabelEdited(t, e),
+        )
+        rowLayout.addWidget(labelEdit, 1)
 
         # Completeness indicator: GLYPH + TEXT (ADR-0010, never colour alone).
         incomplete = seedCount < _MIN_SEEDS_FOR_COMPLETE
         statusText = f"{_INCOMPLETE_GLYPH} {_INCOMPLETE_TEXT}" if incomplete else _COMPLETE_TEXT
-        item.setText(_COL_STATUS, statusText)
+        statusLabel = qt.QLabel(statusText)
+        rowLayout.addWidget(statusLabel)
 
-        for pointIndex in range(seedCount):
-            self._appendSeedItem(item, territoryId, pointIndex)
+        self._territory_rows[territoryId] = {
+            "widget": rowWidget,
+            "place": placeButton,
+            "visibility": visibilityButton,
+            "colour": colourButton,
+            "label": labelEdit,
+            "status": statusLabel,
+        }
+        return rowWidget
 
     def _appendSeedItem(self, parentItem: Any, territoryId: str, pointIndex: int) -> None:
         child = qt.QTreeWidgetItem(parentItem)
-        # On-surface status text for the seed (surface-snapped on placement)
-        # lives in the Label column so it aligns under the territory label;
-        # the tree indentation in col 0 conveys the hierarchy.
-        child.setText(_COL_LABEL, f"Seed {pointIndex + 1} — on surface")
+        rowWidget = self._buildSeedRow(territoryId, pointIndex)
+        self._tree.setItemWidget(child, _COMPOSITE_COLUMN, rowWidget)
 
-        deleteButton = qt.QPushButton("Delete")
+    def _buildSeedRow(self, territoryId: str, pointIndex: int) -> Any:
+        """Compose a seed row's horizontal control STRIP (ADR-0037 slice-4).
+
+        Order: on-surface status label (stretch) -> delete ``QToolButton``.
+        The tree indentation under the territory item conveys the hierarchy.
+        """
+        rowWidget = qt.QWidget()
+        rowLayout = qt.QHBoxLayout(rowWidget)
+        rowLayout.setContentsMargins(2, 1, 2, 1)
+        rowLayout.setSpacing(4)
+
+        # On-surface status text (surface-snapped on placement).
+        statusLabel = qt.QLabel(f"Seed {pointIndex + 1} — on surface")
+        rowLayout.addWidget(statusLabel, 1)
+
+        deleteButton = qt.QToolButton()
+        deleteButton.setAutoRaise(True)
+        deleteButton.setText("Delete")
+        deleteButton.setToolTip("Remove this seed")
         deleteButton.connect(
             "clicked(bool)",
             lambda _checked, t=territoryId, i=pointIndex: self._removePoint(t, i),
         )
-        self._tree.setItemWidget(child, _COL_STATUS, deleteButton)
+        rowLayout.addWidget(deleteButton)
+
+        self._seed_rows[(territoryId, pointIndex)] = {
+            "widget": rowWidget,
+            "status": statusLabel,
+            "delete": deleteButton,
+        }
+        return rowWidget
 
     def _removePoint(self, territoryId: str, pointIndex: int) -> None:
         """The ONE point-removal path shared by delete-by-seed + delete-by-pick.
@@ -541,11 +664,3 @@ class TerritoriesTableWidget(qt.QWidget):
         """
         if self._carrier is not None:
             self._carrier.RemoveNthAnnotationPoint(territoryId, pointIndex)
-
-    def _onItemChanged(self, item: Any, column: int) -> None:
-        """Write an edited territory label back to the carrier's display slot."""
-        if item is None or self._rebuilding or column != _COL_LABEL:
-            return
-        territory = item.data(_COL_TERRITORY_DATA_COL, _ROLE_TERRITORY)
-        if territory:
-            self.setTerritoryLabel(territory, item.text(_COL_LABEL))

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -1,29 +1,44 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
-"""ADR-0037 Stage-2 — the VascularTerritories annotation table widget.
+"""ADR-0037 Stage-2 — the VascularTerritories annotation tree widget.
 
 ADR-0037 §Decision 3 replaces the legacy markups-selector / place-widget
-panel with a Python-composed CUSTOM ``qt.QTableWidget`` (ADR-0004): the
+panel with a Python-composed CUSTOM ``qt.QTreeWidget`` (ADR-0004): the
 surface-snap + territory-grouping contract has no stock point-list fit (the
 same call ADR-0034 made against ``qMRMLSegmentsTableView``).
 
-The table is a VIEW over the Stage-1 annotation carrier
+Unlike the flat ADR-0034 segments table, territories have a genuine
+parent/child structure — seed points nest under their territory — so the
+panel composes a two-level ``qt.QTreeWidget`` (territories as TOP-LEVEL
+items, seed points as CHILD items with a disclosure triangle + indentation)
+rather than a flat ``qt.QTableWidget`` whose seed sub-rows leave dead cells
+under the Place / Visibility / Colour columns (§Decision 2 slice-4
+amendment).
+
+The tree is a VIEW over the Stage-1 annotation carrier
 (``vtkMRMLCustomTerritoriesNode``): it OBSERVES the carrier's
 ``vtkCommand::ModifiedEvent`` and rebuilds, and its edits write BACK to the
 carrier (geometry via the point carrier + the placement Pipeline's shared
 removal path, display via the per-territory display slot).  The arm state
-lives on the ``TerritoryPlacementPipeline`` (pipeline-managed, not a Slicer
-mouse mode); "Add Territory" mints an empty territory + arms into it, and a
-surface click through the pipeline seam appends one seed to the ACTIVE
-territory.
+lives on the shared highlight DISPLAY NODE (``TerritoryInteractionState``,
+not a Slicer mouse mode); "Add Territory" mints an empty territory + arms
+into it, and a surface click through the pipeline seam appends one seed to
+the ACTIVE territory.
 
-Rows are PER-POINT, grouped under per-territory HEADER rows:
+The 5-column layout (``Place | Visibility | Colour | Label | Status``) is
+UNCHANGED across the flat-table -> tree rewrite; a ``QTreeWidget`` has
+columns too:
 
-* HEADER row (one per territory): per-territory visibility toggle, colour
-  swatch, editable label, and a completeness indicator rendered as GLYPH +
-  TEXT (ADR-0010, never colour alone) — display-only in Stage 2 (extraction
-  gating is Stage 3).
-* CHILD row (one per seed point): on-surface status + a delete affordance.
+* TERRITORY (top-level) item: per-territory Place toggle / eye-icon
+  visibility toggle / colour swatch in cols 0/1/2, an editable label in
+  col 3, and a completeness indicator rendered as GLYPH + TEXT (ADR-0010,
+  never colour alone) in col 4 — display-only in Stage 2 (extraction gating
+  is Stage 3).
+* SEED (child) item: nested under its territory's top-level item; the
+  on-surface status text lives in the Label column (col 3, aligning under
+  the territory label) and the delete affordance is a cell widget in the
+  Status column (col 4); cols 0/1/2 stay blank because the tree indentation
+  conveys the hierarchy.
 
 See also:
   * Docs/adr/0037-vascular-territories-off-markups.md  (the decision)
@@ -55,16 +70,22 @@ _TERRITORY_PALETTE = (
     (0.90, 0.49, 0.13),  # orange
 )
 
-#: Column layout of the custom table (ADR-0037 §Decision 2 slice-4 amendment).
+#: Column layout of the custom tree (ADR-0037 §Decision 2 slice-4 amendment).
 #: A leftmost per-territory Place toggle drives explicit, exclusive arming.  A
-#: HEADER row uses columns as [place | visibility | colour | label | status]; a
-#: CHILD row uses [<blank> | <blank> | <blank> | status text | delete].
+#: TERRITORY (top-level) item uses columns as
+#: [place | visibility | colour | label | status]; a SEED (child) item uses
+#: [<blank> | <blank> | <blank> | status text | delete].
 _COL_PLACE = 0
 _COL_VISIBILITY = 1
 _COL_COLOUR = 2
 _COL_LABEL = 3
 _COL_STATUS = 4
 _COLUMN_COUNT = 5
+
+#: The tree column the top-level territory id is stashed on (item data is
+#: per-column on a ``QTreeWidgetItem``); the Label column doubles as the id
+#: carrier so the itemChanged / reader seams read it back off one column.
+_COL_TERRITORY_DATA_COL = _COL_LABEL
 
 #: A territory needs at least this many seeds to be complete (a centerline
 #: needs a start + an end); fewer reads incomplete (display-only, Stage 2).
@@ -76,18 +97,17 @@ _INCOMPLETE_GLYPH = "⚠"  # WARNING SIGN
 _INCOMPLETE_TEXT = "Incomplete — needs at least two seeds"
 _COMPLETE_TEXT = "Ready"
 
-#: The Qt item-data role carrying a header row's territory id / a child row's
-#: (territory id, point index).  Used by the row-model reader seams.
+#: The Qt item-data role carrying a top-level item's territory id.  Used by
+#: the itemChanged label write-back to identify which territory was renamed.
 _ROLE_TERRITORY = qt.Qt.UserRole + 1
-_ROLE_POINT_INDEX = qt.Qt.UserRole + 2
-_ROLE_IS_HEADER = qt.Qt.UserRole + 3
 
 
 class TerritoriesTableWidget(qt.QWidget):
-    """Custom table view + editor over the annotation carrier (ADR-0037).
+    """Custom tree view + editor over the annotation carrier (ADR-0037).
 
-    Constructed over the Stage-1 carrier and the shared highlight display
-    node:
+    Composes a two-level ``qt.QTreeWidget`` — territories are TOP-LEVEL
+    items, seed points CHILD items nested under them — constructed over the
+    Stage-1 carrier and the shared highlight display node:
 
         ``TerritoriesTableWidget(carrier=<vtkMRMLCustomTerritoriesNode>,
                                  displayNode=<vtkMRMLTerritoriesHighlightDisplayNode>)``.
@@ -107,35 +127,34 @@ class TerritoriesTableWidget(qt.QWidget):
         self._displayNode = displayNode
         # Bind the carrier onto the shared display node so the LayerDM-driven
         # placement Pipeline (which the widget cannot reach directly) resolves
-        # the same carrier the table edits.
+        # the same carrier the tree edits.
         _state.set_carrier(displayNode, carrier)
         self._carrier_observer_tag: int | None = None
         # Guards against the write-back edits re-triggering a rebuild mid-edit.
         self._rebuilding = False
         # Deterministic territory order: minted / points-bearing / display
         # territories in first-seen order (so an EMPTY minted territory keeps
-        # its header row).
+        # its top-level item).
         self._territory_order: list[str] = []
-        # Row -> (territoryId, pointIndex | None); rebuilt on every repaint.
-        self._row_info: list[tuple[str, int | None]] = []
+        # territoryId -> its top-level QTreeWidgetItem; rebuilt every repaint.
+        self._territory_items: dict[str, Any] = {}
         # Auto-mint counter for "Add Territory".
         self._mint_counter = 0
         # The territory the surgeon last selected (drives "Add seeds"); the
-        # explicit selection survives an offscreen ``currentRow`` of -1.
+        # explicit selection survives an offscreen selection state.
         self._selected_territory: str = ""
 
         layout = qt.QVBoxLayout(self)
 
-        self._table = qt.QTableWidget()
-        self._table.setColumnCount(_COLUMN_COUNT)
-        self._table.setHorizontalHeaderLabels(
+        self._tree = qt.QTreeWidget()
+        self._tree.setColumnCount(_COLUMN_COUNT)
+        self._tree.setHeaderLabels(
             ["Place", "Visible", "Colour", "Territory / label", "Status"]
         )
-        self._table.horizontalHeader().setStretchLastSection(True)
-        self._table.verticalHeader().setVisible(False)
-        self._table.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
-        self._table.setSelectionMode(qt.QAbstractItemView.SingleSelection)
-        layout.addWidget(self._table)
+        self._tree.header().setStretchLastSection(True)
+        self._tree.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
+        self._tree.setSelectionMode(qt.QAbstractItemView.SingleSelection)
+        layout.addWidget(self._tree)
 
         buttons = qt.QHBoxLayout()
         # ADR-0037 §Decision 2 slice-4: placement is an explicit per-territory
@@ -147,7 +166,7 @@ class TerritoriesTableWidget(qt.QWidget):
         layout.addLayout(buttons)
 
         self._addTerritoryButton.connect("clicked(bool)", lambda _checked: self.addTerritory())
-        self._table.connect("itemChanged(QTableWidgetItem*)", self._onItemChanged)
+        self._tree.connect("itemChanged(QTreeWidgetItem*,int)", self._onItemChanged)
 
         self._attachCarrierObserver()
         self._rebuild()
@@ -183,42 +202,48 @@ class TerritoriesTableWidget(qt.QWidget):
         self._rebuild()
 
     # ------------------------------------------------------------------ #
-    # Row-model reader seams
+    # Item-model reader seams
     # ------------------------------------------------------------------ #
 
-    def table(self) -> Any:
-        """The underlying ``qt.QTableWidget``."""
-        return self._table
+    def tree(self) -> Any:
+        """The underlying ``qt.QTreeWidget``."""
+        return self._tree
 
-    def isHeaderRow(self, row: int) -> bool:
-        if row < 0 or row >= len(self._row_info):
-            return False
-        _territory, pointIndex = self._row_info[row]
-        return pointIndex is None
+    def territoryIds(self) -> list[str]:
+        """The territory ids of the top-level items, in display order.
 
-    def territoryOfRow(self, row: int) -> str:
-        if row < 0 or row >= len(self._row_info):
-            return ""
-        return self._row_info[row][0]
+        ``_territory_items`` is populated in top-level-item order during
+        ``_rebuild`` (an insertion-ordered dict), so its keys are the display
+        order.
+        """
+        return list(self._territory_items.keys())
 
-    def pointIndexOfRow(self, row: int):
-        if row < 0 or row >= len(self._row_info):
-            return None
-        return self._row_info[row][1]
+    def territoryItem(self, territoryId: str) -> Any:
+        """The top-level ``QTreeWidgetItem`` for ``territoryId`` (or ``None``)."""
+        return self._territory_items.get(territoryId)
 
-    def rowStatusText(self, row: int) -> str:
-        item = self._table.item(row, _COL_STATUS)
-        return item.text() if item is not None else ""
+    def seedItems(self, territoryId: str) -> list[Any]:
+        """The child ``QTreeWidgetItem`` list for ``territoryId``, in order."""
+        parent = self._territory_items.get(territoryId)
+        if parent is None:
+            return []
+        return [parent.child(j) for j in range(parent.childCount())]
 
-    def rowHasIncompleteGlyph(self, row: int) -> bool:
-        return _INCOMPLETE_GLYPH in self.rowStatusText(row)
+    def territoryStatusText(self, territoryId: str) -> str:
+        """The completeness status TEXT shown on the territory's top-level item."""
+        item = self._territory_items.get(territoryId)
+        return item.text(_COL_STATUS) if item is not None else ""
+
+    def territoryHasIncompleteGlyph(self, territoryId: str) -> bool:
+        """Whether the territory carries the incomplete GLYPH (ADR-0010)."""
+        return _INCOMPLETE_GLYPH in self.territoryStatusText(territoryId)
 
     # ------------------------------------------------------------------ #
     # Territory lifecycle (arming)
     # ------------------------------------------------------------------ #
 
     def addTerritory(self, territoryId: str | None = None) -> str:
-        """Mint an empty territory, select its header row, arm the pipeline.
+        """Mint an empty territory, select its item, arm the pipeline.
 
         Returns the (possibly auto-generated) territory id.  Auto-generated
         ids avoid colliding with an existing territory.
@@ -228,9 +253,9 @@ class TerritoriesTableWidget(qt.QWidget):
         newTerritory = territoryId not in self._territory_order
         if newTerritory:
             self._territory_order.append(territoryId)
-        # Give the territory a display slot so its header row survives before
-        # any seed lands (an empty minted territory is enumerable), and a
-        # distinct palette colour so it reads apart in the swatch + 3D seeds.
+        # Give the territory a display slot so its top-level item survives
+        # before any seed lands (an empty minted territory is enumerable), and
+        # a distinct palette colour so it reads apart in the swatch + 3D seeds.
         if self._carrier is not None:
             self._carrier.SetTerritoryVisibility(territoryId, True)
             if newTerritory:
@@ -246,6 +271,13 @@ class TerritoriesTableWidget(qt.QWidget):
         self._rebuild()
         self.selectTerritoryRow(territoryId)
         return territoryId
+
+    def armForSelectedTerritory(self) -> None:
+        """Re-arm placement into the selected territory (the "Add seeds" seam)."""
+        if not self._selected_territory:
+            return
+        self._armInto(self._selected_territory)
+        self._rebuild()
 
     def done(self) -> None:
         """The shared disarm body: clear the arm state + hide the highlight.
@@ -270,12 +302,11 @@ class TerritoriesTableWidget(qt.QWidget):
         self._rebuild()
 
     def selectTerritoryRow(self, territoryId: str) -> None:
-        """Select the header row of ``territoryId`` (a no-op if absent)."""
+        """Select the top-level item of ``territoryId`` (a no-op if absent)."""
         self._selected_territory = territoryId
-        for row, (territory, pointIndex) in enumerate(self._row_info):
-            if pointIndex is None and territory == territoryId:
-                self._table.setCurrentCell(row, _COL_LABEL)
-                return
+        item = self._territory_items.get(territoryId)
+        if item is not None:
+            self._tree.setCurrentItem(item)
 
     def _armInto(self, territoryId: str) -> None:
         """Arm placement into ``territoryId`` via the shared display node.
@@ -296,7 +327,7 @@ class TerritoriesTableWidget(qt.QWidget):
         Toggling ON arms placement into ``territoryId`` EXCLUSIVELY (one armed
         at a time); toggling OFF disarms via the shared ``done()`` body.  The
         follow-up rebuild re-derives every Place toggle's checked state from the
-        display node, so the other rows un-check themselves.  Ignored while a
+        display node, so the other items un-check themselves.  Ignored while a
         rebuild is programmatically setting the derived checked state (the
         ``_rebuilding`` guard) so re-deriving does not recursively re-arm.
         """
@@ -353,21 +384,18 @@ class TerritoriesTableWidget(qt.QWidget):
         if self._carrier is not None:
             self._carrier.SetTerritoryLabel(territoryId, str(label))
 
-    def deleteRow(self, row: int) -> None:
-        """Delete-from-table entry point — converges on the shared removal path.
+    def deleteSeed(self, territoryId: str, pointIndex: int) -> None:
+        """Delete-from-tree entry point — converges on the shared removal path.
 
         Routes through ``_removePoint`` to the carrier's
         ``RemoveNthAnnotationPoint`` — the SAME carrier method the placement
-        Pipeline's pick-delete reaches, so delete-by-row and delete-by-pick
-        converge on one deletion path (ADR-0037 §Decision 3).
+        Pipeline's pick-delete (``DeleteAnnotationPoint``) reaches, so
+        delete-by-seed and delete-by-pick converge on one deletion path
+        (ADR-0037 §Decision 3).
         """
-        if self.isHeaderRow(row):
+        if not territoryId or pointIndex is None:
             return
-        territory = self.territoryOfRow(row)
-        pointIndex = self.pointIndexOfRow(row)
-        if not territory or pointIndex is None:
-            return
-        self._removePoint(territory, pointIndex)
+        self._removePoint(territoryId, int(pointIndex))
 
     # ------------------------------------------------------------------ #
     # Repaint
@@ -378,8 +406,8 @@ class TerritoriesTableWidget(qt.QWidget):
 
         Union of the first-seen minted order, the carrier's points-bearing
         territories, and its display-slot territories — so a points-bearing
-        territory added outside the table (a pipeline click) still gets a
-        header row, and an empty minted territory keeps its header row.
+        territory added outside the tree (a pipeline click) still gets a
+        top-level item, and an empty minted territory keeps its top-level item.
         """
         order = list(self._territory_order)
         seen = set(order)
@@ -397,27 +425,17 @@ class TerritoriesTableWidget(qt.QWidget):
     def _rebuild(self) -> None:
         self._rebuilding = True
         try:
-            self._table.blockSignals(True)
-            self._table.setRowCount(0)
-            self._row_info = []
+            self._tree.blockSignals(True)
+            self._tree.clear()
+            self._territory_items = {}
             for territory in self._territories():
-                self._appendHeaderRow(territory)
-                count = (
-                    self._carrier.GetNumberOfAnnotationPoints(territory)
-                    if self._carrier is not None
-                    else 0
-                )
-                for pointIndex in range(count):
-                    self._appendChildRow(territory, pointIndex)
+                self._appendTerritoryItem(territory)
+            self._tree.expandAll()
         finally:
-            self._table.blockSignals(False)
+            self._tree.blockSignals(False)
             self._rebuilding = False
 
-    def _appendHeaderRow(self, territoryId: str) -> None:
-        row = self._table.rowCount
-        self._table.insertRow(row)
-        self._row_info.append((territoryId, None))
-
+    def _appendTerritoryItem(self, territoryId: str) -> None:
         seedCount = (
             self._carrier.GetNumberOfAnnotationPoints(territoryId)
             if self._carrier is not None
@@ -435,6 +453,13 @@ class TerritoriesTableWidget(qt.QWidget):
             rgb = self._carrier.GetTerritoryColor(territoryId)
             color = (rgb[0], rgb[1], rgb[2])
 
+        item = qt.QTreeWidgetItem(self._tree)
+        item.setData(_COL_TERRITORY_DATA_COL, _ROLE_TERRITORY, territoryId)
+        # The Label column carries the editable territory label.
+        item.setText(_COL_LABEL, label)
+        item.setFlags(item.flags() | qt.Qt.ItemIsEditable)
+        self._territory_items[territoryId] = item
+
         # Place toggle (ADR-0037 §Decision 2 slice-4): a checkable button that
         # arms placement into THIS territory, exclusively.  Its checked state is
         # RE-DERIVED from the shared display node on every rebuild, never stored
@@ -451,7 +476,7 @@ class TerritoriesTableWidget(qt.QWidget):
             "toggled(bool)",
             lambda checked, t=territoryId: self._onPlaceToggled(t, checked),
         )
-        self._table.setCellWidget(row, _COL_PLACE, placeButton)
+        self._tree.setItemWidget(item, _COL_PLACE, placeButton)
 
         # Visibility: a Slicer-idiomatic eye-on / eye-off ``QToolButton`` (the
         # segmentation convention, ADR-0037 §Decision 3 slice-4 UX polish), NOT
@@ -464,7 +489,7 @@ class TerritoriesTableWidget(qt.QWidget):
             "toggled(bool)",
             lambda checked, t=territoryId, b=visibilityButton: self._onVisibilityToggled(t, b, checked),
         )
-        self._table.setCellWidget(row, _COL_VISIBILITY, visibilityButton)
+        self._tree.setItemWidget(item, _COL_VISIBILITY, visibilityButton)
 
         # Colour swatch: the Slicer-idiomatic ``ctkColorPickerButton`` (the
         # segmentation / resection convention) -- it renders its own colour
@@ -482,60 +507,45 @@ class TerritoriesTableWidget(qt.QWidget):
                 t, c.redF(), c.greenF(), c.blueF()
             ),
         )
-        self._table.setCellWidget(row, _COL_COLOUR, colourButton)
-
-        # Editable label; header rows carry the territory id / point index on
-        # the label item's data roles for the row-model readers.
-        labelItem = qt.QTableWidgetItem(label)
-        labelItem.setData(_ROLE_TERRITORY, territoryId)
-        labelItem.setData(_ROLE_IS_HEADER, True)
-        labelItem.setFlags(qt.Qt.ItemIsEnabled | qt.Qt.ItemIsSelectable | qt.Qt.ItemIsEditable)
-        self._table.setItem(row, _COL_LABEL, labelItem)
+        self._tree.setItemWidget(item, _COL_COLOUR, colourButton)
 
         # Completeness indicator: GLYPH + TEXT (ADR-0010, never colour alone).
         incomplete = seedCount < _MIN_SEEDS_FOR_COMPLETE
         statusText = f"{_INCOMPLETE_GLYPH} {_INCOMPLETE_TEXT}" if incomplete else _COMPLETE_TEXT
-        statusItem = qt.QTableWidgetItem(statusText)
-        statusItem.setFlags(qt.Qt.ItemIsEnabled)
-        self._table.setItem(row, _COL_STATUS, statusItem)
+        item.setText(_COL_STATUS, statusText)
 
-    def _appendChildRow(self, territoryId: str, pointIndex: int) -> None:
-        row = self._table.rowCount
-        self._table.insertRow(row)
-        self._row_info.append((territoryId, pointIndex))
+        for pointIndex in range(seedCount):
+            self._appendSeedItem(item, territoryId, pointIndex)
 
-        # On-surface status text for the seed (surface-snapped on placement).
-        statusItem = qt.QTableWidgetItem(f"Seed {pointIndex + 1} — on surface")
-        statusItem.setData(_ROLE_TERRITORY, territoryId)
-        statusItem.setData(_ROLE_POINT_INDEX, pointIndex)
-        statusItem.setData(_ROLE_IS_HEADER, False)
-        statusItem.setFlags(qt.Qt.ItemIsEnabled | qt.Qt.ItemIsSelectable)
-        self._table.setItem(row, _COL_LABEL, statusItem)
+    def _appendSeedItem(self, parentItem: Any, territoryId: str, pointIndex: int) -> None:
+        child = qt.QTreeWidgetItem(parentItem)
+        # On-surface status text for the seed (surface-snapped on placement)
+        # lives in the Label column so it aligns under the territory label;
+        # the tree indentation in col 0 conveys the hierarchy.
+        child.setText(_COL_LABEL, f"Seed {pointIndex + 1} — on surface")
 
         deleteButton = qt.QPushButton("Delete")
         deleteButton.connect(
             "clicked(bool)",
             lambda _checked, t=territoryId, i=pointIndex: self._removePoint(t, i),
         )
-        self._table.setCellWidget(row, _COL_STATUS, deleteButton)
+        self._tree.setItemWidget(child, _COL_STATUS, deleteButton)
 
     def _removePoint(self, territoryId: str, pointIndex: int) -> None:
-        """The ONE point-removal path shared by delete-by-row + delete-by-cell.
+        """The ONE point-removal path shared by delete-by-seed + delete-by-pick.
 
         Calls the carrier's ``RemoveNthAnnotationPoint`` directly — the SAME
         carrier method the placement Pipeline's pick-delete
-        (``DeleteAnnotationPoint``) reaches, so delete-by-row and
+        (``DeleteAnnotationPoint``) reaches, so delete-by-seed and
         delete-by-pick converge on one deletion path (ADR-0037 §Decision 3).
         """
         if self._carrier is not None:
             self._carrier.RemoveNthAnnotationPoint(territoryId, pointIndex)
 
-    def _onItemChanged(self, item: Any) -> None:
-        """Write an edited header label back to the carrier's display slot."""
-        if item is None or self._rebuilding:
+    def _onItemChanged(self, item: Any, column: int) -> None:
+        """Write an edited territory label back to the carrier's display slot."""
+        if item is None or self._rebuilding or column != _COL_LABEL:
             return
-        if not bool(item.data(_ROLE_IS_HEADER)):
-            return
-        territory = item.data(_ROLE_TERRITORY)
+        territory = item.data(_COL_TERRITORY_DATA_COL, _ROLE_TERRITORY)
         if territory:
-            self.setTerritoryLabel(territory, item.text())
+            self.setTerritoryLabel(territory, item.text(_COL_LABEL))

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import ctk
 import qt
 import vtk
 
@@ -395,14 +396,22 @@ class TerritoriesTableWidget(qt.QWidget):
         )
         self._table.setCellWidget(row, _COL_VISIBILITY, visibilityBox)
 
-        # Colour swatch (a button whose background carries the RGB; a click
-        # opens the colour picker).
-        colourButton = qt.QPushButton()
-        colourButton.setFlat(True)
-        colourButton.setAutoFillBackground(True)
-        qcolor = qt.QColor(int(color[0] * 255), int(color[1] * 255), int(color[2] * 255))
-        colourButton.setStyleSheet(f"background-color: {qcolor.name()};")
-        colourButton.connect("clicked(bool)", lambda _checked, t=territoryId: self._pickColour(t))
+        # Colour swatch: the Slicer-idiomatic ``ctkColorPickerButton`` (the
+        # segmentation / resection convention) -- it renders its own colour
+        # square, opens the picker on click, and emits ``colorChanged``.
+        # ``setColor`` BEFORE ``connect`` so seeding the initial colour does
+        # not fire the write-back.
+        colourButton = ctk.ctkColorPickerButton()
+        colourButton.displayColorName = False
+        colourButton.setColor(
+            qt.QColor(int(color[0] * 255), int(color[1] * 255), int(color[2] * 255))
+        )
+        colourButton.connect(
+            "colorChanged(QColor)",
+            lambda c, t=territoryId: self.setTerritoryColor(
+                t, c.redF(), c.greenF(), c.blueF()
+            ),
+        )
         self._table.setCellWidget(row, _COL_COLOUR, colourButton)
 
         # Editable label; header rows carry the territory id / point index on
@@ -450,15 +459,6 @@ class TerritoriesTableWidget(qt.QWidget):
         """
         if self._carrier is not None:
             self._carrier.RemoveNthAnnotationPoint(territoryId, pointIndex)
-
-    def _pickColour(self, territoryId: str) -> None:
-        current = qt.QColor(255, 255, 255)
-        if self._carrier is not None:
-            rgb = self._carrier.GetTerritoryColor(territoryId)
-            current = qt.QColor(int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255))
-        chosen = qt.QColorDialog.getColor(current, self)
-        if chosen.isValid():
-            self.setTerritoryColor(territoryId, chosen.redF(), chosen.greenF(), chosen.blueF())
 
     def _onItemChanged(self, item: Any) -> None:
         """Write an edited header label back to the carrier's display slot."""

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -55,14 +55,16 @@ _TERRITORY_PALETTE = (
     (0.90, 0.49, 0.13),  # orange
 )
 
-#: Column layout of the custom table.  A HEADER row uses columns as
-#: [visibility | colour | label | status]; a CHILD row uses
-#: [<blank> | <blank> | status text | delete].
-_COL_VISIBILITY = 0
-_COL_COLOUR = 1
-_COL_LABEL = 2
-_COL_STATUS = 3
-_COLUMN_COUNT = 4
+#: Column layout of the custom table (ADR-0037 §Decision 2 slice-4 amendment).
+#: A leftmost per-territory Place toggle drives explicit, exclusive arming.  A
+#: HEADER row uses columns as [place | visibility | colour | label | status]; a
+#: CHILD row uses [<blank> | <blank> | <blank> | status text | delete].
+_COL_PLACE = 0
+_COL_VISIBILITY = 1
+_COL_COLOUR = 2
+_COL_LABEL = 3
+_COL_STATUS = 4
+_COLUMN_COUNT = 5
 
 #: A territory needs at least this many seeds to be complete (a centerline
 #: needs a start + an end); fewer reads incomplete (display-only, Stage 2).
@@ -126,7 +128,9 @@ class TerritoriesTableWidget(qt.QWidget):
 
         self._table = qt.QTableWidget()
         self._table.setColumnCount(_COLUMN_COUNT)
-        self._table.setHorizontalHeaderLabels(["Visible", "Colour", "Territory / label", "Status"])
+        self._table.setHorizontalHeaderLabels(
+            ["Place", "Visible", "Colour", "Territory / label", "Status"]
+        )
         self._table.horizontalHeader().setStretchLastSection(True)
         self._table.verticalHeader().setVisible(False)
         self._table.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
@@ -134,18 +138,15 @@ class TerritoriesTableWidget(qt.QWidget):
         layout.addWidget(self._table)
 
         buttons = qt.QHBoxLayout()
+        # ADR-0037 §Decision 2 slice-4: placement is an explicit per-territory
+        # Place toggle in the leftmost column, so the "Add seeds" + "Done" panel
+        # buttons retire; the shared disarm body survives as ``done()``.
         self._addTerritoryButton = qt.QPushButton("Add Territory")
-        self._addSeedsButton = qt.QPushButton("Add seeds")
-        self._doneButton = qt.QPushButton("Done")
         buttons.addWidget(self._addTerritoryButton)
-        buttons.addWidget(self._addSeedsButton)
-        buttons.addWidget(self._doneButton)
         buttons.addStretch(1)
         layout.addLayout(buttons)
 
         self._addTerritoryButton.connect("clicked(bool)", lambda _checked: self.addTerritory())
-        self._addSeedsButton.connect("clicked(bool)", lambda _checked: self.armForSelectedTerritory())
-        self._doneButton.connect("clicked(bool)", lambda _checked: self.done())
         self._table.connect("itemChanged(QTableWidgetItem*)", self._onItemChanged)
 
         self._attachCarrierObserver()
@@ -237,29 +238,36 @@ class TerritoriesTableWidget(qt.QWidget):
                     (len(self._territory_order) - 1) % len(_TERRITORY_PALETTE)
                 ]
                 self._carrier.SetTerritoryColor(territoryId, r, g, b)
+        # Arm BEFORE the rebuild so the minted territory's Place toggle
+        # re-derives as checked (the checked state is display-node-derived, not
+        # stored — ADR-0037 §Decision 2 slice-4).  Arming is exclusive, so any
+        # previously-armed territory's toggle re-derives un-checked.
+        self._armInto(territoryId)
         self._rebuild()
         self.selectTerritoryRow(territoryId)
-        self._armInto(territoryId)
         return territoryId
 
-    def armForSelectedTerritory(self) -> None:
-        """Re-arm placement into the selected row's territory ("Add seeds")."""
-        territory = self._selectedTerritory()
-        if not territory:
-            return
-        self._armInto(territory)
-
-    def _selectedTerritory(self) -> str:
-        """The selected row's territory (explicit selection wins over the row)."""
-        if self._selected_territory:
-            return self._selected_territory
-        return self.territoryOfRow(self._table.currentRow)
-
     def done(self) -> None:
-        """Disarm placement ("Done" / Esc) and hide the adhering highlight."""
+        """The shared disarm body: clear the arm state + hide the highlight.
+
+        The single disarm path reused by a Place toggle switching OFF and by
+        the widget's ``exit()`` module-active gate (ADR-0037 §Decision 2
+        slice-4).  Idempotent.
+        """
         _state.set_armed(self._displayNode, False)
         if self._displayNode is not None and hasattr(self._displayNode, "SetVisibility"):
             self._displayNode.SetVisibility(False)
+
+    def disarm(self) -> None:
+        """Disarm + refresh the toggles (the widget's module-active gate seam).
+
+        The public entry the widget's ``exit()`` calls: the shared ``done()``
+        body plus a rebuild so every Place toggle re-derives un-checked
+        (ADR-0037 §Decision 2 slice-4).  The toggle-OFF path drives ``done()``
+        + its own rebuild directly, so it does not go through here.
+        """
+        self.done()
+        self._rebuild()
 
     def selectTerritoryRow(self, territoryId: str) -> None:
         """Select the header row of ``territoryId`` (a no-op if absent)."""
@@ -281,6 +289,46 @@ class TerritoriesTableWidget(qt.QWidget):
         _state.set_armed(self._displayNode, True)
         if self._displayNode is not None and hasattr(self._displayNode, "SetVisibility"):
             self._displayNode.SetVisibility(True)
+
+    def _onPlaceToggled(self, territoryId: str, checked: bool) -> None:
+        """Handle a per-territory Place toggle (ADR-0037 §Decision 2 slice-4).
+
+        Toggling ON arms placement into ``territoryId`` EXCLUSIVELY (one armed
+        at a time); toggling OFF disarms via the shared ``done()`` body.  The
+        follow-up rebuild re-derives every Place toggle's checked state from the
+        display node, so the other rows un-check themselves.  Ignored while a
+        rebuild is programmatically setting the derived checked state (the
+        ``_rebuilding`` guard) so re-deriving does not recursively re-arm.
+        """
+        if self._rebuilding:
+            return
+        if checked:
+            self._armInto(territoryId)
+        else:
+            self.done()
+        self._rebuild()
+
+    def _onVisibilityToggled(self, territoryId: str, button: Any, checked: bool) -> None:
+        """Flip the carrier's per-territory visibility + swap the eye icon."""
+        if self._rebuilding:
+            return
+        self.setTerritoryVisibility(territoryId, checked)
+        self._applyEyeIcon(button, checked)
+
+    def _applyEyeIcon(self, button: Any, visible: bool) -> None:
+        """Paint the eye-on / eye-off affordance on a visibility toggle.
+
+        Prefers Slicer's stock segmentation eye icons; falls back to a glyph so
+        the toggle stays usable when the resource is unavailable.
+        """
+        iconPath = ":/Icons/Small/SlicerVisible.png" if visible else ":/Icons/Small/SlicerInvisible.png"
+        icon = qt.QIcon(iconPath)
+        if icon.isNull():
+            button.setIcon(qt.QIcon())
+            button.setText("👁" if visible else "—")
+        else:
+            button.setText("")
+            button.setIcon(icon)
 
     def _mintTerritoryId(self) -> str:
         while True:
@@ -387,14 +435,36 @@ class TerritoriesTableWidget(qt.QWidget):
             rgb = self._carrier.GetTerritoryColor(territoryId)
             color = (rgb[0], rgb[1], rgb[2])
 
-        # Visibility toggle.
-        visibilityBox = qt.QCheckBox()
-        visibilityBox.setChecked(visible)
-        visibilityBox.connect(
-            "toggled(bool)",
-            lambda checked, t=territoryId: self.setTerritoryVisibility(t, checked),
+        # Place toggle (ADR-0037 §Decision 2 slice-4): a checkable button that
+        # arms placement into THIS territory, exclusively.  Its checked state is
+        # RE-DERIVED from the shared display node on every rebuild, never stored
+        # in a Python field, so it survives the carrier-Modified rebuild.
+        placeButton = qt.QToolButton()
+        placeButton.setCheckable(True)
+        placeButton.setText("Place")
+        placeButton.setToolTip("Arm placement into this territory (exclusive)")
+        placeButton.setChecked(
+            _state.is_armed(self._displayNode)
+            and _state.get_active_territory(self._displayNode) == territoryId
         )
-        self._table.setCellWidget(row, _COL_VISIBILITY, visibilityBox)
+        placeButton.connect(
+            "toggled(bool)",
+            lambda checked, t=territoryId: self._onPlaceToggled(t, checked),
+        )
+        self._table.setCellWidget(row, _COL_PLACE, placeButton)
+
+        # Visibility: a Slicer-idiomatic eye-on / eye-off ``QToolButton`` (the
+        # segmentation convention, ADR-0037 §Decision 3 slice-4 UX polish), NOT
+        # a bare QCheckBox.  Checked state is derived from the carrier.
+        visibilityButton = qt.QToolButton()
+        visibilityButton.setCheckable(True)
+        visibilityButton.setChecked(visible)
+        self._applyEyeIcon(visibilityButton, visible)
+        visibilityButton.connect(
+            "toggled(bool)",
+            lambda checked, t=territoryId, b=visibilityButton: self._onVisibilityToggled(t, b, checked),
+        )
+        self._table.setCellWidget(row, _COL_VISIBILITY, visibilityButton)
 
         # Colour swatch: the Slicer-idiomatic ``ctkColorPickerButton`` (the
         # segmentation / resection convention) -- it renders its own colour


### PR DESCRIPTION
## What

Adds the **per-territory Place mode** to VascularTerritories (ADR-0037 §Decision 2/3 slice-4 amendment) and rebuilds the panel as a **header-less, single-column tree of composite row widgets** — no column grid — with territories as top-level rows and seed points nested underneath.

Stacked on `feature/vasc-territories-slice3-compute` (#601); retarget to `preview` once that merges.

## Why

Placement was previously implicit ("Add Territory arms and never disarms"), and the interim columnar table left dead cells under the Place/Visibility/Colour columns on seed sub-rows. This makes placement an explicit, per-territory, exclusive toggle gated on the module being active, and gives each row a clean widget strip instead of a column grid.

## Changes

- **Per-territory exclusive Place toggle** — a checkable button per territory; arming one disarms the others. Arm state lives on the shared `vtkMRMLTerritoriesHighlightDisplayNode` (via `TerritoryInteractionState`); the toggle's checked state is **re-derived** from the display node on each rebuild, never stored, so it survives the carrier-`Modified` rebuild.
- **Module-active gate** — `exit()` disarms placement (clears armed/active, hides the highlight, un-checks the toggle) so no view claims an add-on-click while the module is inactive; `enter()` auto-arms nothing.
- **Eye-icon visibility** — the visibility control is a checkable `QToolButton` (segmentation convention), not a checkbox.
- **Hierarchical rows** — seeds render as child items nested under their territory; placing a seed adds exactly one child row.
- **Composite-row tree** — the panel is a single-column, header-less `QTreeWidget`; each line is a `QWidget`+`QHBoxLayout` strip (Place · eye · colour · editable label · status; seed rows: status · delete). Retires the `Add seeds`/`Done` panel buttons (the `done()` disarm body survives as shared logic).
- **Colour cell** is a `ctkColorPickerButton`.

## Tests

Invariant-test-first (ADR-0027): the contract was pinned skip-pending before each rewrite. 28 invariants across `test_territories_placemode.py` + `test_territories_table.py` — the 5-column layout / exclusive Place toggle / re-derived checked state / module-active exit-disarm / eye-icon / child-on-placement / label-edit / seed-delete / colour. All 28 run and pass launched; they skip cleanly bare (no Qt / wrapped node).

## ADR

Amends ADR-0037 to record the place-mode UX and the composite-row, header-less tree (a two-level territory→seeds hierarchy diverging from ADR-0034's flat segments table, justified by the genuine parent/child structure).

---

*Drafted with the assistance of Claude (Anthropic claude-opus-4-8) under maintainer supervision.*
