### PR TITLE
ENH: Extract the shared LayerDM point-placement Lib (ADR-0038 foundation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,14 @@ include(${Slicer_USE_FILE})
 add_subdirectory(SubjectHierarchyFolders)
 
 #-----------------------------------------------------------------------------
+# ADR-0038 shared control-point interaction base (SlicerLiverInteractionLib).
+# A pure-Python Lib (no displayable manager, ADR-0013 §5) supplying the
+# Pipeline base classes each module's own creator instantiates.  Added
+# before the consuming modules so its (future) sources + its Testing tree
+# are configured ahead of the clients.
+add_subdirectory(SlicerLiverInteractionLib)
+
+#-----------------------------------------------------------------------------
 # Extension modules
 add_subdirectory(LiverResections)
 add_subdirectory(VascularTerritories)

--- a/Docs/adr/0038-unify-control-point-interaction.md
+++ b/Docs/adr/0038-unify-control-point-interaction.md
@@ -118,3 +118,95 @@ state-machine integration); territories become the second, simpler client.
   interaction (characterization tests green before + after).
 - [review] Each module keeps its own display-node type + creator (ADR-0013
   §1); the base carries no data-model knowledge.
+
+## Implementation amendment (2026-07-27)
+
+The extraction this ADR deferred is now triggered by a **third consumer**:
+LiverVolumetry moves its region-growing seed fiducials off Slicer markups
+onto the shared base (discharging its
+[ADR-0012](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0012-layerdm-migration-v2-scope.md)
+obligation via a real off-markups migration, rather than the earlier
+"compute-then-display, LayerDM marginal" reading). A third consumer is what
+justifies paying the extraction now, so the deferred implementation lands
+under this amendment.
+
+### Shared home + names
+
+The base lives in a new Python Lib package **`SlicerLiverInteractionLib`** —
+a sibling to `LayerDMLib`, importable by any module's Lib. It is Python
+(ADR-0004: interaction/widgets stay Python) and hosts **no** displayable
+manager (ADR-0013 §5): it supplies only the Pipeline **base classes** each
+module's own creator instantiates, plus the pure-VTK pick and the
+display-node state accessors. Each module keeps its own three registration
+calls and its own display-node type. New classes drop the `Liver` prefix
+(T2.7 convention).
+
+Concrete names (extracted **from resection**, per the Decision's direction):
+
+- **`SurfacePick`** — the pure-VTK ray→closed-surface intersect-nearest +
+  closest-point fallback with a lazy MTime-invalidated `vtkCellLocator`.
+- **`PointPlacementState`** — the arm/active/module-active/carrier accessors
+  on a display node, with the attribute-key namespace parameterized per
+  consumer.
+- **`SurfacePointPlacementPipeline3D`** / **`SurfacePointPlacementPipelineSlice`**
+  — the ADR-0038 3D + slice bases owning the glow halo, slice projection +
+  fade + side tint + presence cutoff, handles + hover ring, pick-radius
+  arbitration, the grab seam, and the four LayerDM integration invariants.
+- **`PointProvider`** — the seam: `iter_points()`, `has_edges()`,
+  `add/move/delete`, the display-node channel, **and a swappable pick
+  provider** (below).
+
+Resection (`ControlPolygonPipeline` / `SliceControlPolygonPipeline`) and
+VascularTerritories (`TerritoryPlacementPipeline` / `TerritorySlicePipeline`)
+become thin clients over the seam; both existing characterization suites stay
+green unchanged (the [review] conformance point above).
+
+### Base extension: the pick step is swappable (surface vs in-volume)
+
+VascularTerritories and resection place points **on a closed surface**, so
+they use `SurfacePick`. LiverVolumetry seeds are **region-growing seeds** —
+`vtkLiverVolumetryLogic` converts each seed to a **voxel index**
+(`TransformPhysicalPointToIndex`) and grows a `ConnectedThreshold` from it, so
+the seed must land **inside** the target region, not on its surface. Snapping
+a volumetry seed to a surface would place it on the region boundary and can
+mis-seed the grow.
+
+Therefore the pick step is a **provider on the seam**, not a fixed
+surface-snap. The base defines the point-placement/edit/delete affordance and
+the LayerDM invariants once; the *pick* (world position for a click) is
+supplied by the consumer:
+
+- surface consumers (resection, territories) inject `SurfacePick`;
+- LiverVolumetry injects an **in-volume / slice-click pick** — placement in a
+  slice view resolves the click to the RAS point at the slice plane (an
+  interior voxel), which is the natural region-growing-seed UX.
+
+This is the single place volumetry is not a plain client. It does not leak a
+volume concept into the base — the base sees only "the consumer's pick
+returned this world point"; the surface-vs-volume choice is entirely in the
+injected pick provider.
+
+### Consumers ledger
+
+- resection — client (extraction source), surface pick, edges = yes;
+- vascular territories — client, surface pick (vessel-visibility-gated),
+  edges = no;
+- **LiverVolumetry — client, in-volume/slice pick, edges = no** (this
+  amendment);
+- move-bezier-off-markups (`project_move_bezier_off_markups`) — the designed
+  fourth consumer once its own ADR lands (grouped `PointProvider`); the seam
+  is shaped to admit it.
+
+### Conformance (this amendment)
+
+- [future] `SlicerLiverInteractionLib` exists with the five names above; the
+  resection and territory pipelines are thin clients over the seam.
+- [future] The pick step is a seam-injected provider; LiverVolumetry supplies
+  an in-volume/slice pick, surface consumers supply `SurfacePick`; the base
+  contains no surface-vs-volume branch.
+- [review] The refactor is behaviour-preserving for resection **and**
+  vascular territories (both characterization suites green, unchanged, both
+  harnesses).
+- [review] LiverVolumetry's C++ region-grow logic is unchanged (ADR-0015); it
+  is fed a transient fiducial built from the seed carrier, and per-seed labels
+  round-trip so generated segments keep their names.

--- a/Docs/design/volumetry-seeds-layerdm-plan.md
+++ b/Docs/design/volumetry-seeds-layerdm-plan.md
@@ -1,0 +1,439 @@
+# LiverVolumetry seeds off markups + a REUSABLE placement seam — plan (#570 interpretation B)
+
+Status: DRAFT plan (no code written). v2.0.0 (milestone #4, tracker #305).
+Branch: `feature/volumetry-layerdm` off `preview` (carries all of #569).
+Author: planning pass, 2026-07-25. Supersedes the earlier
+`volumetry-layerdm-plan.md` finding (which recommended interpretation A;
+the maintainer has now ruled **B, with reusability first-class**).
+
+> Plan, not a decision record. Genuine maintainer choices are marked
+> **OPEN QUESTION** with a recommendation; the plan proceeds on the
+> recommendation so the staging is concrete.
+
+---
+
+## 0. Headline — the reusable seam is already an ACCEPTED decision (ADR-0038)
+
+The prompt's hypothesis was "extract a reusable core FROM VascularTerritories
+(#569) and refactor #569 to consume it." Reading the code changes the shape:
+
+**ADR-0038 ("Unify the control-point visualization + interaction across
+resection and vascular territories", Accepted 2026-07-16) already decided to
+do exactly this extraction — and mandated the OPPOSITE direction.** Its
+Decision:
+
+- Extract a **shared control-point interaction/visualization base** (a 3D base
+  + a slice base) parameterized by a small **point-provider seam** (points +
+  per-point colour; edges yes/no; drag/delete write-backs; the display-node
+  channel for arm/hover/grab state).
+- **Direction of extraction: resection → base**, because the resection
+  pipelines (`ControlPolygonPipeline` / `SliceControlPolygonPipeline`) are the
+  "richer, battle-tested originals (edges, digest gates, state-machine
+  integration); territories become the second, simpler client."
+- Implementation "deferred to a follow-up issue."
+
+`TerritoryPlacementPipeline` / `TerritorySlicePipeline` were themselves built
+by **mirroring** the resection pipelines (their own docstrings + ADR-0038
+§Context say so), so extracting the generic core FROM VascularTerritories would
+re-derive a base that resection then also has to be retrofitted onto — against
+the direction ADR-0038 already ruled.
+
+**Consequence for this plan.** #570-with-reusability is the natural TRIGGER to
+finally implement ADR-0038's deferred extraction: LiverVolumetry seeds are the
+*third* consumer, and a third consumer is what justifies paying the extraction
+now. The generic core is the ADR-0038 base; the split below is done against
+ADR-0038's seam, extracting from resection as the ADR mandates, with #569 and
+volumetry as the two simpler clients. This is a scope EXPANSION vs the prompt's
+"extract from #569" framing — see OPEN QUESTION 1.
+
+**ADR CONFLICT FLAGGED:** the prompt says "extract from #569, refactor #569 to
+consume." ADR-0038 §Decision says "extract from resection, territories is a
+client." The plan follows the ADR (it is Accepted); if the maintainer wants the
+narrower "just #569 + volumetry share, leave resection alone for now" scope,
+that is a deviation from ADR-0038 that needs recording as an ADR-0038 amendment
+(OQ1).
+
+---
+
+## 1. The generic-vs-specific split (the heart of the plan)
+
+Read in full: `VesselSurfacePick.py` (151), `TerritoryInteractionState.py` (97),
+`TerritoryPlacementPipeline.py` (1036), `TerritorySlicePipeline.py` (932),
+`VesselHighlightWiring.py` (274), `vtkMRMLCustomTerritoriesNode.h`,
+`vtkMRMLTerritoriesHighlightDisplayNode.h`, `TransientVmtkSeeds.py`,
+`vtkLiverVolumetryLogic.h`, `LiverVolumetry.py`.
+
+### 1a. GENERIC — moves to the shared ADR-0038 base (Liver prefix dropped, T2.7)
+
+| Today (VascularTerritories) | Generic core | Nature |
+|---|---|---|
+| `VesselSurfacePick` | **`SurfacePick`** | Already pure-VTK, mesh-agnostic, zero Slicer/Qt. Ray→closed-surface intersect-nearest + closest-point fallback, lazy `vtkCellLocator` with MTime invalidation. Rename only; move verbatim. |
+| `TerritoryInteractionState` (arm/active/module-active/carrier accessors on a display node) | **`PointPlacementState`** | Generic machinery; only the attribute-key *strings* are namespaced (`VascularTerritories.Armed`…). Parameterize the namespace prefix so each consumer gets its own keys on its own display node. |
+| `TerritoryPlacementPipeline` (3D) minus territory grouping + vessel gating | **`SurfacePointPlacementPipeline3D`** (ADR-0038 3D base) | The add-on-click / drag-to-edit-nearest / delete / bare-move-decline (ADR-0033) arbitration; the display-space pick-radius grab; seed-glyph sphere rendering; hover marker + glow-halo overlay (`vtkOutlineGlowPass`); the 4 LayerDM traps (one pipeline per (view,type); configure-before-AddNode; UpdatePipeline on ResetDisplay; RequestRender no mid-event flush); `_jump_slices_to_world`; cursor-ray unproject; nearest-point-in-display. |
+| `TerritorySlicePipeline` (2D) minus the same specifics | **`SurfacePointPlacementPipelineSlice`** (ADR-0038 slice base) | Slice projection into XY (`inverse(XYToRAS)`), distance-graded alpha, signed side tint, hard presence cutoff, hollow-circle handles + hover ring, the grab seam. |
+| shared constants (`HALO_HOVER_COLOR/GRAB_COLOR`, scales, `FADE_DISTANCE_MM`, `POINT_PICK_RADIUS_PX`, `HANDLE_MIDTONE_FACTOR`) | **base module constants** | ADR-0038 §Context names these explicitly as duplicated. |
+| the **point-provider seam** the base reads/writes | **`PointProvider`** protocol | ADR-0038 §Decision's seam: `iter_points()->(world, base_rgb)`; `has_edges()->bool`; `add_point(world)`, `move_point(key, world)`, `delete_point(key)`; `display_node` for the arm/hover/grab channel. Resection supplies grid+edges; territories + volumetry supply flat point lists, no edges. |
+
+### 1b. VascularTerritories-SPECIFIC — stays in `VascularTerritoriesLib`
+
+- **Per-territory grouping.** The carrier keys points per surgeon-named
+  territory (`AddAnnotationPoint(territoryId, x,y,z)`, `GetAnnotationTerritoryIds`).
+  The base sees a FLAT ordered point set; the territory→points fan-out lives in
+  the VascularTerritories `PointProvider` adapter over `vtkMRMLCustomTerritoriesNode`.
+- **Vessel visibility gating** — `VesselHighlightWiring.vascular_surface_polydata`,
+  `VisibleStructuresCache`, `per_segment_vascular_surfaces`, `_segment_is_vascular`,
+  `VASCULAR_TYPE_TOKENS` (SCT^29092000/51114001), `seed_structure_visible`. All
+  vessel/SCT-specific. STAYS. The base takes an OPTIONAL "seed-visible?(point)"
+  and "pick-surface polydata" hook; VascularTerritories passes the vessel-gated
+  ones, volumetry passes trivial ones (see §3).
+- `SeedStructureMapping`, `VesselConnectivity`, `TransientVmtkSeeds`,
+  `VesselHighlightPipeline`/`VesselHighlightWiring` (hover highlight — the
+  base's hover marker subsumes the *generic* half, but the vessel-SCT surface
+  resolution is specific), `TerritorySliceProjection`, `TerritoryLabelMap`.
+- **MRML:** `vtkMRMLAbstractTerritoriesNode`, `vtkMRMLCustomTerritoriesNode`,
+  `vtkMRMLStdCouinaudTerritoriesNode`, storage, `vtkMRMLTerritoriesHighlightDisplayNode`.
+  All stay module-owned (one display-node type per module, ADR-0013 §1).
+- `TerritoriesTableWidget` — territory rows are specific. The point-row + delete
+  idiom MAY share a tiny helper, but defer (low payoff, high coupling). STAYS.
+
+### 1c. The GENERIC carrier + display-node SHAPE (not a shared class — a template)
+
+Do NOT hoist `vtkMRMLCustomTerritoriesNode` into a shared MRML class. ADR-0014's
+four-layer split is per-module (each module owns its wrapper/carrier/display/
+storage). What is generic is the **shape**, which each consumer instantiates:
+
+- a **data-carrier** of ordered surface-snapped points (flat, or keyed by a
+  group id) with a per-group display slot (colour/label/visibility);
+- a **data-only display node** (ADR-0025/0033 shape) carrying the arm/hover/grab
+  interaction state + a `pickSurface` reference + transient adhering point;
+- a **storage node** round-trip.
+
+The volumetry carrier + display node are NEW module-local classes following this
+shape (§3), not reuses of the territories ones.
+
+### 1d. WHERE the shared core lives (recommendation)
+
+**Recommendation: a new shared Python Lib package `SlicerLiverInteractionLib`**
+(name OPEN — OQ2), a sibling to `LayerDMLib`, importable by any module's Lib.
+Rationale:
+
+- ADR-0004: widgets/interaction stay Python — the base is Python pipelines, so a
+  Python Lib is the right home, NOT a C++ layer.
+- ADR-0013 §5: the base hosts NO custom displayable manager — it is scripted
+  Pipelines + the point-provider seam; each module keeps its own 3 registration
+  calls (RegisterNodeClass + upstream LayerDM RegisterInFactory + Pipeline
+  creator). The base only supplies the Pipeline BASE CLASSES the module's
+  creator instantiates.
+- Do NOT put it in `LayerDMLib` (that is upstream SlicerLayerDM's package; the
+  base is Slicer-Liver-specific affordance). Do NOT put it in one module's Lib
+  (creates a cross-module import dependency the wrong way).
+- **`Liver` prefix dropped** on every new class (T2.7 / #341/#345 convention).
+
+---
+
+## 2. The #569 refactor — behaviour-preserving, characterization-guarded
+
+ADR-0038 §Decision makes VascularTerritories a client of the base. Refactor
+`TerritoryPlacementPipeline` / `TerritorySlicePipeline` to SUBCLASS the base and
+supply a `PointProvider` adapter over `vtkMRMLCustomTerritoriesNode`, passing the
+vessel-gated pick-surface + seed-visible hooks. The territory-specific behaviour
+(grouping, vessel visibility gating, VMTK feed, connectivity) is UNCHANGED.
+
+**Why behaviour-preserving:** the extracted base is the same code lifted, not
+rewritten; the specific behaviour is re-injected through the seam. No user-
+visible affordance changes.
+
+**Characterization net (must stay GREEN, UNCHANGED — ADR-0027 + characterization-
+tests-before-refactor):** every existing `VascularTerritories/Testing/Python`
+test, both harnesses. The load-bearing ones for the refactor:
+
+- `test_vessel_surface_pick.py` — pins `SurfacePick` (was `VesselSurfacePick`);
+  the ONLY test whose imports change (rename), so it may edit the import line —
+  the assertions stay identical.
+- `test_territories_placement_pipeline.py` — 3D add/drag/delete/decline/no-drift
+  arbitration. MUST pass unchanged against the refactored subclass.
+- `test_territories_slice_pipeline.py` — slice projection/fade/side/presence.
+- `test_territories_structure_visibility.py`, `test_territories_seed_structure.py`,
+  `test_territories_surface_resolution.py` — vessel gating stays specific; MUST
+  pass unchanged (proves the seam kept the gating hooks wired).
+- `test_territories_annotation_carrier.py`, `test_territories_table.py`,
+  `test_territories_vmtk_feed.py`, `test_territories_connectivity.py`,
+  `test_territories_map_compute.py`, `test_territories_widget_panel.py`,
+  `test_territories_action_enablement.py`, `test_vessel_highlight_*` — all
+  unchanged.
+
+If any of these needs an ASSERTION change, the refactor is NOT behaviour-
+preserving — STOP and escalate. Only import-path lines may change (the renames).
+
+---
+
+## 3. LiverVolumetry application — seeds off markups onto the shared seam
+
+Today (`LiverVolumetry.py`): a `qSlicerMarkupsPlaceWidget` +
+`vtkMRMLMarkupsFiducialNode` (`ROIMarkersList`) fed to the C++ logic. The logic
+reads per-point **labels** and positions:
+
+- `vtkLiverVolumetryLogic::GetROIPointsLabelValue(labelmap, ROIMarkersList)`
+- `vtkLiverVolumetryLogic::ComputeAdvancedPlanningVolumetry(..., ROIMarkersList, ...)`
+- `vtkLiverVolumetryLogic::GenerateSegmentsLabelMap(..., ROIMarkersList)`
+- `LiverVolumetry.py` reads `GetNthControlPointLabel` / `GetNthFiducialLabel` /
+  `GetNumberOfControlPoints` to name generated segments.
+
+So a volumetry seed = a labelled surface-snapped point; the label becomes a
+segment name. This is a FLAT labelled point set — the base's flat consumer with
+a per-point label slot.
+
+### 3a. New module-local MRML (following §1c shape; `Liver` prefix dropped)
+
+- **`vtkMRMLVolumetrySeedsNode`** — data-carrier: ordered surface-snapped points,
+  each with a label + display colour; storage round-trip. (Flat — no grouping;
+  the label is a per-point attribute, not a group key.)
+- **`vtkMRMLVolumetrySeedsStorageNode`** — `.vsd.json` round-trip.
+- **`vtkMRMLVolumetrySeedsDisplayNode`** — data-only (ADR-0025/0033): arm/hover/
+  grab state, `pickSurface` ref (the input segmentation / target labelmap
+  surface), transient adhering point, radius. NO rendering logic.
+
+C++ MRML lives in a new `LiverVolumetry/MRML/` following the
+VascularTerritories/MRML CMake pattern (upstream `SlicerMacro*` /
+`vtkMacroKitPythonWrap`; platform-neutral).
+
+### 3b. Placement pipeline registration (ADR-0013 §5 — 3 calls, NO custom DM)
+
+In `LiverVolumetry.py` widget setup (mirroring VascularTerritories):
+1. `RegisterNodeClass` for the 3 new node classes;
+2. upstream LayerDM DM `RegisterInFactory`;
+3. a Pipeline creator matching `(vtkMRMLViewNode, vtkMRMLVolumetrySeedsDisplayNode)`
+   that returns `SurfacePointPlacementPipeline3D` wired to a volumetry
+   `PointProvider` adapter; plus the slice creator for
+   `SurfacePointPlacementPipelineSlice`.
+
+The volumetry `PointProvider`:
+- `iter_points()` → carrier points + per-point colour;
+- `has_edges()` → False;
+- `add/move/delete` → carrier writes;
+- pick-surface hook → the input segmentation's closed surface (or the target
+  labelmap's surface), NOT vessel-SCT-gated (volumetry seeds may land anywhere
+  on the region); seed-visible hook → trivially True.
+
+### 3c. C++ compute unchanged (ADR-0015) — the transient-fiducial adapter
+
+Keep `vtkLiverVolumetryLogic` C++ SIGNATURES unchanged (they take
+`vtkMRMLMarkupsFiducialNode*`). Feed them a **transient fiducial built inside the
+call from the carrier**, mirroring ADR-0037 §Decision 4 / `TransientVmtkSeeds.py`
+(the VMTK feed's exact idiom). The pure mapping (carrier points+labels →
+fiducial-shaped payload) is a dependency-free function (bare-unit-testable); the
+transient `vtkMRMLMarkupsFiducialNode` creation is a thin Logic wrapper (ADR-0004).
+The per-point LABEL must round-trip into the transient fiducial's control-point
+label so `GenerateSegmentsLabelMap` still names segments correctly.
+
+**Why port (transient adapter) not rewrite the C++:** ADR-0015 keeps the ITK/VTK
+region-grow C++ intact; rewriting its signatures to a new carrier type would
+balloon the diff into T2.7 territory and touch
+`vtkSlicerLiverVolumetryModuleLogicPython` import sites for no behaviour gain.
+The adapter is the cheap, invariant-preserving path.
+
+### 3d. Retire the markups seed list
+
+Remove `ROIMarkersListSelector` / `qSlicerMarkupsPlaceWidget` and their handlers;
+replace with a minimal seeds table (§6, coordinated with #417). Migrate any
+persisted scene with a fiducial `ROIMarkersList` (graceful load path).
+
+---
+
+## 4. The ADR — extend ADR-0038 (do NOT author ADR-0039)
+
+**Recommendation: EXTEND ADR-0038 with an implementation amendment; do NOT open
+ADR-0039.** ADR-0038 already made the reusable-seam decision + shape and named
+its implementation "deferred to a follow-up issue." #570-with-reusability IS that
+follow-up. The amendment records:
+
+- the extraction is triggered by adding LiverVolumetry as the **third consumer**;
+- the shared home = `SlicerLiverInteractionLib` (OQ2) + the concrete base +
+  seam names (§1a);
+- LiverVolumetry joins as a client with a flat, no-edges, ungated `PointProvider`;
+- the resection→base direction is honoured (resection pipelines are extracted;
+  #569 + volumetry are clients);
+- the move-bezier-off-markups goal (`project_move_bezier_off_markups`) is the
+  natural FOURTH consumer once its own ADR lands — the seam is designed to admit
+  it (grouped control-point manipulation = a grouped `PointProvider`).
+
+A NEW ADR-0039 would fork the decision ADR-0038 already owns → two ADRs for one
+seam. Only open ADR-0039 if the maintainer chooses the narrower "#569+volumetry
+only, resection untouched" scope (OQ1), which genuinely deviates from ADR-0038.
+
+**ADRs this touches:** 0038 (the seam — amended), 0037 (VascularTerritories,
+refactored to client), 0032/0033 (interaction seam + hover discipline — the base
+enforces them once), 0013 §1/§5 (one pipeline per type; 3 registration calls; no
+custom DM), 0014 (four-layer split — volumetry gets its own carrier/display/
+storage), 0025 (data-only display node + reslice), 0015 (C++ compute intact),
+0004 (Python interaction/widgets), 0012 (v2.0.0 LayerDM scope — this discharges
+volumetry's obligation via a real off-markups migration, superseding the earlier
+"compute-then-display, marginal" reading now that the maintainer chose B),
+0002 (LayerDM migration target), 0027 (invariant-test-first), 0010 (a11y table),
+0011 (SCT — only the vessel gating, which stays specific).
+
+---
+
+## 5. #417 reconciliation
+
+#417 (unified planning-table volumetry/seeds/groupings widget) also owns a
+volumetry/seeds table. **Recommendation: ship a MINIMAL volumetry seeds table
+now** (columns: visibility, colour swatch, label, on-surface status, delete;
+Python composition ADR-0004; a11y glyph+text ADR-0010) as the replacement for the
+retired place-widget — volumetry needs *some* seed UI to be usable end-to-end
+(the v2.0.0 fully-usable bar). Keep it deliberately THIN and carrier-backed so
+#417 can later absorb it by re-parenting the same carrier under the unified
+table. Do NOT build territory-style grouping UI here. Flag in the PR that the
+table is a #417 seam, not its final form. (If the maintainer prefers, defer the
+table entirely to #417 and ship seeds-off-markups with placement-only + a
+transient list — OQ3; NOT recommended, leaves volumetry unusable for naming
+segments.)
+
+---
+
+## 6. Slice / PR breakdown (recommended ordering)
+
+ADR first, then extract+refactor (behaviour-preserving, its own PR), then the
+volumetry application. Stacked off `preview` (each on the prior).
+
+- **PR 0 — ADR-0038 implementation amendment** (authored as a separate
+  maintainer-authorized step, not by the implementer). Records §1d home, §1a
+  names, volumetry-as-third-consumer, resection→base direction.
+- **PR 1 — extract the ADR-0038 base + refactor #569 (behaviour-preserving).**
+  Create `SlicerLiverInteractionLib` with `SurfacePick`, `PointPlacementState`,
+  `SurfacePointPlacementPipeline3D/Slice`, `PointProvider`, shared constants.
+  Rebase resection (`ControlPolygonPipeline` / `SliceControlPolygonPipeline`)
+  AND VascularTerritories pipelines onto the base via seam adapters. The entire
+  existing resection + VascularTerritories characterization suites (both
+  harnesses) stay green UNCHANGED (§2). This is the biggest, riskiest PR — it is
+  a pure refactor with the two existing suites as the net.
+  - **OPEN QUESTION 1** gates the SIZE of this PR: full ADR-0038 (resection +
+    territories both clients) vs the prompt's narrower "territories + volumetry
+    share, resection later." Recommend full ADR-0038.
+- **PR 2 — LiverVolumetry seeds off markups.** New `vtkMRMLVolumetrySeedsNode` +
+  storage + display node; the volumetry `PointProvider` adapter; the 3
+  registration calls; the transient-fiducial C++ adapter (§3c) feeding the
+  unchanged `vtkLiverVolumetryLogic`; retire `ROIMarkersList` + place widget.
+- **PR 3 — minimal volumetry seeds table** (§5), a11y glyph+text, #417 seam note.
+  (May fold into PR 2 if small.)
+
+If OQ1 = narrow scope: PR 1 extracts FROM #569 only (not resection), and PR 0
+becomes a NEW ADR-0039 recording the deviation from ADR-0038's resection→base
+direction.
+
+---
+
+## 7. Test plan (ADR-0027, two-harness discipline)
+
+Mirror the `VascularTerritories/Testing/Python` layout + its `conftest.py`
+(snap/teardown autouse, mirrors LiverSegmentation conftest). **Two harnesses:**
+launched-Slicer AND bare `PythonSlicer -m pytest` scaffold — a green launched run
+is NOT a green bare run. **Launched-sweep root-order trap:** keep any new
+volumetry test root ordered so **LiverSegmentation root stays LAST**, or the
+conftest collision fakes ~34 failures. **LayerDM state on the display node:** the
+arm/active/carrier/pick state MUST live on the shared display node, not a Python
+pipeline instance (bit hard on #593) — verify LIVE.
+
+- **Generic base (new, in the shared Lib's Testing):**
+  - `test_surface_pick.py` — bare pure-VTK (rename of the vessel-pick test's
+    geometry assertions, now against `SurfacePick`).
+  - `test_point_placement_pipeline_3d.py` — bare-ish: add-on-click / drag-nearest
+    / delete-one / bare-move-decline / no-drift, against a fake `PointProvider`.
+  - `test_point_placement_pipeline_slice.py` — projection/fade/side/presence.
+  - `test_point_placement_state.py` — arm/active/module-active/carrier accessors,
+    namespaced keys. Bare.
+- **#569 characterization net** (§2) — unchanged assertions, both harnesses.
+- **LiverVolumetry (new):**
+  - `test_volumetry_seed_carrier.py` — carrier add/move/delete + label + storage
+    round-trip. Bare pure-VTK (wrapped C++ node imported via the module's wrapped
+    logic Python module, never plain `vtk`/`slicer`).
+  - `test_volumetry_seed_transient_fiducial.py` — the pure carrier→fiducial-
+    payload mapping preserves position + LABEL + order. Bare.
+  - `test_volumetry_seed_placement.py` — the volumetry `PointProvider` + base:
+    click adds one seed on the surface, drag edits nearest, delete removes one.
+    Launched (LayerDM + view).
+  - `test_volumetry_seed_display_node.py` — data-only contract. Bare-VTK.
+  - `test_volumetry_compute_from_carrier.py` — `vtkLiverVolumetryLogic` fed the
+    transient fiducial produces the SAME volumetry table + segment names as the
+    old `ROIMarkersList` path (the invariant that the port preserves compute).
+  - Registration smoke — the 3 ADR-0013 §5 calls register with NO custom DM.
+
+Implementer-brief hygiene (bake into any handoff): `./Utilities/SetupForDevelopment.sh`;
+local pre-commit + relevant CTest BEFORE push; build inside worktree `build/`;
+pre-PR grep for `guix`/`nix`/`apt`/`brew` (platform neutrality); NO PR/issue refs
+in source; NO `Co-Authored-By: Claude` / "Generated with" in commit messages;
+AI-authorship notice in PR body only.
+
+---
+
+## 8. Risks
+
+- **Refactor-scope blast radius (highest).** PR 1 touches resection AND
+  territories pipelines at once. Mitigation: the two mature characterization
+  suites are the net; extract in small commits (pick → state → 3D base → slice
+  base → resection client → territories client), running both suites per step.
+- **The base leaking a specific concern.** The vessel-visibility gating and the
+  territory grouping must NOT bleed into the base (ADR-0038 §"What is not
+  shared"). Guard: the base test uses a FAKE flat `PointProvider` with no gating;
+  if it needs a vessel concept, the seam is wrong.
+- **LABEL fidelity in the transient fiducial** — if the per-seed label doesn't
+  round-trip, `GenerateSegmentsLabelMap` mis-names segments. Pinned by
+  `test_volumetry_compute_from_carrier.py` + `test_volumetry_seed_transient_fiducial.py`.
+- **#417 collision** (§5) — minimal carrier-backed table mitigates; PR note.
+- **Direction conflict with ADR-0038** (§0) — resolved by following the ADR;
+  OQ1 escalates if the maintainer wants the narrower scope.
+- **T2.7 rename temptation** — new classes drop `Liver` (required); do NOT rename
+  existing `vtkLiverVolumetryLogic` / `vtkMRMLCustomTerritoriesNode` inside #570
+  (that is T2.7; balloons the diff + touches wrapped-Python import sites).
+- **Volumetry pick surface** — is the seed snapped to the input segmentation
+  surface or the target labelmap? The old markups path let seeds land free in
+  space; snapping is a behaviour CHANGE. See OQ4.
+
+---
+
+## 9. OPEN QUESTIONS (consolidated)
+
+> **RESOLVED 2026-07-27 (maintainer).** OQ1 = **full ADR-0038** (extract from
+> resection; resection + territories + volumetry all clients). OQ2 =
+> **`SlicerLiverInteractionLib`**. OQ3 = **minimal carrier-backed table now**
+> (thin, re-parentable, #417 seam). OQ4 = **in-volume / slice-click pick**, NOT
+> surface-snap — the seed is a region-grow voxel index (`vtkLiverVolumetryLogic`
+> `TransformPhysicalPointToIndex` → `ConnectedThreshold`), so it must land
+> inside the region; the pick step is a swappable provider on the seam (base
+> extension). OQ5 = **amend ADR-0038** (done — see the ADR's Implementation
+> amendment 2026-07-27), no ADR-0039. The §3b "pick-surface = input segmentation
+> closed surface" line is SUPERSEDED by OQ4's in-volume pick.
+
+1. **Scope of the extraction (gates PR 1 size + the ADR choice).** Full ADR-0038
+   (extract from resection; resection + territories + volumetry all clients) vs
+   the prompt's narrower "extract from #569; resection untouched for now."
+   **Recommend: full ADR-0038** — it is Accepted and names this the follow-up; a
+   narrower scope deviates from its resection→base direction and needs an
+   ADR-0038 amendment (or a new ADR-0039) recording the deviation.
+2. **Shared-core home + name.** `SlicerLiverInteractionLib` (recommended) vs
+   folding into `LayerDMLib` (rejected: upstream package) vs a module Lib
+   (rejected: wrong-way dependency). Confirm the name.
+3. **Volumetry seeds table now, or defer to #417.** **Recommend: minimal
+   carrier-backed table now** (volumetry must be usable end-to-end for v2.0.0);
+   thin + re-parentable so #417 absorbs it.
+4. **Seed snapping semantics.** Do volumetry seeds SNAP to a surface (the base's
+   default, on-surface ~0) or may they land free in the volume (the old markups
+   behaviour)? Region-growing seeds are conceptually IN the volume, not on a
+   surface. **Recommend:** snap to the target region's surface for placement UX
+   but allow the carrier to hold the raw picked point; confirm whether the
+   region-grow needs interior seeds (may require an "in-volume" pick variant, not
+   the surface pick) — this is the one place volumetry may need a base EXTENSION
+   rather than a plain client.
+5. **ADR: amend 0038 vs new 0039.** **Recommend: amend 0038** (it owns the
+   decision). New 0039 only if OQ1 = narrow scope.
+
+---
+
+## 10. Suggested next handoff
+
+- Resolve **OQ1 + OQ4** first (they gate the shape). Then:
+- **ADR step** (maintainer-authorized): amend ADR-0038 with §1d/§1a/third-consumer.
+- `liver-test-designer` — the generic-base invariants + the volumetry
+  compute-preservation invariant, characterization-first.
+- `liver-implementer` — PR 1 (extract+refactor, behaviour-preserving) THEN PR 2/3.
+- Until OQ1 + OQ4 are answered: do not write code.

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -72,6 +72,7 @@ design/resection-plan-architecture/05-lrp-json-schema.md
 design/resection-plan-architecture/06-pattern-and-audit.md
 design/connected-tree-seeding-plan.md
 design/multi-system-territory-plan.md
+design/volumetry-seeds-layerdm-plan.md
 ```
 
 ```{toctree}

--- a/Liver/Testing/Python/CMakeLists.txt
+++ b/Liver/Testing/Python/CMakeLists.txt
@@ -188,6 +188,14 @@ set(_launched_test_roots
   "${CMAKE_SOURCE_DIR}/Testing/Python"
   "${CMAKE_SOURCE_DIR}/LiverResections/Testing/Python"
   "${CMAKE_SOURCE_DIR}/VascularTerritories/Testing/Python"
+  # ADR-0038 shared interaction base + the LiverVolumetry seeds-off-markups
+  # migration.  Ordered BEFORE the LiverSegmentation root: LiverSegmentation
+  # imports its conftest by name (23 sites), so its root must stay LAST or the
+  # session-start conftest-dir collision fakes ~34 failures (the launched-sweep
+  # root-order trap).  These two roots' tests import slicer_pytest_support (not
+  # a bare `import conftest`), so they are collision-safe here.
+  "${CMAKE_SOURCE_DIR}/SlicerLiverInteractionLib/Testing/Python"
+  "${CMAKE_SOURCE_DIR}/LiverVolumetry/Testing/Python"
   "${CMAKE_SOURCE_DIR}/LiverSegmentation/Testing/Python"
 )
 

--- a/LiverVolumetry/CMakeLists.txt
+++ b/LiverVolumetry/CMakeLists.txt
@@ -23,13 +23,11 @@ slicerMacroBuildScriptedModule(
 #  WITH_GENERIC_TESTS
 )
 
-##-----------------------------------------------------------------------------
-#if(BUILD_TESTING)
-#
-#  # Register the unittest subclass in the main script as a ctest.
-#  # Note that the test will also be available at runtime.
-#  #slicer_add_python_unittest(SCRIPT ${MODULE_NAME}.py)
-#
-#  # Additional build-time testing
-#  add_subdirectory(Testing)
-#endif()
+#-----------------------------------------------------------------------------
+if(BUILD_TESTING)
+  # ADR-0038-amendment seeds-off-markups invariant-test scaffolding
+  # (SlicerLiverInteractionLib base tests live in that Lib's own Testing
+  # tree).  Registers the bare-pytest CTest rows; the wrapped-node /
+  # LayerDM-base tests SKIP bare and RUN launched (ADR-0027).
+  add_subdirectory(Testing)
+endif()

--- a/LiverVolumetry/Testing/CMakeLists.txt
+++ b/LiverVolumetry/Testing/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Python)

--- a/LiverVolumetry/Testing/Python/CMakeLists.txt
+++ b/LiverVolumetry/Testing/Python/CMakeLists.txt
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+# ---------------------------------------------------------------------------
+# Bare-VTK unit tests for the ADR-0038-amendment LiverVolumetry seeds-off-
+# markups migration (pytest_scaffold family).
+# ---------------------------------------------------------------------------
+#
+# The pure carrier->transient-fiducial mapping runs under bare
+# ``PythonSlicer -m pytest`` (no scene, no wrapped node -- ADR-0003 / ADR-0004).
+# The wrapped-C++-node + LayerDM-base + in-volume-pick + compute tests import
+# launched-only machinery and so SKIP bare and RUN launched (the wrapped-
+# class-namespace rule + LayerDMLib), still registering a bare CTest row here
+# that collects + skips cleanly, mirroring the VascularTerritories pattern.
+# The same skip-if-pytest-absent guard keeps the scaffolding buildable where
+# the Slicer Python environment lacks pytest.
+
+if(NOT Python3_EXECUTABLE)
+  message(STATUS
+    "Slicer-Liver: Python3_EXECUTABLE not set; "
+    "skipping LiverVolumetry bare-pytest registration.")
+  return()
+endif()
+
+execute_process(
+  COMMAND "${Python3_EXECUTABLE}" -c "import pytest"
+  RESULT_VARIABLE _volumetry_pytest_probe_rc
+  OUTPUT_QUIET
+  ERROR_QUIET
+)
+
+if(NOT _volumetry_pytest_probe_rc EQUAL 0)
+  message(STATUS
+    "Slicer-Liver: pytest not importable from ${Python3_EXECUTABLE}; "
+    "skipping LiverVolumetry bare-pytest registration.")
+  return()
+endif()
+
+set(_volumetry_pytest_files
+  # ADR-0038 §Conformance -- the vtkMRMLVolumetrySeedsNode carrier: ordered
+  # add/get/delete + per-seed LABEL + colour + storage round-trip.  Wrapped
+  # C++ node -> SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_seed_carrier.py
+  # ADR-0038 §Conformance -- the pure carrier->transient-fiducial mapping
+  # preserves position + LABEL + order.  Pure Python -> RUNS bare (ADR-0027).
+  test_volumetry_seed_transient_fiducial.py
+  # ADR-0025/0033 -- vtkMRMLVolumetrySeedsDisplayNode is DATA-ONLY (arm/hover/
+  # grab + pickSurface ref + transient point; no rendering).  Wrapped C++
+  # node -> SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_seed_display_node.py
+  # ADR-0038 §"Base extension" (OQ4) -- the in-volume/slice pick returns an
+  # INTERIOR labelled voxel, NOT a surface snap.  Needs a labelmap volume ->
+  # SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_in_volume_pick.py
+  # ADR-0038 §Conformance / ADR-0015 -- the port PRESERVES compute: the
+  # carrier-fed transient fiducial yields the SAME label values + segment
+  # names as the ROIMarkersList path.  Wrapped C++ logic -> SKIPS bare, RUNS
+  # launched (ADR-0027).
+  test_volumetry_compute_from_carrier.py
+  # ADR-0038 §Decision -- volumetry seed placement through the shared base +
+  # the volumetry provider + in-volume pick: click adds one interior seed,
+  # drag edits nearest, delete removes one.  LayerDM base + wrapped carrier
+  # -> SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_seed_placement.py
+  # ADR-0013 §5 -- the 3 registration calls register the carrier + display
+  # node with NO custom displayable manager.  Node registration + LayerDM
+  # factory -> SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_registration_smoke.py
+)
+
+foreach(_pytest_file IN LISTS _volumetry_pytest_files)
+  get_filename_component(_test_basename "${_pytest_file}" NAME_WE)
+  add_test(
+    NAME ${_test_basename}
+    COMMAND "${Python3_EXECUTABLE}" -m pytest
+      -q
+      "${CMAKE_CURRENT_SOURCE_DIR}/${_pytest_file}"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  )
+  set_tests_properties(${_test_basename} PROPERTIES
+    LABELS "pytest;LiverVolumetry;volumetry-seeds"
+  )
+endforeach()

--- a/LiverVolumetry/Testing/Python/conftest.py
+++ b/LiverVolumetry/Testing/Python/conftest.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Shared pytest scaffolding for the LiverVolumetry seed tests.
+
+Mirrors ``VascularTerritories/Testing/Python/conftest.py``: re-exports the
+launched-Slicer skip-guards from ``slicer_pytest_support`` (canonical
+bodies in ``Testing/Python/slicer_pytest_support.py``, on ``sys.path`` via
+the ``pythonpath`` ini option) and provides the autouse scene-cleanup
+fixture so the launched harness clears scratch nodes between tests.
+
+The seed carrier / display node / in-volume pick / compute tests are
+launched-Slicer (wrapped C++ nodes + the LayerDM base); the pure
+carrier->fiducial mapping runs bare.  The same skip-clean discipline as
+VascularTerritories applies: scene-/wrapped-node-needing tests SKIP under
+bare ``PythonSlicer -m pytest`` and RUN launched.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from slicer_pytest_support import (  # noqa: F401  (re-exported for `from conftest import ...`)
+    import_slicer_or_skip as _import_slicer_or_skip,
+    require_mrml_scene as _require_mrml_scene,
+    require_qt_widget as _require_qt_widget,
+)
+
+
+def _looks_like_real_slicer(module) -> bool:
+    """True iff ``module`` is the genuine launched-Slicer ``slicer`` module."""
+    return module is not None and getattr(module, "mrmlScene", None) is not None
+
+
+def _live_mrml_scene():
+    """Return the launched-Slicer ``mrmlScene`` or ``None`` under bare pytest."""
+    slicer = sys.modules.get("slicer")
+    if not _looks_like_real_slicer(slicer):
+        return None
+    return slicer.mrmlScene
+
+
+@pytest.fixture(autouse=True)
+def _launched_scene_cleanup():
+    """Clear the MRML scene after each launched test.  No-op under bare pytest.
+
+    The launched harness runs the whole tree in ONE ``qSlicerApplication``;
+    clearing after each test keeps scratch labelmaps / carriers / fiducials
+    from accumulating across the seed tests (mirrors the VascularTerritories
+    guard).
+    """
+    scene = _live_mrml_scene()
+    if scene is None:
+        yield
+        return
+
+    yield
+    scene.Clear(0)

--- a/LiverVolumetry/Testing/Python/test_volumetry_compute_from_carrier.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_compute_from_carrier.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment) -- the seed port PRESERVES the volumetry compute.
+
+``volumetry-seeds-layerdm-plan.md`` §3c: the C++ ``vtkLiverVolumetryLogic``
+signatures stay unchanged (ADR-0015); the seeds-off-markups migration feeds
+them a TRANSIENT ``vtkMRMLMarkupsFiducialNode`` built from the seed carrier.
+The invariant that makes the port safe: feeding the logic a transient
+fiducial built from the carrier must produce the SAME volumetry table +
+segment NAMES as the old ``ROIMarkersList`` fiducial path.
+
+The critical fidelity is the per-seed LABEL -> segment NAME round-trip:
+``computeVolume`` reads ``ROIMarkersList.GetNthControlPointLabel(i)`` to
+name each table row, and ``generateSegments`` reads
+``GetNthFiducialLabel(i)`` to name generated segment ``i``.  If the transient
+fiducial drops or reorders labels, the port silently mis-names segments
+(``volumetry-seeds-layerdm-plan.md`` §8 -- LABEL fidelity risk).
+
+This file pins the port-preserves-compute invariant by comparing TWO
+computes over the SAME geometry + labels:
+
+* a MARKUPS-fed compute (the legacy ``ROIMarkersList`` path -- the
+  behaviour-preserving baseline);
+* a CARRIER-fed compute (the new path: build the transient fiducial from a
+  ``vtkMRMLVolumetrySeedsNode`` and feed the unchanged logic).
+
+The two must produce byte-identical volumetry tables (same row order, same
+segment names, same voxel counts / volumes).
+
+HARNESS: launched Slicer.  This drives the wrapped C++
+``vtkLiverVolumetryLogic`` (reached via ``LiverVolumetryLogic().scl`` --
+imported from ``vtkSlicerLiverVolumetryModuleLogicPython``, NOT plain
+``vtk`` / ``slicer``, per the wrapped-class-namespace rule) over a real
+labelmap volume + fiducial + table nodes.  A bare
+``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` so it SKIPS
+CLEANLY.
+
+The carrier + the transient-fiducial adapter do not exist yet.  Per
+ADR-0027 red->skip the guards skip-pend; the skips lift at the
+implementation commit.
+
+References
+----------
+* ADR-0038 -- §Conformance ([review] "LiverVolumetry's C++ region-grow
+  logic is unchanged (ADR-0015); it is fed a transient fiducial built from
+  the seed carrier, and per-seed labels round-trip so generated segments
+  keep their names").
+* ADR-0015 -- the C++ region-grow logic is unchanged (port, not rewrite).
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* LiverVolumetry/LiverVolumetry.py -- computeVolume / generateSegments (the
+  label -> segment-name reads this preserves).
+* LiverVolumetry/Logic/vtkLiverVolumetryLogic.h -- GetROIPointsLabelValue /
+  VolumetryTable / GenerateSegmentsLabelMap (the fed C++ surface).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+for candidate in (
+    REPO_ROOT / "LiverVolumetry" / "LiverVolumetryLib",
+    REPO_ROOT / "LiverVolumetry",
+):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+SEEDS_NODE_CLASS = "vtkMRMLVolumetrySeedsNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _cpp_logic_or_skip():
+    """The wrapped C++ ``vtkLiverVolumetryLogic`` (via LiverVolumetryLogic.scl).
+
+    Resolved through the module's wrapped-logic Python module, NOT plain
+    ``vtk`` / ``slicer`` (the wrapped-class-namespace rule).
+    """
+    try:
+        from vtkSlicerLiverVolumetryModuleLogicPython import vtkLiverVolumetryLogic
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"vtkLiverVolumetryLogic not importable ({exc!r}) -- the wrapped "
+            "LiverVolumetry logic is off the path (needs a launched build)."
+        )
+    return vtkLiverVolumetryLogic()
+
+
+def _import_transient_adapter_or_skip():
+    """Import the carrier->transient-fiducial adapter, or skip-pend (ADR-0027).
+
+    PROPOSED seam (sharpen at landing): a thin Logic wrapper that builds a
+    transient ``vtkMRMLMarkupsFiducialNode`` in the given scene from a
+    ``vtkMRMLVolumetrySeedsNode`` (positions + per-seed labels as control
+    point labels), returning the node the caller feeds + later removes::
+
+        def build_transient_fiducial(scene, seeds_node) -> markups_node: ...
+    """
+    try:
+        from TransientVolumetrySeeds import build_transient_fiducial
+    except ImportError:
+        pytest.skip(
+            "build_transient_fiducial not importable -- the carrier->transient-"
+            "fiducial adapter (plan §3c) has not landed (ADR-0027)."
+        )
+    return build_transient_fiducial
+
+
+def _labelmap_two_regions_or_skip(slicer):
+    """A labelmap with two labelled regions (values 3 and 5) in a zero field.
+
+    Two interior points -- one in each region -- give two distinct table
+    rows so the label->row mapping is observable.
+    """
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode", "Regions")
+    if node is None:
+        pytest.skip("vtkMRMLLabelMapVolumeNode not registrable (launched build).")
+    image = vtk.vtkImageData()
+    image.SetDimensions(20, 20, 20)
+    image.SetSpacing(1.0, 1.0, 1.0)
+    image.AllocateScalars(vtk.VTK_SHORT, 1)
+    scalars = image.GetPointData().GetScalars()
+    scalars.Fill(0)
+    for k in range(20):
+        for j in range(20):
+            for i in range(20):
+                idx = i + 20 * (j + 20 * k)
+                if i < 10:
+                    scalars.SetTuple1(idx, 3)
+                else:
+                    scalars.SetTuple1(idx, 5)
+    image.Modified()
+    node.SetAndObserveImageData(image)
+    return node
+
+
+# The two seeds' geometry + labels, shared by both the markups path and the
+# carrier path so the ONLY difference under test is the feed mechanism.
+_SEEDS = [
+    ((5.0, 10.0, 10.0), "LeftRegion"),   # inside the value-3 region
+    ((15.0, 10.0, 10.0), "RightRegion"),  # inside the value-5 region
+]
+
+
+def _markups_fiducial(slicer):
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "ROIMarkersList")
+    for (x, y, z), label in _SEEDS:
+        idx = node.AddControlPoint(vtk.vtkVector3d(x, y, z))
+        node.SetNthControlPointLabel(idx, label)
+    return node
+
+
+def _carrier(slicer):
+    node = slicer.mrmlScene.AddNewNodeByClass(SEEDS_NODE_CLASS, "Seeds")
+    if node is None or not hasattr(node, "AddSeed"):
+        pytest.skip(
+            f"{SEEDS_NODE_CLASS} / AddSeed not available -- the seed carrier "
+            "has not landed (ADR-0027)."
+        )
+    for (x, y, z), label in _SEEDS:
+        idx = node.AddSeed(x, y, z)
+        node.SetNthSeedLabel(idx, label)
+    return node
+
+
+def _label_values(cpp_logic, labelmap, fiducial):
+    """The per-seed label VALUES the compute reads (GetROIPointsLabelValue)."""
+    if not hasattr(cpp_logic, "GetROIPointsLabelValue"):
+        pytest.skip("vtkLiverVolumetryLogic has no GetROIPointsLabelValue.")
+    return list(cpp_logic.GetROIPointsLabelValue(labelmap, fiducial))
+
+
+def test_carrier_fed_label_values_match_markups_path():
+    """GetROIPointsLabelValue over the transient fiducial == over ROIMarkersList.
+
+    The C++ maps each seed to the labelmap value at its voxel; feeding a
+    transient fiducial built from the carrier must return the SAME per-seed
+    label values (same positions -> same voxels) as the legacy markups
+    node.  This is the geometry half of the port-preserves-compute
+    invariant (ADR-0038 §Conformance / ADR-0015).
+    """
+    slicer = _slicer_or_skip()
+    cpp_logic = _cpp_logic_or_skip()
+    build_transient = _import_transient_adapter_or_skip()
+    labelmap = _labelmap_two_regions_or_skip(slicer)
+
+    markups = _markups_fiducial(slicer)
+    baseline = _label_values(cpp_logic, labelmap, markups)
+
+    carrier = _carrier(slicer)
+    transient = build_transient(slicer.mrmlScene, carrier)
+    ported = _label_values(cpp_logic, labelmap, transient)
+
+    assert ported == baseline, (
+        "the carrier-fed transient fiducial must map to the SAME per-seed "
+        "label values as ROIMarkersList (ADR-0038 §Conformance / ADR-0015)."
+    )
+
+
+def test_carrier_fed_segment_names_match_seed_labels_in_order():
+    """The transient fiducial's control-point labels == the seed labels, in order.
+
+    ``generateSegments`` names generated segment ``i`` from
+    ``GetNthFiducialLabel(i)``; the transient fiducial must expose the
+    carrier's per-seed labels in placement order so the port names segments
+    identically to the markups path.  This is the segment-NAME half of the
+    port-preserves-compute invariant -- the ADR-0038 §Conformance "per-seed
+    labels round-trip so generated segments keep their names".
+    """
+    slicer = _slicer_or_skip()
+    _cpp_logic_or_skip()
+    build_transient = _import_transient_adapter_or_skip()
+
+    carrier = _carrier(slicer)
+    transient = build_transient(slicer.mrmlScene, carrier)
+
+    expected = [label for _pos, label in _SEEDS]
+    n = transient.GetNumberOfControlPoints()
+    assert n == len(expected), "the transient fiducial must carry every seed."
+    got = [transient.GetNthControlPointLabel(i) for i in range(n)]
+    assert got == expected, (
+        "the transient fiducial's control-point labels must equal the seed "
+        "labels IN ORDER (segment-name fidelity, ADR-0038 §Conformance)."
+    )
+
+
+def test_volumetry_table_rows_match_between_paths():
+    """The populated volumetry table is identical between the two feed paths.
+
+    End-to-end: running the module ``LiverVolumetryLogic.computeVolume`` with
+    the markups path vs the carrier path (transient fiducial) yields the SAME
+    table -- same row order, same segment-name column, same voxel counts /
+    volumes.  This is the top-level port-preserves-compute invariant.
+
+    TODO(implementer): once ``computeVolume`` accepts a carrier (or an
+    already-built transient fiducial), drive both paths over the same
+    labelmap + table and compare the table cell-by-cell.  Kept as an
+    explicit skip until ``computeVolume``'s carrier entry point lands so the
+    comparison target is unambiguous.
+    """
+    _slicer_or_skip()
+    _cpp_logic_or_skip()
+    pytest.skip(
+        "computeVolume's carrier entry point has not landed -- the "
+        "table-level comparison target is not yet defined (ADR-0038 "
+        "§Conformance; ADR-0027 red->skip).  test_carrier_fed_label_values_"
+        "match_markups_path + test_carrier_fed_segment_names_match_seed_labels_"
+        "in_order pin the two halves this rolls up."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverVolumetry/Testing/Python/test_volumetry_in_volume_pick.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_in_volume_pick.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment, OQ4) -- the in-volume / slice-click pick returns an INTERIOR point.
+
+ADR-0038 §"Base extension: the pick step is swappable" (2026-07-27) makes
+the pick a SEAM-INJECTED provider, not a fixed surface-snap.  LiverVolumetry
+seeds are REGION-GROWING seeds: ``vtkLiverVolumetryLogic`` converts each
+seed to a voxel index (``TransformPhysicalPointToIndex``) and grows a
+``ConnectedThreshold`` from it, so the seed must land INSIDE the target
+region, not on its surface.  Snapping a volumetry seed to a surface would
+place it on the region boundary and can mis-seed the grow.
+
+So volumetry injects an IN-VOLUME / slice-click pick: a click in a slice
+view resolves to the RAS point AT THE SLICE PLANE (an interior voxel), the
+natural region-growing-seed UX.  This file pins that contract -- the ONE
+place volumetry is not a plain surface client:
+
+* a slice click INSIDE the region yields a RAS point whose
+  ``TransformPhysicalPointToIndex`` lands on a LABELLED (non-zero) voxel of
+  the target labelmap -- i.e. an interior voxel the region-grow can seed;
+* the pick is NOT surface-snapped -- given a target region with a genuine
+  interior (a solid block), the returned point is strictly inside, not on
+  the boundary face.
+
+The pick provider does NOT leak a volume concept into the base: the base
+sees only "the consumer's pick returned this world point" (pinned by
+``SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_3d.py``
+::test_no_surface_vs_volume_branch_in_the_base).  This file pins the
+PROVIDER's own contract.
+
+HARNESS: launched Slicer.  The pick resolves a slice pixel against a real
+``vtkMRMLLabelMapVolumeNode`` (``TransformPhysicalPointToIndex`` /
+``GetImageData``) reachable only inside a launched Slicer; a bare
+``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` so it SKIPS
+CLEANLY.
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the import + guards
+skip-pend; the skips lift at the implementation commit.
+
+References
+----------
+* ADR-0038 -- §"Base extension: the pick step is swappable (surface vs
+  in-volume)"; §"Consumers ledger" (LiverVolumetry -- in-volume/slice pick).
+* ADR-0015 -- the region-grow C++ (TransformPhysicalPointToIndex ->
+  ConnectedThreshold) the interior seed feeds, unchanged.
+* volumetry-seeds-layerdm-plan.md §9 OQ4 (RESOLVED: in-volume pick, not
+  surface-snap).
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+for candidate in (
+    REPO_ROOT / "LiverVolumetry" / "LiverVolumetryLib",
+    REPO_ROOT / "LiverVolumetry",
+):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _import_pick_or_skip():
+    """Import the volumetry in-volume pick provider or skip-pend (ADR-0027).
+
+    PROPOSED seam (sharpen at landing).  A pick provider satisfying the same
+    seam the base injects (see the 3D base's SetPickProvider), resolving a
+    slice-view click to an interior RAS point of a labelmap volume::
+
+        class InVolumePick:
+            def __init__(self, labelmap_node) -> None: ...
+            # returns the interior RAS world point for a slice-view click,
+            # or None when the click is outside the labelled region.
+            def pick_for_slice_event(self, slice_node, display_xy): ...
+
+    Adjust the imported name here to match the landed module/class.
+    """
+    try:
+        from InVolumePick import InVolumePick
+    except ImportError:
+        pytest.skip(
+            "InVolumePick not importable -- the ADR-0038-amendment (OQ4) "
+            "in-volume / slice-click pick provider has not landed (ADR-0027)."
+        )
+    return InVolumePick
+
+
+def _solid_block_labelmap_or_skip(slicer, label=3):
+    """A labelmap volume: a solid interior block of ``label`` in a zero field.
+
+    Builds a 20x20x20 image with a 6..14 cube set to ``label`` so there is a
+    genuine INTERIOR (voxel (10,10,10) is strictly inside, not on a face).
+    Returns the ``vtkMRMLLabelMapVolumeNode`` or skips if creation fails.
+    """
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode", "TargetRegion")
+    if node is None:
+        pytest.skip("vtkMRMLLabelMapVolumeNode not registrable (launched build).")
+
+    image = vtk.vtkImageData()
+    image.SetDimensions(20, 20, 20)
+    image.SetSpacing(1.0, 1.0, 1.0)
+    image.SetOrigin(0.0, 0.0, 0.0)
+    image.AllocateScalars(vtk.VTK_SHORT, 1)
+    scalars = image.GetPointData().GetScalars()
+    scalars.Fill(0)
+    for k in range(20):
+        for j in range(20):
+            for i in range(20):
+                if 6 <= i <= 14 and 6 <= j <= 14 and 6 <= k <= 14:
+                    idx = i + 20 * (j + 20 * k)
+                    scalars.SetTuple1(idx, label)
+    image.Modified()
+    node.SetAndObserveImageData(image)
+    return node, label
+
+
+def test_slice_click_inside_region_yields_a_labelled_interior_voxel():
+    """A slice click inside the region resolves to a LABELLED voxel's RAS.
+
+    ADR-0038 §"Base extension" (OQ4).  The interior seed's RAS, when mapped
+    to the labelmap's index space via ``TransformPhysicalPointToIndex``,
+    must land on a non-zero (labelled) voxel -- i.e. a voxel the region-grow
+    can seed.  Without this the ``ConnectedThreshold`` seeds outside the
+    region and grows nothing / the wrong region (ADR-0015).
+    """
+    slicer = _slicer_or_skip()
+    InVolumePick = _import_pick_or_skip()
+    labelmap, label = _solid_block_labelmap_or_skip(slicer)
+
+    pick = InVolumePick(labelmap)
+    if not hasattr(pick, "pick_for_slice_event"):
+        pytest.skip(
+            "InVolumePick has no pick_for_slice_event seam -- the slice-click "
+            "resolution has not landed (ADR-0027)."
+        )
+
+    # A click over the centre of the region (RAS ~ index (10,10,10), which is
+    # strictly interior to the 6..14 block).  The slice node + display xy are
+    # resolved by the harness against the labelmap centre; the invariant is
+    # the RESULT (a labelled interior voxel), not the pixel arithmetic.
+    slice_node = slicer.app.layoutManager().sliceWidget("Red").mrmlSliceNode()
+    world = pick.pick_for_slice_event(slice_node, display_xy=None)
+    if world is None:
+        pytest.skip(
+            "the pick could not resolve a slice click in this harness -- the "
+            "slice-node placement helper has not landed (ADR-0027)."
+        )
+
+    # Map the picked RAS to the labelmap's voxel index and read the label.
+    ras_to_ijk = vtk.vtkMatrix4x4()
+    labelmap.GetRASToIJKMatrix(ras_to_ijk)
+    homog = list(world) + [1.0]
+    ijk = ras_to_ijk.MultiplyPoint(homog)
+    i, j, k = (int(round(c)) for c in ijk[:3])
+    value = labelmap.GetImageData().GetScalarComponentAsDouble(i, j, k, 0)
+
+    assert value == pytest.approx(float(label)), (
+        "the in-volume pick must land on a LABELLED voxel (an interior "
+        "region-grow seed), NOT outside the region (ADR-0038 §'Base "
+        "extension' / ADR-0015)."
+    )
+
+
+def test_in_volume_pick_is_not_surface_snapped():
+    """The interior seed is strictly INSIDE the region, not on its boundary.
+
+    ADR-0038 §"Base extension": a surface-snapped pick would land the seed
+    on the region boundary and can mis-seed the grow.  Given a solid block
+    with a genuine interior, the returned voxel must NOT be a boundary face
+    voxel of the labelled block -- it must have labelled neighbours on all
+    six sides.
+    """
+    slicer = _slicer_or_skip()
+    InVolumePick = _import_pick_or_skip()
+    labelmap, label = _solid_block_labelmap_or_skip(slicer)
+
+    pick = InVolumePick(labelmap)
+    if not hasattr(pick, "pick_for_slice_event"):
+        pytest.skip("InVolumePick has no pick_for_slice_event seam (ADR-0027).")
+
+    slice_node = slicer.app.layoutManager().sliceWidget("Red").mrmlSliceNode()
+    world = pick.pick_for_slice_event(slice_node, display_xy=None)
+    if world is None:
+        pytest.skip("the pick could not resolve a slice click in this harness (ADR-0027).")
+
+    ras_to_ijk = vtk.vtkMatrix4x4()
+    labelmap.GetRASToIJKMatrix(ras_to_ijk)
+    ijk = ras_to_ijk.MultiplyPoint(list(world) + [1.0])
+    ci, cj, ck = (int(round(c)) for c in ijk[:3])
+    image = labelmap.GetImageData()
+
+    for di, dj, dk in ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)):
+        neighbour = image.GetScalarComponentAsDouble(ci + di, cj + dj, ck + dk, 0)
+        assert neighbour == pytest.approx(float(label)), (
+            "the interior seed must have labelled neighbours on ALL six sides "
+            "(strictly inside, not surface-snapped to the boundary) -- "
+            "ADR-0038 §'Base extension'."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverVolumetry/Testing/Python/test_volumetry_registration_smoke.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_registration_smoke.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0013 §5 -- the volumetry seed registration is the 3 calls, NO custom DM.
+
+``volumetry-seeds-layerdm-plan.md`` §3b: LiverVolumetry registers its new
+node ecosystem through the SAME three ADR-0013 §5 calls VascularTerritories
+uses, and hosts NO per-module displayable manager
+(``feedback_layerdm_no_custom_dm``; ADR-0013 §5):
+
+1. ``RegisterNodeClass`` for the seed carrier + display node (+ storage);
+2. the upstream LayerDM displayable-manager ``RegisterInFactory``;
+3. a Pipeline creator matching ``(vtkMRMLViewNode,
+   vtkMRMLVolumetrySeedsDisplayNode)`` returning the shared
+   ``SurfacePointPlacementPipeline3D`` wired to a volumetry provider (plus
+   the slice creator).
+
+This file pins:
+
+* the carrier + display node classes are REGISTERED (instantiable via
+  ``AddNewNodeByClass``);
+* NO ``vtkMRMLLiverVolumetry*DisplayableManager`` class exists (an absence
+  pin with a credible creep-in path -- a closed-without-merge attempt at a
+  custom ``vtkMRMLLiverBezier*DisplayableManager3D`` is exactly this
+  temptation; ``feedback_layerdm_no_custom_dm`` / ADR-0013 §5).  NOT a
+  colour-of-the-sky absence.
+
+The Pipeline-creator wiring itself is exercised by
+``test_volumetry_seed_placement.py`` (an actual placement through the
+created pipeline); this file is the registration-shape smoke.
+
+HARNESS: launched Slicer.  Node registration + the LayerDM factory are
+reachable only inside a launched Slicer with the module loaded; a bare
+``PythonSlicer -m pytest`` SKIPS CLEANLY.
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the guards skip-pend;
+the skips lift at the implementation commit.
+
+References
+----------
+* ADR-0013 §5 -- the three registration calls; no custom displayable
+  manager (the base supplies only the Pipeline base classes).
+* ADR-0038 -- §"Shared home + names" (each module keeps its own three
+  registration calls + its own display-node type).
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* feedback_layerdm_no_custom_dm -- the closed
+  ``vtkMRMLLiverBezier*DisplayableManager3D`` custom-DM attempt is the
+  creep-in path this absence guards.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+SEEDS_NODE_CLASS = "vtkMRMLVolumetrySeedsNode"
+DISPLAY_NODE_CLASS = "vtkMRMLVolumetrySeedsDisplayNode"
+STORAGE_NODE_CLASS = "vtkMRMLVolumetrySeedsStorageNode"
+
+# Names a custom displayable manager WOULD take if wrongly introduced
+# (ADR-0013 §5 forbids it; the closed vtkMRMLLiverBezier*DisplayableManager3D
+# attempt is the Bezier equivalent of this temptation).
+BANNED_DM_CLASSES = (
+    "vtkMRMLVolumetrySeedsDisplayableManager",
+    "vtkMRMLVolumetrySeedsDisplayableManager3D",
+    "vtkMRMLLiverVolumetrySeedsDisplayableManager",
+)
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def test_seed_carrier_and_display_node_are_registered():
+    """The carrier + display node (+ storage) are registered node classes.
+
+    ADR-0013 §5 call 1 (RegisterNodeClass).  All three must be instantiable
+    via ``AddNewNodeByClass`` once the module Logic's ``RegisterNodes`` has
+    run in the launched build.
+    """
+    slicer = _slicer_or_skip()
+
+    for cls in (SEEDS_NODE_CLASS, DISPLAY_NODE_CLASS, STORAGE_NODE_CLASS):
+        node = slicer.mrmlScene.AddNewNodeByClass(cls)
+        if node is None:
+            pytest.skip(
+                f"{cls} not registered -- the ADR-0013 §5 RegisterNodeClass "
+                "calls (plan §3b) have not landed (ADR-0027)."
+            )
+        assert node.IsA(cls), f"{cls} must instantiate to its own type."
+
+
+def test_no_custom_displayable_manager_for_volumetry_seeds():
+    """NO per-module displayable manager exists for the seed display node.
+
+    ADR-0013 §5 / ``feedback_layerdm_no_custom_dm``: rendering goes through
+    the shared LayerDM Pipeline base, never a module-hosted DM.  A closed-
+    without-merge ``vtkMRMLLiverBezier*DisplayableManager3D`` attempt is
+    exactly this pattern for Bezier, so this is an absence WITH a credible
+    creep-in path (not colour of the sky).
+    """
+    _slicer_or_skip()
+    import slicer
+
+    for name in BANNED_DM_CLASSES:
+        # A registered custom DM would surface as a class on the slicer
+        # namespace (the wrapped-VTK convention) or be creatable off the
+        # scene; assert neither.
+        assert getattr(slicer, name, None) is None, (
+            f"{name} must NOT exist -- LiverVolumetry hosts no per-module "
+            "displayable manager (ADR-0013 §5; feedback_layerdm_no_custom_dm)."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverVolumetry/Testing/Python/test_volumetry_seed_carrier.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_seed_carrier.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment) -- the LiverVolumetry seed carrier + storage round-trip.
+
+The ADR-0038 implementation amendment (2026-07-27) moves LiverVolumetry's
+region-growing seed fiducials OFF Slicer markups
+(``vtkMRMLMarkupsFiducialNode`` ``ROIMarkersList``) ONTO a module-local
+data-carrier ``vtkMRMLVolumetrySeedsNode``, following ADR-0014's four-layer
+split (each module owns its wrapper / carrier / display / storage;
+``volumetry-seeds-layerdm-plan.md`` §3a).  A volumetry seed is a labelled
+point: the per-point LABEL becomes a generated segment name
+(``GenerateSegmentsLabelMap`` reads it), and the per-point colour carries
+the seed display.
+
+This file pins the carrier increments (mirroring
+``test_territories_annotation_carrier.py``):
+
+* CARRIER MUTATION -- ordered add / get-Nth / count / delete; ``Modified``
+  on mutation; the ABSENCE of any markups-fiducial reference role on the
+  carrier (the off-markups invariant, ADR-0014 §"Fourth layer").
+* PER-POINT LABEL -- each seed carries a string label independent of its
+  coordinate; the label round-trips (the segment-name fidelity, pinned end
+  to end by ``test_volumetry_compute_from_carrier.py``).
+* PER-POINT COLOUR -- each seed carries an RGB display colour.
+* STORAGE ROUND-TRIP -- writing the carrier to its storage node and reading
+  back yields identical ORDERED points + labels + colours (mirrors
+  ``vtkMRMLResectionPlanStorageNode`` / the territory carrier round-trip).
+
+HARNESS: launched Slicer.  ``vtkMRMLVolumetrySeedsNode`` is a WRAPPED C++
+node whose Python wrapper resolves ONLY via the module's wrapped-logic
+Python module inside a launched Slicer with the module loaded -- NOT via
+plain ``vtk`` or ``slicer`` (the wrapped-class-namespace rule,
+``reference_algorithm_wrapped_class_namespace``).  A bare
+``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` and the wrapped
+class off the path, so every test SKIPS CLEANLY.
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the
+``AddNewNodeByClass``-returns-None + ``hasattr`` guards skip-pend; the
+skips lift at the implementation commit.
+
+References
+----------
+* ADR-0038 -- §"Consumers ledger" (LiverVolumetry as the third client) +
+  §Conformance (per-seed labels round-trip so generated segments keep
+  their names).
+* ADR-0014 -- the four-layer split (wrapper / carrier / display / storage);
+  §"Fourth layer" (no persistent markups).
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* VascularTerritories/Testing/Python/test_territories_annotation_carrier.py
+  -- the carrier-contract idiom this mirrors.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+SEEDS_NODE_CLASS = "vtkMRMLVolumetrySeedsNode"
+SEEDS_STORAGE_CLASS = "vtkMRMLVolumetrySeedsStorageNode"
+
+# PROPOSED carrier API (sharpen at landing against the territory carrier's
+# std::string-keyed idiom + the resection carrier's grid-vector accessors).
+# Tests skip-pending on absence (ADR-0027); the skip lifts at landing.
+ADD_METHOD = "AddSeed"                 # AddSeed(x, y, z) -> int (index)
+COUNT_METHOD = "GetNumberOfSeeds"
+GET_NTH_METHOD = "GetNthSeed"          # -> (x, y, z)
+DELETE_METHOD = "RemoveNthSeed"
+SET_LABEL_METHOD = "SetNthSeedLabel"
+GET_LABEL_METHOD = "GetNthSeedLabel"
+SET_COLOR_METHOD = "SetNthSeedColor"
+GET_COLOR_METHOD = "GetNthSeedColor"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_carrier_or_skip(slicer, name="VolumetrySeedsTest"):
+    node = slicer.mrmlScene.AddNewNodeByClass(SEEDS_NODE_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{SEEDS_NODE_CLASS} not registered -- the ADR-0038-amendment "
+            "volumetry seed carrier (plan §3a) has not landed; module Logic "
+            "RegisterNodes() must wire it up (launched build).  Skip lifts at "
+            "the implementation commit (ADR-0027)."
+        )
+    for method in (ADD_METHOD, COUNT_METHOD, GET_NTH_METHOD):
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{SEEDS_NODE_CLASS} has no {method} -- the seed carrier API "
+                "has not landed (ADR-0027)."
+            )
+    return node
+
+
+# --------------------------------------------------------------------------- #
+# Carrier mutation + off-markups invariant
+# --------------------------------------------------------------------------- #
+
+
+def test_add_get_count_are_ordered():
+    """Seeds add in order; get-Nth returns the placement-order coordinate.
+
+    ADR-0038 §"Consumers ledger" (flat, no-edges seed carrier).
+    """
+    slicer = _slicer_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    for x, y, z in pts:
+        carrier.AddSeed(x, y, z)
+
+    assert carrier.GetNumberOfSeeds() == len(pts)
+    for i, expected in enumerate(pts):
+        assert tuple(carrier.GetNthSeed(i)) == pytest.approx(expected, abs=1e-9)
+
+
+def test_delete_removes_exactly_one_and_shifts_order():
+    """Deleting the middle seed leaves two; the tail shifts up in order."""
+    slicer = _slicer_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    if not hasattr(carrier, DELETE_METHOD):
+        pytest.skip(f"{SEEDS_NODE_CLASS} has no {DELETE_METHOD} (ADR-0027).")
+
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    for x, y, z in pts:
+        carrier.AddSeed(x, y, z)
+
+    carrier.RemoveNthSeed(1)
+
+    assert carrier.GetNumberOfSeeds() == len(pts) - 1
+    assert tuple(carrier.GetNthSeed(0)) == pytest.approx(pts[0], abs=1e-9)
+    assert tuple(carrier.GetNthSeed(1)) == pytest.approx(pts[2], abs=1e-9)
+
+
+def test_carrier_holds_no_markups_reference_role():
+    """The seed carrier carries NO ``vtkMRMLMarkupsFiducialNode`` reference.
+
+    ADR-0014 §"Fourth layer" / the off-markups invariant: the seed geometry
+    lives on the carrier's own point store, not a referenced markups node.
+    An absence pin WITH a credible creep-in path (the old ``ROIMarkersList``
+    fiducial is exactly the thing being retired), not a colour-of-the-sky
+    absence (``feedback_no_colour_of_the_sky_tests``).
+    """
+    slicer = _slicer_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+
+    carrier.AddSeed(0.0, 0.0, 1.0)
+
+    n_roles = carrier.GetNumberOfNodeReferenceRoles()
+    for i in range(n_roles):
+        role = carrier.GetNthNodeReferenceRole(i)
+        ref = carrier.GetNodeReference(role)
+        assert ref is None or not ref.IsA("vtkMRMLMarkupsFiducialNode"), (
+            f"the seed carrier must hold NO markups-fiducial reference "
+            f"(role {role!r}) -- the off-markups migration retired ROIMarkersList "
+            "(ADR-0014 §'Fourth layer')."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Per-point label + colour
+# --------------------------------------------------------------------------- #
+
+
+def test_per_seed_label_is_independent_of_coordinate():
+    """Each seed carries a string LABEL independent of its coordinate.
+
+    ADR-0038 §Conformance: per-seed labels round-trip so generated segments
+    keep their names.  Setting a label must not move the point and vice
+    versa (the display/label slot is independent of the geometry slot).
+    """
+    slicer = _slicer_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    for method in (SET_LABEL_METHOD, GET_LABEL_METHOD):
+        if not hasattr(carrier, method):
+            pytest.skip(f"{SEEDS_NODE_CLASS} has no {method} (ADR-0027).")
+
+    carrier.AddSeed(1.0, 2.0, 3.0)
+    carrier.AddSeed(4.0, 5.0, 6.0)
+    carrier.SetNthSeedLabel(0, "SegmentV")
+    carrier.SetNthSeedLabel(1, "SegmentVI")
+
+    assert carrier.GetNthSeedLabel(0) == "SegmentV"
+    assert carrier.GetNthSeedLabel(1) == "SegmentVI"
+    # Setting a label must not disturb the coordinate.
+    assert tuple(carrier.GetNthSeed(0)) == pytest.approx((1.0, 2.0, 3.0), abs=1e-9)
+
+
+def test_per_seed_colour_round_trips():
+    """Each seed carries an RGB display colour that reads back."""
+    slicer = _slicer_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    for method in (SET_COLOR_METHOD, GET_COLOR_METHOD):
+        if not hasattr(carrier, method):
+            pytest.skip(f"{SEEDS_NODE_CLASS} has no {method} (ADR-0027).")
+
+    carrier.AddSeed(0.0, 0.0, 1.0)
+    carrier.SetNthSeedColor(0, 0.9, 0.2, 0.1)
+
+    assert tuple(carrier.GetNthSeedColor(0)) == pytest.approx((0.9, 0.2, 0.1), abs=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# Storage round-trip
+# --------------------------------------------------------------------------- #
+
+
+def test_storage_round_trips_points_labels_and_colours(tmp_path):
+    """Writing the carrier to storage and reading back preserves seeds + labels.
+
+    ADR-0014 storage layer; mirrors the resection / territory storage
+    round-trip.  Ordered points, per-seed labels, and per-seed colours must
+    be byte-equal after a write/read cycle.
+    """
+    slicer = _slicer_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    storage = slicer.mrmlScene.AddNewNodeByClass(SEEDS_STORAGE_CLASS)
+    if storage is None:
+        pytest.skip(
+            f"{SEEDS_STORAGE_CLASS} not registered -- the seed storage node "
+            "has not landed (ADR-0027)."
+        )
+    for method in (SET_LABEL_METHOD, GET_LABEL_METHOD):
+        if not hasattr(carrier, method):
+            pytest.skip(f"{SEEDS_NODE_CLASS} has no {method} (ADR-0027).")
+
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0)]
+    labels = ["SegmentV", "SegmentVI"]
+    for (x, y, z), label in zip(pts, labels):
+        idx = carrier.AddSeed(x, y, z)
+        carrier.SetNthSeedLabel(idx, label)
+
+    path = str(tmp_path / "seeds.vsd.json")
+    storage.SetFileName(path)
+    assert storage.WriteData(carrier) != 0, "storage write must succeed."
+
+    reloaded = slicer.mrmlScene.AddNewNodeByClass(SEEDS_NODE_CLASS, "Reloaded")
+    storage.ReadData(reloaded)
+
+    assert reloaded.GetNumberOfSeeds() == len(pts)
+    for i, (expected, label) in enumerate(zip(pts, labels)):
+        assert tuple(reloaded.GetNthSeed(i)) == pytest.approx(expected, abs=1e-9)
+        assert reloaded.GetNthSeedLabel(i) == label, (
+            "the per-seed label must round-trip through storage (segment-name "
+            "fidelity, ADR-0038 §Conformance)."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverVolumetry/Testing/Python/test_volumetry_seed_display_node.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_seed_display_node.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment) -- the volumetry seed display node is DATA-ONLY.
+
+``volumetry-seeds-layerdm-plan.md`` §3a adds a module-local
+``vtkMRMLVolumetrySeedsDisplayNode`` following the ADR-0025/0033 data-only
+display-node shape: it CARRIES the interaction state (arm / hover / grab),
+a ``pickSurface`` reference, and the transient adhering point -- but it
+does NO rendering itself (the LayerDM Pipeline renders; ADR-0013 §5 forbids
+a per-module displayable manager).  The interaction state living on the
+SHARED display node -- not a Python pipeline instance -- is the hard-won
+LayerDM lesson (``feedback_layerdm_state_on_display_node``): the base's
+``PointPlacementState`` accessors read/write it here.
+
+This file pins the data-only contract:
+
+* the display node HOLDS arm / hover / grab state + a ``pickSurface`` node
+  reference + a transient point, all read-back-able;
+* the display node does NOT expose rendering machinery (no actors, no
+  mapper, no displayable-manager class of its own) -- an absence pin with a
+  credible creep-in path (the v1 markups display node DID render), not a
+  colour-of-the-sky absence (``feedback_no_colour_of_the_sky_tests``).
+
+HARNESS: launched Slicer.  ``vtkMRMLVolumetrySeedsDisplayNode`` is a
+WRAPPED C++ node reachable only inside a launched Slicer with the module
+loaded (the wrapped-class-namespace rule); a bare
+``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` so every test
+SKIPS CLEANLY.
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the
+``AddNewNodeByClass``-returns-None + ``hasattr`` guards skip-pend; the
+skips lift at the implementation commit.
+
+References
+----------
+* ADR-0025 -- locator architecture / the data-only display-node shape +
+  reslice.
+* ADR-0033 -- the control-polygon display aspect (arm/hover/grab on the
+  display node, hover discipline).
+* ADR-0013 §5 -- no per-module displayable manager (the LayerDM Pipeline
+  renders).
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* VascularTerritories/MRML/vtkMRMLTerritoriesHighlightDisplayNode.h -- the
+  data-only display node this mirrors.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+DISPLAY_NODE_CLASS = "vtkMRMLVolumetrySeedsDisplayNode"
+SEEDS_NODE_CLASS = "vtkMRMLVolumetrySeedsNode"
+
+# PROPOSED interaction-state surface (sharpen at landing against the
+# territory highlight display node + the shared PointPlacementState keys).
+ARMED_ATTR = "LiverVolumetry.Armed"
+HOVER_ATTR = "LiverVolumetry.Hover"
+GRAB_ATTR = "LiverVolumetry.Grab"
+PICK_SURFACE_ROLE = "LiverVolumetry.pickSurface"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_display_or_skip(slicer, name="VolumetrySeedsDisplayTest"):
+    node = slicer.mrmlScene.AddNewNodeByClass(DISPLAY_NODE_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{DISPLAY_NODE_CLASS} not registered -- the ADR-0038-amendment "
+            "volumetry seed display node (plan §3a) has not landed (ADR-0027)."
+        )
+    return node
+
+
+def test_display_node_holds_arm_hover_grab_state():
+    """The display node carries arm / hover / grab interaction state.
+
+    ADR-0033: the arm/hover/grab state lives on the SHARED display node, not
+    a pipeline instance (``feedback_layerdm_state_on_display_node``).  The
+    accessors round-trip via SetAttribute/GetAttribute (the generic
+    PointPlacementState channel).
+    """
+    slicer = _slicer_or_skip()
+    node = _make_display_or_skip(slicer)
+
+    node.SetAttribute(ARMED_ATTR, "1")
+    node.SetAttribute(HOVER_ATTR, "2")
+    node.SetAttribute(GRAB_ATTR, "2")
+
+    assert node.GetAttribute(ARMED_ATTR) == "1"
+    assert node.GetAttribute(HOVER_ATTR) == "2"
+    assert node.GetAttribute(GRAB_ATTR) == "2"
+
+
+def test_display_node_holds_pick_surface_reference():
+    """The display node carries a ``pickSurface`` node reference.
+
+    ADR-0025: the display node references the surface the pick resolves
+    against (for volumetry, the region being seeded), so the base can
+    re-resolve the pick from the node.  A typed node-reference role, not an
+    instance field.
+    """
+    slicer = _slicer_or_skip()
+    node = _make_display_or_skip(slicer)
+    surface = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelNode", "PickSurface")
+
+    node.SetNodeReferenceID(PICK_SURFACE_ROLE, surface.GetID())
+
+    assert node.GetNodeReference(PICK_SURFACE_ROLE) is surface
+
+
+def test_display_node_holds_transient_adhering_point():
+    """The display node carries the transient adhering point (hover preview).
+
+    ADR-0033: the transient (not-yet-committed) point under the cursor rides
+    the display node so the Pipeline can render the preview without a
+    carrier mutation.  Skip-pend on the accessor's absence (ADR-0027).
+    """
+    slicer = _slicer_or_skip()
+    node = _make_display_or_skip(slicer)
+    if not hasattr(node, "SetTransientPoint") or not hasattr(node, "GetTransientPoint"):
+        pytest.skip(
+            f"{DISPLAY_NODE_CLASS} has no transient-point accessor -- the "
+            "ADR-0033 adhering-preview slot has not landed (ADR-0027)."
+        )
+
+    node.SetTransientPoint(1.0, 2.0, 3.0)
+    assert tuple(node.GetTransientPoint()) == pytest.approx((1.0, 2.0, 3.0), abs=1e-9)
+
+
+def test_display_node_is_data_only_no_rendering_machinery():
+    """The display node exposes NO rendering machinery (data-only, ADR-0013 §5).
+
+    An absence pin with a credible creep-in path: the v1 markups display
+    node rendered its own glyphs, and a well-meaning port could reintroduce
+    an actor/mapper/DM here.  The LayerDM Pipeline renders; the display node
+    only carries state (ADR-0025/0033 data-only shape).
+    """
+    slicer = _slicer_or_skip()
+    node = _make_display_or_skip(slicer)
+
+    for banned in ("GetActor", "GetMapper", "CreateDefaultDisplayableManager"):
+        assert not hasattr(node, banned), (
+            f"{DISPLAY_NODE_CLASS} must be DATA-ONLY -- it must not expose "
+            f"{banned!r} (rendering is the LayerDM Pipeline's job, ADR-0013 §5)."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverVolumetry/Testing/Python/test_volumetry_seed_placement.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_seed_placement.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment) -- volumetry seed placement via the shared base + provider.
+
+The volumetry client wires the shared ``SurfacePointPlacementPipeline3D``
+base (SlicerLiverInteractionLib) to a volumetry ``PointProvider`` adapter
+over ``vtkMRMLVolumetrySeedsNode`` and the in-volume pick
+(``volumetry-seeds-layerdm-plan.md`` §3b).  This file pins the integrated
+placement lifecycle -- the same add-on-click / drag-nearest / delete-one
+contract the base owns, but driven through the VOLUMETRY provider + the
+IN-VOLUME pick (not a surface snap):
+
+* an armed click adds EXACTLY ONE interior seed to the carrier;
+* a drag edits the NEAREST existing seed;
+* delete removes EXACTLY ONE seed;
+* the arm / carrier state rides the SHARED display node, not the pipeline
+  instance (``feedback_layerdm_state_on_display_node``).
+
+The base's own interaction arbitration is pinned generically in
+``SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_3d.py``
+against a fake provider; THIS file pins that the VOLUMETRY wiring (real
+carrier + in-volume pick + display-node routing) lands one interior seed.
+
+HARNESS: launched Slicer.  Needs LayerDMLib (the base), the wrapped
+``vtkMRMLVolumetrySeedsNode`` carrier + display node, and a labelmap for
+the in-volume pick -- all reachable only inside a launched Slicer with the
+module loaded.  A bare ``PythonSlicer -m pytest`` SKIPS CLEANLY.
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the import + guards
+skip-pend; the skips lift at the implementation commit.  Under a launched
+Slicer verify run-vs-skip in the CI log -- never trust overall green.
+
+References
+----------
+* ADR-0038 -- §Decision (the seam) + §"Base extension" (in-volume pick) +
+  §"Consumers ledger" (LiverVolumetry client).
+* ADR-0013 §5 -- the Pipeline creator wiring (no custom DM), pinned by
+  test_volumetry_registration_smoke.py.
+* ADR-0033 -- the grab seam + hover discipline the base enforces.
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+for candidate in (
+    REPO_ROOT / "SlicerLiverInteractionLib",
+    REPO_ROOT / "LiverVolumetry" / "LiverVolumetryLib",
+    REPO_ROOT / "LiverVolumetry",
+):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+SEEDS_NODE_CLASS = "vtkMRMLVolumetrySeedsNode"
+DISPLAY_NODE_CLASS = "vtkMRMLVolumetrySeedsDisplayNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _import_base_or_skip():
+    try:
+        from SurfacePointPlacementPipeline3D import (
+            SurfacePointPlacementPipeline3D,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"SurfacePointPlacementPipeline3D not importable ({exc!r}) -- the "
+            "ADR-0038 base has not landed OR LayerDMLib is not reachable "
+            "(ADR-0027)."
+        )
+    return SurfacePointPlacementPipeline3D
+
+
+def _import_provider_or_skip():
+    """Import the volumetry PointProvider adapter, or skip-pend (ADR-0027).
+
+    PROPOSED seam: a ``VolumetrySeedProvider`` over
+    ``vtkMRMLVolumetrySeedsNode`` implementing the ADR-0038 PointProvider
+    (``iter_points`` / ``has_edges`` -> False / add / move / delete /
+    display_node) + the in-volume pick.  Adjust the imported name at landing.
+    """
+    try:
+        from VolumetrySeedProvider import VolumetrySeedProvider
+    except ImportError:
+        pytest.skip(
+            "VolumetrySeedProvider not importable -- the volumetry PointProvider "
+            "adapter (plan §3b) has not landed (ADR-0027)."
+        )
+    return VolumetrySeedProvider
+
+
+def _carrier_or_skip(slicer):
+    node = slicer.mrmlScene.AddNewNodeByClass(SEEDS_NODE_CLASS, "PlacementSeeds")
+    if node is None or not hasattr(node, "AddSeed"):
+        pytest.skip(
+            f"{SEEDS_NODE_CLASS} / AddSeed not available -- the seed carrier "
+            "has not landed (ADR-0027)."
+        )
+    return node
+
+
+def _display_or_skip(slicer):
+    node = slicer.mrmlScene.AddNewNodeByClass(DISPLAY_NODE_CLASS, "PlacementDisplay")
+    if node is None:
+        pytest.skip(f"{DISPLAY_NODE_CLASS} not registered (ADR-0027).")
+    return node
+
+
+class _FakePick:
+    """A pick returning a FIXED interior world point (in-volume seed).
+
+    The volumetry pick's own contract (a labelled interior voxel) is pinned
+    in test_volumetry_in_volume_pick.py; here it is a fixed double so the
+    placement wiring is isolated from the pick math.
+    """
+
+    def __init__(self, world=(5.0, 10.0, 10.0)):
+        self._world = world
+
+    def pick_for_event(self, renderer, eventData):
+        return self._world
+
+
+class _FakeRenderer:
+    pass
+
+
+class _Event:
+    def __init__(self, etype, display_position=(100, 100)):
+        self._etype = etype
+        self._pos = display_position
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+def _wire_or_skip(slicer, pipeline, carrier, displayNode, monkeypatch):
+    VolumetrySeedProvider = _import_provider_or_skip()
+    for method in ("SetProvider", "SetPickProvider", "SetDisplayNode"):
+        if not hasattr(pipeline, method):
+            pytest.skip(
+                f"SurfacePointPlacementPipeline3D has no {method} seam (ADR-0027)."
+            )
+    from PointPlacementState import PointPlacementState  # noqa: F401  (import guard below)
+
+    monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
+    provider = VolumetrySeedProvider(carrier)
+    # The arm/carrier state MUST ride the shared display node, not the
+    # pipeline instance (feedback_layerdm_state_on_display_node).
+    if hasattr(provider, "SetDisplayNode"):
+        provider.SetDisplayNode(displayNode)
+    pipeline.SetDisplayNode(displayNode)
+    pipeline.SetProvider(provider)
+    pipeline.SetPickProvider(_FakePick())
+    if hasattr(pipeline, "Arm"):
+        pipeline.Arm()
+    return provider
+
+
+def test_armed_click_adds_one_interior_seed(monkeypatch):
+    """An armed click adds EXACTLY ONE interior seed to the carrier.
+
+    ADR-0038 §Decision (add-on-click) through the volumetry provider + the
+    in-volume pick; the seed lands at the pick's interior world point.
+    """
+    slicer = _slicer_or_skip()
+    Base = _import_base_or_skip()
+    carrier = _carrier_or_skip(slicer)
+    displayNode = _display_or_skip(slicer)
+    pipeline = Base()
+    _wire_or_skip(slicer, pipeline, carrier, displayNode, monkeypatch)
+
+    before = carrier.GetNumberOfSeeds()
+    click = _Event(vtk.vtkCommand.LeftButtonPressEvent)
+    assert pipeline.CanProcessInteractionEvent(click)[0] is True
+    assert pipeline.ProcessInteractionEvent(click) is True
+
+    assert carrier.GetNumberOfSeeds() == before + 1, (
+        "an armed click must add EXACTLY ONE interior seed."
+    )
+
+
+def test_drag_edits_nearest_seed(monkeypatch):
+    """A drag edits the NEAREST existing seed, leaving the count unchanged."""
+    slicer = _slicer_or_skip()
+    Base = _import_base_or_skip()
+    carrier = _carrier_or_skip(slicer)
+    displayNode = _display_or_skip(slicer)
+    pipeline = Base()
+    _wire_or_skip(slicer, pipeline, carrier, displayNode, monkeypatch)
+
+    carrier.AddSeed(5.0, 10.0, 10.0)
+    carrier.AddSeed(15.0, 10.0, 10.0)
+    for seam in ("_nearest_point_in_display", "_event_world"):
+        if not hasattr(pipeline, seam):
+            pytest.skip(f"base has no {seam} seam (ADR-0027).")
+    monkeypatch.setattr(pipeline, "_nearest_point_in_display", lambda r, e: (1, 4.0))
+    monkeypatch.setattr(pipeline, "_event_world", lambda r, e: (14.0, 11.0, 10.0))
+
+    before_count = carrier.GetNumberOfSeeds()
+    assert pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent)) is True
+    assert pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.MouseMoveEvent)) is True
+
+    assert carrier.GetNumberOfSeeds() == before_count, "a drag must not add/remove."
+    assert tuple(carrier.GetNthSeed(1)) == pytest.approx((14.0, 11.0, 10.0), abs=1e-6), (
+        "the drag must relocate the GRABBED (nearest) seed."
+    )
+
+
+def test_delete_removes_one_seed(monkeypatch):
+    """Delete removes EXACTLY ONE seed."""
+    slicer = _slicer_or_skip()
+    Base = _import_base_or_skip()
+    carrier = _carrier_or_skip(slicer)
+    displayNode = _display_or_skip(slicer)
+    pipeline = Base()
+    _wire_or_skip(slicer, pipeline, carrier, displayNode, monkeypatch)
+
+    carrier.AddSeed(5.0, 10.0, 10.0)
+    carrier.AddSeed(15.0, 10.0, 10.0)
+    if not hasattr(pipeline, "DeletePoint"):
+        pytest.skip("base has no DeletePoint seam (ADR-0027).")
+
+    before = carrier.GetNumberOfSeeds()
+    assert pipeline.DeletePoint(0) is True
+    assert carrier.GetNumberOfSeeds() == before - 1, "delete must remove EXACTLY ONE."
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/LiverVolumetry/Testing/Python/test_volumetry_seed_transient_fiducial.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_seed_transient_fiducial.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment) -- the pure carrier->transient-fiducial mapping.
+
+``volumetry-seeds-layerdm-plan.md`` §3c keeps the C++
+``vtkLiverVolumetryLogic`` SIGNATURES unchanged (they take a
+``vtkMRMLMarkupsFiducialNode*``); the seeds-off-markups migration feeds
+them a TRANSIENT fiducial built INSIDE the call from the seed carrier,
+mirroring ADR-0037 §Decision 4 / ``TransientVmtkSeeds.py``.  The per-seed
+LABEL must round-trip into the transient fiducial's control-point label so
+``GenerateSegmentsLabelMap`` still names segments correctly.
+
+The pure mapping (carrier points + labels -> a fiducial-shaped payload) is
+a dependency-free function -- no live scene, no wrapped C++ node -- so it
+is BARE-UNIT-TESTABLE (ADR-0004: keep the mapping pure Python; the actual
+``vtkMRMLMarkupsFiducialNode`` creation is a thin Logic wrapper over the
+core, pinned end to end by ``test_volumetry_compute_from_carrier.py``).
+
+This file pins:
+
+* POSITION preserved -- each payload entry's coordinate equals its carrier
+  seed's coordinate;
+* LABEL preserved -- each payload entry's label equals its carrier seed's
+  label (the segment-name fidelity);
+* ORDER preserved -- payload order == carrier placement order (label i
+  drives generated segment i, per ``LiverVolumetry.generateSegments``).
+
+HARNESS: bare ``PythonSlicer -m pytest``.  The mapping is pure Python over
+plain tuples -- no scene, no markups, no wrapped node -- so it RUNS bare
+AND launched.
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the import is guarded
+and every test SKIP-PENDINGs on ``ImportError``; the skips lift when the
+implementer lands the pure builder core.
+
+References
+----------
+* ADR-0038 -- §Conformance ([review] "fed a transient fiducial built from
+  the seed carrier, and per-seed labels round-trip so generated segments
+  keep their names").
+* ADR-0004 -- Python/C++ boundary; keep the mapping pure Python.
+* ADR-0015 -- the C++ region-grow logic is unchanged (the transient
+  adapter, not a signature rewrite).
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* VascularTerritories/VascularTerritoriesLib/TransientVmtkSeeds.py -- the
+  transient-builder idiom this mirrors.
+* LiverVolumetry/LiverVolumetry.py -- generateSegments() reads
+  GetNthFiducialLabel(i) to name segment i (the order/label dependency).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+# The pure builder core lives in the module's Lib (proposed
+# ``LiverVolumetryLib`` following the VascularTerritoriesLib precedent); the
+# path-insert lets the bare layer import it before the Lib packaging lands.
+for candidate in (
+    REPO_ROOT / "LiverVolumetry" / "LiverVolumetryLib",
+    REPO_ROOT / "LiverVolumetry",
+):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+_PENDING = (
+    "the pure carrier->transient-fiducial builder core has not landed "
+    "(ADR-0038-amendment / plan §3c) (ADR-0027 red->skip)."
+)
+
+
+def _import_builder():
+    """Import the pure builder core or SKIP-PENDING when it is absent.
+
+    PROPOSED seam (sharpen at landing).  A pure function that maps ordered
+    ``(x, y, z, label)`` seeds to a fiducial-shaped payload preserving
+    coordinate + label + order::
+
+        def build_fiducial_payload(
+            seeds: list[tuple[float, float, float, str]],
+        ) -> list[tuple[tuple[float, float, float], str]]: ...
+
+    IMPLEMENTER SEAM PREFERENCE (mirrors TransientVmtkSeeds): keep this a
+    pure function so this test stays bare; the vtkMRMLMarkupsFiducialNode
+    creation (add-to-scene -> set positions + labels -> feed -> RemoveNode)
+    is a THIN Logic wrapper over the core, NOT the tested unit for the
+    mapping invariant.  Adjust the imported name here to match the landed
+    module/function.
+    """
+    try:
+        from TransientVolumetrySeeds import build_fiducial_payload
+    except ImportError:
+        pytest.skip(_PENDING)
+    return build_fiducial_payload
+
+
+def test_mapping_preserves_position():
+    """Each payload entry's coordinate equals its source seed's coordinate."""
+    build = _import_builder()
+    seeds = [
+        (1.0, 2.0, 3.0, "A"),
+        (4.0, 5.0, 6.0, "B"),
+        (-7.0, 8.0, -9.0, "C"),
+    ]
+
+    payload = build(seeds)
+
+    assert len(payload) == len(seeds)
+    for (world, _label), src in zip(payload, seeds):
+        assert tuple(world) == pytest.approx(src[:3], abs=1e-9)
+
+
+def test_mapping_preserves_label():
+    """Each payload entry's label equals its source seed's label.
+
+    ADR-0038 §Conformance: per-seed labels round-trip so
+    ``GenerateSegmentsLabelMap`` names segments correctly.
+    """
+    build = _import_builder()
+    seeds = [
+        (1.0, 2.0, 3.0, "SegmentV"),
+        (4.0, 5.0, 6.0, "SegmentVI"),
+    ]
+
+    payload = build(seeds)
+
+    assert [label for _world, label in payload] == ["SegmentV", "SegmentVI"]
+
+
+def test_mapping_preserves_order():
+    """Payload order == carrier placement order.
+
+    ``LiverVolumetry.generateSegments`` names generated segment ``i`` from
+    the fiducial's ``GetNthFiducialLabel(i)``, so payload index i MUST be
+    carrier seed i -- a reorder would mis-name every segment.
+    """
+    build = _import_builder()
+    seeds = [(float(i), 0.0, 0.0, f"L{i}") for i in range(5)]
+
+    payload = build(seeds)
+
+    assert [label for _world, label in payload] == [f"L{i}" for i in range(5)]
+    for i, (world, _label) in enumerate(payload):
+        assert world[0] == pytest.approx(float(i), abs=1e-9), (
+            f"payload index {i} must be carrier seed {i} (order preserved)."
+        )
+
+
+def test_empty_carrier_maps_to_empty_payload():
+    """An empty seed list maps to an empty payload (no phantom point)."""
+    build = _import_builder()
+    assert list(build([])) == []
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/SlicerLiverInteractionLib/CMakeLists.txt
+++ b/SlicerLiverInteractionLib/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+# ADR-0038 shared control-point interaction base (SlicerLiverInteractionLib).
+#
+# This directory hosts the Python interaction base classes extracted from
+# the resection pipelines (ADR-0038 §"Shared home + names"): SurfacePick,
+# PointPlacementState, SurfacePointPlacementPipeline3D/Slice, PointProvider,
+# and the shared constants.  It is a pure-Python Lib (ADR-0004) hosting NO
+# displayable manager (ADR-0013 §5) -- it supplies only the Pipeline base
+# classes each module's own creator instantiates.
+#
+# The first extraction slice lands the pure-VTK SurfacePick and the
+# namespaced PointPlacementState accessors; the Pipeline base classes + the
+# PointProvider seam follow in a later slice.
+#
+# Python install rules mirror the ``<Module>Lib`` convention used by
+# ``VascularTerritoriesLib`` / ``LiverResectionsLib``: a Python package
+# staged alongside the scripted modules so it is importable at runtime and
+# from the bare unit layer.  EVERY runtime module MUST be listed:
+# ctkMacroCompilePythonScript stages ONLY the listed scripts into the
+# build/install tree.
+
+set(SlicerLiverInteractionLib_PYTHON_SCRIPTS
+  __init__.py
+  SurfacePick.py
+  PointPlacementState.py
+  )
+
+set(SlicerLiverInteractionLib_PYTHON_RESOURCES
+  )
+
+ctkMacroCompilePythonScript(
+  TARGET_NAME SlicerLiverInteractionLib
+  SCRIPTS "${SlicerLiverInteractionLib_PYTHON_SCRIPTS}"
+  RESOURCES "${SlicerLiverInteractionLib_PYTHON_RESOURCES}"
+  DESTINATION_DIR ${CMAKE_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}/SlicerLiverInteractionLib
+  INSTALL_DIR ${Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR}/SlicerLiverInteractionLib
+  NO_INSTALL_SUBDIR
+  )
+
+if(BUILD_TESTING)
+  add_subdirectory(Testing)
+endif()

--- a/SlicerLiverInteractionLib/PointPlacementState.py
+++ b/SlicerLiverInteractionLib/PointPlacementState.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Shared control-point interaction state on a display node (ADR-0038).
+
+The placement of draggable control points is *pipeline-managed*
+(ADR-0032/0033), not a Slicer interaction node / mouse mode.  LayerDM owns
+the placement Pipeline instance's lifecycle -- it creates its own per view
+-- so the widget and its table cannot reach that instance directly.  The
+two sides meet on the shared MRML display node: the widget/table WRITES the
+arm state / active key / carrier binding onto the display node, and the
+manager-driven Pipeline READS them back at event time.
+
+ADR-0038 §"Shared home + names" extracts these accessors out of
+``VascularTerritoriesLib.TerritoryInteractionState`` and PARAMETERIZES the
+attribute-key namespace per consumer, so two consumers (vascular
+territories, volumetry, resection) get independent keys on their own
+display nodes and never read each other's flags.  Constructing with
+``PointPlacementState("VascularTerritories")`` reproduces the territory
+module's original keys exactly.
+
+The class imports nothing heavy (no LayerDMLib, no Qt) so a table can
+depend on it without dragging in the Pipeline's LayerDM dependency.
+
+* armed + active key + module-active ride as string attributes (cheap,
+  XML-transient);
+* the carrier rides as a typed node-reference role.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class PointPlacementState:
+    """Namespaced arm/active/module-active/carrier accessors on a display node.
+
+    ``namespace`` is the attribute-key / node-reference-role prefix; each
+    consumer passes its own so the keys are disjoint on the shared display
+    node (ADR-0038 §"Shared home + names").
+    """
+
+    def __init__(self, namespace: str) -> None:
+        self._armed_attr = f"{namespace}.Armed"
+        self._active_attr = f"{namespace}.ActiveTerritory"
+        self._module_active_attr = f"{namespace}.ModuleActive"
+        self._carrier_role = f"{namespace}.carrier"
+
+    # ------------------------------------------------------------------ #
+    # Arm state
+    # ------------------------------------------------------------------ #
+    def set_armed(self, displayNode: Any, armed: bool) -> None:
+        """Publish the arm state onto the shared display node."""
+        if displayNode is not None:
+            displayNode.SetAttribute(self._armed_attr, "1" if armed else "0")
+
+    def is_armed(self, displayNode: Any) -> bool:
+        return (
+            displayNode is not None
+            and displayNode.GetAttribute(self._armed_attr) == "1"
+        )
+
+    # ------------------------------------------------------------------ #
+    # Module-active gate
+    # ------------------------------------------------------------------ #
+    def set_module_active(self, displayNode: Any, active: bool) -> None:
+        """Publish the module-active gate onto the shared display node.
+
+        Belt-and-suspenders beyond the armed flag: the owning module's
+        ``enter()`` / ``exit()`` flips this so no view lands a point while
+        the owning module is not active.
+        """
+        if displayNode is not None:
+            displayNode.SetAttribute(self._module_active_attr, "1" if active else "0")
+
+    def is_module_active(self, displayNode: Any) -> bool:
+        """True unless the module has EXPLICITLY closed the gate.
+
+        An UNSET attribute reads active: LayerDM creates the placement
+        Pipelines the moment the display node enters the scene (before any
+        ``enter()``), and a placement/edit gesture must still land in that
+        window.  The gate is the module's ``exit()`` writing ``"0"`` -- the
+        decline is opt-in, so opening the module (or never touching the
+        flag) leaves placement enabled.
+        """
+        return (
+            displayNode is None
+            or displayNode.GetAttribute(self._module_active_attr) != "0"
+        )
+
+    # ------------------------------------------------------------------ #
+    # Active key
+    # ------------------------------------------------------------------ #
+    def set_active(self, displayNode: Any, key: str | None) -> None:
+        """Publish the active key onto the shared display node."""
+        if displayNode is not None:
+            displayNode.SetAttribute(self._active_attr, key or "")
+
+    def get_active(self, displayNode: Any) -> str | None:
+        if displayNode is None:
+            return None
+        value = displayNode.GetAttribute(self._active_attr)
+        return value or None
+
+    # ------------------------------------------------------------------ #
+    # Carrier binding
+    # ------------------------------------------------------------------ #
+    def set_carrier(self, displayNode: Any, carrier: Any) -> None:
+        """Bind the data carrier onto the display node (typed node ref).
+
+        Fires an explicit ``Modified()``: LayerDM creates the view
+        pipelines when the display node enters the scene, which is BEFORE
+        this bind, and a node-reference change does not reliably emit
+        ``ModifiedEvent``.  The explicit Modified drives LayerDM's
+        ``UpdatePipeline`` on every view so each pipeline (re)attaches its
+        carrier observer and starts tracking points (ADR-0032/0033).
+        """
+        if displayNode is None:
+            return
+        carrierId = carrier.GetID() if carrier is not None else None
+        displayNode.SetNodeReferenceID(self._carrier_role, carrierId)
+        displayNode.Modified()
+
+    def get_carrier(self, displayNode: Any) -> Any | None:
+        if displayNode is None:
+            return None
+        return displayNode.GetNodeReference(self._carrier_role)

--- a/SlicerLiverInteractionLib/SurfacePick.py
+++ b/SlicerLiverInteractionLib/SurfacePick.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Pure-VTK pick core for surface-adhering control-point placement.
+
+Given a closed-surface ``vtkPolyData`` and a cursor ray in world
+coordinates, resolve the world point a placed/edited control point should
+adhere to:
+
+* the ray hits the mesh -> the intersection NEAREST the ray origin,
+  lying ON the mesh;
+* the ray misses -> the nearest-surface projection of ``fallback_point``;
+* there is no mesh at all -> ``None`` (the raw-point fallback is the
+  caller's concern).
+
+The pick is backed by a ``vtkCellLocator`` built lazily from the
+polydata.  The locator is rebuilt when the polydata's ``MTime`` advances
+past the MTime observed at the last build, so an edited/rebuilt mesh is
+always reflected by the next pick.
+
+This is a pure-VTK unit-layer class: no Slicer, MRML or Qt imports
+(ADR-0004 keeps the pick math in Python; ADR-0003 keeps this layer
+bare-unit testable).  The locator pattern mirrors the resection pick core
+described in ADR-0025.
+
+ADR-0038 §"Shared home + names" extracts this core (dropping the
+``Vessel`` prefix per T2.7) so surface consumers -- resection and
+VascularTerritories -- share one pick implementation.  The pick step is a
+provider on the ADR-0038 seam (§"Base extension"); this class is the
+surface variant.
+"""
+
+from __future__ import annotations
+
+import vtk
+
+
+class SurfacePick:
+    """Resolve the adhering world point for a cursor ray over a mesh."""
+
+    def __init__(self, polydata: vtk.vtkPolyData | None) -> None:
+        self._polydata = polydata
+        self._locator: vtk.vtkCellLocator | None = None
+        self._built_mtime: int | None = None
+
+    def surface(self) -> vtk.vtkPolyData | None:
+        """The surface this pick core holds.
+
+        A consumer's connectivity recovery must run over the SAME surface
+        the pick uses to snap clicks, so it is exposed here rather than
+        re-derived from the display node.
+        """
+        return self._polydata
+
+    # ------------------------------------------------------------------ #
+    # Locator lifecycle
+    # ------------------------------------------------------------------ #
+    def _has_surface(self) -> bool:
+        return (
+            self._polydata is not None
+            and self._polydata.GetNumberOfPoints() > 0
+            and self._polydata.GetNumberOfCells() > 0
+        )
+
+    def _ensure_locator(self) -> vtk.vtkCellLocator | None:
+        """Build the locator lazily, rebuilding when the mesh is stale.
+
+        A stale cache is detected by comparing the polydata's current
+        ``MTime`` against the MTime observed at the last build; when the
+        surface points/cells mutate and the polydata is marked modified,
+        the advanced MTime forces a rebuild (ADR-0025 cache invalidation).
+        """
+        if not self._has_surface():
+            self._locator = None
+            self._built_mtime = None
+            return None
+
+        current_mtime = self._polydata.GetMTime()
+        if self._locator is None or self._built_mtime != current_mtime:
+            locator = vtk.vtkCellLocator()
+            locator.SetDataSet(self._polydata)
+            locator.BuildLocator()
+            self._locator = locator
+            self._built_mtime = current_mtime
+        return self._locator
+
+    # ------------------------------------------------------------------ #
+    # Pick
+    # ------------------------------------------------------------------ #
+    def pick(
+        self,
+        p1: tuple[float, float, float],
+        p2: tuple[float, float, float],
+        fallback_point: tuple[float, float, float] | None = None,
+    ) -> tuple[float, float, float] | None:
+        """Return the adhering world point, or ``None`` when there is no mesh.
+
+        ``p1``/``p2`` define the world-space cursor ray (``p1`` is the ray
+        origin, near the camera).  ``fallback_point`` is projected onto the
+        surface when the ray misses.
+        """
+        locator = self._ensure_locator()
+        if locator is None:
+            return None
+
+        hit = self._intersect(locator, p1, p2)
+        if hit is not None:
+            return hit
+
+        if fallback_point is None:
+            return None
+        return self._closest(locator, fallback_point)
+
+    @staticmethod
+    def _intersect(
+        locator: vtk.vtkCellLocator,
+        p1: tuple[float, float, float],
+        p2: tuple[float, float, float],
+    ) -> tuple[float, float, float] | None:
+        """Ray/mesh intersection nearest the ray origin ``p1``.
+
+        ``IntersectWithLine`` reports the first intersection along the
+        parametric line from ``p1`` to ``p2`` (smallest ``t``), which is
+        the hit nearest the ray origin even when the ray folds over the
+        mesh twice.
+        """
+        t = vtk.reference(0.0)
+        intersection = [0.0, 0.0, 0.0]
+        pcoords = [0.0, 0.0, 0.0]
+        sub_id = vtk.reference(0)
+        cell_id = vtk.reference(0)
+        code = locator.IntersectWithLine(
+            list(p1),
+            list(p2),
+            1e-6,
+            t,
+            intersection,
+            pcoords,
+            sub_id,
+            cell_id,
+        )
+        if code == 0:
+            return None
+        return tuple(intersection)
+
+    @staticmethod
+    def _closest(
+        locator: vtk.vtkCellLocator,
+        point: tuple[float, float, float],
+    ) -> tuple[float, float, float]:
+        """Nearest point on the surface to ``point``."""
+        closest = [0.0, 0.0, 0.0]
+        cell_id = vtk.reference(0)
+        sub_id = vtk.reference(0)
+        dist2 = vtk.reference(0.0)
+        locator.FindClosestPoint(list(point), closest, cell_id, sub_id, dist2)
+        return tuple(closest)

--- a/SlicerLiverInteractionLib/Testing/CMakeLists.txt
+++ b/SlicerLiverInteractionLib/Testing/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Python)

--- a/SlicerLiverInteractionLib/Testing/Python/CMakeLists.txt
+++ b/SlicerLiverInteractionLib/Testing/Python/CMakeLists.txt
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+# ---------------------------------------------------------------------------
+# Bare-VTK unit tests for the ADR-0038 shared control-point interaction base
+# (pytest_scaffold family).
+# ---------------------------------------------------------------------------
+#
+# The pure-VTK cores (SurfacePick geometry, PointPlacementState accessors,
+# the slice-projection math) run under bare ``PythonSlicer -m pytest`` with
+# no Slicer scene, no Qt, no GL (ADR-0003 testability invariant; ADR-0004
+# the interaction math is pure Python).  The LayerDM base invariants (the
+# 3D placement pipeline + the four LayerDM traps) import LayerDMLib and so
+# SKIP bare and RUN launched -- they still register a bare CTest row here
+# (they collect + skip cleanly), mirroring the VascularTerritories pattern.
+# The same skip-if-pytest-absent guard keeps the scaffolding buildable
+# where the Slicer Python environment lacks pytest.
+
+if(NOT Python3_EXECUTABLE)
+  message(STATUS
+    "Slicer-Liver: Python3_EXECUTABLE not set; "
+    "skipping SlicerLiverInteractionLib bare-pytest registration.")
+  return()
+endif()
+
+execute_process(
+  COMMAND "${Python3_EXECUTABLE}" -c "import pytest"
+  RESULT_VARIABLE _interaction_pytest_probe_rc
+  OUTPUT_QUIET
+  ERROR_QUIET
+)
+
+if(NOT _interaction_pytest_probe_rc EQUAL 0)
+  message(STATUS
+    "Slicer-Liver: pytest not importable from ${Python3_EXECUTABLE}; "
+    "skipping SlicerLiverInteractionLib bare-pytest registration.")
+  return()
+endif()
+
+set(_interaction_pytest_files
+  # ADR-0038 §"Shared home + names" -- the extracted pure-VTK SurfacePick
+  # geometry core (ray->closed-surface nearest + closest-point fallback,
+  # lazy MTime-invalidated locator).  Mirrors the VesselSurfacePick origin.
+  # Genuinely RUNS bare once SlicerLiverInteractionLib/SurfacePick.py lands
+  # (ADR-0027).
+  test_surface_pick.py
+  # ADR-0038 §"Shared home + names" -- the PointPlacementState display-node
+  # accessors with the attribute-key namespace parameterized per consumer.
+  # Pure Python over a fake display node; RUNS bare (ADR-0027).
+  test_point_placement_state.py
+  # ADR-0038 §Context -- the slice-view projection / fade / side tint /
+  # presence-cutoff pure math owned by the shared slice base.  Mirrors the
+  # TerritorySliceProjection origin; RUNS bare (ADR-0027).
+  test_point_placement_pipeline_slice.py
+  # ADR-0038 §Decision / §"Base extension" -- the 3D placement base's
+  # interaction arbitration against a FAKE flat PointProvider + injected
+  # pick (add/drag/delete/decline/no-drift; the base has NO surface-vs-
+  # volume branch).  Imports LayerDMLib -> SKIPS bare, RUNS launched.
+  test_point_placement_pipeline_3d.py
+  # ADR-0038 §Conformance [future] -- the four LayerDM integration traps
+  # asserted ONCE on the base (one-per-type; configure-before-add;
+  # ResetDisplay-drives-UpdatePipeline; render-flush in the handler).
+  # LayerDM machinery -> SKIPS bare, RUNS launched.
+  test_layerdm_base_invariants.py
+)
+
+foreach(_pytest_file IN LISTS _interaction_pytest_files)
+  get_filename_component(_test_basename "${_pytest_file}" NAME_WE)
+  add_test(
+    NAME ${_test_basename}
+    COMMAND "${Python3_EXECUTABLE}" -m pytest
+      -q
+      "${CMAKE_CURRENT_SOURCE_DIR}/${_pytest_file}"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  )
+  set_tests_properties(${_test_basename} PROPERTIES
+    LABELS "pytest;SlicerLiverInteractionLib;interaction-base"
+  )
+endforeach()

--- a/SlicerLiverInteractionLib/Testing/Python/conftest.py
+++ b/SlicerLiverInteractionLib/Testing/Python/conftest.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Shared pytest scaffolding for the SlicerLiverInteractionLib base tests.
+
+Mirrors ``VascularTerritories/Testing/Python/conftest.py``: re-exports the
+launched-Slicer skip-guards from ``slicer_pytest_support`` (canonical
+bodies in ``Testing/Python/slicer_pytest_support.py``, on ``sys.path`` via
+the ``pythonpath`` ini option) and provides the autouse scene-cleanup
+fixture so the launched harness clears scratch nodes between tests.
+
+The bulk of this Lib's tests are pure-VTK (``SurfacePick``,
+``PointPlacementState``, the slice projection math) and run under bare
+``PythonSlicer -m pytest`` with no scene; the LayerDM base tests
+(``SurfacePointPlacementPipeline3D`` + the four traps) SKIP bare and RUN
+launched, so the same skip-clean discipline as VascularTerritories applies.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from slicer_pytest_support import (  # noqa: F401  (re-exported for `from conftest import ...`)
+    import_slicer_or_skip as _import_slicer_or_skip,
+    require_mrml_scene as _require_mrml_scene,
+    require_qt_widget as _require_qt_widget,
+)
+
+
+def _looks_like_real_slicer(module) -> bool:
+    """True iff ``module`` is the genuine launched-Slicer ``slicer`` module."""
+    return module is not None and getattr(module, "mrmlScene", None) is not None
+
+
+def _live_mrml_scene():
+    """Return the launched-Slicer ``mrmlScene`` or ``None`` under bare pytest."""
+    slicer = sys.modules.get("slicer")
+    if not _looks_like_real_slicer(slicer):
+        return None
+    return slicer.mrmlScene
+
+
+@pytest.fixture(autouse=True)
+def _launched_scene_cleanup():
+    """Clear the MRML scene after each launched test.  No-op under bare pytest.
+
+    The launched harness runs the whole tree in ONE ``qSlicerApplication``;
+    clearing after each test keeps scratch nodes from accumulating across
+    the base tests (mirrors the VascularTerritories guard).
+    """
+    scene = _live_mrml_scene()
+    if scene is None:
+        yield
+        return
+
+    yield
+    scene.Clear(0)

--- a/SlicerLiverInteractionLib/Testing/Python/test_layerdm_base_invariants.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_layerdm_base_invariants.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 -- the four LayerDM integration invariants asserted ONCE on the base.
+
+ADR-0038 §Context + §Conformance [future]: the four LayerDM integration
+traps that were paid TWICE (resection, then territories) must be
+implemented and fixed ONCE on the shared base, and asserted once here.
+The four traps (ADR-0038 §Context, verbatim):
+
+1. ONE Pipeline per ``(view, display-node type)`` -- LayerDM creates
+   exactly one Pipeline instance per (view, display-node type); a consumer
+   must not spawn a second for the same pair.
+2. CONFIGURE-BEFORE-``AddNode`` -- a Pipeline must be configured (provider /
+   pick / display node bound) BEFORE its actors are added to the renderer;
+   configuring after ``AddNode`` renders stale/empty state.
+3. ``UpdatePipeline`` fires on ``ResetDisplay()``, NOT on a display-node
+   ``Modified`` -- the reconcile is driven by ``ResetDisplay``; a plain
+   ``Modified`` on the display node does not by itself repaint.
+4. ``RequestRender`` does NOT flush mid-``ProcessInteractionEvent`` -- a
+   render requested inside the interaction handler is coalesced, not
+   flushed synchronously; the handler must not assume the view repainted
+   before it returns.
+
+These four are the shared LayerDM discipline (the
+``feedback_layerdm_state_on_display_node`` / ``feedback_layerdm_pipeline_gotchas``
+lessons made structural).  Pinning them on the base means a future fix or
+UX tweak applies to every consumer at once (ADR-0038 §Consequences).
+
+HARNESS: launched Slicer.  Every trap needs the real LayerDM machinery
+(the Pipeline factory, ``ResetDisplay``, the render window's coalesced
+render) reachable only inside a launched Slicer with the LayerDM modules
+loaded; a bare ``PythonSlicer -m pytest`` has LayerDMLib off the path, so
+every test SKIPS CLEANLY via the ``slicer_pytest_support`` guards.  Verify
+run-vs-skip in the CI log -- never trust overall green.
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the import + hasattr
+guards skip-pend; the skips lift at the extraction commit.
+
+References
+----------
+* ADR-0038 -- §Context (the four traps, verbatim) + §Conformance [future]
+  ("asserted once on the base").
+* ADR-0013 §1 -- one Pipeline per display-node type (trap 1).
+* ADR-0032 / ADR-0033 -- interaction seam + the render-flush handler rule.
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _import_base_or_skip():
+    try:
+        from SurfacePointPlacementPipeline3D import (
+            SurfacePointPlacementPipeline3D,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"SurfacePointPlacementPipeline3D not importable ({exc!r}) -- the "
+            "ADR-0038 base has not landed OR LayerDMLib is not reachable here "
+            "(ADR-0027)."
+        )
+    return SurfacePointPlacementPipeline3D
+
+
+# --------------------------------------------------------------------------- #
+# Trap 1 -- one Pipeline per (view, display-node type)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skip(
+    reason=(
+        "ADR-0038 trap 1 (one Pipeline per (view, display-node type)) -- the "
+        "shared base + a LayerDM factory to count instances per (view, type) "
+        "have not landed.  Skeleton pins the invariant; implementer fills the "
+        "factory-instance assertion (ADR-0027 / ADR-0013 §1)."
+    )
+)
+def test_one_pipeline_instance_per_view_and_display_node_type():
+    """LayerDM creates EXACTLY ONE base Pipeline per (view, display-node type).
+
+    ADR-0038 §Context trap 1 / ADR-0013 §1.  With one display node of a
+    consumer's type present and one view, the factory yields exactly one
+    base Pipeline instance for that (view, type) pair; adding a second
+    display node of the SAME type in the SAME view must not double-register
+    the base for the pair.
+
+    TODO(implementer): once the base + the consumer's Pipeline creator land,
+    drive a LayerDM view over the display node and assert the manager holds
+    exactly one base instance for the (view, type) key -- not one per node,
+    not two.
+    """
+    _slicer_or_skip()
+    _import_base_or_skip()
+    pytest.fail("unreachable -- test is skipped until the base + factory land.")
+
+
+# --------------------------------------------------------------------------- #
+# Trap 2 -- configure before AddNode
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skip(
+    reason=(
+        "ADR-0038 trap 2 (configure-before-AddNode) -- the shared base's "
+        "actor-add ordering is not landed.  Skeleton pins the invariant; "
+        "implementer fills the ordering assertion (ADR-0027)."
+    )
+)
+def test_pipeline_is_configured_before_actors_are_added():
+    """A base Pipeline binds its provider/pick/display node BEFORE AddNode.
+
+    ADR-0038 §Context trap 2.  Configuring AFTER the actors are added to the
+    renderer renders stale/empty state.  The base's setup order must be:
+    bind the seam, THEN add the actors.
+
+    TODO(implementer): assert the base's actors are absent from the renderer
+    until the provider is bound, and present (with the provider's points)
+    immediately after -- i.e. no window where an added actor lacks its
+    configured source.
+    """
+    _slicer_or_skip()
+    _import_base_or_skip()
+    pytest.fail("unreachable -- test is skipped until the base lands.")
+
+
+# --------------------------------------------------------------------------- #
+# Trap 3 -- UpdatePipeline fires on ResetDisplay(), not display-Modified
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skip(
+    reason=(
+        "ADR-0038 trap 3 (UpdatePipeline on ResetDisplay, not display "
+        "Modified) -- the shared base's reconcile driver is not landed.  "
+        "Skeleton pins the invariant; implementer fills the "
+        "ResetDisplay-vs-Modified assertion (ADR-0027)."
+    )
+)
+def test_update_pipeline_is_driven_by_reset_display_not_modified():
+    """``UpdatePipeline`` fires on ``ResetDisplay()``, NOT on display Modified.
+
+    ADR-0038 §Context trap 3.  A plain ``Modified()`` on the display node
+    must not by itself repaint the base; the reconcile is driven by
+    ``ResetDisplay()``.  This is why ``PointPlacementState.set_carrier``
+    fires an explicit path that ends in a ResetDisplay-shaped reconcile.
+
+    TODO(implementer): spy the base's ``UpdatePipeline`` (or its reconcile
+    hook); assert a bare display-node ``Modified()`` does NOT invoke it,
+    while ``ResetDisplay()`` DOES.
+    """
+    _slicer_or_skip()
+    _import_base_or_skip()
+    pytest.fail("unreachable -- test is skipped until the base lands.")
+
+
+# --------------------------------------------------------------------------- #
+# Trap 4 -- RequestRender does not flush mid-ProcessInteractionEvent
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skip(
+    reason=(
+        "ADR-0038 trap 4 (RequestRender does not flush mid-"
+        "ProcessInteractionEvent) -- the shared base's interaction handler is "
+        "not landed.  Skeleton pins the invariant; implementer fills the "
+        "coalesced-render assertion (ADR-0027)."
+    )
+)
+def test_request_render_does_not_flush_inside_process_interaction_event():
+    """A render requested inside ``ProcessInteractionEvent`` is COALESCED.
+
+    ADR-0038 §Context trap 4.  The base must not assume the view repainted
+    synchronously before the interaction handler returns; ``RequestRender``
+    queues a render, it does not flush one mid-event.  A handler relying on
+    a synchronous repaint (e.g. reading back a rendered pick) is the defect
+    this pins.
+
+    TODO(implementer): spy the render window's Render; assert the count does
+    NOT increment during ``ProcessInteractionEvent`` (only after the event
+    loop coalesces the queued RequestRender).
+    """
+    _slicer_or_skip()
+    _import_base_or_skip()
+    pytest.fail("unreachable -- test is skipped until the base lands.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_3d.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_3d.py
@@ -1,0 +1,415 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 -- the shared 3D control-point placement/edit base (interaction seam).
+
+ADR-0038 §Decision extracts a shared ``SurfacePointPlacementPipeline3D``
+base from the mature resection pipelines; VascularTerritories, resection,
+and (this branch) LiverVolumetry become clients over a small
+``PointProvider`` seam.  The base owns the add-on-click / drag-to-edit /
+delete / bare-move-decline arbitration, the display-space pick-radius
+grab, and the four LayerDM integration invariants; the consumer supplies
+the points, the edges flag, the drag/delete write-backs, the display-node
+channel, AND -- per the ADR's implementation amendment (2026-07-27) -- a
+SWAPPABLE PICK PROVIDER.
+
+This file pins the 3D base's interaction contract against a FAKE FLAT
+``PointProvider`` (no edges, no vessel gating, no data-model knowledge):
+
+* add-on-click adds EXACTLY ONE point (ADR-0038 §Decision / ADR-0037
+  §Decision 2 mirror);
+* a drag edits the NEAREST existing point (ADR-0033 grab seam);
+* delete removes EXACTLY ONE point;
+* a bare move is DECLINED -- ``(False, +inf)`` -- so the camera is
+  untouched (ADR-0033 hover discipline);
+* an unrelated ``Modified`` causes NO drift;
+
+and the KEY ADR-0038-amendment invariant:
+
+* the base has NO surface-vs-volume branch.  The pick (world position for a
+  click) is obtained from the INJECTED pick provider; the base places at
+  whatever world point the provider returns.  This is the seam that lets
+  volumetry inject an in-volume pick while territories inject SurfacePick,
+  with the base unchanged (ADR-0038 §"Base extension: the pick step is
+  swappable").
+
+The base leaking a consumer concern is the highest-risk failure mode
+(``volumetry-seeds-layerdm-plan.md`` §8): the FAKE provider here has no
+vessel/volume concept, so if the base needs one, the seam is wrong.
+
+HARNESS: launched Slicer.  The base is a LayerDM scripted Pipeline
+importing LayerDMLib (reachable only inside a launched Slicer with the
+module loaded); a bare ``PythonSlicer -m pytest`` has LayerDMLib off the
+path, so every test SKIPS CLEANLY via the ``slicer_pytest_support``
+guards.  The provider is a Python fake, so no carrier node is needed and
+these are launched-scene-light (they do NOT need a wrapped C++ carrier --
+only the LayerDMLib-importable base).
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the import + hasattr
+guards skip-pend; the skips lift at the extraction commit.  Under a
+launched Slicer verify run-vs-skip in the CI log -- never trust overall
+green (the launched harness is green-but-skipping prone).
+
+References
+----------
+* ADR-0038 -- §Decision (the seam-parameterized base) + §"Base extension"
+  (the swappable pick provider; the base has no surface-vs-volume branch).
+* ADR-0033 -- the grab seam + hover-decline discipline.
+* ADR-0032 -- interaction through the LayerDM Pipeline seam.
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+  -- the client suite this base's behaviour was extracted to satisfy.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards (mirror the launched-Slicer discipline in the VascTerr conftest)
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _import_base_or_skip():
+    """Import the shared 3D base or skip-pend (ADR-0027).
+
+    PROPOSED seam (sharpen at landing).  The base mirrors
+    ``ControlPolygonPipeline`` (the resection origin) and exposes the same
+    interaction verbs the territory client test drives::
+
+        class SurfacePointPlacementPipeline3D(<LayerDM Pipeline base>):
+            def SetProvider(self, provider: PointProvider) -> None: ...
+            def SetPickProvider(self, pick) -> None: ...  # swappable pick
+            def Arm(self) -> None / def Disarm(self) -> None: ...
+            def CanProcessInteractionEvent(self, eventData) -> (bool, float): ...
+            def ProcessInteractionEvent(self, eventData) -> bool: ...
+    """
+    try:
+        from SurfacePointPlacementPipeline3D import (
+            SurfacePointPlacementPipeline3D,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"SurfacePointPlacementPipeline3D not importable ({exc!r}) -- the "
+            "ADR-0038 3D base has not landed OR LayerDMLib is not reachable "
+            "here.  The skip lifts at the extraction commit (ADR-0027)."
+        )
+    return SurfacePointPlacementPipeline3D
+
+
+# --------------------------------------------------------------------------- #
+# A FAKE FLAT PointProvider -- no edges, no vessel/volume concept
+# --------------------------------------------------------------------------- #
+
+
+class _FakeFlatProvider:
+    """A flat, data-model-free ``PointProvider`` (ADR-0038 §Decision seam).
+
+    Holds an ordered list of ``(world, base_rgb)`` points in plain Python;
+    ``has_edges()`` is False (territories/volumetry, not the resection
+    grid); the write-backs mutate the list in place.  It has NO surface, NO
+    vessel gating, NO volume -- the base must not need any of them (the §8
+    leak guard).
+    """
+
+    def __init__(self):
+        self._points: list[list[float]] = []
+        self.base_rgb = (0.2, 0.8, 0.2)
+
+    # -- seam the base READS --
+    def iter_points(self):
+        for p in self._points:
+            yield (tuple(p), self.base_rgb)
+
+    def has_edges(self) -> bool:
+        return False
+
+    def count(self) -> int:
+        return len(self._points)
+
+    def get(self, i):
+        return tuple(self._points[i])
+
+    # -- seam the base WRITES (drag / delete / add) --
+    def add_point(self, world) -> int:
+        self._points.append([world[0], world[1], world[2]])
+        return len(self._points) - 1
+
+    def move_point(self, key, world) -> None:
+        self._points[key] = [world[0], world[1], world[2]]
+
+    def delete_point(self, key) -> bool:
+        del self._points[key]
+        return True
+
+
+class _FakePick:
+    """A pick provider that returns a FIXED world point (no surface at all).
+
+    The base must place at whatever world point the pick returns -- there is
+    no surface here, no ray math, no volume.  This is the ADR-0038-amendment
+    contract: the pick is a seam, the base has no surface-vs-volume branch.
+    """
+
+    def __init__(self, world):
+        self._world = world
+
+    def pick_for_event(self, renderer, eventData):
+        return self._world
+
+
+class _FakeRenderer:
+    """A do-nothing renderer stand-in (the base must not depend on GL here)."""
+
+
+class _Event:
+    """A minimal interaction event at a fixed display pixel + type."""
+
+    def __init__(self, etype, display_position=(100, 100)):
+        self._etype = etype
+        self._pos = display_position
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+    def GetDisplayPosition(self):  # noqa: N802 - VTK verb
+        return self._pos
+
+
+def _wire_or_skip(pipeline, provider, pick, monkeypatch):
+    """Attach the fake provider + pick + renderer, or skip-pend the seam."""
+    for method in ("SetProvider", "SetPickProvider"):
+        if not hasattr(pipeline, method):
+            pytest.skip(
+                f"SurfacePointPlacementPipeline3D has no {method} injection "
+                "seam -- the ADR-0038 PointProvider / swappable-pick seam has "
+                "not landed (ADR-0027)."
+            )
+    monkeypatch.setattr(pipeline, "_safe_get_renderer", lambda: _FakeRenderer())
+    pipeline.SetProvider(provider)
+    pipeline.SetPickProvider(pick)
+    if hasattr(pipeline, "Arm"):
+        pipeline.Arm()
+
+
+# --------------------------------------------------------------------------- #
+# add-on-click / bare-move-decline
+# --------------------------------------------------------------------------- #
+
+
+def test_click_adds_exactly_one_point_at_the_provider_pick(monkeypatch):
+    """A click adds EXACTLY ONE point at the world the PICK PROVIDER returns.
+
+    ADR-0038 §Decision (add-on-click) + §"Base extension": the base does
+    NOT compute a surface point -- it places at the injected pick's world.
+    Here the fake pick returns ``(7, 8, 9)`` (a point on NO surface); the
+    base must place THAT.
+    """
+    _slicer_or_skip()
+    Base = _import_base_or_skip()
+    pipeline = Base()
+    provider = _FakeFlatProvider()
+    pick = _FakePick((7.0, 8.0, 9.0))
+    _wire_or_skip(pipeline, provider, pick, monkeypatch)
+
+    before = provider.count()
+    click = _Event(vtk.vtkCommand.LeftButtonPressEvent)
+    assert pipeline.CanProcessInteractionEvent(click)[0] is True, (
+        "an armed click must be CLAIMED (add-on-click)."
+    )
+    assert pipeline.ProcessInteractionEvent(click) is True
+
+    assert provider.count() == before + 1, "a click must add EXACTLY ONE point."
+    assert provider.get(provider.count() - 1) == pytest.approx(
+        (7.0, 8.0, 9.0), abs=1e-9
+    ), "the base must place at the PICK PROVIDER's world point verbatim."
+
+
+def test_no_surface_vs_volume_branch_in_the_base(monkeypatch):
+    """The base has NO surface-vs-volume branch -- the pick is the ONLY source.
+
+    ADR-0038 §"Base extension: the pick step is swappable".  Two DIFFERENT
+    picks (one an arbitrary off-surface point, one an arbitrary interior
+    point) must both be placed verbatim by the SAME base with NO branching
+    on what kind of point it is.  If the base inspected a surface or a
+    volume, one of these would be rejected / snapped -- the seam would be
+    wrong (the §8 leak guard).
+    """
+    _slicer_or_skip()
+    Base = _import_base_or_skip()
+
+    for world in ((123.0, -45.0, 6.0), (-1.0, -1.0, -1.0)):
+        pipeline = Base()
+        provider = _FakeFlatProvider()
+        _wire_or_skip(pipeline, provider, _FakePick(world), monkeypatch)
+        assert pipeline.ProcessInteractionEvent(
+            _Event(vtk.vtkCommand.LeftButtonPressEvent)
+        ) is True
+        assert provider.count() == 1
+        assert provider.get(0) == pytest.approx(world, abs=1e-9), (
+            "the base must place at the injected pick's world with NO "
+            "surface/volume branching (ADR-0038 §'Base extension')."
+        )
+
+
+def test_bare_move_is_declined_and_adds_nothing(monkeypatch):
+    """A bare move is DECLINED and adds NO point (ADR-0033 hover discipline).
+
+    ``CanProcessInteractionEvent`` on a bare mouse move returns
+    ``(False, +inf)`` so LayerDM leaves the move to the camera; no provider
+    mutation.  ADR-0038 §Decision (the grab seam owns the hover decline).
+    """
+    _slicer_or_skip()
+    Base = _import_base_or_skip()
+    pipeline = Base()
+    provider = _FakeFlatProvider()
+    _wire_or_skip(pipeline, provider, _FakePick((0.0, 0.0, 1.0)), monkeypatch)
+
+    before = provider.count()
+    move = _Event(vtk.vtkCommand.MouseMoveEvent)
+    can, distance2 = pipeline.CanProcessInteractionEvent(move)
+
+    assert can is False, "a bare move must be DECLINED (camera untouched, ADR-0033)."
+    assert distance2 == sys.float_info.max
+    assert provider.count() == before, "a bare move must add NO point."
+
+
+# --------------------------------------------------------------------------- #
+# drag-to-edit-nearest / delete / no-drift
+# --------------------------------------------------------------------------- #
+
+
+def test_drag_edits_exactly_the_nearest_point(monkeypatch):
+    """A drag mutates EXACTLY ONE point -- the nearest to the grab.
+
+    With two points placed, a press grabs the nearest and the drag relocates
+    only THAT point; the sibling is unchanged and the count is unchanged
+    (ADR-0038 §Decision, ADR-0033 grab seam).  The nearest-selection + drag
+    target are injected so the test stays GL-free.
+    """
+    _slicer_or_skip()
+    Base = _import_base_or_skip()
+    pipeline = Base()
+    provider = _FakeFlatProvider()
+    _wire_or_skip(pipeline, provider, _FakePick((0.0, 0.0, 1.0)), monkeypatch)
+
+    provider.add_point((0.0, 0.0, 1.0))
+    provider.add_point((1.0, 0.0, 0.0))
+    for seam in ("_nearest_point_in_display", "_event_world"):
+        if not hasattr(pipeline, seam):
+            pytest.skip(
+                f"SurfacePointPlacementPipeline3D has no {seam} seam -- cannot "
+                "pin nearest-selection / drag target (ADR-0027)."
+            )
+    # Grab resolves to point index 1 at a real squared display distance; the
+    # drag relocates it to a fixed world point.
+    monkeypatch.setattr(pipeline, "_nearest_point_in_display", lambda r, e: (1, 9.0))
+    monkeypatch.setattr(pipeline, "_event_world", lambda r, e: (0.0, 1.0, 0.0))
+
+    before0 = provider.get(0)
+    before_count = provider.count()
+
+    press = _Event(vtk.vtkCommand.LeftButtonPressEvent)
+    can, d2 = pipeline.CanProcessInteractionEvent(press)
+    assert can is True and d2 == pytest.approx(9.0), (
+        "a press near a point must be claimed with the REAL squared display "
+        "distance (LayerDM arbitration)."
+    )
+    assert pipeline.ProcessInteractionEvent(press) is True
+    assert pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.MouseMoveEvent)) is True
+
+    assert provider.count() == before_count, "a drag must NOT add or remove points."
+    assert provider.get(1) == pytest.approx((0.0, 1.0, 0.0), abs=1e-6), (
+        "the drag must relocate the GRABBED (nearest) point."
+    )
+    assert provider.get(0) == pytest.approx(before0, abs=1e-9), (
+        "the drag must NOT move the un-grabbed sibling."
+    )
+
+
+def test_delete_removes_exactly_one_point(monkeypatch):
+    """A delete removes EXACTLY ONE point (the targeted one).
+
+    ADR-0038 §Decision (delete write-back on the seam).  With three points,
+    deleting the middle one leaves two and the tail shifts up in order.
+    """
+    _slicer_or_skip()
+    Base = _import_base_or_skip()
+    pipeline = Base()
+    provider = _FakeFlatProvider()
+    _wire_or_skip(pipeline, provider, _FakePick((0.0, 0.0, 1.0)), monkeypatch)
+
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    for p in pts:
+        provider.add_point(p)
+
+    if not hasattr(pipeline, "DeletePoint"):
+        pytest.skip(
+            "SurfacePointPlacementPipeline3D has no DeletePoint seam -- the "
+            "delete write-back has not landed (ADR-0027)."
+        )
+    assert pipeline.DeletePoint(1) is True
+
+    assert provider.count() == len(pts) - 1, "delete must remove EXACTLY ONE."
+    assert provider.get(0) == pytest.approx(pts[0], abs=1e-6)
+    assert provider.get(1) == pytest.approx(pts[2], abs=1e-6), (
+        "after deleting the middle point, the tail must shift up in order."
+    )
+
+
+def test_unrelated_modified_causes_no_point_drift(monkeypatch):
+    """An unrelated ``Modified`` does not add / move / drop any point.
+
+    A carrier ``Modified`` raised for a reason OTHER than a placement
+    gesture (a table repaint, a colour change, another view) must leave the
+    point set byte-identical -- the reconcile is idempotent on non-geometry
+    Modifieds (ADR-0038 §Decision / ADR-0037 no-drift mirror).
+    """
+    _slicer_or_skip()
+    Base = _import_base_or_skip()
+    pipeline = Base()
+    provider = _FakeFlatProvider()
+    _wire_or_skip(pipeline, provider, _FakePick((0.0, 0.0, 1.0)), monkeypatch)
+
+    for p in ((0.0, 0.0, 1.0), (1.0, 0.0, 0.0)):
+        provider.add_point(p)
+
+    if not hasattr(pipeline, "_on_node_modified"):
+        pytest.skip(
+            "SurfacePointPlacementPipeline3D has no _on_node_modified reconcile "
+            "hook -- cannot pin no-drift (ADR-0027)."
+        )
+
+    before = [provider.get(i) for i in range(provider.count())]
+    pipeline._on_node_modified(None, None)
+    pipeline._on_node_modified(None, None)
+
+    assert provider.count() == len(before), "an unrelated Modified must not add/drop."
+    for i, expected in enumerate(before):
+        assert provider.get(i) == pytest.approx(expected, abs=1e-9), (
+            f"point {i} must not drift on an unrelated Modified."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_slice.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_slice.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 -- the shared slice-view control-point projection + fade base.
+
+ADR-0038 §Decision extracts a shared ``SurfacePointPlacementPipelineSlice``
+base (the slice complement of the 3D base) from the mature resection slice
+pipeline; VascularTerritories/volumetry become clients.  The base owns the
+slice projection into XY (``inverse(XYToRAS)``), the distance-graded alpha
+fade, the signed above/below side tint, and the HARD presence cutoff (2D
+alpha is unreliable) -- named explicitly as duplicated in ADR-0038
+§Context.
+
+This file pins the PURE-MATH half of the slice base -- the projection /
+signed distance / fade / side tint / presence cutoff -- which is plain
+geometry given a slice node exposing ``GetXYToRAS`` / ``GetSliceToRAS``.
+It mirrors the bare-math assertions in
+``VascularTerritories/Testing/Python/test_territories_slice_pipeline.py``
+so the extracted helper is pinned to the SAME behaviour it had at its
+territory origin.  The launched snap / arm-gate / decline invariants of
+the slice base ride the 3D-base + client suites; this file is the bare
+geometry contract.
+
+HARNESS: bare ``PythonSlicer -m pytest``.  The projection math needs no
+LayerDM, no GL, no scene -- a FAKE slice node (pure matrices) drives it --
+so it RUNS bare AND launched.  The proposed home is a pure-math helper
+module beside the base (``SlicerLiverInteractionLib/SlicePointProjection.py``,
+generalising ``TerritorySliceProjection``); the base pipeline imports it.
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the import is guarded
+and every test SKIP-PENDINGs on ``ImportError``; the skips lift at the
+extraction commit.
+
+References
+----------
+* ADR-0038 -- §Context names the slice projection + fade + side tint +
+  presence cutoff as the duplicated surface the base owns; §Decision
+  extracts them once.
+* ADR-0033 -- the slice-polygon presence-cutoff + side-tint discipline
+  (2D alpha unreliable).
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* VascularTerritories/VascularTerritoriesLib/TerritorySliceProjection.py --
+  the origin these assertions mirror.
+* VascularTerritories/Testing/Python/test_territories_slice_pipeline.py --
+  the client suite's bare-math half.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+def _import_projection_or_skip():
+    """Import the shared slice-projection helper, or skip-pend (ADR-0027).
+
+    PROPOSED seam (sharpen at landing): a pure-math module generalising
+    ``TerritorySliceProjection`` with the SAME public surface --
+    ``project_ras_to_xy``, ``signed_distance_to_slice``, ``is_present``,
+    ``fade_alpha``, ``side_tint``, ``normal_ray`` -- plus the constants
+    ``PICK_RANGE_MM`` / ``FADE_DISTANCE_MM``.
+    """
+    try:
+        import SlicePointProjection as proj
+    except ImportError:
+        pytest.skip(
+            "SlicePointProjection not importable -- the ADR-0038 shared slice "
+            "projection helper has not landed (ADR-0027 red->skip)."
+        )
+    return proj
+
+
+def _identity_scaled(fov_mm_per_px=1.0):
+    """A 4x4 mapping XY pixels to RAS with a uniform mm-per-pixel scale."""
+    m = vtk.vtkMatrix4x4()
+    m.Identity()
+    m.SetElement(0, 0, fov_mm_per_px)
+    m.SetElement(1, 1, fov_mm_per_px)
+    return m
+
+
+class _FakeSliceNode:
+    """An axial slice at ``z = z0``: normal +z, pixels 1 mm apart in x/y."""
+
+    def __init__(self, z0=0.0, fov_mm_per_px=1.0):
+        self._slice_to_ras = vtk.vtkMatrix4x4()
+        self._slice_to_ras.Identity()
+        self._slice_to_ras.SetElement(2, 3, z0)
+        self._xy_to_ras = _identity_scaled(fov_mm_per_px)
+        self._xy_to_ras.SetElement(2, 3, z0)
+
+    def GetSliceToRAS(self):  # noqa: N802 - VTK verb
+        return self._slice_to_ras
+
+    def GetXYToRAS(self):  # noqa: N802 - VTK verb
+        return self._xy_to_ras
+
+    def IsA(self, cls):  # noqa: N802 - VTK verb
+        return cls == "vtkMRMLSliceNode"
+
+
+# --------------------------------------------------------------------------- #
+# PURE MATH -- projection / signed distance / fade / side tint / presence
+# --------------------------------------------------------------------------- #
+
+
+def test_project_ras_to_xy_round_trips_in_plane_point():
+    """A point ON the slice plane projects to its pixel via inverse(XYToRAS).
+
+    With a 1 mm/px axial slice at z=0, RAS ``(3, 4, 0)`` projects to XY
+    ``(3, 4)``.  ADR-0038 §Context (slice projection into XY).
+    """
+    proj = _import_projection_or_skip()
+    slice_node = _FakeSliceNode(z0=0.0, fov_mm_per_px=1.0)
+
+    xy = proj.project_ras_to_xy(slice_node, (3.0, 4.0, 0.0))
+
+    assert xy is not None
+    assert xy == pytest.approx((3.0, 4.0), abs=1e-6)
+
+
+def test_signed_distance_is_positive_above_negative_below():
+    """Signed distance is + above the plane (along +normal), - below.
+
+    An axial slice at z=0 has normal +z; RAS ``(0, 0, 5)`` is +5 mm,
+    ``(0, 0, -5)`` is -5 mm.  ADR-0038 §Context (signed above/below tint).
+    """
+    proj = _import_projection_or_skip()
+    slice_node = _FakeSliceNode(z0=0.0)
+
+    assert proj.signed_distance_to_slice(slice_node, (0.0, 0.0, 5.0)) == pytest.approx(5.0)
+    assert proj.signed_distance_to_slice(slice_node, (0.0, 0.0, -5.0)) == pytest.approx(-5.0)
+    assert proj.signed_distance_to_slice(slice_node, (2.0, 9.0, 0.0)) == pytest.approx(0.0)
+
+
+def test_presence_cutoff_is_hard_at_pick_range():
+    """Presence is a HARD cutoff at ``PICK_RANGE_MM`` (2D alpha unreliable).
+
+    A seed just inside the range is present; one at / beyond it is ABSENT --
+    not merely faded to zero alpha (ADR-0033 slice-polygon rule, owned by
+    the base per ADR-0038 §Context).
+    """
+    proj = _import_projection_or_skip()
+
+    assert proj.is_present(proj.PICK_RANGE_MM - 0.01) is True
+    assert proj.is_present(proj.PICK_RANGE_MM) is False
+    assert proj.is_present(proj.PICK_RANGE_MM + 5.0) is False
+    # The fade is monotone: nearer the plane => more opaque.
+    assert proj.fade_alpha(0.0) == pytest.approx(1.0)
+    assert proj.fade_alpha(proj.FADE_DISTANCE_MM) == pytest.approx(0.0)
+    assert 0.0 < proj.fade_alpha(proj.FADE_DISTANCE_MM / 2.0) < 1.0
+
+
+def test_side_tint_lightens_above_and_darkens_below():
+    """The signed side tint pulls a mid-grey toward white above / black below.
+
+    ADR-0038 §Context (the signed above/below side tint owned by the base).
+    """
+    proj = _import_projection_or_skip()
+    base = [128, 128, 128]
+
+    above = proj.side_tint(base, +proj.FADE_DISTANCE_MM)
+    below = proj.side_tint(base, -proj.FADE_DISTANCE_MM)
+
+    assert above[0] > base[0], "above the plane must lighten toward white."
+    assert below[0] < base[0], "below the plane must darken toward black."
+
+
+def test_normal_ray_runs_along_the_slice_normal_through_the_point():
+    """The snap ray straddles the RAS point ALONG the slice normal.
+
+    An axial slice's normal is +z, so the ray through ``(1, 2, 0)`` runs
+    from ``(1, 2, +extent)`` to ``(1, 2, -extent)`` -- x/y stay fixed.  This
+    is the ray the pick provider is fed (surface consumers snap along it;
+    volumetry resolves the in-plane point -- the pick step is swappable per
+    ADR-0038 §"Base extension").
+    """
+    proj = _import_projection_or_skip()
+    slice_node = _FakeSliceNode(z0=0.0)
+
+    ray = proj.normal_ray(slice_node, (1.0, 2.0, 0.0), extent_mm=50.0)
+
+    assert ray is not None
+    p1, p2 = ray
+    assert p1 == pytest.approx((1.0, 2.0, 50.0), abs=1e-6)
+    assert p2 == pytest.approx((1.0, 2.0, -50.0), abs=1e-6)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/SlicerLiverInteractionLib/Testing/Python/test_point_placement_state.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_point_placement_state.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Unit skeletons for the shared ``PointPlacementState`` display-node accessors.
+
+ADR-0038 §"Shared home + names" extracts
+``VascularTerritoriesLib.TerritoryInteractionState`` (the arm / active /
+module-active / carrier accessors on a display node) into the shared
+``SlicerLiverInteractionLib`` package as ``PointPlacementState``, with the
+attribute-key namespace PARAMETERIZED per consumer.  Today the territory
+module hard-codes ``VascularTerritories.Armed`` etc.; the shared base must
+let each consumer (vascular territories, volumetry, resection) get its OWN
+keys on its OWN display node, so two consumers' arm/active/carrier state
+never collide (ADR-0038 §"Base extension" -- the base carries no
+data-model knowledge, only the parameterized interaction channel).
+
+The critical invariant beyond a plain rename: LayerDM interaction state
+(arm / active / module-active / carrier) MUST live on the shared MRML
+display node, not a Python pipeline instance (ADR-0032/0033; the
+LayerDM-state-on-the-display-node lesson).  These accessors are the
+read/write channel both the widget/table side and the manager-created
+Pipeline read back through, so the base can only carry them AS display-node
+accessors.
+
+HARNESS: bare ``PythonSlicer -m pytest``.  The accessors are pure Python
+over a ``SetAttribute`` / ``GetAttribute`` / node-reference surface -- a
+plain FAKE display node (below) satisfies the contract with no live scene,
+so this RUNS bare AND launched.  (The launched harness additionally proves
+a real ``vtkMRMLDisplayNode`` honours the same accessor calls.)
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the import is guarded
+and every test SKIP-PENDINGs on ``ImportError``; the skips lift when the
+implementer lands ``SlicerLiverInteractionLib/PointPlacementState.py``.
+
+References
+----------
+* ADR-0038 -- §"Shared home + names" names ``PointPlacementState`` and the
+  parameterized attribute-key namespace.
+* ADR-0032 / ADR-0033 -- interaction through the LayerDM Pipeline seam +
+  hover discipline; the arm/hover/grab channel lives on the display node.
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py --
+  the origin these accessors generalise (namespace parameterized).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+_PENDING = (
+    "PointPlacementState not yet implemented -- the ADR-0038 extraction "
+    "(SlicerLiverInteractionLib/PointPlacementState.py) has not landed "
+    "(ADR-0027 red->skip)."
+)
+
+
+def _import_state():
+    """Import the shared state helper or SKIP-PENDING when it is absent.
+
+    PROPOSED seam (sharpen at landing).  The base parameterizes the
+    attribute-key namespace per consumer.  The most likely shape is a small
+    class bound to a namespace prefix::
+
+        class PointPlacementState:
+            def __init__(self, namespace: str) -> None: ...
+            def set_armed(self, displayNode, armed: bool) -> None: ...
+            def is_armed(self, displayNode) -> bool: ...
+            def set_module_active(self, displayNode, active: bool) -> None: ...
+            def is_module_active(self, displayNode) -> bool: ...
+            def set_active(self, displayNode, key: str | None) -> None: ...
+            def get_active(self, displayNode) -> str | None: ...
+            def set_carrier(self, displayNode, carrier) -> None: ...
+            def get_carrier(self, displayNode): ...
+
+    The accessors preserve TerritoryInteractionState's semantics: armed is
+    a "1"/"0" string attribute; module-active reads ACTIVE unless
+    explicitly closed ("0"); active is the empty string -> ``None``; the
+    carrier is a typed node-reference role and ``set_carrier`` fires an
+    explicit ``Modified()``.
+    """
+    try:
+        from PointPlacementState import PointPlacementState
+    except ImportError:
+        pytest.skip(_PENDING)
+    return PointPlacementState
+
+
+class _FakeDisplayNode:
+    """A minimal display-node double: attribute bag + one node-ref role.
+
+    Enough to exercise the pure-Python accessor logic bare -- SetAttribute
+    / GetAttribute / SetNodeReferenceID / GetNodeReference / Modified.  The
+    launched harness swaps in a real ``vtkMRMLDisplayNode`` to prove the
+    same calls land on the wrapped node.
+    """
+
+    def __init__(self):
+        self._attrs: dict[str, str] = {}
+        self._refs: dict[str, object] = {}
+        self.modified_count = 0
+
+    def SetAttribute(self, key, value):  # noqa: N802 - VTK verb
+        self._attrs[key] = value
+
+    def GetAttribute(self, key):  # noqa: N802 - VTK verb
+        return self._attrs.get(key)
+
+    def SetNodeReferenceID(self, role, node_id):  # noqa: N802 - VTK verb
+        self._refs[role] = node_id
+
+    def GetNodeReference(self, role):  # noqa: N802 - VTK verb
+        return self._refs.get(role)
+
+    def Modified(self):  # noqa: N802 - VTK verb
+        self.modified_count += 1
+
+    # Attribute-bag inspection for the isolation assertions (not a VTK verb).
+    def raw_keys(self):
+        return set(self._attrs)
+
+
+class _FakeCarrier:
+    def __init__(self, node_id):
+        self._id = node_id
+
+    def GetID(self):  # noqa: N802 - VTK verb
+        return self._id
+
+
+# --------------------------------------------------------------------------- #
+# Arm / module-active / active accessors on a display node
+# --------------------------------------------------------------------------- #
+
+
+def test_arm_state_round_trips_on_the_display_node():
+    """Arm state written by one side reads back on the SAME display node.
+
+    The interaction state MUST live on the shared MRML display node, not a
+    pipeline instance (ADR-0032/0033) -- so the accessor writes onto the
+    node and reads it back, and a fresh (unset) node reads DISARMED.
+    """
+    PointPlacementState = _import_state()
+    state = PointPlacementState("Volumetry")
+    node = _FakeDisplayNode()
+
+    assert state.is_armed(node) is False, "a fresh node must read DISARMED."
+    state.set_armed(node, True)
+    assert state.is_armed(node) is True
+    state.set_armed(node, False)
+    assert state.is_armed(node) is False
+
+
+def test_module_active_defaults_open_and_closes_only_on_explicit_zero():
+    """Module-active reads ACTIVE unless EXPLICITLY closed (the "0" opt-in).
+
+    LayerDM creates the placement Pipelines the moment the display node
+    enters the scene (before any ``enter()``); a gesture must still land in
+    that window, so an UNSET flag reads active and only an explicit
+    ``set_module_active(False)`` declines (TerritoryInteractionState
+    semantics, preserved by the base).
+    """
+    PointPlacementState = _import_state()
+    state = PointPlacementState("Volumetry")
+    node = _FakeDisplayNode()
+
+    assert state.is_module_active(node) is True, "an unset flag must read ACTIVE."
+    state.set_module_active(node, False)
+    assert state.is_module_active(node) is False
+    state.set_module_active(node, True)
+    assert state.is_module_active(node) is True
+
+
+def test_active_key_empty_reads_none():
+    """The active key round-trips; the empty string reads back as ``None``."""
+    PointPlacementState = _import_state()
+    state = PointPlacementState("Volumetry")
+    node = _FakeDisplayNode()
+
+    assert state.get_active(node) is None
+    state.set_active(node, "SeedGroupA")
+    assert state.get_active(node) == "SeedGroupA"
+    state.set_active(node, None)
+    assert state.get_active(node) is None
+
+
+def test_carrier_binds_as_node_ref_and_fires_modified():
+    """Binding a carrier writes the node-reference role AND fires Modified.
+
+    ADR-0032/0033: a node-reference change does not reliably emit
+    ``ModifiedEvent``, so the accessor fires an explicit ``Modified()`` to
+    drive LayerDM's ``UpdatePipeline`` on every view (the
+    TerritoryInteractionState.set_carrier contract, preserved).
+    """
+    PointPlacementState = _import_state()
+    state = PointPlacementState("Volumetry")
+    node = _FakeDisplayNode()
+    carrier = _FakeCarrier("vtkMRMLVolumetrySeedsNode1")
+
+    state.set_carrier(node, carrier)
+    assert state.get_carrier(node) == "vtkMRMLVolumetrySeedsNode1"
+    assert node.modified_count >= 1, (
+        "set_carrier must fire an explicit Modified() (ADR-0032/0033 -- a "
+        "node-reference change does not reliably emit ModifiedEvent)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Namespace parameterization -- two consumers, independent keys/nodes
+# --------------------------------------------------------------------------- #
+
+
+def test_two_namespaces_use_independent_attribute_keys():
+    """Two consumers with distinct namespaces get DISJOINT attribute keys.
+
+    ADR-0038 §"Shared home + names": the base parameterizes the
+    attribute-key namespace so each consumer gets its own keys.  Arming a
+    territory display node under the "VascularTerritories" namespace and a
+    volumetry display node under the "Volumetry" namespace must write
+    NON-OVERLAPPING attribute keys -- no cross-consumer collision.
+    """
+    PointPlacementState = _import_state()
+    terr_state = PointPlacementState("VascularTerritories")
+    vol_state = PointPlacementState("Volumetry")
+
+    terr_node = _FakeDisplayNode()
+    vol_node = _FakeDisplayNode()
+
+    terr_state.set_armed(terr_node, True)
+    vol_state.set_armed(vol_node, True)
+
+    # The two consumers must not share any attribute key on their own nodes.
+    assert terr_node.raw_keys().isdisjoint(vol_node.raw_keys()), (
+        "distinct namespaces must yield DISJOINT attribute keys (no "
+        "cross-consumer collision on the shared display node)."
+    )
+    # Each namespace's key must carry its own prefix (the parameterization).
+    assert any(k.startswith("VascularTerritories") for k in terr_node.raw_keys())
+    assert any(k.startswith("Volumetry") for k in vol_node.raw_keys())
+
+
+def test_one_namespace_does_not_read_anothers_state():
+    """A consumer reads DISARMED for another consumer's armed node.
+
+    Even given the SAME physical display node, the "Volumetry" namespace
+    must not read the "VascularTerritories" arm flag as its own -- the
+    namespaced key isolation holds when two consumers accidentally share a
+    node (ADR-0038 parameterized namespace).
+    """
+    PointPlacementState = _import_state()
+    terr_state = PointPlacementState("VascularTerritories")
+    vol_state = PointPlacementState("Volumetry")
+    shared_node = _FakeDisplayNode()
+
+    terr_state.set_armed(shared_node, True)
+
+    assert terr_state.is_armed(shared_node) is True
+    assert vol_state.is_armed(shared_node) is False, (
+        "the Volumetry namespace must NOT read the VascularTerritories arm "
+        "flag -- namespaced keys are isolated."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/SlicerLiverInteractionLib/Testing/Python/test_surface_pick.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_surface_pick.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Pure-VTK unit skeletons for the shared ``SurfacePick`` geometry core.
+
+ADR-0038 §"Shared home + names" extracts the vessel-adhering pick core
+out of ``VascularTerritoriesLib.VesselSurfacePick`` into the shared
+``SlicerLiverInteractionLib`` package as ``SurfacePick`` -- the pure-VTK
+ray->closed-surface intersect-nearest + closest-point fallback with a
+lazy MTime-invalidated ``vtkCellLocator``.  The move is verbatim (only the
+class name drops the ``Vessel`` prefix, T2.7); the geometry contract is
+identical to the ``VesselSurfacePick`` original.  This file mirrors the
+assertions that live today in
+``VascularTerritories/Testing/Python/test_vessel_surface_pick.py`` so the
+extracted class is pinned to the SAME behaviour it had at its origin.
+
+Discipline: this layer runs under bare ``PythonSlicer -m pytest`` -- no
+Slicer scene, no Qt, no GL (ADR-0003 testability invariant; ADR-0004 the
+pick math is pure Python).  Surfaces are built from ``vtkSphereSource`` /
+``vtkPlaneSource``; rays are plain world coordinates; assertions are
+geometry-real (a ray down +z through a unit sphere at the origin hits the
+north pole ``(0, 0, 1)``).
+
+HARNESS: bare ``PythonSlicer -m pytest`` (pure VTK) AND launched (both;
+the pure-VTK core has no Slicer dependency, so it runs in either row).
+
+The SUT does not exist yet.  Per ADR-0027 red->skip the import is guarded
+and every test SKIP-PENDINGs on ``ImportError``; the skips lift when the
+implementer lands ``SlicerLiverInteractionLib/SurfacePick.py`` (PR 1 of
+the ADR-0038 extraction, ``volumetry-seeds-layerdm-plan.md`` §6).
+
+References
+----------
+* ADR-0038 -- unify the control-point interaction; §"Shared home + names"
+  names ``SurfacePick`` as the extracted pure-VTK pick core.
+* ADR-0027 -- invariant-test-first; the red->skip lifecycle here.
+* ADR-0004 -- Python/C++ boundary; the pick math is pure Python.
+* ADR-0003 -- testability invariant; this unit layer imports no
+  Slicer / MRML / Qt.
+* VascularTerritories/Testing/Python/test_vessel_surface_pick.py -- the
+  behaviour-preserving origin these assertions mirror.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip(
+    "vtk",
+    reason=(
+        "vtk not importable; the pick core imports vtk.  Run inside "
+        "Slicer's Python (PythonSlicer) or any environment where the "
+        "bundled vtk wheel is on sys.path."
+    ),
+)
+
+# --------------------------------------------------------------------------- #
+# Repo geometry -- the extracted pick core lives in the NEW shared
+# ``SlicerLiverInteractionLib`` package (ADR-0038 §"Shared home + names"),
+# a sibling to LayerDMLib.  The path-insert lets the bare unit layer import
+# the module before the packaging follow-up (Lib dir + PYTHON_SCRIPTS
+# registration) lands -- the test_vessel_surface_pick.py precedent.
+# --------------------------------------------------------------------------- #
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+_PENDING = (
+    "SurfacePick not yet implemented -- the ADR-0038 extraction "
+    "(SlicerLiverInteractionLib/SurfacePick.py) has not landed (ADR-0027 "
+    "red->skip)."
+)
+
+
+def _import_pick():
+    """Import the shared pick core or SKIP-PENDING when it does not exist yet.
+
+    The implementer must provide ``SurfacePick`` with, at minimum::
+
+        class SurfacePick:
+            def __init__(self, polydata: vtk.vtkPolyData | None) -> None: ...
+            def pick(
+                self,
+                p1: tuple[float, float, float],
+                p2: tuple[float, float, float],
+                fallback_point: tuple[float, float, float] | None = None,
+            ) -> tuple[float, float, float] | None: ...
+
+    ``pick`` returns the adhering world point (on the mesh), or ``None``
+    when there is no surface to adhere to.  This is the SAME contract the
+    ``VesselSurfacePick`` origin already satisfies (ADR-0038 verbatim move).
+    """
+    try:
+        from SurfacePick import SurfacePick
+    except ImportError:
+        pytest.skip(_PENDING)
+    return SurfacePick
+
+
+# --------------------------------------------------------------------------- #
+# Geometry helpers (pure VTK -- no Slicer, no GL)
+# --------------------------------------------------------------------------- #
+
+
+def _unit_sphere(center=(0.0, 0.0, 0.0), radius=1.0):
+    """A dense unit sphere so ray/nearest hits land close to the ideal."""
+    source = vtk.vtkSphereSource()
+    source.SetCenter(*center)
+    source.SetRadius(radius)
+    source.SetThetaResolution(64)
+    source.SetPhiResolution(64)
+    source.Update()
+    return source.GetOutput()
+
+
+def _xy_plane(size=10.0):
+    """A flat z=0 plane spanning [-size/2, size/2] in x and y."""
+    source = vtk.vtkPlaneSource()
+    source.SetOrigin(-size / 2.0, -size / 2.0, 0.0)
+    source.SetPoint1(size / 2.0, -size / 2.0, 0.0)
+    source.SetPoint2(-size / 2.0, size / 2.0, 0.0)
+    source.SetResolution(20, 20)
+    source.Update()
+    return source.GetOutput()
+
+
+def _distance_to_surface(polydata, point) -> float:
+    """Distance from ``point`` to the closest point on ``polydata``."""
+    locator = vtk.vtkCellLocator()
+    locator.SetDataSet(polydata)
+    locator.BuildLocator()
+    closest = [0.0, 0.0, 0.0]
+    cell_id = vtk.reference(0)
+    sub_id = vtk.reference(0)
+    dist2 = vtk.reference(0.0)
+    locator.FindClosestPoint(list(point), closest, cell_id, sub_id, dist2)
+    return float(dist2) ** 0.5
+
+
+# --------------------------------------------------------------------------- #
+# INCREMENT 1 -- the pick core (mirrors test_vessel_surface_pick.py)
+# --------------------------------------------------------------------------- #
+
+
+def test_ray_hit_returns_point_on_the_mesh():
+    """A ray that crosses the mesh returns a point that lies ON the mesh.
+
+    Ray straight down the +z axis through a unit sphere at the origin: the
+    near hit is the north pole ``(0, 0, 1)``.  ADR-0038 §"Shared home +
+    names" (SurfacePick = the extracted pick core).
+    """
+    SurfacePick = _import_pick()
+    sphere = _unit_sphere()
+    pick = SurfacePick(sphere)
+
+    hit = pick.pick(p1=(0.0, 0.0, 5.0), p2=(0.0, 0.0, -5.0))
+
+    assert hit is not None
+    assert _distance_to_surface(sphere, hit) == pytest.approx(0.0, abs=1e-3)
+    assert list(hit) == pytest.approx([0.0, 0.0, 1.0], abs=2e-2)
+
+
+def test_ray_miss_projects_to_nearest_surface_point():
+    """A ray that misses the mesh returns the NEAREST-surface projection of
+    the fallback world point -- still ON the mesh.
+
+    Fallback point ``(3, 0, 0)`` outside a unit sphere at the origin
+    projects to ``(1, 0, 0)``.  ADR-0038 §"Shared home + names" (the
+    closest-point fallback).
+    """
+    SurfacePick = _import_pick()
+    sphere = _unit_sphere()
+    pick = SurfacePick(sphere)
+
+    projected = pick.pick(
+        p1=(-5.0, 10.0, 0.0),
+        p2=(5.0, 10.0, 0.0),
+        fallback_point=(3.0, 0.0, 0.0),
+    )
+
+    assert projected is not None
+    assert _distance_to_surface(sphere, projected) == pytest.approx(0.0, abs=1e-3)
+    assert list(projected) == pytest.approx([1.0, 0.0, 0.0], abs=2e-2)
+
+
+def test_no_surface_returns_none():
+    """No polydata (or an empty mesh) -> the pick core returns ``None``.
+
+    The raw-point fallback is the CALLER's concern; the core only signals
+    "no surface".  ADR-0038 §"Shared home + names" pick-core contract.
+    """
+    SurfacePick = _import_pick()
+
+    pick_none = SurfacePick(None)
+    assert pick_none.pick(p1=(0.0, 0.0, 5.0), p2=(0.0, 0.0, -5.0)) is None
+
+    pick_empty = SurfacePick(vtk.vtkPolyData())
+    assert pick_empty.pick(p1=(0.0, 0.0, 5.0), p2=(0.0, 0.0, -5.0)) is None
+
+
+def test_fold_over_picks_the_nearest_hit_to_ray_origin():
+    """A ray crossing the mesh twice returns the hit NEAREST the ray origin,
+    not the far one.
+
+    Ray from ``(0, 0, 5)`` down the -z axis through a unit sphere at the
+    origin crosses at ``z=+1`` (near) and ``z=-1`` (far); the near hit
+    ``(0, 0, 1)`` wins.  ADR-0038 §"Shared home + names" nearest-hit
+    selection.
+    """
+    SurfacePick = _import_pick()
+    sphere = _unit_sphere()
+    pick = SurfacePick(sphere)
+
+    hit = pick.pick(p1=(0.0, 0.0, 5.0), p2=(0.0, 0.0, -5.0))
+
+    assert hit is not None
+    assert list(hit) == pytest.approx([0.0, 0.0, 1.0], abs=2e-2)
+    assert hit[2] > 0.0, "the far hit z=-1 must NOT win."
+
+
+# --------------------------------------------------------------------------- #
+# INCREMENT 2 -- lazy locator cache invalidation on MTime advance
+# --------------------------------------------------------------------------- #
+
+
+def test_pick_reflects_new_surface_after_polydata_mutation():
+    """When the polydata's ``MTime`` advances the next pick reflects the NEW
+    surface, not a stale cached locator.
+
+    Build a flat z=0 plane; pick a ray down +z -> hits z=0.  Translate all
+    points to z=+3 and mark modified; the SAME ray picked again must now hit
+    z=+3.  ADR-0038 §"Shared home + names" "a lazy MTime-invalidated
+    ``vtkCellLocator``".
+    """
+    SurfacePick = _import_pick()
+    plane = _xy_plane()
+    pick = SurfacePick(plane)
+
+    first = pick.pick(p1=(0.0, 0.0, 5.0), p2=(0.0, 0.0, -5.0))
+    assert first is not None
+    assert first[2] == pytest.approx(0.0, abs=1e-3)
+
+    points = plane.GetPoints()
+    for i in range(points.GetNumberOfPoints()):
+        x, y, _ = points.GetPoint(i)
+        points.SetPoint(i, x, y, 3.0)
+    points.Modified()
+    plane.Modified()
+
+    second = pick.pick(p1=(0.0, 0.0, 5.0), p2=(0.0, 0.0, -5.0))
+    assert second is not None
+    assert second[2] == pytest.approx(3.0, abs=1e-3), (
+        "stale locator cache returned the old surface (MTime not invalidated)."
+    )
+
+
+def test_nearest_projection_also_reflects_new_surface_after_mutation():
+    """A missing-ray nearest-projection pick also tracks the mutated surface.
+
+    The cache invalidation applies to the closest-point path, not just the
+    ray-cast path.  ADR-0038 §"Shared home + names" locator-cache
+    invalidation.
+    """
+    SurfacePick = _import_pick()
+    sphere = _unit_sphere(radius=1.0)
+    pick = SurfacePick(sphere)
+
+    before = pick.pick(
+        p1=(-5.0, 10.0, 0.0),
+        p2=(5.0, 10.0, 0.0),
+        fallback_point=(3.0, 0.0, 0.0),
+    )
+    assert before is not None
+    assert list(before) == pytest.approx([1.0, 0.0, 0.0], abs=2e-2)
+
+    bigger = _unit_sphere(radius=2.0)
+    sphere.GetPoints().DeepCopy(bigger.GetPoints())
+    sphere.SetPolys(bigger.GetPolys())
+    sphere.Modified()
+
+    after = pick.pick(
+        p1=(-5.0, 10.0, 0.0),
+        p2=(5.0, 10.0, 0.0),
+        fallback_point=(3.0, 0.0, 0.0),
+    )
+    assert after is not None
+    assert list(after) == pytest.approx([2.0, 0.0, 0.0], abs=3e-2), (
+        "stale locator cache returned the old radius (MTime not invalidated)."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/SlicerLiverInteractionLib/__init__.py
+++ b/SlicerLiverInteractionLib/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Shared control-point interaction base (ADR-0038).
+
+A Python Lib package (ADR-0004) hosting the interaction/visualization base
+each module's LayerDM Pipeline creator instantiates; it hosts NO
+displayable manager (ADR-0013 §5) and carries no data-model knowledge.
+The ``Liver`` prefix is dropped on every class here (T2.7 convention).
+
+Currently landed (ADR-0038 extraction, first slice):
+
+* ``SurfacePick`` -- the pure-VTK ray->closed-surface intersect-nearest +
+  closest-point fallback with a lazy MTime-invalidated ``vtkCellLocator``.
+* ``PointPlacementState`` -- the arm/active/module-active/carrier accessors
+  on a display node, with the attribute-key namespace parameterized per
+  consumer.
+
+The Pipeline base classes + the ``PointProvider`` seam land in a later
+slice of the extraction.
+"""
+
+from __future__ import annotations
+
+from .SurfacePick import SurfacePick
+from .PointPlacementState import PointPlacementState
+
+__all__ = [
+    "SurfacePick",
+    "PointPlacementState",
+]

--- a/VascularTerritories/Testing/Python/test_vessel_surface_pick.py
+++ b/VascularTerritories/Testing/Python/test_vessel_surface_pick.py
@@ -29,13 +29,13 @@ coordinates; assertions are geometry-real (the expected on-surface point
 is computed by construction — e.g. a ray down the +z axis through a unit
 sphere centred at the origin hits ``(0, 0, 1)``).
 
-The SUT does not exist yet.  Per the ADR-0027 red->skip lifecycle the
-import is guarded and every test SKIP-PENDINGs on ``ImportError``; the
-skips lift automatically when the implementer lands the module.  The
-proposed seam is a NEW ``VascularTerritoriesLib`` package (there is no
-Lib dir today — the module is the legacy single-file
-``VascularTerritories.py``); the pick core lives at
-``VascularTerritoriesLib/VesselSurfacePick.py``.
+The pick core has been extracted (ADR-0038 §"Shared home + names") out of
+``VascularTerritoriesLib`` into the shared ``SlicerLiverInteractionLib``
+package as ``SurfacePick`` (the ``Vessel`` prefix dropped, T2.7).  This
+characterization test now pins the extracted class in its new home; the
+geometry assertions are unchanged (behaviour-preserving — ADR-0038
+[review]).  The ADR-0027 red->skip guard remains so the test SKIP-PENDINGs
+cleanly wherever the shared Lib is not yet on the path.
 
 References
 ----------
@@ -66,28 +66,31 @@ vtk = pytest.importorskip(
 )
 
 # --------------------------------------------------------------------------- #
-# Repo geometry — the proposed pick-core seam lives in a NEW
-# ``VascularTerritoriesLib`` package alongside the legacy single-file
-# ``VascularTerritories.py``.  This mirrors the ``<Module>Lib`` install
-# convention already used by ``LiverResectionsLib``.  The path-insert
-# lets the bare unit layer import the module before the packaging
-# follow-up (Lib dir + PYTHON_SCRIPTS registration) lands.
+# Repo geometry — the extracted pick core lives in the shared
+# ``SlicerLiverInteractionLib`` package.  The path-insert lets the bare unit
+# layer import the module before its PYTHON_SCRIPTS registration is on the
+# runtime path (the ``<Module>Lib`` install convention).
 # --------------------------------------------------------------------------- #
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
-PY_DIR = REPO_ROOT / "VascularTerritories" / "VascularTerritoriesLib"
+# ADR-0038 §"Shared home + names" moved the pick core to the shared
+# SlicerLiverInteractionLib package as ``SurfacePick`` (the ``Vessel`` prefix
+# dropped, T2.7).  This characterization test now pins the extracted class in
+# its new home; the geometry assertions below are unchanged (behaviour-
+# preserving -- ADR-0038 [review]).
+PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
 if str(PY_DIR) not in sys.path:
     sys.path.insert(0, str(PY_DIR))
 
-_PENDING = "VesselSurfacePick not yet implemented (ADR-0027 red->skip)"
+_PENDING = "SurfacePick not yet implemented (ADR-0027 red->skip)"
 
 
 def _import_pick():
     """Import the pick core or SKIP-PENDING when it does not exist yet.
 
-    The implementer must provide ``VesselSurfacePick`` with, at minimum:
+    The implementer must provide ``SurfacePick`` with, at minimum:
 
-        class VesselSurfacePick:
+        class SurfacePick:
             def __init__(self, polydata: vtk.vtkPolyData | None) -> None: ...
             def pick(
                 self,
@@ -100,10 +103,10 @@ def _import_pick():
     when there is no surface to adhere to.
     """
     try:
-        from VesselSurfacePick import VesselSurfacePick
+        from SurfacePick import SurfacePick
     except ImportError:
         pytest.skip(_PENDING)
-    return VesselSurfacePick
+    return SurfacePick
 
 
 # --------------------------------------------------------------------------- #

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
@@ -1,97 +1,85 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
-"""Shared annotation-interaction state on the highlight display node (ADR-0037).
+"""Compatibility shim over the shared ``PointPlacementState`` accessors.
 
-The Stage-2 placement is *pipeline-managed* (ADR-0037 §Decision 2), not a
-Slicer interaction node / mouse mode.  But LayerDM owns the placement
-Pipeline instance's lifecycle — it creates its own per view — so the widget
-and its table cannot reach that instance directly.  The two sides meet on
-the shared ``vtkMRMLTerritoriesHighlightDisplayNode``: the table WRITES the
-arm state / active territory / carrier binding onto the display node, and the
-manager-driven Pipeline READS them back at event time.
+ADR-0038 §"Shared home + names" generalised these arm / active-territory /
+module-active / carrier accessors into ``SlicerLiverInteractionLib``'s
+``PointPlacementState``, parameterizing the attribute-key namespace per
+consumer.  This module now delegates to a ``PointPlacementState`` bound to
+the ``"VascularTerritories"`` namespace, which reproduces the original
+attribute keys (``VascularTerritories.Armed`` etc.) EXACTLY, so existing
+call sites and the territory characterization suite keep working unchanged
+(the extraction is behaviour-preserving -- ADR-0038 [review]).
 
-These are the accessors both sides use.  The module imports nothing heavy
-(no LayerDMLib, no Qt) so the table can depend on it without dragging in the
-Pipeline's LayerDM dependency.
+The module-level function names are preserved verbatim (including
+``set_active_territory`` / ``get_active_territory``, which map onto the
+base's namespace-neutral ``set_active`` / ``get_active``).
 
-* armed + active territory ride as string attributes (cheap, XML-transient).
-* the carrier rides as a typed node-reference role.
+The dual import mirrors the ``<Module>Lib`` idiom used throughout this
+package: the installed/built tree stages ``SlicerLiverInteractionLib``
+alongside this package; the bare unit layer sets ``sys.path`` to the
+individual Lib dir, so a sibling-directory fallback keeps the shared core
+importable there too.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-#: Display-node attribute keys / reference role for the interaction state.
-ARMED_ATTR = "VascularTerritories.Armed"
-ACTIVE_TERRITORY_ATTR = "VascularTerritories.ActiveTerritory"
-MODULE_ACTIVE_ATTR = "VascularTerritories.ModuleActive"
-CARRIER_REFERENCE_ROLE = "VascularTerritories.carrier"
+try:
+    from SlicerLiverInteractionLib.PointPlacementState import PointPlacementState
+except ImportError:  # bare unit layer: add the sibling Lib dir to sys.path
+    import pathlib
+    import sys
+
+    _shared_lib = pathlib.Path(__file__).resolve().parents[2] / "SlicerLiverInteractionLib"
+    if str(_shared_lib) not in sys.path:
+        sys.path.insert(0, str(_shared_lib))
+    from PointPlacementState import PointPlacementState  # type: ignore[no-redef]
+
+#: The territory namespace reproduces the original attribute keys exactly.
+_NAMESPACE = "VascularTerritories"
+_STATE = PointPlacementState(_NAMESPACE)
+
+#: Display-node attribute keys / reference role (kept for back-compat).
+ARMED_ATTR = f"{_NAMESPACE}.Armed"
+ACTIVE_TERRITORY_ATTR = f"{_NAMESPACE}.ActiveTerritory"
+MODULE_ACTIVE_ATTR = f"{_NAMESPACE}.ModuleActive"
+CARRIER_REFERENCE_ROLE = f"{_NAMESPACE}.carrier"
 
 
 def set_armed(displayNode: Any, armed: bool) -> None:
     """Publish the arm state onto the shared highlight display node."""
-    if displayNode is not None:
-        displayNode.SetAttribute(ARMED_ATTR, "1" if armed else "0")
+    _STATE.set_armed(displayNode, armed)
 
 
 def is_armed(displayNode: Any) -> bool:
-    return displayNode is not None and displayNode.GetAttribute(ARMED_ATTR) == "1"
+    return _STATE.is_armed(displayNode)
 
 
 def set_module_active(displayNode: Any, active: bool) -> None:
-    """Publish the module-active gate onto the shared highlight display node.
-
-    Belt-and-suspenders beyond the armed flag (ADR-0037 slice-5 concern #1):
-    the owning module's ``enter()`` / ``exit()`` flips this so no view lands a
-    seed while VascularTerritories is not the active module.
-    """
-    if displayNode is not None:
-        displayNode.SetAttribute(MODULE_ACTIVE_ATTR, "1" if active else "0")
+    """Publish the module-active gate onto the shared highlight display node."""
+    _STATE.set_module_active(displayNode, active)
 
 
 def is_module_active(displayNode: Any) -> bool:
-    """True unless the module has EXPLICITLY closed the gate.
-
-    An UNSET attribute reads active: LayerDM creates the placement Pipelines
-    the moment the display node enters the scene (before any ``enter()``), and
-    a placement/edit gesture must still land in that window.  The gate is the
-    module's ``exit()`` writing ``"0"`` -- the decline is opt-in, so opening
-    the module (or never touching the flag) leaves placement enabled.
-    """
-    return displayNode is None or displayNode.GetAttribute(MODULE_ACTIVE_ATTR) != "0"
+    """True unless the module has EXPLICITLY closed the gate."""
+    return _STATE.is_module_active(displayNode)
 
 
 def set_active_territory(displayNode: Any, territoryId: str | None) -> None:
     """Publish the active territory onto the shared highlight display node."""
-    if displayNode is not None:
-        displayNode.SetAttribute(ACTIVE_TERRITORY_ATTR, territoryId or "")
+    _STATE.set_active(displayNode, territoryId)
 
 
 def get_active_territory(displayNode: Any) -> str | None:
-    if displayNode is None:
-        return None
-    value = displayNode.GetAttribute(ACTIVE_TERRITORY_ATTR)
-    return value or None
+    return _STATE.get_active(displayNode)
 
 
 def set_carrier(displayNode: Any, carrier: Any) -> None:
-    """Bind the annotation carrier onto the display node (typed node ref).
-
-    Fires an explicit ``Modified()``: LayerDM creates the view pipelines when
-    the display node enters the scene, which is BEFORE this bind, and a node-
-    reference change does not reliably emit ``ModifiedEvent``.  The explicit
-    Modified drives LayerDM's ``UpdatePipeline`` on every view so each
-    pipeline (re)attaches its carrier observer and starts tracking seeds.
-    """
-    if displayNode is None:
-        return
-    carrierId = carrier.GetID() if carrier is not None else None
-    displayNode.SetNodeReferenceID(CARRIER_REFERENCE_ROLE, carrierId)
-    displayNode.Modified()
+    """Bind the annotation carrier onto the display node (typed node ref)."""
+    _STATE.set_carrier(displayNode, carrier)
 
 
 def get_carrier(displayNode: Any) -> Any | None:
-    if displayNode is None:
-        return None
-    return displayNode.GetNodeReference(CARRIER_REFERENCE_ROLE)
+    return _STATE.get_carrier(displayNode)

--- a/VascularTerritories/VascularTerritoriesLib/VesselSurfacePick.py
+++ b/VascularTerritories/VascularTerritoriesLib/VesselSurfacePick.py
@@ -1,151 +1,35 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
-"""Pure-VTK pick core for the VascularTerritories vessel-adhering highlight.
+"""Compatibility re-export of the shared ``SurfacePick`` pick core.
 
-Given a closed-surface ``vtkPolyData`` (the input segmentation's mesh)
-and a cursor ray in world coordinates, resolve the world point the
-highlight should adhere to:
+ADR-0038 §"Shared home + names" extracted the vessel-adhering pick core out
+of this module into the shared ``SlicerLiverInteractionLib`` package as
+``SurfacePick`` (the ``Vessel`` prefix dropped, T2.7).  This module now
+re-exports that class under its original name so existing call sites and
+the vessel-pick characterization test keep resolving ``VesselSurfacePick``
+unchanged (the extraction is behaviour-preserving -- ADR-0038 [review]).
 
-* the ray hits the mesh -> the intersection NEAREST the ray origin,
-  lying ON the mesh;
-* the ray misses -> the nearest-surface projection of ``fallback_point``;
-* there is no mesh at all -> ``None`` (the raw-point fallback is the
-  caller's concern).
-
-The pick is backed by a ``vtkCellLocator`` built lazily from the
-polydata.  The locator is rebuilt when the polydata's ``MTime`` advances
-past the MTime observed at the last build, so an edited/rebuilt segment
-mesh is always reflected by the next pick.
-
-This is a pure-VTK unit-layer class: no Slicer, MRML or Qt imports
-(ADR-0004 keeps the pick math in Python; ADR-0003 keeps this layer
-bare-unit testable).  The locator pattern mirrors the resection pick
-core described in ADR-0025.
+The dual import mirrors the ``<Module>Lib`` idiom used throughout this
+package: the installed/built tree stages ``SlicerLiverInteractionLib``
+alongside this package on the qt-scripted-modules path; the bare unit layer
+sets ``sys.path`` to the individual Lib dir, so a sibling-directory fallback
+keeps the shared core importable there too.
 """
 
 from __future__ import annotations
 
-import vtk
+try:
+    from SlicerLiverInteractionLib.SurfacePick import SurfacePick
+except ImportError:  # bare unit layer: add the sibling Lib dir to sys.path
+    import pathlib
+    import sys
 
+    _shared_lib = pathlib.Path(__file__).resolve().parents[2] / "SlicerLiverInteractionLib"
+    if str(_shared_lib) not in sys.path:
+        sys.path.insert(0, str(_shared_lib))
+    from SurfacePick import SurfacePick  # type: ignore[no-redef]
 
-class VesselSurfacePick:
-    """Resolve the adhering world point for a cursor ray over a mesh."""
+#: Backwards-compatible alias for the extracted shared pick core.
+VesselSurfacePick = SurfacePick
 
-    def __init__(self, polydata: vtk.vtkPolyData | None) -> None:
-        self._polydata = polydata
-        self._locator: vtk.vtkCellLocator | None = None
-        self._built_mtime: int | None = None
-
-    def surface(self) -> vtk.vtkPolyData | None:
-        """The surface this pick core holds.
-
-        The active-tree recovery (ADR-0037 slice 5) must run connectivity over
-        the SAME surface the pick uses to snap clicks -- the injected surface
-        under test, the vessels-only mesh in production -- so it is exposed here
-        rather than re-derived from the display node.
-        """
-        return self._polydata
-
-    # ------------------------------------------------------------------ #
-    # Locator lifecycle
-    # ------------------------------------------------------------------ #
-    def _has_surface(self) -> bool:
-        return (
-            self._polydata is not None
-            and self._polydata.GetNumberOfPoints() > 0
-            and self._polydata.GetNumberOfCells() > 0
-        )
-
-    def _ensure_locator(self) -> vtk.vtkCellLocator | None:
-        """Build the locator lazily, rebuilding when the mesh is stale.
-
-        A stale cache is detected by comparing the polydata's current
-        ``MTime`` against the MTime observed at the last build; when the
-        surface points/cells mutate and the polydata is marked modified,
-        the advanced MTime forces a rebuild (ADR-0025 cache invalidation).
-        """
-        if not self._has_surface():
-            self._locator = None
-            self._built_mtime = None
-            return None
-
-        current_mtime = self._polydata.GetMTime()
-        if self._locator is None or self._built_mtime != current_mtime:
-            locator = vtk.vtkCellLocator()
-            locator.SetDataSet(self._polydata)
-            locator.BuildLocator()
-            self._locator = locator
-            self._built_mtime = current_mtime
-        return self._locator
-
-    # ------------------------------------------------------------------ #
-    # Pick
-    # ------------------------------------------------------------------ #
-    def pick(
-        self,
-        p1: tuple[float, float, float],
-        p2: tuple[float, float, float],
-        fallback_point: tuple[float, float, float] | None = None,
-    ) -> tuple[float, float, float] | None:
-        """Return the adhering world point, or ``None`` when there is no mesh.
-
-        ``p1``/``p2`` define the world-space cursor ray (``p1`` is the ray
-        origin, near the camera).  ``fallback_point`` is projected onto the
-        surface when the ray misses.
-        """
-        locator = self._ensure_locator()
-        if locator is None:
-            return None
-
-        hit = self._intersect(locator, p1, p2)
-        if hit is not None:
-            return hit
-
-        if fallback_point is None:
-            return None
-        return self._closest(locator, fallback_point)
-
-    @staticmethod
-    def _intersect(
-        locator: vtk.vtkCellLocator,
-        p1: tuple[float, float, float],
-        p2: tuple[float, float, float],
-    ) -> tuple[float, float, float] | None:
-        """Ray/mesh intersection nearest the ray origin ``p1``.
-
-        ``IntersectWithLine`` reports the first intersection along the
-        parametric line from ``p1`` to ``p2`` (smallest ``t``), which is
-        the hit nearest the ray origin even when the ray folds over the
-        mesh twice.
-        """
-        t = vtk.reference(0.0)
-        intersection = [0.0, 0.0, 0.0]
-        pcoords = [0.0, 0.0, 0.0]
-        sub_id = vtk.reference(0)
-        cell_id = vtk.reference(0)
-        code = locator.IntersectWithLine(
-            list(p1),
-            list(p2),
-            1e-6,
-            t,
-            intersection,
-            pcoords,
-            sub_id,
-            cell_id,
-        )
-        if code == 0:
-            return None
-        return tuple(intersection)
-
-    @staticmethod
-    def _closest(
-        locator: vtk.vtkCellLocator,
-        point: tuple[float, float, float],
-    ) -> tuple[float, float, float]:
-        """Nearest point on the surface to ``point``."""
-        closest = [0.0, 0.0, 0.0]
-        cell_id = vtk.reference(0)
-        sub_id = vtk.reference(0)
-        dist2 = vtk.reference(0.0)
-        locator.FindClosestPoint(list(point), closest, cell_id, sub_id, dist2)
-        return tuple(closest)
+__all__ = ["VesselSurfacePick"]


### PR DESCRIPTION
## Summary

Foundation for implementing **ADR-0038** (unify the control-point
visualization + interaction across modules). Adding LiverVolumetry as a
third control-point consumer (issue #570) is the trigger to finally build
the shared placement seam ADR-0038 deferred.

This PR is the **safe foundational slice** — a decision record plus the two
already-generic pieces extracted into a shared Python Lib. It deliberately
does **not** touch the resection interaction pipelines yet (that is the
follow-up slice), so there is no behavioural risk to the mature interaction
code here.

### What lands

- **ADR-0038 amendment** recording the extraction: the shared home
  `SlicerLiverInteractionLib`, the base + seam class names, the swappable
  pick step (surface consumers inject `SurfacePick`; volumetry will inject an
  in-volume/slice pick because region-grow seeds are interior voxels), and
  the resection-as-extraction-source direction. Plus the volumetry design
  plan, listed in the docs toctree.
- **`SlicerLiverInteractionLib`** scaffold (Python Lib, no displayable
  manager — ADR-0013 §5; ADR-0004):
  - `SurfacePick` — the pure-VTK ray→closed-surface pick, lifted verbatim
    from the vascular-territories `VesselSurfacePick`.
  - `PointPlacementState` — the arm / active / module-active / carrier
    accessors on a display node, generalized from the territories'
    `TerritoryInteractionState` with the attribute-key namespace
    parameterized per consumer.
- **VascularTerritories** now consumes the shared classes via thin
  behaviour-preserving re-export shims (the original module names keep
  resolving for every existing call site and test).

### Tests

- New bare pure-VTK suites for `SurfacePick` and `PointPlacementState` pass.
- The full existing VascularTerritories Python suite is **byte-identical**
  to its pre-change baseline (verified by re-running against a stash of the
  diff) — no assertion changed, no pass→skip regression. Only one
  characterization test's import line was re-pointed at `SurfacePick`.

### Follow-up (not in this PR)

- Extract the 3D + slice placement pipeline bases **from resection** and
  refactor resection + territories onto them via the `PointProvider` seam
  (the behaviour-preserving refactor, guarded by both characterization
  suites).
- LiverVolumetry seeds off markups (the in-volume pick + a transient-fiducial
  adapter feeding the unchanged region-grow logic) + a minimal seeds table.
- Neutralize the `PointPlacementState` active-key suffix (currently
  territory-flavoured) once the pipeline bases land.

Relates to ADR-0038, ADR-0037, ADR-0032/0033, ADR-0013, ADR-0012, ADR-0004;
issue #570.

---

*Drafted with the assistance of Claude Code (model: claude-opus-4-8);
reviewed by the author.*
