### PR TITLE
ENH: VascularTerritories multi-system seeding + centerline extraction (ADR-0037 slice 5)

### DIFF
--- a/Docs/adr/0037-vascular-territories-off-markups.md
+++ b/Docs/adr/0037-vascular-territories-off-markups.md
@@ -296,17 +296,25 @@ in the row strip whose `editingFinished` routes through `setTerritoryLabel` to
 the carrier's display slot — the composite-row replacement for the retired
 in-item editable text (and its tree `itemChanged` label handler).
 
-## Amendment — connected-tree-constrained centerline seeding (slice 5)
+## Amendment — multi-system per-structure centerline seeding (slice 5)
 
 The compute-path amendment resolved the centerline **input surface** by
 merging every segment of the input segmentation (the fix that first made a
 real surface reach VMTK).  Real multi-structure liver data (liver parenchyma +
 portal + hepatic veins + tumour, one node) shows merge-all is wrong: VMTK
 extracts one centerline tree from a **connected** surface, but the venous
-systems are disjoint components (and a single segment may carry contributions
-from more than one system).  A territory's seed set must therefore lie on a
-single connected vessel tree — portal and hepatic never connect — or the
-extraction is meaningless (a medial path tunnelling through fused structures).
+systems are disjoint components.  A medial path tunnelling through fused
+structures is meaningless.
+
+An earlier revision of this amendment LOCKED each territory to one connected
+vessel tree: the first seed picked the system and later seeds snapped back onto
+it, with the component glowing.  That is clinically wrong.  A vascular territory
+may legitimately be defined by seeds in **multiple disjoint structures** — e.g.
+points on a hepatic vein plus points on the portal vein.  Portal and hepatic
+are disjoint components whose centerlines are derived **independently** and BOTH
+feed the one territory's map region.  The single-tree lock forbade exactly the
+case the surgeon needs, so it is removed in favour of the multi-system model
+below.
 
 ### Vessel surface by vascular SCT type (extends the compute amendment)
 
@@ -321,40 +329,60 @@ Real data tags vessels under category `SCT^85756007` (Tissue) with the generic
 Vein/Artery types rather than portal/hepatic-specific codes, so the match is
 on the broad vascular concepts.
 
-### First seed defines the active vessel tree
+### A territory owns seeds across possibly-multiple structures
 
-When a territory is armed and its **first** seed is placed, a connectivity
-filter seeded at that landing point selects the connected component of the
-vascular surface it lands on: that component is the territory's **active
-vessel tree**.  It is persisted per territory (a representative point / region
-identity on the carrier) so it survives the carrier-`Modified` rebuild and the
-later extraction runs over the same component.  `enter()` still auto-arms
-nothing; the active tree is established by the first seed, not by a
-pre-placement selection.
+A territory owns a set of seeds; each seed belongs to the **structure** — the
+input segment whose closed surface it is nearest.  A seed's structure is a
+DERIVED property (nearest closed surface), recomputed on demand from the carrier
+point + the current per-segment surfaces; no carrier slot and no node family are
+added ([ADR-0014](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0014-livermarkups-dissolution.md)).
+A point equidistant to two structures resolves to the **first** structure in
+segment-id order (deterministic).  There is no single-tree lock and no glow
+halo; a later seed is placed where the pick snaps it, with no snap-back.
 
-### Seeds constrained to the active tree
+### The visibility-gated pick is the only placement constraint
 
-Once a territory has an active tree, subsequent seeds are constrained to it: a
-click on a different connected component snaps to the nearest point on the
-active tree (or is rejected), so a territory's seeds are always one connected
-tree.  The per-extraction VMTK surface is that single component — **this
-supersedes the compute amendment's merge-all input surface.**
+The pick surface stays vessels-only and **visibility-gated**: hiding a system
+removes it from the pick, so hiding a system is how the surgeon avoids stray
+seeds on it.  This is the only placement constraint — a territory MAY straddle
+disjoint systems.  `enter()` still auto-arms nothing.
 
-### Active tree highlighted while placing
+### Extraction groups a territory's seeds by structure
 
-The active vessel tree is highlighted in the 3D and 2D views during placement
-(extending the vessel-adhering highlight of
-[ADR-0036](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0036-vessel-highlight-separate-instance.md)),
-so the surgeon sees which system a territory is bound to.  The exact visual
-treatment is deferred to implementation.
+Extraction MAPS each of a territory's seeds to its structure, GROUPS the seeds
+by structure, and runs VMTK **once per structure with ≥2 seeds**, over that
+structure's closed surface (narrowed to the seed's connected component so a
+segment that accidentally carries two disjoint tubes still feeds VMTK one
+coherent tree).  A structure with <2 seeds is **skipped** and flags the
+territory (glyph + text,
+[ADR-0010](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0010-accessibility-and-i18n.md)),
+because it cannot yield a centerline.  A territory spanning two structures
+therefore yields **N centerlines** — one per ≥2-seed structure — all grouped
+under the territory id, all marked with the territory's int, all feeding the one
+map region.  Each per-structure surface **supersedes the compute amendment's
+merge-all input surface.**
+
+### Seed rows coloured by structure
+
+In the annotation table each seed's child row carries a colour swatch tinted
+with its **structure's** segment display colour (the colour the surgeon sees in
+the 3D vessel render, not the territory palette), paired with the structure name
+(ADR-0010, colour never alone).
 
 ### Conformance (slice 5)
 
 - [test] The vessel-surface resolver keeps only vascular-SCT-type segments and
   excludes the liver-SCT and tumour segments.
-- [test] Two seeds on disjoint components resolve to different active trees;
-  the per-extraction surface is a single connected component, not the merge.
-- [test] A second seed on a different component snaps to / is rejected against
-  the territory's active tree (never straddles two trees).
-- [review] The active-tree identity persists across a carrier-`Modified`
-  rebuild; extraction runs over the persisted component.
+- [test] The seed→structure mapping is deterministic: a seed maps to the
+  nearest structure's surface; an equidistant boundary point tiebreaks to the
+  first structure in order.
+- [test] The ≥2-per-structure gate: a structure with <2 seeds is skipped; a
+  territory touching an under-seeded structure is flagged (glyph + text).
+- [test] A mixed-system territory (≥2 seeds on two structures) yields two
+  centerlines, both grouped under the territory id; the per-extraction surface
+  is a single connected component, not the merge.
+- [test] No straddle-snap: a later seed placed over a different visible
+  structure stays where it lands (never re-snapped onto an earlier structure).
+- [review] Re-extraction is idempotent: a territory's prior centerlines are
+  cleared once before its structure loop, so re-running replaces rather than
+  accrues.

--- a/Docs/adr/0037-vascular-territories-off-markups.md
+++ b/Docs/adr/0037-vascular-territories-off-markups.md
@@ -323,7 +323,7 @@ The centerline surface candidates are the input segments whose
 / `SCT^51114001` (Artery) and the broader vessel set — not a per-segment
 selection (a segment can mix systems) and not merge-all.  The liver
 (`SCT^10200004`, resolved by
-[ADR-0011](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0011-terminology-standard-clinical-terms.md)'s
+[ADR-0011](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0011-sct-terminology-dispatch.md)'s
 tag match, which supplies the *map region*) and tumour segments are excluded.
 Real data tags vessels under category `SCT^85756007` (Tissue) with the generic
 Vein/Artery types rather than portal/hepatic-specific codes, so the match is

--- a/Docs/adr/0037-vascular-territories-off-markups.md
+++ b/Docs/adr/0037-vascular-territories-off-markups.md
@@ -295,3 +295,66 @@ With the column grid gone, the territory label is an editable `qt.QLineEdit`
 in the row strip whose `editingFinished` routes through `setTerritoryLabel` to
 the carrier's display slot — the composite-row replacement for the retired
 in-item editable text (and its tree `itemChanged` label handler).
+
+## Amendment — connected-tree-constrained centerline seeding (slice 5)
+
+The compute-path amendment resolved the centerline **input surface** by
+merging every segment of the input segmentation (the fix that first made a
+real surface reach VMTK).  Real multi-structure liver data (liver parenchyma +
+portal + hepatic veins + tumour, one node) shows merge-all is wrong: VMTK
+extracts one centerline tree from a **connected** surface, but the venous
+systems are disjoint components (and a single segment may carry contributions
+from more than one system).  A territory's seed set must therefore lie on a
+single connected vessel tree — portal and hepatic never connect — or the
+extraction is meaningless (a medial path tunnelling through fused structures).
+
+### Vessel surface by vascular SCT type (extends the compute amendment)
+
+The centerline surface candidates are the input segments whose
+`TerminologyEntry` **type** code is a vascular concept — `SCT^29092000` (Vein)
+/ `SCT^51114001` (Artery) and the broader vessel set — not a per-segment
+selection (a segment can mix systems) and not merge-all.  The liver
+(`SCT^10200004`, resolved by
+[ADR-0011](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0011-terminology-standard-clinical-terms.md)'s
+tag match, which supplies the *map region*) and tumour segments are excluded.
+Real data tags vessels under category `SCT^85756007` (Tissue) with the generic
+Vein/Artery types rather than portal/hepatic-specific codes, so the match is
+on the broad vascular concepts.
+
+### First seed defines the active vessel tree
+
+When a territory is armed and its **first** seed is placed, a connectivity
+filter seeded at that landing point selects the connected component of the
+vascular surface it lands on: that component is the territory's **active
+vessel tree**.  It is persisted per territory (a representative point / region
+identity on the carrier) so it survives the carrier-`Modified` rebuild and the
+later extraction runs over the same component.  `enter()` still auto-arms
+nothing; the active tree is established by the first seed, not by a
+pre-placement selection.
+
+### Seeds constrained to the active tree
+
+Once a territory has an active tree, subsequent seeds are constrained to it: a
+click on a different connected component snaps to the nearest point on the
+active tree (or is rejected), so a territory's seeds are always one connected
+tree.  The per-extraction VMTK surface is that single component — **this
+supersedes the compute amendment's merge-all input surface.**
+
+### Active tree highlighted while placing
+
+The active vessel tree is highlighted in the 3D and 2D views during placement
+(extending the vessel-adhering highlight of
+[ADR-0036](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0036-vessel-highlight-separate-instance.md)),
+so the surgeon sees which system a territory is bound to.  The exact visual
+treatment is deferred to implementation.
+
+### Conformance (slice 5)
+
+- [test] The vessel-surface resolver keeps only vascular-SCT-type segments and
+  excludes the liver-SCT and tumour segments.
+- [test] Two seeds on disjoint components resolve to different active trees;
+  the per-extraction surface is a single connected component, not the merge.
+- [test] A second seed on a different component snaps to / is rejected against
+  the territory's active tree (never straddles two trees).
+- [review] The active-tree identity persists across a carrier-`Modified`
+  rebuild; extraction runs over the persisted component.

--- a/Docs/design/connected-tree-seeding-plan.md
+++ b/Docs/design/connected-tree-seeding-plan.md
@@ -1,0 +1,303 @@
+# Implementation plan — connected-tree-constrained centerline seeding (ADR-0037 slice 5)
+
+- **Status:** Planning (no code)
+- **Design of record:** [ADR-0037](../adr/0037-vascular-territories-off-markups.md)
+  §"Amendment — connected-tree-constrained centerline seeding (slice 5)".
+- **Branch:** `feature/vasc-territories-connected-tree`, stacked on #602 (slice 4).
+- **Cross-checked ADRs:** 0037 (all amendments), 0036, 0011, 0033, 0032, 0013, 0014, 0027, 0004, 0025.
+
+## Scope
+
+Constrain a territory's seed set to a single connected vessel tree. The
+compute amendment resolved the VMTK input surface by merging every segment
+(`80432b3`); real liver data (parenchyma + portal + hepatic + tumour in one
+node) makes merge-all wrong — portal and hepatic are disjoint components and
+a medial path tunnelling between them is meaningless. Slice 5 (a) filters the
+surface candidates to vascular-SCT-typed segments, (b) makes the first seed of
+a territory define its active connected tree, (c) constrains later seeds to
+that component (snap-or-reject), (d) runs each per-territory extraction over
+that single component (superseding merge-all), and (e) highlights the active
+tree while placing.
+
+## Locked design (from ADR-0037, not re-litigated here)
+
+1. Vessel candidates = segments whose `TerminologyEntry` TYPE is vascular
+   (`SCT^29092000` Vein / `SCT^51114001` Artery + broad vessel set); exclude
+   liver (`SCT^10200004`) + tumour. Real data tags vessels under category
+   `SCT^85756007` Tissue with generic Vein/Artery types.
+2. First seed defines the territory's active connected tree.
+3. Later seeds snap-to / reject against the active tree.
+4. Per-extraction VMTK surface = that one component (supersedes `80432b3`).
+5. Active tree highlighted in 3D + 2D while placing (styling deferred).
+
+**RESOLVED (baked in):** active-tree persistence = reuse
+`AnnotationPoints[territory][0]` as the connectivity seed. No new carrier
+slot, no stored mesh, no volatile region id. The active tree is recovered on
+demand by re-running `vtkPolyDataConnectivityFilter` in `ClosestPointRegion`
+mode seeded at the territory's first annotation point. By the single-tree
+constraint every seed lies on the same component, so any surviving seed
+(including a new index-0 after deletion) recovers the same tree; deleting the
+first seed is safe. All seeds deleted ⇒ no active tree. Interaction state
+(armed / active-territory) stays on the display node
+(per `feedback_layerdm_state_on_display_node`); durable identity rides the
+carrier's existing point round-trip (ADR-0014 layering).
+
+## Grounding in the current code
+
+- **Vessel merge-all seam:** `VesselHighlightWiring.closed_surface_polydata`
+  (`VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py`)
+  appends *every* segment's closed surface into one mesh. Three consumers:
+  `TerritoryPlacementPipeline._ensure_pick` (3D pick),
+  `TerritorySlicePipeline` (2D pick), and
+  `VascularTerritories.polyDataFromNode` (line 1077, the extraction surface
+  via `_preprocessedSurface` → `preprocessAndDecimate`).
+  `VesselHighlightPipeline` also builds its pick core from it.
+- **SCT-tag precedent:** `vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId`
+  (`Logic/vtkSlicerVascularTerritoriesLogic.cxx:317`) already does exactly the
+  match we need for the inverse set — substring match `SCT^10200004` on the
+  segment's `GetTag("TerminologyEntry", tag)`, tolerant of the meaning string,
+  ADR-0011-conformant. The vessel resolver is the same idiom with the vascular
+  token set and the liver/tumour exclusion.
+- **Extraction path:** `extractCenterlines` (line 732) → `_preprocessedSurface`
+  (781, decimates once, shared across territories) → per-territory
+  `_extractOneTerritory` (796). The `<2-seed` skip (`4090aa5`) is at line 773;
+  the triangulate-before-decimate fix (`15de967`) lives in the C++
+  `scl.preprocessAndDecimate` behind `preprocessAndDecimate` (1046).
+- **Carrier API:** `vtkMRMLCustomTerritoriesNode` exposes
+  `AddAnnotationPoint` / `GetNthAnnotationPoint` /
+  `GetNumberOfAnnotationPoints` / `RemoveNthAnnotationPoint` /
+  `GetAnnotationTerritoryIds`. Index-0 is the first placed seed — the RESOLVED
+  connectivity seed.
+- **Placement pipelines:** `TerritoryPlacementPipeline._event_world_on_surface`
+  (623) snaps via `VesselSurfacePick.pick`; `_add_point` (604) writes the
+  carrier. The 2D twin is `TerritorySlicePipeline`. Both resolve the pick
+  surface from the display node's `GetPickSurfaceNode()`.
+- **Highlight node:** `vtkMRMLTerritoriesHighlightDisplayNode` carries
+  `Adhering` / `AdheringPointWorld` (transient) + `GetPickSurfaceNode()`; no
+  place for a mesh (consistent with the RESOLVED no-stored-mesh call).
+
+No `vtkPolyDataConnectivityFilter` exists in the module yet.
+
+## Component design
+
+### C1 — vessel-surface resolver (C++, on the Logic)
+
+**Where:** a new `vtkSlicerVascularTerritoriesLogic` method, e.g.
+`GetVascularSegmentIds(vtkMRMLSegmentationNode*)` returning the vascular
+segment ids, plus `GetVascularSurfacePolyData(node)` appending only those
+segments' closed surfaces. C++, mirroring `GetLiverSegmentId` — the SCT
+substring match already lives there; keeping the vascular match beside it
+keeps one terminology-dispatch site (ADR-0011) and avoids a Python
+reimplementation of the tag read. This is a Logic *query*, not a widget
+concern, so ADR-0004 (widgets are Python) does not pull it to Python.
+
+**Filtering:** for each segment, read `GetTag("TerminologyEntry", tag)`; keep
+if `tag` contains any vascular token; drop if it contains `SCT^10200004`
+(liver) or a tumour token. Match is a substring on `SCT^<code>` (scheme+code),
+tolerant of the meaning string — identical to `GetLiverSegmentId`.
+
+**Python seam:** `VesselHighlightWiring` grows a
+`vascular_surface_polydata(segmentation, logic=None)` that, given the Logic,
+delegates to `GetVascularSurfacePolyData`; the existing
+`closed_surface_polydata` (merge-all) STAYS for the pick path (see the
+pick-vs-extraction split below). `polyDataFromNode` switches its segmentation
+branch (line 1077) from `closed_surface_polydata` to the vascular resolver so
+extraction sees only vessels.
+
+**Pick vs extraction (DECISION):** the highlight/pick path (`_ensure_pick` in
+both pipelines, `VesselHighlightPipeline`) stays **merge-all** — a surgeon may
+hover/snap anywhere on any vessel to *drop* the first seed, and the
+first-seed-defines-the-tree rule needs the whole vascular surface reachable.
+The *extraction* surface narrows to the active component (C3). Rationale: the
+constraint is enforced at seed-commit time (C4), not by hiding surface from the
+cursor; snapping the cursor pre-commit would prevent ever choosing a different
+tree for a *new* territory. Recommended: pick uses the vascular-filtered
+merge (vessels only, but all vessel components), NOT the raw all-segment merge
+— so the cursor never snaps to liver/tumour. So: `closed_surface_polydata`
+(all segments) is replaced everywhere by `vascular_surface_polydata` (vessels,
+all components) for the *pick*, and by the single-component surface for the
+*extraction*.
+
+### C2 — connectivity recovery helper (C++ on the Logic, Python-thin)
+
+**Where:** C++ `vtkSlicerVascularTerritoriesLogic::GetConnectedComponentAt(
+vtkPolyData* vascularSurface, double seed[3], vtkPolyData* out)` running
+`vtkPolyDataConnectivityFilter` in `SetExtractionModeToClosestPointRegion()`
+with `SetClosestPoint(seed)`. C++ keeps it off the GL/interaction thread and
+reuses the mapper-relocation-free Logic surface; a pure-VTK Python helper in
+`VesselHighlightWiring` is an acceptable alternative (bare-testable without a
+built module) — **recommended: Python pure-VTK helper**
+`connected_component_at(polydata, seed)` in a small new lib module
+(`VesselConnectivity.py`), because the invariant tests (C6) want it bare and
+`vtkPolyDataConnectivityFilter` is fully Python-wrapped with no C++-only
+dependency. Put the SCT filter in C++ (it reads MRML segment tags) and the
+connectivity in Python (it is pure polydata) — clean ADR-0004 split.
+
+**Performance:** the connectivity filter is O(cells) with a region-grow;
+on a decimated vessel surface it is cheap, but it runs on *every seed placement*
+(to test which component the click landed on) and on *every extraction*. Cache
+by `(polydata MTime, seed-cell)` inside the placement pipeline the same way
+`VesselSurfacePick` caches its locator by MTime — recover once per territory
+per surface-version, not per mouse event. See OPEN QUESTION Q3.
+
+### C3 — per-extraction single-component surface
+
+`extractCenterlines` currently decimates one shared surface for all
+territories (line 759-764). Slice 5 makes the surface **per-territory**: for
+each territory carrying ≥2 seeds, recover its active component from the
+vascular surface seeded at index-0 (C2), then decimate THAT component. This
+supersedes `80432b3`'s merge-all input. Ordering vs `15de967`: recover the
+component FIRST (on the full-res vascular surface, so connectivity is not
+fragmented by decimation), THEN triangulate+decimate the component — the
+existing `preprocessAndDecimate` (which triangulates then decimates) runs on
+the single component. The `<2-seed` skip (`4090aa5`, line 773) is unchanged
+and runs *before* recovery so we never recover a component for an under-seeded
+territory.
+
+### C4 — seed-constraint enforcement (placement pipelines)
+
+Both `TerritoryPlacementPipeline` (3D) and `TerritorySlicePipeline` (2D) gain
+the same commit-time gate in the add-on-click path (`_add_point` /
+`ProcessInteractionEvent`):
+
+- **First seed** (`GetNumberOfAnnotationPoints(territory) == 0`): no active
+  tree yet — accept the surface-snapped world point as-is. Index-0 becomes the
+  connectivity seed (RESOLVED). No recovery needed on this click.
+- **Later seed** (`>= 1` point): recover the active component from the
+  vascular surface seeded at index-0 (C2); test whether the just-snapped world
+  point lies on that component (point-in-component: build a `vtkCellLocator` /
+  `FindClosestPoint` on the recovered component and compare distance to a
+  tolerance, OR compare the connectivity region id of the picked cell). If on
+  the active component → accept. If on a different component → **snap** the
+  point to the nearest point on the active component (RECOMMENDED over reject:
+  a silent reject feels broken; a snap keeps the territory coherent and is the
+  ADR's first-listed option "snaps to the nearest point"). See OPEN QUESTION Q2.
+
+**Where the hit-component test runs:** in the pipeline, after
+`_event_world_on_surface` returns the snapped world point and before
+`_add_point`. The recovered component is cached per (territory, surface MTime).
+The 2D twin reuses the identical helper — the snap runs in world space, so the
+slice-normal ray result feeds the same gate.
+
+### C5 — active-tree highlight
+
+Extend the existing highlight (ADR-0036) to paint the recovered active
+component while a territory is armed. Drive it from the placement pipeline: on
+`Arm()` / active-territory change, recover the component (C2) and hand it to a
+highlight actor. The single-3D-pipeline constraint (ADR-0013 §1, already noted
+in `TerritoryPlacementPipeline` docstring: it renders the hover marker itself)
+means the active-tree surface actor is a THIRD actor owned by
+`TerritoryPlacementPipeline` (alongside `_seed_actor`, `_marker_actor`), not a
+new pipeline on the same display-node type. The 2D twin renders the component's
+slice contour analogously. Styling (colour/opacity/edge) is deferred — see
+OPEN QUESTION Q4. Recovery for the highlight reuses the C2 cache; no extra
+compute.
+
+## Invariant-test plan (ADR-0027)
+
+Bare-testable (pure-VTK / MRML-node, no GUI):
+
+- **T1 — SCT filter** (`test_territories_surface_resolution.py`, extend):
+  a segmentation with liver (`SCT^10200004`) + vein (`SCT^29092000`) + tumour
+  segments → the vascular resolver keeps only the vessel segment(s), excludes
+  liver + tumour. Needs Slicer segmentation logic for closed surfaces → the
+  filter *decision* (id set) is bare-testable on a fake segment carrying tags;
+  the surface-append stays launched (mirrors the existing i1/i2 split in that
+  file). The C++ id-set query gets a Cxx test beside
+  `vtkSlicerVascularTerritoriesLogicLiverSegmentIdTest.cxx` —
+  `...VascularSegmentIdsTest.cxx`.
+- **T2 — connectivity picks one component**
+  (new `test_territories_connectivity.py`, bare): a two-tube polydata (disjoint
+  components) → `connected_component_at(seed_on_tube_A)` returns only tube A's
+  cells; a seed on tube B returns only B. Also: the per-extraction surface for a
+  territory is a single connected component (`vtkPolyDataConnectivityFilter`
+  with `SetExtractionModeToAllRegions` reports exactly 1 region).
+- **T3 — two seeds on disjoint components resolve to different active trees**
+  (bare, same file): index-0 on A and a fresh territory's index-0 on B recover
+  disjoint components.
+
+Launched (need Slicer views / interaction):
+
+- **T4 — placement constraint** (`test_territories_placement_pipeline.py` +
+  slice twin, extend): first seed accepted anywhere on the vascular surface; a
+  second seed whose snapped world point is on a different component is SNAPPED
+  onto the active component (asserted: the added point lies on the index-0
+  component within tolerance, never straddles). Uses the existing injected
+  pick-core seam so it stays GL-free where possible; the connectivity recovery
+  runs on the injected polydata.
+- **T5 — highlight** (launched, eyeball-gated appearance; pinned invariant is
+  that the active-tree actor's input is the index-0 component, following the
+  `VesselHighlightPipeline` "pick integration pinned, GL appearance eyeball"
+  precedent).
+
+Persistence invariant [review, ADR-0037 slice-5 Conformance]: recovering the
+component from index-0 after a carrier-`Modified` rebuild yields the same
+component; deleting index-0 (leaving a later seed as the new index-0) still
+recovers the same component. Add as a bare test in T3's file.
+
+## Slice breakdown (RECOMMENDATION)
+
+**Split into two stacked PRs** on `feature/vasc-territories-connected-tree`:
+
+- **PR-A (compute):** C1 vessel-SCT resolver (C++ + Python seam) + C2
+  connectivity helper + C3 per-extraction single-component surface. Tests
+  T1/T2/T3 + the persistence invariant. This is the correctness core and is
+  fully bare/launched-testable without touching interaction. It supersedes
+  `80432b3` (call that out in the PR body, not in code, per
+  `feedback_no_pr_refs_in_code`).
+- **PR-B (UX):** C4 placement snap-or-reject constraint (3D + 2D) + C5
+  active-tree highlight. Tests T4/T5. Depends on PR-A's helpers.
+
+Rationale: PR-A changes what VMTK is fed (a real bug fix, mergeable on its own
+and independently verifiable); PR-B changes what the surgeon can do at
+placement time. Keeping them separate keeps the compute fix from being blocked
+on the interaction/GL review and matches the ADR's own compute-vs-UX seam.
+
+## ADR conformance / conflicts
+
+- **ADR-0011:** the vascular match reuses the `GetLiverSegmentId` SCT-tag
+  idiom; no SCT codes leak into labelmap scalars (those stay arbitrary ints per
+  the compute amendment). No conflict.
+- **ADR-0013 §5:** no new pipeline, no custom DM — the active-tree actor is
+  owned by the existing `TerritoryPlacementPipeline` (one pipeline per
+  display-node type). No conflict.
+- **ADR-0014:** durable identity rides the carrier's existing point round-trip;
+  no new node family, no new carrier slot. Conforms.
+- **ADR-0032 / 0033:** the constraint runs inside the existing
+  `ProcessInteractionEvent` commit path; bare-move still declines. No conflict.
+- **ADR-0036:** the active-tree highlight extends the vessel-adhering
+  highlight; ADR-0037 already names this. No conflict.
+- **ADR-0037 compute amendment:** slice 5 explicitly SUPERSEDES merge-all — the
+  ADR records this. No conflict.
+- **Closed vocabulary / platform neutrality / no-PR-refs-in-code:** new C++
+  classes drop the `Liver` prefix (already true for the Territories family);
+  no build-system changes; no PR/issue numbers in source.
+
+## OPEN QUESTIONS (maintainer decides; planning proceeds on the recommendation)
+
+- **Q1 — exact vascular-SCT match set.** ADR-0037 says "the broad vessel set"
+  (generic Vein `SCT^29092000` / Artery `SCT^51114001`) because real data tags
+  under category `SCT^85756007` Tissue with generic types, not portal/hepatic
+  codes. **Recommendation:** match the two generic type codes plus a short
+  documented allowlist of common vessel type codes (e.g. blood vessel
+  structure), and EXCLUDE by liver + a tumour token; keep the token list in one
+  named constant in the Logic. Proceeding on the broad-generic set.
+- **Q2 — snap vs reject for an off-tree later seed.** **Recommendation: snap**
+  to the nearest point on the active component (ADR lists snap first; less
+  surprising than a swallowed click). Proceeding on snap; a rejected-click
+  variant is a one-line switch if the maintainer prefers.
+- **Q3 — connectivity performance.** Recovery per seed-placement and per
+  extraction. **Recommendation:** cache the recovered component per
+  (territory, vascular-surface MTime) in the placement pipeline (VesselSurfacePick
+  MTime-cache precedent); recover on the full-res vascular surface once, reuse
+  for gate + highlight + extraction. Proceeding on the cache.
+- **Q4 — active-tree highlight styling.** ADR defers it. **Recommendation:**
+  reuse the hover-marker colour family at low opacity for the active component
+  surface; ship a plain semi-transparent tint in PR-B and leave a styling
+  follow-up. Proceeding on the plain tint.
+- **Q5 — components that accidentally touch.** If portal and hepatic voxels
+  abut after closed-surface meshing, connectivity would fuse them into one
+  region and the constraint silently permits a straddling seed set.
+  **Recommendation:** out of scope for slice 5 (the ADR assumes disjoint
+  systems); note it as a known limitation and a candidate morphological-gap
+  follow-up. Proceeding without a gap-opening step.

--- a/Docs/design/multi-system-territory-plan.md
+++ b/Docs/design/multi-system-territory-plan.md
@@ -1,0 +1,385 @@
+# Implementation plan — multi-system territory seeding (ADR-0037 slice 5, REVISED)
+
+- **Status:** Planning (no code)
+- **Design of record:** [ADR-0037](../adr/0037-vascular-territories-off-markups.md)
+  §"Amendment — connected-tree-constrained centerline seeding (slice 5)" —
+  this plan REVISES that amendment (see §ADR revision below).
+- **Branch:** `feature/vasc-territories-connected-tree` (slice-5 work already
+  landed, commits `3256bc7..cfab74d`; NOT pushed).
+- **Cross-checked ADRs:** 0037 (all amendments), 0036, 0011, 0013, 0014,
+  0034, 0010, 0004, 0027.
+
+## Why the current design is wrong
+
+The landed slice-5 design LOCKS each territory to ONE connected vessel tree:
+the first seed picks the system, later seeds snap to that component
+(`_constrain_to_active_tree`), and the component glows (`_highlight_tree_actor`).
+That is clinically wrong. A vascular territory may legitimately be defined by
+seeds in MULTIPLE disjoint systems — e.g. points a,b on a hepatic vein plus
+c,d on the portal vein. Portal and hepatic are disjoint components whose
+centerlines are derived INDEPENDENTLY, and BOTH contribute to the one
+territory's map region. The single-tree lock forbids exactly the case the
+surgeon needs.
+
+The revised model: a **territory** owns a set of seeds; each seed belongs to
+the **structure** (input segment) whose closed surface it is nearest; VMTK
+runs **once per structure that has ≥2 seeds**; each resulting centerline is
+tagged with the territory's int and all feed the territory's map region.
+
+## Scope
+
+Remove the single-tree placement lock and the glow halo. Introduce a pure-VTK
+seed→structure mapping. Group extraction by structure (one VMTK run per
+≥2-seed structure, N centerlines per territory). Colour each seed row by its
+structure's segment colour. Flag a territory whose any touched structure has
+<2 seeds. Revise the ADR-0037 slice-5 amendment to record the flip.
+
+---
+
+## Part A — what to REMOVE
+
+### A1. The single-tree placement lock (C4)
+
+- `TerritoryPlacementPipeline._constrain_to_active_tree` (3D) and
+  `TerritorySlicePipeline._constrain_to_active_tree` (2D): DELETE. In both
+  `ProcessInteractionEvent` add-on-click paths drop the
+  `world = self._constrain_to_active_tree(world)` line — the raw
+  surface-snapped `world` from `_event_world_on_surface` /
+  `_snap_event_to_surface` goes straight to `_add_point`. The visibility-gated
+  pick already restricts snapping to VISIBLE vessels
+  (`vascular_surface_polydata`), which is the retained, correct gate: hide a
+  system to avoid stray seeds on it.
+- `nearest_point_on` (VesselConnectivity.py): becomes UNUSED once
+  `_constrain_to_active_tree` is gone. KEEP the function only if the
+  seed→structure mapping (B) reuses it; per the recommendation below the
+  mapping uses a closed-surface cell/point locator per segment, so
+  `nearest_point_on` over a single merged tree is no longer called. RECOMMEND
+  deleting it and its dedicated test in `test_territories_connectivity.py`,
+  unless B's mapping ends up delegating to it.
+
+### A2. The glow halo / active-tree highlight (C5)
+
+In `TerritoryPlacementPipeline`:
+- DELETE `_highlight_tree_mapper`, `_highlight_tree_actor`,
+  `ACTIVE_TREE_GLOW_COLOR`, `activeTreePolyData`, `highlightActor`,
+  `_reconcile_active_tree_highlight`, and `_active_tree_polydata` /
+  `_active_tree_cache_key`.
+- In `_attach_halo_renderer` drop `overlay.AddActor(self._highlight_tree_actor)`
+  (the SEED-hover glow halo `_halo_actor` STAYS — that is the yellow/green
+  edit cue, unrelated to the active tree).
+- In `_reconcile_highlight` drop the trailing
+  `self._reconcile_active_tree_highlight()` call.
+
+In `TerritorySlicePipeline`:
+- DELETE `activeTreePolyData`, `_constrain_to_active_tree`,
+  `_active_tree_polydata`, `_active_tree_cache_key` and the
+  `connected_component_at` / `nearest_point_on` import.
+
+### A3. `connected_component_at` — reassess
+
+`connected_component_at` is still used by
+`VascularTerritories._territorySurface` to narrow the per-territory VMTK input.
+Under the revised extraction (B4) the VMTK input surface becomes the
+**per-structure** closed surface (each structure is meshed independently and
+is already a coherent surface for VMTK). Whether a further connectivity
+narrowing is still needed depends on whether a single input SEGMENT can carry
+DISJOINT pieces (the "structure with disjoint pieces" edge case, Q4). RECOMMEND:
+KEEP `connected_component_at` and KEEP narrowing the per-structure surface to
+the connected component of the structure's OWN seed centroid (or its first
+seed), so a segment that accidentally holds two disjoint tubes still feeds VMTK
+one coherent tree. This preserves the `15de967` triangulate-before-decimate
+ordering. So `connected_component_at` survives, `nearest_point_on` does not.
+
+### KEEP (do not touch)
+
+- The visibility-gated pick (`vascular_surface_polydata` + `visibility_mtime`,
+  `_ensure_pick` MTime rebuild) in both pipelines — the correct "hide a system
+  to avoid stray seeds" mechanism.
+- The `<2-seed` skip in `extractCenterlines` (`4090aa5`) — refined into a
+  per-structure gate (B4), not removed.
+- The VMTK triangulate/decimate (`preprocessAndDecimate`, `15de967`).
+- All seed rendering, hover/grab halo, cross-view reslice, arm/module-gate.
+
+---
+
+## Part B — what to BUILD
+
+### B1. Seed→structure mapping helper (pure-VTK Python lib)
+
+**Location:** a new pure-VTK helper, RECOMMENDED in a new small module
+`VascularTerritoriesLib/SeedStructureMapping.py` (mirrors `VesselConnectivity`:
+imports `vtk` only, bare-unit-testable, no MRML/Slicer/Qt/GL). Rationale
+(ADR-0004 split): the geometry (nearest closed-surface to a point) is pure
+polydata → Python; the segment→closed-surface + segment→colour resolution
+reads MRML segment state and rides existing C++/Python seams.
+
+**Signature (pure core):**
+```
+nearest_structure(structures, point) -> key | None
+```
+where `structures` is an ordered sequence of `(key, closed_surface_polydata)`
+and `key` is the segment id (str). Builds a `vtkCellLocator`
+(`FindClosestPoint`) per structure surface, returns the key of the structure
+with the smallest distance to `point`. A `(distance)` tie or an equal-distance
+boundary point resolves to the FIRST structure in order (deterministic; Q3).
+
+**MRML-facing wrapper (in `VascularTerritories.py` logic or a thin adapter):**
+resolve the per-segment closed surfaces once via the C++
+`GetVascularSegmentIds` + `GetClosedSurfaceRepresentation` per id (NOT the
+merged `GetVascularSurfacePolyData`, which loses the id→surface split). Pass
+the `(segmentId, surface)` list to `nearest_structure`. The segment id is the
+stable structure identity (matches the maintainer's "structure/segment" mental
+model; in real data segment ≡ component).
+
+**Caching/perf (Q3):** cache the per-segment `vtkCellLocator`s keyed by
+`visibility_mtime(segmentation)` (same MTime seam the pick uses), so the N
+locators are built once per surface-version, not per seed. Mapping a seed is
+then N `FindClosestPoint` calls (N = vessel-segment count, small — 2–4 in real
+data). This is cheaper than the current per-seed `vtkPolyDataConnectivityFilter`
+region-grow.
+
+### B2. Persisting the seed→structure assignment
+
+A seed's structure is a DERIVED property (nearest surface), recomputable, so
+it need NOT be a new carrier slot (ADR-0014: no new node family, no new carrier
+slot). RECOMMEND: compute on demand from the carrier point + the current
+segmentation surfaces, cached in the pipeline/table by MTime. This keeps the
+carrier's existing point round-trip as the only durable state (conforms to the
+slice-5 "reuse the carrier round-trip" persistence decision, now without a
+connectivity seed).
+
+**OPEN QUESTION Q5** (below): if re-mapping on every table repaint is too
+costly OR if a seed's nearest-structure can flip when a surface is hidden, we
+may want to STAMP the assignment at placement time. Recommendation: derive on
+demand for now; revisit only if a flicker/perf issue surfaces.
+
+### B3. Table: coloured seed rows + per-structure warning glyph
+
+`TerritoriesTableWidget` changes (composite-row tree, single column):
+
+**Seed-row colour by structure.** In `_buildSeedRow`, the seed row currently
+shows a plain `QLabel("Seed N — on surface")`. Add a small colour swatch
+(a `QLabel` with a filled pixmap, or reuse the `ctkColorPickerButton`
+render-only) tinted with the seed's STRUCTURE colour. The colour comes from
+the INPUT SEGMENTATION's per-segment display colour
+(`segmentationDisplayNode.GetSegmentDisplayColor(segmentId)` /
+`segment.GetColor()`), NOT the territory palette. Resolve the seed's structure
+via B1. ADR-0010: colour is NEVER the only cue — pair the swatch with the
+structure's NAME text (e.g. "Seed 2 — Portal vein") so the row is legible
+without colour.
+
+**OPEN QUESTION Q6:** segment display colour vs a generated palette. The
+maintainer said "the segmentation's per-segment display colour."
+RECOMMENDATION: use the segment display colour (matches what the surgeon sees
+in the 3D vessel render, zero new mapping). Fall back to the territory palette
+only when the segment colour is unavailable.
+
+**Territory warning glyph on any <2-seed structure.** The current territory
+status is a flat `seedCount < 2` check (`_MIN_SEEDS_FOR_COMPLETE`). REPLACE it
+with a per-structure query: group the territory's seeds by structure (B1),
+and if ANY touched structure has <2 seeds, show the warning glyph + text
+("⚠ <structure> needs at least two seeds"), because that structure cannot
+yield a centerline. Extend `_territoryStatus`/`_buildTerritoryRow` to compute
+the grouping. Keep the existing glyph+text rendering (ADR-0010). The check
+lives in a small table/logic query `territory_structure_seed_counts(carrier,
+territory, mapping)` — reused by extraction (B4) so the table and the extractor
+agree on the gate. RECOMMEND placing that query in `SeedStructureMapping.py`
+(pure, bare-testable) taking already-mapped `(seed, structureKey)` pairs.
+
+### B4. Extraction: group by structure (`extractCenterlines`)
+
+In `VascularTerritories.extractCenterlines` / `_extractOneTerritory`:
+
+- For each territory carrying points, MAP each seed to its structure (B1) over
+  the FULL-res per-segment surfaces.
+- GROUP the territory's seeds by structure id.
+- For each structure with **≥2 seeds**: resolve that structure's closed
+  surface (`GetClosedSurfaceRepresentation(segmentId)`), optionally narrow to
+  its connected component (A3 / Q4), triangulate+decimate
+  (`preprocessAndDecimate`, preserving `15de967`), build ONE transient
+  fiducial from that structure's ordered seeds, run VMTK ONCE, and wire the
+  resulting centerline into `CenterlineRefs` + `Groupings` under the
+  TERRITORY id (unchanged wiring), marked with the territory's int
+  (`MarkSegmentWithID` via the existing `_wireCenterlineOutput`).
+- A structure with **<2 seeds** is SKIPPED (no VMTK run) and contributes to
+  the territory's warning flag (B3).
+- A territory spanning two structures → TWO VMTK runs → TWO centerlines, both
+  grouped under the territory, both marked with the territory's int.
+
+**Idempotency:** `_clearTerritoryCenterlines` currently clears ALL of a
+territory's prior refs before wiring the new one, then `_wireCenterlineOutput`
+appends ONE. With N centerlines per territory this must change: clear the
+territory's refs ONCE at the start of the territory's extraction, then APPEND
+each structure's centerline. RECOMMEND: hoist the clear out of
+`_wireCenterlineOutput` into `extractCenterlines` (once per territory, before
+the structure loop), and let `_wireCenterlineOutput` only append. Re-extraction
+then yields exactly the current ≥2-seed structures' centerlines.
+
+**Map compute already handles N:** `build_centerline_model` iterates ALL
+`CenterlineRefs`, reads each centerline's territory via `Groupings`, marks it
+with the territory's derived int (`territory_label_ints`), and sums them into
+the search model. Multiple centerlines sharing one territory int already feed
+one map region. No change needed to `calculateVascularTerritoryMap` or
+`MarkSegmentWithID`. CONFIRMED by reading `build_centerline_model`.
+
+- `_vascularSurface` (merged vessels) and `_territorySurface`
+  (connected-component-at-seed[0]) are SUPERSEDED for the grouped path. Keep
+  `_vascularSurface`'s per-segment resolution but expose the per-segment split
+  (see B1 wrapper). `_territorySurface`'s index-0 recovery is replaced by
+  per-structure surfaces; retire it (or repurpose it as the per-structure
+  connected-component narrow, A3).
+
+---
+
+## Part C — tests to CHANGE / ADD (ADR-0027)
+
+### Must change (landed slice-5 tests that encode the removed design)
+
+- `test_territories_placemode_constraint.py`: the C4 constraint tests
+  (`test_first_seed_defines_the_active_tree`, later-seed-snaps,
+  `activeTreePolyData`/`highlightActor` seam) assert the REMOVED lock+halo.
+  REWRITE to pin the NEW invariant: a later seed on a DIFFERENT component is
+  KEPT AS-IS (no snap) — a territory MAY straddle systems. Drop the
+  `activeTreePolyData` / `highlightActor` assertions.
+- `test_territories_connectivity.py`: keep the `connected_component_at` tests
+  IF A3 keeps per-structure narrowing; drop the `nearest_point_on` +
+  index-0-persistence-for-the-lock tests (the persistence rationale is gone).
+- The C5 highlight assertions (in the constraint file and any
+  `test_vessel_highlight_*` overlap): drop the active-tree actor input pin.
+- `test_territories_surface_resolution.py`: the vessel-SCT resolver
+  (`GetVascularSegmentIds` / `GetVascularSurfacePolyData`) STAYS valid and its
+  suite mostly holds; ADD a per-segment-split assertion if B1's wrapper needs
+  id→surface (the merged resolver test is unaffected).
+- `test_territories_vmtk_feed.py`: extend for group-by-structure — a territory
+  with seeds on two structures produces TWO centerlines; the ≥2-per-structure
+  gate skips a 1-seed structure; idempotent re-extraction.
+
+### New invariants to pin
+
+- **Seed→structure mapping** (new `test_territories_seed_structure.py`, bare):
+  a seed nearest structure A's surface maps to A; nearest B maps to B; a
+  boundary/tie resolves deterministically to the first-in-order structure.
+- **Per-structure ≥2 warning** (bare, table or mapping query): a territory
+  with 2 seeds on A + 1 on B flags the warning (B under-seeded); 2+2 does not.
+- **Extraction one-centerline-per-≥2-seed-structure** (feed test): grouping
+  drives exactly one VMTK run per qualifying structure; the mixed-system
+  territory yields 2 centerlines both grouped under the territory.
+- **No straddle-snap** (constraint file, rewritten): a later off-component seed
+  is added at its own snapped point, unchanged.
+
+---
+
+## Part D — ADR-0037 slice-5 amendment revision
+
+Rewrite ADR-0037 §"Amendment — connected-tree-constrained centerline seeding
+(slice 5)" so the design of record FLIPS:
+
+- REMOVE "First seed defines the active vessel tree", "Seeds constrained to
+  the active tree", and "Active tree highlighted while placing".
+- REPLACE with: (a) a territory owns seeds across possibly-multiple disjoint
+  structures; (b) each seed is assigned to the input SEGMENT whose closed
+  surface it is nearest; (c) the pick stays visibility-gated (hide a system to
+  avoid stray seeds) — this is the only placement constraint; (d) extraction
+  GROUPS a territory's seeds by structure and runs VMTK once per structure with
+  ≥2 seeds, over that structure's surface; (e) a structure with <2 seeds is
+  skipped and flags the territory (glyph+text, ADR-0010); (f) N centerlines
+  per territory, all marked with the territory int, all feeding the one map
+  region; (g) seed rows in the table are coloured by structure (segment
+  display colour) with the structure name (ADR-0010); (h) no glow halo.
+- Keep the vessel-SCT-type surface section (still correct).
+- Update §Conformance (slice 5): replace the "two seeds → different trees /
+  snap / persist" points with "seed→structure mapping is deterministic",
+  "≥2-per-structure gate", "one centerline per ≥2-seed structure", "mixed-
+  system territory yields 2 centerlines", "no straddle-snap".
+
+Note the amendment may reference PR numbers in prose (planning docs may);
+code comments referencing the superseded design must NOT carry PR/issue refs
+(`feedback_no_pr_refs_in_code`).
+
+---
+
+## Slice / PR breakdown
+
+This is all on the unpushed `feature/vasc-territories-connected-tree` branch.
+The landed slice-5 commits encode the wrong design, so the cleanest history is
+NOT to pile a revert on top.
+
+**RECOMMENDATION: amend in place via an interactive rebase is risky (13
+commits, shared conceptual chain). Instead add follow-on commits that (1)
+remove the lock+halo, (2) add mapping+grouping, (3) revise ADR+tests — then
+squash-clean at PR time if the maintainer wants linear history.** Concretely:
+
+- **Commit 1 (BUG/ENH):** remove `_constrain_to_active_tree` (both pipelines),
+  the active-tree highlight actor + overlay wiring, `nearest_point_on`; rewrite
+  the constraint test to pin no-straddle-snap. Green both harnesses.
+- **Commit 2 (ENH):** `SeedStructureMapping.py` + the group-by-structure
+  extraction rework + the N-centerline idempotency hoist; feed + mapping tests.
+- **Commit 3 (ENH):** table seed-row colour-by-structure + per-structure
+  warning glyph; table tests.
+- **Commit 4 (DOC):** ADR-0037 slice-5 amendment revision + this plan.
+
+Rationale: commit 1 is a pure removal (independently reviewable, restores
+correct placement freedom); commit 2 is the compute core; commit 3 is UX;
+commit 4 records the decision. Keeps the compute change reviewable apart from
+the GL/table review. Validate BOTH the launched-Slicer harness and the bare
+`PythonSlicer -m pytest` scaffold before pushing (`feedback_two_python_test_
+harnesses`); watch the LiverSegmentation-root-last launched-sweep trap.
+
+---
+
+## ADR conformance / conflicts
+
+- **ADR-0011:** seed→structure mapping keys on the same SCT-typed segment set
+  (`GetVascularSegmentIds`); no new terminology dispatch site. No conflict.
+- **ADR-0013 §1/§5:** removing the third highlight actor REDUCES pipeline
+  surface; no new pipeline, no custom DM. Group-by-structure is a Logic
+  concern, not a DM. No conflict.
+- **ADR-0014:** seed→structure is DERIVED (no new carrier slot / node family);
+  durable state stays the carrier point round-trip. Conforms.
+- **ADR-0004:** the pure geometry (nearest-surface) lives in a Python lib;
+  segment tag/colour reads ride existing seams. Conforms.
+- **ADR-0010:** seed colour is paired with structure NAME text; the warning is
+  glyph+text. Conforms — flag any implementation that ships colour alone.
+- **ADR-0034:** the table stays a Python-composed custom tree. Conforms.
+- **ADR-0036:** the vessel-adhering hover highlight is untouched; only the
+  active-tree GLOW (a slice-5 addition) is removed. No conflict.
+- **ADR-0027:** every behaviour change is pinned by a bare/launched invariant
+  before implementation (test-first). Conforms.
+- **Closed vocabulary / platform neutrality / no-PR-refs-in-code:** new class
+  `SeedStructureMapping` drops any `Liver` prefix (Territories family already
+  does); no build-system changes; no PR/issue numbers in source.
+
+---
+
+## OPEN QUESTIONS (maintainer decides; planning proceeds on the recommendation)
+
+- **Q1 — grouping unit: segment vs raw connected component.** The maintainer
+  said "structure/segment". In real data segment ≡ component.
+  **RECOMMENDATION: group by SEGMENT (id).** It matches the surgeon's mental
+  model, gives a stable colour (the segment display colour), and survives a
+  segment that is one connected surface. Proceeding on segment grouping.
+- **Q2 — a structure (segment) with DISJOINT pieces.** If one segment holds
+  two disjoint tubes, VMTK over the whole segment surface tunnels between them.
+  **RECOMMENDATION: narrow each per-structure surface to the connected
+  component of that structure's seeds (keep `connected_component_at`), seeded
+  at the structure's first-in-territory seed.** Note as a known limitation if
+  a structure's seeds span its own two pieces (rare); proceeding with the
+  single-component narrow.
+- **Q3 — seed on a boundary between two structures.** A point equidistant to
+  two surfaces. **RECOMMENDATION: deterministic first-in-order tiebreak** (by
+  segment id order from `GetVascularSegmentIds`); document it. A tolerance-band
+  "ambiguous" flag is a possible follow-up. Proceeding on the tiebreak.
+- **Q4 — perf of nearest-structure mapping per seed.** N `FindClosestPoint`
+  per seed (N = vessel segments, small). **RECOMMENDATION: cache the N cell
+  locators by `visibility_mtime`; map on demand.** Cheaper than the removed
+  per-seed connectivity. Proceeding on the cache.
+- **Q5 — derive-on-demand vs stamp-at-placement for the seed's structure.**
+  **RECOMMENDATION: derive on demand** (no carrier slot, ADR-0014). Revisit only
+  if a hidden-surface re-map flicker or a repaint-perf issue appears.
+- **Q6 — seed-row colour: segment display colour vs generated palette.** The
+  maintainer specified the segment display colour. **RECOMMENDATION: segment
+  display colour** (matches the 3D vessel render), palette only as a fallback.
+  Proceeding on the segment colour.
+- **Q7 — `nearest_point_on` deletion.** It becomes unused once the lock is
+  removed. **RECOMMENDATION: delete it + its test** unless a reviewer wants it
+  retained as a utility. Proceeding on deletion.

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -70,6 +70,8 @@ design/resection-plan-architecture/03-storage-ownership.md
 design/resection-plan-architecture/04-save-load-flows.md
 design/resection-plan-architecture/05-lrp-json-schema.md
 design/resection-plan-architecture/06-pattern-and-audit.md
+design/connected-tree-seeding-plan.md
+design/multi-system-territory-plan.md
 ```
 
 ```{toctree}

--- a/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
+++ b/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.cxx
@@ -349,6 +349,130 @@ std::string vtkSlicerVascularTerritoriesLogic::GetLiverSegmentId(vtkMRMLSegmenta
   return "";
 }
 
+namespace
+{
+// ADR-0037 slice 5 (Q1): the vascular TYPE-code allowlist.  Real liver data
+// tags vessels under category SCT^85756007 (Tissue) with the generic Vein /
+// Artery TYPE codes, so the match set is the two generic codes rather than the
+// per-vessel portal/hepatic codes.  Substring match on scheme+code in the
+// segment's TerminologyEntry tag, tolerant of the meaning string (identical to
+// GetLiverSegmentId, ADR-0011).  Kept as ONE named constant so the terminology
+// dispatch has a single site.
+const std::vector<std::string>& VascularTypeTokens()
+{
+  static const std::vector<std::string> tokens = {
+    "SCT^29092000", // Vein
+    "SCT^51114001", // Artery
+  };
+  return tokens;
+}
+
+// Segment TYPE codes explicitly excluded from the vessel set: the liver
+// parenchyma supplies the map region (not a vessel tree) and the tumour is not
+// a vascular structure (ADR-0037 slice 5; ADR-0011).
+const std::vector<std::string>& NonVascularTypeTokens()
+{
+  static const std::vector<std::string> tokens = {
+    "SCT^10200004", // Liver
+    "SCT^19227008", // Malignant neoplasm (tumour)
+  };
+  return tokens;
+}
+} // namespace
+
+//----------------------------------------------------------------------------
+std::vector<std::string> vtkSlicerVascularTerritoriesLogic::GetVascularSegmentIds(vtkMRMLSegmentationNode* segmentationNode)
+{
+  // Return a std::vector<std::string>: the VTK Python wrapper exposes it as a
+  // plain iterable list (a vtkStringArray return is NOT Python-iterable).
+  std::vector<std::string> vascularSegmentIds;
+  if (!segmentationNode)
+  {
+    return vascularSegmentIds;
+  }
+  vtkSegmentation* segmentation = segmentationNode->GetSegmentation();
+  if (!segmentation)
+  {
+    return vascularSegmentIds;
+  }
+  // Keep segments whose TerminologyEntry TYPE code is vascular (Vein / Artery),
+  // dropping the liver + tumour segments -- the inverse of GetLiverSegmentId,
+  // reusing the same SCT-substring idiom (ADR-0011).
+  std::vector<std::string> segmentIds;
+  segmentation->GetSegmentIDs(segmentIds);
+  for (const std::string& segmentId : segmentIds)
+  {
+    vtkSegment* segment = segmentation->GetSegment(segmentId);
+    if (!segment)
+    {
+      continue;
+    }
+    std::string tag;
+    if (!segment->GetTag("TerminologyEntry", tag))
+    {
+      continue;
+    }
+    bool excluded = false;
+    for (const std::string& token : NonVascularTypeTokens())
+    {
+      if (tag.find(token) != std::string::npos)
+      {
+        excluded = true;
+        break;
+      }
+    }
+    if (excluded)
+    {
+      continue;
+    }
+    for (const std::string& token : VascularTypeTokens())
+    {
+      if (tag.find(token) != std::string::npos)
+      {
+        vascularSegmentIds.push_back(segmentId);
+        break;
+      }
+    }
+  }
+  return vascularSegmentIds;
+}
+
+//----------------------------------------------------------------------------
+void vtkSlicerVascularTerritoriesLogic::GetVascularSurfacePolyData(vtkMRMLSegmentationNode* segmentationNode, vtkPolyData* outPolyData)
+{
+  if (!outPolyData)
+  {
+    return;
+  }
+  outPolyData->Initialize();
+  if (!segmentationNode)
+  {
+    return;
+  }
+  // Resolve the vessels-only surface: append the closed-surface reps of just
+  // the vascular segments (the merge connectivity later splits per territory,
+  // ADR-0037 slice 5).  This supersedes the merge-all input on the extraction
+  // path while the pick/highlight path keeps snapping to all vessels.
+  std::vector<std::string> vascularSegmentIds = this->GetVascularSegmentIds(segmentationNode);
+  segmentationNode->CreateClosedSurfaceRepresentation();
+  vtkNew<vtkAppendPolyData> append;
+  for (const std::string& vascularSegmentId : vascularSegmentIds)
+  {
+    vtkNew<vtkPolyData> mesh;
+    segmentationNode->GetClosedSurfaceRepresentation(vascularSegmentId, mesh);
+    if (mesh->GetNumberOfPoints() > 0)
+    {
+      append->AddInputData(mesh);
+    }
+  }
+  if (append->GetNumberOfInputConnections(0) == 0)
+  {
+    return;
+  }
+  append->Update();
+  outPolyData->ShallowCopy(append->GetOutput());
+}
+
 void vtkSlicerVascularTerritoriesLogic::calculateVascularTerritoryMap(vtkMRMLSegmentationNode* vascularTerritorySegmentationNode,
                                                                       vtkMRMLScalarVolumeNode* refVolume,
                                                                       vtkMRMLSegmentationNode* segmentation,

--- a/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.h
+++ b/VascularTerritories/Logic/vtkSlicerVascularTerritoriesLogic.h
@@ -49,6 +49,7 @@
 #include <vtkSmartPointer.h>
 
 #include <string>
+#include <vector>
 
 // Forward delcarations
 class vtkKdTreePointLocator;
@@ -122,6 +123,24 @@ public:
   /// with arbitrary segment names).  Empty string when there is no scene / no
   /// segmentation / no SCT-liver-tagged segment.
   std::string GetLiverSegmentId(vtkMRMLSegmentationNode* segmentationNode);
+
+  /// Return the segment ids of ``segmentationNode`` whose ``TerminologyEntry``
+  /// TYPE code is vascular (Vein ``SCT^29092000`` / Artery ``SCT^51114001`` —
+  /// the documented allowlist), EXCLUDING the liver (``SCT^10200004``) and
+  /// tumour (``SCT^19227008``) segments.  Mirrors the ``GetLiverSegmentId``
+  /// SCT-substring idiom (ADR-0011); narrows the centerline surface candidates
+  /// to vessels (ADR-0037 slice 5).  Returned as a ``std::vector<std::string>``
+  /// (the VTK Python wrapper exposes it as a plain iterable list — a
+  /// ``vtkStringArray`` return is not Python-iterable); empty when there is no
+  /// scene / segmentation / vessel-tagged segment.
+  std::vector<std::string> GetVascularSegmentIds(vtkMRMLSegmentationNode* segmentationNode);
+
+  /// Append the closed-surface representations of only the vascular segments
+  /// (as resolved by ``GetVascularSegmentIds``) into ``outPolyData`` — the
+  /// vessels-only merge the per-territory connectivity later splits (ADR-0037
+  /// slice 5, supersedes the merge-all extraction input).  Initialises
+  /// ``outPolyData`` first; leaves it empty when no vascular segment resolves.
+  void GetVascularSurfacePolyData(vtkMRMLSegmentationNode* segmentationNode, vtkPolyData* outPolyData);
 
 protected:
   vtkSlicerVascularTerritoriesLogic();

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -152,6 +152,12 @@ set(_vascterr_pytest_files
   # extractor a None/empty mesh.  Needs Slicer's segmentation logic + a live
   # scene so it SKIP-PENDS bare and RUNS launched; the VMTK compute itself
   # stays env-/eyeball-gated in test_territories_vmtk_feed.py (ADR-0027).
+  # ALSO hosts the ADR-0037 slice-5 (PR-A) vessel-SCT-filter invariant (T1):
+  # GetVascularSegmentIds keeps only vascular-SCT-typed segments (Vein
+  # SCT^29092000 / Artery SCT^51114001) and excludes the liver (SCT^10200004)
+  # and tumour segments, mirroring the GetLiverSegmentId C++ idiom on logic.scl;
+  # launched (segmentation infra + wrapped C++ logic), SKIP-PENDING bare + until
+  # the resolver lands (ADR-0027).
   test_territories_surface_resolution.py
   # ADR-0037 §Decision 2/3 (slice 4) -- per-territory Place mode + module-active
   # gate + composite-row panel polish.  Placement becomes an EXPLICIT,
@@ -170,6 +176,22 @@ set(_vascterr_pytest_files
   # SKIP-PENDING bare / while the composite-row seam is absent, and RUN launched
   # once the composite-row tree + eye toggle land (ADR-0027).
   test_territories_placemode.py
+  # ADR-0037 slice 5 (PR-A, connected-tree seeding) -- the connectivity-recovery
+  # invariant.  The compute amendment merged EVERY segment into the VMTK input;
+  # real liver data (portal + hepatic are disjoint components) makes merge-all
+  # wrong, so a territory's active surface narrows to the single connected
+  # component its index-0 seed lands on.  The recovery is a PURE-VTK helper
+  # (vtkPolyDataConnectivityFilter in ClosestPointRegion mode; no MRML, no GL):
+  # a seed on one of two disjoint spheres recovers ONLY that sphere's component
+  # (single region, zero points from the other); two disjoint seeds resolve to
+  # different trees; and re-deriving from a NEW index-0 (after first-seed
+  # deletion) recovers the SAME component (the reuse-AnnotationPoints[0]
+  # persistence decision).  Import-guarded on the not-yet-existing
+  # VascularTerritoriesLib/VesselConnectivity.py; the file COLLECTS + SKIP-
+  # PENDINGs cleanly bare and genuinely RUNS bare (pure VTK) once the helper
+  # lands (ADR-0027).  The vessel-SCT-filter twin (T1) lives launched in
+  # test_territories_surface_resolution.py.
+  test_territories_connectivity.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -192,6 +192,28 @@ set(_vascterr_pytest_files
   # lands (ADR-0027).  The vessel-SCT-filter twin (T1) lives launched in
   # test_territories_surface_resolution.py.
   test_territories_connectivity.py
+  # ADR-0037 slice 5 (PR-B, placement UX) -- the active-tree seed CONSTRAINT +
+  # highlight + module-active gate on the placement pipelines.  PR-A landed the
+  # compute core (vessels-only surface, C++ GetVascularSegmentIds, the pure-VTK
+  # connected_component_at, per-extraction single-component surface); PR-B adds
+  # the interaction layer: the first seed of an armed territory DEFINES its
+  # active vessel tree (the connected component of that point), a later seed on a
+  # DIFFERENT component is re-snapped onto the active component (never off-tree),
+  # so a territory's seeds always lie on ONE connected component (the component
+  # of AnnotationPoints[territory][0]); an active-tree highlight actor (owned by
+  # the placement pipeline, no new displayable manager per ADR-0013) takes the
+  # seed[0] component as its INPUT (styling deferred -- only the input identity
+  # is pinned); and the module-active gate declines an add-on-click while the
+  # owning module is inactive (belt-and-suspenders beyond the display-node armed
+  # flag).  The SUT surface is TWO disjoint spheres (vtkAppendPolyData of two
+  # separated vtkSphereSource) wired as the vessels-only pick surface, with the
+  # stub-renderer + injected-pick pattern from test_territories_placement_pipeline
+  # so clicks map to chosen world points on sphere A or sphere B.  Needs
+  # LayerDMLib + the wrapped carrier + the shared highlight display node;
+  # import-/hasattr-guarded on the not-yet-existing PR-B seams (activeTreePolyData
+  # / highlightActor / SetModuleActive + the later-seed constraint gate), they
+  # SKIP-PENDING bare and RUN launched once PR-B lands (ADR-0027).
+  test_territories_placemode_constraint.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -113,6 +113,12 @@ set(_vascterr_pytest_files
   # guard / per-territory invariants need the module Logic + a live scene
   # so they SKIP-PENDING bare and RUN launched; the REAL extraction wiring
   # is SlicerVMTK-env-gated and skips cleanly off that image (ADR-0027).
+  # ALSO hosts the REVISED slice-5 GROUP-BY-STRUCTURE invariant (i7): a
+  # territory with >=2 seeds on TWO structures (vein + artery) yields TWO
+  # centerlines, both grouped under the territory; a structure with <2 seeds is
+  # SKIPPED (the per-structure >=2 gate).  Launched (module Logic + a real
+  # multi-segment segmentation + a stubbed line extractor, so no SlicerVMTK is
+  # needed); SKIPS bare (ADR-0027).
   test_territories_vmtk_feed.py
   # ADR-0037 §Decision 3 (slice 2) -- the PANEL modernisation to Python-widget
   # composition (ADR-0004): the table-duplicating v1 selector/place-widget
@@ -176,44 +182,67 @@ set(_vascterr_pytest_files
   # SKIP-PENDING bare / while the composite-row seam is absent, and RUN launched
   # once the composite-row tree + eye toggle land (ADR-0027).
   test_territories_placemode.py
-  # ADR-0037 slice 5 (PR-A, connected-tree seeding) -- the connectivity-recovery
-  # invariant.  The compute amendment merged EVERY segment into the VMTK input;
-  # real liver data (portal + hepatic are disjoint components) makes merge-all
-  # wrong, so a territory's active surface narrows to the single connected
-  # component its index-0 seed lands on.  The recovery is a PURE-VTK helper
+  # ADR-0037 slice 5 (REVISED, multi-system seeding) -- the PER-STRUCTURE
+  # connected-component narrow.  The compute amendment merged EVERY segment into
+  # the VMTK input; real liver data (portal + hepatic are disjoint) makes
+  # merge-all wrong.  The REVISED design drops the single-active-tree LOCK (a
+  # territory may straddle disjoint structures; extraction groups by structure),
+  # but connectivity SURVIVES for a different job: narrowing each PER-STRUCTURE
+  # surface to the connected component of that structure's OWN seed, so a single
+  # input segment carrying two disjoint tubes still feeds VMTK one coherent tree
+  # (the A3/Q2 edge case).  The recovery is a PURE-VTK helper
   # (vtkPolyDataConnectivityFilter in ClosestPointRegion mode; no MRML, no GL):
   # a seed on one of two disjoint spheres recovers ONLY that sphere's component
-  # (single region, zero points from the other); two disjoint seeds resolve to
-  # different trees; and re-deriving from a NEW index-0 (after first-seed
-  # deletion) recovers the SAME component (the reuse-AnnotationPoints[0]
-  # persistence decision).  Import-guarded on the not-yet-existing
-  # VascularTerritoriesLib/VesselConnectivity.py; the file COLLECTS + SKIP-
-  # PENDINGs cleanly bare and genuinely RUNS bare (pure VTK) once the helper
-  # lands (ADR-0027).  The vessel-SCT-filter twin (T1) lives launched in
-  # test_territories_surface_resolution.py.
+  # (single region, zero points from the other).  The retired reuse-index-0
+  # persistence test is REMOVED with the lock.  Import-guarded on the
+  # not-yet-existing VascularTerritoriesLib/VesselConnectivity.py; the file
+  # COLLECTS + SKIP-PENDINGs cleanly bare and genuinely RUNS bare (pure VTK) once
+  # the helper lands (ADR-0027).  The vessel-SCT-filter twin (T1) + per-segment
+  # closed-surface split (T1d) live launched in
+  # test_territories_surface_resolution.py; the seed->structure mapping twin is
+  # test_territories_seed_structure.py.
   test_territories_connectivity.py
-  # ADR-0037 slice 5 (PR-B, placement UX) -- the active-tree seed CONSTRAINT +
-  # highlight + module-active gate on the placement pipelines.  PR-A landed the
-  # compute core (vessels-only surface, C++ GetVascularSegmentIds, the pure-VTK
-  # connected_component_at, per-extraction single-component surface); PR-B adds
-  # the interaction layer: the first seed of an armed territory DEFINES its
-  # active vessel tree (the connected component of that point), a later seed on a
-  # DIFFERENT component is re-snapped onto the active component (never off-tree),
-  # so a territory's seeds always lie on ONE connected component (the component
-  # of AnnotationPoints[territory][0]); an active-tree highlight actor (owned by
-  # the placement pipeline, no new displayable manager per ADR-0013) takes the
-  # seed[0] component as its INPUT (styling deferred -- only the input identity
-  # is pinned); and the module-active gate declines an add-on-click while the
-  # owning module is inactive (belt-and-suspenders beyond the display-node armed
-  # flag).  The SUT surface is TWO disjoint spheres (vtkAppendPolyData of two
-  # separated vtkSphereSource) wired as the vessels-only pick surface, with the
-  # stub-renderer + injected-pick pattern from test_territories_placement_pipeline
-  # so clicks map to chosen world points on sphere A or sphere B.  Needs
-  # LayerDMLib + the wrapped carrier + the shared highlight display node;
-  # import-/hasattr-guarded on the not-yet-existing PR-B seams (activeTreePolyData
-  # / highlightActor / SetModuleActive + the later-seed constraint gate), they
-  # SKIP-PENDING bare and RUN launched once PR-B lands (ADR-0027).
+  # ADR-0037 slice 5 (REVISED, multi-system seeding) -- placement no longer
+  # LOCKS a territory to one connected vessel tree.  The landed slice-5 design
+  # (first seed defines the active tree, later seeds snap back, the component
+  # glows) was clinically wrong: a vascular territory may own seeds across
+  # MULTIPLE disjoint structures (portal + hepatic), derived independently and
+  # both feeding the one map region.  This suite pins the FLIP: NO STRADDLE-SNAP
+  # -- a later add-on-click on a DIFFERENT visible structure STAYS there (two
+  # seeds, two structures); the retired active-tree lock+halo (activeTreePolyData
+  # / highlightActor / _constrain_to_active_tree / _highlight_tree_actor) are
+  # asserted GONE (an absence pin with a credible creep-in path -- the named
+  # attributes exist on the landed branch and must be removed); the visibility-
+  # gated pick is the only placement constraint (pinned in
+  # test_territories_surface_resolution T1c, not here); and the retained
+  # module-active + armed gates still decline clicks.  The SUT surface is TWO
+  # disjoint spheres (vtkAppendPolyData of two separated vtkSphereSource) wired
+  # as the vessels-only pick surface, with the stub-renderer + injected-pick
+  # pattern from test_territories_placement_pipeline so clicks map to chosen
+  # world points on structure A or structure B.  Needs LayerDMLib + the wrapped
+  # carrier + the shared highlight display node; the no-straddle-snap + retired-
+  # halo invariants go GREEN when the implementer removes the lock+halo, the
+  # module-gate invariants SKIP-PENDING until the pipeline seams land, all RUN
+  # launched (ADR-0027).
   test_territories_placemode_constraint.py
+  # ADR-0037 slice 5 (REVISED, multi-system seeding) -- the seed->structure
+  # mapping (pure-VTK).  Each of a territory's seeds is assigned to the input
+  # SEGMENT (structure) whose CLOSED SURFACE it is nearest (portal / hepatic /
+  # ...), so a territory may straddle disjoint structures and extraction can
+  # group by structure.  The geometry (nearest closed surface to a point) is
+  # PURE polydata -> Python (ADR-0004 split): nearest_structure(structures,
+  # point) -> key builds one vtkCellLocator per structure surface and returns
+  # the nearest structure's key, with a deterministic first-in-order tiebreak on
+  # a boundary point (Q3); territory_structure_seed_counts(assignments) groups
+  # mapped (seed, structureKey) pairs into {key: count}, the SAME >=2-per-
+  # structure gate the extractor (test_territories_vmtk_feed) and the table
+  # warning (test_territories_table) read so they agree.  Import-guarded on the
+  # not-yet-existing VascularTerritoriesLib/SeedStructureMapping.py; the file
+  # COLLECTS + SKIP-PENDINGs cleanly bare and genuinely RUNS bare (pure VTK) once
+  # the helper lands (ADR-0027).  The MRML-facing segment->surface/colour
+  # resolution rides existing seams, pinned launched in
+  # test_territories_surface_resolution (T1d) + test_territories_table.
+  test_territories_seed_structure.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -243,6 +243,28 @@ set(_vascterr_pytest_files
   # resolution rides existing seams, pinned launched in
   # test_territories_surface_resolution (T1d) + test_territories_table.
   test_territories_seed_structure.py
+  # ADR-0037 slice 5 -- the Extract + Compute actions GATE ON REAL
+  # PRECONDITIONS (§Decision 4).  Extract enables iff an input is selected AND
+  # SlicerVMTK is present AND a territory has a STRUCTURE with >=2 seeds (the
+  # same per-structure grouping the extractor runs on, via the shared
+  # territoryStructureSeedCounts query); Compute enables iff an input is
+  # selected AND a reference volume exists AND a centerline has been extracted
+  # (CenterlineRefs non-empty).  Needs the wrapped carrier + a live scene (i1
+  # also Qt); the shared count query + the widget enablement invariants
+  # SKIP-PENDING bare + until the seam lands and RUN launched, reusing the
+  # stub-centerline CenterlineRefs idiom so no SlicerVMTK is required (ADR-0027).
+  test_territories_action_enablement.py
+  # ADR-0037 slice 5 -- centerlines + seeds FOLLOW the anatomical-structure
+  # show/hide.  Hiding a structure (input segment) omits its seeds from the 3D
+  # seed glyphs AND the 2D projection (each seed mapped to its nearest structure
+  # via SeedStructureMapping, gated on the segment's display visibility) and
+  # hides its extracted centerline (tagged with VascularTerritories.
+  # StructureSegmentId, synced by a widget-level segmentation-display-node
+  # observer -- ADR-0013 §5, no displayable manager); showing restores them.
+  # Needs the wrapped carrier + highlight display node + a live multi-segment
+  # segmentation (i2 also Qt); SKIP-PENDING bare + until the seams land and RUN
+  # launched (ADR-0027).
+  test_territories_structure_visibility.py
 )
 
 foreach(_pytest_file IN LISTS _vascterr_pytest_files)

--- a/VascularTerritories/Testing/Python/CMakeLists.txt
+++ b/VascularTerritories/Testing/Python/CMakeLists.txt
@@ -94,7 +94,12 @@ set(_vascterr_pytest_files
   # surviving and no persisted fiducial.  Needs Qt + the wrapped carrier +
   # LayerDMLib; import-/hasattr-guarded on the not-yet-existing table widget
   # + carrier display slot + Pipeline arm seam, they SKIP-PENDING bare and
-  # RUN launched once the seam lands (ADR-0027).
+  # RUN launched once the seam lands (ADR-0027).  ALSO hosts the post-review
+  # refinement guard (green regression): Add Territory arms the new territory
+  # (its Place toggle reads checked) but must NOT auto-select its tree row --
+  # arming, not selection, is the active-state cue (ADR-0037 §Decision 2
+  # slice-4).  This RUNS + PASSES launched now, guarding a re-introduced
+  # setCurrentItem.
   test_territories_table.py
   # ADR-0037 §2D -- the slice-view territory placement + distance-faded viz
   # (mirrors SliceControlPolygonPipeline, ADR-0033): the projection / signed
@@ -146,7 +151,13 @@ set(_vascterr_pytest_files
   # The pure label-map core RUNS BARE; the carrier-sourcing / derived-output /
   # selector-retirement / button-wiring invariants need the wrapped carrier +
   # module widget + Logic so they SKIP-PENDING bare and RUN launched; the real
-  # C++ map run stays eyeball-gated (stubbed here) (ADR-0027).
+  # C++ map run stays eyeball-gated (stubbed here) (ADR-0027).  ALSO hosts the
+  # post-review refinement guard (green regression): each map-output segment is
+  # NAMED + COLOURED for its TERRITORY (GetTerritoryLabel / GetTerritoryColor),
+  # keyed by the segment's label value through TerritoryLabelMap
+  # (_applyTerritoryNamesAndColors), so the map reads the same as the table
+  # (ADR-0037 §Decision 4 / §Decision 1).  Driven against a hand-built map
+  # segmentation with known label values, so it RUNS + PASSES launched now.
   test_territories_map_compute.py
   # ADR-0037 §Decision 4 -- the centerline SURFACE-RESOLUTION invariant: a
   # segmentation input's closed surface must be resolved through the real
@@ -253,6 +264,12 @@ set(_vascterr_pytest_files
   # also Qt); the shared count query + the widget enablement invariants
   # SKIP-PENDING bare + until the seam lands and RUN launched, reusing the
   # stub-centerline CenterlineRefs idiom so no SlicerVMTK is required (ADR-0027).
+  # ALSO hosts the post-review refinement guards (green regression): a
+  # successful Extract AND a Compute both DISARM placement (toggle the active
+  # Place button off via the table's shared done() body, writing armed=0 onto
+  # the shared display node) so a stray click after the action drops no seed
+  # (ADR-0037 §Decision 4).  VMTK gate / extractor / C++ map run are stubbed, so
+  # these RUN + PASS launched now without SlicerVMTK.
   test_territories_action_enablement.py
   # ADR-0037 slice 5 -- centerlines + seeds FOLLOW the anatomical-structure
   # show/hide.  Hiding a structure (input segment) omits its seeds from the 3D
@@ -263,7 +280,15 @@ set(_vascterr_pytest_files
   # observer -- ADR-0013 §5, no displayable manager); showing restores them.
   # Needs the wrapped carrier + highlight display node + a live multi-segment
   # segmentation (i2 also Qt); SKIP-PENDING bare + until the seams land and RUN
-  # launched (ADR-0027).
+  # launched (ADR-0027).  ALSO hosts the post-review refinement guards (green
+  # regression): (a) the seed-repaint TRIGGER -- a SetSegmentVisibility toggle
+  # repaints the seed glyphs VIA THE PIPELINE'S OWN OBSERVER (not a direct
+  # rebuild call, unlike i1's filter test); (b) SetSegmentVisibility advances the
+  # visibility_mtime cache-invalidation key; (c) the hover/grab hit-test
+  # (_nearest_point_in_display) excludes a hidden-structure seed even under the
+  # cursor; (d) VisibleStructuresCache builds per-structure vtkCellLocators ONCE
+  # per visibility MTime and reuses them across seed_visible calls (the hover-
+  # perf fix).  All RUN + PASS launched now.
   test_territories_structure_visibility.py
 )
 

--- a/VascularTerritories/Testing/Python/test_territories_action_enablement.py
+++ b/VascularTerritories/Testing/Python/test_territories_action_enablement.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 slice 5 — the Extract + Compute actions gate on real preconditions.
+
+The panel's Extract-centerlines and Compute-territory-map actions no longer
+enable on ANY input selection: each reads LIVE state so a surgeon cannot click
+an action that cannot yet run (ADR-0037 §Decision 4):
+
+* Extract centerlines: enabled iff an input segmentation is selected AND
+  SlicerVMTK is present AND at least one territory has a STRUCTURE with >=2
+  seeds -- i.e. something is actually extractable (the SAME per-structure
+  grouping the extraction path runs on).
+* Compute territory map: enabled iff an input segmentation is selected AND a
+  reference volume exists AND at least one centerline has been extracted (the
+  carrier's ``CenterlineRefs`` is non-empty).
+
+This file pins:
+
+* i1 (launched, widget) — with an input selected but no >=2-seed structure,
+  Extract is DISABLED; after >=2 seeds land on a structure it ENABLES.  Compute
+  is DISABLED until ``CenterlineRefs`` is non-empty (+ a reference volume);
+  populated via the stub-centerline idiom from ``test_territories_map_compute``
+  so no SlicerVMTK is needed.
+* i2 (launched) — the shared ``territoryStructureSeedCounts`` query returns the
+  per-structure counts the extraction groups on, so the enablement, the
+  extractor's >=2-per-structure gate, and the table warning cannot diverge.
+
+Both need the wrapped carrier + a live scene (and i1 also Qt), so they SKIP
+cleanly bare and RUN launched (ADR-0027).  The extractable-structure check is
+SlicerVMTK-independent (it is pure grouping), so i1 exercises the Extract gate
+even off the VMTK image by driving ``_hasExtractableStructure`` directly for
+the seed-count half while asserting the button's disabled state stands in for
+"nothing extractable".
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 4)
+  * VascularTerritories/Testing/Python/test_territories_map_compute.py  (the
+    stub-centerline CenterlineRefs idiom this file reuses)
+  * VascularTerritories/Testing/Python/test_territories_seed_structure.py  (the
+    per-structure grouping this query shares)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+SEGMENTATION_CLASS = "vtkMRMLSegmentationNode"
+
+_VEIN_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^29092000^Vein~^^~Anatomic codes~^^~^^"
+)
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror the launched-Slicer discipline in conftest.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _logic_or_skip(slicer):
+    try:
+        from VascularTerritories import VascularTerritoriesLogic
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VascularTerritoriesLogic not importable ({exc!r}).")
+    return VascularTerritoriesLogic()
+
+
+def _make_carrier_or_skip(slicer, name="ActionEnablementCarrier"):
+    node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} not registered -- module Logic "
+            "RegisterNodes() must wire this up (launched build)."
+        )
+    if not hasattr(node, "AddAnnotationPoint"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no AddAnnotationPoint -- the "
+            "ADR-0037 annotation carrier has not landed (ADR-0027)."
+        )
+    return node
+
+
+def _vessel_segmentation(slicer, center=(0.0, 0.0, 0.0), radius=20.0, name="EnablementVessel"):
+    """A one-segment vascular-tagged segmentation (the extractable structure)."""
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(radius)
+    source.SetThetaResolution(24)
+    source.SetPhiResolution(24)
+    source.Update()
+    modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", name + "Model")
+    modelNode.SetAndObservePolyData(source.GetOutput())
+    seg = slicer.mrmlScene.AddNewNodeByClass(SEGMENTATION_CLASS, name)
+    seg.CreateDefaultDisplayNodes()
+    slicer.modules.segmentations.logic().ImportModelToSegmentationNode(modelNode, seg)
+    slicer.mrmlScene.RemoveNode(modelNode)
+    obj = seg.GetSegmentation()
+    segId = obj.GetNthSegmentID(0)
+    obj.GetSegment(segId).SetTag("TerminologyEntry", _VEIN_TERMINOLOGY)
+    return seg, segId
+
+
+# =========================================================================== #
+# i2 — the shared per-structure seed-count query
+# =========================================================================== #
+
+
+def test_territory_structure_seed_counts_matches_grouping():
+    """i2: ``territoryStructureSeedCounts`` returns the per-structure counts.
+
+    The query groups a territory's seeds by their nearest structure exactly as
+    the extraction path does, so the enablement, the extractor's
+    >=2-per-structure gate, and the table warning agree (ADR-0037 slice 5).
+    Two seeds on the vessel yield ``{vesselSegId: 2}``.  Launched-only; SKIPS
+    bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    if not hasattr(logic, "territoryStructureSeedCounts"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no territoryStructureSeedCounts -- "
+            "the ADR-0037 slice-5 shared per-structure count query has not "
+            "landed (ADR-0027)."
+        )
+    carrier = _make_carrier_or_skip(slicer)
+    seg, segId = _vessel_segmentation(slicer)
+
+    # Two seeds near the vessel centre so both map to the vessel structure.
+    carrier.AddAnnotationPoint("T1", 0.0, 0.0, 5.0)
+    carrier.AddAnnotationPoint("T1", 0.0, 0.0, -5.0)
+
+    counts = logic.territoryStructureSeedCounts(carrier, seg, "T1")
+
+    assert counts, "the query must return the per-structure counts, not empty."
+    assert counts.get(segId) == 2, (
+        f"both seeds must group onto the vessel structure {segId!r}; "
+        f"got {counts!r}."
+    )
+    # An empty carrier / territory yields no counts.
+    assert logic.territoryStructureSeedCounts(carrier, seg, "Empty") == {}, (
+        "a territory with no seeds must return an empty count map."
+    )
+
+
+# =========================================================================== #
+# i1 — the Extract / Compute enablement gates (launched, widget)
+# =========================================================================== #
+
+
+def _make_widget_or_skip(slicer):
+    from slicer_pytest_support import require_qt_widget as _require_qt_widget
+
+    _require_qt_widget()
+    from VascularTerritories import VascularTerritoriesWidget
+
+    widget = VascularTerritoriesWidget()
+    widget.setup()
+    return widget
+
+
+def _detach_scene_observers(slicer, widget):
+    for event, handler in (
+        (slicer.mrmlScene.StartCloseEvent, widget.onSceneStartClose),
+        (slicer.mrmlScene.EndCloseEvent, widget.onSceneEndClose),
+    ):
+        try:
+            widget.removeObserver(slicer.mrmlScene, event, handler)
+        except Exception:  # noqa: BLE001 - best-effort across widget shapes
+            pass
+
+
+def _attach_stub_centerline(slicer, logic, carrier, territoryId, name="EnablementCenterline"):
+    """Wire a small line model into the carrier's CenterlineRefs (no VMTK)."""
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 10.0)
+    points.InsertNextPoint(0.0, 0.0, -10.0)
+    lines = vtk.vtkCellArray()
+    lines.InsertNextCell(2)
+    lines.InsertCellPoint(0)
+    lines.InsertCellPoint(1)
+    poly = vtk.vtkPolyData()
+    poly.SetPoints(points)
+    poly.SetLines(lines)
+    model = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", name)
+    model.SetAndObserveMesh(poly)
+    role = getattr(logic, "CENTERLINE_REFERENCE_ROLE", "CenterlineRefs")
+    carrier.AddNodeReferenceID(role, model.GetID())
+    if hasattr(carrier, "SetGrouping"):
+        carrier.SetGrouping(model.GetID(), territoryId)
+    return model
+
+
+def test_extract_gated_on_extractable_structure(qt_widgets):
+    """i1: Extract is DISABLED without a >=2-seed structure, ENABLES with one.
+
+    ADR-0037 §Decision 4: Extract needs SlicerVMTK AND an extractable
+    >=2-seed structure.  Off the VMTK image the button stays disabled by the
+    VMTK gate, so the extractable-structure half is asserted through
+    ``_hasExtractableStructure`` directly (SlicerVMTK-independent -- it is pure
+    grouping); the button-enabled state is asserted only when VMTK is present.
+    Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    if not hasattr(widget, "_updateActionEnablement") or not hasattr(
+        widget, "_hasExtractableStructure"
+    ):
+        pytest.skip(
+            "the ADR-0037 slice-5 action-enablement seam "
+            "(_updateActionEnablement / _hasExtractableStructure) has not "
+            "landed (ADR-0027)."
+        )
+
+    seg, _segId = _vessel_segmentation(slicer)
+    widget.ui.inputSurfaceSelector.setCurrentNode(seg)
+    carrier = widget._ensureAnnotationCarrier()
+
+    # No seeds yet: nothing extractable, and (regardless of VMTK) the button is
+    # disabled.
+    widget._updateActionEnablement()
+    assert widget._hasExtractableStructure(seg) is False, (
+        "with no seeds there is no extractable >=2-seed structure."
+    )
+    assert widget.ui.addCenterlineSegmentButton.enabled is False, (
+        "Extract must be DISABLED with nothing extractable (ADR-0037 §Decision 4)."
+    )
+
+    # Two seeds on the vessel -> a >=2-seed structure exists.
+    carrier.AddAnnotationPoint("T1", 0.0, 0.0, 5.0)
+    carrier.AddAnnotationPoint("T1", 0.0, 0.0, -5.0)
+    widget._updateActionEnablement()
+    assert widget._hasExtractableStructure(seg) is True, (
+        "two seeds on the vessel must expose an extractable >=2-seed structure."
+    )
+    # The button ENABLES only when SlicerVMTK is also present; assert the
+    # VMTK-independent extractable half above, and the button state under VMTK.
+    if widget.logic.extractionActionEnabled():
+        assert widget.ui.addCenterlineSegmentButton.enabled is True, (
+            "Extract must ENABLE once something is extractable AND SlicerVMTK "
+            "is present (ADR-0037 §Decision 4)."
+        )
+
+
+def test_compute_gated_on_centerline_and_reference_volume(qt_widgets):
+    """i1: Compute is DISABLED until CenterlineRefs is non-empty (+ ref volume).
+
+    ADR-0037 §Decision 4: Compute needs an input segmentation, a reference
+    volume, and at least one extracted centerline.  The centerline is populated
+    via the stub-centerline idiom (no SlicerVMTK).  Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    if not hasattr(widget, "_updateActionEnablement"):
+        pytest.skip(
+            "the ADR-0037 slice-5 action-enablement seam has not landed "
+            "(ADR-0027)."
+        )
+
+    seg, _segId = _vessel_segmentation(slicer)
+    widget.ui.inputSurfaceSelector.setCurrentNode(seg)
+    carrier = widget._ensureAnnotationCarrier()
+
+    # A reference volume, but no centerline yet: Compute stays disabled.
+    ref_volume = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLScalarVolumeNode", "EnablementRefVolume")
+    image = vtk.vtkImageData()
+    image.SetDimensions(4, 4, 4)
+    image.AllocateScalars(vtk.VTK_SHORT, 1)
+    ref_volume.SetAndObserveImageData(image)
+
+    widget._updateActionEnablement()
+    assert widget.ui.calculateVascularTerritoryMapButton.enabled is False, (
+        "Compute must be DISABLED with no extracted centerline (ADR-0037 "
+        "§Decision 4)."
+    )
+
+    # A centerline in CenterlineRefs flips Compute on (input + volume present).
+    _attach_stub_centerline(slicer, widget.logic, carrier, "T1")
+    widget._updateActionEnablement()
+    assert widget.ui.calculateVascularTerritoryMapButton.enabled is True, (
+        "Compute must ENABLE once a centerline is extracted (CenterlineRefs "
+        "non-empty), an input is selected, and a reference volume exists."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_action_enablement.py
+++ b/VascularTerritories/Testing/Python/test_territories_action_enablement.py
@@ -304,5 +304,170 @@ def test_compute_gated_on_centerline_and_reference_volume(qt_widgets):
     )
 
 
+# =========================================================================== #
+# POST-REVIEW REFINEMENT — Extract + Compute both DISARM placement
+# =========================================================================== #
+#
+# The reviewer's refinement (ADR-0037 §Decision 4): starting an Extract or a
+# Compute ENDS the placement gesture -- the widget toggles the active Place
+# button OFF via the table's shared ``disarm()`` body (which writes armed=0 onto
+# the shared display node) so a stray click after the action does not drop
+# another seed.  The extract path early-returns before VMTK is confirmed, so the
+# disarm rides the SUCCESS path (VMTK/extractor stubbed here); the compute path
+# disarms after the map run (also stubbed).  Green regression guards: RUN +
+# PASS launched now.
+
+
+def _import_interaction_state_or_skip():
+    try:
+        from VascularTerritoriesLib import TerritoryInteractionState as state
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoryInteractionState not importable ({exc!r}) (ADR-0027).")
+    return state
+
+
+def _arm_widget_placement_or_skip(widget, state):
+    """Arm placement on the widget's shared highlight display node, or skip.
+
+    Mirrors the table's ``_armInto``: writes armed=1 onto the shared display
+    node -- the handle the placement Pipeline and the table's ``disarm()`` both
+    read/write.
+    """
+    displayNode = getattr(widget, "_highlightDisplayNode", None)
+    if displayNode is None:
+        pytest.skip(
+            "widget has no _highlightDisplayNode -- the shared display node the "
+            "disarm writes to is unavailable (launched build; ADR-0027)."
+        )
+    if getattr(widget, "_territoriesTable", None) is None:
+        pytest.skip(
+            "widget has no _territoriesTable -- the disarm routes through the "
+            "table's shared done() body (ADR-0027)."
+        )
+    state.set_armed(displayNode, True)
+    assert state.is_armed(displayNode) is True, (
+        "precondition: placement must read armed before the action disarms it."
+    )
+    return displayNode
+
+
+def test_extract_centerlines_disarms_placement(qt_widgets, monkeypatch):
+    """A successful Extract ENDS the placement gesture (disarms via the table).
+
+    Post-review refinement (ADR-0037 §Decision 4): extracting toggles the active
+    Place button off so a stray click after extraction does not drop another
+    seed.  The disarm rides the SUCCESS path (the action early-returns when
+    SlicerVMTK is absent), so ``extractionActionEnabled`` + ``extractCenterlines``
+    + the centerline-visibility sync are stubbed -- no SlicerVMTK needed.  Pins
+    the display node reading dis-armed after ``onAddCenterlineSegment()``.
+    Launched (widget); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    if not hasattr(widget, "onAddCenterlineSegment") or not hasattr(
+        widget, "_disarmPlacement"
+    ):
+        pytest.skip(
+            "widget has no onAddCenterlineSegment / _disarmPlacement -- the "
+            "ADR-0037 disarm-on-extract refinement has not landed (ADR-0027)."
+        )
+
+    state = _import_interaction_state_or_skip()
+    seg, _segId = _vessel_segmentation(slicer)
+    widget.ui.inputSurfaceSelector.setCurrentNode(seg)
+    displayNode = _arm_widget_placement_or_skip(widget, state)
+
+    # Stub the VMTK gate + the extraction + the visibility sync so the SUCCESS
+    # path runs (and reaches the disarm) without SlicerVMTK.
+    monkeypatch.setattr(widget.logic, "extractionActionEnabled", lambda: True)
+    monkeypatch.setattr(
+        widget.logic, "extractCenterlines", lambda carrier, surface, segId: None)
+    monkeypatch.setattr(widget, "_syncCenterlineVisibility", lambda: None)
+
+    widget.onAddCenterlineSegment()
+
+    assert state.is_armed(displayNode) is False, (
+        "a successful Extract must DISARM placement (toggle the Place button "
+        "off) so a stray click adds no seed (ADR-0037 §Decision 4)."
+    )
+
+
+def test_compute_territory_map_disarms_placement(qt_widgets, monkeypatch):
+    """A Compute ENDS the placement gesture (disarms via the table).
+
+    Post-review refinement (ADR-0037 §Decision 4): computing the map toggles the
+    active Place button off too.  ``build_centerline_model`` /
+    ``ensureTerritoryMapOutput`` / ``calculateVascularTerritoryMap`` /
+    ``_applyTerritoryNamesAndColors`` are stubbed so the wiring reaches the
+    disarm without the real C++ map run (which stays eyeball-gated); a reference
+    volume is provided so the button does not early-return.  Pins the display
+    node reading dis-armed after ``onCalculateVascularTerritoryMapButton()``.
+    Launched (widget); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    for method in ("onCalculateVascularTerritoryMapButton", "_disarmPlacement",
+                   "build_centerline_model"):
+        target = widget if method != "build_centerline_model" else widget.logic
+        if not hasattr(target, method):
+            pytest.skip(
+                f"{method} absent -- the ADR-0037 disarm-on-compute refinement "
+                "has not landed (ADR-0027)."
+            )
+
+    state = _import_interaction_state_or_skip()
+    seg, _segId = _vessel_segmentation(slicer)
+    widget.ui.inputSurfaceSelector.setCurrentNode(seg)
+    displayNode = _arm_widget_placement_or_skip(widget, state)
+
+    # A reference volume so the button's refVolume guard passes.
+    ref_volume = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLScalarVolumeNode", "DisarmComputeRefVolume")
+    image = vtk.vtkImageData()
+    image.SetDimensions(4, 4, 4)
+    image.AllocateScalars(vtk.VTK_SHORT, 1)
+    ref_volume.SetAndObserveImageData(image)
+
+    # A centerline model with >= 2 points so the numberOfPoints guard passes.
+    def _stub_build(carrier, colormap):
+        points = vtk.vtkPoints()
+        points.InsertNextPoint(0.0, 0.0, 10.0)
+        points.InsertNextPoint(0.0, 0.0, -10.0)
+        poly = vtk.vtkPolyData()
+        poly.SetPoints(points)
+        model = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLModelNode", "DisarmComputeCenterline")
+        model.SetAndObserveMesh(poly)
+        return model
+
+    monkeypatch.setattr(widget.logic, "build_centerline_model", _stub_build)
+    if hasattr(widget.logic, "ensureTerritoryMapOutput"):
+        target_seg = slicer.mrmlScene.AddNewNodeByClass(
+            SEGMENTATION_CLASS, "DisarmComputeTarget")
+        target_seg.SetAttribute("VascularTerritories.SegmentationId", "1")
+        monkeypatch.setattr(
+            widget.logic, "ensureTerritoryMapOutput", lambda carrier: target_seg)
+    monkeypatch.setattr(
+        widget.logic, "calculateVascularTerritoryMap",
+        lambda target, refVolume, inputSeg, centerline, colormap: None)
+    if hasattr(widget, "_applyTerritoryNamesAndColors"):
+        monkeypatch.setattr(
+            widget, "_applyTerritoryNamesAndColors", lambda carrier, mapSeg: None)
+
+    widget.onCalculateVascularTerritoryMapButton()
+
+    assert state.is_armed(displayNode) is False, (
+        "a Compute must DISARM placement (toggle the Place button off) so a "
+        "stray click adds no seed (ADR-0037 §Decision 4)."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_connectivity.py
+++ b/VascularTerritories/Testing/Python/test_territories_connectivity.py
@@ -1,23 +1,32 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
 
-"""ADR-0037 slice 5 (PR-A) — the connected-vessel-tree recovery invariant.
+"""ADR-0037 slice 5 (REVISED) — the per-structure connected-component narrow.
 
 The compute amendment resolved the VMTK input surface by MERGING every
 segment; real liver data (parenchyma + portal + hepatic + tumour, one node)
 makes merge-all wrong — portal and hepatic veins are DISJOINT connected
-components and a medial path tunnelling between them is meaningless.  Slice 5
-narrows a territory's active surface to the SINGLE connected component its
-first seed lands on (``AnnotationPoints[territory][0]`` is the RESOLVED
-connectivity seed, per the ADR's "reuse index-0" persistence decision).
+components and a medial path tunnelling between them is meaningless.
+
+The REVISED slice-5 design (Docs/design/multi-system-territory-plan.md, §Part A
+A3 / Q2) drops the single-active-tree LOCK: a territory may own seeds across
+MULTIPLE disjoint structures, and extraction GROUPS by structure and runs VMTK
+once per ≥2-seed structure.  ``connected_component_at`` SURVIVES the revision
+for a different job — narrowing each PER-STRUCTURE surface to the connected
+component of that structure's own seed, so a single input segment that
+accidentally carries two DISJOINT tubes still feeds VMTK one coherent tree
+(the "structure with disjoint pieces" edge case).  The retired job was the
+single-tree lock + its "reuse AnnotationPoints[0]" persistence; that test is
+REMOVED (the lock is gone).
 
 The connectivity recovery is a PURE-VTK helper (no MRML scene, no Slicer, no
 Qt, no GL): given a surface ``vtkPolyData`` + a seed point, return the single
 connected component containing that point (``vtkPolyDataConnectivityFilter`` in
-``ClosestPointRegion`` mode).  The plan puts the SCT filter in C++ (it reads
-MRML segment tags — pinned launched in ``test_territories_surface_resolution``)
+``ClosestPointRegion`` mode).  The plan puts the SCT filter + seed->structure
+mapping in the MRML-facing layer (reads segment tags/colours — pinned launched
+in ``test_territories_surface_resolution`` + ``test_territories_seed_structure``)
 and the connectivity in Python (pure polydata) — a clean ADR-0004 split.  This
-file is the core new-module BARE invariant: it RUNS bare once
+file is the core BARE invariant: it RUNS bare once
 ``VascularTerritoriesLib/VesselConnectivity.py`` lands.
 
 * T2 (BARE) — connectivity picks ONE component.  A polydata of two DISJOINT
@@ -26,17 +35,14 @@ file is the core new-module BARE invariant: it RUNS bare once
   count / bounds and holding ZERO points from sphere B; a seed on sphere B
   returns B.  The recovered component is a SINGLE connected region
   (``vtkPolyDataConnectivityFilter`` in ``AllRegions`` mode reports exactly 1).
-* T3 (BARE) — two seeds on disjoint components resolve to DIFFERENT active
-  trees; the per-extraction surface is a single region (not the merge); and the
-  index-0 persistence invariant — deleting the first seed and re-deriving from
-  the new index-0 recovers the SAME component (pins the "reuse
-  AnnotationPoints[0]" persistence decision, ADR-0037 slice-5 Conformance
-  [review]).
+* T3 (BARE) — the PER-STRUCTURE narrow: a segment surface carrying two disjoint
+  pieces narrows to the SINGLE piece the structure's seed lands on (the A3/Q2
+  edge case), so VMTK never tunnels between the two pieces of one segment.
 
-Red->green (ADR-0027): every test import-guards on the not-yet-existing
-``VesselConnectivity`` helper and SKIP-PENDINGs cleanly bare until it lands;
-the skips lift at the PR-A implementation commit, at which point T2/T3 RUN bare
-(pure VTK, no launched Slicer needed).
+Red->green (ADR-0027): every test import-guards on the ``VesselConnectivity``
+helper and SKIP-PENDINGs cleanly bare until it lands; the skips lift at the
+implementation commit, at which point T2/T3 RUN bare (pure VTK, no launched
+Slicer needed).
 
 -- SEAM THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
 
@@ -50,17 +56,19 @@ A pure-VTK helper module ``VascularTerritoriesLib.VesselConnectivity`` with:
     ``seed`` is a 3-tuple / sequence of 3 floats (world coordinates).
 
 If the implementer names the function or module differently, update the two
-constants below — the invariants are the SINGLE-COMPONENT recovery + the
-index-0 persistence, not the specific spelling.
+constants below — the invariant is the SINGLE-COMPONENT recovery (used for the
+per-structure narrow), not the specific spelling.
 
 See also:
+  * Docs/design/multi-system-territory-plan.md  (§Part A A3/Q2 per-structure narrow)
   * Docs/adr/0037-vascular-territories-off-markups.md
     (§Amendment — connected-tree-constrained centerline seeding (slice 5))
   * Docs/adr/0004-python-cpp-boundary.md  (pure polydata -> Python)
   * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
-  * Docs/design/connected-tree-seeding-plan.md  (C2 connectivity helper; T2/T3)
   * VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
     (closed_surface_polydata — the merge-all surface slice 5 supersedes)
+  * VascularTerritories/Testing/Python/test_territories_seed_structure.py
+    (the seed->structure mapping bare twin)
   * VascularTerritories/Testing/Python/test_territories_surface_resolution.py
     (the launched vessel-SCT-filter twin, T1)
 """
@@ -256,68 +264,43 @@ def test_connectivity_recovers_the_other_component_for_a_b_seed():
 
 
 # =========================================================================== #
-# T3 — different seeds -> different trees; index-0 persistence (BARE)
+# T3 — the per-structure narrow: one segment carrying two disjoint pieces
 # =========================================================================== #
 
 
-def test_disjoint_seeds_resolve_to_different_trees():
-    """T3: seeds on disjoint components recover DIFFERENT (disjoint) trees.
+def test_per_structure_narrow_picks_the_seeds_piece():
+    """T3: a segment with TWO disjoint pieces narrows to the seed's piece.
 
-    A territory whose index-0 seed is on A and another whose index-0 seed is on
-    B recover disjoint components — no shared points, so the two territories
-    never straddle a fused surface (ADR-0037 slice-5 Conformance [test]).
-    Pure VTK — RUNS bare.
+    The revised extraction resolves each structure's closed surface and narrows
+    it to the connected component of that structure's OWN seed, so a single
+    input segment that accidentally carries two disjoint tubes still feeds VMTK
+    ONE coherent tree — a medial path never tunnels between the two pieces (the
+    A3/Q2 "structure with disjoint pieces" edge case; multi-system plan §Part A).
+    Modelled by the two-sphere fixture standing in for one segment's two pieces:
+    a seed on piece A recovers only A, a seed on piece B recovers only B.  Pure
+    VTK — RUNS bare.
     """
     connected_component_at = _connected_component_at_or_skip()
-    two_spheres, sphere_a, sphere_b = _two_disjoint_spheres()
+    two_pieces, piece_a, piece_b = _two_disjoint_spheres()
 
-    tree_a = connected_component_at(two_spheres, CENTER_A)
-    tree_b = connected_component_at(two_spheres, CENTER_B)
+    from_a = connected_component_at(two_pieces, CENTER_A)
+    from_b = connected_component_at(two_pieces, CENTER_B)
 
-    assert tree_a.GetNumberOfPoints() == sphere_a.GetNumberOfPoints()
-    assert tree_b.GetNumberOfPoints() == sphere_b.GetNumberOfPoints()
-    # Disjoint: A's tree carries no B points and vice-versa.
-    assert _points_inside_sphere(tree_a, CENTER_B, RADIUS) == 0, (
-        "tree A must carry no points from the B system (ADR-0037 slice 5)."
+    assert from_a.GetNumberOfPoints() == piece_a.GetNumberOfPoints(), (
+        "a seed on piece A must narrow the structure surface to piece A only "
+        f"({from_a.GetNumberOfPoints()} != {piece_a.GetNumberOfPoints()})."
     )
-    assert _points_inside_sphere(tree_b, CENTER_A, RADIUS) == 0, (
-        "tree B must carry no points from the A system (ADR-0037 slice 5)."
+    assert from_b.GetNumberOfPoints() == piece_b.GetNumberOfPoints(), (
+        "a seed on piece B must narrow to piece B only "
+        f"({from_b.GetNumberOfPoints()} != {piece_b.GetNumberOfPoints()})."
     )
-
-
-def test_index_zero_persistence_survives_first_seed_deletion():
-    """T3: re-deriving from a NEW index-0 recovers the SAME component.
-
-    ADR-0037 slice-5 Conformance [review] (the RESOLVED persistence decision):
-    all of a territory's seeds lie on one component, so deleting the FIRST seed
-    (leaving a later seed as the new index-0) still recovers the SAME active
-    tree — the "reuse AnnotationPoints[0]" identity is stable under index-0
-    deletion.  Modelled purely: two seeds that both lie on sphere A recover the
-    same component regardless of which is index-0.  Pure VTK — RUNS bare.
-    """
-    connected_component_at = _connected_component_at_or_skip()
-    two_spheres, sphere_a, _sphere_b = _two_disjoint_spheres()
-
-    # Two distinct seeds, BOTH on sphere A (the single-tree constraint holds:
-    # every seed of a territory lies on the same component).
-    first_seed = (CENTER_A[0] - RADIUS + 1.0, CENTER_A[1], CENTER_A[2])
-    later_seed = (CENTER_A[0] + RADIUS - 1.0, CENTER_A[1], CENTER_A[2])
-
-    from_first = connected_component_at(two_spheres, first_seed)
-    # After deleting the first seed, the new index-0 is ``later_seed``.
-    from_later = connected_component_at(two_spheres, later_seed)
-
-    assert from_first.GetNumberOfPoints() == sphere_a.GetNumberOfPoints(), (
-        "the index-0 seed must recover sphere A's whole component."
+    # Each narrowed piece is disjoint from the other — no tunnelling.
+    assert _points_inside_sphere(from_a, CENTER_B, RADIUS) == 0, (
+        "the A-narrowed surface must carry no points from piece B (no "
+        "tunnelling between one segment's disjoint pieces; A3/Q2)."
     )
-    assert from_later.GetNumberOfPoints() == from_first.GetNumberOfPoints(), (
-        "re-deriving the active tree from the NEW index-0 (after deleting the "
-        "first seed) must recover the SAME component -- the reuse-index-0 "
-        "identity is stable under first-seed deletion (ADR-0037 slice-5 "
-        "Conformance [review])."
-    )
-    assert _points_inside_sphere(from_later, CENTER_B, RADIUS) == 0, (
-        "the re-derived tree must still be A-only, never fused with B."
+    assert _points_inside_sphere(from_b, CENTER_A, RADIUS) == 0, (
+        "the B-narrowed surface must carry no points from piece A (A3/Q2)."
     )
 
 

--- a/VascularTerritories/Testing/Python/test_territories_connectivity.py
+++ b/VascularTerritories/Testing/Python/test_territories_connectivity.py
@@ -1,0 +1,325 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 slice 5 (PR-A) — the connected-vessel-tree recovery invariant.
+
+The compute amendment resolved the VMTK input surface by MERGING every
+segment; real liver data (parenchyma + portal + hepatic + tumour, one node)
+makes merge-all wrong — portal and hepatic veins are DISJOINT connected
+components and a medial path tunnelling between them is meaningless.  Slice 5
+narrows a territory's active surface to the SINGLE connected component its
+first seed lands on (``AnnotationPoints[territory][0]`` is the RESOLVED
+connectivity seed, per the ADR's "reuse index-0" persistence decision).
+
+The connectivity recovery is a PURE-VTK helper (no MRML scene, no Slicer, no
+Qt, no GL): given a surface ``vtkPolyData`` + a seed point, return the single
+connected component containing that point (``vtkPolyDataConnectivityFilter`` in
+``ClosestPointRegion`` mode).  The plan puts the SCT filter in C++ (it reads
+MRML segment tags — pinned launched in ``test_territories_surface_resolution``)
+and the connectivity in Python (pure polydata) — a clean ADR-0004 split.  This
+file is the core new-module BARE invariant: it RUNS bare once
+``VascularTerritoriesLib/VesselConnectivity.py`` lands.
+
+* T2 (BARE) — connectivity picks ONE component.  A polydata of two DISJOINT
+  spheres (``vtkAppendPolyData`` of two ``vtkSphereSource`` at separated
+  centres); a seed on sphere A returns a component matching sphere A's point
+  count / bounds and holding ZERO points from sphere B; a seed on sphere B
+  returns B.  The recovered component is a SINGLE connected region
+  (``vtkPolyDataConnectivityFilter`` in ``AllRegions`` mode reports exactly 1).
+* T3 (BARE) — two seeds on disjoint components resolve to DIFFERENT active
+  trees; the per-extraction surface is a single region (not the merge); and the
+  index-0 persistence invariant — deleting the first seed and re-deriving from
+  the new index-0 recovers the SAME component (pins the "reuse
+  AnnotationPoints[0]" persistence decision, ADR-0037 slice-5 Conformance
+  [review]).
+
+Red->green (ADR-0027): every test import-guards on the not-yet-existing
+``VesselConnectivity`` helper and SKIP-PENDINGs cleanly bare until it lands;
+the skips lift at the PR-A implementation commit, at which point T2/T3 RUN bare
+(pure VTK, no launched Slicer needed).
+
+-- SEAM THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
+
+A pure-VTK helper module ``VascularTerritoriesLib.VesselConnectivity`` with:
+
+  * ``connected_component_at(polydata, seed) -> vtkPolyData`` — run
+    ``vtkPolyDataConnectivityFilter`` with
+    ``SetExtractionModeToClosestPointRegion()`` +
+    ``SetClosestPoint(seed)`` and return the single connected component
+    containing ``seed``.  Pure polydata in / out; no MRML, no Slicer.
+    ``seed`` is a 3-tuple / sequence of 3 floats (world coordinates).
+
+If the implementer names the function or module differently, update the two
+constants below — the invariants are the SINGLE-COMPONENT recovery + the
+index-0 persistence, not the specific spelling.
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md
+    (§Amendment — connected-tree-constrained centerline seeding (slice 5))
+  * Docs/adr/0004-python-cpp-boundary.md  (pure polydata -> Python)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * Docs/design/connected-tree-seeding-plan.md  (C2 connectivity helper; T2/T3)
+  * VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
+    (closed_surface_polydata — the merge-all surface slice 5 supersedes)
+  * VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+    (the launched vessel-SCT-filter twin, T1)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+# The pure-VTK connectivity seam (proposed; sharpen at landing).
+CONNECTIVITY_MODULE = "VascularTerritoriesLib.VesselConnectivity"
+CONNECTED_COMPONENT_FUNC = "connected_component_at"
+
+# Two well-separated sphere centres so their meshes never share a point and
+# connectivity keeps them as two disjoint regions.
+CENTER_A = (0.0, 0.0, 0.0)
+CENTER_B = (100.0, 0.0, 0.0)
+RADIUS = 10.0
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guard (import-guard on the not-yet-existing pure helper; ADR-0027)
+# --------------------------------------------------------------------------- #
+
+
+def _connected_component_at_or_skip():
+    """Return the pure ``connected_component_at`` helper, or skip-pend (ADR-0027).
+
+    The plan's PREFERRED bare-testable seam: a surface polydata + a seed point
+    -> the single connected component containing the seed.  Import-guards on
+    the not-yet-existing ``VesselConnectivity`` module so the file COLLECTS +
+    SKIP-PENDINGs cleanly bare until PR-A lands; the skip lifts at the
+    implementation commit, when the test RUNS bare (pure VTK).
+    """
+    try:
+        import importlib
+
+        module = importlib.import_module(CONNECTIVITY_MODULE)
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"{CONNECTIVITY_MODULE} not importable ({exc!r}) -- the ADR-0037 "
+            "slice-5 (PR-A) connectivity-recovery helper has not landed.  The "
+            "skip lifts at the implementation commit (ADR-0027)."
+        )
+    func = getattr(module, CONNECTED_COMPONENT_FUNC, None)
+    if func is None:
+        pytest.skip(
+            f"{CONNECTIVITY_MODULE} has no {CONNECTED_COMPONENT_FUNC} -- the "
+            "ADR-0037 slice-5 (PR-A) connectivity-recovery helper has not "
+            "landed (ADR-0027)."
+        )
+    return func
+
+
+# --------------------------------------------------------------------------- #
+# Pure-VTK fixtures (no Slicer, no MRML, no GL)
+# --------------------------------------------------------------------------- #
+
+
+def _sphere(center, radius=RADIUS):
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(radius)
+    source.SetThetaResolution(16)
+    source.SetPhiResolution(16)
+    source.Update()
+    return source.GetOutput()
+
+
+def _two_disjoint_spheres():
+    """A single polydata holding two DISJOINT sphere components (A then B).
+
+    ``vtkAppendPolyData`` concatenates the two meshes into one dataset without
+    merging coincident points (there are none — the centres are 100 apart), so
+    ``vtkPolyDataConnectivityFilter`` sees exactly two regions.
+    """
+    sphere_a = _sphere(CENTER_A)
+    sphere_b = _sphere(CENTER_B)
+    append = vtk.vtkAppendPolyData()
+    append.AddInputData(sphere_a)
+    append.AddInputData(sphere_b)
+    append.Update()
+    return append.GetOutput(), sphere_a, sphere_b
+
+
+def _number_of_regions(polydata):
+    """The number of connected regions in ``polydata`` (AllRegions mode)."""
+    conn = vtk.vtkPolyDataConnectivityFilter()
+    conn.SetInputData(polydata)
+    conn.SetExtractionModeToAllRegions()
+    conn.Update()
+    return conn.GetNumberOfExtractedRegions()
+
+
+def _points_inside_sphere(polydata, center, radius, tolerance=1.0e-3):
+    """Count ``polydata`` points lying on/inside the sphere ``(center, radius)``.
+
+    Used to prove a recovered component holds ZERO points from the OTHER
+    sphere — a component-purity check independent of point ordering.
+    """
+    count = 0
+    cx, cy, cz = center
+    r2 = (radius + tolerance) ** 2
+    for i in range(polydata.GetNumberOfPoints()):
+        px, py, pz = polydata.GetPoint(i)
+        if (px - cx) ** 2 + (py - cy) ** 2 + (pz - cz) ** 2 <= r2:
+            count += 1
+    return count
+
+
+# =========================================================================== #
+# T2 — connectivity picks one component (BARE, pure VTK)
+# =========================================================================== #
+
+
+def test_connectivity_recovers_only_seed_component():
+    """T2: a seed on sphere A recovers ONLY sphere A's component.
+
+    ``connected_component_at(two_spheres, seed_on_A)`` returns a component with
+    sphere A's point count and holding ZERO points inside sphere B — the
+    disjoint B system is never fused into A's tree (ADR-0037 slice-5
+    Conformance [test]).  Pure VTK — RUNS bare.
+    """
+    connected_component_at = _connected_component_at_or_skip()
+    two_spheres, sphere_a, sphere_b = _two_disjoint_spheres()
+
+    seed_on_a = CENTER_A  # dead centre of sphere A; ClosestPointRegion picks A
+    component = connected_component_at(two_spheres, seed_on_a)
+
+    assert component is not None and component.GetNumberOfPoints() > 0, (
+        "the recovered component must be a non-empty polydata (ADR-0037 "
+        "slice 5)."
+    )
+    assert component.GetNumberOfPoints() == sphere_a.GetNumberOfPoints(), (
+        "the recovered component must match sphere A's point count "
+        f"({component.GetNumberOfPoints()} != {sphere_a.GetNumberOfPoints()}) "
+        "-- connectivity must not fuse the disjoint B system into A."
+    )
+    assert _points_inside_sphere(component, CENTER_B, RADIUS) == 0, (
+        "the recovered component must hold ZERO points from the DISJOINT "
+        "sphere B -- a territory's tree is one connected component (ADR-0037 "
+        "slice 5)."
+    )
+
+
+def test_connectivity_recovered_component_is_single_region():
+    """T2: the recovered component is a SINGLE connected region.
+
+    Re-running ``vtkPolyDataConnectivityFilter`` in ``AllRegions`` mode over
+    the recovered component reports exactly ONE region — the per-extraction
+    VMTK surface is a single connected tree, not the two-region merge (ADR-0037
+    slice 5, supersedes merge-all).  Pure VTK — RUNS bare.
+    """
+    connected_component_at = _connected_component_at_or_skip()
+    two_spheres, _sphere_a, _sphere_b = _two_disjoint_spheres()
+
+    # Sanity: the input genuinely has two regions (the merge slice 5 fixes).
+    assert _number_of_regions(two_spheres) == 2, (
+        "the two-sphere fixture must present TWO disjoint regions."
+    )
+
+    component = connected_component_at(two_spheres, CENTER_A)
+
+    assert _number_of_regions(component) == 1, (
+        "the recovered per-extraction surface must be a SINGLE connected "
+        f"region (got {_number_of_regions(component)}) -- this supersedes the "
+        "compute amendment's merge-all input (ADR-0037 slice 5)."
+    )
+
+
+def test_connectivity_recovers_the_other_component_for_a_b_seed():
+    """T2: a seed on sphere B recovers ONLY sphere B's component.
+
+    The mirror of the A case — the helper is seed-directed, not fixed to the
+    first region — so a click on the OTHER system binds to the OTHER tree
+    (ADR-0037 slice 5).  Pure VTK — RUNS bare.
+    """
+    connected_component_at = _connected_component_at_or_skip()
+    two_spheres, _sphere_a, sphere_b = _two_disjoint_spheres()
+
+    component = connected_component_at(two_spheres, CENTER_B)
+
+    assert component is not None and component.GetNumberOfPoints() == (
+        sphere_b.GetNumberOfPoints()), (
+        "a seed on sphere B must recover sphere B's component "
+        f"({None if component is None else component.GetNumberOfPoints()} != "
+        f"{sphere_b.GetNumberOfPoints()}) (ADR-0037 slice 5)."
+    )
+    assert _points_inside_sphere(component, CENTER_A, RADIUS) == 0, (
+        "the B-seeded component must hold ZERO points from sphere A."
+    )
+
+
+# =========================================================================== #
+# T3 — different seeds -> different trees; index-0 persistence (BARE)
+# =========================================================================== #
+
+
+def test_disjoint_seeds_resolve_to_different_trees():
+    """T3: seeds on disjoint components recover DIFFERENT (disjoint) trees.
+
+    A territory whose index-0 seed is on A and another whose index-0 seed is on
+    B recover disjoint components — no shared points, so the two territories
+    never straddle a fused surface (ADR-0037 slice-5 Conformance [test]).
+    Pure VTK — RUNS bare.
+    """
+    connected_component_at = _connected_component_at_or_skip()
+    two_spheres, sphere_a, sphere_b = _two_disjoint_spheres()
+
+    tree_a = connected_component_at(two_spheres, CENTER_A)
+    tree_b = connected_component_at(two_spheres, CENTER_B)
+
+    assert tree_a.GetNumberOfPoints() == sphere_a.GetNumberOfPoints()
+    assert tree_b.GetNumberOfPoints() == sphere_b.GetNumberOfPoints()
+    # Disjoint: A's tree carries no B points and vice-versa.
+    assert _points_inside_sphere(tree_a, CENTER_B, RADIUS) == 0, (
+        "tree A must carry no points from the B system (ADR-0037 slice 5)."
+    )
+    assert _points_inside_sphere(tree_b, CENTER_A, RADIUS) == 0, (
+        "tree B must carry no points from the A system (ADR-0037 slice 5)."
+    )
+
+
+def test_index_zero_persistence_survives_first_seed_deletion():
+    """T3: re-deriving from a NEW index-0 recovers the SAME component.
+
+    ADR-0037 slice-5 Conformance [review] (the RESOLVED persistence decision):
+    all of a territory's seeds lie on one component, so deleting the FIRST seed
+    (leaving a later seed as the new index-0) still recovers the SAME active
+    tree — the "reuse AnnotationPoints[0]" identity is stable under index-0
+    deletion.  Modelled purely: two seeds that both lie on sphere A recover the
+    same component regardless of which is index-0.  Pure VTK — RUNS bare.
+    """
+    connected_component_at = _connected_component_at_or_skip()
+    two_spheres, sphere_a, _sphere_b = _two_disjoint_spheres()
+
+    # Two distinct seeds, BOTH on sphere A (the single-tree constraint holds:
+    # every seed of a territory lies on the same component).
+    first_seed = (CENTER_A[0] - RADIUS + 1.0, CENTER_A[1], CENTER_A[2])
+    later_seed = (CENTER_A[0] + RADIUS - 1.0, CENTER_A[1], CENTER_A[2])
+
+    from_first = connected_component_at(two_spheres, first_seed)
+    # After deleting the first seed, the new index-0 is ``later_seed``.
+    from_later = connected_component_at(two_spheres, later_seed)
+
+    assert from_first.GetNumberOfPoints() == sphere_a.GetNumberOfPoints(), (
+        "the index-0 seed must recover sphere A's whole component."
+    )
+    assert from_later.GetNumberOfPoints() == from_first.GetNumberOfPoints(), (
+        "re-deriving the active tree from the NEW index-0 (after deleting the "
+        "first seed) must recover the SAME component -- the reuse-index-0 "
+        "identity is stable under first-seed deletion (ADR-0037 slice-5 "
+        "Conformance [review])."
+    )
+    assert _points_inside_sphere(from_later, CENTER_B, RADIUS) == 0, (
+        "the re-derived tree must still be A-only, never fused with B."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_map_compute.py
+++ b/VascularTerritories/Testing/Python/test_territories_map_compute.py
@@ -879,6 +879,124 @@ def test_calculate_button_resolves_inputs_without_selector(qt_widgets, monkeypat
     )
 
 
+# =========================================================================== #
+# POST-REVIEW REFINEMENT — map segments named + coloured per TERRITORY
+# =========================================================================== #
+#
+# The map output segments come from the classified-labelmap import, so each
+# output segment's NAME + COLOUR initially come from the colormap, keyed by the
+# label VALUE (the territory's derived 1-based int).  The refinement re-labels +
+# re-colours each output segment to the TERRITORY it represents so the map reads
+# the same as the table (ADR-0037 §Decision 4 / §Decision 1 display slot).
+# ``_applyTerritoryNamesAndColors(carrier, mapSegmentationNode)`` does this,
+# keyed by ``TerritoryLabelMap.territory_label_ints``.  Pinned directly against
+# a hand-built map segmentation with known label values (the full C++ map run
+# stays eyeball-gated), so this RUNS + PASSES launched now (green regression
+# guard).
+
+
+def _make_map_segmentation_with_label_values(slicer, label_values):
+    """A segmentation with one empty segment per label value (map-output shape).
+
+    Each segment carries a distinct ``LabelValue`` and a deliberately WRONG
+    name + colour (the colormap-derived defaults ``_applyTerritoryNamesAndColors``
+    must overwrite), so the assertion proves the re-label/re-colour happened.
+    """
+    seg = slicer.mrmlScene.AddNewNodeByClass(SEGMENTATION_CLASS, "MapOutputTest")
+    if seg is None:
+        pytest.skip("vtkMRMLSegmentationNode not registered (launched build).")
+    core = seg.GetSegmentation()
+    for value in label_values:
+        # AddEmptySegment mints the segment with a deliberately WRONG name +
+        # colour (the colormap-derived defaults ``_applyTerritoryNamesAndColors``
+        # must overwrite); its LabelValue is set explicitly to the derived int.
+        segId = core.AddEmptySegment(
+            f"MapSeg{value}", f"colormap-default-{value}", [0.5, 0.5, 0.5])
+        core.GetSegment(segId).SetLabelValue(int(value))
+    return seg
+
+
+def test_map_segments_named_and_coloured_per_territory(qt_widgets):
+    """Each map segment gets its TERRITORY's label + colour, keyed by label value.
+
+    Post-review refinement (ADR-0037 §Decision 4 / §Decision 1): the map's
+    output segments carry the territory's derived 1-based int as their label
+    VALUE; ``_applyTerritoryNamesAndColors`` re-keys each segment to its
+    territory (via ``TerritoryLabelMap.territory_label_ints``) and stamps the
+    territory's ``GetTerritoryLabel`` + ``GetTerritoryColor`` so the map reads
+    the same as the table.  Driven directly against a hand-built map
+    segmentation with label values 1 + 2 (the full C++ map run stays
+    eyeball-gated).  Launched (widget + wrapped carrier); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    if not hasattr(widget, "_applyTerritoryNamesAndColors"):
+        pytest.skip(
+            "VascularTerritoriesWidget has no _applyTerritoryNamesAndColors -- "
+            "the ADR-0037 map re-label/re-colour refinement has not landed "
+            "(ADR-0027)."
+        )
+    label_ints = _import_label_map_module_or_skip()
+    if getattr(label_ints, LABEL_MAP_PURE_FUNC, None) is None:
+        pytest.skip(
+            f"{LABEL_MAP_MODULE} has no {LABEL_MAP_PURE_FUNC} (ADR-0027)."
+        )
+
+    carrier = widget._ensureAnnotationCarrier()
+    if carrier is None:
+        pytest.skip("annotation carrier unavailable (launched build; ADR-0027).")
+    for method in ("SetTerritoryLabel", "SetTerritoryColor", "GetTerritoryLabel",
+                   "GetTerritoryColor"):
+        if not hasattr(carrier, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} display slot "
+                "(ADR-0027)."
+            )
+
+    # Two territories, in a known order, each with a distinct label + colour.
+    _populate_two_territories(carrier)
+    ordered_ids = list(carrier.GetAnnotationTerritoryIds())
+    if len(ordered_ids) < 2:
+        pytest.skip("fewer than two territories resolved on the carrier.")
+    label_map = dict(getattr(label_ints, LABEL_MAP_PURE_FUNC)(ordered_ids))
+    expected = {}
+    palette = {ordered_ids[0]: (0.9, 0.1, 0.2), ordered_ids[1]: (0.1, 0.2, 0.9)}
+    for territoryId in ordered_ids[:2]:
+        friendly = f"Surgeon-{territoryId}"
+        carrier.SetTerritoryLabel(territoryId, friendly)
+        r, g, b = palette[territoryId]
+        carrier.SetTerritoryColor(territoryId, r, g, b)
+        expected[label_map[territoryId]] = (friendly, (r, g, b))
+
+    # A map segmentation whose segments carry the derived label values.
+    mapSeg = _make_map_segmentation_with_label_values(slicer, list(expected.keys()))
+
+    widget._applyTerritoryNamesAndColors(carrier, mapSeg)
+
+    core = mapSeg.GetSegmentation()
+    for i in range(core.GetNumberOfSegments()):
+        segment = core.GetNthSegment(i)
+        value = int(segment.GetLabelValue())
+        assert value in expected, (
+            f"the map segment's label value {value} must key to a territory."
+        )
+        friendly, rgb = expected[value]
+        assert segment.GetName() == friendly, (
+            f"map segment (label {value}) must be NAMED for its territory "
+            f"({friendly!r}); got {segment.GetName()!r} (ADR-0037 §Decision 4)."
+        )
+        colour = segment.GetColor()
+        assert (round(colour[0], 3), round(colour[1], 3), round(colour[2], 3)) == (
+            round(rgb[0], 3), round(rgb[1], 3), round(rgb[2], 3)
+        ), (
+            f"map segment (label {value}) must take its TERRITORY's colour "
+            f"{rgb}; got {tuple(colour)} (ADR-0037 §Decision 1 display slot)."
+        )
+
+
 # --------------------------------------------------------------------------- #
 # Liver-segment resolution — the map compute finds the liver region by its
 # SNOMED-CT tag (ADR-0011), and fails legibly when no such segment exists.

--- a/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+++ b/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
@@ -548,5 +548,77 @@ def test_display_node_routes_arm_active_and_click(monkeypatch):
     )
 
 
+# --------------------------------------------------------------------------- #
+# slice-5 (PR-B) — module-active gate (concern #1) at the pipeline level
+# --------------------------------------------------------------------------- #
+
+
+def test_module_inactive_pipeline_declines_add_on_click(monkeypatch):
+    """#1a: an armed add-on-click places nothing while the module is inactive.
+
+    ADR-0037 slice-5 (PR-B) concern #1: a belt-and-suspenders gate BEYOND the
+    display-node armed flag -- even armed, the placement Pipeline declines an
+    add-on-click while the owning module is not active, so no view lands a seed
+    while VascularTerritories is inactive.  Modelled via the ``SetModuleActive``
+    seam the PR-B implementer adds; skip-pends until it lands (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    _wire_pipeline_or_skip(slicer, pipeline, carrier, monkeypatch)
+    if not hasattr(pipeline, "SetModuleActive"):
+        pytest.skip(
+            "TerritoryPlacementPipeline has no SetModuleActive() gate -- the "
+            "ADR-0037 slice-5 (PR-B) module-active gate (concern #1) has not "
+            "landed (ADR-0027)."
+        )
+    if hasattr(pipeline, "Arm"):
+        pipeline.Arm()
+
+    pipeline.SetModuleActive(False)
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent))
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "an add-on-click must place NOTHING while the module is inactive "
+        "(ADR-0037 slice-5 concern #1, belt-and-suspenders beyond the armed "
+        "flag)."
+    )
+
+    pipeline.SetModuleActive(True)
+    assert pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent)) is True
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
+        "with the module active + armed, the add-on-click must land ONE seed."
+    )
+
+
+def test_disarmed_pipeline_click_places_nothing(monkeypatch):
+    """#1b: a dis-armed pipeline click places nothing (arm-gate regression pin).
+
+    ADR-0037 §Decision 3 (re-pinned under slice 5): a click while the pipeline
+    is dis-armed adds no seed.  A regression guard so the PR-B constraint /
+    highlight changes do not accidentally relax the arm gate.
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    _wire_pipeline_or_skip(slicer, pipeline, carrier, monkeypatch)
+    if not hasattr(pipeline, "Disarm"):
+        pytest.skip(
+            "TerritoryPlacementPipeline has no Disarm() seam -- the ADR-0037 "
+            "arm gate has not landed (ADR-0027)."
+        )
+    if hasattr(pipeline, "SetModuleActive"):
+        pipeline.SetModuleActive(True)  # isolate the arm gate from the module gate
+    pipeline.Disarm()
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent))
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "a dis-armed add-on-click must place nothing (ADR-0037 §Decision 3)."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_placemode_constraint.py
+++ b/VascularTerritories/Testing/Python/test_territories_placemode_constraint.py
@@ -1,65 +1,68 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
 
-"""ADR-0037 slice 5 (PR-B) — active-tree seed constraint + highlight + module gate.
+"""ADR-0037 slice 5 (REVISED) — multi-system territory seeding placement.
 
-PR-A landed the compute core (the vessels-only surface resolver
-``vascular_surface_polydata`` / the C++ ``GetVascularSegmentIds`` / the pure-VTK
-``VesselConnectivity.connected_component_at`` / the per-extraction
-single-component surface, and made the pick surface vessels-only).  PR-B adds
-the INTERACTION layer on top: the placement pipelines constrain a territory's
-seed set to ONE connected vessel tree, highlight that tree while armed, and
-decline add-on-clicks while the owning module is inactive.
+The LANDED slice-5 design LOCKED each territory to ONE connected vessel tree:
+the first seed defined the active component, later seeds were snapped back onto
+it, and the component glowed.  That is clinically wrong — a vascular territory
+may legitimately be defined by seeds in MULTIPLE disjoint systems (portal +
+hepatic), which are disjoint components whose centerlines are derived
+INDEPENDENTLY and BOTH feed the one territory's map region.  The revised design
+(Docs/design/multi-system-territory-plan.md, §Part A / §Part D) REMOVES the
+single-tree placement lock and the glow halo.
 
-The invariants pinned here (ADR-0037 §"Amendment — connected-tree-constrained
-centerline seeding (slice 5)" + §Conformance (slice 5)):
+The invariants pinned here (revised ADR-0037 §"Amendment — connected-tree-
+constrained centerline seeding (slice 5)" §Conformance):
 
-* C4a FIRST-SEED-DEFINES-TREE.  The first seed placed into an armed territory
-  is accepted at its snapped surface point and DEFINES the territory's active
-  vessel tree = the connected component of that point (recovered via
-  ``VesselConnectivity.connected_component_at`` over the vessels-only surface).
-* C4b LATER-SEED-SNAPS-TO-ACTIVE.  A later seed whose raw snap lands on a
-  DIFFERENT connected component is re-snapped to the nearest point on the
-  ACTIVE component — never placed off-tree.
-* C4c NET SINGLE-COMPONENT.  After ANY sequence of clicks, every one of a
-  territory's seeds lies on ONE connected component — the component of
-  ``AnnotationPoints[territory][0]``.
-* C5 ACTIVE-TREE HIGHLIGHT.  While a territory is armed, a pipeline-owned actor
-  (no new displayable manager, ADR-0013) renders the active connected tree; its
-  INPUT polydata is the seed[0] component (styling deferred — the input
-  IDENTITY is pinned, not the appearance).
+* NO STRADDLE-SNAP.  With a seed already on structure A, a later add-on-click
+  whose surface snap lands on a DIFFERENT visible structure B is placed WHERE
+  IT LANDS — on B — never re-snapped back onto A.  A territory MAY straddle
+  disjoint systems: two seeds, two structures.  (Inverts the retired C4b/C4c
+  active-tree constraint.)
+* VISIBILITY-GATED PICK IS THE ONLY PLACEMENT CONSTRAINT.  The pick surface
+  stays vessels-only + visibility-gated (hide a system to avoid stray seeds);
+  this is the RETAINED gate, exercised by test_territories_surface_resolution
+  (T1c) — not re-pinned here.
 * #1a MODULE-INACTIVE-DECLINES.  With the owning module NOT active, an
   add-on-click places nothing (belt-and-suspenders beyond the armed flag).
 * #1b ARMED-FLAG STILL GATES.  A dis-armed display node -> a click places
   nothing; ``enter()`` auto-arms nothing / ``exit()`` disarms (slice-4
-  regression pins, re-verified under the slice-5 surface).
+  regression pins, re-verified under the revised surface).
 
--- SEAMS THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
+-- WHAT THIS FILE RETIRED (revised design of record) --
 
-On BOTH ``TerritoryPlacementPipeline`` (3D) and ``TerritorySlicePipeline`` (2D),
-extending the existing add-on-click path (``ProcessInteractionEvent`` ->
-``_add_point``):
+The landed slice-5 (PR-B) suite pinned the REMOVED lock + halo:
+``test_first_seed_defines_the_active_tree`` (C4a),
+``test_later_seed_on_other_component_snaps_to_active_tree`` (C4b),
+``test_net_single_component_after_a_b_a_clicks`` (C4c),
+``test_active_tree_highlight_actor_input_is_seed_zero_component`` (C5), and the
+2D twin ``test_slice_pipeline_later_seed_snaps_to_active_tree``.  Those asserted
+``activeTreePolyData`` / ``highlightActor`` / ``_constrain_to_active_tree`` — all
+removed.  C4b/C4c/C5 are INVERTED into ``test_later_seed_on_other_structure_stays``
+(3D) + ``test_slice_pipeline_later_seed_on_other_structure_stays`` (2D); the C5
+highlight actor is retired to ``test_active_tree_highlight_actor_is_gone`` (an
+absence pin with a credible creep-in path — the named attribute must be removed,
+per the no-colour-of-the-sky rule).
 
-  * the LATER-seed constraint gate: after the raw surface snap and before the
-    carrier write, when the active territory already carries >=1 seed, recover
-    the active component (``connected_component_at`` seeded at index-0 over the
-    vessels-only pick surface) and re-snap the click to the nearest point on
-    THAT component when the raw snap lands on a different component;
-  * ``activeTreePolyData() -> vtkPolyData | None`` — the recovered active tree
-    for the active territory (the seed[0] component), or ``None`` when the
-    active territory has no seed.  Used to assert C4/C5 without reaching into
-    private caches;
-  * ``highlightActor() -> vtkActor | None`` — the pipeline-owned active-tree
-    highlight actor whose input polydata IS ``activeTreePolyData()`` while
-    armed (C5); a THIRD actor alongside ``_seed_actor`` / ``_marker_actor``,
-    not a new pipeline on the same display-node type (ADR-0013 §1);
-  * ``SetModuleActive(bool)`` / ``IsModuleActive() -> bool`` — the module-active
-    gate flag (concern #1); an add-on-click is declined when the module is not
-    active, independent of the armed flag.
+-- SEAMS THIS FILE READS --
+
+On BOTH ``TerritoryPlacementPipeline`` (3D) and ``TerritorySlicePipeline`` (2D):
+
+  * the add-on-click path (``ProcessInteractionEvent`` -> ``_add_point``) with
+    NO ``_constrain_to_active_tree`` gate — the raw surface-snapped ``world``
+    goes straight to ``_add_point`` (no straddle-snap);
+  * ``SetPickCore`` / ``SetDisplayNode`` / the raw-snap seam
+    (``_event_world_on_surface`` 3D / ``_snap_event_to_surface`` 2D) — the
+    injection surface used to script which structure each click lands on;
+  * ``SetModuleActive(bool)`` / ``IsModuleActive()`` — the module-active gate
+    (concern #1);
+  * the REMOVED ``activeTreePolyData`` / ``highlightActor`` /
+    ``_highlight_tree_actor`` — asserted GONE.
 
 If the implementer names these differently, update the constants below — the
-invariants are the SINGLE-COMPONENT seed set + the highlight-input identity +
-the module-active decline, not the specific spelling.
+invariants are NO straddle-snap + the module-active decline + the retired halo,
+not the specific spelling.
 
 -- WHY LAUNCHED-SLICER --
 
@@ -68,35 +71,33 @@ module loaded) + the wrapped ``vtkMRMLCustomTerritoriesNode`` carrier + the
 shared ``vtkMRMLTerritoriesHighlightDisplayNode``.  A bare ``PythonSlicer -m
 pytest`` has ``slicer.mrmlScene is None`` and LayerDMLib off the path, so every
 test here SKIPS CLEANLY via the shared ``slicer_pytest_support`` guards.  The
-connectivity recovery itself is pure-VTK (covered bare by
-``test_territories_connectivity.py``); here it runs on a REAL multi-component
-vessel surface (two disjoint spheres) wired as the pick surface + the injected
-pick core, so the CONSTRAINT is exercised end-to-end through the click path.
+SUT surface is TWO disjoint spheres (``vtkAppendPolyData`` of two separated
+``vtkSphereSource``) wired as the vessels-only pick surface, with the
+stub-renderer + injected-pick pattern from test_territories_placement_pipeline,
+so clicks map to chosen world points on structure A or structure B.
 
 -- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
 
-Pre-implementation the PR-B seams (the later-seed constraint, the
-``activeTreePolyData`` / ``highlightActor`` accessors, the module-active flag)
-do not exist, so the ``hasattr`` guards skip-pend; the skips lift at the PR-B
-implementation commit.  Under a launched Slicer, verify run-vs-skip in the CI
-log once the seam lands — never trust overall green (the launched harness is
+The no-straddle-snap invariant RUNS once the lock is removed; before then the
+landed lock re-snaps the second seed onto A and the test FAILS (red->green in
+reverse — it goes GREEN when the implementer deletes ``_constrain_to_active_tree``).
+The retired-halo absence test likewise flips to PASS when the attribute is
+removed.  Under a launched Slicer, verify run-vs-skip in the CI log once the
+revision lands — never trust overall green (the launched harness is
 green-but-skipping prone).
 
 See also:
+  * Docs/design/multi-system-territory-plan.md  (§Part A remove; §Part C tests)
   * Docs/adr/0037-vascular-territories-off-markups.md
     (§Amendment — connected-tree-constrained centerline seeding (slice 5))
-  * Docs/adr/0013-no-custom-displayable-manager.md  (pipeline-owned actor)
-  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
-  * Docs/design/connected-tree-seeding-plan.md  (C4 / C5 / concern #1)
-  * VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
-  * VascularTerritories/Testing/Python/test_territories_connectivity.py  (bare)
-  * VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
-  * VascularTerritories/Testing/Python/test_territories_slice_pipeline.py
+  * Docs/adr/0013-no-custom-displayable-manager.md
+  * Docs/adr/0027-invariant-test-first.md
+  * VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+  * VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+  * VascularTerritories/Testing/Python/test_territories_seed_structure.py  (bare)
 """
 
 from __future__ import annotations
-
-import importlib
 
 import pytest
 
@@ -106,18 +107,17 @@ CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
 HIGHLIGHT_DISPLAY_CLASS = "vtkMRMLTerritoriesHighlightDisplayNode"
 TERRITORY_A = "SegmentVII"
 
-# The pure-VTK connectivity seam (PR-A; used to compute the EXPECTED active tree
-# independently of the pipeline's own recovery).
-CONNECTIVITY_MODULE = "VascularTerritoriesLib.VesselConnectivity"
-CONNECTED_COMPONENT_FUNC = "connected_component_at"
-
-# PR-B pipeline accessors (proposed; sharpen at landing).
-ACTIVE_TREE_ACCESSOR = "activeTreePolyData"
-HIGHLIGHT_ACTOR_ACCESSOR = "highlightActor"
 MODULE_ACTIVE_SETTER = "SetModuleActive"
 
+# The active-tree lock + halo accessors the revised design REMOVES; the absence
+# pin asserts these are gone.
+RETIRED_TREE_ACCESSOR = "activeTreePolyData"
+RETIRED_HIGHLIGHT_ACCESSOR = "highlightActor"
+RETIRED_CONSTRAINT_METHOD = "_constrain_to_active_tree"
+RETIRED_HALO_ACTOR_ATTR = "_highlight_tree_actor"
+
 # Two well-separated sphere centres so their meshes never share a point and
-# connectivity keeps them as two disjoint regions (the connectivity-test idiom).
+# connectivity keeps them as two disjoint structures.
 CENTER_A = (0.0, 0.0, 0.0)
 CENTER_B = (100.0, 0.0, 0.0)
 RADIUS = 10.0
@@ -183,24 +183,6 @@ def _import_interaction_state_or_skip():
     return state
 
 
-def _connected_component_at_or_skip():
-    """The PR-A pure-VTK connectivity helper, used to compute the EXPECTED tree."""
-    try:
-        module = importlib.import_module(CONNECTIVITY_MODULE)
-    except Exception as exc:  # pragma: no cover - import-environment dependent
-        pytest.skip(
-            f"{CONNECTIVITY_MODULE} not importable ({exc!r}) -- PR-A connectivity "
-            "helper absent (ADR-0027)."
-        )
-    func = getattr(module, CONNECTED_COMPONENT_FUNC, None)
-    if func is None:
-        pytest.skip(
-            f"{CONNECTIVITY_MODULE} has no {CONNECTED_COMPONENT_FUNC} -- PR-A "
-            "connectivity helper absent (ADR-0027)."
-        )
-    return func
-
-
 def _make_carrier_or_skip(slicer, name="ConstraintCarrierTest"):
     node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
     if node is None:
@@ -227,23 +209,24 @@ def _make_display_node_or_skip(slicer, name="ConstraintHighlightTest"):
     return node
 
 
-def _require_constraint_seam_or_skip(pipeline):
-    """Skip-pend unless the PR-B active-tree constraint accessor has landed.
+def _require_no_straddle_snap_seam_or_skip(pipeline):
+    """Skip-pend unless the pipeline's add-on-click path + injection seams exist.
 
-    ``activeTreePolyData`` is the accessor the C4/C5 assertions read; its
-    absence means the PR-B seam has not landed, so every constraint test
-    collects + SKIP-PENDINGs cleanly and RUNS once PR-B lands (ADR-0027).
+    The revised design REMOVES ``_constrain_to_active_tree`` — the raw
+    surface-snapped world goes straight to ``_add_point``.  We can only assert
+    "no straddle-snap" once the pipeline exposes the pick + display seams; if
+    they are absent the pipeline has not landed at all, so skip-pend (ADR-0027).
     """
-    if not hasattr(pipeline, ACTIVE_TREE_ACCESSOR):
-        pytest.skip(
-            f"{type(pipeline).__name__} has no {ACTIVE_TREE_ACCESSOR}() accessor "
-            "-- the ADR-0037 slice-5 (PR-B) active-tree seed constraint has not "
-            "landed (ADR-0027)."
-        )
+    for method in ("SetPickCore", "SetDisplayNode", "SetActiveTerritory", "Arm"):
+        if not hasattr(pipeline, method):
+            pytest.skip(
+                f"{type(pipeline).__name__} has no {method} seam -- the ADR-0037 "
+                "placement pipeline has not landed (ADR-0027)."
+            )
 
 
 # --------------------------------------------------------------------------- #
-# Multi-component vessel surface: TWO disjoint spheres (A at origin, B at +x)
+# Multi-structure vessel surface: TWO disjoint spheres (A at origin, B at +x)
 # --------------------------------------------------------------------------- #
 
 
@@ -258,7 +241,7 @@ def _sphere(center, radius=RADIUS):
 
 
 def _two_disjoint_spheres():
-    """A single polydata holding two DISJOINT sphere components (A then B)."""
+    """A single polydata holding two DISJOINT sphere structures (A then B)."""
     sphere_a = _sphere(CENTER_A)
     sphere_b = _sphere(CENTER_B)
     append = vtk.vtkAppendPolyData()
@@ -268,29 +251,17 @@ def _two_disjoint_spheres():
     return append.GetOutput(), sphere_a, sphere_b
 
 
-def _points_inside_sphere(polydata, center, radius, tolerance=1.0e-3):
-    """Count ``polydata`` points on/inside the sphere ``(center, radius)``."""
-    count = 0
-    cx, cy, cz = center
-    r2 = (radius + tolerance) ** 2
-    for i in range(polydata.GetNumberOfPoints()):
-        px, py, pz = polydata.GetPoint(i)
-        if (px - cx) ** 2 + (py - cy) ** 2 + (pz - cz) ** 2 <= r2:
-            count += 1
-    return count
-
-
 def _bounds_center(polydata):
     b = polydata.GetBounds()
     return ((b[0] + b[1]) / 2.0, (b[2] + b[3]) / 2.0, (b[4] + b[5]) / 2.0)
 
 
 class _FakeRenderer:
-    """Display->world unprojects any pixel to a chosen +something ray.
+    """Display->world unprojects any pixel to a chosen ray.
 
-    The ray hits whichever sphere the test selects: the fake pick core resolves
-    the click to a fixed world point on sphere A or sphere B (see
-    ``_StubPickToPoint``), so the renderer only needs to hand back a stable ray.
+    The fake pick core resolves the click to a fixed world point on sphere A or
+    sphere B (see the scripted raw snap), so the renderer only needs to hand
+    back a stable ray.
     """
 
     def SetDisplayPoint(self, x, y, z):  # noqa: N802 - VTK verb
@@ -338,12 +309,12 @@ def _wire_pipeline_on_two_spheres_or_skip(
 ):
     """Wire the pipeline over the two-sphere surface with a scripted snap.
 
-    ``snap_targets`` is a list of world points the RAW surface snap yields on
-    successive clicks (the injected ``_event_world_on_surface`` return values).
-    Each is a genuine point on sphere A or sphere B, so the constraint gate is
-    what re-snaps an off-tree later click.  The pick surface is set to the two
-    disjoint spheres so the pipeline's own ``connected_component_at`` recovery
-    (over the vessels-only surface) has a real multi-component mesh to work on.
+    ``snap_targets`` is a list of world points the raw surface snap yields on
+    successive clicks (the injected ``_event_world_on_surface`` /
+    ``_snap_event_to_surface`` return values).  Each is a genuine point on
+    sphere A or sphere B; the revised placement path must place each WHERE IT
+    LANDS (no straddle-snap).  The pick surface is the two disjoint spheres so
+    the pipeline resolves the same multi-structure mesh production uses.
     """
     VesselSurfacePick = _import_pick_or_skip()
     for method in ("SetPickCore", "SetDisplayNode"):
@@ -357,15 +328,15 @@ def _wire_pipeline_on_two_spheres_or_skip(
     monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
     state.set_carrier(displayNode, carrier)
     pipeline.SetDisplayNode(displayNode)
-    # Inject the pick core over the REAL two-component surface (the vessels-only
-    # pick surface PR-A resolves in production).  SetDisplayNode resets the pick,
-    # so inject AFTER binding it.
+    # Inject the pick core over the REAL two-structure surface (the vessels-only
+    # pick surface production resolves).  SetDisplayNode resets the pick, so
+    # inject AFTER binding it.
     pipeline.SetPickCore(VesselSurfacePick(two_spheres))
 
-    # Script the RAW snap so we choose which component each click lands on.  The
+    # Script the raw snap so we choose which structure each click lands on.  The
     # 3D and 2D pipelines both funnel the snapped world point through
-    # ``_add_point`` after the constraint gate, so injecting the raw snap here
-    # exercises the gate deterministically without a GL context.
+    # ``_add_point``; injecting the raw snap exercises the placement path
+    # deterministically without a GL context.
     calls = {"i": 0}
 
     def _fake_snap(*_args, **_kwargs):
@@ -396,76 +367,33 @@ def _all_points(carrier, territory):
     return [tuple(carrier.GetNthAnnotationPoint(territory, i)) for i in range(n)]
 
 
+def _on_structure(point, center, tol=1.0e-2):
+    d2 = sum((point[k] - center[k]) ** 2 for k in range(3))
+    return d2 <= (RADIUS + tol) ** 2
+
+
 # =========================================================================== #
-# C4a — the first seed defines the territory's active tree
+# NO STRADDLE-SNAP — a later seed on a DIFFERENT structure STAYS there (3D)
 # =========================================================================== #
 
 
-def test_first_seed_defines_the_active_tree(monkeypatch):
-    """C4a: the first click accepts the surface point + defines the active tree.
+def test_later_seed_on_other_structure_stays(monkeypatch):
+    """A later click on structure B lands ON B — not re-snapped onto A.
 
-    Arming an EMPTY territory and clicking on sphere A places exactly one seed
-    at A's surface point; the territory's active vessel tree is A's connected
-    component (asserted via ``activeTreePolyData()`` matching the independent
-    ``connected_component_at(surface, seedA)`` point-count + carrying zero B
-    points).  ADR-0037 slice-5 "First seed defines the active vessel tree".
+    INVERTS the retired C4b/C4c active-tree constraint.  With a seed already on
+    structure A, an add-on-click whose surface snap lands on the DISJOINT
+    structure B places the seed WHERE IT LANDS (on B): exactly one new seed,
+    the territory now STRADDLES the two systems (one seed on A, one on B).  A
+    territory may legitimately own seeds across multiple disjoint structures
+    (revised ADR-0037 slice-5 Conformance "no straddle-snap"; multi-system plan
+    §Part A).
     """
     slicer = _slicer_or_skip()
     TerritoryPlacementPipeline = _import_pipeline_or_skip()
     pipeline = TerritoryPlacementPipeline()
     carrier = _make_carrier_or_skip(slicer)
     displayNode = _make_display_node_or_skip(slicer)
-    _require_constraint_seam_or_skip(pipeline)
-    connected_component_at = _connected_component_at_or_skip()
-
-    seed_a = _surface_point_on(_sphere(CENTER_A))
-    two_spheres = _wire_pipeline_on_two_spheres_or_skip(
-        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a]
-    )
-    pipeline.SetActiveTerritory(TERRITORY_A)
-    pipeline.Arm()
-
-    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
-    assert _click(pipeline) is True
-    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
-        "the first armed click must add EXACTLY ONE seed (C4a)."
-    )
-
-    active_tree = getattr(pipeline, ACTIVE_TREE_ACCESSOR)()
-    assert active_tree is not None and active_tree.GetNumberOfPoints() > 0, (
-        "after the first seed the pipeline must expose a non-empty active tree."
-    )
-    expected = connected_component_at(two_spheres, seed_a)
-    assert active_tree.GetNumberOfPoints() == expected.GetNumberOfPoints(), (
-        "the active tree must be sphere A's connected component "
-        f"({active_tree.GetNumberOfPoints()} != {expected.GetNumberOfPoints()}) "
-        "-- the first seed DEFINES the tree (ADR-0037 slice 5)."
-    )
-    assert _points_inside_sphere(active_tree, CENTER_B, RADIUS) == 0, (
-        "the active tree must carry ZERO points from the disjoint B system."
-    )
-
-
-# =========================================================================== #
-# C4b — a later seed on a different component snaps onto the active tree
-# =========================================================================== #
-
-
-def test_later_seed_on_other_component_snaps_to_active_tree(monkeypatch):
-    """C4b: a later click on sphere B lands ON sphere A's component, not B.
-
-    With a seed already on A (the active tree), a click whose RAW snap lands on
-    sphere B is re-snapped to the nearest point on the ACTIVE component: the
-    placed point lies within A's component (containment check) and NOT on B.
-    Exactly one new seed; all seeds still lie on A.  ADR-0037 slice-5 "Seeds
-    constrained to the active tree".
-    """
-    slicer = _slicer_or_skip()
-    TerritoryPlacementPipeline = _import_pipeline_or_skip()
-    pipeline = TerritoryPlacementPipeline()
-    carrier = _make_carrier_or_skip(slicer)
-    displayNode = _make_display_node_or_skip(slicer)
-    _require_constraint_seam_or_skip(pipeline)
+    _require_no_straddle_snap_seam_or_skip(pipeline)
 
     seed_a = _surface_point_on(_sphere(CENTER_A))
     seed_b = _surface_point_on(_sphere(CENTER_B))
@@ -474,141 +402,129 @@ def test_later_seed_on_other_component_snaps_to_active_tree(monkeypatch):
     )
     pipeline.SetActiveTerritory(TERRITORY_A)
     pipeline.Arm()
+    if hasattr(pipeline, MODULE_ACTIVE_SETTER):
+        getattr(pipeline, MODULE_ACTIVE_SETTER)(True)
 
-    assert _click(pipeline) is True  # first seed on A defines the tree
+    assert _click(pipeline) is True  # first seed on A
     before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
-    assert _click(pipeline) is True  # raw snap on B -> must be re-snapped to A
+    assert _click(pipeline) is True  # snap on B -> must STAY on B
 
     assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
-        "the constrained later click must add EXACTLY ONE seed (never two, "
-        "never zero)."
+        "the second add-on-click must add EXACTLY ONE seed."
     )
     points = _all_points(carrier, TERRITORY_A)
-    for i, p in enumerate(points):
-        dist_a2 = sum((p[k] - CENTER_A[k]) ** 2 for k in range(3))
-        dist_b2 = sum((p[k] - CENTER_B[k]) ** 2 for k in range(3))
-        assert dist_a2 <= (RADIUS + 1.0e-2) ** 2, (
-            f"seed {i} at {p} must lie on sphere A's component (the active tree)."
-        )
-        assert dist_b2 > (RADIUS + 1.0) ** 2, (
-            f"seed {i} at {p} must NOT lie on the disjoint sphere B -- an "
-            "off-tree click is re-snapped to the active tree (ADR-0037 slice 5)."
-        )
+    assert len(points) == 2
+
+    on_a = [p for p in points if _on_structure(p, CENTER_A)]
+    on_b = [p for p in points if _on_structure(p, CENTER_B)]
+    assert len(on_a) == 1, (
+        f"exactly one seed must remain on structure A; got {len(on_a)} of "
+        f"{points}."
+    )
+    assert len(on_b) == 1, (
+        "the later seed placed over structure B must STAY on B -- the revised "
+        "design does NOT re-snap it back onto A's active tree (revised ADR-0037 "
+        f"slice 5, no straddle-snap); got {len(on_b)} B-seeds of {points}."
+    )
 
 
 # =========================================================================== #
-# C4c — net single-component after A -> B -> A
+# NO STRADDLE-SNAP — the SLICE (2D) pipeline behaves the same
 # =========================================================================== #
 
 
-def test_net_single_component_after_a_b_a_clicks(monkeypatch):
-    """C4c: after clicks targeting A, B, then A, every seed lies on A's component.
+def test_slice_pipeline_later_seed_on_other_structure_stays(monkeypatch):
+    """2D twin: a slice add-on-click on structure B stays on B (no snap).
 
-    The net invariant: no matter the raw-snap sequence, all of a territory's
-    seeds lie on ONE connected component -- the component of
-    ``AnnotationPoints[territory][0]`` (ADR-0037 slice-5 Conformance [test]
-    "never straddles two trees").
+    INVERTS the retired 2D ``test_slice_pipeline_later_seed_snaps_to_active_tree``.
+    The slice pipeline shares the commit-time placement path (the snap runs in
+    world space), so a slice click whose raw snap lands on B places its seed on
+    B — the territory straddles the two systems (revised ADR-0037 slice 5).
     """
     slicer = _slicer_or_skip()
-    TerritoryPlacementPipeline = _import_pipeline_or_skip()
-    pipeline = TerritoryPlacementPipeline()
+    TerritorySlicePipeline = _import_slice_pipeline_or_skip()
+    pipeline = TerritorySlicePipeline()
     carrier = _make_carrier_or_skip(slicer)
     displayNode = _make_display_node_or_skip(slicer)
-    _require_constraint_seam_or_skip(pipeline)
-    connected_component_at = _connected_component_at_or_skip()
-
-    seed_a0 = _surface_point_on(_sphere(CENTER_A))
-    seed_b = _surface_point_on(_sphere(CENTER_B))
-    # A second genuine point on A (opposite pole) so the A-targeting clicks are
-    # distinct surface points, not a repeat of index-0.
-    seed_a1 = (CENTER_A[0], CENTER_A[1], CENTER_A[2] + RADIUS)
-    two_spheres = _wire_pipeline_on_two_spheres_or_skip(
-        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a0, seed_b, seed_a1]
-    )
-    pipeline.SetActiveTerritory(TERRITORY_A)
-    pipeline.Arm()
-
-    assert _click(pipeline) is True  # A (defines tree)
-    assert _click(pipeline) is True  # raw B (must re-snap to A)
-    assert _click(pipeline) is True  # A
-
-    points = _all_points(carrier, TERRITORY_A)
-    assert len(points) == 3, "each of the three clicks must add exactly one seed."
-
-    # Every seed lies on the component of index-0.
-    index0_component = connected_component_at(two_spheres, points[0])
-    assert _points_inside_sphere(index0_component, CENTER_B, RADIUS) == 0, (
-        "the index-0 component (the active tree) must be A-only."
-    )
-    for i, p in enumerate(points):
-        dist_b2 = sum((p[k] - CENTER_B[k]) ** 2 for k in range(3))
-        assert dist_b2 > (RADIUS + 1.0) ** 2, (
-            f"seed {i} at {p} must not lie on the disjoint B system -- every "
-            "seed lies on the index-0 component (ADR-0037 slice 5 C4c)."
-        )
-
-
-# =========================================================================== #
-# C5 — the active-tree highlight actor's input is the seed[0] component
-# =========================================================================== #
-
-
-def test_active_tree_highlight_actor_input_is_seed_zero_component(monkeypatch):
-    """C5: the highlight actor's input polydata == the seed[0] component.
-
-    While a territory is armed, a pipeline-owned actor (no new DM, ADR-0013)
-    renders the active connected tree; its INPUT polydata is the seed[0]
-    component (same point count / bounds as ``connected_component_at(surface,
-    seed0)``).  Styling is deferred -- only the input IDENTITY is pinned.
-    """
-    slicer = _slicer_or_skip()
-    TerritoryPlacementPipeline = _import_pipeline_or_skip()
-    pipeline = TerritoryPlacementPipeline()
-    carrier = _make_carrier_or_skip(slicer)
-    displayNode = _make_display_node_or_skip(slicer)
-    _require_constraint_seam_or_skip(pipeline)
-    connected_component_at = _connected_component_at_or_skip()
-    if not hasattr(pipeline, HIGHLIGHT_ACTOR_ACCESSOR):
-        pytest.skip(
-            f"TerritoryPlacementPipeline has no {HIGHLIGHT_ACTOR_ACCESSOR}() "
-            "accessor -- the ADR-0037 slice-5 (PR-B) active-tree highlight has "
-            "not landed (ADR-0027)."
-        )
+    for method in ("SetPickCore", "SetDisplayNode"):
+        if not hasattr(pipeline, method):
+            pytest.skip(
+                f"{type(pipeline).__name__} has no {method} seam (ADR-0027)."
+            )
 
     seed_a = _surface_point_on(_sphere(CENTER_A))
-    two_spheres = _wire_pipeline_on_two_spheres_or_skip(
-        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a]
+    seed_b = _surface_point_on(_sphere(CENTER_B))
+    _wire_pipeline_on_two_spheres_or_skip(
+        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a, seed_b]
     )
-    pipeline.SetActiveTerritory(TERRITORY_A)
-    pipeline.Arm()
-    assert _click(pipeline) is True  # define the active tree
+    if hasattr(pipeline, "SetActiveTerritory"):
+        pipeline.SetActiveTerritory(TERRITORY_A)
+    else:
+        state = _import_interaction_state_or_skip()
+        state.set_active_territory(displayNode, TERRITORY_A)
+    state = _import_interaction_state_or_skip()
+    state.set_armed(displayNode, True)
+    if hasattr(pipeline, MODULE_ACTIVE_SETTER):
+        getattr(pipeline, MODULE_ACTIVE_SETTER)(True)
 
-    actor = getattr(pipeline, HIGHLIGHT_ACTOR_ACCESSOR)()
-    assert actor is not None, (
-        "the pipeline must own an active-tree highlight actor while armed (C5)."
+    assert _click(pipeline) is True  # first seed on A
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    assert _click(pipeline) is True  # snap on B -> must STAY on B
+
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
+        "the 2D later click must add EXACTLY ONE seed."
     )
-    mapper = actor.GetMapper()
-    assert mapper is not None, "the highlight actor must carry a mapper."
-    actor_input = mapper.GetInput()
-    assert actor_input is not None and actor_input.GetNumberOfPoints() > 0, (
-        "the highlight actor's input must be the non-empty active tree."
+    points = _all_points(carrier, TERRITORY_A)
+    on_b = [p for p in points if _on_structure(p, CENTER_B)]
+    assert len(on_b) == 1, (
+        "the 2D later seed over structure B must STAY on B -- the revised slice "
+        "pipeline does NOT re-snap it onto A (revised ADR-0037 slice 5); got "
+        f"{on_b} of {points}."
     )
 
-    expected = connected_component_at(two_spheres, seed_a)
-    assert actor_input.GetNumberOfPoints() == expected.GetNumberOfPoints(), (
-        "the highlight actor's INPUT must be the seed[0] component "
-        f"({actor_input.GetNumberOfPoints()} != {expected.GetNumberOfPoints()}) "
-        "-- the input identity is pinned, styling deferred (ADR-0037 slice 5)."
-    )
-    assert _points_inside_sphere(actor_input, CENTER_B, RADIUS) == 0, (
-        "the highlight tree must carry ZERO points from the disjoint B system."
-    )
-    # The highlight input tracks the pipeline's own active-tree accessor.
-    active_tree = getattr(pipeline, ACTIVE_TREE_ACCESSOR)()
-    assert actor_input.GetNumberOfPoints() == active_tree.GetNumberOfPoints(), (
-        "the highlight actor input must be the SAME component the pipeline "
-        "exposes as its active tree (C5)."
-    )
+
+# =========================================================================== #
+# RETIRED HALO — the active-tree highlight actor + lock method are GONE
+# =========================================================================== #
+
+
+def test_active_tree_highlight_actor_is_gone(monkeypatch):
+    """The active-tree glow halo + single-tree lock accessors are REMOVED.
+
+    The revised design deletes the glow halo (``highlightActor`` /
+    ``activeTreePolyData`` / ``_highlight_tree_actor``) and the single-tree lock
+    (``_constrain_to_active_tree``).  This is an ABSENCE pin with a credible
+    creep-in path (the named attributes exist on the landed branch and must be
+    deleted, per the no-colour-of-the-sky rule): assert the pipeline no longer
+    exposes any of them.  The SEED-hover halo (``_halo_actor``) is unrelated and
+    STAYS — not asserted here.
+
+    Red->green: FAILS while the landed lock+halo attributes survive; PASSES once
+    the implementer removes them (revised ADR-0037 slice 5, §Part A).
+    """
+    _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    # Only meaningful once the pipeline is a real, wired instance; if the core
+    # placement seams are absent the pipeline has not landed at all.
+    if not hasattr(pipeline, "SetDisplayNode") or not hasattr(pipeline, "Arm"):
+        pytest.skip(
+            "TerritoryPlacementPipeline core seams absent -- pipeline has not "
+            "landed (ADR-0027)."
+        )
+
+    for attr in (
+        RETIRED_TREE_ACCESSOR,
+        RETIRED_HIGHLIGHT_ACCESSOR,
+        RETIRED_CONSTRAINT_METHOD,
+        RETIRED_HALO_ACTOR_ATTR,
+    ):
+        assert not hasattr(pipeline, attr), (
+            f"the single-tree lock + glow halo attribute {attr!r} must be "
+            "REMOVED -- a territory may straddle disjoint systems, so the "
+            "active-tree lock+halo are retired (revised ADR-0037 slice 5, "
+            "§Part A)."
+        )
 
 
 # =========================================================================== #
@@ -619,10 +535,10 @@ def test_active_tree_highlight_actor_input_is_seed_zero_component(monkeypatch):
 def test_module_inactive_declines_add_on_click(monkeypatch):
     """#1a: an add-on-click places nothing while the module is NOT active.
 
-    Belt-and-suspenders beyond the armed flag (concern #1): even ARMED, an
-    add-on-click is declined while the owning module is inactive, so no view
+    RETAINED from the landed suite (unaffected by the lock removal): even ARMED,
+    an add-on-click is declined while the owning module is inactive, so no view
     lands a seed while VascularTerritories is not the active module.  Modelled
-    via the ``SetModuleActive`` gate the seam exposes.
+    via the ``SetModuleActive`` gate.
     """
     slicer = _slicer_or_skip()
     TerritoryPlacementPipeline = _import_pipeline_or_skip()
@@ -632,8 +548,8 @@ def test_module_inactive_declines_add_on_click(monkeypatch):
     if not hasattr(pipeline, MODULE_ACTIVE_SETTER):
         pytest.skip(
             f"TerritoryPlacementPipeline has no {MODULE_ACTIVE_SETTER}() gate -- "
-            "the ADR-0037 slice-5 (PR-B) module-active gate (concern #1) has not "
-            "landed (ADR-0027)."
+            "the ADR-0037 slice-5 module-active gate (concern #1) has not landed "
+            "(ADR-0027)."
         )
 
     seed_a = _surface_point_on(_sphere(CENTER_A))
@@ -662,16 +578,16 @@ def test_module_inactive_declines_add_on_click(monkeypatch):
 
 
 # =========================================================================== #
-# #1b — the armed flag still gates (slice-4 regression re-pin under slice 5)
+# #1b — the armed flag still gates (slice-4 regression re-pin)
 # =========================================================================== #
 
 
 def test_disarmed_display_node_click_places_nothing(monkeypatch):
     """#1b: a dis-armed display node -> an add-on-click places nothing.
 
-    Re-pins the slice-4 arm gate at the pipeline level under the slice-5
+    Re-pins the slice-4 arm gate at the pipeline level under the revised
     surface: with the shared display node dis-armed, an add-on-click adds no
-    seed (ADR-0037 §Decision 3; a regression guard for the PR-B changes).
+    seed (ADR-0037 §Decision 3; a regression guard for the revision).
     """
     slicer = _slicer_or_skip()
     TerritoryPlacementPipeline = _import_pipeline_or_skip()
@@ -700,10 +616,10 @@ def test_disarmed_display_node_click_places_nothing(monkeypatch):
 def test_enter_auto_arms_nothing_exit_disarms():
     """#1b: enter() auto-arms nothing; exit() disarms (module-active gate).
 
-    Re-pins the slice-4 module-active gate at the widget level under slice 5:
-    ``enter()`` leaves the shared display node dis-armed, and ``exit()`` clears
-    an armed state (ADR-0037 slice-4 amendment §Module-active gate).  Launched;
-    needs the composed widget.
+    Re-pins the slice-4 module-active gate at the widget level under the
+    revision: ``enter()`` leaves the shared display node dis-armed, and
+    ``exit()`` clears an armed state (ADR-0037 slice-4 amendment §Module-active
+    gate).  Launched; needs the composed widget.
     """
     _slicer_or_skip()
     import slicer as _slicer  # noqa: F811 — the widget lives on the launched module
@@ -745,56 +661,6 @@ def test_enter_auto_arms_nothing_exit_disarms():
     )
 
     widget.cleanup()
-
-
-# =========================================================================== #
-# C4 twin — the SLICE pipeline enforces the same net single-component invariant
-# =========================================================================== #
-
-
-def test_slice_pipeline_later_seed_snaps_to_active_tree(monkeypatch):
-    """C4b (2D twin): the slice pipeline re-snaps an off-tree later seed to A.
-
-    The 2D ``TerritorySlicePipeline`` shares the commit-time constraint gate
-    (the snap runs in world space, so the slice-normal ray result feeds the
-    SAME gate).  With a seed on A, a slice click whose raw snap lands on B is
-    re-snapped onto A's component -- exactly one new seed, all seeds on A.
-    """
-    slicer = _slicer_or_skip()
-    TerritorySlicePipeline = _import_slice_pipeline_or_skip()
-    pipeline = TerritorySlicePipeline()
-    carrier = _make_carrier_or_skip(slicer)
-    displayNode = _make_display_node_or_skip(slicer)
-    _require_constraint_seam_or_skip(pipeline)
-
-    seed_a = _surface_point_on(_sphere(CENTER_A))
-    seed_b = _surface_point_on(_sphere(CENTER_B))
-    _wire_pipeline_on_two_spheres_or_skip(
-        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a, seed_b]
-    )
-    if hasattr(pipeline, "SetActiveTerritory"):
-        pipeline.SetActiveTerritory(TERRITORY_A)
-    else:
-        state = _import_interaction_state_or_skip()
-        state.set_active_territory(displayNode, TERRITORY_A)
-    state = _import_interaction_state_or_skip()
-    state.set_armed(displayNode, True)
-    if hasattr(pipeline, MODULE_ACTIVE_SETTER):
-        getattr(pipeline, MODULE_ACTIVE_SETTER)(True)
-
-    assert _click(pipeline) is True  # first seed on A defines the tree
-    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
-    assert _click(pipeline) is True  # raw snap on B -> re-snapped to A
-
-    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
-        "the 2D constrained later click must add EXACTLY ONE seed."
-    )
-    for i, p in enumerate(_all_points(carrier, TERRITORY_A)):
-        dist_b2 = sum((p[k] - CENTER_B[k]) ** 2 for k in range(3))
-        assert dist_b2 > (RADIUS + 1.0) ** 2, (
-            f"slice seed {i} at {p} must not lie on the disjoint B system -- the "
-            "2D pipeline shares the active-tree constraint (ADR-0037 slice 5)."
-        )
 
 
 if __name__ == "__main__":

--- a/VascularTerritories/Testing/Python/test_territories_placemode_constraint.py
+++ b/VascularTerritories/Testing/Python/test_territories_placemode_constraint.py
@@ -1,0 +1,801 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 slice 5 (PR-B) — active-tree seed constraint + highlight + module gate.
+
+PR-A landed the compute core (the vessels-only surface resolver
+``vascular_surface_polydata`` / the C++ ``GetVascularSegmentIds`` / the pure-VTK
+``VesselConnectivity.connected_component_at`` / the per-extraction
+single-component surface, and made the pick surface vessels-only).  PR-B adds
+the INTERACTION layer on top: the placement pipelines constrain a territory's
+seed set to ONE connected vessel tree, highlight that tree while armed, and
+decline add-on-clicks while the owning module is inactive.
+
+The invariants pinned here (ADR-0037 §"Amendment — connected-tree-constrained
+centerline seeding (slice 5)" + §Conformance (slice 5)):
+
+* C4a FIRST-SEED-DEFINES-TREE.  The first seed placed into an armed territory
+  is accepted at its snapped surface point and DEFINES the territory's active
+  vessel tree = the connected component of that point (recovered via
+  ``VesselConnectivity.connected_component_at`` over the vessels-only surface).
+* C4b LATER-SEED-SNAPS-TO-ACTIVE.  A later seed whose raw snap lands on a
+  DIFFERENT connected component is re-snapped to the nearest point on the
+  ACTIVE component — never placed off-tree.
+* C4c NET SINGLE-COMPONENT.  After ANY sequence of clicks, every one of a
+  territory's seeds lies on ONE connected component — the component of
+  ``AnnotationPoints[territory][0]``.
+* C5 ACTIVE-TREE HIGHLIGHT.  While a territory is armed, a pipeline-owned actor
+  (no new displayable manager, ADR-0013) renders the active connected tree; its
+  INPUT polydata is the seed[0] component (styling deferred — the input
+  IDENTITY is pinned, not the appearance).
+* #1a MODULE-INACTIVE-DECLINES.  With the owning module NOT active, an
+  add-on-click places nothing (belt-and-suspenders beyond the armed flag).
+* #1b ARMED-FLAG STILL GATES.  A dis-armed display node -> a click places
+  nothing; ``enter()`` auto-arms nothing / ``exit()`` disarms (slice-4
+  regression pins, re-verified under the slice-5 surface).
+
+-- SEAMS THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
+
+On BOTH ``TerritoryPlacementPipeline`` (3D) and ``TerritorySlicePipeline`` (2D),
+extending the existing add-on-click path (``ProcessInteractionEvent`` ->
+``_add_point``):
+
+  * the LATER-seed constraint gate: after the raw surface snap and before the
+    carrier write, when the active territory already carries >=1 seed, recover
+    the active component (``connected_component_at`` seeded at index-0 over the
+    vessels-only pick surface) and re-snap the click to the nearest point on
+    THAT component when the raw snap lands on a different component;
+  * ``activeTreePolyData() -> vtkPolyData | None`` — the recovered active tree
+    for the active territory (the seed[0] component), or ``None`` when the
+    active territory has no seed.  Used to assert C4/C5 without reaching into
+    private caches;
+  * ``highlightActor() -> vtkActor | None`` — the pipeline-owned active-tree
+    highlight actor whose input polydata IS ``activeTreePolyData()`` while
+    armed (C5); a THIRD actor alongside ``_seed_actor`` / ``_marker_actor``,
+    not a new pipeline on the same display-node type (ADR-0013 §1);
+  * ``SetModuleActive(bool)`` / ``IsModuleActive() -> bool`` — the module-active
+    gate flag (concern #1); an add-on-click is declined when the module is not
+    active, independent of the armed flag.
+
+If the implementer names these differently, update the constants below — the
+invariants are the SINGLE-COMPONENT seed set + the highlight-input identity +
+the module-active decline, not the specific spelling.
+
+-- WHY LAUNCHED-SLICER --
+
+The pipelines need LayerDMLib (reachable only inside a launched Slicer with the
+module loaded) + the wrapped ``vtkMRMLCustomTerritoriesNode`` carrier + the
+shared ``vtkMRMLTerritoriesHighlightDisplayNode``.  A bare ``PythonSlicer -m
+pytest`` has ``slicer.mrmlScene is None`` and LayerDMLib off the path, so every
+test here SKIPS CLEANLY via the shared ``slicer_pytest_support`` guards.  The
+connectivity recovery itself is pure-VTK (covered bare by
+``test_territories_connectivity.py``); here it runs on a REAL multi-component
+vessel surface (two disjoint spheres) wired as the pick surface + the injected
+pick core, so the CONSTRAINT is exercised end-to-end through the click path.
+
+-- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
+
+Pre-implementation the PR-B seams (the later-seed constraint, the
+``activeTreePolyData`` / ``highlightActor`` accessors, the module-active flag)
+do not exist, so the ``hasattr`` guards skip-pend; the skips lift at the PR-B
+implementation commit.  Under a launched Slicer, verify run-vs-skip in the CI
+log once the seam lands — never trust overall green (the launched harness is
+green-but-skipping prone).
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md
+    (§Amendment — connected-tree-constrained centerline seeding (slice 5))
+  * Docs/adr/0013-no-custom-displayable-manager.md  (pipeline-owned actor)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * Docs/design/connected-tree-seeding-plan.md  (C4 / C5 / concern #1)
+  * VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
+  * VascularTerritories/Testing/Python/test_territories_connectivity.py  (bare)
+  * VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+  * VascularTerritories/Testing/Python/test_territories_slice_pipeline.py
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+HIGHLIGHT_DISPLAY_CLASS = "vtkMRMLTerritoriesHighlightDisplayNode"
+TERRITORY_A = "SegmentVII"
+
+# The pure-VTK connectivity seam (PR-A; used to compute the EXPECTED active tree
+# independently of the pipeline's own recovery).
+CONNECTIVITY_MODULE = "VascularTerritoriesLib.VesselConnectivity"
+CONNECTED_COMPONENT_FUNC = "connected_component_at"
+
+# PR-B pipeline accessors (proposed; sharpen at landing).
+ACTIVE_TREE_ACCESSOR = "activeTreePolyData"
+HIGHLIGHT_ACTOR_ACCESSOR = "highlightActor"
+MODULE_ACTIVE_SETTER = "SetModuleActive"
+
+# Two well-separated sphere centres so their meshes never share a point and
+# connectivity keeps them as two disjoint regions (the connectivity-test idiom).
+CENTER_A = (0.0, 0.0, 0.0)
+CENTER_B = (100.0, 0.0, 0.0)
+RADIUS = 10.0
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror the launched-Slicer discipline in the sibling suites)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _import_pipeline_or_skip():
+    try:
+        from VascularTerritoriesLib.TerritoryPlacementPipeline import (
+            TerritoryPlacementPipeline,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoryPlacementPipeline not importable ({exc!r}) -- ADR-0037 "
+            "placement Pipeline / LayerDMLib not reachable (ADR-0027)."
+        )
+    return TerritoryPlacementPipeline
+
+
+def _import_slice_pipeline_or_skip():
+    try:
+        from VascularTerritoriesLib.TerritorySlicePipeline import (
+            TerritorySlicePipeline,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritorySlicePipeline not importable ({exc!r}) -- ADR-0037 §2D "
+            "slice Pipeline / LayerDMLib not reachable (ADR-0027)."
+        )
+    return TerritorySlicePipeline
+
+
+def _import_pick_or_skip():
+    try:
+        from VesselSurfacePick import VesselSurfacePick
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VesselSurfacePick not importable ({exc!r}).")
+    return VesselSurfacePick
+
+
+def _import_interaction_state_or_skip():
+    try:
+        import TerritoryInteractionState as state
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"TerritoryInteractionState not importable ({exc!r}) -- the ADR-0037 "
+            "shared display-node state module has not landed (ADR-0027)."
+        )
+    return state
+
+
+def _connected_component_at_or_skip():
+    """The PR-A pure-VTK connectivity helper, used to compute the EXPECTED tree."""
+    try:
+        module = importlib.import_module(CONNECTIVITY_MODULE)
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"{CONNECTIVITY_MODULE} not importable ({exc!r}) -- PR-A connectivity "
+            "helper absent (ADR-0027)."
+        )
+    func = getattr(module, CONNECTED_COMPONENT_FUNC, None)
+    if func is None:
+        pytest.skip(
+            f"{CONNECTIVITY_MODULE} has no {CONNECTED_COMPONENT_FUNC} -- PR-A "
+            "connectivity helper absent (ADR-0027)."
+        )
+    return func
+
+
+def _make_carrier_or_skip(slicer, name="ConstraintCarrierTest"):
+    node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} not registered -- module Logic "
+            "RegisterNodes() must wire this up (launched build)."
+        )
+    for method in ("AddAnnotationPoint", "GetNumberOfAnnotationPoints", "GetNthAnnotationPoint"):
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} -- the ADR-0037 "
+                "annotation carrier has not landed (ADR-0027)."
+            )
+    return node
+
+
+def _make_display_node_or_skip(slicer, name="ConstraintHighlightTest"):
+    node = slicer.mrmlScene.AddNewNodeByClass(HIGHLIGHT_DISPLAY_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{HIGHLIGHT_DISPLAY_CLASS} not registered -- the shared highlight "
+            "display node (ADR-0036/0037) is unavailable (launched build)."
+        )
+    return node
+
+
+def _require_constraint_seam_or_skip(pipeline):
+    """Skip-pend unless the PR-B active-tree constraint accessor has landed.
+
+    ``activeTreePolyData`` is the accessor the C4/C5 assertions read; its
+    absence means the PR-B seam has not landed, so every constraint test
+    collects + SKIP-PENDINGs cleanly and RUNS once PR-B lands (ADR-0027).
+    """
+    if not hasattr(pipeline, ACTIVE_TREE_ACCESSOR):
+        pytest.skip(
+            f"{type(pipeline).__name__} has no {ACTIVE_TREE_ACCESSOR}() accessor "
+            "-- the ADR-0037 slice-5 (PR-B) active-tree seed constraint has not "
+            "landed (ADR-0027)."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Multi-component vessel surface: TWO disjoint spheres (A at origin, B at +x)
+# --------------------------------------------------------------------------- #
+
+
+def _sphere(center, radius=RADIUS):
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(radius)
+    source.SetThetaResolution(16)
+    source.SetPhiResolution(16)
+    source.Update()
+    return source.GetOutput()
+
+
+def _two_disjoint_spheres():
+    """A single polydata holding two DISJOINT sphere components (A then B)."""
+    sphere_a = _sphere(CENTER_A)
+    sphere_b = _sphere(CENTER_B)
+    append = vtk.vtkAppendPolyData()
+    append.AddInputData(sphere_a)
+    append.AddInputData(sphere_b)
+    append.Update()
+    return append.GetOutput(), sphere_a, sphere_b
+
+
+def _points_inside_sphere(polydata, center, radius, tolerance=1.0e-3):
+    """Count ``polydata`` points on/inside the sphere ``(center, radius)``."""
+    count = 0
+    cx, cy, cz = center
+    r2 = (radius + tolerance) ** 2
+    for i in range(polydata.GetNumberOfPoints()):
+        px, py, pz = polydata.GetPoint(i)
+        if (px - cx) ** 2 + (py - cy) ** 2 + (pz - cz) ** 2 <= r2:
+            count += 1
+    return count
+
+
+def _bounds_center(polydata):
+    b = polydata.GetBounds()
+    return ((b[0] + b[1]) / 2.0, (b[2] + b[3]) / 2.0, (b[4] + b[5]) / 2.0)
+
+
+class _FakeRenderer:
+    """Display->world unprojects any pixel to a chosen +something ray.
+
+    The ray hits whichever sphere the test selects: the fake pick core resolves
+    the click to a fixed world point on sphere A or sphere B (see
+    ``_StubPickToPoint``), so the renderer only needs to hand back a stable ray.
+    """
+
+    def SetDisplayPoint(self, x, y, z):  # noqa: N802 - VTK verb
+        pass
+
+    def DisplayToWorld(self):  # noqa: N802 - VTK verb
+        pass
+
+    def GetWorldPoint(self):  # noqa: N802 - VTK verb
+        return (0.0, 0.0, 5.0, 1.0)
+
+    def SetWorldPoint(self, *a):  # noqa: N802 - VTK verb
+        pass
+
+    def WorldToDisplay(self):  # noqa: N802 - VTK verb
+        pass
+
+    def GetDisplayPoint(self):  # noqa: N802 - VTK verb
+        # Return a display point far from any seed so the click is an
+        # add-on-click, never a grab.
+        return (1.0e6, 1.0e6, 0.0)
+
+
+class _Event:
+    """A minimal interaction event at a fixed display pixel + type."""
+
+    def __init__(self, etype, display_position=(100, 100)):
+        self._etype = etype
+        self._pos = display_position
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+def _surface_point_on(sphere_polydata):
+    """A genuine surface point on ``sphere_polydata`` (its first mesh point)."""
+    return tuple(sphere_polydata.GetPoint(0))
+
+
+def _wire_pipeline_on_two_spheres_or_skip(
+    slicer, pipeline, carrier, displayNode, monkeypatch, snap_targets
+):
+    """Wire the pipeline over the two-sphere surface with a scripted snap.
+
+    ``snap_targets`` is a list of world points the RAW surface snap yields on
+    successive clicks (the injected ``_event_world_on_surface`` return values).
+    Each is a genuine point on sphere A or sphere B, so the constraint gate is
+    what re-snaps an off-tree later click.  The pick surface is set to the two
+    disjoint spheres so the pipeline's own ``connected_component_at`` recovery
+    (over the vessels-only surface) has a real multi-component mesh to work on.
+    """
+    VesselSurfacePick = _import_pick_or_skip()
+    for method in ("SetPickCore", "SetDisplayNode"):
+        if not hasattr(pipeline, method):
+            pytest.skip(
+                f"{type(pipeline).__name__} has no {method} seam (ADR-0027)."
+            )
+    state = _import_interaction_state_or_skip()
+    two_spheres, _sphere_a, _sphere_b = _two_disjoint_spheres()
+
+    monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
+    state.set_carrier(displayNode, carrier)
+    pipeline.SetDisplayNode(displayNode)
+    # Inject the pick core over the REAL two-component surface (the vessels-only
+    # pick surface PR-A resolves in production).  SetDisplayNode resets the pick,
+    # so inject AFTER binding it.
+    pipeline.SetPickCore(VesselSurfacePick(two_spheres))
+
+    # Script the RAW snap so we choose which component each click lands on.  The
+    # 3D and 2D pipelines both funnel the snapped world point through
+    # ``_add_point`` after the constraint gate, so injecting the raw snap here
+    # exercises the gate deterministically without a GL context.
+    calls = {"i": 0}
+
+    def _fake_snap(*_args, **_kwargs):
+        i = calls["i"]
+        calls["i"] = i + 1
+        if i < len(snap_targets):
+            return snap_targets[i]
+        return snap_targets[-1]
+
+    if hasattr(pipeline, "_event_world_on_surface"):
+        monkeypatch.setattr(pipeline, "_event_world_on_surface", _fake_snap)
+    elif hasattr(pipeline, "_snap_event_to_surface"):
+        monkeypatch.setattr(pipeline, "_snap_event_to_surface", _fake_snap)
+    else:
+        pytest.skip(
+            f"{type(pipeline).__name__} has no raw-snap seam to inject "
+            "(_event_world_on_surface / _snap_event_to_surface) (ADR-0027)."
+        )
+    return two_spheres
+
+
+def _click(pipeline):
+    return pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent))
+
+
+def _all_points(carrier, territory):
+    n = carrier.GetNumberOfAnnotationPoints(territory)
+    return [tuple(carrier.GetNthAnnotationPoint(territory, i)) for i in range(n)]
+
+
+# =========================================================================== #
+# C4a — the first seed defines the territory's active tree
+# =========================================================================== #
+
+
+def test_first_seed_defines_the_active_tree(monkeypatch):
+    """C4a: the first click accepts the surface point + defines the active tree.
+
+    Arming an EMPTY territory and clicking on sphere A places exactly one seed
+    at A's surface point; the territory's active vessel tree is A's connected
+    component (asserted via ``activeTreePolyData()`` matching the independent
+    ``connected_component_at(surface, seedA)`` point-count + carrying zero B
+    points).  ADR-0037 slice-5 "First seed defines the active vessel tree".
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    _require_constraint_seam_or_skip(pipeline)
+    connected_component_at = _connected_component_at_or_skip()
+
+    seed_a = _surface_point_on(_sphere(CENTER_A))
+    two_spheres = _wire_pipeline_on_two_spheres_or_skip(
+        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a]
+    )
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    pipeline.Arm()
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    assert _click(pipeline) is True
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
+        "the first armed click must add EXACTLY ONE seed (C4a)."
+    )
+
+    active_tree = getattr(pipeline, ACTIVE_TREE_ACCESSOR)()
+    assert active_tree is not None and active_tree.GetNumberOfPoints() > 0, (
+        "after the first seed the pipeline must expose a non-empty active tree."
+    )
+    expected = connected_component_at(two_spheres, seed_a)
+    assert active_tree.GetNumberOfPoints() == expected.GetNumberOfPoints(), (
+        "the active tree must be sphere A's connected component "
+        f"({active_tree.GetNumberOfPoints()} != {expected.GetNumberOfPoints()}) "
+        "-- the first seed DEFINES the tree (ADR-0037 slice 5)."
+    )
+    assert _points_inside_sphere(active_tree, CENTER_B, RADIUS) == 0, (
+        "the active tree must carry ZERO points from the disjoint B system."
+    )
+
+
+# =========================================================================== #
+# C4b — a later seed on a different component snaps onto the active tree
+# =========================================================================== #
+
+
+def test_later_seed_on_other_component_snaps_to_active_tree(monkeypatch):
+    """C4b: a later click on sphere B lands ON sphere A's component, not B.
+
+    With a seed already on A (the active tree), a click whose RAW snap lands on
+    sphere B is re-snapped to the nearest point on the ACTIVE component: the
+    placed point lies within A's component (containment check) and NOT on B.
+    Exactly one new seed; all seeds still lie on A.  ADR-0037 slice-5 "Seeds
+    constrained to the active tree".
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    _require_constraint_seam_or_skip(pipeline)
+
+    seed_a = _surface_point_on(_sphere(CENTER_A))
+    seed_b = _surface_point_on(_sphere(CENTER_B))
+    _wire_pipeline_on_two_spheres_or_skip(
+        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a, seed_b]
+    )
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    pipeline.Arm()
+
+    assert _click(pipeline) is True  # first seed on A defines the tree
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    assert _click(pipeline) is True  # raw snap on B -> must be re-snapped to A
+
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
+        "the constrained later click must add EXACTLY ONE seed (never two, "
+        "never zero)."
+    )
+    points = _all_points(carrier, TERRITORY_A)
+    for i, p in enumerate(points):
+        dist_a2 = sum((p[k] - CENTER_A[k]) ** 2 for k in range(3))
+        dist_b2 = sum((p[k] - CENTER_B[k]) ** 2 for k in range(3))
+        assert dist_a2 <= (RADIUS + 1.0e-2) ** 2, (
+            f"seed {i} at {p} must lie on sphere A's component (the active tree)."
+        )
+        assert dist_b2 > (RADIUS + 1.0) ** 2, (
+            f"seed {i} at {p} must NOT lie on the disjoint sphere B -- an "
+            "off-tree click is re-snapped to the active tree (ADR-0037 slice 5)."
+        )
+
+
+# =========================================================================== #
+# C4c — net single-component after A -> B -> A
+# =========================================================================== #
+
+
+def test_net_single_component_after_a_b_a_clicks(monkeypatch):
+    """C4c: after clicks targeting A, B, then A, every seed lies on A's component.
+
+    The net invariant: no matter the raw-snap sequence, all of a territory's
+    seeds lie on ONE connected component -- the component of
+    ``AnnotationPoints[territory][0]`` (ADR-0037 slice-5 Conformance [test]
+    "never straddles two trees").
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    _require_constraint_seam_or_skip(pipeline)
+    connected_component_at = _connected_component_at_or_skip()
+
+    seed_a0 = _surface_point_on(_sphere(CENTER_A))
+    seed_b = _surface_point_on(_sphere(CENTER_B))
+    # A second genuine point on A (opposite pole) so the A-targeting clicks are
+    # distinct surface points, not a repeat of index-0.
+    seed_a1 = (CENTER_A[0], CENTER_A[1], CENTER_A[2] + RADIUS)
+    two_spheres = _wire_pipeline_on_two_spheres_or_skip(
+        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a0, seed_b, seed_a1]
+    )
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    pipeline.Arm()
+
+    assert _click(pipeline) is True  # A (defines tree)
+    assert _click(pipeline) is True  # raw B (must re-snap to A)
+    assert _click(pipeline) is True  # A
+
+    points = _all_points(carrier, TERRITORY_A)
+    assert len(points) == 3, "each of the three clicks must add exactly one seed."
+
+    # Every seed lies on the component of index-0.
+    index0_component = connected_component_at(two_spheres, points[0])
+    assert _points_inside_sphere(index0_component, CENTER_B, RADIUS) == 0, (
+        "the index-0 component (the active tree) must be A-only."
+    )
+    for i, p in enumerate(points):
+        dist_b2 = sum((p[k] - CENTER_B[k]) ** 2 for k in range(3))
+        assert dist_b2 > (RADIUS + 1.0) ** 2, (
+            f"seed {i} at {p} must not lie on the disjoint B system -- every "
+            "seed lies on the index-0 component (ADR-0037 slice 5 C4c)."
+        )
+
+
+# =========================================================================== #
+# C5 — the active-tree highlight actor's input is the seed[0] component
+# =========================================================================== #
+
+
+def test_active_tree_highlight_actor_input_is_seed_zero_component(monkeypatch):
+    """C5: the highlight actor's input polydata == the seed[0] component.
+
+    While a territory is armed, a pipeline-owned actor (no new DM, ADR-0013)
+    renders the active connected tree; its INPUT polydata is the seed[0]
+    component (same point count / bounds as ``connected_component_at(surface,
+    seed0)``).  Styling is deferred -- only the input IDENTITY is pinned.
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    _require_constraint_seam_or_skip(pipeline)
+    connected_component_at = _connected_component_at_or_skip()
+    if not hasattr(pipeline, HIGHLIGHT_ACTOR_ACCESSOR):
+        pytest.skip(
+            f"TerritoryPlacementPipeline has no {HIGHLIGHT_ACTOR_ACCESSOR}() "
+            "accessor -- the ADR-0037 slice-5 (PR-B) active-tree highlight has "
+            "not landed (ADR-0027)."
+        )
+
+    seed_a = _surface_point_on(_sphere(CENTER_A))
+    two_spheres = _wire_pipeline_on_two_spheres_or_skip(
+        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a]
+    )
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    pipeline.Arm()
+    assert _click(pipeline) is True  # define the active tree
+
+    actor = getattr(pipeline, HIGHLIGHT_ACTOR_ACCESSOR)()
+    assert actor is not None, (
+        "the pipeline must own an active-tree highlight actor while armed (C5)."
+    )
+    mapper = actor.GetMapper()
+    assert mapper is not None, "the highlight actor must carry a mapper."
+    actor_input = mapper.GetInput()
+    assert actor_input is not None and actor_input.GetNumberOfPoints() > 0, (
+        "the highlight actor's input must be the non-empty active tree."
+    )
+
+    expected = connected_component_at(two_spheres, seed_a)
+    assert actor_input.GetNumberOfPoints() == expected.GetNumberOfPoints(), (
+        "the highlight actor's INPUT must be the seed[0] component "
+        f"({actor_input.GetNumberOfPoints()} != {expected.GetNumberOfPoints()}) "
+        "-- the input identity is pinned, styling deferred (ADR-0037 slice 5)."
+    )
+    assert _points_inside_sphere(actor_input, CENTER_B, RADIUS) == 0, (
+        "the highlight tree must carry ZERO points from the disjoint B system."
+    )
+    # The highlight input tracks the pipeline's own active-tree accessor.
+    active_tree = getattr(pipeline, ACTIVE_TREE_ACCESSOR)()
+    assert actor_input.GetNumberOfPoints() == active_tree.GetNumberOfPoints(), (
+        "the highlight actor input must be the SAME component the pipeline "
+        "exposes as its active tree (C5)."
+    )
+
+
+# =========================================================================== #
+# #1a — the module-active gate declines an add-on-click while inactive
+# =========================================================================== #
+
+
+def test_module_inactive_declines_add_on_click(monkeypatch):
+    """#1a: an add-on-click places nothing while the module is NOT active.
+
+    Belt-and-suspenders beyond the armed flag (concern #1): even ARMED, an
+    add-on-click is declined while the owning module is inactive, so no view
+    lands a seed while VascularTerritories is not the active module.  Modelled
+    via the ``SetModuleActive`` gate the seam exposes.
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    if not hasattr(pipeline, MODULE_ACTIVE_SETTER):
+        pytest.skip(
+            f"TerritoryPlacementPipeline has no {MODULE_ACTIVE_SETTER}() gate -- "
+            "the ADR-0037 slice-5 (PR-B) module-active gate (concern #1) has not "
+            "landed (ADR-0027)."
+        )
+
+    seed_a = _surface_point_on(_sphere(CENTER_A))
+    _wire_pipeline_on_two_spheres_or_skip(
+        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a]
+    )
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    pipeline.Arm()
+
+    # Armed, but the module is inactive: the add-on-click must place nothing.
+    getattr(pipeline, MODULE_ACTIVE_SETTER)(False)
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    _click(pipeline)
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "an add-on-click must place NOTHING while the module is inactive -- the "
+        "module-active gate (concern #1) is belt-and-suspenders beyond the "
+        "armed flag (ADR-0037 slice 5)."
+    )
+
+    # Re-activating the module lets the same armed click land a seed.
+    getattr(pipeline, MODULE_ACTIVE_SETTER)(True)
+    assert _click(pipeline) is True
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
+        "with the module active + armed, the add-on-click must land ONE seed."
+    )
+
+
+# =========================================================================== #
+# #1b — the armed flag still gates (slice-4 regression re-pin under slice 5)
+# =========================================================================== #
+
+
+def test_disarmed_display_node_click_places_nothing(monkeypatch):
+    """#1b: a dis-armed display node -> an add-on-click places nothing.
+
+    Re-pins the slice-4 arm gate at the pipeline level under the slice-5
+    surface: with the shared display node dis-armed, an add-on-click adds no
+    seed (ADR-0037 §Decision 3; a regression guard for the PR-B changes).
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+
+    seed_a = _surface_point_on(_sphere(CENTER_A))
+    _wire_pipeline_on_two_spheres_or_skip(
+        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a]
+    )
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    # Explicitly dis-armed on the shared display node.
+    state.set_armed(displayNode, False)
+    if hasattr(pipeline, MODULE_ACTIVE_SETTER):
+        getattr(pipeline, MODULE_ACTIVE_SETTER)(True)  # isolate the arm gate
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    _click(pipeline)
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "a dis-armed add-on-click must place nothing (ADR-0037 §Decision 3)."
+    )
+
+
+def test_enter_auto_arms_nothing_exit_disarms():
+    """#1b: enter() auto-arms nothing; exit() disarms (module-active gate).
+
+    Re-pins the slice-4 module-active gate at the widget level under slice 5:
+    ``enter()`` leaves the shared display node dis-armed, and ``exit()`` clears
+    an armed state (ADR-0037 slice-4 amendment §Module-active gate).  Launched;
+    needs the composed widget.
+    """
+    _slicer_or_skip()
+    import slicer as _slicer  # noqa: F811 — the widget lives on the launched module
+
+    try:
+        from VascularTerritories import VascularTerritoriesWidget
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VascularTerritoriesWidget not importable ({exc!r}) (ADR-0027).")
+
+    widget = VascularTerritoriesWidget()
+    widget.setup()
+    # Drop the widget's scene observers before the autouse scene-clear fires.
+    for event, handler in (
+        (_slicer.mrmlScene.StartCloseEvent, widget.onSceneStartClose),
+        (_slicer.mrmlScene.EndCloseEvent, widget.onSceneEndClose),
+    ):
+        try:
+            widget.removeObserver(_slicer.mrmlScene, event, handler)
+        except Exception:  # noqa: BLE001 — best-effort across widget shapes
+            pass
+
+    displayNode = getattr(widget, "_highlightDisplayNode", None)
+    if displayNode is None:
+        widget.cleanup()
+        pytest.skip(
+            "widget did not expose the shared display node handle (ADR-0027)."
+        )
+    state = _import_interaction_state_or_skip()
+
+    widget.enter()
+    assert state.is_armed(displayNode) is False, (
+        "enter() must auto-arm nothing (ADR-0037 slice-4 module-active gate)."
+    )
+
+    state.set_armed(displayNode, True)
+    widget.exit()
+    assert state.is_armed(displayNode) is False, (
+        "exit() must disarm placement (ADR-0037 slice-4 module-active gate)."
+    )
+
+    widget.cleanup()
+
+
+# =========================================================================== #
+# C4 twin — the SLICE pipeline enforces the same net single-component invariant
+# =========================================================================== #
+
+
+def test_slice_pipeline_later_seed_snaps_to_active_tree(monkeypatch):
+    """C4b (2D twin): the slice pipeline re-snaps an off-tree later seed to A.
+
+    The 2D ``TerritorySlicePipeline`` shares the commit-time constraint gate
+    (the snap runs in world space, so the slice-normal ray result feeds the
+    SAME gate).  With a seed on A, a slice click whose raw snap lands on B is
+    re-snapped onto A's component -- exactly one new seed, all seeds on A.
+    """
+    slicer = _slicer_or_skip()
+    TerritorySlicePipeline = _import_slice_pipeline_or_skip()
+    pipeline = TerritorySlicePipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    _require_constraint_seam_or_skip(pipeline)
+
+    seed_a = _surface_point_on(_sphere(CENTER_A))
+    seed_b = _surface_point_on(_sphere(CENTER_B))
+    _wire_pipeline_on_two_spheres_or_skip(
+        slicer, pipeline, carrier, displayNode, monkeypatch, [seed_a, seed_b]
+    )
+    if hasattr(pipeline, "SetActiveTerritory"):
+        pipeline.SetActiveTerritory(TERRITORY_A)
+    else:
+        state = _import_interaction_state_or_skip()
+        state.set_active_territory(displayNode, TERRITORY_A)
+    state = _import_interaction_state_or_skip()
+    state.set_armed(displayNode, True)
+    if hasattr(pipeline, MODULE_ACTIVE_SETTER):
+        getattr(pipeline, MODULE_ACTIVE_SETTER)(True)
+
+    assert _click(pipeline) is True  # first seed on A defines the tree
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    assert _click(pipeline) is True  # raw snap on B -> re-snapped to A
+
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before + 1, (
+        "the 2D constrained later click must add EXACTLY ONE seed."
+    )
+    for i, p in enumerate(_all_points(carrier, TERRITORY_A)):
+        dist_b2 = sum((p[k] - CENTER_B[k]) ** 2 for k in range(3))
+        assert dist_b2 > (RADIUS + 1.0) ** 2, (
+            f"slice seed {i} at {p} must not lie on the disjoint B system -- the "
+            "2D pipeline shares the active-tree constraint (ADR-0037 slice 5)."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_seed_structure.py
+++ b/VascularTerritories/Testing/Python/test_territories_seed_structure.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 slice 5 (REVISED) — the seed->structure mapping (pure-VTK).
+
+The revised multi-system design (Docs/design/multi-system-territory-plan.md,
+§Part B B1 / B3) assigns each of a territory's seeds to the input SEGMENT
+(structure) whose CLOSED SURFACE the seed is nearest — portal, hepatic, ...  A
+territory may own seeds across MULTIPLE disjoint structures; the mapping is what
+lets extraction group by structure (§B4) and the table colour each seed row by
+its structure (§B3).
+
+The geometry (nearest closed surface to a point) is PURE polydata -> Python
+(ADR-0004 split); the segment->closed-surface + segment->colour resolution
+reads MRML and rides existing seams, pinned launched in
+``test_territories_surface_resolution`` (T1d) + ``test_territories_table``.
+This file is the BARE invariant for the pure core: it RUNS bare once
+``VascularTerritoriesLib/SeedStructureMapping.py`` lands.
+
+* m1 (BARE) — NEAREST STRUCTURE.  Given an ordered ``[(key, surface), ...]`` of
+  two DISJOINT sphere structures, a point on structure A's surface maps to A's
+  key; a point on B's maps to B's; a point clearly inside/near A maps to A.
+* m2 (BARE) — DETERMINISTIC TIEBREAK.  A point EQUIDISTANT to two structures
+  (the midpoint between two symmetric spheres) maps to the FIRST structure in
+  order — deterministic, order-driven (Q3).  Swapping the order flips the
+  result, proving the tiebreak is first-in-order, not geometry-lucky.
+* m3 (BARE) — EMPTY / DEGENERATE.  An empty structure list maps to ``None`` (no
+  structure to assign); a single-structure list maps every point to that one
+  key.
+* m4 (BARE) — PER-STRUCTURE SEED COUNTS + THE <2 WARNING GATE.  Given already-
+  mapped ``[(seed, structureKey), ...]`` pairs, ``territory_structure_seed_counts``
+  groups them into ``{structureKey: count}``; a territory with 2 seeds on A + 1
+  on B has a structure (B) with <2 seeds (the warning case, §B3 / §B6), while
+  2 on A + 2 on B has none.  This is the SAME gate the extractor uses (§B4) so
+  the table warning and the extraction skip agree.
+
+-- SEAM THE IMPLEMENTER MUST PROVIDE (proposed; sharpen at landing) --
+
+A pure-VTK helper module ``VascularTerritoriesLib.SeedStructureMapping`` with:
+
+  * ``nearest_structure(structures, point) -> key | None`` — ``structures`` is
+    an ORDERED sequence of ``(key, closed_surface_polydata)`` (``key`` = the
+    segment id str); builds a ``vtkCellLocator`` (``FindClosestPoint``) per
+    surface and returns the key of the nearest structure to ``point``.  A
+    distance tie resolves to the FIRST structure in order (deterministic, Q3).
+    ``point`` is a 3-tuple of world floats.  Empty ``structures`` -> ``None``.
+  * ``territory_structure_seed_counts(assignments) -> dict[key, int]`` where
+    ``assignments`` is a sequence of ``(seed, structureKey)`` pairs (or just
+    ``structureKey`` values); returns ``{structureKey: count}``.  Reused by the
+    table warning (§B3) and the extractor's ≥2-per-structure gate (§B4) so the
+    two agree on which structures are under-seeded.
+
+If the implementer names these differently, update the constants below — the
+invariants are nearest-surface assignment + first-in-order tiebreak + the
+per-structure count grouping, not the specific spelling.
+
+-- RUN-VS-SKIP DISCIPLINE (ADR-0027) --
+
+Pre-implementation ``SeedStructureMapping`` does not exist, so every test
+import-guards and SKIP-PENDINGs cleanly bare; the skips lift at the
+implementation commit, at which point m1-m4 RUN bare (pure VTK, no launched
+Slicer).
+
+See also:
+  * Docs/design/multi-system-territory-plan.md  (§Part B B1/B3/B4)
+  * Docs/adr/0037-vascular-territories-off-markups.md
+    (§Amendment — connected-tree-constrained centerline seeding (slice 5))
+  * Docs/adr/0004-python-cpp-boundary.md  (pure polydata -> Python)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py  (the
+    pure-VTK connectivity sibling)
+  * VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+    (the launched per-segment closed-surface split, T1d)
+  * VascularTerritories/Testing/Python/test_territories_vmtk_feed.py
+    (the launched group-by-structure extraction twin)
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+# The pure-VTK seed->structure mapping seam (proposed; sharpen at landing).
+MAPPING_MODULE = "VascularTerritoriesLib.SeedStructureMapping"
+NEAREST_STRUCTURE_FUNC = "nearest_structure"
+STRUCTURE_SEED_COUNTS_FUNC = "territory_structure_seed_counts"
+
+# Two well-separated sphere centres so their meshes never share a point.
+CENTER_A = (0.0, 0.0, 0.0)
+CENTER_B = (100.0, 0.0, 0.0)
+RADIUS = 10.0
+
+# Structure keys stand in for real segment ids (str, per GetVascularSegmentIds).
+KEY_A = "Segment_Portal"
+KEY_B = "Segment_Hepatic"
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (import-guard on the not-yet-existing pure helper; ADR-0027)
+# --------------------------------------------------------------------------- #
+
+
+def _mapping_module_or_skip():
+    try:
+        return importlib.import_module(MAPPING_MODULE)
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"{MAPPING_MODULE} not importable ({exc!r}) -- the revised ADR-0037 "
+            "slice-5 seed->structure mapping helper has not landed.  The skip "
+            "lifts at the implementation commit (ADR-0027)."
+        )
+
+
+def _nearest_structure_or_skip():
+    module = _mapping_module_or_skip()
+    func = getattr(module, NEAREST_STRUCTURE_FUNC, None)
+    if func is None:
+        pytest.skip(
+            f"{MAPPING_MODULE} has no {NEAREST_STRUCTURE_FUNC} -- the revised "
+            "ADR-0037 slice-5 seed->structure mapping helper has not landed "
+            "(ADR-0027)."
+        )
+    return func
+
+
+def _structure_seed_counts_or_skip():
+    module = _mapping_module_or_skip()
+    func = getattr(module, STRUCTURE_SEED_COUNTS_FUNC, None)
+    if func is None:
+        pytest.skip(
+            f"{MAPPING_MODULE} has no {STRUCTURE_SEED_COUNTS_FUNC} -- the revised "
+            "ADR-0037 slice-5 per-structure seed-count query has not landed "
+            "(ADR-0027)."
+        )
+    return func
+
+
+# --------------------------------------------------------------------------- #
+# Pure-VTK fixtures (no Slicer, no MRML, no GL)
+# --------------------------------------------------------------------------- #
+
+
+def _sphere(center, radius=RADIUS):
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(radius)
+    source.SetThetaResolution(16)
+    source.SetPhiResolution(16)
+    source.Update()
+    return source.GetOutput()
+
+
+def _two_structures():
+    """An ordered ``[(KEY_A, sphere_A), (KEY_B, sphere_B)]`` structure list."""
+    return [(KEY_A, _sphere(CENTER_A)), (KEY_B, _sphere(CENTER_B))]
+
+
+def _surface_point_on(sphere_polydata):
+    """A genuine surface point on ``sphere_polydata`` (its first mesh point)."""
+    return tuple(sphere_polydata.GetPoint(0))
+
+
+# =========================================================================== #
+# m1 — nearest structure (BARE)
+# =========================================================================== #
+
+
+def test_point_on_structure_a_maps_to_a():
+    """m1: a point on structure A's surface maps to A's key.
+
+    The seed lands on the portal surface; the mapping assigns it the portal
+    segment id (revised ADR-0037 slice 5; multi-system plan §B1).  Pure VTK —
+    RUNS bare.
+    """
+    nearest_structure = _nearest_structure_or_skip()
+    structures = _two_structures()
+    seed_on_a = _surface_point_on(structures[0][1])
+
+    assert nearest_structure(structures, seed_on_a) == KEY_A, (
+        "a seed on structure A's surface must map to A's key "
+        "(seed->structure mapping, §B1)."
+    )
+
+
+def test_point_on_structure_b_maps_to_b():
+    """m1: a point on structure B's surface maps to B's key.
+
+    The mirror of the A case — the mapping is nearest-surface, not fixed to the
+    first structure — so a seed on the hepatic surface maps to hepatic.  Pure
+    VTK — RUNS bare.
+    """
+    nearest_structure = _nearest_structure_or_skip()
+    structures = _two_structures()
+    seed_on_b = _surface_point_on(structures[1][1])
+
+    assert nearest_structure(structures, seed_on_b) == KEY_B, (
+        "a seed on structure B's surface must map to B's key (§B1)."
+    )
+
+
+def test_point_near_a_centre_maps_to_a():
+    """m1: a point deep inside/near A maps to A regardless of B's presence.
+
+    A point at A's centre is far closer to A's surface than to B's, so it maps
+    to A — a sanity check that the nearest-surface distance drives the
+    assignment (§B1).  Pure VTK — RUNS bare.
+    """
+    nearest_structure = _nearest_structure_or_skip()
+    structures = _two_structures()
+
+    assert nearest_structure(structures, CENTER_A) == KEY_A
+    assert nearest_structure(structures, CENTER_B) == KEY_B
+
+
+# =========================================================================== #
+# m2 — deterministic first-in-order tiebreak (BARE, Q3)
+# =========================================================================== #
+
+
+def test_boundary_point_tiebreaks_to_first_in_order():
+    """m2: a point equidistant to two structures maps to the FIRST in order.
+
+    A seed at the midpoint between two symmetric spheres is equidistant to both
+    surfaces; the mapping resolves the tie to the FIRST structure in the ordered
+    list (deterministic, Q3).  Swapping the structure order flips the result —
+    proving the tiebreak is first-in-order, not a geometry accident.  Pure VTK —
+    RUNS bare.
+    """
+    nearest_structure = _nearest_structure_or_skip()
+    structures = _two_structures()
+    midpoint = tuple((CENTER_A[k] + CENTER_B[k]) / 2.0 for k in range(3))
+
+    first_a = nearest_structure(structures, midpoint)
+    first_b = nearest_structure(list(reversed(structures)), midpoint)
+
+    assert first_a == KEY_A, (
+        "an equidistant boundary point must tiebreak to the FIRST structure in "
+        f"order (KEY_A); got {first_a!r} (revised ADR-0037 slice 5, Q3)."
+    )
+    assert first_b == KEY_B, (
+        "reversing the order must flip the tiebreak to the new first structure "
+        f"(KEY_B); got {first_b!r} -- the tiebreak is first-in-order, not "
+        "geometry-lucky (Q3)."
+    )
+
+
+# =========================================================================== #
+# m3 — empty / single-structure degenerate cases (BARE)
+# =========================================================================== #
+
+
+def test_empty_structure_list_maps_to_none():
+    """m3: no structures -> the mapping returns None (nothing to assign)."""
+    nearest_structure = _nearest_structure_or_skip()
+    assert nearest_structure([], CENTER_A) is None, (
+        "an empty structure list must map to None -- there is no structure to "
+        "assign the seed to (§B1)."
+    )
+
+
+def test_single_structure_maps_every_point_to_it():
+    """m3: one structure -> every point maps to its key."""
+    nearest_structure = _nearest_structure_or_skip()
+    structures = [(KEY_A, _sphere(CENTER_A))]
+    assert nearest_structure(structures, CENTER_A) == KEY_A
+    # A far-away point still maps to the only structure available.
+    assert nearest_structure(structures, CENTER_B) == KEY_A, (
+        "with a single structure, even a distant seed maps to that one key (§B1)."
+    )
+
+
+# =========================================================================== #
+# m4 — per-structure seed counts + the <2 warning gate (BARE)
+# =========================================================================== #
+
+
+def test_structure_seed_counts_group_by_structure():
+    """m4: the counts query groups mapped seeds by structure key.
+
+    Given already-mapped ``(seed, structureKey)`` pairs, the query returns
+    ``{structureKey: count}`` — the grouping both the extractor's ≥2-per-
+    structure gate (§B4) and the table warning (§B3 / §B6) read, so they agree.
+    Pure — RUNS bare.
+    """
+    counts = _structure_seed_counts_or_skip()
+    assignments = [
+        ((0.0, 0.0, 0.0), KEY_A),
+        ((1.0, 0.0, 0.0), KEY_A),
+        ((0.0, 1.0, 0.0), KEY_B),
+    ]
+
+    grouped = counts(assignments)
+
+    assert dict(grouped) == {KEY_A: 2, KEY_B: 1}, (
+        "the per-structure seed counts must group the mapped seeds by structure "
+        f"key (expected {{{KEY_A!r}: 2, {KEY_B!r}: 1}}, got {dict(grouped)}) "
+        "(§B3/§B4)."
+    )
+
+
+def test_two_plus_one_flags_an_under_seeded_structure():
+    """m4: 2 seeds on A + 1 on B leaves B under the ≥2 gate (the warning case).
+
+    A territory with 2 seeds on structure A and 1 on structure B has a touched
+    structure (B) with <2 seeds — B cannot yield a centerline, so the territory
+    is flagged (§B6) and B is skipped by extraction (§B4).  Pure — RUNS bare.
+    """
+    counts = _structure_seed_counts_or_skip()
+    grouped = counts(
+        [
+            ((0.0, 0.0, 0.0), KEY_A),
+            ((1.0, 0.0, 0.0), KEY_A),
+            ((0.0, 1.0, 0.0), KEY_B),
+        ]
+    )
+
+    under_seeded = [k for k, n in dict(grouped).items() if n < 2]
+    assert under_seeded == [KEY_B], (
+        "a 2-on-A + 1-on-B territory must flag structure B as under-seeded "
+        f"(<2 seeds); got under-seeded {under_seeded} (§B4/§B6)."
+    )
+
+
+def test_two_plus_two_has_no_under_seeded_structure():
+    """m4: 2 seeds on A + 2 on B -> every touched structure clears the ≥2 gate.
+
+    A territory evenly seeded across two structures has NO under-seeded
+    structure, so it is complete and BOTH structures yield a centerline (§B4 /
+    §B5 the mixed-system-two-centerlines case).  Pure — RUNS bare.
+    """
+    counts = _structure_seed_counts_or_skip()
+    grouped = counts(
+        [
+            ((0.0, 0.0, 0.0), KEY_A),
+            ((1.0, 0.0, 0.0), KEY_A),
+            ((0.0, 1.0, 0.0), KEY_B),
+            ((0.0, 2.0, 0.0), KEY_B),
+        ]
+    )
+
+    under_seeded = [k for k, n in dict(grouped).items() if n < 2]
+    assert under_seeded == [], (
+        "a 2-on-A + 2-on-B territory must have NO under-seeded structure -- both "
+        f"structures clear the >=2 gate; got under-seeded {under_seeded} "
+        "(§B4/§B5)."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_structure_visibility.py
+++ b/VascularTerritories/Testing/Python/test_territories_structure_visibility.py
@@ -317,6 +317,330 @@ def test_hiding_a_structure_omits_its_2d_projected_seeds():
 
 
 # =========================================================================== #
+# POST-REVIEW REFINEMENT — the seed-repaint TRIGGER fires via the pipeline's
+# OWN observer (not just the filter), and SetSegmentVisibility advances the
+# cache-invalidation MTime key.
+# =========================================================================== #
+#
+# The reviewer flagged that i1 above pins the seed-visibility FILTER but calls
+# ``_rebuild_seed_actor()`` DIRECTLY -- it never proves the pipeline REPAINTS on
+# its own when a structure is toggled.  A segment show/hide modifies the
+# SEGMENTATION display node (not the carrier), so the glyph rebuild needs its
+# own trigger: ``_ensure_pick_surface_observed`` observes that display node and
+# ``_on_node_modified`` rebuilds.  These pin the TRIGGER (green regression
+# guards, RUN launched now).
+
+
+def test_visibility_toggle_repaints_seeds_via_pipeline_observer(monkeypatch):
+    """Toggling a structure's visibility repaints seeds VIA THE PIPELINE OBSERVER.
+
+    Post-review refinement (ADR-0037 slice 5): a segment show/hide modifies the
+    SEGMENTATION display node, not the carrier, so the seed-glyph rebuild needs
+    its own trigger -- ``_ensure_pick_surface_observed`` observes the pickSurface
+    segmentation's display node and ``_on_node_modified`` rebuilds.  This does
+    NOT call ``_rebuild_seed_actor`` directly (unlike i1's filter test): it
+    toggles ``SetSegmentVisibility`` and asserts the glyph count changed on its
+    OWN, proving the observer fires the rebuild.  Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    Pipeline = _import_pipeline_or_skip(
+        "TerritoryPlacementPipeline", "TerritoryPlacementPipeline")
+    pipeline = Pipeline()
+    for seam in ("SetDisplayNode", "UpdatePipeline", "_ensure_pick_surface_observed"):
+        if not hasattr(pipeline, seam):
+            pytest.skip(
+                f"TerritoryPlacementPipeline has no {seam} -- the seed-repaint "
+                "trigger seam has not landed (ADR-0027)."
+            )
+
+    carrier = _make_carrier_or_skip(slicer)
+    display = _make_display_node_or_skip(slicer)
+    seg, segA, segB = _two_structure_segmentation(slicer)
+    segDisplay = seg.GetDisplayNode()
+
+    import TerritoryInteractionState as state
+
+    state.set_carrier(display, carrier)
+    display.SetAndObservePickSurfaceNodeID(seg.GetID())
+    pipeline.SetDisplayNode(display)
+
+    carrier.AddAnnotationPoint(TERRITORY, *_A_CENTER)
+    carrier.AddAnnotationPoint(TERRITORY, *_B_CENTER)
+
+    _require_two_mapped_structures(pipeline, segA, segB)
+
+    # Attach the segment-visibility observer through the documented re-sync hook
+    # (the production attach path), then seed the glyph set once.
+    pipeline.UpdatePipeline()
+    both = _seed_point_count(pipeline._seed_polydata)
+    assert both == 2, (
+        f"both seeds must render after the initial sync (got {both})."
+    )
+
+    # Toggle B hidden via the SEGMENTATION display node -- do NOT call
+    # _rebuild_seed_actor directly.  The pipeline's own observer must fire the
+    # rebuild, dropping B's seed.
+    segDisplay.SetSegmentVisibility(segB, False)
+    assert _seed_point_count(pipeline._seed_polydata) == 1, (
+        "hiding structure B must drop its seed VIA THE PIPELINE'S OWN OBSERVER "
+        "(the repaint trigger, ADR-0037 slice 5) -- not a direct rebuild call."
+    )
+
+    # Re-showing restores it, again via the observer.
+    segDisplay.SetSegmentVisibility(segB, True)
+    assert _seed_point_count(pipeline._seed_polydata) == 2, (
+        "showing structure B must restore its seed via the observer trigger."
+    )
+
+
+def test_set_segment_visibility_advances_visibility_mtime():
+    """``SetSegmentVisibility`` advances the display node MTime ``visibility_mtime`` reads.
+
+    Post-review refinement (ADR-0037 slice 5): the pick + structure caches
+    invalidate off ``VesselHighlightWiring.visibility_mtime(segmentation)`` --
+    the segmentation display node's MTime.  A segment show/hide MUST advance it,
+    else the cached vessels-only surface + per-structure locators never rebuild
+    and a hidden vessel stays live.  Pins the cache-invalidation KEY directly.
+    Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    try:
+        from VascularTerritoriesLib.VesselHighlightWiring import visibility_mtime
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"visibility_mtime not importable ({exc!r}) (ADR-0027).")
+
+    seg, _segA, segB = _two_structure_segmentation(slicer)
+
+    before = visibility_mtime(seg)
+    seg.GetDisplayNode().SetSegmentVisibility(segB, False)
+    after = visibility_mtime(seg)
+
+    assert after > before, (
+        "SetSegmentVisibility must advance the segmentation display node's MTime "
+        "that visibility_mtime reads -- the cache-invalidation key (ADR-0037 "
+        f"slice 5); before={before}, after={after}."
+    )
+
+
+# =========================================================================== #
+# POST-REVIEW REFINEMENT — hover/grab hit-test excludes hidden-structure seeds
+# =========================================================================== #
+#
+# The nearest-point hit-test (``_nearest_point_in_display``, consulted by the
+# hover + grab paths in CanProcessInteractionEvent) must skip a seed whose
+# structure is hidden: a hidden seed is not drawn, so it must not be a
+# hover/grab target either (ADR-0037 slice 5).  The hit-test consults
+# ``self._structures.seed_visible`` before considering each seed.  A stub
+# renderer projects each seed's world point onto the SAME display pixel the
+# event carries, so the visible seed is a target and the hidden one is not.
+
+
+class _ProjectAllToEventPixelRenderer:
+    """A renderer stub projecting every world point onto the event's pixel.
+
+    ``_nearest_point_in_display`` calls ``SetWorldPoint`` / ``WorldToDisplay`` /
+    ``GetDisplayPoint`` per seed; returning the event pixel for every world
+    point makes the squared display distance 0 for whichever seeds the hit-test
+    DOES consider -- so a seed appears "under the cursor" iff the visibility
+    filter lets it through.  GL-free, mirroring the placement-pipeline suite's
+    stub-renderer idiom.
+    """
+
+    def __init__(self, event_pixel=(100, 100)):
+        self._event_pixel = event_pixel
+
+    def SetWorldPoint(self, x, y, z, w):  # noqa: N802 - VTK verb
+        pass
+
+    def WorldToDisplay(self):  # noqa: N802 - VTK verb
+        pass
+
+    def GetDisplayPoint(self):  # noqa: N802 - VTK verb
+        return (self._event_pixel[0], self._event_pixel[1], 0.0)
+
+
+class _Event:
+    """A minimal interaction event at a fixed display pixel."""
+
+    def __init__(self, display_position=(100, 100)):
+        self._pos = display_position
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+def test_hit_test_excludes_hidden_structure_seeds(monkeypatch):
+    """The hover/grab hit-test returns no target for a hidden-structure seed.
+
+    Post-review refinement (ADR-0037 slice 5): a hidden seed is not drawn, so
+    ``_nearest_point_in_display`` must not offer it as a hover/grab target even
+    when the cursor pixel is over it.  With one seed on structure B and the
+    stub renderer projecting it onto the event pixel, the hit-test returns B's
+    seed when B is shown and NO target when B is hidden.  Launched-only; SKIPS
+    bare.  If the display projection cannot resolve headless, pins the seam
+    level (the filter ``seed_visible`` consulted by the hit-test) instead.
+    """
+    slicer = _slicer_or_skip()
+    Pipeline = _import_pipeline_or_skip(
+        "TerritoryPlacementPipeline", "TerritoryPlacementPipeline")
+    pipeline = Pipeline()
+    if not hasattr(pipeline, "_nearest_point_in_display") or not hasattr(
+        pipeline, "SetDisplayNode"
+    ):
+        pytest.skip(
+            "TerritoryPlacementPipeline lacks _nearest_point_in_display / "
+            "SetDisplayNode -- the hit-test seam has not landed (ADR-0027)."
+        )
+
+    carrier = _make_carrier_or_skip(slicer)
+    display = _make_display_node_or_skip(slicer)
+    seg, segA, segB = _two_structure_segmentation(slicer)
+    segDisplay = seg.GetDisplayNode()
+
+    import TerritoryInteractionState as state
+
+    state.set_carrier(display, carrier)
+    # The hit-test scans the ACTIVE territory's points; make TERRITORY active so
+    # ``_placement_territory`` resolves it (else the scan has no territory).
+    state.set_active_territory(display, TERRITORY)
+    display.SetAndObservePickSurfaceNodeID(seg.GetID())
+    pipeline.SetDisplayNode(display)
+
+    # A single seed on structure B (so a hit is unambiguous).
+    carrier.AddAnnotationPoint(TERRITORY, *_B_CENTER)
+    _require_two_mapped_structures(pipeline, segA, segB)
+
+    renderer = _ProjectAllToEventPixelRenderer()
+    event = _Event()
+
+    # Shown: the seed IS a grab target (distance2 ~= 0 on the event pixel).
+    segDisplay.SetSegmentVisibility(segB, True)
+    territory, index, distance2 = pipeline._nearest_point_in_display(renderer, event)
+    if territory is None:
+        # The stub-renderer display projection did not resolve a target in this
+        # launch: fall back to pinning at the SEAM the hit-test consults --
+        # seed_visible gates the seed in/out -- so the invariant is still guarded
+        # (ADR-0037 slice 5), just below the display-projection level.
+        point = carrier.GetNthAnnotationPoint(TERRITORY, 0)
+        assert pipeline._structures.seed_visible(display, point) is True, (
+            "a visible-structure seed must pass the hit-test's seed_visible gate."
+        )
+        segDisplay.SetSegmentVisibility(segB, False)
+        assert pipeline._structures.seed_visible(display, point) is False, (
+            "a HIDDEN-structure seed must FAIL the hit-test's seed_visible gate, "
+            "so the hit-test excludes it (ADR-0037 slice 5)."
+        )
+        return
+    assert index == 0 and distance2 < 1.0, (
+        "a visible-structure seed under the cursor must be a hover/grab target."
+    )
+
+    # Hidden: the same seed is NOT a target -- the hit-test skips it.
+    segDisplay.SetSegmentVisibility(segB, False)
+    territory_hidden, index_hidden, distance2_hidden = pipeline._nearest_point_in_display(
+        renderer, event)
+    assert territory_hidden is None and index_hidden is None, (
+        "a HIDDEN-structure seed must NOT be a hover/grab target, even with the "
+        "cursor over it -- the hit-test consults seed_visible (ADR-0037 slice 5)."
+    )
+
+
+# =========================================================================== #
+# POST-REVIEW REFINEMENT — VisibleStructuresCache builds per-structure locators
+# ONCE and reuses them while the visibility MTime is unchanged (hover-perf fix).
+# =========================================================================== #
+#
+# The per-structure ``vtkCellLocator``s are expensive to build on ~100k-point
+# vessel surfaces, and the per-seed nearest-structure query runs on every seed
+# repaint (which the hover-reslice fires often).  The cache MUST build them once
+# per visibility MTime and reuse across ``seed_visible`` calls, rebuilding only
+# when the MTime advances (ADR-0037 slice 5 performance).
+
+
+class _FakeDisplayNodeWithPickSurface:
+    """A minimal display node exposing only ``GetPickSurfaceNode`` for the cache.
+
+    The ``VisibleStructuresCache`` resolves its structures from a display node's
+    ``GetPickSurfaceNode`` -- so a tiny fake carrying a real tagged segmentation
+    exercises the cache without the wrapped highlight display node.
+    """
+
+    def __init__(self, segmentation):
+        self._segmentation = segmentation
+
+    def GetPickSurfaceNode(self):  # noqa: N802 - VTK verb
+        return self._segmentation
+
+
+def test_structures_cache_builds_locators_once_and_reuses(monkeypatch):
+    """``VisibleStructuresCache`` builds per-structure locators once, reuses them.
+
+    Post-review refinement (ADR-0037 slice 5 performance): the cache prebuilds
+    one ``vtkCellLocator`` per structure keyed by the visibility MTime, so a
+    repaint does not rebuild a locator per seed.  Counts ``vtkCellLocator``
+    construction across many ``seed_visible`` calls at a fixed visibility MTime:
+    the locators are built exactly once (at first resolve), then reused.  A
+    ``SetSegmentVisibility`` (advancing the MTime) is what forces a rebuild.
+    Launched (resolves off a tagged segmentation); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    try:
+        from VascularTerritoriesLib.VesselHighlightWiring import VisibleStructuresCache
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VisibleStructuresCache not importable ({exc!r}) (ADR-0027).")
+
+    seg, segA, segB = _two_structure_segmentation(slicer)
+    fake_display = _FakeDisplayNodeWithPickSurface(seg)
+    cache = VisibleStructuresCache()
+
+    # Precondition: the two structures must resolve, else there are no locators
+    # to count (skip on a fixture gap rather than fail).
+    structures = cache.resolve(fake_display)
+    keys = {segId for segId, _surface, _visible in structures}
+    if segA not in keys or segB not in keys:
+        pytest.skip(
+            "the two vessel structures did not resolve from the pickSurface "
+            f"(closed-surface reps unbuilt in this launch); resolved {keys!r}."
+        )
+
+    # Count vtkCellLocator construction from here on.  A fresh cache to observe
+    # the FIRST build cleanly.
+    cache = VisibleStructuresCache()
+    construction_count = {"n": 0}
+    real_locator = vtk.vtkCellLocator
+
+    def _counting_locator(*args, **kwargs):
+        construction_count["n"] += 1
+        return real_locator(*args, **kwargs)
+
+    monkeypatch.setattr(vtk, "vtkCellLocator", _counting_locator)
+
+    # Many seed_visible calls at a FIXED visibility MTime.
+    probe = (_B_CENTER[0], _B_CENTER[1], _B_CENTER[2])
+    for _ in range(10):
+        cache.seed_visible(fake_display, probe)
+
+    built_once = construction_count["n"]
+    assert built_once >= 1, (
+        "the cache must build at least one per-structure locator on first "
+        "resolve."
+    )
+    assert built_once <= len(structures), (
+        "the cache must build AT MOST one locator per structure -- not one per "
+        f"seed_visible call (built {built_once} for {len(structures)} "
+        "structures across 10 calls; ADR-0037 slice 5 performance)."
+    )
+
+    # A visibility change (MTime advance) is what forces a rebuild.
+    seg.GetDisplayNode().SetSegmentVisibility(segB, False)
+    cache.seed_visible(fake_display, probe)
+    assert construction_count["n"] > built_once, (
+        "advancing the visibility MTime (SetSegmentVisibility) must rebuild the "
+        "per-structure locators -- the cache is keyed on that MTime."
+    )
+
+
+# =========================================================================== #
 # i2 — CENTERLINE visibility follows the structure show/hide (widget observer)
 # =========================================================================== #
 

--- a/VascularTerritories/Testing/Python/test_territories_structure_visibility.py
+++ b/VascularTerritories/Testing/Python/test_territories_structure_visibility.py
@@ -31,7 +31,7 @@ segmentation, so they SKIP cleanly bare and RUN launched (ADR-0027).
 
 See also:
   * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 4 + slice 5)
-  * Docs/adr/0013-layerdm-migration.md  (§5 — no custom displayable manager;
+  * Docs/adr/0013-layerdm-pipeline-pattern.md  (§5 — no custom displayable manager;
     the centerline follow is a widget-level Python observer)
   * VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
     (the display-node + pickSurface routing this file reuses)

--- a/VascularTerritories/Testing/Python/test_territories_structure_visibility.py
+++ b/VascularTerritories/Testing/Python/test_territories_structure_visibility.py
@@ -1,0 +1,426 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""ADR-0037 slice 5 — centerlines + seeds follow the anatomical-structure show/hide.
+
+Hiding a structure (input segment) via the structures table hides everything
+derived from it:
+
+* SEEDS — the 3D ``TerritoryPlacementPipeline`` seed glyphs and the 2D
+  ``TerritorySlicePipeline`` projected seeds drop the points whose nearest
+  STRUCTURE is hidden, and restore them when the structure is shown.  The seed
+  is mapped to its structure exactly as extraction groups it
+  (``SeedStructureMapping.nearest_structure`` over the per-segment vessel closed
+  surfaces).
+* CENTERLINES — each extracted centerline model is tagged with its structure
+  segment id (``VascularTerritories.StructureSegmentId``) at creation; the
+  widget observes the input segmentation's display node and sets each
+  ``CenterlineRefs`` model's display visibility to its structure's visibility.
+
+This file pins:
+
+* i1 (launched) — SEED visibility: with seeds on two structures, hiding one
+  omits its seeds from the 3D seed-glyph polydata (and the 2D projection);
+  showing restores them.
+* i2 (launched) — CENTERLINE visibility: a centerline tagged with a structure
+  segment id hides when that segment is hidden (and reappears when shown), via
+  the widget's segmentation-display-node observer.
+
+All need the wrapped carrier + highlight display node + a live multi-segment
+segmentation, so they SKIP cleanly bare and RUN launched (ADR-0027).
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 4 + slice 5)
+  * Docs/adr/0013-layerdm-migration.md  (§5 — no custom displayable manager;
+    the centerline follow is a widget-level Python observer)
+  * VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+    (the display-node + pickSurface routing this file reuses)
+  * VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+    (the multi-segment vascular segmentation fixtures)
+  * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+HIGHLIGHT_DISPLAY_CLASS = "vtkMRMLTerritoriesHighlightDisplayNode"
+SEGMENTATION_CLASS = "vtkMRMLSegmentationNode"
+TERRITORY = "T1"
+
+_VEIN_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^29092000^Vein~^^~Anatomic codes~^^~^^"
+)
+_ARTERY_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^51114001^Artery~^^~Anatomic codes~^^~^^"
+)
+
+# The two structures sit far apart so a seed at each centre maps unambiguously
+# to its own structure (nearest-closed-surface).
+_A_CENTER = (0.0, 0.0, 0.0)
+_B_CENTER = (100.0, 0.0, 0.0)
+_RADIUS = 15.0
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror the launched-Slicer discipline in conftest.py)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_carrier_or_skip(slicer, name="StructureVisibilityCarrier"):
+    node = slicer.mrmlScene.AddNewNodeByClass(CUSTOM_TERRITORIES_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} not registered -- module Logic "
+            "RegisterNodes() must wire this up (launched build)."
+        )
+    if not hasattr(node, "AddAnnotationPoint"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no AddAnnotationPoint -- the "
+            "ADR-0037 annotation carrier has not landed (ADR-0027)."
+        )
+    return node
+
+
+def _make_display_node_or_skip(slicer, name="StructureVisibilityHighlight"):
+    node = slicer.mrmlScene.AddNewNodeByClass(HIGHLIGHT_DISPLAY_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{HIGHLIGHT_DISPLAY_CLASS} not registered -- the shared highlight "
+            "display node (ADR-0036/0037) is unavailable (launched build)."
+        )
+    return node
+
+
+def _add_tagged_sphere(slicer, segmentation, terminology, name, center):
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(_RADIUS)
+    source.SetThetaResolution(20)
+    source.SetPhiResolution(20)
+    source.Update()
+    modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", name)
+    modelNode.SetAndObservePolyData(source.GetOutput())
+    slicer.modules.segmentations.logic().ImportModelToSegmentationNode(
+        modelNode, segmentation)
+    slicer.mrmlScene.RemoveNode(modelNode)
+    obj = segmentation.GetSegmentation()
+    segId = obj.GetNthSegmentID(obj.GetNumberOfSegments() - 1)
+    obj.GetSegment(segId).SetTag("TerminologyEntry", terminology)
+    return segId
+
+
+def _two_structure_segmentation(slicer):
+    """A segmentation with two disjoint vascular structures (vein + artery)."""
+    seg = slicer.mrmlScene.AddNewNodeByClass(SEGMENTATION_CLASS, "TwoStructureVessel")
+    seg.CreateDefaultDisplayNodes()
+    seg.CreateClosedSurfaceRepresentation()
+    segA = _add_tagged_sphere(slicer, seg, _VEIN_TERMINOLOGY, "StructureA", _A_CENTER)
+    segB = _add_tagged_sphere(slicer, seg, _ARTERY_TERMINOLOGY, "StructureB", _B_CENTER)
+    seg.CreateClosedSurfaceRepresentation()
+    return seg, segA, segB
+
+
+def _import_pipeline_or_skip(module_name, class_name):
+    try:
+        import importlib
+
+        module = importlib.import_module(module_name)
+    except Exception as exc:  # pragma: no cover - LayerDMLib off the bare path
+        pytest.skip(
+            f"{module_name} not importable ({exc!r}) -- LayerDMLib is reachable "
+            "only from a launched Slicer (ADR-0027)."
+        )
+    cls = getattr(module, class_name, None)
+    if cls is None:
+        pytest.skip(f"{module_name} has no {class_name} (ADR-0027).")
+    return cls
+
+
+def _seed_point_count(polydata) -> int:
+    pts = polydata.GetPoints()
+    return pts.GetNumberOfPoints() if pts is not None else 0
+
+
+def _require_two_mapped_structures(pipeline, segA, segB):
+    """Skip unless both structures resolve AND the two seeds map to distinct ones.
+
+    Reads the pipeline's own ``_visible_structures`` (the display-node
+    pickSurface resolution the seed filter uses) and the shared
+    ``nearest_structure`` mapping, so a launch where the closed-surface reps did
+    not build (empty structures, or both seeds collapsing to one) SKIPS -- the
+    show/hide follow has nothing to gate on -- rather than FAILING on a fixture
+    gap.  When the mapping resolves, the follow is genuinely exercised.
+    """
+    if not hasattr(pipeline, "_visible_structures"):
+        pytest.skip(
+            "TerritoryPlacementPipeline has no _visible_structures seam "
+            "(ADR-0027)."
+        )
+    structures = pipeline._visible_structures()
+    keys = {segId for segId, _surface, _visible in structures}
+    if segA not in keys or segB not in keys:
+        pytest.skip(
+            "the two vessel structures did not resolve from the pickSurface "
+            f"(closed-surface reps unbuilt in this launch); resolved {keys!r}."
+        )
+    from VascularTerritoriesLib.SeedStructureMapping import nearest_structure
+
+    keyed = [(segId, surface) for segId, surface, _visible in structures]
+    if nearest_structure(keyed, _A_CENTER) != segA or nearest_structure(keyed, _B_CENTER) != segB:
+        pytest.skip(
+            "the seeds did not map to distinct structures in this launch -- "
+            "cannot exercise the per-structure show/hide follow."
+        )
+
+
+# =========================================================================== #
+# i1 — SEED visibility follows the structure show/hide (3D + 2D)
+# =========================================================================== #
+
+
+def test_hiding_a_structure_omits_its_3d_seed_glyphs(monkeypatch):
+    """i1: hiding a structure drops its seeds from the 3D seed-glyph polydata.
+
+    With one seed on structure A and one on structure B (each mapping to its own
+    vessel), the 3D pipeline renders two seed glyphs.  Hiding structure B via the
+    segmentation display node drops B's seed (one glyph); showing it restores
+    both.  ADR-0037 slice 5.  Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    Pipeline = _import_pipeline_or_skip(
+        "TerritoryPlacementPipeline", "TerritoryPlacementPipeline")
+    pipeline = Pipeline()
+    if not hasattr(pipeline, "SetDisplayNode"):
+        pytest.skip("TerritoryPlacementPipeline has no SetDisplayNode (ADR-0027).")
+
+    carrier = _make_carrier_or_skip(slicer)
+    display = _make_display_node_or_skip(slicer)
+    seg, segA, segB = _two_structure_segmentation(slicer)
+    segDisplay = seg.GetDisplayNode()
+
+    import TerritoryInteractionState as state
+
+    state.set_carrier(display, carrier)
+    display.SetAndObservePickSurfaceNodeID(seg.GetID())
+    pipeline.SetDisplayNode(display)
+
+    # A seed at each structure's centre -> each maps to its own structure.
+    carrier.AddAnnotationPoint(TERRITORY, *_A_CENTER)
+    carrier.AddAnnotationPoint(TERRITORY, *_B_CENTER)
+
+    # Precondition: the pipeline must resolve BOTH structures from the display
+    # node's pickSurface, and the two seeds must map to DISTINCT structures --
+    # otherwise the closed-surface reps did not build in this launch and the
+    # follow has nothing to gate on (skip, don't fail on a fixture gap).
+    _require_two_mapped_structures(pipeline, segA, segB)
+
+    pipeline._rebuild_seed_actor()
+    both = _seed_point_count(pipeline._seed_polydata)
+    assert both == 2, (
+        f"both seeds must render before hiding (got {both}); the precondition "
+        "guard above ensures the structures + mapping resolved."
+    )
+
+    segDisplay.SetSegmentVisibility(segB, False)
+    pipeline._rebuild_seed_actor()
+    assert _seed_point_count(pipeline._seed_polydata) == 1, (
+        "hiding structure B must omit its seed from the 3D seed glyphs "
+        "(ADR-0037 slice 5)."
+    )
+
+    segDisplay.SetSegmentVisibility(segB, True)
+    pipeline._rebuild_seed_actor()
+    assert _seed_point_count(pipeline._seed_polydata) == 2, (
+        "showing structure B must restore its seed to the 3D seed glyphs."
+    )
+
+
+def test_hiding_a_structure_omits_its_2d_projected_seeds():
+    """i1: hiding a structure drops its seeds from the 2D projection.
+
+    The slice pipeline projects only the seeds whose structure is visible.
+    Hiding structure B drops B's projected seed; showing it restores both.
+    ADR-0037 slice 5.  Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    Pipeline = _import_pipeline_or_skip(
+        "TerritorySlicePipeline", "TerritorySlicePipeline")
+    pipeline = Pipeline()
+    if not hasattr(pipeline, "SetDisplayNode") or not hasattr(pipeline, "GetProjectedKeys"):
+        pytest.skip(
+            "TerritorySlicePipeline lacks SetDisplayNode / GetProjectedKeys "
+            "(ADR-0027)."
+        )
+
+    carrier = _make_carrier_or_skip(slicer)
+    display = _make_display_node_or_skip(slicer)
+    seg, segA, segB = _two_structure_segmentation(slicer)
+    segDisplay = seg.GetDisplayNode()
+
+    import TerritoryInteractionState as state
+
+    # A slice node the projection reslices against (Red).
+    sliceNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLSliceNode")
+    if sliceNode is None:
+        pytest.skip("no vtkMRMLSliceNode available for the 2D projection.")
+
+    state.set_carrier(display, carrier)
+    display.SetAndObservePickSurfaceNodeID(seg.GetID())
+    pipeline.SetDisplayNode(display)
+    if hasattr(pipeline, "SetViewNode"):
+        pipeline.SetViewNode(sliceNode)
+    else:
+        pipeline._slice_node = sliceNode
+
+    # Seeds at each structure centre, both in the axial (z=0) plane so the
+    # presence cutoff keeps them in the Red slice's projection.
+    carrier.AddAnnotationPoint(TERRITORY, *_A_CENTER)
+    carrier.AddAnnotationPoint(TERRITORY, *_B_CENTER)
+
+    pipeline._reproject()
+    both = len(pipeline.GetProjectedKeys())
+    if both != 2:
+        pytest.skip(
+            "the two seeds did not both project (slice frame / structure "
+            f"mapping unavailable in this launch); got {both} -- cannot "
+            "exercise the follow."
+        )
+
+    segDisplay.SetSegmentVisibility(segB, False)
+    pipeline._reproject()
+    assert len(pipeline.GetProjectedKeys()) == 1, (
+        "hiding structure B must omit its seed from the 2D projection "
+        "(ADR-0037 slice 5)."
+    )
+
+    segDisplay.SetSegmentVisibility(segB, True)
+    pipeline._reproject()
+    assert len(pipeline.GetProjectedKeys()) == 2, (
+        "showing structure B must restore its projected seed."
+    )
+
+
+# =========================================================================== #
+# i2 — CENTERLINE visibility follows the structure show/hide (widget observer)
+# =========================================================================== #
+
+
+def _make_widget_or_skip(slicer):
+    from slicer_pytest_support import require_qt_widget as _require_qt_widget
+
+    _require_qt_widget()
+    from VascularTerritories import VascularTerritoriesWidget
+
+    widget = VascularTerritoriesWidget()
+    widget.setup()
+    return widget
+
+
+def _detach_scene_observers(slicer, widget):
+    for event, handler in (
+        (slicer.mrmlScene.StartCloseEvent, widget.onSceneStartClose),
+        (slicer.mrmlScene.EndCloseEvent, widget.onSceneEndClose),
+    ):
+        try:
+            widget.removeObserver(slicer.mrmlScene, event, handler)
+        except Exception:  # noqa: BLE001 - best-effort across widget shapes
+            pass
+
+
+def _attach_stub_centerline(slicer, logic, carrier, territoryId, structureId, name):
+    """Wire a line model into CenterlineRefs, tagged with its structure id."""
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 10.0)
+    points.InsertNextPoint(0.0, 0.0, -10.0)
+    lines = vtk.vtkCellArray()
+    lines.InsertNextCell(2)
+    lines.InsertCellPoint(0)
+    lines.InsertCellPoint(1)
+    poly = vtk.vtkPolyData()
+    poly.SetPoints(points)
+    poly.SetLines(lines)
+    model = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", name)
+    model.SetAndObserveMesh(poly)
+    model.CreateDefaultDisplayNodes()
+    attribute = getattr(
+        logic, "CENTERLINE_STRUCTURE_ATTRIBUTE",
+        "VascularTerritories.StructureSegmentId")
+    model.SetAttribute(attribute, structureId)
+    role = getattr(logic, "CENTERLINE_REFERENCE_ROLE", "CenterlineRefs")
+    carrier.AddNodeReferenceID(role, model.GetID())
+    if hasattr(carrier, "SetGrouping"):
+        carrier.SetGrouping(model.GetID(), territoryId)
+    return model
+
+
+def test_centerline_hides_when_its_structure_is_hidden(qt_widgets):
+    """i2: a centerline hides when its structure segment is hidden, reappears on show.
+
+    ADR-0037 slice 5: the widget observes the input segmentation's display node
+    and syncs each ``CenterlineRefs`` model's visibility to its structure's
+    visibility, read off the ``VascularTerritories.StructureSegmentId`` tag.
+    A widget-level Python observer (ADR-0013 §5 — no displayable manager).
+    Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    if not hasattr(widget, "_syncCenterlineVisibility"):
+        pytest.skip(
+            "the ADR-0037 slice-5 centerline-visibility follow "
+            "(_syncCenterlineVisibility) has not landed (ADR-0027)."
+        )
+    if not hasattr(widget.logic, "CENTERLINE_STRUCTURE_ATTRIBUTE"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no CENTERLINE_STRUCTURE_ATTRIBUTE -- "
+            "the ADR-0037 slice-5 structure-id tag has not landed (ADR-0027)."
+        )
+
+    seg, segA, segB = _two_structure_segmentation(slicer)
+    segDisplay = seg.GetDisplayNode()
+    widget.ui.inputSurfaceSelector.setCurrentNode(seg)
+    carrier = widget._ensureAnnotationCarrier()
+
+    # A centerline tagged with structure B.
+    model = _attach_stub_centerline(
+        slicer, widget.logic, carrier, TERRITORY, segB, "StructureBCenterline")
+    # Re-sync now that the centerline exists (segmentationNodeSelected already
+    # aimed the observer; a direct sync stands in for the extract-time sync).
+    widget._syncCenterlineVisibility()
+    modelDisplay = model.GetDisplayNode()
+    assert modelDisplay is not None
+
+    # Hiding structure B hides its centerline.
+    segDisplay.SetSegmentVisibility(segB, False)
+    assert bool(modelDisplay.GetVisibility()) is False, (
+        "hiding structure B must hide its extracted centerline (ADR-0037 "
+        "slice 5)."
+    )
+
+    # Showing structure B brings the centerline back.
+    segDisplay.SetSegmentVisibility(segB, True)
+    assert bool(modelDisplay.GetVisibility()) is True, (
+        "showing structure B must restore its centerline's visibility."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+++ b/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
@@ -490,5 +490,37 @@ def test_pick_surface_is_vessels_only_excluding_parenchyma():
     )
 
 
+def test_pick_surface_excludes_a_hidden_vessel():
+    """T1c: hiding a vessel drops it from the pick surface (collision).
+
+    ADR-0037 slice 5: "collision detection is not done for objects not shown."
+    ``vascular_surface_polydata`` appends only VISIBLE vascular segments, so
+    hiding the vein (e.g. via the panel's structures table) removes it from the
+    pick + connectivity + highlight surface -- a click can then only snap to the
+    still-visible artery even where the two overlap.  Launched-only.
+    """
+    slicer = _slicer_or_skip()
+    try:
+        from VascularTerritoriesLib.VesselHighlightWiring import (
+            vascular_surface_polydata,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VesselHighlightWiring vessels-only seam absent ({exc!r}).")
+    segmentation, ids = _multi_segment_segmentation(slicer)
+    display = segmentation.GetDisplayNode()
+    if display is None or not hasattr(display, "SetSegmentVisibility"):
+        pytest.skip("segmentation display node lacks SetSegmentVisibility.")
+
+    both_visible = vascular_surface_polydata(segmentation)
+    display.SetSegmentVisibility(ids["vein"], False)
+    artery_only = vascular_surface_polydata(segmentation)
+
+    assert both_visible is not None and artery_only is not None
+    assert artery_only.GetNumberOfPoints() < both_visible.GetNumberOfPoints(), (
+        "hiding the vein must shrink the pick surface -- a hidden vessel is not "
+        "pickable (ADR-0037 slice 5)."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+++ b/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
@@ -42,7 +42,9 @@ the feed handing ``None`` to the extractor and PASSES once the feed skips a
 missing surface.  Launched-only (Slicer segmentation logic + a live scene);
 SKIP bare.
 
-This file also pins the slice-5 (PR-A) VESSEL-SCT-FILTER invariant (T1):
+This file also pins the slice-5 VESSEL-SCT-FILTER invariant (T1) and, for the
+REVISED multi-system design, the PER-SEGMENT closed-surface split (T1d) the
+seed->structure mapping consumes (multi-system-territory-plan §Part B B1):
 
 * T1 (launched) — VESSEL-SCT RESOLVER.  ADR-0037 slice 5 narrows the
   centerline surface candidates to segments whose ``TerminologyEntry`` TYPE
@@ -519,6 +521,79 @@ def test_pick_surface_excludes_a_hidden_vessel():
     assert artery_only.GetNumberOfPoints() < both_visible.GetNumberOfPoints(), (
         "hiding the vein must shrink the pick surface -- a hidden vessel is not "
         "pickable (ADR-0037 slice 5)."
+    )
+
+
+# =========================================================================== #
+# T1d — per-segment closed-surface split (revised slice 5 seed->structure map)
+# =========================================================================== #
+#
+# The REVISED slice 5 (multi-system-territory-plan §Part B B1) needs the
+# per-SEGMENT closed surfaces, NOT the merged vessels-only mesh: the
+# seed->structure mapping builds one cell locator per vessel segment surface to
+# find the nearest structure to a seed.  The merged GetVascularSurfacePolyData
+# loses the id->surface split, so the mapping resolves each vessel segment's
+# closed surface independently via GetVascularSegmentIds +
+# GetClosedSurfaceRepresentation(segmentId).  This pins that split is available
+# and yields a distinct, non-empty surface per vessel segment.
+
+
+def test_per_segment_closed_surfaces_are_distinct_and_non_empty():
+    """T1d: each vessel segment resolves its OWN non-empty closed surface.
+
+    The seed->structure mapping (revised slice 5) needs an ORDERED
+    ``(segmentId, closed_surface)`` list — one surface per vessel segment — so
+    it can find the nearest structure to a seed.  The C++ resolver's
+    ``GetVascularSegmentIds`` supplies the ordered vessel ids; each id resolves
+    a non-empty closed surface via ``GetClosedSurfaceRepresentation(segmentId)``,
+    and the two vessel surfaces are DISTINCT (the vein surface sits near its own
+    centre, the artery near the artery centre) — the merged mesh would fuse
+    them and lose the split.  Launched-only (segmentation infra + wrapped C++
+    logic); SKIPS bare, and SKIP-PENDINGs until the resolver lands (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    cpp = _cpp_vascular_logic_or_skip(logic)
+    segmentation, ids = _multi_segment_segmentation(slicer)
+
+    vesselIds = list(cpp.GetVascularSegmentIds(segmentation))
+    assert set(vesselIds) == {ids["vein"], ids["artery"]}, (
+        "the per-segment split must enumerate exactly the vessel segments "
+        f"(vein + artery); got {vesselIds} (revised ADR-0037 slice 5)."
+    )
+
+    # Resolve each vessel segment's own closed surface (the mapping's per-segment
+    # locator input); the segmentation node exposes GetClosedSurfaceRepresentation.
+    if not hasattr(segmentation, "GetClosedSurfaceRepresentation"):
+        pytest.skip(
+            "segmentation node lacks GetClosedSurfaceRepresentation -- the "
+            "per-segment surface resolution seam is unavailable (ADR-0027)."
+        )
+    surfaces = {}
+    for segId in vesselIds:
+        mesh = vtk.vtkPolyData()
+        segmentation.GetClosedSurfaceRepresentation(segId, mesh)
+        surfaces[segId] = mesh
+
+    for segId, mesh in surfaces.items():
+        assert mesh.GetNumberOfPoints() > 0, (
+            f"vessel segment {segId!r} must resolve a NON-EMPTY closed surface "
+            "for the seed->structure mapping (revised ADR-0037 slice 5)."
+        )
+
+    # The two vessel surfaces sit at DISTINCT locations (their bounds centres are
+    # the vein-centre and artery-centre the fixture placed apart) -- the merged
+    # mesh would collapse the id->surface split the mapping relies on.
+    def _bounds_centre(poly):
+        b = poly.GetBounds()
+        return ((b[0] + b[1]) / 2.0, (b[2] + b[3]) / 2.0, (b[4] + b[5]) / 2.0)
+
+    centres = [_bounds_centre(surfaces[i]) for i in vesselIds]
+    dx = sum((centres[0][k] - centres[1][k]) ** 2 for k in range(3)) ** 0.5
+    assert dx > 1.0, (
+        "the two vessel segments' closed surfaces must be DISTINCT (separated "
+        "centres) -- the per-segment split must not fuse them (revised ADR-0037 "
+        f"slice 5); centre distance was {dx:.3f}."
     )
 
 

--- a/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+++ b/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
@@ -456,5 +456,39 @@ def test_vascular_resolver_keeps_vessels_excludes_liver_and_tumour():
     )
 
 
+def test_pick_surface_is_vessels_only_excluding_parenchyma():
+    """T1b: the pick surface (``vascular_surface_polydata``) drops the parenchyma.
+
+    ADR-0037 slice 5: the click-snap + hover surface is vessels-only, so the
+    cursor snaps to a vessel and never the liver parenchyma or a tumour.  For a
+    tagged multi-segment segmentation the vessels-only mesh is strictly smaller
+    than the whole-segmentation mesh (the parenchyma + tumour geometry is
+    absent).  Launched-only (segmentation infra); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    try:
+        from VascularTerritoriesLib.VesselHighlightWiring import (
+            closed_surface_polydata,
+            vascular_surface_polydata,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"VesselHighlightWiring vessels-only seam absent ({exc!r}).")
+    segmentation, _ids = _multi_segment_segmentation(slicer)
+
+    whole = closed_surface_polydata(segmentation)
+    vessels = vascular_surface_polydata(segmentation)
+
+    assert whole is not None and whole.GetNumberOfPoints() > 0
+    assert vessels is not None and vessels.GetNumberOfPoints() > 0, (
+        "the vessels-only pick surface must be non-empty for a segmentation "
+        "carrying vessel segments (ADR-0037 slice 5)."
+    )
+    assert vessels.GetNumberOfPoints() < whole.GetNumberOfPoints(), (
+        "the vessels-only pick surface must be strictly smaller than the whole "
+        "segmentation -- the parenchyma + tumour geometry must be absent so the "
+        "cursor never snaps to the liver blob (ADR-0037 slice 5)."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
+++ b/VascularTerritories/Testing/Python/test_territories_surface_resolution.py
@@ -42,11 +42,29 @@ the feed handing ``None`` to the extractor and PASSES once the feed skips a
 missing surface.  Launched-only (Slicer segmentation logic + a live scene);
 SKIP bare.
 
+This file also pins the slice-5 (PR-A) VESSEL-SCT-FILTER invariant (T1):
+
+* T1 (launched) — VESSEL-SCT RESOLVER.  ADR-0037 slice 5 narrows the
+  centerline surface candidates to segments whose ``TerminologyEntry`` TYPE
+  code is vascular (``SCT^29092000`` Vein / ``SCT^51114001`` Artery + a
+  documented allowlist), EXCLUDING the liver (``SCT^10200004``) and tumour
+  segments.  Given a multi-segment segmentation carrying real-data-shaped tags
+  (liver, vein, artery, tumour), the resolver returns ONLY the vessel segment
+  ids.  Mirrors the ``GetLiverSegmentId`` C++ idiom (``logic.scl``); needs
+  segmentation infra + the wrapped C++ logic so it SKIPS cleanly bare and RUNS
+  launched, and SKIP-PENDINGs on the not-yet-existing resolver method until
+  PR-A lands (ADR-0027).
+
 See also:
-  * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 4)
+  * Docs/adr/0037-vascular-territories-off-markups.md  (§Decision 4;
+    §Amendment — connected-tree-constrained centerline seeding (slice 5))
+  * Docs/adr/0011-terminology-standard-clinical-terms.md  (the SCT-tag match)
   * Docs/adr/0027-invariant-test-first.md  (RED / skip-pending discipline)
+  * Docs/design/connected-tree-seeding-plan.md  (C1 vessel-surface resolver; T1)
   * VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
     (closed_surface_polydata — the shared surface-resolution seam)
+  * VascularTerritories/Testing/Python/test_territories_connectivity.py
+    (the bare pure-VTK connectivity twin, T2/T3)
   * VascularTerritories/Testing/Python/test_territories_vmtk_feed.py
     (the transient-node lifecycle + real VMTK run)
   * VascularTerritories/Testing/Python/conftest.py  (the skip guards)
@@ -59,6 +77,7 @@ import pytest
 vtk = pytest.importorskip("vtk")
 
 CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
+SEGMENTATION_CLASS = "vtkMRMLSegmentationNode"
 
 TERRITORY_A = "SegmentVII"
 
@@ -295,6 +314,146 @@ def test_empty_surface_is_not_fed_to_the_extractor(monkeypatch):
             "the feed must NOT invoke the real extractor with an EMPTY "
             "surface (0 points) (ADR-0037 §Decision 4)."
         )
+
+
+# =========================================================================== #
+# T1 — vessel-SCT resolver keeps vessels, excludes liver + tumour (launched)
+# =========================================================================== #
+#
+# ADR-0037 slice 5 (PR-A): the centerline surface candidates are the input
+# segments whose TerminologyEntry TYPE code is a vascular concept (Vein /
+# Artery + a documented allowlist); the liver-SCT and tumour segments are
+# excluded.  Real data tags vessels under category SCT^85756007 (Tissue) with
+# the generic Vein/Artery types, so the fixtures use those real-data shapes.
+
+# Slice-5 (PR-A) vessel-resolver seam (proposed; sharpen at landing).  Mirrors
+# the GetLiverSegmentId idiom on the wrapped C++ logic (logic.scl).
+VASCULAR_SEGMENT_IDS_METHOD = "GetVascularSegmentIds"
+
+# Real-data-shaped TerminologyEntry tags (category ~ type), matching the
+# _LIVER_TERMINOLOGY shape used in test_territories_map_compute.py.  Vessels
+# are tagged under category SCT^85756007 (Tissue) with the generic Vein/Artery
+# types; the liver + tumour carry their own category/type pairs.
+_LIVER_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^123037004^Anatomical Structure~SCT^10200004^Liver~^^~Anatomic codes~^^~^^"
+)
+_VEIN_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^29092000^Vein~^^~Anatomic codes~^^~^^"
+)
+_ARTERY_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^51114001^Artery~^^~Anatomic codes~^^~^^"
+)
+_TUMOUR_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^260787004^Physical object~SCT^19227008^Malignant neoplasm~^^~Anatomic codes~^^~^^"
+)
+
+
+def _cpp_vascular_logic_or_skip(logic):
+    """The wrapped C++ logic exposing ``GetVascularSegmentIds`` (``logic.scl``).
+
+    The vessel-SCT resolver mirrors ``GetLiverSegmentId`` — it lives on the C++
+    logic (it reads MRML segment tags), reached through ``scl``.  SKIP-PENDINGs
+    on the not-yet-existing resolver method until PR-A lands (ADR-0027).
+    """
+    cpp = getattr(logic, "scl", None)
+    if cpp is None:
+        pytest.skip(
+            "VascularTerritoriesLogic has no scl (the wrapped C++ logic) -- "
+            "launched build required (ADR-0027)."
+        )
+    if not hasattr(cpp, VASCULAR_SEGMENT_IDS_METHOD):
+        pytest.skip(
+            f"vtkSlicerVascularTerritoriesLogic has no {VASCULAR_SEGMENT_IDS_METHOD}"
+            " -- the ADR-0037 slice-5 (PR-A) vessel-SCT resolver has not landed."
+            "  The skip lifts at the implementation commit (ADR-0027)."
+        )
+    return cpp
+
+
+def _add_tagged_segment(slicer, segmentation, terminology, name, center):
+    """Import one closed-surface sphere segment tagged with ``terminology``."""
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(10.0)
+    source.SetThetaResolution(16)
+    source.SetPhiResolution(16)
+    source.Update()
+    modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", name)
+    modelNode.SetAndObservePolyData(source.GetOutput())
+    slicer.modules.segmentations.logic().ImportModelToSegmentationNode(
+        modelNode, segmentation)
+    slicer.mrmlScene.RemoveNode(modelNode)
+    segmentation_obj = segmentation.GetSegmentation()
+    segId = segmentation_obj.GetNthSegmentID(segmentation_obj.GetNumberOfSegments() - 1)
+    segmentation_obj.GetSegment(segId).SetTag("TerminologyEntry", terminology)
+    return segId
+
+
+def _multi_segment_segmentation(slicer):
+    """A segmentation with liver + vein + artery + tumour segments (tagged).
+
+    Returns ``(segmentation, {role: segId})`` so the test can assert the
+    resolver keeps the two vessel segments and drops the liver + tumour.
+    """
+    seg = slicer.mrmlScene.AddNewNodeByClass(
+        SEGMENTATION_CLASS, "VesselResolveMultiSeg")
+    seg.CreateDefaultDisplayNodes()
+    ids = {
+        "liver": _add_tagged_segment(
+            slicer, seg, _LIVER_TERMINOLOGY, "LiverModel", (0.0, 0.0, 0.0)),
+        "vein": _add_tagged_segment(
+            slicer, seg, _VEIN_TERMINOLOGY, "VeinModel", (40.0, 0.0, 0.0)),
+        "artery": _add_tagged_segment(
+            slicer, seg, _ARTERY_TERMINOLOGY, "ArteryModel", (80.0, 0.0, 0.0)),
+        "tumour": _add_tagged_segment(
+            slicer, seg, _TUMOUR_TERMINOLOGY, "TumourModel", (120.0, 0.0, 0.0)),
+    }
+    return seg, ids
+
+
+def test_vascular_resolver_keeps_vessels_excludes_liver_and_tumour():
+    """T1: ``GetVascularSegmentIds`` keeps vessels, drops liver + tumour.
+
+    ADR-0037 slice 5 narrows the centerline surface candidates to segments
+    whose ``TerminologyEntry`` TYPE code is vascular (``SCT^29092000`` Vein /
+    ``SCT^51114001`` Artery), EXCLUDING the liver (``SCT^10200004``) and tumour
+    segments.  Given a segmentation carrying real-data-shaped tags for all
+    four, the resolver returns EXACTLY the vein + artery segment ids — never the
+    liver or the tumour (ADR-0037 slice-5 Conformance [test]; ADR-0011 SCT-tag
+    match).  Launched-only (segmentation infra + wrapped C++ logic); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    cpp = _cpp_vascular_logic_or_skip(logic)
+    segmentation, ids = _multi_segment_segmentation(slicer)
+
+    resolved = set(cpp.GetVascularSegmentIds(segmentation))
+
+    assert ids["vein"] in resolved, (
+        "the vessel resolver must KEEP the SCT^29092000 (Vein) segment "
+        "(ADR-0037 slice 5)."
+    )
+    assert ids["artery"] in resolved, (
+        "the vessel resolver must KEEP the SCT^51114001 (Artery) segment "
+        "(ADR-0037 slice 5)."
+    )
+    assert ids["liver"] not in resolved, (
+        "the vessel resolver must EXCLUDE the SCT^10200004 (Liver) segment -- "
+        "the liver supplies the map region, not a vessel tree (ADR-0037 slice "
+        "5; ADR-0011)."
+    )
+    assert ids["tumour"] not in resolved, (
+        "the vessel resolver must EXCLUDE the tumour segment (ADR-0037 slice 5)."
+    )
+    assert resolved == {ids["vein"], ids["artery"]}, (
+        "the vessel resolver must return EXACTLY the vessel segments "
+        f"({{{ids['vein']}, {ids['artery']}}}), got {resolved} (ADR-0037 slice "
+        "5)."
+    )
 
 
 if __name__ == "__main__":

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -1130,6 +1130,67 @@ def test_under_seeded_structure_flags_the_territory(qt_widgets):
 
 
 # --------------------------------------------------------------------------- #
+# POST-REVIEW REFINEMENT — Add Territory does NOT auto-select the new row
+# --------------------------------------------------------------------------- #
+#
+# The reviewer's refinement (ADR-0037 §Decision 2 slice-4): "Add Territory"
+# mints + arms a territory but must NOT also SELECT its tree row.  Arming (the
+# Place toggle reading checked) is the sole active-state cue, so a row selection
+# on top of it is redundant and confuses which affordance drives placement.
+# ``addTerritory``'s docstring pins this ("The new row is NOT selected/
+# highlighted -- arming ... is the active-state cue").  Green regression guard:
+# these RUN + PASS launched now, guarding against a re-introduced setCurrentItem.
+
+
+def test_add_territory_does_not_auto_select_the_new_row(qt_widgets):
+    """Add Territory arms the new territory but leaves its tree row UNSELECTED.
+
+    Post-review refinement (ADR-0037 §Decision 2 slice-4): minting a territory
+    arms placement into it (its Place toggle reads checked) but must NOT select
+    its row -- arming is the active-state cue, a redundant selection is not.
+    Pins that after ``addTerritory()`` the tree's current item is not the new
+    row (and the selection is empty), while the Place toggle still reads checked.
+    Launched (Qt + carrier); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "addTerritory") or not hasattr(table, "placeButton"):
+        pytest.skip(
+            "TerritoriesTableWidget has no addTerritory / placeButton seam "
+            "(ADR-0027)."
+        )
+
+    territory = table.addTerritory()
+
+    tree = table.tree()
+    newItem = table.territoryItem(territory)
+    assert newItem is not None, "the minted territory must have a top-level item."
+
+    # The new row is NOT the current item, and nothing is selected: arming, not
+    # selection, is the active-state cue (ADR-0037 §Decision 2 slice-4).
+    assert tree.currentItem() is not newItem, (
+        "Add Territory must NOT auto-select the new territory's row -- arming "
+        "(the checked Place toggle) is the active-state cue, not a selection."
+    )
+    assert len(tree.selectedItems()) == 0, (
+        "Add Territory must leave the tree selection empty (no auto-select)."
+    )
+
+    # Arming IS the cue: the new territory's Place toggle reads checked.
+    place = table.placeButton(territory)
+    assert place is not None and place.checked is True, (
+        "the minted territory's Place toggle must read checked (arming is the "
+        "active-state cue, ADR-0037 §Decision 2 slice-4)."
+    )
+
+
+# --------------------------------------------------------------------------- #
 # RETIREMENT — selector gone; highlight wiring survives; no persisted markups
 # --------------------------------------------------------------------------- #
 

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -924,6 +924,212 @@ def test_territory_with_fewer_than_two_seeds_is_flagged_incomplete(qt_widgets):
 
 
 # --------------------------------------------------------------------------- #
+# REVISED slice 5 — coloured seed rows + per-structure warning glyph
+# --------------------------------------------------------------------------- #
+#
+# The revised multi-system design (Docs/design/multi-system-territory-plan.md
+# §B3 / §B6): each seed child row carries a colour swatch tinted with the seed's
+# STRUCTURE colour (the input segmentation's per-segment display colour) PAIRED
+# with the structure NAME (ADR-0010, never colour alone); and a territory
+# touching any structure with <2 seeds shows the WARNING glyph+text (that
+# structure cannot yield a centerline).  The table resolves a seed's structure
+# via the seed->structure mapping (§B1) over the input segmentation, so it needs
+# the segmentation bound.
+
+# Two disjoint vessel segments (Vein + Artery) with distinct display colours so
+# the seed rows can be tinted per structure.
+_VEIN_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^29092000^Vein~^^~Anatomic codes~^^~^^"
+)
+_ARTERY_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^51114001^Artery~^^~Anatomic codes~^^~^^"
+)
+_VEIN_CENTRE = (0.0, 0.0, 0.0)
+_ARTERY_CENTRE = (100.0, 0.0, 0.0)
+_VESSEL_RADIUS = 10.0
+
+# Table structure-colour reader seams (proposed; sharpen at landing).  §B3.
+SEED_STRUCTURE_ID_ACCESSOR = "seedStructureId"
+SEED_STRUCTURE_COLOR_ACCESSOR = "seedStructureColor"
+SET_INPUT_SEGMENTATION_SEAM = "setInputSegmentation"
+
+
+def _two_vessel_segmentation_or_skip(slicer):
+    """A segmentation with a Vein + Artery vessel segment, distinct colours."""
+    import vtk  # local: the table test module does not import vtk at top level
+
+    seg = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLSegmentationNode", "TableTwoVessels")
+    if seg is None:
+        pytest.skip("vtkMRMLSegmentationNode not registered (launched build).")
+    seg.CreateDefaultDisplayNodes()
+
+    def _add(terminology, name, center, colour):
+        source = vtk.vtkSphereSource()
+        source.SetCenter(*center)
+        source.SetRadius(_VESSEL_RADIUS)
+        source.SetThetaResolution(16)
+        source.SetPhiResolution(16)
+        source.Update()
+        modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", name)
+        modelNode.SetAndObservePolyData(source.GetOutput())
+        slicer.modules.segmentations.logic().ImportModelToSegmentationNode(
+            modelNode, seg)
+        slicer.mrmlScene.RemoveNode(modelNode)
+        segmentation = seg.GetSegmentation()
+        segId = segmentation.GetNthSegmentID(segmentation.GetNumberOfSegments() - 1)
+        segmentation.GetSegment(segId).SetTag("TerminologyEntry", terminology)
+        segmentation.GetSegment(segId).SetColor(*colour)
+        return segId
+
+    veinId = _add(_VEIN_TERMINOLOGY, "VeinModel", _VEIN_CENTRE, (0.1, 0.2, 0.9))
+    arteryId = _add(_ARTERY_TERMINOLOGY, "ArteryModel", _ARTERY_CENTRE, (0.9, 0.1, 0.1))
+    return seg, {"vein": veinId, "artery": arteryId}
+
+
+def _bind_segmentation_or_skip(table, segmentation):
+    """Bind the input segmentation to the table, or skip-pend (ADR-0027)."""
+    if not hasattr(table, SET_INPUT_SEGMENTATION_SEAM):
+        pytest.skip(
+            f"TerritoriesTableWidget has no {SET_INPUT_SEGMENTATION_SEAM} seam "
+            "-- the revised slice-5 seed-row structure-colour binding has not "
+            "landed (ADR-0027)."
+        )
+    getattr(table, SET_INPUT_SEGMENTATION_SEAM)(segmentation)
+
+
+def test_seed_row_is_coloured_by_its_structure(qt_widgets):
+    """Each seed child row carries its STRUCTURE's segment display colour + name.
+
+    Revised slice 5 (§B3): a seed on the vein reads the vein segment's display
+    colour, a seed on the artery reads the artery's — NOT the territory palette.
+    The colour is paired with the structure NAME in the row text (ADR-0010,
+    never colour alone).  Pinned via the ``seedStructureId`` / ``seedStructureColor``
+    reader seams.  Launched (Qt + segmentation); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    for seam in (SEED_STRUCTURE_ID_ACCESSOR, SEED_STRUCTURE_COLOR_ACCESSOR):
+        if not hasattr(table, seam):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {seam} seam -- the revised "
+                "slice-5 seed-row structure colour reader has not landed "
+                "(ADR-0027)."
+            )
+
+    segmentation, ids = _two_vessel_segmentation_or_skip(slicer)
+    _bind_segmentation_or_skip(table, segmentation)
+
+    # One seed on the vein surface, one on the artery surface.
+    vein_seed = (_VEIN_CENTRE[0], _VEIN_CENTRE[1], _VEIN_CENTRE[2] + _VESSEL_RADIUS)
+    artery_seed = (_ARTERY_CENTRE[0], _ARTERY_CENTRE[1], _ARTERY_CENTRE[2] + _VESSEL_RADIUS)
+    carrier.AddAnnotationPoint(TERRITORY_A, *vein_seed)
+    carrier.AddAnnotationPoint(TERRITORY_A, *artery_seed)
+    carrier.Modified()
+
+    assert table.seedStructureId(TERRITORY_A, 0) == ids["vein"], (
+        "the first seed (on the vein surface) must map to the vein segment id "
+        f"({ids['vein']!r}); got {table.seedStructureId(TERRITORY_A, 0)!r} "
+        "(revised ADR-0037 slice 5, §B3)."
+    )
+    assert table.seedStructureId(TERRITORY_A, 1) == ids["artery"], (
+        "the second seed (on the artery surface) must map to the artery segment "
+        f"id ({ids['artery']!r}); got {table.seedStructureId(TERRITORY_A, 1)!r}."
+    )
+
+    vein_colour = table.seedStructureColor(TERRITORY_A, 0)
+    artery_colour = table.seedStructureColor(TERRITORY_A, 1)
+    assert vein_colour is not None and artery_colour is not None, (
+        "each seed row must resolve its structure's display colour (§B3)."
+    )
+    # The two structures were given distinct segment display colours, so the two
+    # seed rows must read DIFFERENT colours -- the swatch is per-structure, not
+    # the (single) territory palette colour.
+    assert tuple(round(c, 3) for c in vein_colour) != tuple(
+        round(c, 3) for c in artery_colour
+    ), (
+        "seeds on DIFFERENT structures must carry DIFFERENT swatch colours -- "
+        "the swatch is the segment display colour, not the territory palette "
+        "(revised ADR-0037 slice 5, §B3)."
+    )
+    # ADR-0010: colour never alone -- the row text names the structure.
+    vein_text = table.seedStatusText(TERRITORY_A, 0) if hasattr(table, "seedStatusText") else ""
+    assert vein_text.strip() != "", (
+        "the seed row must pair its colour swatch with structure TEXT (ADR-0010, "
+        "never colour alone)."
+    )
+
+
+def test_under_seeded_structure_flags_the_territory(qt_widgets):
+    """A territory touching a <2-seed structure shows the WARNING glyph+text.
+
+    Revised slice 5 (§B6): the completeness check is PER STRUCTURE, not a flat
+    seed count.  A territory with 2 seeds on the vein but only 1 on the artery
+    has a structure (the artery) that cannot yield a centerline, so the
+    territory is flagged (glyph + text, ADR-0010); a 2-on-vein + 2-on-artery
+    territory is NOT flagged.  Pinned via the existing
+    ``territoryHasIncompleteGlyph`` reader, extended to the per-structure gate.
+    Launched (Qt + segmentation); SKIPS bare.
+
+    Red->green: FAILS against the flat ``seedCount < 2`` check (a 3-seed
+    territory reads complete regardless of structure split), PASSES once the
+    check groups by structure.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    for seam in ("territoryStatusText", "territoryHasIncompleteGlyph"):
+        if not hasattr(table, seam):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {seam} status seam (ADR-0027).")
+
+    segmentation, _ids = _two_vessel_segmentation_or_skip(slicer)
+    _bind_segmentation_or_skip(table, segmentation)
+
+    def _vein(k):
+        return (_VEIN_CENTRE[0], _VEIN_CENTRE[1] + k, _VEIN_CENTRE[2] + _VESSEL_RADIUS)
+
+    def _artery(k):
+        return (_ARTERY_CENTRE[0], _ARTERY_CENTRE[1] + k, _ARTERY_CENTRE[2] + _VESSEL_RADIUS)
+
+    # TERRITORY_A: 2 on the vein + 1 on the artery -> artery under-seeded -> flag.
+    carrier.AddAnnotationPoint(TERRITORY_A, *_vein(0.0))
+    carrier.AddAnnotationPoint(TERRITORY_A, *_vein(2.0))
+    carrier.AddAnnotationPoint(TERRITORY_A, *_artery(0.0))
+    # TERRITORY_B: 2 on the vein + 2 on the artery -> no under-seeded structure.
+    carrier.AddAnnotationPoint(TERRITORY_B, *_vein(0.0))
+    carrier.AddAnnotationPoint(TERRITORY_B, *_vein(2.0))
+    carrier.AddAnnotationPoint(TERRITORY_B, *_artery(0.0))
+    carrier.AddAnnotationPoint(TERRITORY_B, *_artery(2.0))
+    carrier.Modified()
+
+    assert table.territoryHasIncompleteGlyph(TERRITORY_A) is True, (
+        "a territory with a <2-seed structure (2 on the vein, 1 on the artery) "
+        "must be FLAGGED -- the under-seeded structure cannot yield a centerline "
+        "(revised ADR-0037 slice 5, §B6).  A flat 3-seed count would wrongly read "
+        "complete."
+    )
+    assert table.territoryStatusText(TERRITORY_A).strip() != "", (
+        "the per-structure warning must carry TEXT (ADR-0010, never colour alone)."
+    )
+    assert table.territoryHasIncompleteGlyph(TERRITORY_B) is False, (
+        "a territory with >=2 seeds on EVERY touched structure (2 vein + 2 "
+        "artery) must NOT be flagged (revised ADR-0037 slice 5, §B6)."
+    )
+
+
+# --------------------------------------------------------------------------- #
 # RETIREMENT — selector gone; highlight wiring survives; no persisted markups
 # --------------------------------------------------------------------------- #
 

--- a/VascularTerritories/Testing/Python/test_territories_vmtk_feed.py
+++ b/VascularTerritories/Testing/Python/test_territories_vmtk_feed.py
@@ -50,6 +50,20 @@ This file pins the Stage-3 increments:
   down), never one merged node — mirroring the legacy per-``VascTerrId``
   grouping.  Asserted by monkeypatching the extraction logic to COUNT
   calls + CAPTURE the fed node, without a real VMTK run.
+* i7 (launched) — GROUP BY STRUCTURE (revised slice 5).  A territory carrying
+  ≥2 seeds on structure A AND ≥2 on structure B (portal + hepatic) yields TWO
+  centerlines — one VMTK run PER ≥2-seed structure — BOTH in ``CenterlineRefs``
+  and BOTH grouped under the territory id (the multi-system map region, §B4/§B5).
+  A territory with 2 seeds on A but only 1 on B yields exactly ONE centerline
+  (A's); the under-seeded structure B is SKIPPED (the per-structure ≥2 gate,
+  §B4).  The extractor is stubbed to a small line polydata (via
+  ``getCenterlineLogic``) so N models are minted without a real VMTK run — the
+  invariant is the group-by-structure invocation shape + the per-structure gate,
+  not the geometry.  Red->green (ADR-0027): FAILS against the landed
+  single-tree extraction (one centerline per territory, later structures lost)
+  and PASSES once extraction groups by structure and appends one centerline per
+  ≥2-seed structure.  Launched (module Logic + a real multi-segment
+  segmentation + stubbed extractor); SKIPS bare.
 * i6 (launched) — RE-EXTRACTION IDEMPOTENCY.  Extracting a territory, then
   RE-EXTRACTING the SAME carrier/territory, leaves EXACTLY ONE
   ``CenterlineRefs`` entry, ONE ``TerritoryCenterline`` model, and a STABLE
@@ -139,6 +153,7 @@ vtk = pytest.importorskip("vtk")
 
 CUSTOM_TERRITORIES_CLASS = "vtkMRMLCustomTerritoriesNode"
 MARKUPS_FIDUCIAL_CLASS = "vtkMRMLMarkupsFiducialNode"
+SEGMENTATION_CLASS = "vtkMRMLSegmentationNode"
 EXTRACT_CENTERLINE_MODULE = "ExtractCenterline"
 
 # Carrier API seam (also pinned by test_territories_annotation_carrier.py).
@@ -716,6 +731,180 @@ def test_re_extraction_replaces_the_territorys_centerline(monkeypatch):
         "the prior TerritoryCenterline model must be removed on "
         "re-extraction, not orphaned in the scene (ADR-0037 §Conformance "
         f"no-drift); found {_count_centerline_models(slicer)} models."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# i7 — group by structure: one centerline per >=2-seed structure (launched)
+# --------------------------------------------------------------------------- #
+#
+# Revised slice 5 (multi-system-territory-plan §B4/§B5): a territory owns seeds
+# across possibly-multiple disjoint structures.  Extraction GROUPS the seeds by
+# structure and runs VMTK ONCE per structure with >=2 seeds; a structure with
+# <2 seeds is skipped.  N centerlines per territory, all grouped under the
+# territory id.  These pin the invocation shape + the per-structure gate with a
+# stubbed extractor (no SlicerVMTK), over a REAL multi-segment segmentation so
+# the seed->structure mapping resolves each seed to a genuine vessel surface.
+
+# Two vessel segments placed far apart so their closed surfaces are disjoint and
+# a seed near each maps unambiguously to that structure.
+_VEIN_CENTRE = (0.0, 0.0, 0.0)
+_ARTERY_CENTRE = (100.0, 0.0, 0.0)
+_VESSEL_RADIUS = 10.0
+
+_VEIN_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^29092000^Vein~^^~Anatomic codes~^^~^^"
+)
+_ARTERY_TERMINOLOGY = (
+    "Segmentation category and type - 3D Slicer General Anatomy list"
+    "~SCT^85756007^Body tissue~SCT^51114001^Artery~^^~Anatomic codes~^^~^^"
+)
+
+
+def _add_tagged_vessel(slicer, segmentation, terminology, name, center):
+    """Import one closed-surface sphere vessel segment tagged with ``terminology``."""
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(_VESSEL_RADIUS)
+    source.SetThetaResolution(16)
+    source.SetPhiResolution(16)
+    source.Update()
+    modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", name)
+    modelNode.SetAndObservePolyData(source.GetOutput())
+    slicer.modules.segmentations.logic().ImportModelToSegmentationNode(
+        modelNode, segmentation)
+    slicer.mrmlScene.RemoveNode(modelNode)
+    seg = segmentation.GetSegmentation()
+    segId = seg.GetNthSegmentID(seg.GetNumberOfSegments() - 1)
+    seg.GetSegment(segId).SetTag("TerminologyEntry", terminology)
+    return segId
+
+
+def _two_vessel_segmentation_or_skip(slicer):
+    """A segmentation with a Vein + Artery vessel segment (disjoint surfaces)."""
+    seg = slicer.mrmlScene.AddNewNodeByClass(SEGMENTATION_CLASS, "VmtkTwoVessels")
+    if seg is None:
+        pytest.skip("vtkMRMLSegmentationNode not registered (launched build).")
+    seg.CreateDefaultDisplayNodes()
+    _add_tagged_vessel(slicer, seg, _VEIN_TERMINOLOGY, "VeinModel", _VEIN_CENTRE)
+    _add_tagged_vessel(slicer, seg, _ARTERY_TERMINOLOGY, "ArteryModel", _ARTERY_CENTRE)
+    return seg
+
+
+def _points_on_structure(center, n):
+    """``n`` distinct genuine-ish points on the sphere of radius _VESSEL_RADIUS."""
+    pts = []
+    for k in range(n):
+        # Spread the points around the sphere so they are distinct.
+        offset = (k - (n - 1) / 2.0) * (_VESSEL_RADIUS / max(n, 1))
+        pts.append((center[0], center[1] + offset, center[2] + _VESSEL_RADIUS))
+    return pts
+
+
+def _stub_line_extractor(logic, monkeypatch):
+    """Stub the extractor so each call mints a fresh small line (no SlicerVMTK)."""
+    class _LineExtractor:
+        def extractCenterline(self, *args, **kwargs):  # noqa: N802 - VMTK verb
+            return _line_polydata()
+
+    monkeypatch.setattr(logic, "getCenterlineLogic", lambda: _LineExtractor())
+
+
+def test_mixed_system_territory_yields_two_centerlines(monkeypatch):
+    """i7: 2 seeds on vein + 2 on artery -> TWO centerlines, both the territory's.
+
+    A territory straddling two disjoint structures runs VMTK once per structure
+    (each with >=2 seeds), so it registers TWO ``CenterlineRefs`` entries, BOTH
+    grouped under the SAME territory id — both feed the one map region (revised
+    ADR-0037 slice 5; multi-system plan §B4/§B5).  The extractor is stubbed to a
+    line so two models are minted without SlicerVMTK.  Launched; SKIPS bare.
+
+    Red->green: FAILS against the landed single-tree extraction (one centerline
+    per territory), PASSES once extraction groups by structure.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    carrier = _make_carrier_or_skip(slicer)
+
+    if not hasattr(logic, "getCenterlineLogic"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineLogic (ADR-0027).")
+    if not hasattr(logic, "getCenterlineReferenceIDs"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineReferenceIDs "
+            "(ADR-0027).")
+    if not hasattr(carrier, "GetGrouping"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no Groupings API (ADR-0027).")
+
+    segmentation = _two_vessel_segmentation_or_skip(slicer)
+    for x, y, z in _points_on_structure(_VEIN_CENTRE, 2):
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    for x, y, z in _points_on_structure(_ARTERY_CENTRE, 2):
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+
+    _stub_line_extractor(logic, monkeypatch)
+    logic.extractCenterlines(carrier, segmentation, "")
+
+    refs = logic.getCenterlineReferenceIDs(carrier)
+    assert len(refs) == 2, (
+        "a territory with >=2 seeds on TWO structures must yield TWO centerlines "
+        f"(one VMTK run per >=2-seed structure); got {refs} (revised ADR-0037 "
+        "slice 5, §B4/§B5)."
+    )
+    for ref in refs:
+        assert carrier.GetGrouping(ref) == TERRITORY_A, (
+            "both centerlines must be grouped under the SAME territory id "
+            f"({TERRITORY_A}) -- both feed the one map region; got "
+            f"{carrier.GetGrouping(ref)!r} for {ref}."
+        )
+
+
+def test_under_seeded_structure_is_skipped(monkeypatch):
+    """i7: 2 seeds on vein + 1 on artery -> ONE centerline (artery skipped).
+
+    The per-structure ≥2 gate: only a structure with >=2 seeds yields a
+    centerline, so a territory with 2 seeds on the vein but only 1 on the artery
+    produces exactly ONE ``CenterlineRefs`` entry (the vein's) — the under-seeded
+    artery is skipped (revised ADR-0037 slice 5; multi-system plan §B4).  The
+    same gate drives the table warning (§B6, pinned in test_territories_table).
+    Launched; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    logic = _logic_or_skip(slicer)
+    carrier = _make_carrier_or_skip(slicer)
+
+    if not hasattr(logic, "getCenterlineLogic"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineLogic (ADR-0027).")
+    if not hasattr(logic, "getCenterlineReferenceIDs"):
+        pytest.skip(
+            "VascularTerritoriesLogic has no getCenterlineReferenceIDs "
+            "(ADR-0027).")
+    if not hasattr(carrier, "GetGrouping"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no Groupings API (ADR-0027).")
+
+    segmentation = _two_vessel_segmentation_or_skip(slicer)
+    for x, y, z in _points_on_structure(_VEIN_CENTRE, 2):
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    # Only ONE seed on the artery -- under the >=2 gate.
+    single_artery = _points_on_structure(_ARTERY_CENTRE, 1)[0]
+    carrier.AddAnnotationPoint(TERRITORY_A, *single_artery)
+
+    _stub_line_extractor(logic, monkeypatch)
+    logic.extractCenterlines(carrier, segmentation, "")
+
+    refs = logic.getCenterlineReferenceIDs(carrier)
+    assert len(refs) == 1, (
+        "a structure with <2 seeds must be SKIPPED (the per-structure >=2 gate) "
+        "-- 2 seeds on the vein + 1 on the artery yields ONE centerline (the "
+        f"vein's); got {refs} (revised ADR-0037 slice 5, §B4)."
+    )
+    assert carrier.GetGrouping(refs[0]) == TERRITORY_A, (
+        "the single surviving centerline must be grouped under the territory id "
+        f"({TERRITORY_A}); got {carrier.GetGrouping(refs[0])!r}."
     )
 
 

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -481,6 +481,13 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
       return
     displayNode = segmentationNode.GetDisplayNode()
     displayNode.SetOpacity3D(0.3)
+    # Enable the workflow actions the moment an input surface is selected --
+    # directly off the selector, not only via the parameter-node round-trip in
+    # updateGUIFromParameterNode (which does not fire reliably when the panel is
+    # composed inside the Liver module), so the Compute-territory-map button is
+    # reachable once a segmentation is chosen (ADR-0037 §Decision 4 two-step
+    # flow).  The extraction action stays additionally gated on SlicerVMTK.
+    self.enableWidgetButtons(True)
 
   def createColorMap(self):
 #    colorTableNodes = slicer.util.getNodes("SlicerLiverColorMap*")
@@ -699,8 +706,18 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     centerlineModelPoints = centerlineModel.GetMesh()
     numberOfPoints = centerlineModelPoints.GetNumberOfPoints()
     refVolumeNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLScalarVolumeNode")
-    if not (refVolumeNode) or (numberOfPoints<2):
-        raise ValueError("Missing inputs to calculate vascular segments")
+    if not refVolumeNode or numberOfPoints < 2:
+        # Reachable now that the button enables on input selection: give a
+        # legible reason instead of an uncaught error when the surgeon computes
+        # before extracting a centerline (or with no reference volume loaded).
+        reason = ("no reference volume is loaded" if not refVolumeNode
+                  else "no centerline has been extracted yet -- place >=2 seeds "
+                       "on a vessel and click 'Extract centerlines' first")
+        logging.warning("VascularTerritories: cannot compute the territory map -- %s.", reason)
+        slicer.util.warningDisplay(
+            f"Cannot compute the territory map: {reason}.",
+            windowTitle="Vascular Territories")
+        return
 
     vascularTerritorySegmentationNode = self.logic.ensureTerritoryMapOutput(carrier)
     # The C++ ``calculateVascularTerritoryMap`` reads + re-stamps the target's

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -1032,6 +1032,21 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
       return
     modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "TerritoryCenterline")
     modelNode.SetAndObserveMesh(centerlinePolyData)
+    # Show the extracted centerline so "Extract centerlines" gives immediate
+    # visual feedback (the model is otherwise a display-less data node -- the
+    # gesture appeared to do nothing).  Coloured by the territory's display
+    # slot when set, so a territory's per-structure centerlines read as one.
+    modelNode.CreateDefaultDisplayNodes()
+    displayNode = modelNode.GetDisplayNode()
+    if displayNode is not None:
+      displayNode.SetVisibility(True)
+      displayNode.SetLineWidth(3)
+      try:
+        color = carrier.GetTerritoryColor(territoryId)
+        if color is not None:
+          displayNode.SetColor(color[0], color[1], color[2])
+      except Exception:  # noqa: BLE001 - colour is best-effort feedback
+        pass
     # ADR-0037 §Decision 4: tag the centerline with the DERIVED labelmap int
     # (from the carrier's territory-id order), not the old string
     # ``VascularTerritories.VascTerrId``.  The scene-scan reader that parsed

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -230,6 +230,12 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # segmentation.
     self.ui.inputSurfaceSelector.connect('currentNodeChanged(bool)', self.updateHighlightPickSurface)
 
+    # Input-structure show/hide (ADR-0037 slice 5): a stock segments table so
+    # the surgeon can hide the parenchyma / tumour / other vessel system and
+    # focus on the vessel tree being annotated.  Composed above the annotation
+    # table (pick what's visible, then annotate).
+    self._setupStructuresTable()
+
     # ADR-0037 Stage-2 table (§Decision 3): the annotation table is composed
     # into the panel here, over the annotation carrier + the placement
     # Pipeline (Python-widget composition, ADR-0004).
@@ -359,6 +365,41 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     segmentationId = segmentation.GetID() if segmentation is not None else None
     node.SetAndObservePickSurfaceNodeID(segmentationId)
 
+  def _setupStructuresTable(self):
+    """Compose a stock ``qMRMLSegmentsTableView`` for input-structure show/hide.
+
+    Visibility-focused: the surgeon hides the parenchyma / tumour / the other
+    vessel system to isolate the vessel tree being annotated.  The stock view
+    (the Segment Editor's own visibility widget) drives the input
+    segmentation's per-segment visibility (3D + 2D); its segmentation node
+    tracks the input selector via ``segmentationNodeSelected``.  A launch
+    without the widget library degrades gracefully (panel loads without it).
+    ADR-0004 (Python-composed panel).
+    """
+    self._structuresTable = None
+    try:
+      table = slicer.qMRMLSegmentsTableView()
+    except Exception as exc:  # noqa: BLE001 - widget lib unavailable in this launch
+      logging.warning(
+        "VascularTerritories: structures table unavailable (%s) -- input-"
+        "structure show/hide is disabled this session.", exc)
+      return
+    table.setMRMLScene(slicer.mrmlScene)
+    # Keep the name + eye toggle; drop the editing columns so it reads as a
+    # focus control, not a segment editor.
+    for setter, value in (
+        ("setVisibilityColumnVisible", True),
+        ("setColorColumnVisible", False),
+        ("setOpacityColumnVisible", False),
+        ("setStatusColumnVisible", False),
+    ):
+      fn = getattr(table, setter, None)
+      if fn is not None:
+        fn(value)
+    self._structuresTable = table
+    self.layout.addWidget(qt.QLabel("Anatomical structures (show / hide):"))
+    self.layout.addWidget(table)
+
   def _setupTerritoriesTable(self):
     """Compose the ADR-0037 Stage-2 annotation table into the panel.
 
@@ -422,6 +463,9 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     self.ui.SegmentationShow3DButton.setEnabled(True)
     segmentationNode = self.ui.inputSurfaceSelector.currentNode()
     self.ui.SegmentationShow3DButton.setSegmentationNode(segmentationNode)
+    structures = getattr(self, "_structuresTable", None)
+    if structures is not None:
+      structures.setSegmentationNode(segmentationNode)
     if segmentationNode is None:
       logging.warning('No segmentationNode')
       return

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -428,6 +428,10 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     displayNode = self._ensureHighlightDisplayNode()
     self.updateHighlightPickSurface()
     self._territoriesTable = TerritoriesTableWidget(carrier=carrier, displayNode=displayNode)
+    # Bind the current input segmentation so seed rows read their structure's
+    # colour + name from the start (revised ADR-0037 slice 5, §B3/§B7).
+    if hasattr(self._territoriesTable, "setInputSegmentation"):
+      self._territoriesTable.setInputSegmentation(self.ui.inputSurfaceSelector.currentNode())
     self.layout.addWidget(self._territoriesTable)
 
   def _ensureAnnotationCarrier(self):
@@ -466,6 +470,12 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     structures = getattr(self, "_structuresTable", None)
     if structures is not None:
       structures.setSegmentationNode(segmentationNode)
+    # Bind the input segmentation to the annotation table too, so each seed row
+    # can read its structure's per-segment display colour + name (revised
+    # ADR-0037 slice 5, §B3/§B7).
+    territoriesTable = getattr(self, "_territoriesTable", None)
+    if territoriesTable is not None and hasattr(territoriesTable, "setInputSegmentation"):
+      territoriesTable.setInputSegmentation(segmentationNode)
     if segmentationNode is None:
       logging.warning('No segmentationNode')
       return
@@ -813,73 +823,112 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     if segmentId:
       territoryIds = [tid for tid in territoryIds if tid == segmentId]
 
-    # ADR-0037 slice 5 supersedes the merge-all input: resolve the vessels-only
-    # surface at FULL resolution (so connectivity is not fragmented by
-    # decimation), then per territory recover the single connected component
-    # its first seed (index-0) lands on and decimate THAT component.  Portal
-    # and hepatic systems are disjoint; a per-territory single-component
-    # surface keeps a medial path from tunnelling between them.
-    vascularSurface = self._vascularSurface(surfaceNode)
+    # Revised ADR-0037 slice 5 (multi-system): a territory may own seeds across
+    # MULTIPLE disjoint structures (portal + hepatic).  Resolve the per-segment
+    # closed surfaces once (each vessel segment is one coherent structure), map
+    # each of a territory's seeds to the structure it is nearest, GROUP by
+    # structure, and run VMTK ONCE per structure with >=2 seeds.  Portal and
+    # hepatic systems are disjoint; the per-structure surface (narrowed to the
+    # seed's connected component) keeps a medial path from tunnelling between
+    # them.
+    structures = self._perSegmentClosedSurfaces(surfaceNode)
 
     extractor = self.getCenterlineLogic()
     for territoryId in territoryIds:
       count = carrier.GetNumberOfAnnotationPoints(territoryId)
-      # A centerline needs at least two endpoints (one inlet + one target);
-      # a territory carrying fewer points is INCOMPLETE (the same threshold
-      # the table flags) -- skip it so one under-seeded territory does not
-      # abort extraction for the rest.  Runs BEFORE component recovery so an
-      # under-seeded territory never triggers connectivity.
-      if count < 2:
+      if count == 0:
         continue
       points = []
       for i in range(count):
         p = carrier.GetNthAnnotationPoint(territoryId, i)
         points.append((p[0], p[1], p[2]))
-      surfacePolyData = self._territorySurface(vascularSurface, points[0])
-      self._extractOneTerritory(carrier, extractor, surfacePolyData, territoryId, points)
+      # Clear this territory's prior centerline(s) ONCE, before the structure
+      # loop, then APPEND one centerline per >=2-seed structure -- so a
+      # territory spanning two structures ends with two refs and re-extraction
+      # replaces rather than accrues (idempotency; §B4).
+      self._clearTerritoryCenterlines(carrier, territoryId)
+      for structureSurface, structurePoints in self._groupSeedsByStructure(points, structures):
+        # A centerline needs at least two endpoints (one inlet + one target);
+        # a structure carrying fewer seeds is under-seeded (the same threshold
+        # the table flags) and is SKIPPED (the per-structure >=2 gate, §B4).
+        if len(structurePoints) < 2:
+          continue
+        surfacePolyData = self._territorySurface(structureSurface, structurePoints[0])
+        self._extractOneTerritory(carrier, extractor, surfacePolyData, territoryId, structurePoints)
 
-  def _vascularSurface(self, surfaceNode):
-    """The vessels-only input surface polydata (full-res), or ``None``.
+  def _perSegmentClosedSurfaces(self, surfaceNode):
+    """The vessel structures as an ordered ``[(segmentId, surface), ...]`` list.
 
-    For a segmentation the vessels-only merge is resolved by the C++ resolver
-    (``GetVascularSurfacePolyData`` — vascular-SCT segments only, ADR-0037
-    slice 5); a model node passes its polydata straight through.  This is the
-    surface connectivity is run over per territory; the pick/highlight path
-    keeps snapping to all vessels via ``closed_surface_polydata``.
+    Mirrors the C++ ``GetVascularSurfacePolyData`` resolution but keeps the
+    per-segment SPLIT (each vascular-SCT segment's closed-surface rep) instead
+    of merging them: the split is the structure identity the seed->structure
+    mapping keys on (revised ADR-0037 slice 5, §B1).  A model node has no
+    segment split, so it presents as a single unnamed structure carrying its
+    own polydata.  Returns ``[]`` when nothing resolves.
     """
     if surfaceNode is None:
-      return None
+      return []
     try:
       if surfaceNode.IsA("vtkMRMLModelNode"):
         polyData = surfaceNode.GetPolyData()
-      elif surfaceNode.IsA("vtkMRMLSegmentationNode"):
-        polyData = vtk.vtkPolyData()
-        self.scl.GetVascularSurfacePolyData(surfaceNode, polyData)
-      else:
-        return None
-      if not polyData or polyData.GetNumberOfPoints() == 0:
-        return None
-      return polyData
+        if not polyData or polyData.GetNumberOfPoints() == 0:
+          return []
+        return [("", polyData)]
+      if not surfaceNode.IsA("vtkMRMLSegmentationNode"):
+        return []
+      surfaceNode.CreateClosedSurfaceRepresentation()
+      structures = []
+      for segId in self.scl.GetVascularSegmentIds(surfaceNode):
+        mesh = vtk.vtkPolyData()
+        surfaceNode.GetClosedSurfaceRepresentation(segId, mesh)
+        if mesh.GetNumberOfPoints() > 0:
+          structures.append((segId, mesh))
+      return structures
     except Exception:  # noqa: BLE001 - degrade gracefully when resolution fails
       logging.warning(
-        "VascularTerritories: vessel-surface resolution failed -- the "
-        "centerline extraction is skipped (no surface to run over).")
-      return None
+        "VascularTerritories: per-segment vessel-surface resolution failed -- "
+        "the centerline extraction is skipped (no structures to run over).")
+      return []
 
-  def _territorySurface(self, vascularSurface, seed):
-    """The decimated single connected component of ``vascularSurface`` at ``seed``.
+  def _groupSeedsByStructure(self, points, structures):
+    """Group a territory's ordered seeds by their nearest structure.
 
-    Recovers the connected component the territory's first seed (index-0) lands
-    on (ADR-0037 slice 5, reuse-index-0 persistence) on the FULL-res vessel
-    surface, then triangulates + decimates THAT component -- preserving the
-    triangulate-before-decimate ordering ``preprocessAndDecimate`` enforces.
-    ``None`` when there is no vessel surface (honest degradation).
+    Maps each seed to its structure via ``SeedStructureMapping.nearest_structure``
+    over the per-segment closed surfaces, and returns ``(structureSurface,
+    points)`` pairs in first-seen structure order (revised ADR-0037 slice 5,
+    §B4) -- the surface is carried through so the caller need not re-map the
+    first seed.  With no resolvable structures the whole territory is treated as
+    one group (single-model input) so a model-node surface still extracts.
     """
-    if vascularSurface is None or vascularSurface.GetNumberOfPoints() == 0:
+    if not structures:
+      return [(None, points)]
+    from VascularTerritoriesLib.SeedStructureMapping import nearest_structure
+    surfaces = dict(structures)
+    grouped = {}
+    order = []
+    for point in points:
+      key = nearest_structure(structures, point)
+      if key not in grouped:
+        grouped[key] = []
+        order.append(key)
+      grouped[key].append(point)
+    return [(surfaces.get(key), grouped[key]) for key in order]
+
+  def _territorySurface(self, structureSurface, seed):
+    """The decimated single connected component of the structure's surface at ``seed``.
+
+    Narrows ``structureSurface`` to the connected component the seed lands on --
+    so a segment that accidentally carries two disjoint tubes still feeds VMTK
+    one coherent tree (revised ADR-0037 slice 5, §A3/Q2) -- then triangulates +
+    decimates THAT component, preserving the triangulate-before-decimate
+    ordering ``preprocessAndDecimate`` enforces.  ``None`` when there is no
+    structure surface (honest degradation).
+    """
+    if structureSurface is None or structureSurface.GetNumberOfPoints() == 0:
       return None
     try:
       from VascularTerritoriesLib.VesselConnectivity import connected_component_at
-      component = connected_component_at(vascularSurface, seed)
+      component = connected_component_at(structureSurface, seed)
       if not component or component.GetNumberOfPoints() == 0:
         return None
       return self.preprocessAndDecimate(component)
@@ -894,8 +943,8 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
 
     Kept as the whole-surface decimation seam pinned by the surface-resolution
     invariant (``test_territories_surface_resolution`` i1); the per-territory
-    extraction path resolves its own single-component surface via
-    ``_vascularSurface`` + ``_territorySurface`` (ADR-0037 slice 5).
+    extraction path resolves its own per-structure single-component surface via
+    ``_perSegmentClosedSurfaces`` + ``_territorySurface`` (ADR-0037 slice 5).
     """
     if surfaceNode is None:
       return None
@@ -972,22 +1021,15 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     watershed scan resolves it.  A ``None`` result (the extractor stubbed to
     a no-op) wires nothing -- the transient-node lifecycle is unaffected.
 
-    Re-extraction is IDEMPOTENT (ADR-0037 §Decision 4 -- the territory map is
-    one centerline per territory): the territory's PRIOR centerline state is
-    cleared BEFORE the new output is wired, so any number of re-extractions
-    leaves exactly one ``CenterlineRefs`` entry, one ``TerritoryCenterline``
-    model, and a stable ``Groupings`` count for that territory.  The prior
-    model is removed from the scene, not orphaned.
+    APPEND-only: the territory's PRIOR centerline state is cleared ONCE by the
+    ``extractCenterlines`` caller before the per-structure loop, so this method
+    only appends.  A territory spanning two structures therefore accrues one
+    ref per >=2-seed structure, and re-extraction (which re-clears first)
+    replaces rather than accumulates (idempotency; §B4).
     """
     centerlinePolyData = self._centerlinePolyDataFromResult(result)
     if centerlinePolyData is None:
       return
-    # Clear this territory's prior centerline(s) before wiring the new one so
-    # re-extraction REPLACES rather than APPENDS (no duplicate refs, no orphan
-    # models, stable Groupings count).  The carrier's grouping map is keyed on
-    # the centerline node ID and exposes no per-key removal, so the map is
-    # rebuilt from the surviving references after the prior model is dropped.
-    self._clearTerritoryCenterlines(carrier, territoryId)
     modelNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "TerritoryCenterline")
     modelNode.SetAndObserveMesh(centerlinePolyData)
     # ADR-0037 §Decision 4: tag the centerline with the DERIVED labelmap int
@@ -1190,9 +1232,10 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
         # (VesselHighlightWiring.closed_surface_polydata): every segment's
         # closed surface appended into one mesh, so placement-snap sees the
         # whole vessel surface.  The centerline EXTRACTION path no longer uses
-        # this merge -- it narrows to the per-territory single connected
-        # component via _vascularSurface + _territorySurface (ADR-0037 slice
-        # 5).  ``None`` when the segmentation carries no segment geometry.
+        # this merge -- it groups a territory's seeds by structure and narrows
+        # each per-structure surface to the seed's connected component via
+        # _perSegmentClosedSurfaces + _territorySurface (ADR-0037 slice 5).
+        # ``None`` when the segmentation carries no segment geometry.
         from VascularTerritoriesLib.VesselHighlightWiring import closed_surface_polydata
         return closed_surface_polydata(surfaceNode)
     else:

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -160,6 +160,10 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # reference tracks the input segmentation and whose Visibility gates
     # the hover Pipeline's paint (live only during marker placement).
     self._highlightDisplayNode = None
+    # The input segmentation's display node the widget observes so hiding a
+    # structure hides its extracted centerline(s) (ADR-0037 slice 5).  Tracked
+    # so the observer can be re-aimed on an input change and removed in cleanup.
+    self._observedSegmentationDisplayNode = None
     ScriptedLoadableModuleWidget.__init__(self, parent)
     VTKObservationMixin.__init__(self)  # needed for parameter node observation
 
@@ -255,7 +259,11 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # + the table stay live (the legacy VMTK-hard-gate on placement is gone).
     self.updateExtractionActionEnablement()
 
-    #self.enableWidgetButtons(False)
+    # Gate the workflow actions on their real preconditions from the start
+    # (ADR-0037 §Decision 4): with no input / no extractable structure / no
+    # centerline, both actions read disabled (the extraction tooltip is set by
+    # updateExtractionActionEnablement above; _updateActionEnablement keeps it).
+    self._updateActionEnablement()
     # Make sure parameter node is initialized (needed for module reload)
     self.initializeParameterNode()
 
@@ -365,6 +373,65 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     segmentationId = segmentation.GetID() if segmentation is not None else None
     node.SetAndObservePickSurfaceNodeID(segmentationId)
 
+  def _observeInputSegmentationVisibility(self, segmentationNode):
+    """Observe the input segmentation's display node for structure show/hide.
+
+    ADR-0037 slice 5: hiding a structure (input segment) via the structures
+    table must hide its extracted centerline(s) too.  A widget-level Python
+    observer (ADR-0013 §5 -- no displayable manager) on the segmentation's
+    display-node ``ModifiedEvent`` re-syncs every ``CenterlineRefs`` model's
+    visibility to its structure's visibility.  Re-aimed on every input change;
+    the observer is removed in ``cleanup``.  (The seed glyphs follow the same
+    show/hide via the pipelines' own ``visibility_mtime`` rebuild.)
+    """
+    displayNode = segmentationNode.GetDisplayNode() if segmentationNode is not None else None
+    previous = self._observedSegmentationDisplayNode
+    if previous is displayNode:
+      self._syncCenterlineVisibility()
+      return
+    if previous is not None:
+      self.removeObserver(previous, vtk.vtkCommand.ModifiedEvent, self._onSegmentationVisibilityChanged)
+    self._observedSegmentationDisplayNode = displayNode
+    if displayNode is not None:
+      self.addObserver(displayNode, vtk.vtkCommand.ModifiedEvent, self._onSegmentationVisibilityChanged)
+    self._syncCenterlineVisibility()
+
+  def _onSegmentationVisibilityChanged(self, caller, event):
+    del caller, event
+    self._syncCenterlineVisibility()
+    # Poke the highlight display node so the LayerDM-driven seed pipelines
+    # (3D + slice) re-run UpdatePipeline and re-evaluate per-seed structure
+    # visibility -- otherwise the seed glyphs would only repaint on the next
+    # interaction / reslice (ADR-0037 slice 5).
+    highlight = getattr(self, "_highlightDisplayNode", None)
+    if highlight is not None and slicer.mrmlScene.IsNodePresent(highlight):
+      highlight.Modified()
+
+  def _syncCenterlineVisibility(self):
+    """Set each ``CenterlineRefs`` model's visibility to its structure's visibility.
+
+    Reads the input segmentation display node's per-segment visibility
+    (``GetSegmentVisibility``) and applies it to every extracted centerline
+    tagged with that segment id (``CENTERLINE_STRUCTURE_ATTRIBUTE``).  A
+    centerline with no structure tag (single-model input) is left alone
+    (ADR-0037 slice 5).
+    """
+    carrier = getattr(self, "_annotationCarrier", None)
+    displayNode = self._observedSegmentationDisplayNode
+    if carrier is None or displayNode is None:
+      return
+    attribute = self.logic.CENTERLINE_STRUCTURE_ATTRIBUTE
+    for centerlineId in self.logic.getCenterlineReferenceIDs(carrier):
+      model = slicer.mrmlScene.GetNodeByID(centerlineId)
+      if model is None:
+        continue
+      structureId = model.GetAttribute(attribute)
+      if not structureId:
+        continue
+      modelDisplay = model.GetDisplayNode()
+      if modelDisplay is not None:
+        modelDisplay.SetVisibility(bool(displayNode.GetSegmentVisibility(structureId)))
+
   def _setupStructuresTable(self):
     """Compose a stock ``qMRMLSegmentsTableView`` for input-structure show/hide.
 
@@ -419,6 +486,12 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     if TerritoriesTableWidget is None:
       return
     carrier = self._ensureAnnotationCarrier()
+    # Re-evaluate the Extract/Compute enablement whenever the carrier changes
+    # (a seed added/deleted, a centerline wired): the action gating reads live
+    # seed + centerline state (ADR-0037 §Decision 4).  Removed in cleanup.
+    if carrier is not None and not self.hasObserver(
+        carrier, vtk.vtkCommand.ModifiedEvent, self._onAnnotationCarrierModified):
+      self.addObserver(carrier, vtk.vtkCommand.ModifiedEvent, self._onAnnotationCarrierModified)
     # The highlight display node is the SHARED handle: the table writes the
     # arm state / active territory / carrier binding onto it, and the
     # LayerDM-driven placement Pipeline reads them back (the widget cannot
@@ -463,6 +536,67 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     self.ui.calculateVascularTerritoryMapButton.setEnabled(state)
     self.ui.inputSurfaceSelector.setEnabled(state)
 
+  def _updateActionEnablement(self):
+    """Gate Extract + Compute on their REAL preconditions (ADR-0037 §Decision 4).
+
+    Replaces the blanket enable-on-any-input: both actions read LIVE state so a
+    surgeon cannot click an action that cannot yet run.
+
+    * Extract centerlines: an input segmentation is selected AND SlicerVMTK is
+      present (``extractionActionEnabled``) AND at least one territory has a
+      STRUCTURE with >=2 seeds -- i.e. something is actually extractable (the
+      SAME per-structure grouping the extraction runs on,
+      ``territoryStructureSeedCounts``).  The VMTK tooltip survives when the
+      extractor is absent.
+    * Compute territory map: an input segmentation is selected AND a reference
+      volume exists AND at least one centerline has been extracted (the
+      carrier's ``CenterlineRefs`` is non-empty).
+
+    Re-evaluated on input-surface change, a carrier ``Modified`` (seeds
+    added/deleted), and the end of the extract / compute handlers.
+    """
+    segmentationNode = self.ui.inputSurfaceSelector.currentNode()
+    hasInput = segmentationNode is not None
+
+    vmtkPresent = self.logic.extractionActionEnabled()
+    extractEnabled = hasInput and vmtkPresent and self._hasExtractableStructure(segmentationNode)
+    self.ui.addCenterlineSegmentButton.setEnabled(extractEnabled)
+    # Keep the VMTK explanation tooltip when the extractor is absent.
+    self.ui.addCenterlineSegmentButton.setToolTip(
+      "" if vmtkPresent else (
+        "Centerline extraction needs the SlicerVMTK extension "
+        "(ExtractCenterline), which is not installed."))
+
+    carrier = getattr(self, "_annotationCarrier", None)
+    hasVolume = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLScalarVolumeNode") is not None
+    hasCenterline = (
+      carrier is not None
+      and len(self.logic.getCenterlineReferenceIDs(carrier)) > 0
+    )
+    self.ui.calculateVascularTerritoryMapButton.setEnabled(
+      hasInput and hasVolume and hasCenterline)
+
+  def _hasExtractableStructure(self, segmentationNode):
+    """True iff some territory has a structure with >=2 seeds (extractable).
+
+    Uses ``territoryStructureSeedCounts`` -- the SAME per-structure grouping the
+    extraction path runs on -- so the enablement and the extractor agree on what
+    is extractable (ADR-0037 slice 5).
+    """
+    carrier = getattr(self, "_annotationCarrier", None)
+    if carrier is None or segmentationNode is None:
+      return False
+    for territoryId in carrier.GetAnnotationTerritoryIds():
+      counts = self.logic.territoryStructureSeedCounts(carrier, segmentationNode, territoryId)
+      if any(count >= 2 for count in counts.values()):
+        return True
+    return False
+
+  def _onAnnotationCarrierModified(self, caller, event):
+    """Re-evaluate the action enablement on a carrier edit (seeds add/delete)."""
+    del caller, event
+    self._updateActionEnablement()
+
   def segmentationNodeSelected(self):
     self.ui.SegmentationShow3DButton.setEnabled(True)
     segmentationNode = self.ui.inputSurfaceSelector.currentNode()
@@ -476,18 +610,21 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     territoriesTable = getattr(self, "_territoriesTable", None)
     if territoriesTable is not None and hasattr(territoriesTable, "setInputSegmentation"):
       territoriesTable.setInputSegmentation(segmentationNode)
+    # Track the input segmentation's display node so hiding a structure hides
+    # its extracted centerline(s) too (ADR-0037 slice 5, §concern anatomical
+    # show/hide).  Re-aim the observer on every input change.
+    self._observeInputSegmentationVisibility(segmentationNode)
     if segmentationNode is None:
       logging.warning('No segmentationNode')
+      self._updateActionEnablement()
       return
     displayNode = segmentationNode.GetDisplayNode()
     displayNode.SetOpacity3D(0.3)
-    # Enable the workflow actions the moment an input surface is selected --
-    # directly off the selector, not only via the parameter-node round-trip in
-    # updateGUIFromParameterNode (which does not fire reliably when the panel is
-    # composed inside the Liver module), so the Compute-territory-map button is
-    # reachable once a segmentation is chosen (ADR-0037 §Decision 4 two-step
-    # flow).  The extraction action stays additionally gated on SlicerVMTK.
-    self.enableWidgetButtons(True)
+    # Gate the workflow actions on their real preconditions (ADR-0037
+    # §Decision 4): a selected input alone no longer enables them -- Extract
+    # needs an extractable >=2-seed structure, Compute needs a centerline + a
+    # reference volume.
+    self._updateActionEnablement()
 
   def createColorMap(self):
 #    colorTableNodes = slicer.util.getNodes("SlicerLiverColorMap*")
@@ -628,7 +765,7 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # not on a retired output-segmentation selector.
     inputSurfaceNode = self._parameterNode.GetNodeReference("InputSurface")
     if inputSurfaceNode and inputSurfaceNode.IsA("vtkMRMLSegmentationNode"):
-        self.enableWidgetButtons(True)
+        self._updateActionEnablement()
 
     # All the GUI updates are done
     self._updatingGUIFromParameterNode = False
@@ -694,6 +831,11 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     finally:
       slicer.app.resumeRender()
       qt.QApplication.restoreOverrideCursor()
+    # Apply the current structure visibility to the freshly-extracted
+    # centerlines, and re-gate Compute now that a centerline exists (ADR-0037
+    # §Decision 4 + slice 5).
+    self._syncCenterlineVisibility()
+    self._updateActionEnablement()
 
   def onCalculateVascularTerritoryMapButton(self):
     # ADR-0037 §Decision 4: resolve every input from the carrier +
@@ -736,6 +878,8 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
     slicer.app.resumeRender()
     qt.QApplication.restoreOverrideCursor()
+    # Re-gate the actions post-compute (ADR-0037 §Decision 4).
+    self._updateActionEnablement()
 
 class _SeedsFirstCenterlineExtractor:
   """Adapt SlicerVMTK's surface-first extractor to a seeds-first call (ADR-0037 §Decision 4).
@@ -864,14 +1008,15 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
       # territory spanning two structures ends with two refs and re-extraction
       # replaces rather than accrues (idempotency; §B4).
       self._clearTerritoryCenterlines(carrier, territoryId)
-      for structureSurface, structurePoints in self._groupSeedsByStructure(points, structures):
+      for structureKey, structureSurface, structurePoints in self._groupSeedsByStructure(points, structures):
         # A centerline needs at least two endpoints (one inlet + one target);
         # a structure carrying fewer seeds is under-seeded (the same threshold
         # the table flags) and is SKIPPED (the per-structure >=2 gate, §B4).
         if len(structurePoints) < 2:
           continue
         surfacePolyData = self._territorySurface(structureSurface, structurePoints[0])
-        self._extractOneTerritory(carrier, extractor, surfacePolyData, territoryId, structurePoints)
+        self._extractOneTerritory(
+          carrier, extractor, surfacePolyData, territoryId, structurePoints, structureKey)
 
   def _perSegmentClosedSurfaces(self, surfaceNode):
     """The vessel structures as an ordered ``[(segmentId, surface), ...]`` list.
@@ -911,14 +1056,16 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     """Group a territory's ordered seeds by their nearest structure.
 
     Maps each seed to its structure via ``SeedStructureMapping.nearest_structure``
-    over the per-segment closed surfaces, and returns ``(structureSurface,
-    points)`` pairs in first-seen structure order (revised ADR-0037 slice 5,
-    §B4) -- the surface is carried through so the caller need not re-map the
-    first seed.  With no resolvable structures the whole territory is treated as
-    one group (single-model input) so a model-node surface still extracts.
+    over the per-segment closed surfaces, and returns ``(structureKey,
+    structureSurface, points)`` triples in first-seen structure order (revised
+    ADR-0037 slice 5, §B4) -- the surface AND the structure key are carried
+    through so the caller need neither re-map the first seed nor re-derive the
+    key for the centerline structure-id tag.  With no resolvable structures the
+    whole territory is treated as one group (single-model input) so a model-node
+    surface still extracts.
     """
     if not structures:
-      return [(None, points)]
+      return [(None, None, points)]
     from VascularTerritoriesLib.SeedStructureMapping import nearest_structure
     surfaces = dict(structures)
     grouped = {}
@@ -929,7 +1076,34 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
         grouped[key] = []
         order.append(key)
       grouped[key].append(point)
-    return [(surfaces.get(key), grouped[key]) for key in order]
+    return [(key, surfaces.get(key), grouped[key]) for key in order]
+
+  def territoryStructureSeedCounts(self, carrier, surfaceNode, territoryId):
+    """The per-structure seed counts a territory groups on (revised ADR-0037 slice 5).
+
+    Resolves the input surface's per-segment closed surfaces once
+    (``_perSegmentClosedSurfaces``), maps each of ``territoryId``'s seeds to its
+    nearest structure, and returns ``{structureKey: count}`` -- the SAME
+    grouping the extraction path runs on (``_groupSeedsByStructure``).  Reused
+    by the extractor's >=2-per-structure gate, the table's under-seeded warning,
+    and the widget's Extract-action enablement, so the three cannot diverge on
+    which structures are extractable.  Returns ``{}`` when the carrier /
+    territory carries no seeds.
+    """
+    if carrier is None or territoryId is None:
+      return {}
+    count = carrier.GetNumberOfAnnotationPoints(territoryId)
+    if count == 0:
+      return {}
+    points = [
+      tuple(carrier.GetNthAnnotationPoint(territoryId, i)[:3])
+      for i in range(count)
+    ]
+    structures = self._perSegmentClosedSurfaces(surfaceNode)
+    counts = {}
+    for structureKey, _surface, groupPoints in self._groupSeedsByStructure(points, structures):
+      counts[structureKey] = counts.get(structureKey, 0) + len(groupPoints)
+    return counts
 
   def _territorySurface(self, structureSurface, seed):
     """The decimated single connected component of the structure's surface at ``seed``.
@@ -976,13 +1150,16 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
         "centerline extraction is skipped (no surface to run over).")
       return None
 
-  def _extractOneTerritory(self, carrier, extractor, surfacePolyData, territoryId, points):
+  def _extractOneTerritory(self, carrier, extractor, surfacePolyData, territoryId, points, structureKey=None):
     """Build a transient fiducial, extract, wire the output, tear the node down.
 
     A None/empty ``surfacePolyData`` is NOT fed to the extractor: the real
     SlicerVMTK extractor hard-fails on it, so the territory's extraction is
     skipped with a warning (honest degradation, not a silent no-op).  The
-    transient-fiducial lifecycle stays intact for the real path.
+    transient-fiducial lifecycle stays intact for the real path.  ``structureKey``
+    (the input segment id the seeds grouped on) is carried through to
+    ``_wireCenterlineOutput`` so the centerline model can be tagged with its
+    structure for the anatomical-structure show/hide follow (ADR-0037 slice 5).
     """
     if surfacePolyData is None or surfacePolyData.GetNumberOfPoints() == 0:
       logging.warning(
@@ -997,7 +1174,7 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
       # returned by getCenterlineLogic flips to SlicerVMTK's surface-first
       # signature for the real run.
       result = extractor.extractCenterline(seedsNode, surfacePolyData)
-      self._wireCenterlineOutput(carrier, territoryId, result)
+      self._wireCenterlineOutput(carrier, territoryId, result, structureKey)
     finally:
       slicer.mrmlScene.RemoveNode(seedsNode)
 
@@ -1028,7 +1205,12 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     return [carrier.GetNthNodeReferenceID(role, i)
             for i in range(carrier.GetNumberOfNodeReferences(role))]
 
-  def _wireCenterlineOutput(self, carrier, territoryId, result):
+  #: The centerline model attribute carrying the input SEGMENT (structure) id
+  #: the seeds grouped on (ADR-0037 slice 5).  The widget reads it to hide the
+  #: centerline when its structure is hidden via the structures table.
+  CENTERLINE_STRUCTURE_ATTRIBUTE = "VascularTerritories.StructureSegmentId"
+
+  def _wireCenterlineOutput(self, carrier, territoryId, result, structureKey=None):
     """Wire an extracted centerline into ``CenterlineRefs`` + ``Groupings``.
 
     Preserves the Stage-4 territory-map contract: the centerline model is
@@ -1073,6 +1255,12 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     derivedInt = territory_label_int(carrier, territoryId)
     if derivedInt is not None:
       modelNode.SetAttribute("VascularTerritories.VascTerrId", str(derivedInt))
+    # Tag with the input SEGMENT (structure) id the seeds grouped on so the
+    # widget can hide this centerline when its structure is hidden via the
+    # structures table (ADR-0037 slice 5).  A None/empty key (single-model
+    # input, no per-segment split) leaves the tag unset -- nothing to follow.
+    if structureKey:
+      modelNode.SetAttribute(self.CENTERLINE_STRUCTURE_ATTRIBUTE, str(structureKey))
     carrier.AddNodeReferenceID(self.CENTERLINE_REFERENCE_ROLE, modelNode.GetID())
     carrier.SetGrouping(modelNode.GetID(), territoryId)
     return modelNode

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -873,6 +873,10 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
     try:
        self.logic.calculateVascularTerritoryMap(vascularTerritorySegmentationNode, refVolumeNode, segmentationNode, centerlineModel, self.colormap)
+       # The map output segments come from the labelmap import (named/coloured
+       # by the colormap's label values); re-label + re-colour each to the
+       # TERRITORY it represents so the map matches the table (ADR-0037).
+       self._applyTerritoryNamesAndColors(carrier, vascularTerritorySegmentationNode)
     except ValueError:
         logging.error("Error: Failing when calculating vascular segments")
 
@@ -880,6 +884,33 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     qt.QApplication.restoreOverrideCursor()
     # Re-gate the actions post-compute (ADR-0037 §Decision 4).
     self._updateActionEnablement()
+
+  def _applyTerritoryNamesAndColors(self, carrier, mapSegmentationNode):
+    """Name + colour the map's segments from their territory's display slot.
+
+    ``calculateVascularTerritoryMap`` imports the classified labelmap, so each
+    output segment's label VALUE is the territory's derived 1-based int
+    (``TerritoryLabelMap``); its name/colour come from the colormap, not the
+    surgeon's territory.  Re-key each segment to its territory and set the
+    territory's label + colour so the map reads the same as the table
+    (ADR-0037 §Decision 4 / §Decision 1 display slot).
+    """
+    if carrier is None or mapSegmentationNode is None:
+      return
+    from VascularTerritoriesLib.TerritoryLabelMap import territory_label_ints
+    territoryOrder = list(carrier.GetAnnotationTerritoryIds())
+    intToTerritory = {value: tid for tid, value in territory_label_ints(territoryOrder).items()}
+    segmentation = mapSegmentationNode.GetSegmentation()
+    for i in range(segmentation.GetNumberOfSegments()):
+      segment = segmentation.GetNthSegment(i)
+      territoryId = intToTerritory.get(int(segment.GetLabelValue()))
+      if territoryId is None:
+        continue
+      label = carrier.GetTerritoryLabel(territoryId) or territoryId
+      segment.SetName(label)
+      color = carrier.GetTerritoryColor(territoryId)
+      if color is not None:
+        segment.SetColor(color[0], color[1], color[2])
 
 class _SeedsFirstCenterlineExtractor:
   """Adapt SlicerVMTK's surface-first extractor to a seeds-first call (ADR-0037 §Decision 4).

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -835,7 +835,16 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # centerlines, and re-gate Compute now that a centerline exists (ADR-0037
     # §Decision 4 + slice 5).
     self._syncCenterlineVisibility()
+    # Extracting ends the placement gesture: toggle the Place button off so a
+    # stray click after extraction does not drop another seed (ADR-0037).
+    self._disarmPlacement()
     self._updateActionEnablement()
+
+  def _disarmPlacement(self):
+    """Toggle the active Place button off (disarm) via the table's shared body."""
+    table = getattr(self, "_territoriesTable", None)
+    if table is not None and hasattr(table, "disarm"):
+      table.disarm()
 
   def onCalculateVascularTerritoryMapButton(self):
     # ADR-0037 §Decision 4: resolve every input from the carrier +
@@ -882,6 +891,8 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
 
     slicer.app.resumeRender()
     qt.QApplication.restoreOverrideCursor()
+    # Computing the map ends the placement gesture too: toggle Place off.
+    self._disarmPlacement()
     # Re-gate the actions post-compute (ADR-0037 §Decision 4).
     self._updateActionEnablement()
 

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -756,12 +756,13 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
     if segmentId:
       territoryIds = [tid for tid in territoryIds if tid == segmentId]
 
-    # Decimate the input surface once; every territory shares the same input
-    # mesh.  A missing/empty surface degrades HONESTLY: the real SlicerVMTK
-    # extractor hard-fails on a None/empty surface (no Voronoi diagram / 0 cap
-    # connections / no surface normals), so ``_extractOneTerritory`` skips the
-    # extraction instead of feeding it a bad surface.
-    surfacePolyData = self._preprocessedSurface(surfaceNode)
+    # ADR-0037 slice 5 supersedes the merge-all input: resolve the vessels-only
+    # surface at FULL resolution (so connectivity is not fragmented by
+    # decimation), then per territory recover the single connected component
+    # its first seed (index-0) lands on and decimate THAT component.  Portal
+    # and hepatic systems are disjoint; a per-territory single-component
+    # surface keeps a medial path from tunnelling between them.
+    vascularSurface = self._vascularSurface(surfaceNode)
 
     extractor = self.getCenterlineLogic()
     for territoryId in territoryIds:
@@ -769,17 +770,76 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
       # A centerline needs at least two endpoints (one inlet + one target);
       # a territory carrying fewer points is INCOMPLETE (the same threshold
       # the table flags) -- skip it so one under-seeded territory does not
-      # abort extraction for the rest.
+      # abort extraction for the rest.  Runs BEFORE component recovery so an
+      # under-seeded territory never triggers connectivity.
       if count < 2:
         continue
       points = []
       for i in range(count):
         p = carrier.GetNthAnnotationPoint(territoryId, i)
         points.append((p[0], p[1], p[2]))
+      surfacePolyData = self._territorySurface(vascularSurface, points[0])
       self._extractOneTerritory(carrier, extractor, surfacePolyData, territoryId, points)
 
+  def _vascularSurface(self, surfaceNode):
+    """The vessels-only input surface polydata (full-res), or ``None``.
+
+    For a segmentation the vessels-only merge is resolved by the C++ resolver
+    (``GetVascularSurfacePolyData`` — vascular-SCT segments only, ADR-0037
+    slice 5); a model node passes its polydata straight through.  This is the
+    surface connectivity is run over per territory; the pick/highlight path
+    keeps snapping to all vessels via ``closed_surface_polydata``.
+    """
+    if surfaceNode is None:
+      return None
+    try:
+      if surfaceNode.IsA("vtkMRMLModelNode"):
+        polyData = surfaceNode.GetPolyData()
+      elif surfaceNode.IsA("vtkMRMLSegmentationNode"):
+        polyData = vtk.vtkPolyData()
+        self.scl.GetVascularSurfacePolyData(surfaceNode, polyData)
+      else:
+        return None
+      if not polyData or polyData.GetNumberOfPoints() == 0:
+        return None
+      return polyData
+    except Exception:  # noqa: BLE001 - degrade gracefully when resolution fails
+      logging.warning(
+        "VascularTerritories: vessel-surface resolution failed -- the "
+        "centerline extraction is skipped (no surface to run over).")
+      return None
+
+  def _territorySurface(self, vascularSurface, seed):
+    """The decimated single connected component of ``vascularSurface`` at ``seed``.
+
+    Recovers the connected component the territory's first seed (index-0) lands
+    on (ADR-0037 slice 5, reuse-index-0 persistence) on the FULL-res vessel
+    surface, then triangulates + decimates THAT component -- preserving the
+    triangulate-before-decimate ordering ``preprocessAndDecimate`` enforces.
+    ``None`` when there is no vessel surface (honest degradation).
+    """
+    if vascularSurface is None or vascularSurface.GetNumberOfPoints() == 0:
+      return None
+    try:
+      from VascularTerritoriesLib.VesselConnectivity import connected_component_at
+      component = connected_component_at(vascularSurface, seed)
+      if not component or component.GetNumberOfPoints() == 0:
+        return None
+      return self.preprocessAndDecimate(component)
+    except Exception:  # noqa: BLE001 - degrade gracefully when preprocessing fails
+      logging.warning(
+        "VascularTerritories: territory-surface preprocessing failed -- the "
+        "centerline extraction is skipped (no surface to run over).")
+      return None
+
   def _preprocessedSurface(self, surfaceNode):
-    """Return the decimated input-surface polydata, or ``None`` on any failure."""
+    """Return the decimated input-surface polydata, or ``None`` on any failure.
+
+    Kept as the whole-surface decimation seam pinned by the surface-resolution
+    invariant (``test_territories_surface_resolution`` i1); the per-territory
+    extraction path resolves its own single-component surface via
+    ``_vascularSurface`` + ``_territorySurface`` (ADR-0037 slice 5).
+    """
     if surfaceNode is None:
       return None
     try:
@@ -1071,9 +1131,11 @@ class VascularTerritoriesLogic(ScriptedLoadableModuleLogic):
         # yield a zero-point mesh.  Converge on the SAME whole-vessel-tree
         # resolution the pick/highlight path uses
         # (VesselHighlightWiring.closed_surface_polydata): every segment's
-        # closed surface appended into one mesh, so placement-snap and
-        # centerline extraction see the identical surface.  ``None`` when the
-        # segmentation carries no segment geometry.
+        # closed surface appended into one mesh, so placement-snap sees the
+        # whole vessel surface.  The centerline EXTRACTION path no longer uses
+        # this merge -- it narrows to the per-territory single connected
+        # component via _vascularSurface + _territorySurface (ADR-0037 slice
+        # 5).  ``None`` when the segmentation carries no segment geometry.
         from VascularTerritoriesLib.VesselHighlightWiring import closed_surface_polydata
         return closed_surface_polydata(surfaceNode)
     else:

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -455,6 +455,13 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # ADR-0037 §Decision 2 slice-4 module-active gate: entering auto-arms
     # NOTHING.  Placement is an explicit per-territory Place toggle in the
     # table, so no view claims an add-on-click merely from opening the module.
+    # Open the module-active gate (ADR-0037 slice-5 concern #1): the
+    # LayerDM-created placement Pipelines read this flag off the shared display
+    # node, so an armed click only lands while VascularTerritories is active.
+    node = self._ensureHighlightDisplayNode()
+    if node is not None:
+      from VascularTerritoriesLib import TerritoryInteractionState as _territoryState
+      _territoryState.set_module_active(node, True)
     # Make sure parameter node exists and observed
     self.initializeParameterNode()
 
@@ -470,6 +477,12 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     table = getattr(self, "_territoriesTable", None)
     if table is not None and hasattr(table, "disarm"):
       table.disarm()
+    # Close the module-active gate (ADR-0037 slice-5 concern #1): no view
+    # claims an add-on-click while VascularTerritories is inactive.
+    node = getattr(self, "_highlightDisplayNode", None)
+    if node is not None:
+      from VascularTerritoriesLib import TerritoryInteractionState as _territoryState
+      _territoryState.set_module_active(node, False)
     # Do not react to parameter node changes (GUI wlil be updated when the user enters into the module)
     self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
 

--- a/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
+++ b/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
@@ -25,6 +25,7 @@ set(VascularTerritoriesLib_PYTHON_SCRIPTS
   TerritoryLabelMap.py
   VesselSurfacePick.py
   VesselHighlightWiring.py
+  VesselConnectivity.py
   VesselHighlightPipeline.py
   TerritoryInteractionState.py
   TerritoryPlacementPipeline.py

--- a/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
+++ b/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
@@ -26,6 +26,7 @@ set(VascularTerritoriesLib_PYTHON_SCRIPTS
   VesselSurfacePick.py
   VesselHighlightWiring.py
   VesselConnectivity.py
+  SeedStructureMapping.py
   VesselHighlightPipeline.py
   TerritoryInteractionState.py
   TerritoryPlacementPipeline.py

--- a/VascularTerritories/VascularTerritoriesLib/SeedStructureMapping.py
+++ b/VascularTerritories/VascularTerritoriesLib/SeedStructureMapping.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Seed -> structure mapping for multi-system territories (ADR-0037 slice 5).
+
+A vascular territory may own seeds across MULTIPLE disjoint structures (input
+segments): points on the portal vein plus points on the hepatic vein, for
+instance.  Each seed belongs to the structure whose CLOSED SURFACE it is
+nearest.  That mapping is what lets extraction GROUP a territory's seeds by
+structure (one VMTK run per structure with >=2 seeds) and the table colour each
+seed row by its structure.
+
+This module is a PURE-VTK helper: no MRML scene, no Slicer, no Qt, no GL — so it
+runs on the bare unit layer.  ``vtkCellLocator`` is fully Python-wrapped, so per
+the ADR-0004 split the geometry (nearest closed surface to a point) lives in
+Python while the segment -> closed-surface + segment -> colour resolution reads
+MRML segment state on the C++/Python seams.
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md
+    (§Amendment — connected-tree-constrained centerline seeding (slice 5))
+  * Docs/adr/0004-python-cpp-boundary.md  (pure polydata -> Python)
+  * VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
+    (the per-structure connected-component narrow sibling)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from collections.abc import Sequence
+
+import vtk
+
+#: Relative squared-distance tolerance below which two structures count as
+#: equidistant; a near-tie keeps the FIRST structure in order (Q3 tiebreak).
+#: Tessellated closed surfaces never yield bit-identical distances, so a plain
+#: strict-less comparison would let floating-point noise decide the tie.
+_TIE_REL_TOL = 1.0e-6
+
+
+def nearest_structure(structures: Sequence, point: Sequence[float]):
+    """The key of the structure whose closed surface is nearest ``point``.
+
+    ``structures`` is an ORDERED sequence of ``(key, closed_surface_polydata)``
+    where ``key`` is the segment id (str).  ``point`` is a 3-float world
+    coordinate.  Builds a ``vtkCellLocator`` (``FindClosestPoint``) per surface
+    and returns the key of the structure with the smallest distance to
+    ``point``.  A distance tie resolves to the FIRST structure in order
+    (deterministic).  An empty ``structures`` -> ``None``.
+    """
+    px, py, pz = float(point[0]), float(point[1]), float(point[2])
+    best_key = None
+    best_distance2 = None
+    for key, surface in structures:
+        if surface is None or surface.GetNumberOfPoints() == 0:
+            continue
+        locator = vtk.vtkCellLocator()
+        locator.SetDataSet(surface)
+        locator.BuildLocator()
+        closest = [0.0, 0.0, 0.0]
+        cell_id = vtk.reference(0)
+        sub_id = vtk.reference(0)
+        distance2 = vtk.reference(0.0)
+        locator.FindClosestPoint((px, py, pz), closest, cell_id, sub_id, distance2)
+        d2 = float(distance2)
+        # Only a STRICTLY closer structure (beyond a relative tolerance)
+        # displaces the incumbent, so a distance tie -- including the tessellated
+        # near-tie of two symmetric surfaces -- keeps the FIRST structure in
+        # order (deterministic tiebreak).
+        if best_distance2 is None or d2 < best_distance2 * (1.0 - _TIE_REL_TOL):
+            best_distance2 = d2
+            best_key = key
+    return best_key
+
+
+def territory_structure_seed_counts(assignments: Sequence) -> dict:
+    """Group mapped seeds into ``{structureKey: count}``.
+
+    ``assignments`` is a sequence of ``(seed, structureKey)`` pairs (the seed
+    itself is ignored — only the structure key matters).  Reused by the table's
+    <2-seed warning and the extractor's >=2-per-structure gate, so the two agree
+    on which structures are under-seeded.
+    """
+    counts: dict[Any, int] = {}
+    for _seed, structure_key in assignments:
+        counts[structure_key] = counts.get(structure_key, 0) + 1
+    return counts

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -419,10 +419,12 @@ class TerritoriesTableWidget(qt.QWidget):
     # ------------------------------------------------------------------ #
 
     def addTerritory(self, territoryId: str | None = None) -> str:
-        """Mint an empty territory, select its item, arm the pipeline.
+        """Mint an empty territory and arm the pipeline into it.
 
         Returns the (possibly auto-generated) territory id.  Auto-generated
-        ids avoid colliding with an existing territory.
+        ids avoid colliding with an existing territory.  The new row is NOT
+        selected/highlighted -- arming (the Place toggle) is the active-state
+        cue, so a row selection on top of it is redundant.
         """
         if territoryId is None:
             territoryId = self._mintTerritoryId()
@@ -445,7 +447,6 @@ class TerritoriesTableWidget(qt.QWidget):
         # previously-armed territory's toggle re-derives un-checked.
         self._armInto(territoryId)
         self._rebuild()
-        self.selectTerritoryRow(territoryId)
         return territoryId
 
     def armForSelectedTerritory(self) -> None:

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -56,8 +56,16 @@ import vtk
 
 try:  # pragma: no cover - exercised once per import path
     from . import TerritoryInteractionState as _state
+    from .SeedStructureMapping import (
+        nearest_structure as _nearest_structure,
+        territory_structure_seed_counts as _structure_seed_counts,
+    )
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     import TerritoryInteractionState as _state  # type: ignore[no-redef]
+    from SeedStructureMapping import (  # type: ignore[no-redef]
+        nearest_structure as _nearest_structure,
+        territory_structure_seed_counts as _structure_seed_counts,
+    )
 
 #: A small distinct palette so minted territories read apart in both the
 #: swatch and the 3D seed glyphs (RGB in 0..1).  Cycled by mint order.
@@ -117,6 +125,14 @@ class TerritoriesTableWidget(qt.QWidget):
 
         self._carrier = carrier
         self._displayNode = displayNode
+        # The input segmentation whose per-segment closed surfaces + display
+        # colours the seed rows read (bound by ``setInputSegmentation``); the
+        # per-segment cell locators are cached by the segmentation's MTime so a
+        # repaint does not re-map every seed from scratch (revised ADR-0037
+        # slice 5, §B3).
+        self._segmentation = None
+        self._structures_cache: list | None = None
+        self._structures_cache_key = None
         # Bind the carrier onto the shared display node so the LayerDM-driven
         # placement Pipeline (which the widget cannot reach directly) resolves
         # the same carrier the tree edits.
@@ -283,6 +299,120 @@ class TerritoriesTableWidget(qt.QWidget):
         """The on-surface status label text on the seed row."""
         status = self._seedControl(territoryId, pointIndex, "status")
         return status.text if status is not None else ""
+
+    # ------------------------------------------------------------------ #
+    # Input segmentation + seed -> structure resolution (revised slice 5)
+    # ------------------------------------------------------------------ #
+
+    def setInputSegmentation(self, segmentationNode: Any) -> None:
+        """Bind the input segmentation whose per-segment colours + surfaces the
+        seed rows read (revised ADR-0037 slice 5, §B3).
+
+        A seed's structure is DERIVED (nearest segment surface), so this binds
+        the source and rebuilds; no carrier slot is written (ADR-0014).
+        """
+        self._segmentation = segmentationNode
+        self._structures_cache = None
+        self._structures_cache_key = None
+        self._rebuild()
+
+    def _structures(self) -> list:
+        """The bound segmentation's vessel structures as ``[(segId, surface)]``.
+
+        Mirrors the extractor's ``_perSegmentClosedSurfaces`` split (each
+        vascular-SCT segment's closed-surface rep) so the table's seed->structure
+        mapping agrees with extraction (§B1).  Cached by the segmentation's
+        MTime.  Returns ``[]`` when nothing is bound / resolves.
+        """
+        segmentation = self._segmentation
+        if segmentation is None or not hasattr(segmentation, "GetSegmentation"):
+            return []
+        key = segmentation.GetMTime()
+        if self._structures_cache is not None and self._structures_cache_key == key:
+            return self._structures_cache
+        structures: list = []
+        try:
+            segmentation.CreateClosedSurfaceRepresentation()
+            core = segmentation.GetSegmentation()
+            for i in range(core.GetNumberOfSegments()):
+                segId = core.GetNthSegmentID(i)
+                mesh = vtk.vtkPolyData()
+                segmentation.GetClosedSurfaceRepresentation(segId, mesh)
+                if mesh.GetNumberOfPoints() > 0:
+                    structures.append((segId, mesh))
+        except Exception:  # noqa: BLE001 - degrade gracefully when resolution fails
+            structures = []
+        self._structures_cache = structures
+        self._structures_cache_key = key
+        return structures
+
+    def _seedPoint(self, territoryId: str, pointIndex: int):
+        if self._carrier is None:
+            return None
+        if int(pointIndex) >= self._carrier.GetNumberOfAnnotationPoints(territoryId):
+            return None
+        p = self._carrier.GetNthAnnotationPoint(territoryId, int(pointIndex))
+        return (p[0], p[1], p[2])
+
+    def seedStructureId(self, territoryId: str, pointIndex: int) -> str | None:
+        """The segment id the seed maps to (nearest structure), or ``None``."""
+        point = self._seedPoint(territoryId, pointIndex)
+        structures = self._structures()
+        if point is None or not structures:
+            return None
+        return _nearest_structure(structures, point)
+
+    def seedStructureColor(self, territoryId: str, pointIndex: int):
+        """The seed's structure's segment display colour ``(r, g, b)`` or ``None``."""
+        segId = self.seedStructureId(territoryId, pointIndex)
+        if segId is None:
+            return None
+        return self._segmentColor(segId)
+
+    def _segmentColor(self, segId: str):
+        segmentation = self._segmentation
+        if segmentation is None or not hasattr(segmentation, "GetSegmentation"):
+            return None
+        try:
+            segment = segmentation.GetSegmentation().GetSegment(segId)
+            if segment is None:
+                return None
+            rgb = segment.GetColor()
+            return (rgb[0], rgb[1], rgb[2])
+        except Exception:  # noqa: BLE001 - defensive across segment shapes
+            return None
+
+    def _segmentName(self, segId: str) -> str:
+        segmentation = self._segmentation
+        if segmentation is None or not hasattr(segmentation, "GetSegmentation"):
+            return ""
+        try:
+            segment = segmentation.GetSegmentation().GetSegment(segId)
+            return segment.GetName() if segment is not None else ""
+        except Exception:  # noqa: BLE001 - defensive across segment shapes
+            return ""
+
+    def _underSeededStructures(self, territoryId: str) -> list:
+        """The structures ``territoryId`` touches with <2 seeds (the warning set).
+
+        Groups the territory's seeds by structure (via the seed->structure
+        mapping) and returns the structure keys with a seed count below the
+        >=2 extraction gate -- the SAME gate the extractor uses so the warning
+        and the skip agree (revised ADR-0037 slice 5, §B4/§B6).  With no bound
+        segmentation the per-structure check cannot run, so returns ``[]`` (the
+        flat seed-count check still flags a <2-seed territory).
+        """
+        structures = self._structures()
+        if self._carrier is None or not structures:
+            return []
+        count = self._carrier.GetNumberOfAnnotationPoints(territoryId)
+        assignments = []
+        for i in range(count):
+            point = self._seedPoint(territoryId, i)
+            if point is not None:
+                assignments.append((point, _nearest_structure(structures, point)))
+        counts = _structure_seed_counts(assignments)
+        return [key for key, n in counts.items() if n < _MIN_SEEDS_FOR_COMPLETE]
 
     # ------------------------------------------------------------------ #
     # Territory lifecycle (arming)
@@ -602,8 +732,21 @@ class TerritoriesTableWidget(qt.QWidget):
         rowLayout.addWidget(labelEdit, 1)
 
         # Completeness indicator: GLYPH + TEXT (ADR-0010, never colour alone).
-        incomplete = seedCount < _MIN_SEEDS_FOR_COMPLETE
-        statusText = f"{_INCOMPLETE_GLYPH} {_INCOMPLETE_TEXT}" if incomplete else _COMPLETE_TEXT
+        # The check is PER STRUCTURE (revised ADR-0037 slice 5, §B6): a
+        # territory that touches any structure with <2 seeds is flagged, because
+        # that structure cannot yield a centerline -- even when the flat seed
+        # count reads complete (e.g. 2 on the vein + 1 on the artery).  The flat
+        # <2-seed check remains as the fallback when no segmentation is bound.
+        underSeeded = self._underSeededStructures(territoryId)
+        if underSeeded:
+            names = ", ".join(
+                self._segmentName(segId) or str(segId) for segId in underSeeded
+            )
+            statusText = f"{_INCOMPLETE_GLYPH} {names} needs at least two seeds"
+        elif seedCount < _MIN_SEEDS_FOR_COMPLETE:
+            statusText = f"{_INCOMPLETE_GLYPH} {_INCOMPLETE_TEXT}"
+        else:
+            statusText = _COMPLETE_TEXT
         statusLabel = qt.QLabel(statusText)
         rowLayout.addWidget(statusLabel)
 
@@ -633,8 +776,33 @@ class TerritoriesTableWidget(qt.QWidget):
         rowLayout.setContentsMargins(2, 1, 2, 1)
         rowLayout.setSpacing(4)
 
-        # On-surface status text (surface-snapped on placement).
-        statusLabel = qt.QLabel(f"Seed {pointIndex + 1} — on surface")
+        # Structure swatch + name (revised ADR-0037 slice 5, §B3): the seed row
+        # is tinted with its STRUCTURE's segment display colour (NOT the
+        # territory palette) and PAIRS the swatch with the structure NAME
+        # (ADR-0010, colour never alone).  Falls back to a plain on-surface
+        # label when no segmentation is bound / the seed maps to no structure.
+        structureId = self.seedStructureId(territoryId, pointIndex)
+        structureColour = self.seedStructureColor(territoryId, pointIndex)
+        swatch = qt.QLabel()
+        swatch.setFixedSize(12, 12)
+        if structureColour is not None:
+            pixmap = qt.QPixmap(12, 12)
+            pixmap.fill(
+                qt.QColor(
+                    int(structureColour[0] * 255),
+                    int(structureColour[1] * 255),
+                    int(structureColour[2] * 255),
+                )
+            )
+            swatch.setPixmap(pixmap)
+            rowLayout.addWidget(swatch)
+
+        if structureId is not None:
+            structureName = self._segmentName(structureId) or structureId
+            statusText = f"Seed {pointIndex + 1} — {structureName}"
+        else:
+            statusText = f"Seed {pointIndex + 1} — on surface"
+        statusLabel = qt.QLabel(statusText)
         rowLayout.addWidget(statusLabel, 1)
 
         deleteButton = qt.QToolButton()
@@ -649,6 +817,7 @@ class TerritoriesTableWidget(qt.QWidget):
 
         self._seed_rows[(territoryId, pointIndex)] = {
             "widget": rowWidget,
+            "swatch": swatch,
             "status": statusLabel,
             "delete": deleteButton,
         }

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
@@ -25,6 +25,7 @@ from typing import Any
 #: Display-node attribute keys / reference role for the interaction state.
 ARMED_ATTR = "VascularTerritories.Armed"
 ACTIVE_TERRITORY_ATTR = "VascularTerritories.ActiveTerritory"
+MODULE_ACTIVE_ATTR = "VascularTerritories.ModuleActive"
 CARRIER_REFERENCE_ROLE = "VascularTerritories.carrier"
 
 
@@ -36,6 +37,29 @@ def set_armed(displayNode: Any, armed: bool) -> None:
 
 def is_armed(displayNode: Any) -> bool:
     return displayNode is not None and displayNode.GetAttribute(ARMED_ATTR) == "1"
+
+
+def set_module_active(displayNode: Any, active: bool) -> None:
+    """Publish the module-active gate onto the shared highlight display node.
+
+    Belt-and-suspenders beyond the armed flag (ADR-0037 slice-5 concern #1):
+    the owning module's ``enter()`` / ``exit()`` flips this so no view lands a
+    seed while VascularTerritories is not the active module.
+    """
+    if displayNode is not None:
+        displayNode.SetAttribute(MODULE_ACTIVE_ATTR, "1" if active else "0")
+
+
+def is_module_active(displayNode: Any) -> bool:
+    """True unless the module has EXPLICITLY closed the gate.
+
+    An UNSET attribute reads active: LayerDM creates the placement Pipelines
+    the moment the display node enters the scene (before any ``enter()``), and
+    a placement/edit gesture must still land in that window.  The gate is the
+    module's ``exit()`` writing ``"0"`` -- the decline is opt-in, so opening
+    the module (or never touching the flag) leaves placement enabled.
+    """
+    return displayNode is None or displayNode.GetAttribute(MODULE_ACTIVE_ATTR) != "0"
 
 
 def set_active_territory(displayNode: Any, territoryId: str | None) -> None:

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -42,7 +42,6 @@ try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
     from .VesselHighlightWiring import (
         vascular_surface_polydata,
-        seed_structure_visible as _seed_structure_visible,
         visibility_mtime as _visibility_mtime,
         VisibleStructuresCache as _VisibleStructuresCache,
     )
@@ -50,7 +49,6 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
     from VesselHighlightWiring import (  # type: ignore[no-redef]
         vascular_surface_polydata,
-        seed_structure_visible as _seed_structure_visible,
         visibility_mtime as _visibility_mtime,
         VisibleStructuresCache as _VisibleStructuresCache,
     )
@@ -960,7 +958,6 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._seed_colors.SetNumberOfComponents(3)
         grab_rgb = tuple(int(c * 255) for c in HALO_GRAB_COLOR)
         hover_rgb = tuple(int(c * 255) for c in HALO_HOVER_COLOR)
-        structures = self._visible_structures()
         carrier = self._get_carrier()
         if carrier is not None:
             for territory in carrier.GetAnnotationTerritoryIds():
@@ -975,8 +972,9 @@ class TerritoryPlacementPipeline(_PipelineBase):
                 count = carrier.GetNumberOfAnnotationPoints(territory)
                 for i in range(count):
                     point = carrier.GetNthAnnotationPoint(territory, i)
-                    # Omit a seed whose structure is hidden (ADR-0037 slice 5).
-                    if not _seed_structure_visible(structures, point):
+                    # Omit a seed whose structure is hidden (ADR-0037 slice 5);
+                    # cached per-structure locators keep this O(log n) per seed.
+                    if not self._structures.seed_visible(self._display_node, point):
                         continue
                     self._seed_points.InsertNextPoint(point[0], point[1], point[2])
                     key = (territory, i)

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -355,8 +355,8 @@ class TerritoryPlacementPipeline(_PipelineBase):
             if renderer is not None:
                 renderer.AddActor(self._seed_actor)
                 renderer.AddActor(self._marker_actor)
-            # The active-tree highlight renders in the glow overlay (halo), not
-            # the view renderer -- added in _attach_halo_renderer.
+            # The edit-hover grab halo renders in a private glow overlay (its
+            # vtkOutlineGlowPass survives qMRMLThreeDView's SetPass reset).
             self._attach_halo_renderer(renderer)
             # Renderer churn cleared the display handle; re-derive it from the
             # base's retained display node (the ControlPolygonPipeline

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -40,10 +40,10 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
-    from .VesselHighlightWiring import closed_surface_polydata
+    from .VesselHighlightWiring import vascular_surface_polydata
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
-    from VesselHighlightWiring import closed_surface_polydata  # type: ignore[no-redef]
+    from VesselHighlightWiring import vascular_surface_polydata  # type: ignore[no-redef]
 
 #: Display-space pick radius for grabbing an existing point, in pixels
 #: (mirrors ``ControlPolygonPipeline.CONTROL_POINT_PICK_RADIUS_PX``).  A
@@ -213,7 +213,9 @@ class TerritoryPlacementPipeline(_PipelineBase):
         segmentation = display.GetPickSurfaceNode()
         if segmentation is None:
             return None
-        polydata = closed_surface_polydata(segmentation)
+        # Vessels-only: the cursor snaps to a vessel, never the liver
+        # parenchyma or a tumour (ADR-0037 slice 5).
+        polydata = vascular_surface_polydata(segmentation)
         if polydata is None:
             return None
         self._pick = VesselSurfacePick(polydata)

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -60,6 +60,12 @@ HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
 HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
 HALO_HOVER_SCALE = 1.6
 
+#: Active-tree glow colour -- a cyan halo around the armed vessel tree,
+#: distinct from the yellow seed-hover / green seed-grab cues.  Rendered
+#: through the same vtkOutlineGlowPass overlay as the seed halo, so the whole
+#: connected tree reads as a glow, not a flat surface tint (ADR-0037 slice 5).
+ACTIVE_TREE_GLOW_COLOR = (0.2, 0.8, 1.0)
+
 #: Interaction state lives on the shared highlight DISPLAY NODE, not on the
 #: Pipeline instance: LayerDM owns the Pipeline instance lifecycle (it creates
 #: its own per view), so the widget/table can only reach the Pipeline the
@@ -203,17 +209,19 @@ class TerritoryPlacementPipeline(_PipelineBase):
         # -- active-tree HIGHLIGHT (ADR-0037 slice 5, C5): a THIRD pipeline-
         # owned actor (no new displayable manager, ADR-0013 §1) that paints the
         # active territory's connected vessel tree while armed -- the seed[0]
-        # component recovered over the pick core's surface.  Styling is a plain
-        # semi-transparent tint (deferred); the pinned invariant is the INPUT
-        # identity == ``activeTreePolyData()``.  Cached per (surface MTime,
-        # seed) so the connectivity filter does not re-run per mouse event.
+        # component recovered over the pick core's surface.  Rendered through
+        # the shared vtkOutlineGlowPass overlay (see ``_attach_halo_renderer``)
+        # so the whole tree reads as a GLOW HALO, not a flat surface tint; the
+        # pinned invariant is the INPUT identity == ``activeTreePolyData()``.
+        # Cached per (surface MTime, seed) so connectivity does not re-run per
+        # mouse event.
         self._active_tree_polydata: Any | None = None
         self._active_tree_cache_key: tuple | None = None
         self._highlight_tree_mapper = vtk.vtkPolyDataMapper()
         self._highlight_tree_actor = vtk.vtkActor()
         self._highlight_tree_actor.SetMapper(self._highlight_tree_mapper)
-        self._highlight_tree_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
-        self._highlight_tree_actor.GetProperty().SetOpacity(0.3)
+        self._highlight_tree_actor.GetProperty().SetColor(*ACTIVE_TREE_GLOW_COLOR)
+        self._highlight_tree_actor.GetProperty().SetLighting(False)
         self._highlight_tree_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
@@ -358,7 +366,8 @@ class TerritoryPlacementPipeline(_PipelineBase):
             if renderer is not None:
                 renderer.AddActor(self._seed_actor)
                 renderer.AddActor(self._marker_actor)
-                renderer.AddActor(self._highlight_tree_actor)
+            # The active-tree highlight renders in the glow overlay (halo), not
+            # the view renderer -- added in _attach_halo_renderer.
             self._attach_halo_renderer(renderer)
             # Renderer churn cleared the display handle; re-derive it from the
             # base's retained display node (the ControlPolygonPipeline
@@ -378,7 +387,6 @@ class TerritoryPlacementPipeline(_PipelineBase):
             if renderer is not None:
                 renderer.RemoveActor(self._seed_actor)
                 renderer.RemoveActor(self._marker_actor)
-                renderer.RemoveActor(self._highlight_tree_actor)
             self._detach_halo_renderer()
             self._renderer = None
             self.cleanup()
@@ -406,6 +414,10 @@ class TerritoryPlacementPipeline(_PipelineBase):
             overlay.InteractiveOff()
             overlay.SetActiveCamera(renderer.GetActiveCamera())
             overlay.AddActor(self._halo_actor)
+            # Route the active-tree highlight through the glow pass too, so the
+            # armed vessel tree reads as a cyan HALO around the vessel rather
+            # than a flat surface tint (ADR-0037 slice 5).
+            overlay.AddActor(self._highlight_tree_actor)
             glow = getattr(vtk, "vtkOutlineGlowPass", None)
             steps = getattr(vtk, "vtkRenderStepsPass", None)
             if glow is not None and steps is not None:

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -804,6 +804,10 @@ class TerritoryPlacementPipeline(_PipelineBase):
         best_d2 = sys.float_info.max
         for i in range(count):
             point = carrier.GetNthAnnotationPoint(territory, i)
+            # A hidden-structure seed is not drawn, so it must not be a
+            # hover/grab target either -- skip it (ADR-0037 slice 5).
+            if not self._structures.seed_visible(self._display_node, point):
+                continue
             renderer.SetWorldPoint(point[0], point[1], point[2], 1.0)
             renderer.WorldToDisplay()
             dx, dy, _dz = renderer.GetDisplayPoint()

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -41,9 +41,11 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
     from .VesselHighlightWiring import vascular_surface_polydata
+    from .VesselConnectivity import connected_component_at, nearest_point_on
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
     from VesselHighlightWiring import vascular_surface_polydata  # type: ignore[no-redef]
+    from VesselConnectivity import connected_component_at, nearest_point_on  # type: ignore[no-redef]
 
 #: Display-space pick radius for grabbing an existing point, in pixels
 #: (mirrors ``ControlPolygonPipeline.CONTROL_POINT_PICK_RADIUS_PX``).  A
@@ -106,6 +108,16 @@ class TerritoryPlacementPipeline(_PipelineBase):
         # Slicer interaction node / mouse mode.
         self._active_territory: str | None = None
         self._armed: bool = False
+
+        # Module-active gate (ADR-0037 slice-5 concern #1): a belt-and-
+        # suspenders decline BEYOND the armed flag -- an add-on-click places
+        # nothing while the owning module has EXPLICITLY closed the gate (its
+        # ``exit()``).  Rides the shared display node in production (read by
+        # ``IsModuleActive``); this instance field is the BARE-unit fallback
+        # (no display node).  Defaults OPEN -- the decline is opt-in, matching
+        # the display-node "unset reads active" rule -- so a Pipeline created
+        # before any ``enter()`` still lands a gesture.
+        self._module_active: bool = True
 
         # Injectable pick core (bare unit layer feeds a known surface); in
         # production ``_ensure_pick`` builds it from the display node's
@@ -187,6 +199,22 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._halo_actor.SetMapper(self._halo_mapper)
         self._halo_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
         self._halo_actor.SetVisibility(False)
+
+        # -- active-tree HIGHLIGHT (ADR-0037 slice 5, C5): a THIRD pipeline-
+        # owned actor (no new displayable manager, ADR-0013 §1) that paints the
+        # active territory's connected vessel tree while armed -- the seed[0]
+        # component recovered over the pick core's surface.  Styling is a plain
+        # semi-transparent tint (deferred); the pinned invariant is the INPUT
+        # identity == ``activeTreePolyData()``.  Cached per (surface MTime,
+        # seed) so the connectivity filter does not re-run per mouse event.
+        self._active_tree_polydata: Any | None = None
+        self._active_tree_cache_key: tuple | None = None
+        self._highlight_tree_mapper = vtk.vtkPolyDataMapper()
+        self._highlight_tree_actor = vtk.vtkActor()
+        self._highlight_tree_actor.SetMapper(self._highlight_tree_mapper)
+        self._highlight_tree_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
+        self._highlight_tree_actor.GetProperty().SetOpacity(0.3)
+        self._highlight_tree_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
     # Wiring seams (unit + production)
@@ -286,6 +314,22 @@ class TerritoryPlacementPipeline(_PipelineBase):
             return _state.is_armed(self._display_node)
         return self._armed
 
+    def SetModuleActive(self, active: bool) -> None:  # noqa: N802 - VTK verb
+        """Open/close the module-active add-on-click gate (concern #1).
+
+        The owning module's ``enter()`` / ``exit()`` flips this; an add-on-click
+        is declined while inactive, independent of the armed flag.  Rides the
+        shared display node in production, the instance field bare.
+        """
+        if self._display_node is not None:
+            _state.set_module_active(self._display_node, bool(active))
+        self._module_active = bool(active)
+
+    def IsModuleActive(self) -> bool:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            return _state.is_module_active(self._display_node)
+        return self._module_active
+
     def _placement_territory(self) -> str | None:
         """The territory a click appends into: the active one, else the bound one."""
         active = self.GetActiveTerritory()
@@ -314,6 +358,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
             if renderer is not None:
                 renderer.AddActor(self._seed_actor)
                 renderer.AddActor(self._marker_actor)
+                renderer.AddActor(self._highlight_tree_actor)
             self._attach_halo_renderer(renderer)
             # Renderer churn cleared the display handle; re-derive it from the
             # base's retained display node (the ControlPolygonPipeline
@@ -333,6 +378,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
             if renderer is not None:
                 renderer.RemoveActor(self._seed_actor)
                 renderer.RemoveActor(self._marker_actor)
+                renderer.RemoveActor(self._highlight_tree_actor)
             self._detach_halo_renderer()
             self._renderer = None
             self.cleanup()
@@ -449,6 +495,9 @@ class TerritoryPlacementPipeline(_PipelineBase):
         if adhering:
             point = display.GetAdheringPointWorld()
             self._marker_actor.SetPosition(point[0], point[1], point[2])
+        # Repaint the active-tree highlight alongside the hover marker so an
+        # arm / active-territory / seed change refreshes the painted tree.
+        self._reconcile_active_tree_highlight()
 
     # ------------------------------------------------------------------ #
     # Interaction — placement / edit (ADR-0032 / ADR-0033)
@@ -553,11 +602,20 @@ class TerritoryPlacementPipeline(_PipelineBase):
                 # NOT the instance flag.
                 if not self.IsArmed():
                     return False
+                # Module-active gate (ADR-0037 slice-5 concern #1): belt-and-
+                # suspenders beyond the armed flag -- decline while the owning
+                # module is inactive so no view lands a seed off-module.
+                if not self.IsModuleActive():
+                    return False
                 # Snap to the surface and add exactly one point to the active
                 # territory.
                 world = self._event_world_on_surface(renderer, eventData)
                 if world is None:
                     return False
+                # Active-tree constraint (ADR-0037 slice 5, C4): the first seed
+                # defines the tree; a later seed off the active component is
+                # re-snapped onto it, so a territory never straddles two trees.
+                world = self._constrain_to_active_tree(world)
                 self._add_point(world)
                 # Repaint immediately: the carrier observer's RequestRender does
                 # not flush a frame mid-interaction (the slice-pipeline lesson).
@@ -617,6 +675,72 @@ class TerritoryPlacementPipeline(_PipelineBase):
             return
         territory, index = target
         carrier.SetNthAnnotationPoint(territory, int(index), float(world[0]), float(world[1]), float(world[2]))
+
+    # ------------------------------------------------------------------ #
+    # Active-tree constraint + highlight (ADR-0037 slice 5, C4/C5)
+    # ------------------------------------------------------------------ #
+
+    def activeTreePolyData(self):  # noqa: N802 - project accessor convention
+        """The active territory's connected vessel tree, or ``None``.
+
+        Recovers the connected component of ``AnnotationPoints[territory][0]``
+        over the SAME surface the pick core holds (the injected surface under
+        test, the vessels-only mesh in production) via
+        ``VesselConnectivity.connected_component_at``.  Returns ``None`` when
+        there is no active territory, no seed, or no pick surface.  Cached per
+        (surface MTime, seed) so connectivity does not re-run per mouse event.
+        """
+        territory = self._placement_territory()
+        carrier = self._get_carrier()
+        if territory is None or carrier is None:
+            return None
+        if carrier.GetNumberOfAnnotationPoints(territory) == 0:
+            return None
+        pick = self._ensure_pick()
+        surface = pick.surface() if pick is not None else None
+        if surface is None:
+            return None
+        seed = tuple(carrier.GetNthAnnotationPoint(territory, 0))
+        key = (surface.GetMTime(), seed)
+        if key != self._active_tree_cache_key:
+            self._active_tree_polydata = connected_component_at(surface, seed)
+            self._active_tree_cache_key = key
+        return self._active_tree_polydata
+
+    def highlightActor(self):  # noqa: N802 - project accessor convention
+        """The pipeline-owned active-tree highlight actor (C5).
+
+        Its mapper input IS ``activeTreePolyData()`` while armed; hidden with an
+        empty input when nothing is armed.  A THIRD actor alongside the seed /
+        marker actors -- never a new pipeline on the same display-node type
+        (ADR-0013 §1).
+        """
+        self._reconcile_active_tree_highlight()
+        return self._highlight_tree_actor
+
+    def _reconcile_active_tree_highlight(self) -> None:
+        """Sync the highlight actor's input + visibility to the active tree."""
+        tree = self.activeTreePolyData() if self.IsArmed() else None
+        if tree is None:
+            self._highlight_tree_mapper.RemoveAllInputs()
+            self._highlight_tree_actor.SetVisibility(False)
+            return
+        self._highlight_tree_mapper.SetInputData(tree)
+        self._highlight_tree_actor.SetVisibility(True)
+
+    def _constrain_to_active_tree(self, world: Any):
+        """Re-snap ``world`` onto the active tree when it lands off-component.
+
+        First seed (no active tree yet) is accepted as-is.  A later seed whose
+        raw snap lands on a DIFFERENT connected component is re-snapped to the
+        nearest point on the active component (``vtkPointLocator``); a seed
+        already on the active tree is unchanged.
+        """
+        tree = self.activeTreePolyData()
+        if tree is None:
+            return world
+        snapped = nearest_point_on(tree, (float(world[0]), float(world[1]), float(world[2])))
+        return snapped if snapped is not None else world
 
     # ------------------------------------------------------------------ #
     # Geometry seams (monkeypatched in the unit layer)

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -40,11 +40,11 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
-    from .VesselHighlightWiring import vascular_surface_polydata
+    from .VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime
     from .VesselConnectivity import connected_component_at, nearest_point_on
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
-    from VesselHighlightWiring import vascular_surface_polydata  # type: ignore[no-redef]
+    from VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime  # type: ignore[no-redef]
     from VesselConnectivity import connected_component_at, nearest_point_on  # type: ignore[no-redef]
 
 #: Display-space pick radius for grabbing an existing point, in pixels
@@ -127,8 +127,12 @@ class TerritoryPlacementPipeline(_PipelineBase):
 
         # Injectable pick core (bare unit layer feeds a known surface); in
         # production ``_ensure_pick`` builds it from the display node's
-        # pickSurface.
+        # pickSurface.  ``_pick_injected`` distinguishes a test-injected core
+        # (never rebuilt) from a production-built one (rebuilt when segment
+        # visibility changes, tracked by ``_pick_surface_mtime``).
         self._pick: VesselSurfacePick | None = None
+        self._pick_injected: bool = False
+        self._pick_surface_mtime: int | None = None
 
         # (territory id, in-territory index) of the point currently GRABBED
         # by a press/move/release drag -- None when no drag is in flight.
@@ -231,6 +235,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
     def SetPickCore(self, pick: VesselSurfacePick | None) -> None:  # noqa: N802 - VTK verb
         """Inject the ``VesselSurfacePick`` over the target surface (unit seam)."""
         self._pick = pick
+        self._pick_injected = pick is not None
 
     def _ensure_pick(self) -> VesselSurfacePick | None:
         """Build the pick core against the display node's ``pickSurface`` mesh.
@@ -238,10 +243,15 @@ class TerritoryPlacementPipeline(_PipelineBase):
         Production (LayerDM-created) instances resolve the surface from the
         shared display node exactly as ``VesselHighlightPipeline`` does, so
         the click-snap and the hover marker adhere to the same mesh with no
-        injection.  A test-injected ``self._pick`` short-circuits this for the
-        bare unit layer.
+        injection.  A test-injected ``self._pick`` (``SetPickCore``)
+        short-circuits this for the bare unit layer.
+
+        The production pick is rebuilt when segment VISIBILITY changes (tracked
+        via the display node's MTime), so hiding a vessel in the structures
+        table removes it from collision detection live -- the cursor can only
+        snap to a visible vessel (ADR-0037 slice 5).
         """
-        if self._pick is not None:
+        if self._pick_injected:
             return self._pick
         display = self._display_node
         if display is None:
@@ -249,8 +259,13 @@ class TerritoryPlacementPipeline(_PipelineBase):
         segmentation = display.GetPickSurfaceNode()
         if segmentation is None:
             return None
-        # Vessels-only: the cursor snaps to a vessel, never the liver
-        # parenchyma or a tumour (ADR-0037 slice 5).
+        mtime = _visibility_mtime(segmentation)
+        if self._pick is not None and mtime == self._pick_surface_mtime:
+            return self._pick
+        # Visible vessels only: the cursor snaps to a vessel you can see, never
+        # the liver parenchyma, a tumour, or a hidden vessel (ADR-0037 slice 5).
+        self._pick = None
+        self._pick_surface_mtime = mtime
         polydata = vascular_surface_polydata(segmentation)
         if polydata is None:
             return None

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -41,11 +41,9 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
     from .VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime
-    from .VesselConnectivity import connected_component_at, nearest_point_on
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
     from VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime  # type: ignore[no-redef]
-    from VesselConnectivity import connected_component_at, nearest_point_on  # type: ignore[no-redef]
 
 #: Display-space pick radius for grabbing an existing point, in pixels
 #: (mirrors ``ControlPolygonPipeline.CONTROL_POINT_PICK_RADIUS_PX``).  A
@@ -59,12 +57,6 @@ POINT_PICK_RADIUS_PX = 20.0
 HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
 HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
 HALO_HOVER_SCALE = 1.6
-
-#: Active-tree glow colour -- a cyan halo around the armed vessel tree,
-#: distinct from the yellow seed-hover / green seed-grab cues.  Rendered
-#: through the same vtkOutlineGlowPass overlay as the seed halo, so the whole
-#: connected tree reads as a glow, not a flat surface tint (ADR-0037 slice 5).
-ACTIVE_TREE_GLOW_COLOR = (0.2, 0.8, 1.0)
 
 #: Interaction state lives on the shared highlight DISPLAY NODE, not on the
 #: Pipeline instance: LayerDM owns the Pipeline instance lifecycle (it creates
@@ -209,24 +201,6 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._halo_actor.SetMapper(self._halo_mapper)
         self._halo_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
         self._halo_actor.SetVisibility(False)
-
-        # -- active-tree HIGHLIGHT (ADR-0037 slice 5, C5): a THIRD pipeline-
-        # owned actor (no new displayable manager, ADR-0013 §1) that paints the
-        # active territory's connected vessel tree while armed -- the seed[0]
-        # component recovered over the pick core's surface.  Rendered through
-        # the shared vtkOutlineGlowPass overlay (see ``_attach_halo_renderer``)
-        # so the whole tree reads as a GLOW HALO, not a flat surface tint; the
-        # pinned invariant is the INPUT identity == ``activeTreePolyData()``.
-        # Cached per (surface MTime, seed) so connectivity does not re-run per
-        # mouse event.
-        self._active_tree_polydata: Any | None = None
-        self._active_tree_cache_key: tuple | None = None
-        self._highlight_tree_mapper = vtk.vtkPolyDataMapper()
-        self._highlight_tree_actor = vtk.vtkActor()
-        self._highlight_tree_actor.SetMapper(self._highlight_tree_mapper)
-        self._highlight_tree_actor.GetProperty().SetColor(*ACTIVE_TREE_GLOW_COLOR)
-        self._highlight_tree_actor.GetProperty().SetLighting(False)
-        self._highlight_tree_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
     # Wiring seams (unit + production)
@@ -429,10 +403,6 @@ class TerritoryPlacementPipeline(_PipelineBase):
             overlay.InteractiveOff()
             overlay.SetActiveCamera(renderer.GetActiveCamera())
             overlay.AddActor(self._halo_actor)
-            # Route the active-tree highlight through the glow pass too, so the
-            # armed vessel tree reads as a cyan HALO around the vessel rather
-            # than a flat surface tint (ADR-0037 slice 5).
-            overlay.AddActor(self._highlight_tree_actor)
             glow = getattr(vtk, "vtkOutlineGlowPass", None)
             steps = getattr(vtk, "vtkRenderStepsPass", None)
             if glow is not None and steps is not None:
@@ -526,9 +496,6 @@ class TerritoryPlacementPipeline(_PipelineBase):
             # adhering point WHILE AIMING (not just on the click), so the slice
             # marker tracks the cursor over the vessel in 3D (ADR-0037 slice 5).
             self._jump_slices_to_world(point)
-        # Repaint the active-tree highlight alongside the hover marker so an
-        # arm / active-territory / seed change refreshes the painted tree.
-        self._reconcile_active_tree_highlight()
 
     # ------------------------------------------------------------------ #
     # Interaction — placement / edit (ADR-0032 / ADR-0033)
@@ -643,10 +610,11 @@ class TerritoryPlacementPipeline(_PipelineBase):
                 world = self._event_world_on_surface(renderer, eventData)
                 if world is None:
                     return False
-                # Active-tree constraint (ADR-0037 slice 5, C4): the first seed
-                # defines the tree; a later seed off the active component is
-                # re-snapped onto it, so a territory never straddles two trees.
-                world = self._constrain_to_active_tree(world)
+                # A later seed is placed WHERE THE PICK SNAPS IT -- on the
+                # visible vessel under the cursor -- with no snap-back.  A
+                # territory may straddle disjoint structures (portal + hepatic);
+                # the visibility-gated pick is the only placement constraint
+                # (revised ADR-0037 slice 5, no straddle-snap).
                 self._add_point(world)
                 # Repaint immediately: the carrier observer's RequestRender does
                 # not flush a frame mid-interaction (the slice-pipeline lesson).
@@ -732,72 +700,6 @@ class TerritoryPlacementPipeline(_PipelineBase):
             return
         territory, index = target
         carrier.SetNthAnnotationPoint(territory, int(index), float(world[0]), float(world[1]), float(world[2]))
-
-    # ------------------------------------------------------------------ #
-    # Active-tree constraint + highlight (ADR-0037 slice 5, C4/C5)
-    # ------------------------------------------------------------------ #
-
-    def activeTreePolyData(self):  # noqa: N802 - project accessor convention
-        """The active territory's connected vessel tree, or ``None``.
-
-        Recovers the connected component of ``AnnotationPoints[territory][0]``
-        over the SAME surface the pick core holds (the injected surface under
-        test, the vessels-only mesh in production) via
-        ``VesselConnectivity.connected_component_at``.  Returns ``None`` when
-        there is no active territory, no seed, or no pick surface.  Cached per
-        (surface MTime, seed) so connectivity does not re-run per mouse event.
-        """
-        territory = self._placement_territory()
-        carrier = self._get_carrier()
-        if territory is None or carrier is None:
-            return None
-        if carrier.GetNumberOfAnnotationPoints(territory) == 0:
-            return None
-        pick = self._ensure_pick()
-        surface = pick.surface() if pick is not None else None
-        if surface is None:
-            return None
-        seed = tuple(carrier.GetNthAnnotationPoint(territory, 0))
-        key = (surface.GetMTime(), seed)
-        if key != self._active_tree_cache_key:
-            self._active_tree_polydata = connected_component_at(surface, seed)
-            self._active_tree_cache_key = key
-        return self._active_tree_polydata
-
-    def highlightActor(self):  # noqa: N802 - project accessor convention
-        """The pipeline-owned active-tree highlight actor (C5).
-
-        Its mapper input IS ``activeTreePolyData()`` while armed; hidden with an
-        empty input when nothing is armed.  A THIRD actor alongside the seed /
-        marker actors -- never a new pipeline on the same display-node type
-        (ADR-0013 §1).
-        """
-        self._reconcile_active_tree_highlight()
-        return self._highlight_tree_actor
-
-    def _reconcile_active_tree_highlight(self) -> None:
-        """Sync the highlight actor's input + visibility to the active tree."""
-        tree = self.activeTreePolyData() if self.IsArmed() else None
-        if tree is None:
-            self._highlight_tree_mapper.RemoveAllInputs()
-            self._highlight_tree_actor.SetVisibility(False)
-            return
-        self._highlight_tree_mapper.SetInputData(tree)
-        self._highlight_tree_actor.SetVisibility(True)
-
-    def _constrain_to_active_tree(self, world: Any):
-        """Re-snap ``world`` onto the active tree when it lands off-component.
-
-        First seed (no active tree yet) is accepted as-is.  A later seed whose
-        raw snap lands on a DIFFERENT connected component is re-snapped to the
-        nearest point on the active component (``vtkPointLocator``); a seed
-        already on the active tree is unchanged.
-        """
-        tree = self.activeTreePolyData()
-        if tree is None:
-            return world
-        snapped = nearest_point_on(tree, (float(world[0]), float(world[1]), float(world[2])))
-        return snapped if snapped is not None else world
 
     # ------------------------------------------------------------------ #
     # Geometry seams (monkeypatched in the unit layer)

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -667,6 +667,32 @@ class TerritoryPlacementPipeline(_PipelineBase):
         if carrier is None or territory is None:
             return
         carrier.AddAnnotationPoint(territory, float(world[0]), float(world[1]), float(world[2]))
+        # A seed placed in a 3D view leaves the 2D slices on whatever plane
+        # they were showing, so the projected slice marker floats off the
+        # seed's anatomy; reslice every slice plane onto the seed (mirrors
+        # LocatorReslicer, ADR-0025) so the 2D views show the slice through it.
+        self._jump_slices_to_world(world)
+
+    def _jump_slices_to_world(self, world: Any) -> None:
+        """Offset every slice view's plane onto ``world`` (JumpSliceByOffsetting).
+
+        Translates each plane along its OWN normal (orientation preserved), so
+        the 2D views reslice to the placed seed.  A no-op (never raising) when
+        the scene or the jump API is unavailable.
+        """
+        if world is None:
+            return
+        scene = self._display_node.GetScene() if self._display_node is not None else None
+        if scene is None:
+            carrier = self._get_carrier()
+            scene = carrier.GetScene() if carrier is not None else None
+        if scene is None:
+            return
+        for i in range(scene.GetNumberOfNodesByClass("vtkMRMLSliceNode")):
+            slice_node = scene.GetNthNodeByClass(i, "vtkMRMLSliceNode")
+            jump = getattr(slice_node, "JumpSliceByOffsetting", None)
+            if jump is not None:
+                jump(float(world[0]), float(world[1]), float(world[2]))
 
     def _relocate_grabbed_point(self, world: Any) -> None:
         carrier = self._get_carrier()

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -152,6 +152,13 @@ class TerritoryPlacementPipeline(_PipelineBase):
         # not the only path); tracked to avoid double-observing.
         self._observed_carrier: Any | None = None
 
+        # The pickSurface segmentation's DISPLAY node, observed so a
+        # segment-visibility toggle in the structures table repaints the seed
+        # glyphs (the seed filter is visibility-aware, but a visibility change
+        # modifies the SEGMENTATION display node -- not the carrier -- so the
+        # glyph rebuild needs its own trigger; ADR-0037 slice 5).
+        self._observed_pick_display: Any | None = None
+
         # -- placed-seed rendering (ADR-0037 §Decision 2): the persistent
         # markers for the carrier's annotation points, glyphed as spheres and
         # coloured per territory from the carrier's display slot.  One actor
@@ -457,6 +464,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
             self._detach_observer(node)
         self._carrier = None
         self._observed_carrier = None
+        self._observed_pick_display = None
         self._drag_target = None
         self._hover_target = None
         self._halo_actor.SetVisibility(False)
@@ -477,6 +485,27 @@ class TerritoryPlacementPipeline(_PipelineBase):
         if carrier is not None:
             self._attach_observer(carrier)
 
+    def _ensure_pick_surface_observed(self) -> None:
+        """Observe the pickSurface segmentation's display node for visibility.
+
+        A segment show/hide modifies the segmentation's DISPLAY node; observe
+        it so the seed glyphs repaint (dropping/restoring a hidden structure's
+        seeds) without a carrier edit.  Re-attaches when the resolved display
+        node changes; idempotent.
+        """
+        display = self._display_node
+        segmentation = (display.GetPickSurfaceNode()
+                        if display is not None and hasattr(display, "GetPickSurfaceNode")
+                        else None)
+        seg_display = segmentation.GetDisplayNode() if segmentation is not None else None
+        if seg_display is self._observed_pick_display:
+            return
+        if self._observed_pick_display is not None:
+            self._detach_observer(self._observed_pick_display)
+        self._observed_pick_display = seg_display
+        if seg_display is not None:
+            self._attach_observer(seg_display)
+
     def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
         """LayerDM's re-sync hook (display-node Modified).
 
@@ -488,6 +517,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
         """
         try:
             self._ensure_carrier_observed()
+            self._ensure_pick_surface_observed()
             self._rebuild_seed_actor()
             self._reconcile_highlight()
         except Exception:  # pragma: no cover - C++ boundary must never raise
@@ -504,6 +534,9 @@ class TerritoryPlacementPipeline(_PipelineBase):
         if display is None or not hasattr(display, "GetAdhering"):
             self._marker_actor.SetVisibility(False)
             return
+        # Attach the segment-visibility observer once the pickSurface is wired
+        # (idempotent) so a later structures-table show/hide repaints the seeds.
+        self._ensure_pick_surface_observed()
         try:
             self._marker_sphere.SetRadius(float(display.GetRadius()))
         except Exception:  # pragma: no cover - defensive

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -40,10 +40,20 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
-    from .VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime
+    from .VesselHighlightWiring import (
+        vascular_surface_polydata,
+        seed_structure_visible as _seed_structure_visible,
+        visibility_mtime as _visibility_mtime,
+        VisibleStructuresCache as _VisibleStructuresCache,
+    )
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
-    from VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime  # type: ignore[no-redef]
+    from VesselHighlightWiring import (  # type: ignore[no-redef]
+        vascular_surface_polydata,
+        seed_structure_visible as _seed_structure_visible,
+        visibility_mtime as _visibility_mtime,
+        VisibleStructuresCache as _VisibleStructuresCache,
+    )
 
 #: Display-space pick radius for grabbing an existing point, in pixels
 #: (mirrors ``ControlPolygonPipeline.CONTROL_POINT_PICK_RADIUS_PX``).  A
@@ -125,6 +135,13 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._pick: VesselSurfacePick | None = None
         self._pick_injected: bool = False
         self._pick_surface_mtime: int | None = None
+
+        # Per-segment vessel structures (segId, surface, visible) for the
+        # seed-glyph show/hide follow (ADR-0037 slice 5), cached by the display
+        # node's visibility MTime so a show/hide repaints the seeds without
+        # re-running the closed-surface split per event (kept cheap, mirroring
+        # ``_ensure_pick``).
+        self._structures = _VisibleStructuresCache()
 
         # (territory id, in-territory index) of the point currently GRABBED
         # by a press/move/release drag -- None when no drag is in flight.
@@ -245,6 +262,15 @@ class TerritoryPlacementPipeline(_PipelineBase):
             return None
         self._pick = VesselSurfacePick(polydata)
         return self._pick
+
+    def _visible_structures(self) -> list:
+        """The per-segment vessel structures ``[(segId, surface, visible)]``.
+
+        Resolved + cached via the shared ``VisibleStructuresCache`` from the
+        display node's ``pickSurface`` (ADR-0037 slice 5); ``[]`` under a
+        test-injected pick (no segmentation) -> seeds are never hidden bare.
+        """
+        return self._structures.resolve(self._display_node)
 
     def SetCarrier(self, carrier: Any, territoryId: str) -> None:  # noqa: N802 - VTK verb
         """Bind the ``vtkMRMLCustomTerritoriesNode`` carrier + active territory.
@@ -891,14 +917,17 @@ class TerritoryPlacementPipeline(_PipelineBase):
 
         The carrier is the source of truth: read every visible territory's
         points, glyph each as a sphere tinted with the territory's display
-        colour (ADR-0037 §Decision 1 display slot).  A no-op-safe rebuild — an
-        empty carrier clears the glyphs.
+        colour (ADR-0037 §Decision 1 display slot).  A seed whose STRUCTURE
+        (nearest input segment) is hidden via the structures table is OMITTED,
+        so hiding a vessel hides its seeds live (ADR-0037 slice 5).  A
+        no-op-safe rebuild — an empty carrier clears the glyphs.
         """
         self._seed_points.Reset()
         self._seed_colors.Reset()
         self._seed_colors.SetNumberOfComponents(3)
         grab_rgb = tuple(int(c * 255) for c in HALO_GRAB_COLOR)
         hover_rgb = tuple(int(c * 255) for c in HALO_HOVER_COLOR)
+        structures = self._visible_structures()
         carrier = self._get_carrier()
         if carrier is not None:
             for territory in carrier.GetAnnotationTerritoryIds():
@@ -913,6 +942,9 @@ class TerritoryPlacementPipeline(_PipelineBase):
                 count = carrier.GetNumberOfAnnotationPoints(territory)
                 for i in range(count):
                     point = carrier.GetNthAnnotationPoint(territory, i)
+                    # Omit a seed whose structure is hidden (ADR-0037 slice 5).
+                    if not _seed_structure_visible(structures, point):
+                        continue
                     self._seed_points.InsertNextPoint(point[0], point[1], point[2])
                     key = (territory, i)
                     if key == self._drag_target:

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -495,6 +495,10 @@ class TerritoryPlacementPipeline(_PipelineBase):
         if adhering:
             point = display.GetAdheringPointWorld()
             self._marker_actor.SetPosition(point[0], point[1], point[2])
+            # Follow the hovered vessel point: reslice the 2D views to the
+            # adhering point WHILE AIMING (not just on the click), so the slice
+            # marker tracks the cursor over the vessel in 3D (ADR-0037 slice 5).
+            self._jump_slices_to_world(point)
         # Repaint the active-tree highlight alongside the hover marker so an
         # arm / active-territory / seed change refreshes the painted tree.
         self._reconcile_active_tree_highlight()

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -48,11 +48,13 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
     from .VesselHighlightWiring import vascular_surface_polydata
+    from .VesselConnectivity import connected_component_at, nearest_point_on
     from . import TerritoryInteractionState as _state
     from . import TerritorySliceProjection as _proj
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
     from VesselHighlightWiring import vascular_surface_polydata  # type: ignore[no-redef]
+    from VesselConnectivity import connected_component_at, nearest_point_on  # type: ignore[no-redef]
     import TerritoryInteractionState as _state  # type: ignore[no-redef]
     import TerritorySliceProjection as _proj  # type: ignore[no-redef]
 
@@ -110,6 +112,16 @@ class TerritorySlicePipeline(_PipelineBase):
         # production ``_ensure_pick`` builds it from the display node's
         # pickSurface (the ``TerritoryPlacementPipeline`` precedent).
         self._pick: VesselSurfacePick | None = None
+
+        # Module-active gate (ADR-0037 slice-5 concern #1) + active-tree cache
+        # (C4/C5).  The gate rides the shared display node in production (read
+        # by ``IsModuleActive``), the instance field bare; defaults OPEN (the
+        # decline is opt-in, matching the display-node "unset reads active"
+        # rule).  The recovered tree is cached per (surface MTime, seed) so
+        # connectivity does not re-run per mouse event.
+        self._module_active: bool = True
+        self._active_tree_polydata: Any | None = None
+        self._active_tree_cache_key: tuple | None = None
 
         # Projected-seed bookkeeping (pick arbitration): parallel lists of
         # (territoryId, index) keys, their XY positions, and |distance| to
@@ -232,6 +244,26 @@ class TerritorySlicePipeline(_PipelineBase):
 
     def _is_armed(self) -> bool:
         return _state.is_armed(self._display_node)
+
+    def SetActiveTerritory(self, territoryId: str | None) -> None:  # noqa: N802 - VTK verb
+        """Set the territory an armed slice click appends into (the ACTIVE one)."""
+        _state.set_active_territory(self._display_node, territoryId)
+
+    def SetModuleActive(self, active: bool) -> None:  # noqa: N802 - VTK verb
+        """Open/close the module-active add-on-click gate (concern #1).
+
+        Mirrors ``TerritoryPlacementPipeline``: a slice add-on-click is declined
+        while the owning module is inactive, independent of the armed flag.
+        Rides the shared display node in production, the instance field bare.
+        """
+        if self._display_node is not None:
+            _state.set_module_active(self._display_node, bool(active))
+        self._module_active = bool(active)
+
+    def IsModuleActive(self) -> bool:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            return _state.is_module_active(self._display_node)
+        return self._module_active
 
     def _safe_get_renderer(self) -> Any | None:
         return self._renderer
@@ -545,9 +577,16 @@ class TerritorySlicePipeline(_PipelineBase):
                     return True
                 if not self._is_armed():
                     return False  # a disarmed click adds nothing
+                # Module-active gate (ADR-0037 slice-5 concern #1): decline
+                # while the owning module is inactive, beyond the armed flag.
+                if not self.IsModuleActive():
+                    return False
                 world = self._snap_event_to_surface(eventData)
                 if world is None:
                     return False
+                # Active-tree constraint (ADR-0037 slice 5, C4): a later seed
+                # off the active component is re-snapped onto it.
+                world = self._constrain_to_active_tree(world)
                 self._add_point(world)
                 # Repaint THIS slice immediately: a RequestRender from the
                 # carrier observer does not flush a frame mid-interaction (the
@@ -630,6 +669,50 @@ class TerritorySlicePipeline(_PipelineBase):
             return
         territory, index = target
         carrier.SetNthAnnotationPoint(territory, int(index), float(world[0]), float(world[1]), float(world[2]))
+
+    # ------------------------------------------------------------------ #
+    # Active-tree constraint (ADR-0037 slice 5, C4) -- shared with the 3D pipeline
+    # ------------------------------------------------------------------ #
+
+    def activeTreePolyData(self):  # noqa: N802 - project accessor convention
+        """The active territory's connected vessel tree, or ``None``.
+
+        The 2D twin of ``TerritoryPlacementPipeline.activeTreePolyData``:
+        recovers the connected component of
+        ``AnnotationPoints[territory][0]`` over the SAME surface the pick core
+        holds (vessels-only in production).  Cached per (surface MTime, seed).
+        """
+        territory = self._placement_territory()
+        carrier = self._get_carrier()
+        if territory is None or carrier is None:
+            return None
+        if carrier.GetNumberOfAnnotationPoints(territory) == 0:
+            return None
+        pick = self._ensure_pick()
+        surface = pick.surface() if pick is not None else None
+        if surface is None:
+            return None
+        seed = tuple(carrier.GetNthAnnotationPoint(territory, 0))
+        key = (surface.GetMTime(), seed)
+        if key != self._active_tree_cache_key:
+            self._active_tree_polydata = connected_component_at(surface, seed)
+            self._active_tree_cache_key = key
+        return self._active_tree_polydata
+
+    def _constrain_to_active_tree(self, world: Any):
+        """Re-snap ``world`` onto the active tree when it lands off-component.
+
+        First seed (no active tree yet) is accepted as-is; a later seed off the
+        active component is re-snapped to its nearest point (``vtkPointLocator``),
+        so a territory never straddles two vessel trees.  The snap runs in world
+        space, so the slice-normal ray result feeds the SAME gate as the 3D
+        camera-ray result.
+        """
+        tree = self.activeTreePolyData()
+        if tree is None:
+            return world
+        snapped = nearest_point_on(tree, (float(world[0]), float(world[1]), float(world[2])))
+        return snapped if snapped is not None else world
 
     # ------------------------------------------------------------------ #
     # Cross-view adhering highlight (publish on hover / render the marker)

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -47,12 +47,12 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
-    from .VesselHighlightWiring import closed_surface_polydata
+    from .VesselHighlightWiring import vascular_surface_polydata
     from . import TerritoryInteractionState as _state
     from . import TerritorySliceProjection as _proj
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
-    from VesselHighlightWiring import closed_surface_polydata  # type: ignore[no-redef]
+    from VesselHighlightWiring import vascular_surface_polydata  # type: ignore[no-redef]
     import TerritoryInteractionState as _state  # type: ignore[no-redef]
     import TerritorySliceProjection as _proj  # type: ignore[no-redef]
 
@@ -214,7 +214,9 @@ class TerritorySlicePipeline(_PipelineBase):
         segmentation = display.GetPickSurfaceNode()
         if segmentation is None:
             return None
-        polydata = closed_surface_polydata(segmentation)
+        # Vessels-only: the cursor snaps to a vessel, never the liver
+        # parenchyma or a tumour (ADR-0037 slice 5).
+        polydata = vascular_surface_polydata(segmentation)
         if polydata is None:
             return None
         self._pick = VesselSurfacePick(polydata)

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -47,13 +47,13 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
-    from .VesselHighlightWiring import vascular_surface_polydata
+    from .VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime
     from .VesselConnectivity import connected_component_at, nearest_point_on
     from . import TerritoryInteractionState as _state
     from . import TerritorySliceProjection as _proj
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
-    from VesselHighlightWiring import vascular_surface_polydata  # type: ignore[no-redef]
+    from VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime  # type: ignore[no-redef]
     from VesselConnectivity import connected_component_at, nearest_point_on  # type: ignore[no-redef]
     import TerritoryInteractionState as _state  # type: ignore[no-redef]
     import TerritorySliceProjection as _proj  # type: ignore[no-redef]
@@ -110,8 +110,11 @@ class TerritorySlicePipeline(_PipelineBase):
 
         # Injectable pick core (bare unit layer feeds a known surface); in
         # production ``_ensure_pick`` builds it from the display node's
-        # pickSurface (the ``TerritoryPlacementPipeline`` precedent).
+        # pickSurface (the ``TerritoryPlacementPipeline`` precedent), rebuilt
+        # when segment visibility changes (``_pick_surface_mtime``).
         self._pick: VesselSurfacePick | None = None
+        self._pick_injected: bool = False
+        self._pick_surface_mtime: int | None = None
 
         # Module-active gate (ADR-0037 slice-5 concern #1) + active-tree cache
         # (C4/C5).  The gate rides the shared display node in production (read
@@ -209,16 +212,18 @@ class TerritorySlicePipeline(_PipelineBase):
     def SetPickCore(self, pick: VesselSurfacePick | None) -> None:  # noqa: N802 - VTK verb
         """Inject the ``VesselSurfacePick`` over the target surface (unit seam)."""
         self._pick = pick
+        self._pick_injected = pick is not None
 
     def _ensure_pick(self) -> VesselSurfacePick | None:
         """Build the pick core against the display node's ``pickSurface`` mesh.
 
         Production instances resolve the surface from the shared display node
         exactly as ``TerritoryPlacementPipeline`` does, so the 2D and 3D snaps
-        adhere to the SAME mesh.  A test-injected ``self._pick`` short-circuits
-        this for the bare unit layer.
+        adhere to the SAME mesh (and both drop a hidden vessel from collision
+        detection on a visibility change).  A test-injected ``self._pick``
+        short-circuits this for the bare unit layer.
         """
-        if self._pick is not None:
+        if self._pick_injected:
             return self._pick
         display = self._display_node
         if display is None:
@@ -226,8 +231,13 @@ class TerritorySlicePipeline(_PipelineBase):
         segmentation = display.GetPickSurfaceNode()
         if segmentation is None:
             return None
-        # Vessels-only: the cursor snaps to a vessel, never the liver
-        # parenchyma or a tumour (ADR-0037 slice 5).
+        mtime = _visibility_mtime(segmentation)
+        if self._pick is not None and mtime == self._pick_surface_mtime:
+            return self._pick
+        # Visible vessels only (ADR-0037 slice 5): the cursor snaps to a vessel
+        # you can see, never the parenchyma, a tumour, or a hidden vessel.
+        self._pick = None
+        self._pick_surface_mtime = mtime
         polydata = vascular_surface_polydata(segmentation)
         if polydata is None:
             return None

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -48,13 +48,11 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
     from .VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime
-    from .VesselConnectivity import connected_component_at, nearest_point_on
     from . import TerritoryInteractionState as _state
     from . import TerritorySliceProjection as _proj
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
     from VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime  # type: ignore[no-redef]
-    from VesselConnectivity import connected_component_at, nearest_point_on  # type: ignore[no-redef]
     import TerritoryInteractionState as _state  # type: ignore[no-redef]
     import TerritorySliceProjection as _proj  # type: ignore[no-redef]
 
@@ -116,15 +114,11 @@ class TerritorySlicePipeline(_PipelineBase):
         self._pick_injected: bool = False
         self._pick_surface_mtime: int | None = None
 
-        # Module-active gate (ADR-0037 slice-5 concern #1) + active-tree cache
-        # (C4/C5).  The gate rides the shared display node in production (read
-        # by ``IsModuleActive``), the instance field bare; defaults OPEN (the
-        # decline is opt-in, matching the display-node "unset reads active"
-        # rule).  The recovered tree is cached per (surface MTime, seed) so
-        # connectivity does not re-run per mouse event.
+        # Module-active gate (ADR-0037 slice-5 concern #1).  The gate rides the
+        # shared display node in production (read by ``IsModuleActive``), the
+        # instance field bare; defaults OPEN (the decline is opt-in, matching
+        # the display-node "unset reads active" rule).
         self._module_active: bool = True
-        self._active_tree_polydata: Any | None = None
-        self._active_tree_cache_key: tuple | None = None
 
         # Projected-seed bookkeeping (pick arbitration): parallel lists of
         # (territoryId, index) keys, their XY positions, and |distance| to
@@ -594,9 +588,10 @@ class TerritorySlicePipeline(_PipelineBase):
                 world = self._snap_event_to_surface(eventData)
                 if world is None:
                     return False
-                # Active-tree constraint (ADR-0037 slice 5, C4): a later seed
-                # off the active component is re-snapped onto it.
-                world = self._constrain_to_active_tree(world)
+                # A later seed is placed WHERE THE PICK SNAPS IT, with no
+                # snap-back: a territory may straddle disjoint structures and
+                # the visibility-gated pick is the only placement constraint
+                # (revised ADR-0037 slice 5, no straddle-snap).
                 self._add_point(world)
                 # Repaint THIS slice immediately: a RequestRender from the
                 # carrier observer does not flush a frame mid-interaction (the
@@ -679,50 +674,6 @@ class TerritorySlicePipeline(_PipelineBase):
             return
         territory, index = target
         carrier.SetNthAnnotationPoint(territory, int(index), float(world[0]), float(world[1]), float(world[2]))
-
-    # ------------------------------------------------------------------ #
-    # Active-tree constraint (ADR-0037 slice 5, C4) -- shared with the 3D pipeline
-    # ------------------------------------------------------------------ #
-
-    def activeTreePolyData(self):  # noqa: N802 - project accessor convention
-        """The active territory's connected vessel tree, or ``None``.
-
-        The 2D twin of ``TerritoryPlacementPipeline.activeTreePolyData``:
-        recovers the connected component of
-        ``AnnotationPoints[territory][0]`` over the SAME surface the pick core
-        holds (vessels-only in production).  Cached per (surface MTime, seed).
-        """
-        territory = self._placement_territory()
-        carrier = self._get_carrier()
-        if territory is None or carrier is None:
-            return None
-        if carrier.GetNumberOfAnnotationPoints(territory) == 0:
-            return None
-        pick = self._ensure_pick()
-        surface = pick.surface() if pick is not None else None
-        if surface is None:
-            return None
-        seed = tuple(carrier.GetNthAnnotationPoint(territory, 0))
-        key = (surface.GetMTime(), seed)
-        if key != self._active_tree_cache_key:
-            self._active_tree_polydata = connected_component_at(surface, seed)
-            self._active_tree_cache_key = key
-        return self._active_tree_polydata
-
-    def _constrain_to_active_tree(self, world: Any):
-        """Re-snap ``world`` onto the active tree when it lands off-component.
-
-        First seed (no active tree yet) is accepted as-is; a later seed off the
-        active component is re-snapped to its nearest point (``vtkPointLocator``),
-        so a territory never straddles two vessel trees.  The snap runs in world
-        space, so the slice-normal ray result feeds the SAME gate as the 3D
-        camera-ray result.
-        """
-        tree = self.activeTreePolyData()
-        if tree is None:
-            return world
-        snapped = nearest_point_on(tree, (float(world[0]), float(world[1]), float(world[2])))
-        return snapped if snapped is not None else world
 
     # ------------------------------------------------------------------ #
     # Cross-view adhering highlight (publish on hover / render the marker)

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -49,7 +49,6 @@ try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
     from .VesselHighlightWiring import (
         vascular_surface_polydata,
-        seed_structure_visible as _seed_structure_visible,
         visibility_mtime as _visibility_mtime,
         VisibleStructuresCache as _VisibleStructuresCache,
     )
@@ -59,7 +58,6 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
     from VesselHighlightWiring import (  # type: ignore[no-redef]
         vascular_surface_polydata,
-        seed_structure_visible as _seed_structure_visible,
         visibility_mtime as _visibility_mtime,
         VisibleStructuresCache as _VisibleStructuresCache,
     )
@@ -475,7 +473,6 @@ class TerritorySlicePipeline(_PipelineBase):
 
         hover_rgb = [int(c * 255) for c in HALO_HOVER_COLOR]
         grab_rgb = [int(c * 255) for c in HALO_GRAB_COLOR]
-        structures = self._visible_structures()
         points = vtk.vtkPoints()
         rgba = vtk.vtkUnsignedCharArray()
         rgba.SetNumberOfComponents(4)
@@ -488,8 +485,9 @@ class TerritorySlicePipeline(_PipelineBase):
                 count = carrier.GetNumberOfAnnotationPoints(territory)
                 for i in range(count):
                     point = carrier.GetNthAnnotationPoint(territory, i)
-                    # Omit a seed whose structure is hidden (ADR-0037 slice 5).
-                    if not _seed_structure_visible(structures, point):
+                    # Omit a seed whose structure is hidden (ADR-0037 slice 5);
+                    # cached per-structure locators keep this O(log n) per seed.
+                    if not self._structures.seed_visible(self._display_node, point):
                         continue
                     signed = _proj.signed_distance(origin, normal, point)
                     if not _proj.is_present(signed):

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -115,6 +115,11 @@ class TerritorySlicePipeline(_PipelineBase):
         self._observer_tags: dict = {}
         self._observed_node_refs: list = []
         self._observed_carrier: Any | None = None
+        # The pickSurface segmentation's display node, observed so a
+        # structures-table show/hide reprojects the 2D seeds (a visibility
+        # change modifies the segmentation display node, not the carrier;
+        # ADR-0037 slice 5).
+        self._observed_pick_display: Any | None = None
 
         # Injectable pick core (bare unit layer feeds a known surface); in
         # production ``_ensure_pick`` builds it from the display node's
@@ -369,6 +374,7 @@ class TerritorySlicePipeline(_PipelineBase):
         """
         try:
             self._ensure_carrier_observed()
+            self._ensure_pick_surface_observed()
             self._reproject()
             self._reconcile_highlight()
         except Exception:  # pragma: no cover - C++ boundary must never raise
@@ -396,6 +402,7 @@ class TerritorySlicePipeline(_PipelineBase):
         self._display_node = None
         self._slice_node = None
         self._observed_carrier = None
+        self._observed_pick_display = None
         self._drag_target = None
         self._hover_target = None
         self._seed_actor.SetVisibility(False)
@@ -412,6 +419,27 @@ class TerritorySlicePipeline(_PipelineBase):
         self._observed_carrier = carrier
         if carrier is not None:
             self._attach_observer(carrier)
+
+    def _ensure_pick_surface_observed(self) -> None:
+        """Observe the pickSurface segmentation's display node for visibility.
+
+        A segment show/hide modifies the segmentation display node (not the
+        carrier); observe it so the 2D seeds reproject -- dropping/restoring a
+        hidden structure's seeds -- via ``_on_node_modified`` (which reprojects
+        for any non-display-node caller).  Idempotent; re-attaches on change.
+        """
+        display = self._display_node
+        segmentation = (display.GetPickSurfaceNode()
+                        if display is not None and hasattr(display, "GetPickSurfaceNode")
+                        else None)
+        seg_display = segmentation.GetDisplayNode() if segmentation is not None else None
+        if seg_display is self._observed_pick_display:
+            return
+        if self._observed_pick_display is not None:
+            self._detach_observer(self._observed_pick_display)
+        self._observed_pick_display = seg_display
+        if seg_display is not None:
+            self._attach_observer(seg_display)
 
     # ------------------------------------------------------------------ #
     # Rendering (viz) -- fading projection into the slice XY

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -47,12 +47,22 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
-    from .VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime
+    from .VesselHighlightWiring import (
+        vascular_surface_polydata,
+        seed_structure_visible as _seed_structure_visible,
+        visibility_mtime as _visibility_mtime,
+        VisibleStructuresCache as _VisibleStructuresCache,
+    )
     from . import TerritoryInteractionState as _state
     from . import TerritorySliceProjection as _proj
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
-    from VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime  # type: ignore[no-redef]
+    from VesselHighlightWiring import (  # type: ignore[no-redef]
+        vascular_surface_polydata,
+        seed_structure_visible as _seed_structure_visible,
+        visibility_mtime as _visibility_mtime,
+        VisibleStructuresCache as _VisibleStructuresCache,
+    )
     import TerritoryInteractionState as _state  # type: ignore[no-redef]
     import TerritorySliceProjection as _proj  # type: ignore[no-redef]
 
@@ -113,6 +123,11 @@ class TerritorySlicePipeline(_PipelineBase):
         self._pick: VesselSurfacePick | None = None
         self._pick_injected: bool = False
         self._pick_surface_mtime: int | None = None
+
+        # Per-segment vessel structures (segId, surface, visible) for the
+        # projected-seed show/hide follow (ADR-0037 slice 5), cached by the
+        # display node's visibility MTime (the ``_ensure_pick`` pattern).
+        self._structures = _VisibleStructuresCache()
 
         # Module-active gate (ADR-0037 slice-5 concern #1).  The gate rides the
         # shared display node in production (read by ``IsModuleActive``), the
@@ -237,6 +252,15 @@ class TerritorySlicePipeline(_PipelineBase):
             return None
         self._pick = VesselSurfacePick(polydata)
         return self._pick
+
+    def _visible_structures(self) -> list:
+        """The per-segment vessel structures ``[(segId, surface, visible)]``.
+
+        Resolved + cached via the shared ``VisibleStructuresCache`` from the
+        display node's ``pickSurface`` (the ``TerritoryPlacementPipeline``
+        seam); ``[]`` under a test-injected pick -> seeds are never hidden bare.
+        """
+        return self._structures.resolve(self._display_node)
 
     def _get_carrier(self) -> Any | None:
         """The carrier the shared display node binds (the 3D-pipeline seam)."""
@@ -423,6 +447,7 @@ class TerritorySlicePipeline(_PipelineBase):
 
         hover_rgb = [int(c * 255) for c in HALO_HOVER_COLOR]
         grab_rgb = [int(c * 255) for c in HALO_GRAB_COLOR]
+        structures = self._visible_structures()
         points = vtk.vtkPoints()
         rgba = vtk.vtkUnsignedCharArray()
         rgba.SetNumberOfComponents(4)
@@ -435,6 +460,9 @@ class TerritorySlicePipeline(_PipelineBase):
                 count = carrier.GetNumberOfAnnotationPoints(territory)
                 for i in range(count):
                     point = carrier.GetNthAnnotationPoint(territory, i)
+                    # Omit a seed whose structure is hidden (ADR-0037 slice 5).
+                    if not _seed_structure_visible(structures, point):
+                        continue
                     signed = _proj.signed_distance(origin, normal, point)
                     if not _proj.is_present(signed):
                         continue  # HARD presence cutoff

--- a/VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Connected-vessel-tree recovery for the centerline feed (ADR-0037 slice 5).
+
+The compute amendment resolved the VMTK input surface by MERGING every
+segment; real liver data (parenchyma + portal + hepatic + tumour in one
+node) makes merge-all wrong — portal and hepatic veins are DISJOINT connected
+components and a medial path tunnelling between them is meaningless.  Slice 5
+narrows a territory's active surface to the SINGLE connected component its
+first seed lands on (``AnnotationPoints[territory][0]`` is the RESOLVED
+connectivity seed, per the ADR's "reuse index-0" persistence decision).
+
+This module is a PURE-VTK helper: no MRML scene, no Slicer, no Qt, no GL — so
+it runs on the bare unit layer.  ``vtkPolyDataConnectivityFilter`` is fully
+Python-wrapped and has no C++-only dependency, so per the ADR-0004 split the
+connectivity (pure polydata) lives in Python while the SCT segment filter (it
+reads MRML segment tags) stays on the C++ Logic.
+
+See also:
+  * Docs/adr/0037-vascular-territories-off-markups.md
+    (§Amendment — connected-tree-constrained centerline seeding (slice 5))
+  * Docs/adr/0004-python-cpp-boundary.md
+  * VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
+    (closed_surface_polydata — the merge-all surface this supersedes)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from collections.abc import Sequence
+
+import vtk
+
+
+def connected_component_at(polydata: Any, seed: Sequence[float]):
+    """The single connected component of ``polydata`` containing ``seed``.
+
+    Runs ``vtkPolyDataConnectivityFilter`` in ``ClosestPointRegion`` mode
+    seeded at the world coordinate ``seed`` (a sequence of three floats) and
+    returns the one connected region whose closest point is nearest ``seed``.
+    Disjoint components (e.g. portal vs hepatic vessel systems) are never fused
+    into the returned tree.
+
+    Returns ``None`` when ``polydata`` is ``None`` / empty; otherwise a
+    ``vtkPolyData`` holding only the seed's component.
+    """
+    if polydata is None or polydata.GetNumberOfPoints() == 0:
+        return None
+
+    connectivity = vtk.vtkPolyDataConnectivityFilter()
+    connectivity.SetInputData(polydata)
+    connectivity.SetExtractionModeToClosestPointRegion()
+    connectivity.SetClosestPoint(seed[0], seed[1], seed[2])
+    connectivity.Update()
+
+    # ClosestPointRegion keeps the region's cells but leaves the input's
+    # unused points in place; clean the output so the recovered component's
+    # point count reflects only its own region (the invariant tests assert on
+    # the point count).
+    cleaner = vtk.vtkCleanPolyData()
+    cleaner.SetInputConnection(connectivity.GetOutputPort())
+    cleaner.PointMergingOff()
+    cleaner.Update()
+    return cleaner.GetOutput()

--- a/VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
@@ -62,3 +62,22 @@ def connected_component_at(polydata: Any, seed: Sequence[float]):
     cleaner.PointMergingOff()
     cleaner.Update()
     return cleaner.GetOutput()
+
+
+def nearest_point_on(polydata: Any, point: Sequence[float]):
+    """The point of ``polydata`` nearest ``point``, or ``None`` when empty.
+
+    Used by the placement pipelines to re-snap an off-tree later seed onto the
+    active connected component (ADR-0037 slice 5, C4).  Pure-VTK
+    (``vtkPointLocator``) so it stays on the bare unit layer alongside
+    ``connected_component_at``.
+    """
+    if polydata is None or polydata.GetNumberOfPoints() == 0:
+        return None
+    locator = vtk.vtkPointLocator()
+    locator.SetDataSet(polydata)
+    locator.BuildLocator()
+    closest_id = locator.FindClosestPoint(point[0], point[1], point[2])
+    if closest_id < 0:
+        return None
+    return tuple(polydata.GetPoint(closest_id))

--- a/VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselConnectivity.py
@@ -1,14 +1,15 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
-"""Connected-vessel-tree recovery for the centerline feed (ADR-0037 slice 5).
+"""Connected-component recovery for the centerline feed (ADR-0037 slice 5).
 
 The compute amendment resolved the VMTK input surface by MERGING every
 segment; real liver data (parenchyma + portal + hepatic + tumour in one
 node) makes merge-all wrong — portal and hepatic veins are DISJOINT connected
-components and a medial path tunnelling between them is meaningless.  Slice 5
-narrows a territory's active surface to the SINGLE connected component its
-first seed lands on (``AnnotationPoints[territory][0]`` is the RESOLVED
-connectivity seed, per the ADR's "reuse index-0" persistence decision).
+components and a medial path tunnelling between them is meaningless.  The
+revised multi-system design GROUPS a territory's seeds by structure and
+narrows each PER-STRUCTURE surface to the SINGLE connected component the
+structure's own seed lands on, so a single input segment that accidentally
+carries two disjoint tubes still feeds VMTK one coherent tree.
 
 This module is a PURE-VTK helper: no MRML scene, no Slicer, no Qt, no GL — so
 it runs on the bare unit layer.  ``vtkPolyDataConnectivityFilter`` is fully
@@ -62,22 +63,3 @@ def connected_component_at(polydata: Any, seed: Sequence[float]):
     cleaner.PointMergingOff()
     cleaner.Update()
     return cleaner.GetOutput()
-
-
-def nearest_point_on(polydata: Any, point: Sequence[float]):
-    """The point of ``polydata`` nearest ``point``, or ``None`` when empty.
-
-    Used by the placement pipelines to re-snap an off-tree later seed onto the
-    active connected component (ADR-0037 slice 5, C4).  Pure-VTK
-    (``vtkPointLocator``) so it stays on the bare unit layer alongside
-    ``connected_component_at``.
-    """
-    if polydata is None or polydata.GetNumberOfPoints() == 0:
-        return None
-    locator = vtk.vtkPointLocator()
-    locator.SetDataSet(polydata)
-    locator.BuildLocator()
-    closest_id = locator.FindClosestPoint(point[0], point[1], point[2])
-    if closest_id < 0:
-        return None
-    return tuple(polydata.GetPoint(closest_id))

--- a/VascularTerritories/VascularTerritoriesLib/VesselHighlightPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselHighlightPipeline.py
@@ -42,10 +42,10 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
-    from .VesselHighlightWiring import vascular_surface_polydata
+    from .VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
-    from VesselHighlightWiring import vascular_surface_polydata  # type: ignore[no-redef]
+    from VesselHighlightWiring import vascular_surface_polydata, visibility_mtime as _visibility_mtime  # type: ignore[no-redef]
 
 _REGISTERED = False
 
@@ -69,8 +69,12 @@ class VesselHighlightPipeline(_PipelineBase):
 
         # Injectable pick core (bare unit layer feeds a known surface);
         # rebuilt when the display node is (re)attached, since that is
-        # where the pickSurface reference can change.
+        # where the pickSurface reference can change.  ``_pick_injected``
+        # marks a test-injected core (never rebuilt); the production core is
+        # rebuilt when segment visibility changes (``_pick_surface_mtime``).
         self._pick: VesselSurfacePick | None = None
+        self._pick_injected: bool = False
+        self._pick_surface_mtime: int | None = None
 
         # Last adhering (point, on-surface) a render was requested for —
         # the digest gate that keeps a fixed cursor from storming renders.
@@ -270,13 +274,12 @@ class VesselHighlightPipeline(_PipelineBase):
         """Build the pick core against the referenced segmentation's mesh.
 
         Resolves the display node's ``pickSurface`` segmentation, ensures a
-        closed-surface representation (creating it if absent — the
-        module's ``polyDataFromNode`` precedent), and rebuilds the pick
-        core when the referenced node changes.  ``None`` when no surface is
-        wired.  A test-injected ``self._pick`` short-circuits this in the
-        bare unit layer.
+        closed-surface representation, and rebuilds the pick core when the
+        referenced node's segment VISIBILITY changes (tracked via the display
+        node MTime).  ``None`` when no surface is wired.  A test-injected
+        ``self._pick`` short-circuits this in the bare unit layer.
         """
-        if self._pick is not None:
+        if self._pick_injected:
             return self._pick
         display = self._display_node
         if display is None:
@@ -284,10 +287,15 @@ class VesselHighlightPipeline(_PipelineBase):
         segmentation = display.GetPickSurfaceNode()
         if segmentation is None:
             return None
+        mtime = _visibility_mtime(segmentation)
+        if self._pick is not None and mtime == self._pick_surface_mtime:
+            return self._pick
         # Shared surface-resolution seam (VesselHighlightWiring): the hover
-        # Pipeline and the snap-on-place path resolve the pick target the
-        # same way (vessels-only, so hover never lights up the parenchyma or a
-        # tumour), so neither duplicates the representation-building logic.
+        # Pipeline and the snap-on-place path resolve the pick target the same
+        # way -- VISIBLE vessels only, so hover never lights up the parenchyma,
+        # a tumour, or a hidden vessel (ADR-0037 slice 5).
+        self._pick = None
+        self._pick_surface_mtime = mtime
         polydata = vascular_surface_polydata(segmentation)
         if polydata is None:
             return None
@@ -304,6 +312,7 @@ class VesselHighlightPipeline(_PipelineBase):
     def SetPickCore(self, pick: VesselSurfacePick | None) -> None:  # noqa: N802 - VTK verb
         """Inject a pick core (bare unit layer seam)."""
         self._pick = pick
+        self._pick_injected = pick is not None
 
     def _safe_get_renderer(self) -> Any | None:
         return self._renderer

--- a/VascularTerritories/VascularTerritoriesLib/VesselHighlightPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselHighlightPipeline.py
@@ -42,10 +42,10 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
-    from .VesselHighlightWiring import closed_surface_polydata
+    from .VesselHighlightWiring import vascular_surface_polydata
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
-    from VesselHighlightWiring import closed_surface_polydata  # type: ignore[no-redef]
+    from VesselHighlightWiring import vascular_surface_polydata  # type: ignore[no-redef]
 
 _REGISTERED = False
 
@@ -286,8 +286,9 @@ class VesselHighlightPipeline(_PipelineBase):
             return None
         # Shared surface-resolution seam (VesselHighlightWiring): the hover
         # Pipeline and the snap-on-place path resolve the pick target the
-        # same way, so neither duplicates the representation-building logic.
-        polydata = closed_surface_polydata(segmentation)
+        # same way (vessels-only, so hover never lights up the parenchyma or a
+        # tumour), so neither duplicates the representation-building logic.
+        polydata = vascular_surface_polydata(segmentation)
         if polydata is None:
             return None
         self._pick = VesselSurfacePick(polydata)

--- a/VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
@@ -109,6 +109,101 @@ def closed_surface_polydata(segmentation: Any):
     return _append_closed_surfaces(segmentation, None)
 
 
+def per_segment_vascular_surfaces(segmentation: Any) -> list:
+    """The vascular segments as ``[(segId, closed_surface, visible)]``.
+
+    Mirrors the extractor's ``_perSegmentClosedSurfaces`` split (each
+    vascular-SCT segment's closed-surface rep) plus each segment's live
+    VISIBILITY on the display node.  The seed pipelines use it to map each seed
+    to its nearest STRUCTURE and omit seeds whose structure is hidden -- so
+    hiding a vessel in the structures table hides its seeds live (ADR-0037
+    slice 5).  Returns ``[]`` when nothing resolves (a model node, an unbuilt
+    rep, or the C++ boundary raising).
+    """
+    if segmentation is None or not hasattr(segmentation, "GetSegmentation"):
+        return []
+    display_node = segmentation.GetDisplayNode()
+    try:
+        segmentation.CreateClosedSurfaceRepresentation()
+        seg = segmentation.GetSegmentation()
+        ids = vtk.vtkStringArray()
+        seg.GetSegmentIDs(ids)
+        surfaces = []
+        for i in range(ids.GetNumberOfValues()):
+            segment_id = ids.GetValue(i)
+            if not _segment_is_vascular(seg.GetSegment(segment_id)):
+                continue
+            mesh = vtk.vtkPolyData()
+            segmentation.GetClosedSurfaceRepresentation(segment_id, mesh)
+            if mesh.GetNumberOfPoints() == 0:
+                continue
+            surfaces.append(
+                (segment_id, mesh, _segment_is_visible(display_node, segment_id))
+            )
+        return surfaces
+    except Exception:  # pragma: no cover - defensive (unbuilt reps, C++ boundary)
+        return []
+
+
+class VisibleStructuresCache:
+    """Per-pipeline cache of a display node's per-segment vessel structures.
+
+    Resolves the ``[(segId, surface, visible)]`` structures from a highlight
+    display node's ``pickSurface`` and caches them by the segmentation's
+    visibility MTime, so a show/hide repaints seeds without re-running the
+    closed-surface split per event (ADR-0037 slice 5).  Shared by the 3D
+    ``TerritoryPlacementPipeline`` and 2D ``TerritorySlicePipeline`` seed
+    filters so neither duplicates the resolution + cache.  Returns ``[]`` when
+    no segmentation is wired (a test-injected pick) -> seeds are never hidden
+    bare.
+    """
+
+    def __init__(self) -> None:
+        self._surfaces: list | None = None
+        self._mtime: int | None = None
+
+    def resolve(self, display_node: Any) -> list:
+        if display_node is None or not hasattr(display_node, "GetPickSurfaceNode"):
+            return []
+        segmentation = display_node.GetPickSurfaceNode()
+        if segmentation is None:
+            return []
+        mtime = visibility_mtime(segmentation)
+        if self._surfaces is not None and mtime == self._mtime:
+            return self._surfaces
+        self._surfaces = per_segment_vascular_surfaces(segmentation)
+        self._mtime = mtime
+        return self._surfaces
+
+
+def seed_structure_visible(per_segment_surfaces: list, point: Any) -> bool:
+    """True when ``point``'s nearest structure is VISIBLE (or maps to none).
+
+    ``per_segment_surfaces`` is the ``[(segId, surface, visible)]`` list from
+    :func:`per_segment_vascular_surfaces`.  The point is mapped to its nearest
+    structure exactly as extraction groups it
+    (``SeedStructureMapping.nearest_structure``), and the seed is shown iff that
+    structure is visible.  With no resolvable structures (a model-node input, an
+    unbuilt rep) the seed is treated as visible -- the show/hide follow has
+    nothing to gate on, so placement is never silently swallowed (ADR-0037
+    slice 5).
+    """
+    if not per_segment_surfaces:
+        return True
+    keyed = [(segId, surface) for segId, surface, _visible in per_segment_surfaces]
+    visible_by_id = {segId: visible for segId, _surface, visible in per_segment_surfaces}
+    # nearest_structure lives in the pure SeedStructureMapping helper; import it
+    # lazily so this module stays dependency-light for its other callers.
+    try:
+        from .SeedStructureMapping import nearest_structure
+    except ImportError:  # top-level import path (the unit layer's sys.path setup)
+        from SeedStructureMapping import nearest_structure  # type: ignore[no-redef]
+    key = nearest_structure(keyed, point)
+    if key is None:
+        return True
+    return bool(visible_by_id.get(key, True))
+
+
 def vascular_surface_polydata(segmentation: Any):
     """The pick/snap surface: VISIBLE, vascular-SCT-typed segments only.
 

--- a/VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
@@ -22,13 +22,30 @@ from typing import Any
 import vtk
 
 
-def closed_surface_polydata(segmentation: Any):
-    """The segmentation's whole closed-surface mesh as one ``vtkPolyData``.
+# Vascular segment SCT *type* codes -- mirror ``vtkSlicerVascularTerritoriesLogic``
+# ``VascularTypeTokens`` so the Python pick surface and the C++ extraction surface
+# agree on what a "vessel" is: Vein / Artery, the broad concepts the real data
+# uses (category Tissue) rather than portal/hepatic-specific codes (ADR-0011).
+VASCULAR_TYPE_TOKENS = ("SCT^29092000", "SCT^51114001")
 
-    Creates the closed-surface representation if absent and appends every
-    segment so the pick/snap sees the whole vessel tree.  Returns ``None``
-    on any failure or an empty segmentation (the caller treats ``None`` as
-    "no surface").
+
+def _segment_is_vascular(segment: Any) -> bool:
+    """True when the segment's ``TerminologyEntry`` type is a vascular concept."""
+    if segment is None:
+        return False
+    ref = vtk.reference("")
+    if not segment.GetTag("TerminologyEntry", ref):
+        return False
+    term = str(ref)
+    return any(token in term for token in VASCULAR_TYPE_TOKENS)
+
+
+def _append_closed_surfaces(segmentation: Any, predicate):
+    """Append the closed surfaces of the segments passing ``predicate``.
+
+    ``predicate=None`` appends every segment.  Returns ``None`` on any failure
+    or when no segment contributes geometry (the caller treats ``None`` as "no
+    surface").
     """
     if segmentation is None:
         return None
@@ -39,8 +56,11 @@ def closed_surface_polydata(segmentation: Any):
         seg.GetSegmentIDs(ids)
         append = vtk.vtkAppendPolyData()
         for i in range(ids.GetNumberOfValues()):
+            segment_id = ids.GetValue(i)
+            if predicate is not None and not predicate(seg.GetSegment(segment_id)):
+                continue
             mesh = vtk.vtkPolyData()
-            segmentation.GetClosedSurfaceRepresentation(ids.GetValue(i), mesh)
+            segmentation.GetClosedSurfaceRepresentation(segment_id, mesh)
             if mesh.GetNumberOfPoints() > 0:
                 append.AddInputData(mesh)
         if append.GetNumberOfInputConnections(0) == 0:
@@ -49,3 +69,25 @@ def closed_surface_polydata(segmentation: Any):
         return append.GetOutput()
     except Exception:  # pragma: no cover - defensive (unbuilt reps, C++ boundary)
         return None
+
+
+def closed_surface_polydata(segmentation: Any):
+    """The segmentation's whole closed-surface mesh as one ``vtkPolyData``.
+
+    Appends EVERY segment.  Retained for callers that legitimately need the
+    whole surface; the pick/snap path uses :func:`vascular_surface_polydata`
+    so the cursor never snaps to the liver parenchyma or a tumour (ADR-0037).
+    """
+    return _append_closed_surfaces(segmentation, None)
+
+
+def vascular_surface_polydata(segmentation: Any):
+    """The vessels-only closed-surface mesh (vascular-SCT-typed segments).
+
+    The pick/snap + hover-highlight surface: appends only segments whose
+    ``TerminologyEntry`` type is vascular (:data:`VASCULAR_TYPE_TOKENS`), so the
+    parenchyma (liver ``SCT^10200004``) and tumours are excluded and a click
+    snaps to a vessel, not the liver blob.  Same vessel set the C++ extraction
+    resolver uses (ADR-0037 slice 5).  ``None`` when no vessel contributes.
+    """
+    return _append_closed_surfaces(segmentation, _segment_is_vascular)

--- a/VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
@@ -40,12 +40,40 @@ def _segment_is_vascular(segment: Any) -> bool:
     return any(token in term for token in VASCULAR_TYPE_TOKENS)
 
 
+def visibility_mtime(segmentation: Any) -> int:
+    """The segmentation display node's MTime (bumps on a segment-visibility toggle).
+
+    The pick pipelines cache the vessels-only surface; they compare this MTime
+    to know when to rebuild so a hide/show in the structures table takes effect
+    live.  Returns ``0`` when there is no display node (nothing to invalidate on).
+    """
+    try:
+        display = segmentation.GetDisplayNode() if segmentation is not None else None
+        return int(display.GetMTime()) if display is not None else 0
+    except Exception:  # pragma: no cover - C++ boundary must never raise
+        return 0
+
+
+def _segment_is_visible(display_node: Any, segment_id: str) -> bool:
+    """True when ``segment_id`` is shown on ``display_node`` (or no display node).
+
+    A missing display node means visibility is unknown -- treat as visible so
+    placement never silently dies when the display handle is unavailable.
+    """
+    if display_node is None:
+        return True
+    getter = getattr(display_node, "GetSegmentVisibility", None)
+    if getter is None:
+        return True
+    return bool(getter(segment_id))
+
+
 def _append_closed_surfaces(segmentation: Any, predicate):
     """Append the closed surfaces of the segments passing ``predicate``.
 
-    ``predicate=None`` appends every segment.  Returns ``None`` on any failure
-    or when no segment contributes geometry (the caller treats ``None`` as "no
-    surface").
+    ``predicate=None`` appends every segment; otherwise ``predicate`` is called
+    ``predicate(segment, segment_id)``.  Returns ``None`` on any failure or when
+    no segment contributes geometry (the caller treats ``None`` as "no surface").
     """
     if segmentation is None:
         return None
@@ -57,7 +85,7 @@ def _append_closed_surfaces(segmentation: Any, predicate):
         append = vtk.vtkAppendPolyData()
         for i in range(ids.GetNumberOfValues()):
             segment_id = ids.GetValue(i)
-            if predicate is not None and not predicate(seg.GetSegment(segment_id)):
+            if predicate is not None and not predicate(seg.GetSegment(segment_id), segment_id):
                 continue
             mesh = vtk.vtkPolyData()
             segmentation.GetClosedSurfaceRepresentation(segment_id, mesh)
@@ -82,12 +110,21 @@ def closed_surface_polydata(segmentation: Any):
 
 
 def vascular_surface_polydata(segmentation: Any):
-    """The vessels-only closed-surface mesh (vascular-SCT-typed segments).
+    """The pick/snap surface: VISIBLE, vascular-SCT-typed segments only.
 
-    The pick/snap + hover-highlight surface: appends only segments whose
-    ``TerminologyEntry`` type is vascular (:data:`VASCULAR_TYPE_TOKENS`), so the
-    parenchyma (liver ``SCT^10200004``) and tumours are excluded and a click
-    snaps to a vessel, not the liver blob.  Same vessel set the C++ extraction
-    resolver uses (ADR-0037 slice 5).  ``None`` when no vessel contributes.
+    Appends a segment iff it is BOTH (a) vascular -- its ``TerminologyEntry``
+    type is a vessel concept (:data:`VASCULAR_TYPE_TOKENS`), so the parenchyma
+    (liver ``SCT^10200004``) and tumours are excluded -- AND (b) VISIBLE on the
+    segmentation's display node.  Hiding a vessel (e.g. via the panel's
+    structures table) therefore removes it from collision detection: the cursor
+    can only snap to a vessel you can see, so hiding the hepatic system lets a
+    click land on the portal even where they overlap (ADR-0037 slice 5).  The
+    connectivity + highlight share this surface, so a hidden tree drops out of
+    all three.  ``None`` when no visible vessel contributes.
     """
-    return _append_closed_surfaces(segmentation, _segment_is_vascular)
+    display_node = segmentation.GetDisplayNode() if segmentation is not None else None
+
+    def _visible_vascular(segment, segment_id):
+        return _segment_is_vascular(segment) and _segment_is_visible(display_node, segment_id)
+
+    return _append_closed_surfaces(segmentation, _visible_vascular)

--- a/VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselHighlightWiring.py
@@ -161,6 +161,14 @@ class VisibleStructuresCache:
     def __init__(self) -> None:
         self._surfaces: list | None = None
         self._mtime: int | None = None
+        # One prebuilt vtkCellLocator per structure, rebuilt only when the
+        # surfaces are (keyed by the same visibility MTime).  Building a locator
+        # on a ~100k-point vessel surface is expensive; the per-seed
+        # nearest-structure query runs on every seed repaint (which the
+        # hover-reslice fires often), so the locators MUST be cached, not rebuilt
+        # per call (ADR-0037 slice 5 performance).
+        self._locators: dict | None = None
+        self._visible_by_id: dict | None = None
 
     def resolve(self, display_node: Any) -> list:
         if display_node is None or not hasattr(display_node, "GetPickSurfaceNode"):
@@ -173,7 +181,48 @@ class VisibleStructuresCache:
             return self._surfaces
         self._surfaces = per_segment_vascular_surfaces(segmentation)
         self._mtime = mtime
+        self._locators = {}
+        self._visible_by_id = {}
+        for seg_id, surface, visible in self._surfaces:
+            self._visible_by_id[seg_id] = visible
+            if surface is not None and surface.GetNumberOfPoints() > 0:
+                locator = vtk.vtkCellLocator()
+                locator.SetDataSet(surface)
+                locator.BuildLocator()
+                self._locators[seg_id] = locator
         return self._surfaces
+
+    def seed_visible(self, display_node: Any, point: Any) -> bool:
+        """True iff ``point``'s nearest structure is visible (cached locators).
+
+        The hot-path replacement for :func:`seed_structure_visible`: maps the
+        seed to its nearest structure with the PREBUILT per-structure locators
+        (first-in-order tiebreak, matching ``nearest_structure``) instead of
+        rebuilding a locator per seed.  No resolvable structure -> visible (the
+        show/hide follow has nothing to gate on).
+        """
+        self.resolve(display_node)
+        if not self._locators:
+            return True
+        px, py, pz = float(point[0]), float(point[1]), float(point[2])
+        best_key = None
+        best_distance2 = None
+        for seg_id, _surface, _visible in self._surfaces:
+            locator = self._locators.get(seg_id)
+            if locator is None:
+                continue
+            closest = [0.0, 0.0, 0.0]
+            cell_id = vtk.reference(0)
+            sub_id = vtk.reference(0)
+            distance2 = vtk.reference(0.0)
+            locator.FindClosestPoint((px, py, pz), closest, cell_id, sub_id, distance2)
+            d2 = float(distance2)
+            if best_distance2 is None or d2 < best_distance2 * (1.0 - 1.0e-6):
+                best_distance2 = d2
+                best_key = seg_id
+        if best_key is None:
+            return True
+        return bool(self._visible_by_id.get(best_key, True))
 
 
 def seed_structure_visible(per_segment_surfaces: list, point: Any) -> bool:

--- a/VascularTerritories/VascularTerritoriesLib/VesselSurfacePick.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselSurfacePick.py
@@ -36,6 +36,16 @@ class VesselSurfacePick:
         self._locator: vtk.vtkCellLocator | None = None
         self._built_mtime: int | None = None
 
+    def surface(self) -> vtk.vtkPolyData | None:
+        """The surface this pick core holds.
+
+        The active-tree recovery (ADR-0037 slice 5) must run connectivity over
+        the SAME surface the pick uses to snap clicks -- the injected surface
+        under test, the vessels-only mesh in production -- so it is exposed here
+        rather than re-derived from the display node.
+        """
+        return self._polydata
+
     # ------------------------------------------------------------------ #
     # Locator lifecycle
     # ------------------------------------------------------------------ #

--- a/VascularTerritories/VascularTerritoriesLib/__init__.py
+++ b/VascularTerritories/VascularTerritoriesLib/__init__.py
@@ -14,6 +14,11 @@ from .VesselHighlightWiring import (
     closed_surface_polydata,
 )
 
+# The connected-vessel-tree recovery (ADR-0037 slice 5) is pure-VTK
+# (``vtkPolyDataConnectivityFilter``), so it imports unconditionally
+# alongside the pick core and the surface-resolution seam.
+from .VesselConnectivity import connected_component_at
+
 # The Stage-3 transient VMTK-seed builder core (ADR-0037 §Decision 4) is
 # dependency-free (no slicer/vtk/Qt) so it imports unconditionally alongside
 # the pure pick core.
@@ -77,6 +82,7 @@ except (ImportError, AttributeError):  # pragma: no cover - Qt unreachable bare
 __all__ = [
     "VesselSurfacePick",
     "closed_surface_polydata",
+    "connected_component_at",
     "build_seed_payload",
     "territory_label_ints",
     "territory_label_int",


### PR DESCRIPTION
## What

ADR-0037 **slice 5** — vascular-territory seeding across vessel systems, plus the placement-UX and compute fixes it surfaced. A vascular territory may own seeds on **multiple disjoint vessel structures** (e.g. portal + hepatic); each structure's centerline is extracted independently and all feed the territory's map region.

Stacked on `feature/vasc-territories-slice4-placemode` (#602); retarget to `preview` once the stack below merges.

## Why

Real liver data (`LiverSegmentation000`: parenchyma + portal + hepatic + tumour in one node) showed the interim merge-all centerline surface was wrong — portal and hepatic are disjoint components, so a VMTK medial path between them is meaningless. Extraction must run per connected structure. Eyeball testing then surfaced the placement/visualisation gaps fixed here.

## Changes (grouped)

**Compute correctness**
- Vessel surface resolved by SNOMED-CT type (Vein/Artery), excluding parenchyma + tumour (C++ `GetVascularSegmentIds` / `GetVascularSurfacePolyData`).
- `preprocessAndDecimate` triangulates before decimating (closed-surface reps arrive as triangle strips) and guards on point count — was silently emitting an empty mesh.
- Centerline extraction **groups a territory's seeds by structure**; runs VMTK once per structure with **≥2 seeds** (clear-once-then-append); a structure with fewer is skipped and flags a **warning glyph** on the territory. All centerlines carry the territory's label → one map region (existing multi-`CenterlineRefs` path).
- Extracted centerline now gets a visible display node (was created but invisible).
- Map compute fails legibly when no liver-SCT segment is present.

**Placement UX**
- Pick/hover surface is **visible vessels only** — the cursor snaps to a vessel you can see, never the parenchyma, a tumour, or a **hidden** vessel (collision follows segment visibility; rebuilds on a visibility toggle).
- No single-tree lock and no glow halo (both reverted per the multi-system design); seeds go where clicked.
- 2D views **reslice to follow the hovered/placed vessel point** in 3D.
- Panel gains an **input-structure show/hide table** (`qMRMLSegmentsTableView`) to isolate a system.
- Territory table **colours each seed row by its structure** and names it (glyph+text, ADR-0010).
- Module-active gate: placement is declined unless the module is active.

## Tests

Invariant-test-first (ADR-0027). Bare pure-VTK suites (seed→structure mapping, connectivity) run bare; the launched suites cover the resolver, per-structure extraction, coloured rows, warning glyph, no-straddle placement, and the module gate. Latest: bare 13/13; launched **133 passed, 1 skipped** (env-gated real SlicerVMTK run), 0 failed, 0 crash.

## ADR

ADR-0037 slice-5 amendment is the design of record, revised to the multi-system model (per-structure extraction, coloured seed rows, no lock/halo). Design notes under `Docs/design/`.

---

*Drafted with the assistance of Claude (Anthropic claude-opus-4-8) under maintainer supervision.*
