### PR TITLE
ENH: ADR-0038 placement base + resection 3D thin client (WIP)

### DIFF
--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   DistanceMaps.py
   LiverBezierSurfacePipeline.py
   LocatorReslicer.py
+  ResectionControlPolygonProvider.py
   ResectionPlanningWidget.py
   ResectionStateMachine.py
   ResectogramLocatorProducer.py

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -38,7 +38,6 @@ import vtk
 try:  # pragma: no cover - exercised once per import path
     from SlicerLiverInteractionLib.SurfacePointPlacementPipeline3D import (
         SurfacePointPlacementPipeline3D as _PipelineBase,
-        _event_type,  # noqa: F401 - re-exported for the sibling SliceControlPolygonPipeline
     )
 except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.path
     import pathlib
@@ -49,7 +48,6 @@ except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.pat
         _sys.path.insert(0, str(_shared_lib))
     from SurfacePointPlacementPipeline3D import (  # type: ignore[no-redef]
         SurfacePointPlacementPipeline3D as _PipelineBase,
-        _event_type,  # noqa: F401 - re-exported for the sibling SliceControlPolygonPipeline
     )
 
 # State constants + safe accessors shared with the sibling Pipeline (single

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -29,7 +29,26 @@ from typing import Any
 
 import vtk
 
-from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+# The shared 3D placement/edit base (ADR-0038 §Decision): resection is the
+# extraction-source client of ``SurfacePointPlacementPipeline3D`` over the
+# PointProvider + swappable-pick seam.  The base drives the generic
+# add/grab/drag/release arbitration; this pipeline keeps the resection data
+# model (the control grid + edges), the Init/Planning gate, and the
+# control-point-depth drag as overrides (ADR-0038 §"What is not shared").
+try:  # pragma: no cover - exercised once per import path
+    from SlicerLiverInteractionLib.SurfacePointPlacementPipeline3D import (
+        SurfacePointPlacementPipeline3D as _PipelineBase,
+    )
+except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.path
+    import pathlib
+    import sys as _sys
+
+    _shared_lib = pathlib.Path(__file__).resolve().parents[2] / "SlicerLiverInteractionLib"
+    if str(_shared_lib) not in _sys.path:
+        _sys.path.insert(0, str(_shared_lib))
+    from SurfacePointPlacementPipeline3D import (  # type: ignore[no-redef]
+        SurfacePointPlacementPipeline3D as _PipelineBase,
+    )
 
 # State constants + safe accessors shared with the sibling Pipeline (single
 # source within this package; the integers mirror the C++ enum on
@@ -42,6 +61,7 @@ try:  # pragma: no cover - exercised once per import path
         _safe_get_mtime,
         _safe_get_state,
     )
+    from .ResectionControlPolygonProvider import ResectionControlPolygonProvider
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     import ResectionStateMachine as _machine  # type: ignore[no-redef]
     from LiverBezierSurfacePipeline import (  # type: ignore[no-redef]
@@ -49,6 +69,9 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
         STATE_PLANNING,
         _safe_get_mtime,
         _safe_get_state,
+    )
+    from ResectionControlPolygonProvider import (  # type: ignore[no-redef]
+        ResectionControlPolygonProvider,
     )
 
 #: The Algorithm-library cells builder (reachable only via the
@@ -103,14 +126,30 @@ class ControlPolygonPipeline(_PipelineBase):
     """
 
     def __init__(self) -> None:
-        super().__init__()
-        self.SetPythonObject(self)
+        # The base seeds ``_display_node`` / ``_renderer`` / ``_drag_key`` /
+        # ``_provider`` / ``_pick_provider`` and calls ``SetPythonObject``.
+        super().__init__(namespace="ResectionControlPolygon")
 
-        self._display_node: Any | None = None
         self._data_node: Any | None = None
-        self._renderer: Any | None = None
         self._observer_tags: dict = {}
         self._observed_node_refs: list = []
+
+        # Wire the ADR-0038 seam: the base reads/writes the control grid via
+        # this provider (grid IS a connected polygon -> has_edges True).  The
+        # provider reads the carrier live through a getter so it always sees
+        # the current LayerDM back-reference; the handle colour is the display
+        # node's HandleColor when it offers one.
+        self.SetProvider(
+            ResectionControlPolygonProvider(
+                carrier_getter=lambda: self._data_node,
+                color_getter=self._current_handle_rgb,
+            )
+        )
+        # No pick provider: resection has no add-on-click (the grid is fixed,
+        # so the base's armed-add branch is dead here), and the drag target
+        # is the grabbed handle's depth via the ``_event_world`` override --
+        # never the surface pick.  Leaving the base's pick provider None makes
+        # the add branch decline, which is the intended resection behaviour.
 
         # Injectable Algorithm-builder seam (bare-VTK unit layer); resolved
         # lazily from the wrapping on first use in production.
@@ -127,9 +166,9 @@ class ControlPolygonPipeline(_PipelineBase):
         # observer callback's render-request gate (see ``_on_node_modified``).
         self._last_render_key: tuple | None = None
 
-        # Flat row-major index of the handle currently GRABBED by the
-        # press/move/release gesture — None when no drag is in flight.
-        self._drag_index: int | None = None
+        # The grabbed handle's flat index lives on the base's ``_drag_key``
+        # (seeded by the base's ``__init__``); this pipeline reads it in the
+        # ``_event_world`` drag override.
 
         # -- handles: control-point sphere glyphs ------------------------- #
         self._handles_polydata = vtk.vtkPolyData()
@@ -343,65 +382,115 @@ class ControlPolygonPipeline(_PipelineBase):
             self._detach_observer(node)
         self._display_node = None
         self._data_node = None
-        self._drag_index = None
+        self._drag_key = None  # the base's grab bookkeeping
         self._hover_index = None
         self._halo_actor.SetVisibility(False)
         self._detach_halo_renderer()
 
+    def _current_handle_rgb(self):
+        """The display node's HandleColor (the provider's per-point base rgb).
+
+        ``None`` -> the provider falls back to its neutral white; a fake
+        display node without ``GetHandleColor`` degrades the same way.
+        """
+        display = self._display_node
+        getter = getattr(display, "GetHandleColor", None) if display else None
+        if getter is None:
+            return None
+        try:
+            c = getter()
+            return (float(c[0]), float(c[1]), float(c[2]))
+        except Exception:  # pragma: no cover - defensive (fake display nodes)
+            return None
+
     # ------------------------------------------------------------------ #
     # Interaction -- the Planning per-point drag (ADR-0033, ex ADR-0032)
+    #
+    # The generic add/grab/drag/release arbitration is the shared base's
+    # (ADR-0038 §Decision).  This pipeline contributes only the
+    # RESECTION-specific parts through the base's extension hooks
+    # (ADR-0038 §"What is not shared"): the Init/Planning gate
+    # (``_admissible``), the control-point-depth drag target
+    # (``_event_world``), the display-distance scan over the grid
+    # (``_nearest_point_in_display``), and the Init->Planning commit + grab
+    # colour + hover halo (``_on_grab`` / ``_on_drag`` / ``_on_release`` /
+    # ``_on_bare_move_decline``).  ``CanProcessInteractionEvent`` /
+    # ``ProcessInteractionEvent`` themselves are NOT overridden here -- the
+    # base drives them.
     # ------------------------------------------------------------------ #
 
-    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
-        """Return ``(canProcess, distance2)`` for the LayerDM focus logic.
+    def _admissible(self) -> bool:
+        """Gate the base's arbitration on the resection state machine.
 
-        The per-point edit is a press/move/release GRAB, not proximity
-        chasing: without a grab, only a LEFT-BUTTON PRESS within
-        ``CONTROL_POINT_PICK_RADIUS_PX`` of a handle is claimed (with the
-        real squared display distance as the arbitration value, ADR-0033);
-        while a handle is grabbed, mouse moves and the ending release are
-        claimed unconditionally (distance2 0 -- the grab owns the gesture).
-        A hover move never edits: claiming bare moves made a released mouse
-        keep deforming the surface on mere proximity.
+        Overrides the base's permissive default so the Init/Planning gate
+        (ADR-0019 / ADR-0035) lives in the client, not in the base
+        (ADR-0038 §"What is not shared").
         """
-        import sys
+        return self._interaction_admissible()
 
-        try:
-            if not self._interaction_admissible():
-                self._drag_index = None  # a state flip mid-gesture drops the grab
-                return False, sys.float_info.max
-            renderer = self._safe_get_renderer()
-            if renderer is None:
-                self._drag_index = None
-                return False, sys.float_info.max
+    def _nearest_point_in_display(self, renderer: Any, eventData: Any):
+        """Delegate the base's nearest-point scan to the grid scan.
 
-            etype = _event_type(eventData)
-            if self._drag_index is not None:
-                if etype in (
-                    vtk.vtkCommand.MouseMoveEvent,
-                    vtk.vtkCommand.LeftButtonReleaseEvent,
-                ):
-                    return True, 0.0
-                return False, sys.float_info.max
+        The base scans the provider's ``iter_points``; resection keeps the
+        control-grid scan as its own seam so the characterization suite can
+        pin it independently (``_nearest_control_point_in_display``).  Same
+        ``(index, distance2)`` contract.
+        """
+        return self._nearest_control_point_in_display(renderer, eventData)
 
-            if etype == vtk.vtkCommand.MouseMoveEvent:
-                # Bare hover: update the halo highlight as a SIDE EFFECT of the
-                # arbitration call and decline -- camera moves stay unclaimed.
-                idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-                within = (
-                    idx is not None
-                    and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
-                )
-                self._set_hover(idx if within else None)
-                return False, sys.float_info.max
-            if etype != vtk.vtkCommand.LeftButtonPressEvent:
-                return False, sys.float_info.max
-            _, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-            if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
-                return True, distance2
-            return False, sys.float_info.max
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            return False, sys.float_info.max
+    def _event_world(self, renderer: Any, eventData: Any):
+        """Back-project onto the GRABBED control point's depth (resection drag).
+
+        Overrides the base's surface-snap default: a control-point drag
+        follows the cursor on the grabbed handle's camera-facing plane, not
+        the picked surface (ADR-0033).  ``None`` (no grab / unresolved)
+        keeps the grab alive without moving anything.
+        """
+        idx = self._drag_key
+        if idx is None:
+            return None
+        return self._event_world_at_control_point(renderer, eventData, idx)
+
+    def _on_bare_move_decline(self, renderer: Any, eventData: Any) -> None:
+        """Raise/clear the hover halo on a declined bare move (side effect)."""
+        idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
+        within = (
+            idx is not None
+            and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+        )
+        self._set_hover(idx if within else None)
+
+    def _on_grab(self, key: Any, renderer: Any, eventData: Any) -> None:
+        """The resection grab: Init->Planning commit + grab colour + halo.
+
+        The FIRST grab of a candidate surface in Init advances the carrier
+        to Planning (the v1 first-surface-grab commit -- no button; raised
+        through the state machine's single-writer discipline, ADR-0035,
+        BEFORE the Planning-gated write so the very gesture is admitted).
+        """
+        if _safe_get_state(self._data_node) == STATE_INIT:
+            _machine.request(self._data_node, _machine.EVENT_SURFACE_GRABBED)
+        self._publish_interaction_state(grabbed=key)
+        self._apply_interaction_scalars()
+        self._hover_index = None
+        self._set_hover(key)  # halo jumps to the grabbed handle
+        # v1 parity: the press itself relocates the grabbed handle to the
+        # cursor (the base's move-only default would defer this to the first
+        # drag move).
+        world = self._event_world_at_control_point(renderer, eventData, key)
+        if world is not None:
+            self._apply_world_point_to_control_point(key, world)
+
+    def _on_drag(self, key: Any) -> None:
+        """The halo follows the grabbed handle during the drag."""
+        self._hover_index = None
+        self._set_hover(key)
+
+    def _on_release(self) -> None:
+        """Drop the grab colour + halo when the base clears the grab."""
+        self._publish_interaction_state(grabbed=-1)
+        self._apply_interaction_scalars()
+        self._set_hover(None)
 
     def _set_hover(self, index: int | None) -> None:
         """Show/move the halo on handle ``index`` (``None`` hides it).
@@ -505,77 +594,6 @@ class ControlPolygonPipeline(_PipelineBase):
 
     def GetHaloActor(self) -> Any:  # noqa: N802 - VTK verb
         return self._halo_actor
-
-    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
-        """Drive the press/move/release grab (Planning edit).
-
-        Press within the pick radius grabs the nearest handle and returns
-        True (the interaction logic keeps focus on a pipeline that returns
-        True); moves while grabbed edit THE GRABBED handle -- not whichever
-        is momentarily nearest -- so the gesture cannot hop between points;
-        the release clears the grab and returns False, releasing the focus.
-        """
-        try:
-            renderer = self._safe_get_renderer()
-            if renderer is None:
-                self._drag_index = None
-                return False
-            if not self._interaction_admissible():
-                self._drag_index = None
-                return False
-
-            etype = _event_type(eventData)
-
-            if self._drag_index is None:
-                if etype != vtk.vtkCommand.LeftButtonPressEvent:
-                    return False
-                idx, distance2 = self._nearest_control_point_in_display(renderer, eventData)
-                if (
-                    idx is None
-                    or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
-                ):
-                    return False
-                # The v1 COMMIT: the first grab of the candidate surface
-                # in Init advances the carrier to Planning (no button;
-                # the state flip retires the init handles + contour).
-                # Raised through the state machine (ADR-0035 single-
-                # writer discipline) BEFORE the grab bookkeeping so the
-                # Planning-gated edit kernel admits this very gesture.
-                if _safe_get_state(self._data_node) == STATE_INIT:
-                    _machine.request(
-                        self._data_node, _machine.EVENT_SURFACE_GRABBED
-                    )
-                self._drag_index = idx
-                self._publish_interaction_state(grabbed=idx)
-                self._apply_interaction_scalars()
-                hover, self._hover_index = idx, None
-                self._set_hover(hover)  # halo jumps to the grabbed handle
-                world = self._event_world_at_control_point(renderer, eventData, idx)
-                if world is not None:
-                    self._apply_world_point_to_control_point(idx, world)
-                return True
-
-            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
-                self._drag_index = None
-                self._publish_interaction_state(grabbed=-1)
-                self._apply_interaction_scalars()
-                self._set_hover(None)
-                return False  # grab over -- release the focus
-
-            if etype == vtk.vtkCommand.MouseMoveEvent:
-                world = self._event_world_at_control_point(
-                    renderer, eventData, self._drag_index
-                )
-                if world is None:
-                    return True  # keep the grab; this move just didn't resolve
-                self._apply_world_point_to_control_point(self._drag_index, world)
-                hover, self._hover_index = self._drag_index, None
-                self._set_hover(hover)  # halo follows the grabbed handle
-                return True
-
-            return False
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            return False
 
     def _apply_world_point_to_control_point(self, index: int, world: Any) -> bool:
         """Move the carrier's control point ``index`` to RAS ``world``.
@@ -898,15 +916,6 @@ class ControlPolygonPipeline(_PipelineBase):
             self.RequestRender()
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass
-
-
-def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name
-    """The VTK event-type id off ``eventData``.
-
-    Called only inside the never-raise interaction boundaries, so plain
-    attribute access is fine here.
-    """
-    return int(eventData.GetType())
 
 
 def _control_points_digest(node: Any) -> tuple:

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -38,6 +38,7 @@ import vtk
 try:  # pragma: no cover - exercised once per import path
     from SlicerLiverInteractionLib.SurfacePointPlacementPipeline3D import (
         SurfacePointPlacementPipeline3D as _PipelineBase,
+        _event_type,  # noqa: F401 - re-exported for the sibling SliceControlPolygonPipeline
     )
 except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.path
     import pathlib
@@ -48,6 +49,7 @@ except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.pat
         _sys.path.insert(0, str(_shared_lib))
     from SurfacePointPlacementPipeline3D import (  # type: ignore[no-redef]
         SurfacePointPlacementPipeline3D as _PipelineBase,
+        _event_type,  # noqa: F401 - re-exported for the sibling SliceControlPolygonPipeline
     )
 
 # State constants + safe accessors shared with the sibling Pipeline (single

--- a/LiverResections/LiverResectionsLib/ResectionControlPolygonProvider.py
+++ b/LiverResections/LiverResectionsLib/ResectionControlPolygonProvider.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The resection control-polygon ``PointProvider`` adapter (ADR-0038 seam).
+
+ADR-0038 §Decision makes resection the extraction-source client of the
+shared ``SurfacePointPlacementPipeline3D`` base over a ``PointProvider``
+seam.  This adapter wraps the Bezier carrier's fixed ``Rows x Cols`` control
+grid: a resection provider is ``has_edges() == True`` (the grid IS a
+connected polygon, unlike the flat territory/volumetry point sets), the
+per-point key is the flat row-major index into the grid, and the drag
+write-back targets ``vtkMRMLBezierSurfaceNode::SetControlPoint`` gated on the
+``Planning`` state (ADR-0019 read-only-after-commit).
+
+The resection-SPECIFIC concerns -- the control grid IS fixed, so ``add_point``
+is a no-op (there is no add-on-click; you grab and drag an existing handle),
+and the Init/Planning state gating lives on the pipeline's ``_admissible``
+override, NOT in the base (ADR-0038 §"What is not shared").  The adapter is
+a thin fan-out over a carrier getter (the pipeline supplies a live getter so
+the provider always reads the current LayerDM back-reference), mirroring the
+``TerritoryPointProvider`` precedent.
+
+Pure Python, no LayerDMLib import -- bare-VTK unit testable (ADR-0003/0004).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Planning-state gate (ADR-0019): the control grid is editable only in
+# Planning.  Mirrors the C++ ResectionState enum on vtkMRMLBezierSurfaceNode
+# (Init = 0, Planning = 1, Confirmed = 2).
+STATE_PLANNING = 1
+
+#: The default per-handle base colour the base renders when the carrier /
+#: display node offers none.  White reads as the neutral, un-highlighted
+#: handle (the grab/hover cues recolour it live).
+DEFAULT_HANDLE_RGB = (1.0, 1.0, 1.0)
+
+
+class ResectionControlPolygonProvider:
+    """Ordered, edged ``PointProvider`` over a Bezier control grid.
+
+    Bound to a carrier getter (and an optional per-point colour getter) so it
+    stays a thin fan-out with no state of its own; the flat key is the
+    row-major grid index the base uses for a grab / drag.
+    """
+
+    def __init__(self, carrier_getter, color_getter=None) -> None:
+        self._carrier_getter = carrier_getter
+        self._color_getter = color_getter
+
+    def _carrier(self) -> Any | None:
+        return self._carrier_getter()
+
+    def _state(self, carrier: Any) -> int | None:
+        getter = getattr(carrier, "GetState", None)
+        if getter is None:
+            return None
+        try:
+            return int(getter())
+        except Exception:  # pragma: no cover - defensive (fake carriers)
+            return None
+
+    # -- seam the base READS -------------------------------------------- #
+
+    def iter_points(self):
+        """Yield ``(world, base_rgb)`` per control point, row-major.
+
+        The base ``enumerate``s this, so the yielded order fixes the flat
+        grid index used as the grab / drag key.
+        """
+        carrier = self._carrier()
+        if carrier is None:
+            return
+        grid = carrier.GetControlGridVector()
+        rows = int(carrier.GetRows())
+        cols = int(carrier.GetCols())
+        rgb = self._base_rgb()
+        for i in range(rows * cols):
+            base = i * 3
+            world = (grid[base], grid[base + 1], grid[base + 2])
+            yield world, rgb
+
+    def _base_rgb(self):
+        if self._color_getter is not None:
+            try:
+                c = self._color_getter()
+                return (float(c[0]), float(c[1]), float(c[2]))
+            except Exception:  # pragma: no cover - defensive
+                pass
+        return DEFAULT_HANDLE_RGB
+
+    def has_edges(self) -> bool:
+        """The control grid IS a connected polygon (ADR-0038 §Context)."""
+        return True
+
+    # -- seam the base WRITES ------------------------------------------- #
+
+    def add_point(self, world) -> Any:
+        """No-op: the control grid is FIXED (no add-on-click for resection).
+
+        Resection has no add gesture -- the grid is minted by the plan
+        re-fit; you grab and drag an existing handle.  Returning ``None``
+        declines any accidental add-on-click at the seam.
+        """
+        return None
+
+    def move_point(self, key, world) -> None:
+        """Move control point ``key`` (flat index) -- Planning-gated (ADR-0019).
+
+        Refuses outside ``Planning`` so a read-only Confirmed carrier cannot
+        be edited (the grabbed-index kernel; it never re-picks, so a drag
+        cannot hop to another handle mid-gesture).
+        """
+        carrier = self._carrier()
+        if carrier is None or key is None:
+            return
+        if self._state(carrier) != STATE_PLANNING:
+            return
+        cols = int(carrier.GetCols())
+        carrier.SetControlPoint(
+            int(key) // cols,
+            int(key) % cols,
+            float(world[0]),
+            float(world[1]),
+            float(world[2]),
+        )
+
+    def delete_point(self, key) -> bool:
+        """No-op: the control grid is FIXED (no per-handle delete)."""
+        return False

--- a/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/SliceControlPolygonPipeline.py
@@ -4,13 +4,20 @@
 
 The markups-style slice half of the control polygon (ADR-0033): the
 ``Rows x Cols`` handles and their connecting edges are projected into the
-slice view's XY space (``inverse(XYToRAS)``, the SliceContourPipeline
-convention) with DISTANCE FADING -- per-point alpha falls off linearly
-with the point's distance to the slice plane, the above/below visual cue
-markups users expect -- and the Planning per-point drag is available FROM
-the slice views: press grabs the nearest projected handle, the drag moves
-it in-plane at the cursor while PRESERVING its out-of-plane offset (no
-snap-to-plane), release ends the gesture.
+slice view's XY space (``inverse(XYToRAS)``) with DISTANCE FADING -- the
+above/below visual cue markups users expect -- and the Planning per-point
+drag is available FROM the slice views: press grabs the nearest projected
+handle, the drag moves it in-plane at the cursor while PRESERVING its
+out-of-plane offset (no snap-to-plane), release ends the gesture.
+
+The generic slice affordance -- the projection/fade/side-tint/presence, the
+hollow-circle handles + hover ring, and the grab-seam arbitration -- is the
+shared ``SurfacePointPlacementPipelineSlice`` base's (ADR-0038 §Decision):
+resection is the extraction-source client over the ``PointProvider`` seam.
+This pipeline keeps the RESECTION-specific parts as narrow overrides
+(ADR-0038 §"What is not shared"): the dashed edge scaffold, the Init/Planning
+state gate, the control-point-depth-offset-preserving drag, and the
+cross-view highlight channel on the display node.
 
 Keyed on ``vtkMRMLControlPolygonDisplayNode`` for ``vtkMRMLSliceNode``
 views only (creators dispatch per view type; the 3D control-polygon
@@ -24,7 +31,34 @@ from typing import Any
 
 import vtk
 
-from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+# The shared slice-view placement/edit base (ADR-0038 §Decision): resection
+# is the extraction-source client of ``SurfacePointPlacementPipelineSlice``
+# over the PointProvider seam.  The base drives the generic grab/drag/release
+# arbitration + the projection/fade/side/presence + the handles/ring; this
+# pipeline keeps the resection data model (the control grid + dashed edges),
+# the Init/Planning gate, and the offset-preserving drag as overrides.
+try:  # pragma: no cover - exercised once per import path
+    from SlicerLiverInteractionLib.SurfacePointPlacementPipelineSlice import (
+        SurfacePointPlacementPipelineSlice as _PipelineBase,
+        HALO_HOVER_COLOR,  # noqa: F401 - the projection hover-colour the char suite reads off this module
+        POINT_PICK_RADIUS_PX as CONTROL_POINT_PICK_RADIUS_PX,
+        _event_type,  # noqa: F401 - the slice event-type helper (imported from the base, ADR-0038)
+    )
+    from SlicerLiverInteractionLib import SlicePointProjection as _proj
+except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.path
+    import pathlib
+    import sys as _sys
+
+    _shared_lib = pathlib.Path(__file__).resolve().parents[2] / "SlicerLiverInteractionLib"
+    if str(_shared_lib) not in _sys.path:
+        _sys.path.insert(0, str(_shared_lib))
+    from SurfacePointPlacementPipelineSlice import (  # type: ignore[no-redef]
+        SurfacePointPlacementPipelineSlice as _PipelineBase,
+        HALO_HOVER_COLOR,  # noqa: F401 - the projection hover-colour the char suite reads off this module
+        POINT_PICK_RADIUS_PX as CONTROL_POINT_PICK_RADIUS_PX,
+        _event_type,  # noqa: F401 - the slice event-type helper (imported from the base, ADR-0038)
+    )
+    import SlicePointProjection as _proj  # type: ignore[no-redef]
 
 try:  # pragma: no cover - exercised once per import path
     from .LiverBezierSurfacePipeline import (
@@ -32,36 +66,22 @@ try:  # pragma: no cover - exercised once per import path
         _safe_get_state,
     )
     from .ControlPolygonPipeline import (
-        CONTROL_POINT_PICK_RADIUS_PX,
-        HALO_GRAB_COLOR,
-        HALO_HOVER_COLOR,
         _control_points_digest,
-        _event_type,
     )
+    from .ResectionControlPolygonProvider import ResectionControlPolygonProvider
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from LiverBezierSurfacePipeline import (  # type: ignore[no-redef]
         STATE_PLANNING,
         _safe_get_state,
     )
     from ControlPolygonPipeline import (  # type: ignore[no-redef]
-        CONTROL_POINT_PICK_RADIUS_PX,
-        HALO_GRAB_COLOR,
-        HALO_HOVER_COLOR,
         _control_points_digest,
-        _event_type,
+    )
+    from ResectionControlPolygonProvider import (  # type: ignore[no-redef]
+        ResectionControlPolygonProvider,
     )
 
 _REGISTERED = False
-
-#: Distance (mm) over which the projection fades to fully transparent --
-#: the above/below-the-plane cue.  Short by design: only control points
-#: NEAR the plane (the manipulable ones) are present in a slice at all.
-FADE_DISTANCE_MM = 15.0
-
-#: Manipulable range == visible range (the markups rule: anything you can
-#: see, you can grab).  A point at exactly FADE_DISTANCE_MM has alpha 0 --
-#: invisible AND unpickable; there is no visible-but-dead band.
-PICK_RANGE_MM = FADE_DISTANCE_MM
 
 #: Dash pattern for the polygon edges (XY pixels): the SCAFFOLD reads
 #: dashed, the solid slice contour is the RESULT -- a structural
@@ -69,30 +89,8 @@ PICK_RANGE_MM = FADE_DISTANCE_MM
 DASH_LENGTH_PX = 8.0
 GAP_LENGTH_PX = 5.0
 
-#: Maximum lightness shift for the above/below-plane cue (the markups
-#: signed-distance convention): points ABOVE the plane tint toward white,
-#: points BELOW toward black, graded by distance.  Sign-neutral hue, so it
-#: composes with any display colour and stays colourblind-legible.
-SIDE_TINT_MAX = 0.55
-
-#: Mid-tone factor applied to the display HandleColor before tinting: the
-#: default handle colour is pure white, which leaves no headroom for the
-#: lighter-above tint -- pulling the base toward mid-tone makes BOTH tint
-#: directions visible.
-HANDLE_MIDTONE_FACTOR = 0.78
-
-#: Slice handle / hover-ring glyph diameters (XY pixels).  Larger than the
-#: default markups glyphs: the handles are grab targets, and the ring must
-#: read as a halo AROUND one.
-HANDLE_GLYPH_SCALE_PX = 13.0
-RING_GLYPH_SCALE_PX = 20.0
-
-
-def _side_tint(rgb: list, signed_distance: float) -> list:
-    """Blend ``rgb`` toward white (above) or black (below) by distance."""
-    fraction = min(1.0, abs(signed_distance) / FADE_DISTANCE_MM) * SIDE_TINT_MAX
-    target = 255 if signed_distance > 0 else 0
-    return [int(c + (target - c) * fraction) for c in rgb]
+#: The default edge colour when the display node offers none.
+DEFAULT_EDGE_RGB = (255, 0, 0)
 
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
@@ -108,65 +106,35 @@ def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
 
 
 class SliceControlPolygonPipeline(_PipelineBase):
-    """Projected, fading, slice-editable control polygon."""
+    """Projected, fading, slice-editable control polygon.
+
+    A thin client of ``SurfacePointPlacementPipelineSlice``: the base owns the
+    handle projection/fade/side/presence + the grab-seam arbitration + the
+    hover ring, this pipeline supplies the resection ``PointProvider`` and the
+    resection-specific edges / state gate / offset-preserving drag.
+    """
 
     def __init__(self) -> None:
+        # The base seeds the handle + ring actors, the projection bookkeeping
+        # (``_projected_keys`` / ``_projected_xy`` / ``_plane_distances``), the
+        # grab key (``_drag_key``), and calls ``SetPythonObject``.
         super().__init__()
-        self.SetPythonObject(self)
 
-        self._display_node: Any | None = None
         self._data_node: Any | None = None
-        self._slice_node: Any | None = None
-        self._renderer: Any | None = None
-        self._observer_tags: dict = {}
-        self._observed_node_refs: list = []
         self._last_update_key: tuple | None = None
         self._last_render_key: tuple | None = None
-        #: Flat row-major index of the grabbed handle (slice-side gesture).
-        self._drag_index: int | None = None
-        #: XY-space positions of the projected handles (pick arbitration).
-        self._projected_xy: list = []
-        #: Per-point |distance| to the slice plane (the pick-range gate).
-        self._plane_distances: list = []
 
-        # Handles: projected points as 2D cross glyphs with RGBA fading.
-        self._handles_polydata = vtk.vtkPolyData()
-        self._handles_polydata.SetPoints(vtk.vtkPoints())
-        self._handle_glyph_source = vtk.vtkGlyphSource2D()
-        self._handle_glyph_source.SetGlyphTypeToCircle()
-        self._handle_glyph_source.FilledOff()
-        self._handle_glyph_source.SetScale(HANDLE_GLYPH_SCALE_PX)
-        self._handles_glyph = vtk.vtkGlyph2D()
-        self._handles_glyph.SetInputData(self._handles_polydata)
-        self._handles_glyph.SetSourceConnection(
-            self._handle_glyph_source.GetOutputPort()
+        # Wire the ADR-0038 seam: the base reads the control grid via this
+        # provider (grid IS a connected polygon -> has_edges True).  The
+        # provider reads the carrier live through a getter so it always sees
+        # the current LayerDM back-reference; the handle colour is the display
+        # node's HandleColor when it offers one.
+        self.SetProvider(
+            ResectionControlPolygonProvider(
+                carrier_getter=lambda: self._data_node,
+                color_getter=self._current_handle_rgb,
+            )
         )
-        self._handles_glyph.SetColorModeToColorByScalar()
-        self._handles_glyph.ScalingOff()
-        self._handles_mapper = vtk.vtkPolyDataMapper2D()
-        self._handles_mapper.SetInputConnection(self._handles_glyph.GetOutputPort())
-        self._handles_actor = vtk.vtkActor2D()
-        self._handles_actor.SetMapper(self._handles_mapper)
-        self._handles_actor.SetVisibility(False)
-
-        # Hover ring: the 2D analogue of the 3D glow halo -- a larger
-        # circle on the hovered/grabbed projected handle.
-        self._ring_polydata = vtk.vtkPolyData()
-        self._ring_polydata.SetPoints(vtk.vtkPoints())
-        self._ring_glyph_source = vtk.vtkGlyphSource2D()
-        self._ring_glyph_source.SetGlyphTypeToCircle()
-        self._ring_glyph_source.FilledOff()
-        self._ring_glyph_source.SetScale(RING_GLYPH_SCALE_PX)
-        self._ring_glyph = vtk.vtkGlyph2D()
-        self._ring_glyph.SetInputData(self._ring_polydata)
-        self._ring_glyph.SetSourceConnection(self._ring_glyph_source.GetOutputPort())
-        self._ring_glyph.ScalingOff()
-        self._ring_mapper = vtk.vtkPolyDataMapper2D()
-        self._ring_mapper.SetInputConnection(self._ring_glyph.GetOutputPort())
-        self._ring_actor = vtk.vtkActor2D()
-        self._ring_actor.SetMapper(self._ring_mapper)
-        self._ring_actor.GetProperty().SetLineWidth(2.0)
-        self._ring_actor.SetVisibility(False)
 
         # Edges: projected polygon lines with per-vertex RGBA fading.
         self._edges_polydata = vtk.vtkPolyData()
@@ -179,32 +147,18 @@ class SliceControlPolygonPipeline(_PipelineBase):
         self._edges_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
-    # LayerDM lifecycle
+    # LayerDM lifecycle -- resection data-node observation (base hooks)
     # ------------------------------------------------------------------ #
 
-    def SetViewNode(self, viewNode: Any) -> None:  # noqa: N802 - VTK verb
-        super().SetViewNode(viewNode)
-        # Observe the slice node OURSELVES (the stale-trace lesson from the
-        # contour sibling): reslicing must re-project + re-fade.
-        if self._slice_node is not None:
-            self._detach_observer(self._slice_node)
-        self._slice_node = viewNode
-        if viewNode is not None:
-            self._attach_observer(viewNode)
-        self._last_update_key = None
-
-    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
-        if self._display_node is not None:
-            self._detach_observer(self._display_node)
+    def _before_display_node_change(self) -> None:
         if self._data_node is not None:
             self._detach_observer(self._data_node)
 
-        super().SetDisplayNode(displayNode)
-        self._display_node = displayNode
+    def _after_display_node_set(self) -> None:
+        display = self._display_node
         self._data_node = None
-        if displayNode is not None:
-            self._data_node = displayNode.GetDisplayableNode()
-            self._attach_observer(displayNode)
+        if display is not None:
+            self._data_node = display.GetDisplayableNode()
             if self._data_node is not None:
                 self._attach_observer(self._data_node)
         self._last_update_key = None
@@ -219,61 +173,29 @@ class SliceControlPolygonPipeline(_PipelineBase):
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass
 
-    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        try:
-            self._renderer = renderer
-            if renderer is not None:
-                renderer.AddActor2D(self._edges_actor)
-                renderer.AddActor2D(self._handles_actor)
-                renderer.AddActor2D(self._ring_actor)
-            if self._display_node is None:
-                display = self.GetDisplayNode()
-                if display is not None:
-                    self.SetDisplayNode(display)
-            # Re-attach the slice-node observer too: cleanup() detached it with
-            # the rest, and the view node is not re-set after churn -- without
-            # this, reslicing stops reprojecting (the stale-trace bug, round
-            # two; mirrors the contour pipeline).
-            if self._slice_node is not None:
-                self._attach_observer(self._slice_node)
-            self._last_update_key = None
-            self.UpdatePipeline()
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            pass
+    def _add_actors(self, renderer: Any) -> None:
+        renderer.AddActor2D(self._edges_actor)
+        super()._add_actors(renderer)
 
-    def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        try:
-            if renderer is not None:
-                renderer.RemoveActor2D(self._handles_actor)
-                renderer.RemoveActor2D(self._edges_actor)
-                renderer.RemoveActor2D(self._ring_actor)
-            self._renderer = None
-            self.cleanup()
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            pass
+    def _remove_actors(self, renderer: Any) -> None:
+        renderer.RemoveActor2D(self._edges_actor)
+        super()._remove_actors(renderer)
+
+    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        super().OnRendererAdded(renderer)
+        self._last_update_key = None
 
     def cleanup(self) -> None:
-        for node in list(self._observed_node_refs):
-            self._detach_observer(node)
-        self._display_node = None
+        super().cleanup()
         self._data_node = None
-        self._drag_index = None
-        self._handles_actor.SetVisibility(False)
         self._edges_actor.SetVisibility(False)
-        self._ring_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
-    # Reconciliation
+    # Reconciliation -- resection state gate + change-key memo
     # ------------------------------------------------------------------ #
-
-    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
-        try:
-            self._reconcile()
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            pass
 
     def _reconcile(self) -> None:
-        """``UpdatePipeline``'s body — plain attribute access throughout."""
+        """Gate the base reproject on the Planning state + the change memo."""
         state = _safe_get_state(self._data_node)
         key = (
             state,
@@ -294,164 +216,6 @@ class SliceControlPolygonPipeline(_PipelineBase):
             # otherwise strand the ring over no handles.
             self._ring_actor.SetVisibility(False)
 
-    def _reproject(self) -> bool:
-        """Project handles + edges into XY with distance fading."""
-        carrier = self._data_node
-        slice_node = self._slice_node
-        if carrier is None or slice_node is None:
-            return False
-        try:
-            grid = carrier.GetControlGridVector()
-            rows, cols = int(carrier.GetRows()), int(carrier.GetCols())
-            if len(grid) < rows * cols * 3:
-                return False
-
-            to_ras = slice_node.GetSliceToRAS()
-            origin = [to_ras.GetElement(r, 3) for r in range(3)]
-            normal = [to_ras.GetElement(r, 2) for r in range(3)]
-            norm = sum(n * n for n in normal) ** 0.5 or 1.0
-            normal = [n / norm for n in normal]
-
-            ras_to_xy = vtk.vtkMatrix4x4()
-            ras_to_xy.DeepCopy(slice_node.GetXYToRAS())
-            ras_to_xy.Invert()
-
-            display = self._display_node
-            handle_rgb = [255, 255, 255]
-            edge_rgb = [255, 0, 0]
-            if display is not None:
-                try:
-                    handle_rgb = [int(c * 255) for c in display.GetHandleColor()]
-                    edge_rgb = [int(c * 255) for c in display.GetEdgeColor()]
-                except Exception:  # pragma: no cover - defensive
-                    pass
-            handle_rgb = [int(c * HANDLE_MIDTONE_FACTOR) for c in handle_rgb]
-
-            points = vtk.vtkPoints()
-            handle_rgba = vtk.vtkUnsignedCharArray()
-            handle_rgba.SetNumberOfComponents(4)
-            edge_rgba = vtk.vtkUnsignedCharArray()
-            edge_rgba.SetNumberOfComponents(4)
-            in_range = []  # HARD presence cutoff (2D alpha is unreliable)
-            hovered, grabbed = self._interaction_state()
-            hover_rgb = [int(c * 255) for c in HALO_HOVER_COLOR]
-            grab_rgb = [int(c * 255) for c in HALO_GRAB_COLOR]
-            self._projected_xy = []
-            self._plane_distances = []
-            for i in range(rows * cols):
-                x, y, z = grid[i * 3], grid[i * 3 + 1], grid[i * 3 + 2]
-                xy = ras_to_xy.MultiplyPoint((x, y, z, 1.0))
-                w = xy[3] or 1.0
-                px, py = xy[0] / w, xy[1] / w
-                points.InsertNextPoint(px, py, 0.0)
-                self._projected_xy.append((px, py))
-                signed = sum(
-                    n * (p - o) for n, p, o in zip(normal, (x, y, z), origin)
-                )
-                distance = abs(signed)
-                self._plane_distances.append(distance)
-                in_range.append(distance < PICK_RANGE_MM)
-                alpha = max(0.0, 1.0 - distance / FADE_DISTANCE_MM)
-                if i == grabbed:
-                    # Cross-view highlight: full alpha, grab colour.
-                    handle_rgba.InsertNextTuple4(*grab_rgb, 255)
-                elif i == hovered:
-                    handle_rgba.InsertNextTuple4(*hover_rgb, 255)
-                else:
-                    # The markups signed-distance cue: above-plane points
-                    # tint toward white, below-plane toward black.
-                    handle_rgba.InsertNextTuple4(
-                        *_side_tint(handle_rgb, signed), int(alpha * 255)
-                    )
-                edge_rgba.InsertNextTuple4(
-                    *_side_tint(edge_rgb, signed), int(alpha * 255)
-                )
-
-            visible_points = vtk.vtkPoints()
-            visible_rgba = vtk.vtkUnsignedCharArray()
-            visible_rgba.SetNumberOfComponents(4)
-            for i, ok in enumerate(in_range):
-                if not ok:
-                    continue  # beyond the manipulable range: NOT present
-                visible_points.InsertNextPoint(*points.GetPoint(i))
-                visible_rgba.InsertNextTuple4(*(int(v) for v in handle_rgba.GetTuple4(i)))
-            self._handles_polydata.SetPoints(visible_points)
-            self._handles_polydata.GetPointData().SetScalars(visible_rgba)
-            self._handles_polydata.Modified()
-
-            # DASHED edges (manual segmentation -- GL line stipple is not
-            # portable): each grid edge is emitted as alternating dash
-            # segments, so the scaffold reads structurally distinct from
-            # the solid resection contour.
-            dash_points = vtk.vtkPoints()
-            dash_rgba = vtk.vtkUnsignedCharArray()
-            dash_rgba.SetNumberOfComponents(4)
-            dash_lines = vtk.vtkCellArray()
-
-            def _edge_pairs():
-                for r in range(rows):
-                    for c in range(cols - 1):
-                        yield r * cols + c, r * cols + c + 1
-                for c in range(cols):
-                    for r in range(rows - 1):
-                        yield r * cols + c, (r + 1) * cols + c
-
-            for a, b in _edge_pairs():
-                if not (in_range[a] or in_range[b]):
-                    continue  # both endpoints absent: no scaffold here
-                # EITHER endpoint in range: draw the connecting dashes so a
-                # visible point never floats without its scaffold (the
-                # tint/fade along the run still shows the far end receding).
-                ax, ay = self._projected_xy[a]
-                bx, by = self._projected_xy[b]
-                ca = edge_rgba.GetTuple4(a)
-                cb = edge_rgba.GetTuple4(b)
-                length = ((bx - ax) ** 2 + (by - ay) ** 2) ** 0.5
-                if length <= 0.0:
-                    continue
-                period = DASH_LENGTH_PX + GAP_LENGTH_PX
-                t = 0.0
-                while t < length:
-                    t_end = min(t + DASH_LENGTH_PX, length)
-                    f0, f1 = t / length, t_end / length
-                    i0 = dash_points.InsertNextPoint(
-                        ax + (bx - ax) * f0, ay + (by - ay) * f0, 0.0
-                    )
-                    i1 = dash_points.InsertNextPoint(
-                        ax + (bx - ax) * f1, ay + (by - ay) * f1, 0.0
-                    )
-                    for f, _i in ((f0, i0), (f1, i1)):
-                        dash_rgba.InsertNextTuple4(*[
-                            int(ca[k] + (cb[k] - ca[k]) * f) for k in range(4)
-                        ])
-                    seg = vtk.vtkLine()
-                    seg.GetPointIds().SetId(0, i0)
-                    seg.GetPointIds().SetId(1, i1)
-                    dash_lines.InsertNextCell(seg)
-                    t += period
-            self._edges_polydata.SetPoints(dash_points)
-            self._edges_polydata.SetLines(dash_lines)
-            self._edges_polydata.GetPointData().SetScalars(dash_rgba)
-            self._edges_polydata.Modified()
-
-            # Hover ring: the 2D halo on the hovered/grabbed handle --
-            # only when that point is PRESENT in this slice (the highlight
-            # must not surface points the plane cannot reach).
-            target = grabbed if grabbed >= 0 else hovered
-            if 0 <= target < len(self._projected_xy) and in_range[target]:
-                ring_points = vtk.vtkPoints()
-                ring_points.InsertNextPoint(*self._projected_xy[target], 0.0)
-                self._ring_polydata.SetPoints(ring_points)
-                self._ring_polydata.Modified()
-                rgb = HALO_GRAB_COLOR if grabbed >= 0 else HALO_HOVER_COLOR
-                self._ring_actor.GetProperty().SetColor(*rgb)
-                self._ring_actor.SetVisibility(True)
-            else:
-                self._ring_actor.SetVisibility(False)
-            return True
-        except Exception:  # pragma: no cover - defensive
-            return False
-
     @staticmethod
     def _slice_matrix_digest(slice_node: Any) -> tuple:
         if slice_node is None:
@@ -469,166 +233,12 @@ class SliceControlPolygonPipeline(_PipelineBase):
             return ()
 
     # ------------------------------------------------------------------ #
-    # Interaction -- the slice-side per-point drag (ADR-0033)
+    # Base extension hooks -- the resection specifics (ADR-0038)
     # ------------------------------------------------------------------ #
 
-    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
-        import sys
-
-        try:
-            if _safe_get_state(self._data_node) != STATE_PLANNING:
-                self._drag_index = None
-                return False, sys.float_info.max
-            etype = _event_type(eventData)
-            if self._drag_index is not None:
-                if etype in (
-                    vtk.vtkCommand.MouseMoveEvent,
-                    vtk.vtkCommand.LeftButtonReleaseEvent,
-                ):
-                    return True, 0.0
-                return False, sys.float_info.max
-            if etype == vtk.vtkCommand.MouseMoveEvent:
-                # Bare hover: publish the cross-view highlight and decline.
-                idx, distance2 = self._nearest_handle_in_display(eventData)
-                within = (
-                    idx is not None
-                    and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
-                )
-                self._publish_interaction_state(hovered=(idx if within else -1))
-                return False, sys.float_info.max
-            if etype != vtk.vtkCommand.LeftButtonPressEvent:
-                return False, sys.float_info.max
-            _, distance2 = self._nearest_handle_in_display(eventData)
-            if distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX:
-                return True, distance2
-            return False, sys.float_info.max
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            return False, sys.float_info.max
-
-    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
-        try:
-            if _safe_get_state(self._data_node) != STATE_PLANNING:
-                self._drag_index = None
-                return False
-            etype = _event_type(eventData)
-
-            if self._drag_index is None:
-                if etype != vtk.vtkCommand.LeftButtonPressEvent:
-                    return False
-                idx, distance2 = self._nearest_handle_in_display(eventData)
-                if (
-                    idx is None
-                    or distance2 > CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
-                ):
-                    return False
-                self._drag_index = idx
-                self._publish_interaction_state(grabbed=idx)
-                return True
-
-            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
-                self._drag_index = None
-                self._publish_interaction_state(grabbed=-1)
-                return False
-
-            if etype == vtk.vtkCommand.MouseMoveEvent:
-                self._move_grabbed_to(eventData)
-                return True
-            return False
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            return False
-
-    def _nearest_handle_in_display(self, eventData: Any):
-        """``(flat_index, distance2)`` of the projected handle nearest the pixel.
-
-        Slice-view display coordinates coincide with the XY space the
-        projection lives in (the slice renderer's convention), so the
-        arbitration compares the event pixel against ``_projected_xy``.
-        """
-        import sys
-
-        ex, ey = eventData.GetDisplayPosition()
-        best_idx, best_d2 = None, sys.float_info.max
-        for i, (px, py) in enumerate(self._projected_xy):
-            # Markups rule: pickable iff visible -- a fully faded point
-            # (>= PICK_RANGE_MM == FADE_DISTANCE_MM) is not manipulable.
-            if i < len(self._plane_distances) and self._plane_distances[i] >= PICK_RANGE_MM:
-                continue
-            d2 = (px - ex) ** 2 + (py - ey) ** 2
-            if d2 < best_d2:
-                best_idx, best_d2 = i, d2
-        return best_idx, best_d2
-
-    def _move_grabbed_to(self, eventData: Any) -> None:
-        """Move the grabbed point to the cursor IN-PLANE, offset preserved."""
-        carrier = self._data_node
-        slice_node = self._slice_node
-        idx = self._drag_index
-        if carrier is None or slice_node is None or idx is None:
-            return
-        try:
-            ex, ey = eventData.GetDisplayPosition()
-            xy_to_ras = slice_node.GetXYToRAS()
-            ras = xy_to_ras.MultiplyPoint((float(ex), float(ey), 0.0, 1.0))
-            w = ras[3] or 1.0
-            in_plane = [ras[0] / w, ras[1] / w, ras[2] / w]
-
-            to_ras = slice_node.GetSliceToRAS()
-            origin = [to_ras.GetElement(r, 3) for r in range(3)]
-            normal = [to_ras.GetElement(r, 2) for r in range(3)]
-            norm = sum(n * n for n in normal) ** 0.5 or 1.0
-            normal = [n / norm for n in normal]
-
-            grid = carrier.GetControlGridVector()
-            current = (grid[idx * 3], grid[idx * 3 + 1], grid[idx * 3 + 2])
-            # Signed out-of-plane offset of the point BEFORE the move.
-            offset = sum(n * (p - o) for n, p, o in zip(normal, current, origin))
-            target = [ip + n * offset for ip, n in zip(in_plane, normal)]
-
-            cols = int(carrier.GetCols())
-            carrier.SetControlPoint(
-                idx // cols, idx % cols, target[0], target[1], target[2]
-            )
-        except Exception:  # pragma: no cover - defensive
-            return
-
-    # ------------------------------------------------------------------ #
-    # Introspection
-    # ------------------------------------------------------------------ #
-
-    def GetDataNode(self) -> Any | None:  # noqa: N802 - VTK verb
-        return self._data_node
-
-    def GetHandlesPolyData(self) -> Any:  # noqa: N802 - VTK verb
-        return self._handles_polydata
-
-    def GetHandlesActor(self) -> Any:  # noqa: N802 - VTK verb
-        return self._handles_actor
-
-    def GetEdgesActor(self) -> Any:  # noqa: N802 - VTK verb
-        return self._edges_actor
-
-    # ------------------------------------------------------------------ #
-    # Observers
-    # ------------------------------------------------------------------ #
-
-    def _attach_observer(self, node: Any) -> None:
-        if node is None or not hasattr(node, "AddObserver"):
-            return
-        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
-        self._observer_tags.setdefault(id(node), []).append(tag)
-        if node not in self._observed_node_refs:
-            self._observed_node_refs.append(node)
-
-    def _detach_observer(self, node: Any) -> None:
-        for tag in self._observer_tags.pop(id(node), []):
-            try:
-                node.RemoveObserver(tag)
-            except Exception:  # pragma: no cover - defensive
-                pass
-        try:
-            self._observed_node_refs.remove(node)
-        except ValueError:
-            pass
+    def _slice_admissible(self) -> bool:
+        """Gate the base's arbitration on the Planning state (ADR-0019)."""
+        return _safe_get_state(self._data_node) == STATE_PLANNING
 
     def _interaction_state(self) -> tuple:
         """(hovered, grabbed) read off the display node; (-1, -1) sans it."""
@@ -637,6 +247,129 @@ class SliceControlPolygonPipeline(_PipelineBase):
             display.GetHoveredControlPoint() if display is not None else -1,
             display.GetGrabbedControlPoint() if display is not None else -1,
         )
+
+    def _edge_base_rgb(self):
+        """The display node's EdgeColor (0..255) -- the dashed scaffold's hue."""
+        display = self._display_node
+        if display is not None:
+            try:
+                return [int(c * 255) for c in display.GetEdgeColor()]
+            except Exception:  # pragma: no cover - defensive
+                pass
+        return list(DEFAULT_EDGE_RGB)
+
+    def _reproject_edges(self, all_xy: list, all_present: list, edge_rgba: Any) -> None:
+        """Emit the grid edges as DASHED XY segments (structural scaffold).
+
+        Manual dash segmentation (GL line stipple is not portable): each grid
+        edge is emitted as alternating dash segments, so the scaffold reads
+        structurally distinct from the solid resection contour.  Runs are
+        gated on EITHER endpoint being present so a visible point never floats
+        without its scaffold (the tint/fade along the run shows the far end
+        receding).
+        """
+        carrier = self._data_node
+        if carrier is None:
+            return
+        try:
+            rows, cols = int(carrier.GetRows()), int(carrier.GetCols())
+        except Exception:  # pragma: no cover - defensive
+            return
+        if len(all_xy) < rows * cols:
+            return
+
+        dash_points = vtk.vtkPoints()
+        dash_rgba = vtk.vtkUnsignedCharArray()
+        dash_rgba.SetNumberOfComponents(4)
+        dash_lines = vtk.vtkCellArray()
+
+        def _edge_pairs():
+            for r in range(rows):
+                for c in range(cols - 1):
+                    yield r * cols + c, r * cols + c + 1
+            for c in range(cols):
+                for r in range(rows - 1):
+                    yield r * cols + c, (r + 1) * cols + c
+
+        for a, b in _edge_pairs():
+            if not (all_present[a] or all_present[b]):
+                continue  # both endpoints absent: no scaffold here
+            ax, ay = all_xy[a]
+            bx, by = all_xy[b]
+            ca = edge_rgba.GetTuple4(a)
+            cb = edge_rgba.GetTuple4(b)
+            length = ((bx - ax) ** 2 + (by - ay) ** 2) ** 0.5
+            if length <= 0.0:
+                continue
+            period = DASH_LENGTH_PX + GAP_LENGTH_PX
+            t = 0.0
+            while t < length:
+                t_end = min(t + DASH_LENGTH_PX, length)
+                f0, f1 = t / length, t_end / length
+                i0 = dash_points.InsertNextPoint(
+                    ax + (bx - ax) * f0, ay + (by - ay) * f0, 0.0
+                )
+                i1 = dash_points.InsertNextPoint(
+                    ax + (bx - ax) * f1, ay + (by - ay) * f1, 0.0
+                )
+                for f, _i in ((f0, i0), (f1, i1)):
+                    dash_rgba.InsertNextTuple4(*[
+                        int(ca[k] + (cb[k] - ca[k]) * f) for k in range(4)
+                    ])
+                seg = vtk.vtkLine()
+                seg.GetPointIds().SetId(0, i0)
+                seg.GetPointIds().SetId(1, i1)
+                dash_lines.InsertNextCell(seg)
+                t += period
+        self._edges_polydata.SetPoints(dash_points)
+        self._edges_polydata.SetLines(dash_lines)
+        self._edges_polydata.GetPointData().SetScalars(dash_rgba)
+        self._edges_polydata.Modified()
+
+    def _on_grab(self, key: Any) -> None:
+        """Publish the grab onto the cross-view highlight channel."""
+        self._publish_interaction_state(grabbed=key)
+
+    def _on_release(self) -> None:
+        """Drop the grab from the cross-view highlight channel."""
+        self._publish_interaction_state(grabbed=-1)
+
+    def _on_bare_move_decline(self, eventData: Any) -> None:
+        """Publish the cross-view hover highlight on a declined bare move."""
+        idx, distance2 = self._nearest_handle_in_display(eventData)
+        within = (
+            idx is not None
+            and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
+        )
+        self._publish_interaction_state(hovered=(idx if within else -1))
+
+    def _move_grabbed_to(self, eventData: Any) -> None:
+        """Move the grabbed point to the cursor IN-PLANE, offset preserved."""
+        carrier = self._data_node
+        slice_node = self._slice_node
+        idx = self._drag_key
+        if carrier is None or slice_node is None or idx is None:
+            return
+        try:
+            ex, ey = eventData.GetDisplayPosition()
+            in_plane = _proj.xy_to_ras_on_plane(slice_node, ex, ey)
+            frame = _proj.slice_frame(slice_node)
+            if in_plane is None or frame is None:
+                return
+            origin, normal = frame
+
+            grid = carrier.GetControlGridVector()
+            current = (grid[idx * 3], grid[idx * 3 + 1], grid[idx * 3 + 2])
+            # Signed out-of-plane offset of the point BEFORE the move.
+            offset = _proj.signed_distance(origin, normal, current)
+            target = [ip + n * offset for ip, n in zip(in_plane, normal)]
+
+            cols = int(carrier.GetCols())
+            carrier.SetControlPoint(
+                idx // cols, idx % cols, target[0], target[1], target[2]
+            )
+        except Exception:  # pragma: no cover - defensive
+            return
 
     def _publish_interaction_state(self, hovered=None, grabbed=None) -> None:
         """Write hover/grab onto the display node (cross-view channel)."""
@@ -651,6 +384,36 @@ class SliceControlPolygonPipeline(_PipelineBase):
             value = -1 if grabbed == -1 else int(grabbed)
             if display.GetGrabbedControlPoint() != value:
                 display.SetGrabbedControlPoint(value)
+
+    def _current_handle_rgb(self):
+        """The display node's HandleColor (the provider's per-point base rgb).
+
+        ``None`` -> the provider falls back to its neutral white; a fake
+        display node without ``GetHandleColor`` degrades the same way.
+        """
+        display = self._display_node
+        getter = getattr(display, "GetHandleColor", None) if display else None
+        if getter is None:
+            return None
+        try:
+            c = getter()
+            return (float(c[0]), float(c[1]), float(c[2]))
+        except Exception:  # pragma: no cover - defensive (fake display nodes)
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Introspection
+    # ------------------------------------------------------------------ #
+
+    def GetDataNode(self) -> Any | None:  # noqa: N802 - VTK verb
+        return self._data_node
+
+    def GetEdgesActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._edges_actor
+
+    # ------------------------------------------------------------------ #
+    # Observer render-loop guard (resection change memo)
+    # ------------------------------------------------------------------ #
 
     def _on_node_modified(self, caller: Any, event: str) -> None:
         del caller, event

--- a/SlicerLiverInteractionLib/CMakeLists.txt
+++ b/SlicerLiverInteractionLib/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SlicerLiverInteractionLib_PYTHON_SCRIPTS
   __init__.py
   SurfacePick.py
   PointPlacementState.py
+  SlicePointProjection.py
   )
 
 set(SlicerLiverInteractionLib_PYTHON_RESOURCES

--- a/SlicerLiverInteractionLib/CMakeLists.txt
+++ b/SlicerLiverInteractionLib/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SlicerLiverInteractionLib_PYTHON_SCRIPTS
   SlicePointProjection.py
   PointProvider.py
   SurfacePointPlacementPipeline3D.py
+  SurfacePointPlacementPipelineSlice.py
   )
 
 set(SlicerLiverInteractionLib_PYTHON_RESOURCES

--- a/SlicerLiverInteractionLib/CMakeLists.txt
+++ b/SlicerLiverInteractionLib/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SlicerLiverInteractionLib_PYTHON_SCRIPTS
   SurfacePick.py
   PointPlacementState.py
   SlicePointProjection.py
+  PointProvider.py
+  SurfacePointPlacementPipeline3D.py
   )
 
 set(SlicerLiverInteractionLib_PYTHON_RESOURCES

--- a/SlicerLiverInteractionLib/PointPlacementState.py
+++ b/SlicerLiverInteractionLib/PointPlacementState.py
@@ -14,9 +14,9 @@ ADR-0038 §"Shared home + names" extracts these accessors out of
 ``VascularTerritoriesLib.TerritoryInteractionState`` and PARAMETERIZES the
 attribute-key namespace per consumer, so two consumers (vascular
 territories, volumetry, resection) get independent keys on their own
-display nodes and never read each other's flags.  Constructing with
-``PointPlacementState("VascularTerritories")`` reproduces the territory
-module's original keys exactly.
+display nodes and never read each other's flags.  The active-key suffix
+defaults to the neutral ``Active``; the vascular-territories shim passes
+``active_suffix="ActiveTerritory"`` to reproduce its historical keys exactly.
 
 The class imports nothing heavy (no LayerDMLib, no Qt) so a table can
 depend on it without dragging in the Pipeline's LayerDM dependency.
@@ -39,9 +39,9 @@ class PointPlacementState:
     node (ADR-0038 §"Shared home + names").
     """
 
-    def __init__(self, namespace: str) -> None:
+    def __init__(self, namespace: str, active_suffix: str = "Active") -> None:
         self._armed_attr = f"{namespace}.Armed"
-        self._active_attr = f"{namespace}.ActiveTerritory"
+        self._active_attr = f"{namespace}.{active_suffix}"
         self._module_active_attr = f"{namespace}.ModuleActive"
         self._carrier_role = f"{namespace}.carrier"
 

--- a/SlicerLiverInteractionLib/PointProvider.py
+++ b/SlicerLiverInteractionLib/PointProvider.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The ADR-0038 point-provider seam + the swappable pick provider.
+
+ADR-0038 §Decision parameterizes the shared control-point interaction base
+by a small **point-provider seam** the consumer supplies.  The base owns the
+generic affordance (add-on-click / drag-to-edit-nearest / delete /
+bare-move-decline, the glow halo, the slice projection + fade, the pick
+arbitration, the grab seam, the four LayerDM invariants); the consumer's
+``PointProvider`` supplies the *data model* -- the points to render, whether
+they form edges, and the drag / delete write-backs -- plus the display-node
+channel for the shared arm/hover/grab state.
+
+Per the ADR's implementation amendment (2026-07-27) the pick step is ALSO a
+provider on the seam (``PickProvider``): surface consumers (resection,
+vascular territories) inject a surface pick, an in-volume consumer
+(LiverVolumetry) injects a slice-click pick, and the base carries NO
+surface-vs-volume branch -- it places at whatever world point the pick
+returns.
+
+These are duck-typed protocols, not enforced base classes: the concrete
+resection / territory / volumetry adapters implement the same method names
+over their own carriers.  They are documented here so the base's contract is
+one place, and so a fake provider (the base's characterization test) has a
+single shape to satisfy.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+from collections.abc import Iterable
+
+#: A world position + its per-point base colour, as the base reads them.
+WorldPoint = tuple[float, float, float]
+Rgb = tuple[float, float, float]
+
+
+class PointProvider(Protocol):
+    """The consumer-supplied data model the base reads + writes (ADR-0038).
+
+    Ordered so a drag / delete key is a stable index into ``iter_points()``.
+    A resection provider wraps the Bezier control grid (``has_edges()`` True);
+    a territory / volumetry provider wraps a flat point set (``has_edges()``
+    False).  The consumer keeps every data-model concern -- grouping, vessel
+    gating, state-machine gating -- OUT of the base (ADR-0038 §"What is not
+    shared"); those live in the concrete adapter's overrides, not here.
+    """
+
+    def iter_points(self) -> Iterable[tuple[WorldPoint, Rgb]]:
+        """Yield ``(world, base_rgb)`` for every point the base renders."""
+        ...
+
+    def has_edges(self) -> bool:
+        """True iff the points form a connected polygon (resection grid)."""
+        ...
+
+    def add_point(self, world: WorldPoint) -> Any:
+        """Append one point at ``world``; return its key (index)."""
+        ...
+
+    def move_point(self, key: Any, world: WorldPoint) -> None:
+        """Relocate the point identified by ``key`` to ``world``."""
+        ...
+
+    def delete_point(self, key: Any) -> bool:
+        """Remove the point identified by ``key``; True iff one was removed."""
+        ...
+
+
+class PickProvider(Protocol):
+    """The swappable click->world pick step (ADR-0038 §"Base extension").
+
+    The base calls ``pick_for_event`` for a click's world position and places
+    at whatever it returns -- there is NO surface-vs-volume branch in the
+    base.  ``SurfacePick`` is the surface variant; an in-volume / slice-click
+    pick is the volumetry variant.  ``None`` declines the placement (the ray
+    missed / no surface), which the base treats as "leave the gesture to the
+    camera".
+    """
+
+    def pick_for_event(self, renderer: Any, eventData: Any) -> WorldPoint | None:
+        """Return the world point for the event's pixel, or ``None`` to decline."""
+        ...

--- a/SlicerLiverInteractionLib/SlicePointProjection.py
+++ b/SlicerLiverInteractionLib/SlicePointProjection.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Pure-math slice projection for surface control points (ADR-0038).
+
+The slice-view control-point base (``SurfacePointPlacementPipelineSlice``)
+projects a consumer's control points into a slice view's XY space, fades
+them by their distance to the slice plane, applies a signed above/below
+side tint, and casts a snap ray along the slice normal.  Those operations
+are pure geometry given a slice node exposing ``GetXYToRAS`` /
+``GetSliceToRAS`` (4x4 ``vtkMatrix4x4``) -- no LayerDM, no GL, no Slicer
+scene -- so they live here as module-level functions the bare unit layer
+can exercise directly (the ``SurfacePick`` pure-VTK-helper split
+precedent).
+
+ADR-0038 §Context names the slice projection into XY (``inverse(XYToRAS)``),
+the distance-graded alpha, the signed above/below side tint, and the HARD
+presence cutoff (2D alpha is unreliable) as the surface the base owns.  The
+resection slice pipeline (``SliceControlPolygonPipeline``, ADR-0033) and the
+vascular-territories slice pipeline (``TerritorySlicePipeline``, ADR-0037)
+carried near-verbatim copies of this math; this module is the single source
+they now both share (``TerritorySliceProjection`` re-exports it).
+
+Imports ``vtk`` only (for the matrix arithmetic); the slice node is passed
+in and duck-typed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Distance (mm) over which the projection fades to fully transparent --
+#: the above/below-the-plane cue.  Short by design: only control points
+#: NEAR the plane are present in a slice at all.
+FADE_DISTANCE_MM = 15.0
+
+#: Presence == visibility: a point at / beyond ``FADE_DISTANCE_MM`` is
+#: absent (2D alpha is unreliable, so presence is a HARD cutoff, not a
+#: faded-to-zero alpha -- the ADR-0033 slice-polygon rule).
+PICK_RANGE_MM = FADE_DISTANCE_MM
+
+#: Maximum lightness shift for the above/below-plane cue: points ABOVE the
+#: plane tint toward white, below toward black, graded by distance.
+#: Sign-neutral, so it composes with any per-point colour and stays
+#: colourblind-legible.
+SIDE_TINT_MAX = 0.55
+
+
+def slice_frame(slice_node: Any):
+    """``(origin, unit_normal)`` of the slice plane in RAS, or ``None``.
+
+    Reads the slice-to-RAS matrix's translation (origin) + normalized
+    third column (plane normal).  ``None`` when no slice node / matrix.
+    """
+    if slice_node is None:
+        return None
+    try:
+        to_ras = slice_node.GetSliceToRAS()
+    except Exception:  # pragma: no cover - defensive (fake nodes)
+        return None
+    if to_ras is None:
+        return None
+    origin = [to_ras.GetElement(r, 3) for r in range(3)]
+    normal = [to_ras.GetElement(r, 2) for r in range(3)]
+    norm = sum(n * n for n in normal) ** 0.5 or 1.0
+    normal = [n / norm for n in normal]
+    return origin, normal
+
+
+def signed_distance(origin, normal, point) -> float:
+    """Signed distance (mm) from ``point`` to a plane ``(origin, unit normal)``.
+
+    Positive on the ``+normal`` side, negative on the other.  The per-point
+    primitive the reproject loop calls after resolving the frame ONCE.
+    """
+    return sum(n * (p - o) for n, p, o in zip(normal, point, origin))
+
+
+def signed_distance_to_slice(slice_node: Any, point) -> float:
+    """Signed distance (mm) from ``point`` (RAS) to the slice plane.
+
+    Positive ABOVE the plane (along the slice normal), negative below.
+    ``+inf`` when the slice frame cannot be resolved.  Convenience wrapper
+    resolving the frame per call -- for a loop, resolve ``slice_frame`` once
+    and call :func:`signed_distance`.
+    """
+    frame = slice_frame(slice_node)
+    if frame is None:
+        return float("inf")
+    return signed_distance(frame[0], frame[1], point)
+
+
+def inverse_xy_to_ras(slice_node: Any):
+    """The slice's ``inverse(XYToRAS)`` as a ``vtkMatrix4x4``, or ``None``.
+
+    Resolved ONCE per reproject and reused for every point (the
+    ``SliceControlPolygonPipeline`` convention).
+    """
+    if slice_node is None:
+        return None
+    try:
+        import vtk
+
+        ras_to_xy = vtk.vtkMatrix4x4()
+        ras_to_xy.DeepCopy(slice_node.GetXYToRAS())
+        ras_to_xy.Invert()
+    except Exception:  # pragma: no cover - defensive (fake nodes)
+        return None
+    return ras_to_xy
+
+
+def apply_matrix_xy(ras_to_xy, point):
+    """Map an RAS ``point`` through a pre-built ``inverse(XYToRAS)`` to XY."""
+    xy = ras_to_xy.MultiplyPoint((point[0], point[1], point[2], 1.0))
+    w = xy[3] or 1.0
+    return xy[0] / w, xy[1] / w
+
+
+def project_ras_to_xy(slice_node: Any, point):
+    """Project an RAS ``point`` into the slice view's XY space, or ``None``.
+
+    Uses ``inverse(XYToRAS)`` -- the slice-view display coordinates coincide
+    with this XY space (the slice renderer convention, shared with
+    ``SliceControlPolygonPipeline``).  Convenience wrapper building the
+    inverse per call -- for a loop, build it once via
+    :func:`inverse_xy_to_ras` and call :func:`apply_matrix_xy`.
+    """
+    ras_to_xy = inverse_xy_to_ras(slice_node)
+    if ras_to_xy is None:
+        return None
+    return apply_matrix_xy(ras_to_xy, point)
+
+
+def xy_to_ras_on_plane(slice_node: Any, ex: float, ey: float):
+    """Resolve a slice-view pixel ``(ex, ey)`` to its RAS point ON the plane.
+
+    ``XYToRAS`` maps the in-plane pixel (z=0) straight onto the slice
+    plane, so this is the click's landing point before the normal-ray snap.
+    ``None`` when the matrix cannot be read.
+    """
+    if slice_node is None:
+        return None
+    try:
+        xy_to_ras = slice_node.GetXYToRAS()
+        ras = xy_to_ras.MultiplyPoint((float(ex), float(ey), 0.0, 1.0))
+    except Exception:  # pragma: no cover - defensive (fake nodes)
+        return None
+    w = ras[3] or 1.0
+    return ras[0] / w, ras[1] / w, ras[2] / w
+
+
+def normal_ray(slice_node: Any, ras_point, extent_mm: float = 1000.0):
+    """A world ray ``(p1, p2)`` through ``ras_point`` ALONG the slice normal.
+
+    Casts from ``ras_point + extent * normal`` to ``ras_point - extent *
+    normal`` so a surface pick can snap the point onto the surface the slice
+    cuts (ADR-0038 §"Base extension"; the pick step is swappable).  ``None``
+    when the slice frame cannot be resolved.
+    """
+    frame = slice_frame(slice_node)
+    if frame is None:
+        return None
+    _origin, normal = frame
+    p1 = tuple(ras_point[i] + normal[i] * extent_mm for i in range(3))
+    p2 = tuple(ras_point[i] - normal[i] * extent_mm for i in range(3))
+    return p1, p2
+
+
+def is_present(distance_mm: float) -> bool:
+    """True iff a point at ``|distance_mm|`` is present in the slice.
+
+    The HARD presence cutoff (2D alpha unreliable): a point at / beyond
+    ``PICK_RANGE_MM`` is absent -- not faded-to-zero (ADR-0033).
+    """
+    return abs(distance_mm) < PICK_RANGE_MM
+
+
+def fade_alpha(distance_mm: float) -> float:
+    """Linear fade [0, 1] of a point by ``|distance_mm|`` to the plane."""
+    return max(0.0, 1.0 - abs(distance_mm) / FADE_DISTANCE_MM)
+
+
+def side_tint(rgb, signed_distance: float):
+    """Blend ``rgb`` toward white (above the plane) or black (below).
+
+    The signed above/below cue shared across every slice-projected control
+    surface (ADR-0038 §Context).
+    """
+    fraction = min(1.0, abs(signed_distance) / FADE_DISTANCE_MM) * SIDE_TINT_MAX
+    target = 255 if signed_distance > 0 else 0
+    return [int(c + (target - c) * fraction) for c in rgb]

--- a/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
+++ b/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
@@ -11,7 +11,8 @@ not shared"):
 * the add-on-click / drag-to-edit-nearest / delete / bare-move-decline
   arbitration (ADR-0033 hover discipline: a bare move returns
   ``(False, +inf)`` so the camera is untouched);
-* the display-space pick-radius grab (``_nearest_point_in_display``);
+* the display-space pick-radius grab (``_nearest_key_in_display``, which
+  defaults to the enumerate-keyed ``_nearest_point_in_display`` scan);
 * the cursor-ray unproject for a drag target (``_event_world``);
 * the point world for a CLICK comes from the injected **pick provider**
   (ADR-0038 §"Base extension" -- the base has NO surface-vs-volume branch);
@@ -186,7 +187,7 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
             if etype != vtk.vtkCommand.LeftButtonPressEvent:
                 return False, sys.float_info.max
 
-            key, distance2 = self._nearest_point_in_display(renderer, eventData)
+            key, distance2 = self._nearest_key_in_display(renderer, eventData)
             if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
                 return True, distance2
 
@@ -221,7 +222,7 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
             if self._drag_key is None:
                 if etype != vtk.vtkCommand.LeftButtonPressEvent:
                     return False
-                key, distance2 = self._nearest_point_in_display(renderer, eventData)
+                key, distance2 = self._nearest_key_in_display(renderer, eventData)
                 if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
                     self._drag_key = key  # grab for a drag (edit gesture)
                     self._on_grab(key, renderer, eventData)
@@ -320,6 +321,20 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
     # GL-touching seams (monkeypatched in the unit layer; overridden by the
     # concrete clients where their data model differs)
     # ------------------------------------------------------------------ #
+
+    def _nearest_key_in_display(self, renderer: Any, eventData: Any):
+        """``(key, distance2)`` of the point nearest the event pixel (grab seam).
+
+        The single seam the arbitration bodies consult for the grab hit-test:
+        it MUST return a 2-tuple ``(key, distance2)`` where ``key`` is the
+        drag key the write-backs expect (``None`` when nothing is near).  The
+        default delegates to ``_nearest_point_in_display`` (the enumerate-keyed
+        scan below); a client whose key is not a flat index -- vascular
+        territories' ``(territoryId, index)`` pair -- overrides THIS adapter
+        and repacks its own richer hit-test into the 2-tuple contract, without
+        touching the arbitration bodies (ADR-0038 §"What is not shared").
+        """
+        return self._nearest_point_in_display(renderer, eventData)
 
     def _nearest_point_in_display(self, renderer: Any, eventData: Any):
         """``(key, distance2)`` of the provider point nearest the event pixel.

--- a/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
+++ b/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The shared 3D control-point placement/edit base (ADR-0038).
+
+ADR-0038 §Decision extracts a shared 3D interaction/visualization base from
+the mature resection pipelines; VascularTerritories, resection and
+LiverVolumetry become clients over the ``PointProvider`` seam.  The base owns
+the GENERIC affordance and NOTHING data-model specific (ADR-0038 §"What is
+not shared"):
+
+* the add-on-click / drag-to-edit-nearest / delete / bare-move-decline
+  arbitration (ADR-0033 hover discipline: a bare move returns
+  ``(False, +inf)`` so the camera is untouched);
+* the display-space pick-radius grab (``_nearest_point_in_display``);
+* the cursor-ray unproject for a drag target (``_event_world``);
+* the point world for a CLICK comes from the injected **pick provider**
+  (ADR-0038 §"Base extension" -- the base has NO surface-vs-volume branch);
+* the arm gate rides the shared display node via ``PointPlacementState``.
+
+The seed-glyph rendering, the hover marker + glow-halo overlay
+(``vtkOutlineGlowPass``), the slice-jump, and the four LayerDM integration
+invariants are the base's remaining generic surface; the concrete clients
+subclass this base, keep their pinned interaction seams, and re-inject their
+data-model + gating (resection's Init/Planning state machine, territories'
+vessel gating) through their overrides -- none of which bleed into the base.
+
+This is a LayerDM scripted Pipeline (imports LayerDMLib, reachable only
+inside a launched Slicer with the module loaded); ADR-0004 keeps the
+interaction math in Python; ADR-0013 §5 keeps it a Pipeline base, NOT a
+displayable manager.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import vtk
+
+from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+
+try:  # pragma: no cover - exercised once per import path
+    from .PointPlacementState import PointPlacementState
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    from PointPlacementState import PointPlacementState  # type: ignore[no-redef]
+
+#: Display-space pick radius for grabbing an existing point, in pixels
+#: (the shared value the resection + territory clients carried; a press
+#: within this radius of a placed point grabs it, a press outside adds one).
+POINT_PICK_RADIUS_PX = 20.0
+
+#: Hover / grab cue colours shared across every control-point surface
+#: (ADR-0038 §Context): hover = yellow, grab = green.
+HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
+HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
+
+
+def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name
+    """The VTK event-type id off ``eventData`` (never-raise boundaries only)."""
+    return int(eventData.GetType())
+
+
+class SurfacePointPlacementPipeline3D(_PipelineBase):
+    """Generic 3D add-on-click / drag / delete over a ``PointProvider``.
+
+    Concrete consumers subclass this and supply a ``PointProvider`` +
+    a pick provider; the base carries no data-model knowledge (ADR-0038).
+    """
+
+    def __init__(self, namespace: str = "SurfacePointPlacement") -> None:
+        super().__init__()
+        self.SetPythonObject(self)
+
+        self._display_node: Any | None = None
+        self._renderer: Any | None = None
+        self._state = PointPlacementState(namespace)
+
+        # The consumer's data model + the swappable click->world pick.
+        self._provider: Any | None = None
+        self._pick_provider: Any | None = None
+
+        # Instance-field fallbacks for the bare unit layer (no display node);
+        # production reads arm / module-active off the shared display node.
+        self._armed: bool = False
+        self._module_active: bool = True
+
+        # Key of the point currently GRABBED by a press/move/release drag,
+        # None when no drag is in flight.
+        self._drag_key: Any | None = None
+
+    # ------------------------------------------------------------------ #
+    # Seam wiring
+    # ------------------------------------------------------------------ #
+
+    def SetProvider(self, provider: Any) -> None:  # noqa: N802 - VTK verb
+        """Inject the consumer's ``PointProvider`` (data model seam)."""
+        self._provider = provider
+
+    def GetProvider(self) -> Any | None:  # noqa: N802 - VTK verb
+        return self._provider
+
+    def SetPickProvider(self, pick: Any) -> None:  # noqa: N802 - VTK verb
+        """Inject the swappable click->world pick (ADR-0038 §"Base extension")."""
+        self._pick_provider = pick
+
+    def _safe_get_renderer(self) -> Any | None:
+        return self._renderer
+
+    # ------------------------------------------------------------------ #
+    # Arm / module-active gate (rides the shared display node)
+    # ------------------------------------------------------------------ #
+
+    def Arm(self) -> None:  # noqa: N802 - VTK verb
+        """Enable add-on-click."""
+        if self._display_node is not None:
+            self._state.set_armed(self._display_node, True)
+        self._armed = True
+
+    def Disarm(self) -> None:  # noqa: N802 - VTK verb
+        """Disable add-on-click; a click then adds nothing."""
+        if self._display_node is not None:
+            self._state.set_armed(self._display_node, False)
+        self._armed = False
+
+    def IsArmed(self) -> bool:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            return self._state.is_armed(self._display_node)
+        return self._armed
+
+    def SetModuleActive(self, active: bool) -> None:  # noqa: N802 - VTK verb
+        """Open/close the belt-and-suspenders add-on-click gate."""
+        if self._display_node is not None:
+            self._state.set_module_active(self._display_node, bool(active))
+        self._module_active = bool(active)
+
+    def IsModuleActive(self) -> bool:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            return self._state.is_module_active(self._display_node)
+        return self._module_active
+
+    # ------------------------------------------------------------------ #
+    # Interaction -- add-on-click / drag-to-edit / decline (ADR-0033)
+    # ------------------------------------------------------------------ #
+
+    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
+        """Return ``(canProcess, distance2)`` for the LayerDM focus logic.
+
+        * a press within ``POINT_PICK_RADIUS_PX`` of an existing point is
+          claimed with the REAL squared display distance (grab for a drag);
+        * an armed press over a pick-resolvable point is claimed with the
+          pick radius squared (add-on-click);
+        * a grabbed move/release is claimed unconditionally;
+        * a bare move is DECLINED (``(False, +inf)``) so the camera is
+          untouched (ADR-0033).
+        """
+        try:
+            renderer = self._safe_get_renderer()
+            if renderer is None:
+                return False, sys.float_info.max
+            etype = _event_type(eventData)
+
+            if self._drag_key is not None:
+                if etype in (
+                    vtk.vtkCommand.MouseMoveEvent,
+                    vtk.vtkCommand.LeftButtonReleaseEvent,
+                ):
+                    return True, 0.0
+                return False, sys.float_info.max
+
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                # Bare hover: DECLINE (camera untouched, ADR-0033).
+                return False, sys.float_info.max
+
+            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                return False, sys.float_info.max
+
+            key, distance2 = self._nearest_point_in_display(renderer, eventData)
+            if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
+                return True, distance2
+
+            if not self.IsArmed():
+                return False, sys.float_info.max
+            if self._pick_world(renderer, eventData) is None:
+                return False, sys.float_info.max
+            return True, POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False, sys.float_info.max
+
+    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
+        """Drive add-on-click / drag-to-edit-nearest (ADR-0038 §Decision)."""
+        try:
+            renderer = self._safe_get_renderer()
+            if renderer is None:
+                self._drag_key = None
+                return False
+            etype = _event_type(eventData)
+
+            if self._drag_key is None:
+                if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                    return False
+                key, distance2 = self._nearest_point_in_display(renderer, eventData)
+                if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
+                    self._drag_key = key  # grab for a drag (edit gesture)
+                    self.RequestRender()
+                    return True
+                if not self.IsArmed():
+                    return False
+                if not self.IsModuleActive():
+                    return False
+                world = self._pick_world(renderer, eventData)
+                if world is None:
+                    return False
+                self._add_point(world)
+                self.RequestRender()
+                return True
+
+            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
+                self._drag_key = None
+                self.RequestRender()
+                return False  # gesture over -- release the focus
+
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                world = self._event_world(renderer, eventData)
+                if world is None:
+                    return True  # keep the grab; this move just didn't resolve
+                self._move_point(self._drag_key, world)
+                self.RequestRender()
+                return True
+
+            return False
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False
+
+    def DeletePoint(self, key: Any) -> bool:  # noqa: N802 - VTK verb
+        """Remove EXACTLY ONE point via the provider (delete write-back)."""
+        provider = self._provider
+        if provider is None:
+            return False
+        return bool(provider.delete_point(key))
+
+    # ------------------------------------------------------------------ #
+    # Provider write-backs
+    # ------------------------------------------------------------------ #
+
+    def _add_point(self, world: Any) -> None:
+        if self._provider is not None:
+            self._provider.add_point((world[0], world[1], world[2]))
+
+    def _move_point(self, key: Any, world: Any) -> None:
+        if self._provider is not None:
+            self._provider.move_point(key, (world[0], world[1], world[2]))
+
+    def _pick_world(self, renderer: Any, eventData: Any):
+        """The click's world point from the injected pick, or ``None``.
+
+        The single place the base resolves a click to a world position; the
+        surface-vs-volume choice is entirely in the injected pick provider
+        (ADR-0038 §"Base extension") -- the base does not branch on it.
+        """
+        pick = self._pick_provider
+        if pick is None:
+            return None
+        return pick.pick_for_event(renderer, eventData)
+
+    # ------------------------------------------------------------------ #
+    # GL-touching seams (monkeypatched in the unit layer; overridden by the
+    # concrete clients where their data model differs)
+    # ------------------------------------------------------------------ #
+
+    def _nearest_point_in_display(self, renderer: Any, eventData: Any):
+        """``(key, distance2)`` of the provider point nearest the event pixel.
+
+        Scans ``iter_points`` projecting each to display and returns the
+        nearest with its REAL squared display distance (LayerDM arbitration).
+        ``(None, +inf)`` when there is no provider / point.
+        """
+        provider = self._provider
+        if provider is None:
+            return None, sys.float_info.max
+        try:
+            ex, ey = eventData.GetDisplayPosition()
+        except Exception:  # pragma: no cover - defensive (fake events)
+            return None, sys.float_info.max
+
+        best_key = None
+        best_d2 = sys.float_info.max
+        for key, (world, _rgb) in enumerate(provider.iter_points()):
+            renderer.SetWorldPoint(world[0], world[1], world[2], 1.0)
+            renderer.WorldToDisplay()
+            dx, dy, _dz = renderer.GetDisplayPoint()
+            d2 = (dx - ex) ** 2 + (dy - ey) ** 2
+            if d2 < best_d2:
+                best_d2 = d2
+                best_key = key
+        return best_key, best_d2
+
+    def _event_world(self, renderer: Any, eventData: Any):
+        """Back-project the event pixel to a world point for a drag target.
+
+        The default unprojects at the near/far clip and returns the pick's
+        surface snap; the concrete clients override where their drag target
+        differs (resection back-projects onto the grabbed point's depth).
+        """
+        return self._pick_world(renderer, eventData)
+
+    # ------------------------------------------------------------------ #
+    # Reconcile (idempotent -- no drift on an unrelated Modified)
+    # ------------------------------------------------------------------ #
+
+    def _on_node_modified(self, caller: Any, event: str) -> None:
+        """Repaint on a carrier ``Modified`` -- idempotent, no point drift.
+
+        The base holds no shadow copy of the point set: the provider IS the
+        source of truth, so a reconcile driven by an unrelated ``Modified``
+        (a table repaint, a colour change) reads the provider and repaints
+        without adding / moving / dropping any point (ADR-0038 no-drift).
+        """
+        del caller, event
+        try:
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass

--- a/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
+++ b/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
@@ -151,11 +151,21 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
           pick radius squared (add-on-click);
         * a grabbed move/release is claimed unconditionally;
         * a bare move is DECLINED (``(False, +inf)``) so the camera is
-          untouched (ADR-0033).
+          untouched (ADR-0033); a client may raise a hover cue as a SIDE
+          EFFECT of the declined bare move via ``_on_bare_move_decline``.
+
+        The ``_admissible`` gate hook (default ``True``) lets a client veto
+        the whole arbitration on its own data-model state -- resection's
+        Init/Planning gate rides here (ADR-0038 §"What is not shared"), NOT
+        as a branch in this base.
         """
         try:
+            if not self._admissible():
+                self._drag_key = None  # a state flip mid-gesture drops the grab
+                return False, sys.float_info.max
             renderer = self._safe_get_renderer()
             if renderer is None:
+                self._drag_key = None
                 return False, sys.float_info.max
             etype = _event_type(eventData)
 
@@ -168,7 +178,9 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
                 return False, sys.float_info.max
 
             if etype == vtk.vtkCommand.MouseMoveEvent:
-                # Bare hover: DECLINE (camera untouched, ADR-0033).
+                # Bare hover: DECLINE (camera untouched, ADR-0033).  The
+                # client's hover cue is a side effect of this declined call.
+                self._on_bare_move_decline(renderer, eventData)
                 return False, sys.float_info.max
 
             if etype != vtk.vtkCommand.LeftButtonPressEvent:
@@ -187,10 +199,21 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
             return False, sys.float_info.max
 
     def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
-        """Drive add-on-click / drag-to-edit-nearest (ADR-0038 §Decision)."""
+        """Drive add-on-click / drag-to-edit-nearest (ADR-0038 §Decision).
+
+        The generic press-grab / move / release skeleton is here; each phase
+        calls a client hook (``_on_grab`` / ``_on_drag`` / ``_on_release``,
+        all no-ops by default) so a client contributes its data-model side
+        effects -- the resection state-machine commit, the grab-colour
+        scalars, the hover halo -- WITHOUT re-implementing the arbitration
+        (ADR-0038 §"What is not shared").
+        """
         try:
             renderer = self._safe_get_renderer()
             if renderer is None:
+                self._drag_key = None
+                return False
+            if not self._admissible():
                 self._drag_key = None
                 return False
             etype = _event_type(eventData)
@@ -201,6 +224,7 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
                 key, distance2 = self._nearest_point_in_display(renderer, eventData)
                 if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
                     self._drag_key = key  # grab for a drag (edit gesture)
+                    self._on_grab(key, renderer, eventData)
                     self.RequestRender()
                     return True
                 if not self.IsArmed():
@@ -216,6 +240,7 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
 
             if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
                 self._drag_key = None
+                self._on_release()
                 self.RequestRender()
                 return False  # gesture over -- release the focus
 
@@ -224,12 +249,41 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
                 if world is None:
                     return True  # keep the grab; this move just didn't resolve
                 self._move_point(self._drag_key, world)
+                self._on_drag(self._drag_key)
                 self.RequestRender()
                 return True
 
             return False
         except Exception:  # pragma: no cover - C++ boundary must never raise
             return False
+
+    # ------------------------------------------------------------------ #
+    # Client extension hooks (no data-model knowledge in the base;
+    # ADR-0038 §"What is not shared").  All no-ops / permissive by default;
+    # the flat clients (territories, volumetry) ignore them, resection
+    # fills them with the state-machine commit + hover/grab cues.
+    # ------------------------------------------------------------------ #
+
+    def _admissible(self) -> bool:
+        """Veto hook for a client's own gate (default: always admit).
+
+        A client whose data model gates interaction (resection's
+        Init/Planning state machine) overrides this; the base carries no
+        such gate.
+        """
+        return True
+
+    def _on_grab(self, key: Any, renderer: Any, eventData: Any) -> None:
+        """Called right after the base grabs ``key`` on a press (default no-op)."""
+
+    def _on_drag(self, key: Any) -> None:
+        """Called right after a drag move relocates ``key`` (default no-op)."""
+
+    def _on_release(self) -> None:
+        """Called right after the base clears the grab on release (default no-op)."""
+
+    def _on_bare_move_decline(self, renderer: Any, eventData: Any) -> None:
+        """Called on a DECLINED bare move (default no-op -- the hover cue seam)."""
 
     def DeletePoint(self, key: Any) -> bool:  # noqa: N802 - VTK verb
         """Remove EXACTLY ONE point via the provider (delete write-back)."""

--- a/SlicerLiverInteractionLib/SurfacePointPlacementPipelineSlice.py
+++ b/SlicerLiverInteractionLib/SurfacePointPlacementPipelineSlice.py
@@ -16,9 +16,17 @@ owns the GENERIC slice affordance and NOTHING data-model specific
 * hollow-circle HANDLE glyphs (grab targets) + a larger hover/grab RING
   glyph (the 2D analogue of the 3D glow halo);
 * the grab seam + ``Can/ProcessInteractionEvent`` arbitration: a press near
-  a projected handle grabs it for a drag, a bare move is DECLINED
-  (``(False, +inf)``) so the camera is untouched (ADR-0033 hover
-  discipline), a grabbed move/release is claimed unconditionally;
+  a projected handle grabs it for a drag, an ARMED press over a
+  pick-resolvable point adds one via the injected pick provider (default-off:
+  a client that injects no pick + never arms -- resection -- never reaches
+  the add branch), a bare move is DECLINED (``(False, +inf)``) so the camera
+  is untouched (ADR-0033 hover discipline), a grabbed move/release is claimed
+  unconditionally;
+* the key seam (``_iter_keyed_points``): the projection stores a client key
+  per point -- a flat ``enumerate`` index by default (resection), a
+  ``(territoryId, index)`` pair for vascular territories -- exposed via
+  ``GetProjectedKeys`` (the slice complement of the 3D base's
+  ``_nearest_key_in_display``);
 * the slice-node observation so reslicing re-projects, and the four LayerDM
   integration invariants (renderer churn re-attach etc.).
 
@@ -45,8 +53,10 @@ from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
 
 try:  # pragma: no cover - exercised once per import path
     from . import SlicePointProjection as _proj
+    from .PointPlacementState import PointPlacementState
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     import SlicePointProjection as _proj  # type: ignore[no-redef]
+    from PointPlacementState import PointPlacementState  # type: ignore[no-redef]
 
 #: Display-space pick radius (XY pixels) for grabbing an existing projected
 #: handle -- the shared value the resection + territory slice clients carried.
@@ -83,7 +93,7 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
     hooks below.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, namespace: str = "SurfacePointPlacement") -> None:
         super().__init__()
         self.SetPythonObject(self)
 
@@ -93,12 +103,29 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
         self._observer_tags: dict = {}
         self._observed_node_refs: list = []
 
-        # The consumer's data model (ADR-0038 seam).
+        # The consumer's data model (ADR-0038 seam) + the swappable click->world
+        # pick.  A client that supplies NO pick provider (resection) has the
+        # add-on-click branch dead by construction; the pick is the sole way
+        # the base resolves a click to a world point (no surface-vs-volume
+        # branch in the base, mirroring the 3D base -- ADR-0038 §"Base
+        # extension").
         self._provider: Any | None = None
+        self._pick_provider: Any | None = None
+
+        # Arm / module-active gate (rides the shared display node via
+        # ``PointPlacementState``).  Instance-field fallbacks drive the bare
+        # unit layer (no display node); production reads them off the display
+        # node.  A client that never arms + injects no pick leaves the
+        # add-on-click branch inert (resection, ADR-0038 default-off).
+        self._state = PointPlacementState(namespace)
+        self._armed: bool = False
+        self._module_active: bool = True
 
         #: Key of the projected handle currently GRABBED by a press/move/
         #: release drag; None when no drag is in flight.  The key is whatever
-        #: the provider's ``iter_points`` enumeration yields (flat index).
+        #: the key seam yields per projected point -- a flat ``enumerate``
+        #: index by default (resection), or a richer client key such as
+        #: vascular territories' ``(territoryId, index)`` pair.
         self._drag_key: Any | None = None
 
         #: XY-space positions of the PRESENT projected handles (pick
@@ -156,6 +183,48 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
 
     def GetProvider(self) -> Any | None:  # noqa: N802 - VTK verb
         return self._provider
+
+    def SetPickProvider(self, pick: Any) -> None:  # noqa: N802 - VTK verb
+        """Inject the swappable click->world pick (ADR-0038 §"Base extension").
+
+        A client that leaves this unset (resection's slice control polygon)
+        has the base's armed add-on-click branch dead: ``_pick_world`` returns
+        ``None``, so nothing is ever placed on a click (only grab-drag +
+        bare-move-decline remain).
+        """
+        self._pick_provider = pick
+
+    # ------------------------------------------------------------------ #
+    # Arm / module-active gate (rides the shared display node)
+    # ------------------------------------------------------------------ #
+
+    def Arm(self) -> None:  # noqa: N802 - VTK verb
+        """Enable add-on-click (only meaningful with a pick provider wired)."""
+        if self._display_node is not None:
+            self._state.set_armed(self._display_node, True)
+        self._armed = True
+
+    def Disarm(self) -> None:  # noqa: N802 - VTK verb
+        """Disable add-on-click; a click then adds nothing."""
+        if self._display_node is not None:
+            self._state.set_armed(self._display_node, False)
+        self._armed = False
+
+    def IsArmed(self) -> bool:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            return self._state.is_armed(self._display_node)
+        return self._armed
+
+    def SetModuleActive(self, active: bool) -> None:  # noqa: N802 - VTK verb
+        """Open/close the belt-and-suspenders add-on-click gate."""
+        if self._display_node is not None:
+            self._state.set_module_active(self._display_node, bool(active))
+        self._module_active = bool(active)
+
+    def IsModuleActive(self) -> bool:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            return self._state.is_module_active(self._display_node)
+        return self._module_active
 
     def _safe_get_renderer(self) -> Any | None:
         return self._renderer
@@ -298,7 +367,7 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
         handle_rgba.SetNumberOfComponents(4)
 
         try:
-            for key, (world, base_rgb) in enumerate(provider.iter_points()):
+            for key, world, base_rgb in self._iter_keyed_points():
                 xy = _proj.apply_matrix_xy(ras_to_xy, world)
                 signed = _proj.signed_distance(origin, normal, world)
                 present = _proj.is_present(signed)
@@ -336,6 +405,24 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
         self._update_ring(hovered, grabbed)
         return True
 
+    def _iter_keyed_points(self):
+        """Yield ``(key, world, base_rgb)`` per provider point (the key seam).
+
+        The single seam the projection consults for a point's KEY: the default
+        pairs the provider's ``iter_points`` with a flat ``enumerate`` index
+        (resection's control-grid order), so ``_projected_keys`` are flat ints.
+        A client whose key is not a flat index -- vascular territories'
+        ``(territoryId, index)`` pair -- overrides THIS seam to supply its own
+        keys in ``iter_points`` order, without the base learning the topology
+        (mirrors the 3D base's ``_nearest_key_in_display`` intent; ADR-0038
+        §"What is not shared").
+        """
+        provider = self._provider
+        if provider is None:
+            return
+        for key, (world, base_rgb) in enumerate(provider.iter_points()):
+            yield key, world, base_rgb
+
     def _update_ring(self, hovered: Any, grabbed: Any) -> None:
         """Show the hover/grab ring on the grabbed (green) or hovered (yellow)
         handle -- only when that point is PRESENT in this slice.
@@ -344,14 +431,14 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
         grab raised in the 3D view over an out-of-range handle), so the ring
         rides the PRESENT projection, not the raw channel index.
         """
-        target = grabbed if _index_ok(grabbed) else hovered
+        target = grabbed if _key_active(grabbed) else hovered
         pts = vtk.vtkPoints()
         show = False
-        if _index_ok(target) and target in self._projected_keys:
+        if _key_active(target) and target in self._projected_keys:
             idx = self._projected_keys.index(target)
             px, py = self._projected_xy[idx]
             pts.InsertNextPoint(px, py, 0.0)
-            colour = HALO_GRAB_COLOR if _index_ok(grabbed) else HALO_HOVER_COLOR
+            colour = HALO_GRAB_COLOR if _key_active(grabbed) else HALO_HOVER_COLOR
             self._ring_actor.GetProperty().SetColor(*colour)
             show = True
         self._ring_polydata.SetPoints(pts)
@@ -370,7 +457,12 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
           untouched (ADR-0033); the hover cue is published as a SIDE EFFECT
           of the declined bare move via ``_on_bare_move_decline``;
         * a press within ``POINT_PICK_RADIUS_PX`` of a projected handle is
-          claimed with the REAL squared display distance (grab for a drag).
+          claimed with the REAL squared display distance (grab for a drag);
+        * an ARMED press over a pick-resolvable point is claimed with the pick
+          radius squared (add-on-click) -- default-off: a client that injects
+          no pick + never arms (resection) never reaches this branch, so its
+          arbitration is byte-for-byte the grab-drag + bare-move-decline it
+          had before (ADR-0038 default-off).
 
         The ``_slice_admissible`` gate hook (default ``True``) lets a client
         veto the whole arbitration on its own data-model state -- resection's
@@ -401,7 +493,13 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
             key, distance2 = self._nearest_handle_in_display(eventData)
             if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
                 return True, distance2
-            return False, sys.float_info.max
+
+            # Armed add-on-click (default-off: no pick / not armed -> declined).
+            if not self.IsArmed():
+                return False, sys.float_info.max
+            if self._pick_world(eventData) is None:
+                return False, sys.float_info.max
+            return True, POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
         except Exception:  # pragma: no cover - C++ boundary must never raise
             return False, sys.float_info.max
 
@@ -426,12 +524,23 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
                     return False
                 key, distance2 = self._nearest_handle_in_display(eventData)
                 if (
-                    key is None
-                    or distance2 > POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
+                    key is not None
+                    and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
                 ):
+                    self._drag_key = key  # grab for a drag (edit gesture)
+                    self._on_grab(key)
+                    return True
+                # Armed add-on-click (default-off: resection injects no pick +
+                # never arms, so this branch is inert and its behaviour is the
+                # grab-drag-only path it had before -- ADR-0038 default-off).
+                if not self.IsArmed():
                     return False
-                self._drag_key = key  # grab for a drag (edit gesture)
-                self._on_grab(key)
+                if not self.IsModuleActive():
+                    return False
+                world = self._pick_world(eventData)
+                if world is None:
+                    return False
+                self._add_point(world)
                 return True
 
             if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
@@ -533,9 +642,48 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
         (no snap-to-plane); a surface client snaps along the slice normal.
         """
 
+    def _pick_world(self, eventData: Any):
+        """The click's world point for an armed add-on-click, or ``None``.
+
+        The single place the base resolves a slice click to a world position
+        (the slice analogue of the 3D base's ``_pick_world``).  The default
+        delegates to the injected pick provider's ``pick_for_event`` (fed only
+        ``eventData`` -- slice picks are GL-free, unlike the 3D camera-ray
+        pick); a client whose snap is a pipeline method (territories'
+        ``_snap_event_to_surface``, the placemode-test monkeypatch seam)
+        overrides THIS to route through it.  With NO pick provider (resection)
+        it returns ``None``, so the add-on-click branch is dead (ADR-0038
+        §"Base extension" -- no surface-vs-volume branch in the base).
+        """
+        pick = self._pick_provider
+        if pick is None:
+            return None
+        return pick.pick_for_event(eventData)
+
+    def _add_point(self, world: Any) -> None:
+        """Append one point at ``world`` via the provider (add write-back).
+
+        Only reached from the armed add-on-click branch, so it is inert for a
+        client that never arms (resection); a client override adds its own
+        side effects (territories' active-territory fan + slice jump).
+        """
+        provider = self._provider
+        if provider is not None:
+            provider.add_point((world[0], world[1], world[2]))
+
     # ------------------------------------------------------------------ #
     # Introspection
     # ------------------------------------------------------------------ #
+
+    def GetProjectedKeys(self) -> list:  # noqa: N802 - VTK verb
+        """The keys of the PRESENT projected handles, in projection order.
+
+        Mirrors the 3D territory client's introspection: the keys the key seam
+        yielded for every point that survived the presence cutoff, so a client
+        suite can assert exactly which points project (e.g. a single present
+        seed keyed ``(territoryId, 0)``).
+        """
+        return list(self._projected_keys)
 
     def GetHandlesPolyData(self) -> Any:  # noqa: N802 - VTK verb
         return self._handles_polydata
@@ -590,3 +738,20 @@ class SurfacePointPlacementPipelineSlice(_PipelineBase):
 def _index_ok(value: Any) -> bool:
     """True iff ``value`` is a usable (non-negative) highlight index."""
     return isinstance(value, int) and value >= 0
+
+
+def _key_active(value: Any) -> bool:
+    """True iff ``value`` denotes a REAL highlight target (a projected key).
+
+    Generalises ``_index_ok`` so a non-int client key -- vascular territories'
+    ``(territoryId, index)`` pair -- is a valid ring target, while the
+    default-off sentinels stay inactive: ``None`` (no client channel) and the
+    resection ``-1`` (no hovered/grabbed control point).  Any other value --
+    an int >= 0 or a tuple key -- is an active target (ADR-0038 §"What is not
+    shared": the base carries no key topology).
+    """
+    if value is None:
+        return False
+    if isinstance(value, int):
+        return value >= 0
+    return True

--- a/SlicerLiverInteractionLib/SurfacePointPlacementPipelineSlice.py
+++ b/SlicerLiverInteractionLib/SurfacePointPlacementPipelineSlice.py
@@ -1,0 +1,592 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The shared slice-view control-point placement/edit base (ADR-0038).
+
+ADR-0038 §Decision extracts a shared slice-view interaction/visualization
+base (the slice complement of ``SurfacePointPlacementPipeline3D``) from the
+mature resection slice pipeline; resection, VascularTerritories and
+LiverVolumetry become clients over the ``PointProvider`` seam.  The base
+owns the GENERIC slice affordance and NOTHING data-model specific
+(ADR-0038 §"What is not shared"):
+
+* the projection of the provider's points into the slice view's XY space,
+  the distance-graded alpha fade, the signed above/below side tint, and the
+  HARD presence cutoff (2D alpha is unreliable) -- all via the pure-math
+  ``SlicePointProjection`` helper (ADR-0038 §Context);
+* hollow-circle HANDLE glyphs (grab targets) + a larger hover/grab RING
+  glyph (the 2D analogue of the 3D glow halo);
+* the grab seam + ``Can/ProcessInteractionEvent`` arbitration: a press near
+  a projected handle grabs it for a drag, a bare move is DECLINED
+  (``(False, +inf)``) so the camera is untouched (ADR-0033 hover
+  discipline), a grabbed move/release is claimed unconditionally;
+* the slice-node observation so reslicing re-projects, and the four LayerDM
+  integration invariants (renderer churn re-attach etc.).
+
+The concrete clients subclass this base, keep their pinned interaction
+seams, and re-inject their data-model + gating through narrow overrides --
+resection's edges/dashed scaffold, its Init/Planning gate, and its
+control-point-depth-offset-preserving drag -- none of which bleed into the
+base (ADR-0038 §"What is not shared").
+
+This is a LayerDM scripted Pipeline (imports LayerDMLib, reachable only
+inside a launched Slicer with the module loaded); ADR-0004 keeps the
+interaction math in Python; ADR-0013 §5 keeps it a Pipeline base, NOT a
+displayable manager.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import vtk
+
+from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+
+try:  # pragma: no cover - exercised once per import path
+    from . import SlicePointProjection as _proj
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    import SlicePointProjection as _proj  # type: ignore[no-redef]
+
+#: Display-space pick radius (XY pixels) for grabbing an existing projected
+#: handle -- the shared value the resection + territory slice clients carried.
+POINT_PICK_RADIUS_PX = 20.0
+
+#: Hover / grab cue colours shared across every slice-projected control
+#: surface (ADR-0038 §Context): hover = yellow, grab = green.
+HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
+HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
+
+#: Slice handle / hover-ring glyph diameters (XY pixels).  Larger than the
+#: default markups glyphs: the handles are grab targets, and the ring must
+#: read as a halo AROUND one.
+HANDLE_GLYPH_SCALE_PX = 13.0
+RING_GLYPH_SCALE_PX = 20.0
+
+#: Mid-tone factor applied to a base handle colour before tinting: a pure
+#: white base leaves no headroom for the lighter-above tint -- pulling the
+#: base toward mid-tone makes BOTH tint directions visible.
+HANDLE_MIDTONE_FACTOR = 0.78
+
+
+def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name
+    """The VTK event-type id off ``eventData`` (never-raise boundaries only)."""
+    return int(eventData.GetType())
+
+
+class SurfacePointPlacementPipelineSlice(_PipelineBase):
+    """Generic projected, fading, slice-editable control-point surface.
+
+    Concrete consumers subclass this and supply a ``PointProvider``; the base
+    carries no data-model knowledge (ADR-0038).  Edges, a state gate, and a
+    depth-preserving drag are client concerns injected through the extension
+    hooks below.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.SetPythonObject(self)
+
+        self._display_node: Any | None = None
+        self._slice_node: Any | None = None
+        self._renderer: Any | None = None
+        self._observer_tags: dict = {}
+        self._observed_node_refs: list = []
+
+        # The consumer's data model (ADR-0038 seam).
+        self._provider: Any | None = None
+
+        #: Key of the projected handle currently GRABBED by a press/move/
+        #: release drag; None when no drag is in flight.  The key is whatever
+        #: the provider's ``iter_points`` enumeration yields (flat index).
+        self._drag_key: Any | None = None
+
+        #: XY-space positions of the PRESENT projected handles (pick
+        #: arbitration) and their parallel keys + |distance| to the plane.
+        self._projected_keys: list = []
+        self._projected_xy: list = []
+        self._plane_distances: list = []
+
+        # Handles: projected points as hollow-circle 2D glyphs with RGBA fade.
+        self._handles_polydata = vtk.vtkPolyData()
+        self._handles_polydata.SetPoints(vtk.vtkPoints())
+        self._handle_glyph_source = vtk.vtkGlyphSource2D()
+        self._handle_glyph_source.SetGlyphTypeToCircle()
+        self._handle_glyph_source.FilledOff()
+        self._handle_glyph_source.SetScale(HANDLE_GLYPH_SCALE_PX)
+        self._handles_glyph = vtk.vtkGlyph2D()
+        self._handles_glyph.SetInputData(self._handles_polydata)
+        self._handles_glyph.SetSourceConnection(
+            self._handle_glyph_source.GetOutputPort()
+        )
+        self._handles_glyph.SetColorModeToColorByScalar()
+        self._handles_glyph.ScalingOff()
+        self._handles_mapper = vtk.vtkPolyDataMapper2D()
+        self._handles_mapper.SetInputConnection(self._handles_glyph.GetOutputPort())
+        self._handles_actor = vtk.vtkActor2D()
+        self._handles_actor.SetMapper(self._handles_mapper)
+        self._handles_actor.SetVisibility(False)
+
+        # Hover ring: the 2D analogue of the 3D glow halo -- a larger hollow
+        # circle on the hovered/grabbed projected handle.
+        self._ring_polydata = vtk.vtkPolyData()
+        self._ring_polydata.SetPoints(vtk.vtkPoints())
+        self._ring_glyph_source = vtk.vtkGlyphSource2D()
+        self._ring_glyph_source.SetGlyphTypeToCircle()
+        self._ring_glyph_source.FilledOff()
+        self._ring_glyph_source.SetScale(RING_GLYPH_SCALE_PX)
+        self._ring_glyph = vtk.vtkGlyph2D()
+        self._ring_glyph.SetInputData(self._ring_polydata)
+        self._ring_glyph.SetSourceConnection(self._ring_glyph_source.GetOutputPort())
+        self._ring_glyph.ScalingOff()
+        self._ring_mapper = vtk.vtkPolyDataMapper2D()
+        self._ring_mapper.SetInputConnection(self._ring_glyph.GetOutputPort())
+        self._ring_actor = vtk.vtkActor2D()
+        self._ring_actor.SetMapper(self._ring_mapper)
+        self._ring_actor.GetProperty().SetLineWidth(2.0)
+        self._ring_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # Seam wiring
+    # ------------------------------------------------------------------ #
+
+    def SetProvider(self, provider: Any) -> None:  # noqa: N802 - VTK verb
+        """Inject the consumer's ``PointProvider`` (data model seam)."""
+        self._provider = provider
+
+    def GetProvider(self) -> Any | None:  # noqa: N802 - VTK verb
+        return self._provider
+
+    def _safe_get_renderer(self) -> Any | None:
+        return self._renderer
+
+    # ------------------------------------------------------------------ #
+    # LayerDM lifecycle
+    # ------------------------------------------------------------------ #
+
+    def SetViewNode(self, viewNode: Any) -> None:  # noqa: N802 - VTK verb
+        super().SetViewNode(viewNode)
+        # Observe the slice node OURSELVES (the stale-trace lesson): reslicing
+        # must re-project + re-fade.
+        if self._slice_node is not None:
+            self._detach_observer(self._slice_node)
+        self._slice_node = viewNode
+        if viewNode is not None:
+            self._attach_observer(viewNode)
+
+    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
+        if self._display_node is not None:
+            self._detach_observer(self._display_node)
+        self._before_display_node_change()
+
+        super().SetDisplayNode(displayNode)
+        self._display_node = displayNode
+        if displayNode is not None:
+            self._attach_observer(displayNode)
+        self._after_display_node_set()
+
+    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        try:
+            self._renderer = renderer
+            if renderer is not None:
+                self._add_actors(renderer)
+            if self._display_node is None:
+                display = self.GetDisplayNode()
+                if display is not None:
+                    self.SetDisplayNode(display)
+            # Re-attach the slice-node observer too: cleanup() detached it
+            # with the rest, and the view node is not re-set after churn --
+            # without this, reslicing stops reprojecting (the stale-trace bug,
+            # round two).
+            if self._slice_node is not None:
+                self._attach_observer(self._slice_node)
+            self.UpdatePipeline()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        try:
+            if renderer is not None:
+                self._remove_actors(renderer)
+            self._renderer = None
+            self.cleanup()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _add_actors(self, renderer: Any) -> None:
+        """Add the base + client actors to ``renderer`` (client extends)."""
+        renderer.AddActor2D(self._handles_actor)
+        renderer.AddActor2D(self._ring_actor)
+
+    def _remove_actors(self, renderer: Any) -> None:
+        """Remove the base + client actors from ``renderer`` (client extends)."""
+        renderer.RemoveActor2D(self._handles_actor)
+        renderer.RemoveActor2D(self._ring_actor)
+
+    def cleanup(self) -> None:
+        for node in list(self._observed_node_refs):
+            self._detach_observer(node)
+        self._display_node = None
+        self._drag_key = None
+        self._handles_actor.SetVisibility(False)
+        self._ring_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # Reconcile
+    # ------------------------------------------------------------------ #
+
+    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        try:
+            self._reconcile()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _reconcile(self) -> None:
+        """``UpdatePipeline``'s body -- plain attribute access throughout.
+
+        The base body is deliberately thin: the client owns the gate + the
+        change-key memo (its data model decides what a repaint depends on),
+        so it overrides ``_reconcile`` and calls ``_reproject`` when its gate
+        admits.  This base default reprojects unconditionally -- the flat
+        clients (territories, volumetry) have no state gate.
+        """
+        visible = self._reproject()
+        self._handles_actor.SetVisibility(bool(visible))
+        if not visible:
+            self._ring_actor.SetVisibility(False)
+
+    def _reproject(self) -> bool:
+        """Project the provider's points into XY with distance fading.
+
+        Owns the generic handle projection + fade + side tint + presence
+        cutoff + hover/grab highlight + ring (ADR-0038 §Context).  After the
+        per-point handle loop it calls the ``_reproject_edges`` hook so a
+        client with edges (resection's dashed scaffold) draws them from the
+        base's per-point bookkeeping WITHOUT the base knowing the topology.
+        """
+        self._projected_keys = []
+        self._projected_xy = []
+        self._plane_distances = []
+        provider = self._provider
+        slice_node = self._slice_node
+        if provider is None or slice_node is None:
+            return False
+
+        frame = _proj.slice_frame(slice_node)
+        ras_to_xy = _proj.inverse_xy_to_ras(slice_node)
+        if frame is None or ras_to_xy is None:
+            return False
+        origin, normal = frame
+
+        hovered, grabbed = self._interaction_state()
+        hover_rgb = [int(c * 255) for c in HALO_HOVER_COLOR]
+        grab_rgb = [int(c * 255) for c in HALO_GRAB_COLOR]
+
+        # Full parallel arrays over EVERY provider point (present or not), so
+        # the edge hook can gate a run on either endpoint's presence.
+        all_xy: list = []
+        all_present: list = []
+        edge_rgba = vtk.vtkUnsignedCharArray()
+        edge_rgba.SetNumberOfComponents(4)
+
+        edge_base = self._edge_base_rgb()
+
+        # Present handles only carry into the rendered polydata (presence IS
+        # the cutoff: a point beyond the range is ABSENT, not faded to zero).
+        handle_points = vtk.vtkPoints()
+        handle_rgba = vtk.vtkUnsignedCharArray()
+        handle_rgba.SetNumberOfComponents(4)
+
+        try:
+            for key, (world, base_rgb) in enumerate(provider.iter_points()):
+                xy = _proj.apply_matrix_xy(ras_to_xy, world)
+                signed = _proj.signed_distance(origin, normal, world)
+                present = _proj.is_present(signed)
+                all_xy.append(xy)
+                all_present.append(present)
+
+                alpha = int(_proj.fade_alpha(signed) * 255)
+                if key == grabbed:
+                    hue4 = (grab_rgb[0], grab_rgb[1], grab_rgb[2], 255)
+                elif key == hovered:
+                    hue4 = (hover_rgb[0], hover_rgb[1], hover_rgb[2], 255)
+                else:
+                    handle_mid = [int(c * 255 * HANDLE_MIDTONE_FACTOR) for c in base_rgb]
+                    tint = _proj.side_tint(handle_mid, signed)
+                    hue4 = (tint[0], tint[1], tint[2], alpha)
+
+                if edge_base is not None:
+                    etint = _proj.side_tint(edge_base, signed)
+                    edge_rgba.InsertNextTuple4(etint[0], etint[1], etint[2], alpha)
+
+                if present:
+                    handle_points.InsertNextPoint(xy[0], xy[1], 0.0)
+                    handle_rgba.InsertNextTuple4(*hue4)
+                    self._projected_keys.append(key)
+                    self._projected_xy.append((xy[0], xy[1]))
+                    self._plane_distances.append(abs(signed))
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+        self._handles_polydata.SetPoints(handle_points)
+        self._handles_polydata.GetPointData().SetScalars(handle_rgba)
+        self._handles_polydata.Modified()
+
+        self._reproject_edges(all_xy, all_present, edge_rgba)
+        self._update_ring(hovered, grabbed)
+        return True
+
+    def _update_ring(self, hovered: Any, grabbed: Any) -> None:
+        """Show the hover/grab ring on the grabbed (green) or hovered (yellow)
+        handle -- only when that point is PRESENT in this slice.
+
+        The highlight must not surface a point the plane cannot reach (a
+        grab raised in the 3D view over an out-of-range handle), so the ring
+        rides the PRESENT projection, not the raw channel index.
+        """
+        target = grabbed if _index_ok(grabbed) else hovered
+        pts = vtk.vtkPoints()
+        show = False
+        if _index_ok(target) and target in self._projected_keys:
+            idx = self._projected_keys.index(target)
+            px, py = self._projected_xy[idx]
+            pts.InsertNextPoint(px, py, 0.0)
+            colour = HALO_GRAB_COLOR if _index_ok(grabbed) else HALO_HOVER_COLOR
+            self._ring_actor.GetProperty().SetColor(*colour)
+            show = True
+        self._ring_polydata.SetPoints(pts)
+        self._ring_polydata.Modified()
+        self._ring_actor.SetVisibility(show)
+
+    # ------------------------------------------------------------------ #
+    # Interaction -- the slice-side grab / drag (ADR-0033)
+    # ------------------------------------------------------------------ #
+
+    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
+        """Return ``(canProcess, distance2)`` for the LayerDM focus logic.
+
+        * a grabbed move/release is claimed unconditionally;
+        * a bare move is DECLINED (``(False, +inf)``) so the camera is
+          untouched (ADR-0033); the hover cue is published as a SIDE EFFECT
+          of the declined bare move via ``_on_bare_move_decline``;
+        * a press within ``POINT_PICK_RADIUS_PX`` of a projected handle is
+          claimed with the REAL squared display distance (grab for a drag).
+
+        The ``_slice_admissible`` gate hook (default ``True``) lets a client
+        veto the whole arbitration on its own data-model state -- resection's
+        Planning gate rides here, NOT as a branch in this base.
+        """
+        try:
+            if not self._slice_admissible():
+                self._drag_key = None  # a state flip mid-gesture drops the grab
+                return False, sys.float_info.max
+            etype = _event_type(eventData)
+
+            if self._drag_key is not None:
+                if etype in (
+                    vtk.vtkCommand.MouseMoveEvent,
+                    vtk.vtkCommand.LeftButtonReleaseEvent,
+                ):
+                    return True, 0.0
+                return False, sys.float_info.max
+
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                # Bare hover: publish the cross-view highlight and DECLINE.
+                self._on_bare_move_decline(eventData)
+                return False, sys.float_info.max
+
+            if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                return False, sys.float_info.max
+
+            key, distance2 = self._nearest_handle_in_display(eventData)
+            if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
+                return True, distance2
+            return False, sys.float_info.max
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False, sys.float_info.max
+
+    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
+        """Drive the slice-side grab-to-edit-nearest (ADR-0038 §Decision).
+
+        The generic press-grab / move / release skeleton is here; each phase
+        calls a client hook (``_on_grab`` / ``_move_grabbed_to`` /
+        ``_on_release``) so the client contributes its data-model side effects
+        -- the offset-preserving in-plane move, the grab colour, the ring --
+        WITHOUT re-implementing the arbitration (ADR-0038 §"What is not
+        shared").
+        """
+        try:
+            if not self._slice_admissible():
+                self._drag_key = None
+                return False
+            etype = _event_type(eventData)
+
+            if self._drag_key is None:
+                if etype != vtk.vtkCommand.LeftButtonPressEvent:
+                    return False
+                key, distance2 = self._nearest_handle_in_display(eventData)
+                if (
+                    key is None
+                    or distance2 > POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
+                ):
+                    return False
+                self._drag_key = key  # grab for a drag (edit gesture)
+                self._on_grab(key)
+                return True
+
+            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
+                self._drag_key = None
+                self._on_release()
+                return False  # gesture over -- release the focus
+
+            if etype == vtk.vtkCommand.MouseMoveEvent:
+                self._move_grabbed_to(eventData)
+                return True
+            return False
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return False
+
+    def _nearest_handle_in_display(self, eventData: Any):
+        """``(key, distance2)`` of the PROJECTED handle nearest the event pixel.
+
+        Slice-view display coordinates coincide with the XY space the
+        projection lives in (the slice renderer's convention), so the
+        arbitration compares the event pixel against ``_projected_xy``.  A
+        handle beyond the presence cutoff is not projected, so it is
+        inherently unpickable (markups short-range manipulation).
+        """
+        try:
+            ex, ey = eventData.GetDisplayPosition()
+        except Exception:  # pragma: no cover - defensive (fake events)
+            return None, sys.float_info.max
+        best_key = None
+        best_d2 = sys.float_info.max
+        for key, (px, py) in zip(self._projected_keys, self._projected_xy):
+            d2 = (px - ex) ** 2 + (py - ey) ** 2
+            if d2 < best_d2:
+                best_d2 = d2
+                best_key = key
+        return best_key, best_d2
+
+    # ------------------------------------------------------------------ #
+    # Client extension hooks (no data-model knowledge in the base;
+    # ADR-0038 §"What is not shared").  All no-ops / permissive by default.
+    # ------------------------------------------------------------------ #
+
+    def _slice_admissible(self) -> bool:
+        """Veto hook for a client's own gate (default: always admit).
+
+        A client whose data model gates interaction (resection's Planning
+        gate, ADR-0019) overrides this; the base carries no such gate.
+        """
+        return True
+
+    def _before_display_node_change(self) -> None:
+        """Called before the display node is swapped (default no-op)."""
+
+    def _after_display_node_set(self) -> None:
+        """Called after a new display node is attached (default no-op)."""
+
+    def _interaction_state(self) -> tuple:
+        """``(hovered, grabbed)`` for the projection highlight (default none).
+
+        A client backing a cross-view highlight channel (the display node's
+        Hovered/Grabbed control point) overrides this to feed the projection
+        the same highlight every view shows.
+        """
+        return -1, -1
+
+    def _edge_base_rgb(self):
+        """The edge base colour (0..255) for the dashed scaffold, or ``None``.
+
+        ``None`` (the default) means the client draws no edges -- the flat
+        territory/volumetry point sets.  A client with a connected polygon
+        (resection's control grid) returns the edge colour so the base
+        computes the per-point side-tinted edge RGBA it feeds the edge hook.
+        """
+        return None
+
+    def _reproject_edges(self, all_xy: list, all_present: list, edge_rgba: Any) -> None:
+        """Draw the connecting edges from the base's per-point bookkeeping.
+
+        Default no-op (the flat clients have no edges).  ``all_xy`` /
+        ``all_present`` are the FULL parallel arrays over every provider
+        point (present or not) so a client can gate an edge run on either
+        endpoint's presence; ``edge_rgba`` holds the base's per-point
+        side-tinted edge colours (empty when ``_edge_base_rgb`` is ``None``).
+        """
+
+    def _on_grab(self, key: Any) -> None:
+        """Called right after the base grabs ``key`` on a press (default no-op)."""
+
+    def _on_release(self) -> None:
+        """Called right after the base clears the grab on release (default no-op)."""
+
+    def _on_bare_move_decline(self, eventData: Any) -> None:
+        """Called on a DECLINED bare move (default no-op -- the hover cue seam)."""
+
+    def _move_grabbed_to(self, eventData: Any) -> None:
+        """Relocate the grabbed handle to the cursor (default no-op).
+
+        A client overrides this with its data-model write-back: resection
+        moves the control point IN-PLANE preserving its out-of-plane offset
+        (no snap-to-plane); a surface client snaps along the slice normal.
+        """
+
+    # ------------------------------------------------------------------ #
+    # Introspection
+    # ------------------------------------------------------------------ #
+
+    def GetHandlesPolyData(self) -> Any:  # noqa: N802 - VTK verb
+        return self._handles_polydata
+
+    def GetHandlesActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._handles_actor
+
+    def GetRingActor(self) -> Any:  # noqa: N802 - VTK verb
+        return self._ring_actor
+
+    # ------------------------------------------------------------------ #
+    # Observers
+    # ------------------------------------------------------------------ #
+
+    def _attach_observer(self, node: Any) -> None:
+        if node is None or not hasattr(node, "AddObserver"):
+            return
+        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
+        self._observer_tags.setdefault(id(node), []).append(tag)
+        if node not in self._observed_node_refs:
+            self._observed_node_refs.append(node)
+
+    def _detach_observer(self, node: Any) -> None:
+        if node is None:
+            return
+        for tag in self._observer_tags.pop(id(node), []):
+            try:
+                node.RemoveObserver(tag)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        try:
+            self._observed_node_refs.remove(node)
+        except ValueError:
+            pass
+
+    def _on_node_modified(self, caller: Any, event: str) -> None:
+        """Reconcile on a carrier / slice ``Modified`` -- reproject + render.
+
+        The base holds no shadow copy of the point set: the provider IS the
+        source of truth, so a reconcile driven by an unrelated ``Modified``
+        reprojects without adding / moving / dropping any point.  The client
+        overrides this to add its render-request loop guard.
+        """
+        del caller, event
+        try:
+            self.UpdatePipeline()
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+
+def _index_ok(value: Any) -> bool:
+    """True iff ``value`` is a usable (non-negative) highlight index."""
+    return isinstance(value, int) and value >= 0

--- a/SlicerLiverInteractionLib/Testing/Python/test_layerdm_base_invariants.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_layerdm_base_invariants.py
@@ -54,7 +54,7 @@ import pytest
 
 vtk = pytest.importorskip("vtk")
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
 if str(PY_DIR) not in sys.path:
     sys.path.insert(0, str(PY_DIR))

--- a/SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_3d.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_3d.py
@@ -69,7 +69,7 @@ import pytest
 
 vtk = pytest.importorskip("vtk")
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
 if str(PY_DIR) not in sys.path:
     sys.path.insert(0, str(PY_DIR))

--- a/SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_slice.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_point_placement_pipeline_slice.py
@@ -53,7 +53,7 @@ import pytest
 
 vtk = pytest.importorskip("vtk")
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
 if str(PY_DIR) not in sys.path:
     sys.path.insert(0, str(PY_DIR))

--- a/SlicerLiverInteractionLib/__init__.py
+++ b/SlicerLiverInteractionLib/__init__.py
@@ -7,24 +7,36 @@ each module's LayerDM Pipeline creator instantiates; it hosts NO
 displayable manager (ADR-0013 §5) and carries no data-model knowledge.
 The ``Liver`` prefix is dropped on every class here (T2.7 convention).
 
-Currently landed (ADR-0038 extraction, first slice):
+Currently landed (ADR-0038 extraction):
 
 * ``SurfacePick`` -- the pure-VTK ray->closed-surface intersect-nearest +
   closest-point fallback with a lazy MTime-invalidated ``vtkCellLocator``.
 * ``PointPlacementState`` -- the arm/active/module-active/carrier accessors
   on a display node, with the attribute-key namespace parameterized per
   consumer.
+* ``SlicePointProjection`` -- the pure-math slice-view projection / fade /
+  side-tint / presence-cutoff (the slice base's geometry half).
+* ``PointProvider`` / ``PickProvider`` -- the seam protocols the consumer
+  supplies (data model + swappable click->world pick).
 
-The Pipeline base classes + the ``PointProvider`` seam land in a later
-slice of the extraction.
+The Pipeline base classes (``SurfacePointPlacementPipeline3D`` /
+``SurfacePointPlacementPipelineSlice``) import LayerDMLib and so are NOT
+eagerly imported here (LayerDMLib is reachable only inside a launched
+Slicer); a consumer imports them by module path, mirroring how the
+resection / territory pipelines import ``LayerDMLib`` directly.
 """
 
 from __future__ import annotations
 
 from .SurfacePick import SurfacePick
 from .PointPlacementState import PointPlacementState
+from . import SlicePointProjection
+from .PointProvider import PointProvider, PickProvider
 
 __all__ = [
     "SurfacePick",
     "PointPlacementState",
+    "SlicePointProjection",
+    "PointProvider",
+    "PickProvider",
 ]

--- a/Testing/Python/unit/test_resection_control_polygon_provider.py
+++ b/Testing/Python/unit/test_resection_control_polygon_provider.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Seam pins for ``ResectionControlPolygonProvider`` (ADR-0038 §Decision).
+
+Resection is the extraction-source client of the shared
+``SurfacePointPlacementPipeline3D`` base; this adapter is the resection
+side of the ``PointProvider`` seam over the Bezier control grid.  These
+pins fix the RESECTION-specific data-model behaviour the base reads/writes
+(ADR-0038 §"What is not shared"):
+
+* ``iter_points`` fans the flat ``Rows x Cols`` grid out in row-major order
+  (so the base's ``enumerate`` key IS the flat grid index) with the display
+  node's per-handle colour;
+* ``has_edges()`` is True (the grid is a connected polygon -- resection,
+  not the flat territory/volumetry sets);
+* ``move_point`` writes ``SetControlPoint`` ONLY in ``Planning`` (ADR-0019
+  read-only-after-commit) and refuses in Init / Confirmed;
+* ``add_point`` / ``delete_point`` are no-ops -- the control grid is fixed
+  (no add-on-click, no per-handle delete).
+
+Pure Python over a carrier stub -- runs in the bare-VTK unit layer (no
+Slicer, no wrapped MRML), so it is the one piece of this refactor that is
+GREEN under bare ``PythonSlicer -m pytest``; the pipeline's own
+characterization suites need LayerDMLib and are launched-only.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "LiverResections" / "LiverResectionsLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+import ResectionControlPolygonProvider as mod  # noqa: E402 - after path insert
+
+STATE_INIT = 0
+STATE_PLANNING = 1
+STATE_CONFIRMED = 2
+
+
+class _StubCarrier:
+    """vtkMRMLBezierSurfaceNode-shaped stub: a flat row-major control grid."""
+
+    def __init__(self, rows=4, cols=4, state=STATE_PLANNING):
+        self._rows = rows
+        self._cols = cols
+        self._state = state
+        # A distinct lattice so nearest / ordering is unambiguous.
+        self._grid = []
+        for r in range(rows):
+            for c in range(cols):
+                self._grid += [float(c) * 10.0, float(r) * 10.0, 5.0]
+
+    def GetRows(self):  # noqa: N802 - VTK verb
+        return self._rows
+
+    def GetCols(self):  # noqa: N802 - VTK verb
+        return self._cols
+
+    def GetControlGridVector(self):  # noqa: N802 - VTK verb
+        return list(self._grid)
+
+    def GetState(self):  # noqa: N802 - VTK verb
+        return self._state
+
+    def SetState(self, state):  # noqa: N802 - VTK verb
+        self._state = int(state)
+
+    def SetControlPoint(self, row, col, x, y, z):  # noqa: N802 - VTK verb
+        base = (row * self._cols + col) * 3
+        self._grid[base] = float(x)
+        self._grid[base + 1] = float(y)
+        self._grid[base + 2] = float(z)
+
+
+def _provider(carrier, color_getter=None):
+    return mod.ResectionControlPolygonProvider(
+        carrier_getter=lambda: carrier, color_getter=color_getter
+    )
+
+
+def test_iter_points_is_row_major_with_colour():
+    """The base's enumerate key is the flat row-major grid index."""
+    carrier = _StubCarrier()
+    provider = _provider(carrier, color_getter=lambda: (0.1, 0.2, 0.3))
+
+    points = list(provider.iter_points())
+    assert len(points) == 16, "a 4x4 grid must fan out to 16 points"
+
+    world5, rgb5 = points[5]  # row 1, col 1 on the seeded lattice
+    assert world5 == pytest.approx((10.0, 10.0, 5.0)), (
+        "point 5 must be the row-major (1, 1) control point"
+    )
+    assert rgb5 == pytest.approx((0.1, 0.2, 0.3)), (
+        "the per-point base colour must be the display node's HandleColor"
+    )
+
+
+def test_iter_points_falls_back_to_neutral_colour():
+    """No colour getter -> the neutral white base handle colour."""
+    carrier = _StubCarrier()
+    provider = _provider(carrier)
+    _world, rgb = next(iter(provider.iter_points()))
+    assert rgb == pytest.approx(mod.DEFAULT_HANDLE_RGB)
+
+
+def test_has_edges_is_true():
+    """Resection's grid IS a connected polygon (ADR-0038 §Context)."""
+    assert _provider(_StubCarrier()).has_edges() is True
+
+
+def test_move_point_writes_the_grid_in_planning():
+    """A drag write relocates exactly the keyed control point in Planning."""
+    carrier = _StubCarrier(state=STATE_PLANNING)
+    provider = _provider(carrier)
+
+    provider.move_point(5, (1.0, 2.0, 3.0))
+
+    grid = carrier.GetControlGridVector()
+    assert (grid[15], grid[16], grid[17]) == pytest.approx((1.0, 2.0, 3.0)), (
+        "point 5 (flat index) must move to the world point"
+    )
+    assert (grid[0], grid[1], grid[2]) == pytest.approx((0.0, 0.0, 5.0)), (
+        "no other point may move"
+    )
+
+
+@pytest.mark.parametrize("state", [STATE_INIT, STATE_CONFIRMED])
+def test_move_point_refuses_outside_planning(state):
+    """ADR-0019 read-only: a move outside Planning writes nothing."""
+    carrier = _StubCarrier(state=state)
+    provider = _provider(carrier)
+    before = carrier.GetControlGridVector()
+
+    provider.move_point(5, (99.0, 99.0, 99.0))
+
+    assert carrier.GetControlGridVector() == before, (
+        f"a move in state {state} must be a no-op (ADR-0019)"
+    )
+
+
+def test_add_and_delete_are_no_ops():
+    """The control grid is FIXED -- no add-on-click, no per-handle delete."""
+    carrier = _StubCarrier(state=STATE_PLANNING)
+    provider = _provider(carrier)
+    before = carrier.GetControlGridVector()
+
+    assert provider.add_point((1.0, 2.0, 3.0)) is None
+    assert provider.delete_point(5) is False
+    assert carrier.GetControlGridVector() == before, (
+        "add / delete must not mutate the fixed grid"
+    )
+
+
+def test_absent_carrier_is_a_clean_no_op():
+    """A null carrier (late binding) yields nothing and writes nothing."""
+    provider = mod.ResectionControlPolygonProvider(carrier_getter=lambda: None)
+    assert list(provider.iter_points()) == []
+    provider.move_point(0, (1.0, 1.0, 1.0))  # must not raise
+    assert provider.add_point((1.0, 1.0, 1.0)) is None
+    assert provider.delete_point(0) is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
+++ b/VascularTerritories/VascularTerritoriesLib/CMakeLists.txt
@@ -29,6 +29,7 @@ set(VascularTerritoriesLib_PYTHON_SCRIPTS
   SeedStructureMapping.py
   VesselHighlightPipeline.py
   TerritoryInteractionState.py
+  TerritoryPointProvider.py
   TerritoryPlacementPipeline.py
   TerritorySliceProjection.py
   TerritorySlicePipeline.py

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
@@ -38,8 +38,11 @@ except ImportError:  # bare unit layer: add the sibling Lib dir to sys.path
     from PointPlacementState import PointPlacementState  # type: ignore[no-redef]
 
 #: The territory namespace reproduces the original attribute keys exactly.
+#: The base's active-key suffix now defaults to the neutral ``Active``; the
+#: territory keeps its historical ``ActiveTerritory`` suffix via the param so
+#: its runtime keys are byte-for-byte unchanged.
 _NAMESPACE = "VascularTerritories"
-_STATE = PointPlacementState(_NAMESPACE)
+_STATE = PointPlacementState(_NAMESPACE, active_suffix="ActiveTerritory")
 
 #: Display-node attribute keys / reference role (kept for back-compat).
 ARMED_ATTR = f"{_NAMESPACE}.Armed"

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
-"""LayerDM Pipeline for vessel-annotation placement + edit (ADR-0037).
+"""LayerDM Pipeline for vessel-annotation placement + edit (ADR-0037/0038).
 
 ADR-0037 §Decision 2 routes vessel-annotation placement and edit through
 the LayerDM scripted Pipeline's interaction seam (ADR-0032 / ADR-0033),
@@ -18,15 +18,26 @@ add-on-click / drag-to-edit / delete-from-table is the whole lifecycle:
 * DELETE removes EXACTLY ONE point;
 * an unrelated ``Modified`` causes no drift.
 
-The point storage lives on ``vtkMRMLCustomTerritoriesNode`` (the carrier
-pinned by ``test_territories_annotation_carrier.py``); this Pipeline
-WRITES to it via the interaction seam, mirroring ``ControlPolygonPipeline``
-/ ``LiverBezierSurfacePipeline`` (the resection interaction seams).
+ADR-0038 §Decision makes this a thin CLIENT of the shared
+``SurfacePointPlacementPipeline3D`` base: the base DRIVES the generic
+add-on-click / drag-to-edit-nearest / delete / bare-move-decline
+arbitration (``Can/ProcessInteractionEvent``), and this client contributes
+ONLY the territory-SPECIFIC concerns through the base's extension hooks
+(ADR-0038 §"What is not shared"):
 
-The pick geometry itself is pure-VTK and covered bare by
-``test_vessel_surface_pick.py``; here the invariants are the arbitration
-(claim click / claim grabbed drag / decline bare move), the exactly-one
-mutation per gesture, and the nearest-point edit selection.
+* per-territory grouping + active-territory routing (the ``add_point`` fan
+  into the active territory, on ``TerritoryPointProvider`` + this pipeline);
+* vessel-visibility gating -- a hidden vessel surface is not pickable and a
+  hidden seed is neither grabbable nor drawn -- via ``_ensure_pick`` over
+  the visibility-filtered ``vascular_surface_polydata`` and the
+  ``VisibleStructuresCache``-backed ``seed_visible`` filter in the hit-test
+  and the seed-glyph rebuild;
+* the vessel hover-adhering marker, the glow halo, the slice-jump, and the
+  per-segment seed show/hide -- none of which bleed into the base.
+
+The point storage lives on ``vtkMRMLCustomTerritoriesNode`` (the carrier
+pinned by ``test_territories_annotation_carrier.py``); this Pipeline WRITES
+to it via the provider seam.
 """
 
 from __future__ import annotations
@@ -36,7 +47,26 @@ from typing import Any
 
 import vtk
 
-from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+# The shared 3D placement/edit base (ADR-0038 §Decision): territories is the
+# flat, vessel-gated client of ``SurfacePointPlacementPipeline3D`` over the
+# PointProvider + swappable-pick seam.  The base drives the generic
+# add/grab/drag/release arbitration; this pipeline keeps the per-territory
+# grouping, the vessel-visibility gating, and the hover/marker/halo cues as
+# overrides (ADR-0038 §"What is not shared").
+try:  # pragma: no cover - exercised once per import path
+    from SlicerLiverInteractionLib.SurfacePointPlacementPipeline3D import (
+        SurfacePointPlacementPipeline3D as _PipelineBase,
+    )
+except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.path
+    import pathlib
+    import sys as _sys
+
+    _shared_lib = pathlib.Path(__file__).resolve().parents[2] / "SlicerLiverInteractionLib"
+    if str(_shared_lib) not in _sys.path:
+        _sys.path.insert(0, str(_shared_lib))
+    from SurfacePointPlacementPipeline3D import (  # type: ignore[no-redef]
+        SurfacePointPlacementPipeline3D as _PipelineBase,
+    )
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
@@ -45,6 +75,7 @@ try:  # pragma: no cover - exercised once per import path
         visibility_mtime as _visibility_mtime,
         VisibleStructuresCache as _VisibleStructuresCache,
     )
+    from .TerritoryPointProvider import TerritoryPointProvider
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
     from VesselHighlightWiring import (  # type: ignore[no-redef]
@@ -52,11 +83,14 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
         visibility_mtime as _visibility_mtime,
         VisibleStructuresCache as _VisibleStructuresCache,
     )
+    from TerritoryPointProvider import (  # type: ignore[no-redef]
+        TerritoryPointProvider,
+    )
 
 #: Display-space pick radius for grabbing an existing point, in pixels
-#: (mirrors ``ControlPolygonPipeline.CONTROL_POINT_PICK_RADIUS_PX``).  A
-#: press within this radius of a placed point grabs it for a drag; a press
-#: outside it (but over the surface) adds a new point.
+#: (mirrors the base's ``POINT_PICK_RADIUS_PX``).  A press within this radius
+#: of a placed point grabs it for a drag; a press outside it (but over the
+#: surface) adds a new point.
 POINT_PICK_RADIUS_PX = 20.0
 
 #: Hover/grab cue colours + halo scale, shared with the resection surface
@@ -89,14 +123,16 @@ class TerritoryPlacementPipeline(_PipelineBase):
     ``registerTerritoryPlacementPipelineCreator()``; keyed on
     ``vtkMRMLTerritoriesHighlightDisplayNode`` (the annotation-interaction
     display node), reusing the adhering highlight's pick core.
+
+    A thin client of ``SurfacePointPlacementPipeline3D``: the base drives the
+    arbitration, this class supplies the territory data model + vessel gating.
     """
 
     def __init__(self) -> None:
-        super().__init__()
-        self.SetPythonObject(self)
+        # The base seeds ``_display_node`` / ``_renderer`` / ``_drag_key`` /
+        # ``_provider`` / ``_pick_provider`` and calls ``SetPythonObject``.
+        super().__init__(namespace="TerritoryPlacement")
 
-        self._display_node: Any | None = None
-        self._renderer: Any | None = None
         self._observer_tags: dict = {}
         self._observed_node_refs: list = []
 
@@ -104,26 +140,35 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._carrier: Any | None = None
         self._territory_id: str | None = None
 
+        # Wire the ADR-0038 seams:
+        #  * the data model -- the base reads/writes the carrier points via
+        #    this provider (flat, no edges -- territory seeds are unordered);
+        #  * the click->world pick -- delegated to ``_event_world_on_surface``
+        #    so the base's add-on-click routes through the vessel-visibility-
+        #    gated surface snap (and the unit layer's monkeypatch), NOT a
+        #    surface-vs-volume branch in the base (ADR-0038 §"Base extension").
+        self.SetProvider(
+            TerritoryPointProvider(
+                carrier_getter=self._get_carrier,
+                territory_getter=self._placement_territory,
+                # Re-read through the pipeline so a unit-layer monkeypatch of
+                # ``_seed_visible`` is honoured and the vessel-visibility gate
+                # stays a single source of truth (the hit-test + seed rebuild
+                # consult the same method).
+                visible_getter=lambda point: self._seed_visible(point),
+            )
+        )
+        self.SetPickProvider(_TerritorySurfacePick(self))
+
         # Stage-2 arming (ADR-0037 §Decision 3).  An armed click appends one
         # seed to the ACTIVE territory; a disarmed click adds nothing.  In
         # production the arm state + active territory + carrier all live on the
         # shared highlight DISPLAY NODE (read by ``GetActiveTerritory`` /
         # ``IsArmed`` / ``_get_carrier``) so the widget/table reach the
-        # manager-driven Pipeline; these instance fields are the BARE-unit
-        # fallback (no display node).  It is still pipeline-managed, not a
-        # Slicer interaction node / mouse mode.
+        # manager-driven Pipeline; the base's instance fields are the
+        # BARE-unit fallback (no display node).  It is still pipeline-managed,
+        # not a Slicer interaction node / mouse mode.
         self._active_territory: str | None = None
-        self._armed: bool = False
-
-        # Module-active gate (ADR-0037 slice-5 concern #1): a belt-and-
-        # suspenders decline BEYOND the armed flag -- an add-on-click places
-        # nothing while the owning module has EXPLICITLY closed the gate (its
-        # ``exit()``).  Rides the shared display node in production (read by
-        # ``IsModuleActive``); this instance field is the BARE-unit fallback
-        # (no display node).  Defaults OPEN -- the decline is opt-in, matching
-        # the display-node "unset reads active" rule -- so a Pipeline created
-        # before any ``enter()`` still lands a gesture.
-        self._module_active: bool = True
 
         # Injectable pick core (bare unit layer feeds a known surface); in
         # production ``_ensure_pick`` builds it from the display node's
@@ -140,10 +185,6 @@ class TerritoryPlacementPipeline(_PipelineBase):
         # re-running the closed-surface split per event (kept cheap, mirroring
         # ``_ensure_pick``).
         self._structures = _VisibleStructuresCache()
-
-        # (territory id, in-territory index) of the point currently GRABBED
-        # by a press/move/release drag -- None when no drag is in flight.
-        self._drag_target: tuple[str, int] | None = None
 
         # Carrier currently observed for the seed-glyph rebuild (production
         # resolves it from the display node, so the bare ``SetCarrier`` bind is
@@ -225,6 +266,21 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._halo_actor.SetVisibility(False)
 
     # ------------------------------------------------------------------ #
+    # Grab bookkeeping -- the base's ``_drag_key`` IS the grabbed
+    # ``(territoryId, index)`` (the key ``_nearest_key_in_display`` returns);
+    # the rendering reads it through this alias so there is one source of
+    # truth (the base's field), not a shadow copy.
+    # ------------------------------------------------------------------ #
+
+    @property
+    def _drag_target(self) -> tuple[str, int] | None:
+        return self._drag_key
+
+    @_drag_target.setter
+    def _drag_target(self, value: tuple[str, int] | None) -> None:
+        self._drag_key = value
+
+    # ------------------------------------------------------------------ #
     # Wiring seams (unit + production)
     # ------------------------------------------------------------------ #
 
@@ -277,6 +333,17 @@ class TerritoryPlacementPipeline(_PipelineBase):
         """
         return self._structures.resolve(self._display_node)
 
+    def _seed_visible(self, point: Any) -> bool:
+        """True iff ``point``'s nearest vessel structure is visible.
+
+        The vessel-visibility gate (ADR-0037 slice 5) the provider's
+        ``iter_points`` and this pipeline's hit-test + seed-glyph rebuild all
+        consult, so a hidden vessel's seeds are neither drawn nor grabbable.
+        This is the REAL #569 seed-visibility notion (vessel SEGMENT
+        visibility via ``VisibleStructuresCache``), NOT a territory-row toggle.
+        """
+        return self._structures.seed_visible(self._display_node, point)
+
     def SetCarrier(self, carrier: Any, territoryId: str) -> None:  # noqa: N802 - VTK verb
         """Bind the ``vtkMRMLCustomTerritoriesNode`` carrier + active territory.
 
@@ -312,6 +379,12 @@ class TerritoryPlacementPipeline(_PipelineBase):
 
     # ------------------------------------------------------------------ #
     # Active-territory + arm seam (Stage 2, ADR-0037 §Decision 3)
+    #
+    # These OVERRIDE the base's ``PointPlacementState``-backed arm gate: the
+    # territory client rides the shared highlight display node via
+    # ``TerritoryInteractionState`` (which also carries the active territory +
+    # the carrier reference), so the widget/table reach the manager-driven
+    # Pipeline through the display node all three hold (ADR-0037 §Decision 3).
     # ------------------------------------------------------------------ #
 
     def SetActiveTerritory(self, territoryId: str | None) -> None:  # noqa: N802 - VTK verb
@@ -364,9 +437,6 @@ class TerritoryPlacementPipeline(_PipelineBase):
         if active is not None:
             return active
         return self._territory_id
-
-    def _safe_get_renderer(self) -> Any | None:
-        return self._renderer
 
     # ------------------------------------------------------------------ #
     # LayerDM lifecycle
@@ -463,7 +533,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._carrier = None
         self._observed_carrier = None
         self._observed_pick_display = None
-        self._drag_target = None
+        self._drag_key = None  # the base's grab bookkeeping
         self._hover_target = None
         self._halo_actor.SetVisibility(False)
 
@@ -555,208 +625,108 @@ class TerritoryPlacementPipeline(_PipelineBase):
             self._jump_slices_to_world(point)
 
     # ------------------------------------------------------------------ #
-    # Interaction — placement / edit (ADR-0032 / ADR-0033)
+    # Interaction -- client extension hooks (ADR-0038 §"What is not shared")
+    #
+    # The generic add-on-click / drag-to-edit-nearest / delete / bare-move-
+    # decline arbitration is the base's; this pipeline contributes only the
+    # TERRITORY-specific parts through the base's hooks: the vessel-gated grab
+    # hit-test (``_nearest_key_in_display``), the surface-snap drag target
+    # (``_event_world``), the per-territory grouping click (``_add_point`` +
+    # the provider), the bare-move hover/adhering cue
+    # (``_on_bare_move_decline``), and the grab/drag/release halo + seed
+    # recolour (``_on_grab`` / ``_on_drag`` / ``_on_release``).
+    # ``Can/ProcessInteractionEvent`` themselves are NOT overridden -- the base
+    # drives them.
     # ------------------------------------------------------------------ #
 
-    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
-        """Return ``(canProcess, distance2)`` for the LayerDM focus logic.
+    def _nearest_key_in_display(self, renderer: Any, eventData: Any):
+        """Repack the territory hit-test into the base's ``(key, distance2)``.
 
-        * A LEFT-BUTTON PRESS within ``POINT_PICK_RADIUS_PX`` of an existing
-          point is claimed with the REAL squared display distance (grab a
-          point for a drag).
-        * A LEFT-BUTTON PRESS over the surface but away from any point is
-          claimed (add-on-click); its arbitration value is the pick radius
-          squared so a nearer grabbable interaction still wins.
-        * While a point is GRABBED, moves and the release are claimed
-          unconditionally (the grab owns the gesture).
-        * A BARE MOVE is DECLINED (``(False, +inf)``) so the camera is
-          untouched (ADR-0033); it only raises the adhering highlight as a
-          side effect.
+        The base's grab seam expects a 2-tuple whose ``key`` round-trips through
+        the provider's ``move_point`` / ``delete_point``.  The territory key is
+        a ``(territoryId, index)`` PAIR, so this override consults the vessel-
+        gated ``_nearest_point_in_display`` (which stays a 3-tuple the unit
+        layer monkeypatches) and repacks it -- without touching the base's
+        arbitration bodies (ADR-0038 §"What is not shared").
         """
-        try:
-            renderer = self._safe_get_renderer()
-            if renderer is None:
-                return False, sys.float_info.max
-            etype = _event_type(eventData)
+        territory, index, distance2 = self._nearest_point_in_display(renderer, eventData)
+        if territory is None or index is None:
+            return None, sys.float_info.max
+        return (territory, index), distance2
 
-            if self._drag_target is not None:
-                if etype in (
-                    vtk.vtkCommand.MouseMoveEvent,
-                    vtk.vtkCommand.LeftButtonReleaseEvent,
-                ):
-                    return True, 0.0
-                return False, sys.float_info.max
+    def _event_world(self, renderer: Any, eventData: Any):
+        """The drag target: the vessel-visibility-gated surface snap.
 
-            if etype == vtk.vtkCommand.MouseMoveEvent:
-                # Bare hover (ADR-0033: side-effect repaint, DECLINE so the
-                # camera is untouched).  Over an existing seed -> glow halo on
-                # it (about-to-move cue) + suppress the placement preview; over
-                # empty surface -> raise the adhering placement preview.
-                territory, index, distance2 = self._nearest_point_in_display(renderer, eventData)
-                if (
-                    territory is not None
-                    and index is not None
-                    and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
-                ):
-                    self._set_hover((territory, index))
-                    self._clear_adhering()
-                else:
-                    self._set_hover(None)
-                    self._raise_highlight(renderer, eventData)
-                self._reconcile_highlight()
-                self.RequestRender()
-                return False, sys.float_info.max
-
-            if etype != vtk.vtkCommand.LeftButtonPressEvent:
-                return False, sys.float_info.max
-
-            _territory, _index, distance2 = self._nearest_point_in_display(renderer, eventData)
-            if distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
-                # Press near an existing point -> grab it for a drag (an edit
-                # gesture; independent of the arm state).
-                return True, distance2
-
-            # Add-on-click requires an armed pipeline (ADR-0037 §Decision 3):
-            # a disarmed press away from any point leaves the gesture to the
-            # camera.
-            if not self.IsArmed():
-                return False, sys.float_info.max
-
-            # Press away from any point: claim only when the ray hits the
-            # surface (add-on-click); otherwise leave the press to the camera.
-            if self._event_world_on_surface(renderer, eventData) is None:
-                return False, sys.float_info.max
-            return True, POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            return False, sys.float_info.max
-
-    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
-        """Drive add-on-click / drag-to-edit (ADR-0037 §Decision 2)."""
-        try:
-            renderer = self._safe_get_renderer()
-            if renderer is None:
-                self._drag_target = None
-                return False
-            etype = _event_type(eventData)
-
-            if self._drag_target is None:
-                if etype != vtk.vtkCommand.LeftButtonPressEvent:
-                    return False
-                territory, index, distance2 = self._nearest_point_in_display(renderer, eventData)
-                if territory is not None and index is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
-                    # Grab the existing point for a drag (edit gesture): swap the
-                    # glow halo + the seed to the grab colour (green).
-                    self._drag_target = (territory, index)
-                    self._position_halo()
-                    self._rebuild_seed_actor()
-                    self.RequestRender()
-                    return True
-                # Add-on-click requires an armed pipeline (ADR-0037
-                # §Decision 3): a disarmed click adds nothing.  Read the
-                # display-node-backed arm state (the table writes it there),
-                # NOT the instance flag.
-                if not self.IsArmed():
-                    return False
-                # Module-active gate (ADR-0037 slice-5 concern #1): belt-and-
-                # suspenders beyond the armed flag -- decline while the owning
-                # module is inactive so no view lands a seed off-module.
-                if not self.IsModuleActive():
-                    return False
-                # Snap to the surface and add exactly one point to the active
-                # territory.
-                world = self._event_world_on_surface(renderer, eventData)
-                if world is None:
-                    return False
-                # A later seed is placed WHERE THE PICK SNAPS IT -- on the
-                # visible vessel under the cursor -- with no snap-back.  A
-                # territory may straddle disjoint structures (portal + hepatic);
-                # the visibility-gated pick is the only placement constraint
-                # (revised ADR-0037 slice 5, no straddle-snap).
-                self._add_point(world)
-                # Repaint immediately: the carrier observer's RequestRender does
-                # not flush a frame mid-interaction (the slice-pipeline lesson).
-                self._rebuild_seed_actor()
-                self.RequestRender()
-                return True
-
-            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
-                self._drag_target = None
-                # Gesture over: drop the grab colour (fall back to hover/none).
-                self._position_halo()
-                self._rebuild_seed_actor()
-                self.RequestRender()
-                return False  # release the focus
-
-            if etype == vtk.vtkCommand.MouseMoveEvent:
-                world = self._event_world_on_surface(renderer, eventData)
-                if world is None:
-                    return True  # keep the grab; this move just didn't resolve
-                self._relocate_grabbed_point(world)
-                # Track the grabbed seed under the drag + repaint immediately.
-                self._position_halo()
-                self._rebuild_seed_actor()
-                self.RequestRender()
-                return True
-
-            return False
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            return False
-
-    def DeleteAnnotationPoint(self, territoryId: str, index: int) -> bool:  # noqa: N802 - VTK verb
-        """Remove EXACTLY ONE annotation point (delete-from-table end).
-
-        ADR-0037 §Decision 2 "delete removes one point"; the tail shifts up
-        in order.  Returns True iff a point was removed.
+        Overrides the base's default (which would call the injected pick): the
+        territory drag follows the cursor on the picked vessel surface via
+        ``_event_world_on_surface`` (the seam the unit layer monkeypatches).
         """
-        carrier = self._get_carrier()
-        if carrier is None:
-            return False
-        return bool(carrier.RemoveNthAnnotationPoint(territoryId, int(index)))
-
-    # ------------------------------------------------------------------ #
-    # Carrier writes
-    # ------------------------------------------------------------------ #
+        return self._event_world_on_surface(renderer, eventData)
 
     def _add_point(self, world: Any) -> None:
-        carrier = self._get_carrier()
-        territory = self._placement_territory()
-        if carrier is None or territory is None:
-            return
-        carrier.AddAnnotationPoint(territory, float(world[0]), float(world[1]), float(world[2]))
+        """The add-on-click fan into the ACTIVE territory + the slice jump.
+
+        Overrides the base's plain provider ``add_point`` so a territory click
+        also reslices the 2D views onto the placed seed (ADR-0025 mirror) --
+        the per-territory grouping itself is the provider's concern (it appends
+        into ``_placement_territory``).
+        """
+        provider = self._provider
+        if provider is not None:
+            provider.add_point((world[0], world[1], world[2]))
         # A seed placed in a 3D view leaves the 2D slices on whatever plane
         # they were showing, so the projected slice marker floats off the
         # seed's anatomy; reslice every slice plane onto the seed (mirrors
         # LocatorReslicer, ADR-0025) so the 2D views show the slice through it.
         self._jump_slices_to_world(world)
+        # Repaint immediately: the carrier observer's RequestRender does not
+        # flush a frame mid-interaction (the slice-pipeline lesson).
+        self._rebuild_seed_actor()
 
-    def _jump_slices_to_world(self, world: Any) -> None:
-        """Offset every slice view's plane onto ``world`` (JumpSliceByOffsetting).
+    def _on_grab(self, key: Any, renderer: Any, eventData: Any) -> None:
+        """Grab an existing seed: swap the glow halo + seed to green."""
+        self._position_halo()
+        self._rebuild_seed_actor()
 
-        Translates each plane along its OWN normal (orientation preserved), so
-        the 2D views reslice to the placed seed.  A no-op (never raising) when
-        the scene or the jump API is unavailable.
+    def _on_drag(self, key: Any) -> None:
+        """Track the grabbed seed under the drag + repaint immediately."""
+        self._position_halo()
+        self._rebuild_seed_actor()
+
+    def _on_release(self) -> None:
+        """Gesture over: drop the grab colour (fall back to hover/none)."""
+        self._position_halo()
+        self._rebuild_seed_actor()
+
+    def _on_bare_move_decline(self, renderer: Any, eventData: Any) -> None:
+        """Raise the hover cue on a declined bare move (ADR-0033 side effect).
+
+        Over an existing seed -> glow halo on it (about-to-move cue) + suppress
+        the placement preview; over empty surface -> raise the adhering
+        placement preview.  A declined bare move, so the camera is untouched.
         """
-        if world is None:
-            return
-        scene = self._display_node.GetScene() if self._display_node is not None else None
-        if scene is None:
-            carrier = self._get_carrier()
-            scene = carrier.GetScene() if carrier is not None else None
-        if scene is None:
-            return
-        for i in range(scene.GetNumberOfNodesByClass("vtkMRMLSliceNode")):
-            slice_node = scene.GetNthNodeByClass(i, "vtkMRMLSliceNode")
-            jump = getattr(slice_node, "JumpSliceByOffsetting", None)
-            if jump is not None:
-                jump(float(world[0]), float(world[1]), float(world[2]))
+        territory, index, distance2 = self._nearest_point_in_display(renderer, eventData)
+        if (
+            territory is not None
+            and index is not None
+            and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
+        ):
+            self._set_hover((territory, index))
+            self._clear_adhering()
+        else:
+            self._set_hover(None)
+            self._raise_highlight(renderer, eventData)
+        self._reconcile_highlight()
 
-    def _relocate_grabbed_point(self, world: Any) -> None:
-        carrier = self._get_carrier()
-        target = self._drag_target
-        if carrier is None or target is None:
-            return
-        territory, index = target
-        carrier.SetNthAnnotationPoint(territory, int(index), float(world[0]), float(world[1]), float(world[2]))
+    def DeleteAnnotationPoint(self, territoryId: str, index: int) -> bool:  # noqa: N802 - VTK verb
+        """Remove EXACTLY ONE annotation point (delete-from-table end).
+
+        ADR-0037 §Decision 2 "delete removes one point"; the tail shifts up
+        in order.  Returns True iff a point was removed.  Routes through the
+        provider's delete write-back (the base's ``DeletePoint`` seam) so the
+        key contract matches the grab / drag path.
+        """
+        return bool(self.DeletePoint((territoryId, int(index))))
 
     # ------------------------------------------------------------------ #
     # Geometry seams (monkeypatched in the unit layer)
@@ -786,7 +756,9 @@ class TerritoryPlacementPipeline(_PipelineBase):
         Scans the carrier's active territory's points, projects each to
         display, and returns the nearest with its REAL squared display
         distance (LayerDM arbitration).  ``(None, None, +inf)`` when there
-        is no carrier / territory / point.
+        is no carrier / territory / point.  A hidden-structure seed is not
+        drawn, so it must not be a hover/grab target either -- skipped via the
+        ``seed_visible`` gate (ADR-0037 slice 5).
         """
         carrier = self._get_carrier()
         territory = self._placement_territory()
@@ -806,7 +778,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
             point = carrier.GetNthAnnotationPoint(territory, i)
             # A hidden-structure seed is not drawn, so it must not be a
             # hover/grab target either -- skip it (ADR-0037 slice 5).
-            if not self._structures.seed_visible(self._display_node, point):
+            if not self._seed_visible(point):
                 continue
             renderer.SetWorldPoint(point[0], point[1], point[2], 1.0)
             renderer.WorldToDisplay()
@@ -902,9 +874,33 @@ class TerritoryPlacementPipeline(_PipelineBase):
                 show = True
         self._halo_actor.SetVisibility(show)
 
+    def _jump_slices_to_world(self, world: Any) -> None:
+        """Offset every slice view's plane onto ``world`` (JumpSliceByOffsetting).
+
+        Translates each plane along its OWN normal (orientation preserved), so
+        the 2D views reslice to the placed seed.  A no-op (never raising) when
+        the scene or the jump API is unavailable.
+        """
+        if world is None:
+            return
+        scene = self._display_node.GetScene() if self._display_node is not None else None
+        if scene is None:
+            carrier = self._get_carrier()
+            scene = carrier.GetScene() if carrier is not None else None
+        if scene is None:
+            return
+        for i in range(scene.GetNumberOfNodesByClass("vtkMRMLSliceNode")):
+            slice_node = scene.GetNthNodeByClass(i, "vtkMRMLSliceNode")
+            jump = getattr(slice_node, "JumpSliceByOffsetting", None)
+            if jump is not None:
+                jump(float(world[0]), float(world[1]), float(world[2]))
+
     # ------------------------------------------------------------------ #
     # Observers (reconcile) + plumbing
     # ------------------------------------------------------------------ #
+
+    def _safe_get_renderer(self) -> Any | None:
+        return self._renderer
 
     def _attach_observer(self, node: Any) -> None:
         if node is None or not hasattr(node, "AddObserver"):
@@ -978,7 +974,7 @@ class TerritoryPlacementPipeline(_PipelineBase):
                     point = carrier.GetNthAnnotationPoint(territory, i)
                     # Omit a seed whose structure is hidden (ADR-0037 slice 5);
                     # cached per-structure locators keep this O(log n) per seed.
-                    if not self._structures.seed_visible(self._display_node, point):
+                    if not self._seed_visible(point):
                         continue
                     self._seed_points.InsertNextPoint(point[0], point[1], point[2])
                     key = (territory, i)
@@ -993,9 +989,25 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._seed_polydata.Modified()
 
 
-def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name
-    """The VTK event-type id off ``eventData``."""
-    return int(eventData.GetType())
+class _TerritorySurfacePick:
+    """The base's pick provider, delegating to the pipeline's surface snap.
+
+    The base places a click at whatever world the injected pick returns
+    (ADR-0038 §"Base extension" -- no surface-vs-volume branch).  Territories'
+    pick is the vessel-visibility-gated surface snap, which also stays the
+    unit-layer monkeypatch seam (``_event_world_on_surface``): this adapter
+    forwards the base's ``pick_for_event`` to it so both the production pick
+    and the injected test double flow through one place.
+    """
+
+    def __init__(self, pipeline) -> None:
+        self._pipeline = pipeline
+
+    def pick_for_event(self, renderer: Any, eventData: Any):
+        # Re-read through the pipeline so a unit-layer monkeypatch of
+        # ``_event_world_on_surface`` is always honoured (the add + drag paths
+        # then share one surface-snap seam).
+        return self._pipeline._event_world_on_surface(renderer, eventData)
 
 
 def registerTerritoryPlacementPipelineCreator() -> None:  # noqa: N802 - project convention

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPointProvider.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPointProvider.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The VascularTerritories ``PointProvider`` adapter (ADR-0038 seam).
+
+ADR-0038 §Decision makes VascularTerritories a client of the shared
+control-point base over a ``PointProvider`` seam.  This adapter fans the
+flat ordered point set the base reads out over the carrier's per-territory
+grouping (``vtkMRMLCustomTerritoriesNode``): a territory provider is
+``has_edges() == False`` (unordered per-territory carrier points, no polygon
+edges -- ADR-0038 §Context), with the add / drag / delete write-backs
+targeting the carrier's ``AddAnnotationPoint`` / ``SetNthAnnotationPoint`` /
+``RemoveNthAnnotationPoint``.
+
+The territory-SPECIFIC concerns -- per-territory grouping, vessel-visibility
+gating, the active-territory placement -- stay in ``VascularTerritoriesLib``
+(the pipeline + this adapter), NOT in the base (ADR-0038 §"What is not
+shared").  ``add_point`` fans into the ACTIVE territory; the per-point key is
+a ``(territoryId, index)`` pair the carrier writes round-trip.
+
+Two visibility notions are in play (they genuinely DIFFER, so this adapter
+keeps BOTH, matching the #569 behaviour the pipeline's ``_rebuild_seed_actor``
+already implements):
+
+* ``carrier.GetTerritoryVisibility(territory)`` -- a territory ROW toggle in
+  the table hides that whole territory's seeds;
+* the per-seed VESSEL-SEGMENT visibility (``visible_getter``) -- a seed whose
+  nearest vessel structure is hidden in the structures table is not drawn.
+
+``iter_points`` gates on BOTH so the base's grab hit-test enumerates exactly
+the seeds the pipeline draws -- the ``(territoryId, index)`` keys line up.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class TerritoryPointProvider:
+    """Flat, no-edges ``PointProvider`` over a custom-territories carrier.
+
+    Bound to resolvers for the carrier, the active territory, and the per-seed
+    vessel-visibility gate (the pipeline supplies live getters so the provider
+    always reads the shared display node's current binding), so it stays a
+    thin fan-out with no state of its own beyond those callables.
+    """
+
+    def __init__(self, carrier_getter, territory_getter, visible_getter=None) -> None:
+        self._carrier_getter = carrier_getter
+        self._territory_getter = territory_getter
+        self._visible_getter = visible_getter
+
+    def _carrier(self) -> Any | None:
+        return self._carrier_getter()
+
+    def _territory(self) -> str | None:
+        return self._territory_getter()
+
+    def _seed_visible(self, point) -> bool:
+        """The per-seed vessel-segment visibility gate (``True`` when unwired)."""
+        if self._visible_getter is None:
+            return True
+        return bool(self._visible_getter(point))
+
+    def iter_points(self):
+        """Yield ``(world, base_rgb)`` per VISIBLE seed, flat across territories.
+
+        Gates on BOTH the territory-row toggle and the per-seed vessel-segment
+        visibility (the #569 semantics), so the enumeration order matches the
+        pipeline's ``_rebuild_seed_actor`` -- the base's grab hit-test then
+        keys line up with what is drawn.  The per-point colour is the
+        territory's display slot colour.
+        """
+        carrier = self._carrier()
+        if carrier is None:
+            return
+        for territory in carrier.GetAnnotationTerritoryIds():
+            if not bool(carrier.GetTerritoryVisibility(territory)):
+                continue
+            rgb = carrier.GetTerritoryColor(territory)
+            base_rgb = (float(rgb[0]), float(rgb[1]), float(rgb[2]))
+            count = carrier.GetNumberOfAnnotationPoints(territory)
+            for i in range(count):
+                point = carrier.GetNthAnnotationPoint(territory, i)
+                if not self._seed_visible(point):
+                    continue
+                yield (float(point[0]), float(point[1]), float(point[2])), base_rgb
+
+    def has_edges(self) -> bool:
+        """Territory seeds are unordered per-territory points -- no edges."""
+        return False
+
+    def add_point(self, world) -> Any:
+        """Append one seed to the ACTIVE territory; return its key."""
+        carrier = self._carrier()
+        territory = self._territory()
+        if carrier is None or territory is None:
+            return None
+        carrier.AddAnnotationPoint(
+            territory, float(world[0]), float(world[1]), float(world[2])
+        )
+        index = carrier.GetNumberOfAnnotationPoints(territory) - 1
+        return (territory, index)
+
+    def move_point(self, key, world) -> None:
+        """Relocate the ``(territoryId, index)`` seed to ``world``."""
+        carrier = self._carrier()
+        if carrier is None or key is None:
+            return
+        territory, index = key
+        carrier.SetNthAnnotationPoint(
+            territory, int(index), float(world[0]), float(world[1]), float(world[2])
+        )
+
+    def delete_point(self, key) -> bool:
+        """Remove the ``(territoryId, index)`` seed; True iff one was removed."""
+        carrier = self._carrier()
+        if carrier is None or key is None:
+            return False
+        territory, index = key
+        return bool(carrier.RemoveNthAnnotationPoint(territory, int(index)))

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPointProvider.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPointProvider.py
@@ -70,6 +70,20 @@ class TerritoryPointProvider:
         keys line up with what is drawn.  The per-point colour is the
         territory's display slot colour.
         """
+        for _key, payload in self.iter_keyed_points():
+            yield payload
+
+    def iter_keyed_points(self):
+        """Yield ``((territoryId, index), (world, base_rgb))`` per VISIBLE seed.
+
+        The KEYED companion to ``iter_points`` (the slice base's key seam,
+        ADR-0038): the same dual-gated traversal, but each payload carries its
+        ``(territoryId, index)`` carrier key so the slice base can store it in
+        ``_projected_keys`` (the ``(territoryId, index)`` grab / drag / delete
+        round-trips through ``move_point`` / ``delete_point``).  ``iter_points``
+        is the key-less projection of this, so BOTH enumerate identically --
+        the drawn seeds and their keys always line up.
+        """
         carrier = self._carrier()
         if carrier is None:
             return
@@ -83,7 +97,8 @@ class TerritoryPointProvider:
                 point = carrier.GetNthAnnotationPoint(territory, i)
                 if not self._seed_visible(point):
                     continue
-                yield (float(point[0]), float(point[1]), float(point[2])), base_rgb
+                world = (float(point[0]), float(point[1]), float(point[2]))
+                yield (territory, i), (world, base_rgb)
 
     def has_edges(self) -> bool:
         """Territory seeds are unordered per-territory points -- no edges."""

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySlicePipeline.py
@@ -8,26 +8,33 @@ node (``TerritoryInteractionState``), so 2D and 3D placement stay in
 lockstep -- an armed click in a slice view appends one surface-snapped seed
 to the ACTIVE territory, exactly as an armed click in a 3D view does.
 
+ADR-0038 §Decision makes this a thin CLIENT of the shared
+``SurfacePointPlacementPipelineSlice`` base: the base DRIVES the generic
+grab-to-edit-nearest / armed add-on-click / bare-move-decline arbitration
+(``Can/ProcessInteractionEvent``) AND the generic projection/fade/side-tint/
+presence + hollow-circle handles + hover ring; this client contributes ONLY
+the territory-SPECIFIC concerns through the base's extension hooks (ADR-0038
+§"What is not shared"):
+
+* per-territory grouping + active-territory routing (the ``add_point`` fan
+  into the active territory, on ``TerritoryPointProvider`` + this pipeline);
+* the key seam override (``_iter_keyed_points`` -> ``(territoryId, index)``
+  keys) so the base's projection stores the carrier key each seed round-trips
+  through;
+* vessel-visibility gating -- a hidden vessel surface is not pickable and a
+  hidden seed is neither grabbable nor drawn -- via ``_ensure_pick`` over the
+  visibility-filtered ``vascular_surface_polydata`` and the
+  ``VisibleStructuresCache``-backed ``seed_visible`` filter in the projection;
+* the vessel-adhering cross-view hover marker (the ``_highlight_actor``
+  preview + the shared display node's AdheringPointWorld channel), and the
+  per-segment seed show/hide -- none of which bleed into the base.
+
 Mirrors ``LiverResectionsLib.SliceControlPolygonPipeline`` (ADR-0033): the
 carrier's annotation points are projected into the slice view's XY space
 (``inverse(XYToRAS)``) with DISTANCE FADING, a signed above/below SIDE
-TINT, and a HARD presence cutoff (2D alpha is unreliable).  Rendering
-rebuilds on a carrier ``Modified`` and on slice reslice (the slice node is
-observed).
-
-Placement (ADR-0037 §2D snap):
-
-* a BARE MOVE is DECLINED (``(False, +inf)``, ADR-0033) -- the camera is
-  untouched;
-* an armed LEFT-BUTTON PRESS over the slice resolves the pixel to RAS ON
-  the plane (``XYToRAS``), casts a ray ALONG THE SLICE NORMAL (both
-  directions), feeds it to ``VesselSurfacePick`` -> the surface-snapped
-  seed is added to the ACTIVE territory;
-* a press near an existing PROJECTED seed within the pick radius grabs it
-  for a drag; the drag relocates along the slice-normal snap;
-* a disarmed press away from any seed leaves the gesture to the camera;
-* DELETE converges on the carrier's ``RemoveNthAnnotationPoint`` (the one
-  deletion path the table + the 3D pick-delete share).
+TINT, and a HARD presence cutoff (2D alpha is unreliable) -- all owned by the
+shared base.  Rendering rebuilds on a carrier ``Modified`` and on slice
+reslice (the slice node is observed).
 
 Keyed on ``(vtkMRMLSliceNode, vtkMRMLTerritoriesHighlightDisplayNode)`` --
 the slice-view half of the annotation placement (the 3D creator accepts
@@ -38,12 +45,37 @@ scripted Pipeline + its creator, never a custom displayable manager.
 
 from __future__ import annotations
 
-import sys
 from typing import Any
 
 import vtk
 
-from LayerDMLib import vtkMRMLLayerDMScriptedPipeline as _PipelineBase
+# The shared slice-view placement/edit base (ADR-0038 §Decision): territories
+# is the vessel-gated client of ``SurfacePointPlacementPipelineSlice`` over the
+# PointProvider + swappable-pick seam.  The base drives the generic
+# grab/drag/release + armed add-on-click arbitration AND the projection/fade/
+# side/presence + handles/ring; this pipeline keeps the per-territory grouping,
+# the vessel-visibility gating, and the cross-view adhering marker as overrides
+# (ADR-0038 §"What is not shared").
+try:  # pragma: no cover - exercised once per import path
+    from SlicerLiverInteractionLib.SurfacePointPlacementPipelineSlice import (
+        SurfacePointPlacementPipelineSlice as _PipelineBase,
+        POINT_PICK_RADIUS_PX,
+        HALO_HOVER_COLOR,
+    )
+    from SlicerLiverInteractionLib import SlicePointProjection as _proj
+except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.path
+    import pathlib
+    import sys as _sys
+
+    _shared_lib = pathlib.Path(__file__).resolve().parents[2] / "SlicerLiverInteractionLib"
+    if str(_shared_lib) not in _sys.path:
+        _sys.path.insert(0, str(_shared_lib))
+    from SurfacePointPlacementPipelineSlice import (  # type: ignore[no-redef]
+        SurfacePointPlacementPipelineSlice as _PipelineBase,
+        POINT_PICK_RADIUS_PX,
+        HALO_HOVER_COLOR,
+    )
+    import SlicePointProjection as _proj  # type: ignore[no-redef]
 
 try:  # pragma: no cover - exercised once per import path
     from .VesselSurfacePick import VesselSurfacePick
@@ -52,8 +84,8 @@ try:  # pragma: no cover - exercised once per import path
         visibility_mtime as _visibility_mtime,
         VisibleStructuresCache as _VisibleStructuresCache,
     )
+    from .TerritoryPointProvider import TerritoryPointProvider
     from . import TerritoryInteractionState as _state
-    from . import TerritorySliceProjection as _proj
 except ImportError:  # top-level import path (the unit layer's sys.path setup)
     from VesselSurfacePick import VesselSurfacePick  # type: ignore[no-redef]
     from VesselHighlightWiring import (  # type: ignore[no-redef]
@@ -61,31 +93,16 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
         visibility_mtime as _visibility_mtime,
         VisibleStructuresCache as _VisibleStructuresCache,
     )
+    from TerritoryPointProvider import (  # type: ignore[no-redef]
+        TerritoryPointProvider,
+    )
     import TerritoryInteractionState as _state  # type: ignore[no-redef]
-    import TerritorySliceProjection as _proj  # type: ignore[no-redef]
 
 _REGISTERED = False
 
-#: Display-space pick radius (XY pixels) for grabbing an existing projected
-#: seed (mirrors ``TerritoryPlacementPipeline.POINT_PICK_RADIUS_PX``).
-POINT_PICK_RADIUS_PX = 20.0
-
-#: Handle / hover-ring glyph diameters (XY pixels), mirroring
-#: ``SliceControlPolygonPipeline``: seeds render as hollow-circle HANDLES
-#: (grab targets), and the ring is a larger hollow circle AROUND the
-#: hovered/grabbed handle.
+#: Adhering-placement preview glyph diameter (XY pixels): the hover marker is a
+#: hollow-circle HANDLE preview, styled like a seed handle (not a crosshair).
 HANDLE_GLYPH_SCALE_PX = 13.0
-RING_GLYPH_SCALE_PX = 20.0
-
-#: Interaction colours shared with the resection surface interaction
-#: (``ControlPolygonPipeline``): hover = yellow, grab = green.
-HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
-HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
-
-#: Pull the per-territory base colour toward mid-tone before the signed-
-#: distance side tint, so BOTH the lighter-above and darker-below cues have
-#: headroom (the ``SliceControlPolygonPipeline`` HANDLE_MIDTONE_FACTOR).
-HANDLE_MIDTONE_FACTOR = 0.78
 
 
 def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
@@ -101,17 +118,26 @@ def _creator_accepts_view(viewNode: Any) -> bool:  # noqa: N803 - VTK arg name
 
 
 class TerritorySlicePipeline(_PipelineBase):
-    """Projected, fading, slice-editable territory annotation seeds."""
+    """Projected, fading, slice-editable territory annotation seeds.
+
+    A thin client of ``SurfacePointPlacementPipelineSlice``: the base owns the
+    handle projection/fade/side/presence + the grab-seam + armed add-on-click
+    arbitration + the hover ring, this pipeline supplies the territory data
+    model (the active-territory fan), the vessel-visibility gating, and the
+    cross-view adhering marker.
+    """
 
     def __init__(self) -> None:
-        super().__init__()
-        self.SetPythonObject(self)
+        # The base seeds ``_display_node`` / ``_slice_node`` / ``_renderer`` /
+        # ``_drag_key`` / ``_provider`` / ``_pick_provider``, the handle + ring
+        # actors, the projection bookkeeping (``_projected_keys`` /
+        # ``_projected_xy`` / ``_plane_distances``), and calls
+        # ``SetPythonObject``.  The ``"TerritoryPlacement"`` namespace is inert
+        # here: the arm / active-territory / carrier accessors are OVERRIDDEN to
+        # ride the shared highlight display node via ``TerritoryInteractionState``
+        # (the 3D client's precedent), so 2D and 3D stay in lockstep.
+        super().__init__(namespace="TerritoryPlacement")
 
-        self._display_node: Any | None = None
-        self._slice_node: Any | None = None
-        self._renderer: Any | None = None
-        self._observer_tags: dict = {}
-        self._observed_node_refs: list = []
         self._observed_carrier: Any | None = None
         # The pickSurface segmentation's display node, observed so a
         # structures-table show/hide reprojects the 2D seeds (a visibility
@@ -132,73 +158,48 @@ class TerritorySlicePipeline(_PipelineBase):
         # display node's visibility MTime (the ``_ensure_pick`` pattern).
         self._structures = _VisibleStructuresCache()
 
-        # Module-active gate (ADR-0037 slice-5 concern #1).  The gate rides the
-        # shared display node in production (read by ``IsModuleActive``), the
-        # instance field bare; defaults OPEN (the decline is opt-in, matching
-        # the display-node "unset reads active" rule).
-        self._module_active: bool = True
-
-        # Projected-seed bookkeeping (pick arbitration): parallel lists of
-        # (territoryId, index) keys, their XY positions, and |distance| to
-        # the slice plane -- rebuilt on every reproject.
-        self._projected_keys: list = []
-        self._projected_xy: list = []
-        self._plane_distances: list = []
-
-        # (territory id, in-territory index) of the projected seed currently
-        # GRABBED by a press/move/release drag -- None when no drag.
-        self._drag_target: tuple[str, int] | None = None
         # (territory id, in-territory index) of the seed under the cursor (the
-        # hover grab affordance), None when the cursor is over none.
+        # hover grab affordance), None when the cursor is over none.  The
+        # grabbed seed is the base's ``_drag_key`` (aliased below), so there is
+        # ONE grab source of truth (the base's field).
         self._hover_target: tuple[str, int] | None = None
 
-        # Seed HANDLES: projected points as hollow-circle 2D glyphs with RGBA
-        # side-tint + distance fade -- the SliceControlPolygonPipeline handle
-        # style (a grab target you can see is a grab target you can move).
-        self._seed_polydata = vtk.vtkPolyData()
-        self._seed_polydata.SetPoints(vtk.vtkPoints())
-        self._seed_glyph_source = vtk.vtkGlyphSource2D()
-        self._seed_glyph_source.SetGlyphTypeToCircle()
-        self._seed_glyph_source.FilledOff()
-        self._seed_glyph_source.SetScale(HANDLE_GLYPH_SCALE_PX)
-        self._seed_glyph = vtk.vtkGlyph2D()
-        self._seed_glyph.SetInputData(self._seed_polydata)
-        self._seed_glyph.SetSourceConnection(self._seed_glyph_source.GetOutputPort())
-        self._seed_glyph.SetColorModeToColorByScalar()
-        self._seed_glyph.ScalingOff()
-        self._seed_mapper = vtk.vtkPolyDataMapper2D()
-        self._seed_mapper.SetInputConnection(self._seed_glyph.GetOutputPort())
-        self._seed_actor = vtk.vtkActor2D()
-        self._seed_actor.GetProperty().SetLineWidth(2.0)
-        self._seed_actor.SetMapper(self._seed_mapper)
-        self._seed_actor.SetVisibility(False)
+        # Wire the ADR-0038 seams:
+        #  * the data model -- the base reads/projects the carrier seeds via
+        #    this provider (flat, no edges -- territory seeds are unordered),
+        #    dual-gated on the territory-row toggle + the per-seed vessel-
+        #    segment visibility (re-read through this pipeline so a unit-layer
+        #    monkeypatch of ``_seed_visible`` is honoured);
+        #  * the click->world pick -- routed through ``_pick_world`` ->
+        #    ``_snap_event_to_surface`` (the vessel-visibility-gated surface
+        #    snap, the unit-layer + placemode-test monkeypatch seam), NOT a
+        #    surface-vs-volume branch in the base (ADR-0038 §"Base extension").
+        self.SetProvider(
+            TerritoryPointProvider(
+                carrier_getter=self._get_carrier,
+                territory_getter=self._placement_territory,
+                visible_getter=lambda point: self._seed_visible(point),
+            )
+        )
+        self.SetPickProvider(_TerritorySlicePick(self))
 
-        # Hover / grab RING: a larger hollow circle on the hovered (yellow) or
-        # grabbed (green) handle -- the 2D analogue of the 3D glow halo, the
-        # SliceControlPolygonPipeline ring.
-        self._ring_polydata = vtk.vtkPolyData()
-        self._ring_polydata.SetPoints(vtk.vtkPoints())
-        self._ring_glyph_source = vtk.vtkGlyphSource2D()
-        self._ring_glyph_source.SetGlyphTypeToCircle()
-        self._ring_glyph_source.FilledOff()
-        self._ring_glyph_source.SetScale(RING_GLYPH_SCALE_PX)
-        self._ring_glyph = vtk.vtkGlyph2D()
-        self._ring_glyph.SetInputData(self._ring_polydata)
-        self._ring_glyph.SetSourceConnection(self._ring_glyph_source.GetOutputPort())
-        self._ring_glyph.ScalingOff()
-        self._ring_mapper = vtk.vtkPolyDataMapper2D()
-        self._ring_mapper.SetInputConnection(self._ring_glyph.GetOutputPort())
-        self._ring_actor = vtk.vtkActor2D()
-        self._ring_actor.SetMapper(self._ring_mapper)
-        self._ring_actor.GetProperty().SetLineWidth(2.0)
-        self._ring_actor.SetVisibility(False)
+        # Seed HANDLES: the base's ``_handles_actor`` IS this pipeline's seed
+        # actor (the base's projection populates it -- hollow-circle 2D glyphs
+        # with the SliceControlPolygonPipeline RGBA side-tint + distance fade).
+        # Alias it (+ the polydata) so the introspection seams the territory
+        # suite reads (``_seed_actor`` / ``_seed_polydata``) resolve to the
+        # base's single source of truth.
+        self._handles_actor.GetProperty().SetLineWidth(2.0)
+        self._seed_actor = self._handles_actor
+        self._seed_polydata = self._handles_polydata
 
         # Adhering-placement PREVIEW: a hollow-circle handle (yellow, the hover
-        # colour) at the shared display node's AdheringPointWorld projected
-        # into THIS slice -- where an armed click would drop a seed.  Published
-        # by whichever view the cursor is in, so it shows in every view at once
-        # (ADR-0033 cross-view cue).  Styled as a handle preview, not a
-        # crosshair, so it reads like the surface interaction.
+        # colour) at the shared display node's AdheringPointWorld projected into
+        # THIS slice -- where an armed click would drop a seed.  Published by
+        # whichever view the cursor is in, so it shows in every view at once
+        # (ADR-0033 cross-view cue).  Territory-specific, so it is NOT a base
+        # actor; built WITH its mapper (a mapperless vtkActor2D crashes under
+        # GL, per the construction contract).
         self._highlight_polydata = vtk.vtkPolyData()
         self._highlight_polydata.SetPoints(vtk.vtkPoints())
         self._highlight_glyph_source = vtk.vtkGlyphSource2D()
@@ -216,6 +217,20 @@ class TerritorySlicePipeline(_PipelineBase):
         self._highlight_actor.GetProperty().SetColor(*HALO_HOVER_COLOR)
         self._highlight_actor.SetMapper(self._highlight_mapper)
         self._highlight_actor.SetVisibility(False)
+
+    # ------------------------------------------------------------------ #
+    # Grab bookkeeping -- the base's ``_drag_key`` IS the grabbed
+    # ``(territoryId, index)`` (the key the projection stores); the rendering
+    # reads it through this alias so there is one source of truth.
+    # ------------------------------------------------------------------ #
+
+    @property
+    def _drag_target(self) -> tuple[str, int] | None:
+        return self._drag_key
+
+    @_drag_target.setter
+    def _drag_target(self, value: tuple[str, int] | None) -> None:
+        self._drag_key = value
 
     # ------------------------------------------------------------------ #
     # Wiring seams (unit + production)
@@ -265,6 +280,18 @@ class TerritorySlicePipeline(_PipelineBase):
         """
         return self._structures.resolve(self._display_node)
 
+    def _seed_visible(self, point: Any) -> bool:
+        """True iff ``point``'s nearest vessel structure is visible.
+
+        The vessel-visibility gate (ADR-0037 slice 5) the provider's keyed
+        traversal consults, so a hidden vessel's seeds are neither drawn nor
+        grabbable (the base projects exactly the provider's points).  The REAL
+        seed-visibility notion (vessel SEGMENT visibility via
+        ``VisibleStructuresCache``), NOT a territory-row toggle (ADR-0037
+        slice 5).
+        """
+        return self._structures.seed_visible(self._display_node, point)
+
     def _get_carrier(self) -> Any | None:
         """The carrier the shared display node binds (the 3D-pipeline seam)."""
         return _state.get_carrier(self._display_node)
@@ -273,12 +300,20 @@ class TerritorySlicePipeline(_PipelineBase):
         """The territory an armed click appends into (the ACTIVE one)."""
         return _state.get_active_territory(self._display_node)
 
-    def _is_armed(self) -> bool:
-        return _state.is_armed(self._display_node)
-
     def SetActiveTerritory(self, territoryId: str | None) -> None:  # noqa: N802 - VTK verb
         """Set the territory an armed slice click appends into (the ACTIVE one)."""
         _state.set_active_territory(self._display_node, territoryId)
+
+    # ------------------------------------------------------------------ #
+    # Arm / module-active gate -- OVERRIDE the base's PointPlacementState
+    # accessors so the territory client rides the shared highlight display node
+    # via ``TerritoryInteractionState`` (the 3D client's precedent), which also
+    # carries the active territory + the carrier reference; 2D and 3D placement
+    # stay in lockstep (ADR-0037 §Decision 3).
+    # ------------------------------------------------------------------ #
+
+    def IsArmed(self) -> bool:  # noqa: N802 - VTK verb
+        return _state.is_armed(self._display_node)
 
     def SetModuleActive(self, active: bool) -> None:  # noqa: N802 - VTK verb
         """Open/close the module-active add-on-click gate (concern #1).
@@ -296,59 +331,30 @@ class TerritorySlicePipeline(_PipelineBase):
             return _state.is_module_active(self._display_node)
         return self._module_active
 
-    def _safe_get_renderer(self) -> Any | None:
-        return self._renderer
-
     # ------------------------------------------------------------------ #
-    # LayerDM lifecycle
+    # LayerDM lifecycle (base hooks + territory observers)
     # ------------------------------------------------------------------ #
 
-    def SetViewNode(self, viewNode: Any) -> None:  # noqa: N802 - VTK verb
-        super().SetViewNode(viewNode)
-        # Observe the slice node OURSELVES: reslicing must re-project + re-fade
-        # (the SliceControlPolygonPipeline stale-trace lesson).
-        if self._slice_node is not None:
-            self._detach_observer(self._slice_node)
-        self._slice_node = viewNode
-        if viewNode is not None:
-            self._attach_observer(viewNode)
-
-    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
-        super().SetDisplayNode(displayNode)
-        if self._display_node is not None and self._display_node is not displayNode:
-            self._detach_observer(self._display_node)
-        self._display_node = displayNode
+    def _after_display_node_set(self) -> None:
         # A (re)attached display node can carry a different pickSurface /
-        # carrier: force both to re-resolve (the highlight-Pipeline precedent).
+        # carrier: force the pick to re-resolve (the highlight-Pipeline
+        # precedent), then re-observe the carrier + pickSurface.
         self._pick = None
-        # Observe the display node so a cross-view adhering-point change
-        # (published by whichever view the cursor is in) repaints this slice's
-        # hover marker.
-        if displayNode is not None:
-            self._attach_observer(displayNode)
         self._ensure_carrier_observed()
+        self._ensure_pick_surface_observed()
+
+    def _add_actors(self, renderer: Any) -> None:
+        super()._add_actors(renderer)
+        renderer.AddActor2D(self._highlight_actor)
+
+    def _remove_actors(self, renderer: Any) -> None:
+        super()._remove_actors(renderer)
+        renderer.RemoveActor2D(self._highlight_actor)
 
     def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        super().OnRendererAdded(renderer)
         try:
-            self._renderer = renderer
-            if renderer is not None:
-                renderer.AddActor2D(self._seed_actor)
-                renderer.AddActor2D(self._ring_actor)
-                renderer.AddActor2D(self._highlight_actor)
-            # Renderer churn cleared the handles (cleanup nulled them to force
-            # this re-derive); re-attach the display + slice observers from the
-            # base's retained nodes (the reattach precedent).
-            if self._display_node is None:
-                display = self.GetDisplayNode()
-                if display is not None:
-                    self.SetDisplayNode(display)
-            if self._slice_node is None:
-                getView = getattr(self, "GetViewNode", None)
-                view = getView() if getView is not None else None
-                if view is not None:
-                    self.SetViewNode(view)
             self._ensure_carrier_observed()
-            self._reproject()
             self._reconcile_highlight()
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass
@@ -358,53 +364,26 @@ class TerritorySlicePipeline(_PipelineBase):
 
         LayerDM's manager owns the display-node observation and calls this when
         the pipeline's display node is Modified (a hover-published adhering
-        point from ANY view, an arm/visibility change) -- the same hook
-        ``VesselHighlightPipeline`` / ``SliceControlPolygonPipeline`` reconcile
-        in.  This is the channel the cross-view highlight rides, not the raw
-        display-node observer (which LayerDM intercepts).
-
-        Also (re)attaches the carrier observer: the display node is added to
-        the scene (LayerDM creates this pipeline) BEFORE the table binds the
-        carrier reference onto it, so the carrier is not resolvable at
-        creation.  This hook fires when the reference IS set (a display-node
-        Modified), so it is where the seed-tracking observer finally attaches
-        -- without it a passive slice never repaints a seed placed elsewhere.
+        point from ANY view, an arm/visibility change).  Also (re)attaches the
+        carrier observer: the display node is added to the scene (LayerDM
+        creates this pipeline) BEFORE the table binds the carrier reference
+        onto it, so the carrier is not resolvable at creation.  This hook fires
+        when the reference IS set, so it is where the seed-tracking observer
+        finally attaches.
         """
         try:
             self._ensure_carrier_observed()
             self._ensure_pick_surface_observed()
-            self._reproject()
+            self._reconcile()
             self._reconcile_highlight()
         except Exception:  # pragma: no cover - C++ boundary must never raise
             pass
 
-    def OnRendererRemoved(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
-        try:
-            if renderer is not None:
-                renderer.RemoveActor2D(self._seed_actor)
-                renderer.RemoveActor2D(self._ring_actor)
-                renderer.RemoveActor2D(self._highlight_actor)
-            self._renderer = None
-            self.cleanup()
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            pass
-
     def cleanup(self) -> None:
-        for node in list(self._observed_node_refs):
-            self._detach_observer(node)
-        # Drop the display + slice handles too: cleanup detaches their
-        # observers, so leaving the handles set would make the OnRendererAdded
-        # re-derive guard (``if self._display_node is None``) skip re-attaching
-        # them after a renderer removal->re-add -> the cross-view adhering
-        # repaint would go unobserved on the re-added renderer.
-        self._display_node = None
-        self._slice_node = None
+        super().cleanup()
         self._observed_carrier = None
         self._observed_pick_display = None
-        self._drag_target = None
         self._hover_target = None
-        self._seed_actor.SetVisibility(False)
-        self._ring_actor.SetVisibility(False)
         self._highlight_actor.SetVisibility(False)
 
     def _ensure_carrier_observed(self) -> None:
@@ -440,238 +419,107 @@ class TerritorySlicePipeline(_PipelineBase):
             self._attach_observer(seg_display)
 
     # ------------------------------------------------------------------ #
-    # Rendering (viz) -- fading projection into the slice XY
+    # Base extension hooks -- the territory specifics (ADR-0038)
     # ------------------------------------------------------------------ #
 
-    def _reproject(self) -> bool:
-        """Project every visible territory's seeds into XY with distance fading.
+    def _iter_keyed_points(self):
+        """Yield ``((territoryId, index), world, base_rgb)`` per visible seed.
 
-        Reads the carrier (the source of truth), projects each seed via
-        ``inverse(XYToRAS)``, fades alpha by its |distance| to the slice
-        plane, applies the signed above/below side tint over the
-        per-territory colour, and drops seeds beyond the HARD presence cutoff
-        (2D alpha unreliable).  Populates the pick-arbitration bookkeeping.
+        The key seam override (ADR-0038): delegate to the provider's keyed
+        traversal so the base's projection stores each seed's carrier key --
+        the ``(territoryId, index)`` pair the grab / drag / delete write-backs
+        round-trip through ``move_point`` / ``delete_point``.  The projected
+        keys ``GetProjectedKeys`` returns are then the territory keys the suite
+        asserts (e.g. ``[(TERRITORY_A, 0)]``), not flat ints.
         """
-        self._projected_keys = []
-        self._projected_xy = []
-        self._plane_distances = []
-        carrier = self._get_carrier()
-        slice_node = self._slice_node
-        if carrier is None or slice_node is None:
-            self._seed_actor.SetVisibility(False)
-            return False
+        provider = self._provider
+        if provider is None:
+            return
+        for key, (world, base_rgb) in provider.iter_keyed_points():
+            yield key, world, base_rgb
 
-        # Hoist the slice frame + the inverse XYToRAS out of the per-seed loop
-        # (the SliceControlPolygonPipeline convention): resolving them once
-        # keeps the reproject O(seeds), not O(seeds) matrix inversions.
-        frame = _proj.slice_frame(slice_node)
-        ras_to_xy = _proj.inverse_xy_to_ras(slice_node)
-        if frame is None or ras_to_xy is None:
-            self._seed_actor.SetVisibility(False)
-            return False
-        origin, normal = frame
+    def _interaction_state(self) -> tuple:
+        """``(hovered, grabbed)`` for the projection highlight.
 
-        hover_rgb = [int(c * 255) for c in HALO_HOVER_COLOR]
-        grab_rgb = [int(c * 255) for c in HALO_GRAB_COLOR]
-        points = vtk.vtkPoints()
-        rgba = vtk.vtkUnsignedCharArray()
-        rgba.SetNumberOfComponents(4)
-        rgba.SetName("SeedColors")
-        try:
-            for territory in carrier.GetAnnotationTerritoryIds():
-                if not bool(carrier.GetTerritoryVisibility(territory)):
-                    continue
-                base = self._territory_rgb(carrier, territory)
-                count = carrier.GetNumberOfAnnotationPoints(territory)
-                for i in range(count):
-                    point = carrier.GetNthAnnotationPoint(territory, i)
-                    # Omit a seed whose structure is hidden (ADR-0037 slice 5);
-                    # cached per-structure locators keep this O(log n) per seed.
-                    if not self._structures.seed_visible(self._display_node, point):
-                        continue
-                    signed = _proj.signed_distance(origin, normal, point)
-                    if not _proj.is_present(signed):
-                        continue  # HARD presence cutoff
-                    xy = _proj.apply_matrix_xy(ras_to_xy, point)
-                    key = (territory, i)
-                    if key == self._drag_target:
-                        # Grabbed handle: full-alpha grab colour (green).
-                        rgba.InsertNextTuple4(grab_rgb[0], grab_rgb[1], grab_rgb[2], 255)
-                    elif key == self._hover_target:
-                        # Hovered handle: full-alpha hover colour (yellow).
-                        rgba.InsertNextTuple4(hover_rgb[0], hover_rgb[1], hover_rgb[2], 255)
-                    else:
-                        # The markups signed-distance cue: mid-toned base tinted
-                        # toward white (above) / black (below), alpha by distance.
-                        tint = _proj.side_tint(base, signed)
-                        alpha = int(_proj.fade_alpha(signed) * 255)
-                        rgba.InsertNextTuple4(tint[0], tint[1], tint[2], alpha)
-                    points.InsertNextPoint(xy[0], xy[1], 0.0)
-                    self._projected_keys.append(key)
-                    self._projected_xy.append((xy[0], xy[1]))
-                    self._plane_distances.append(abs(signed))
-        except Exception:  # pragma: no cover - defensive
-            self._seed_actor.SetVisibility(False)
-            return False
-
-        self._seed_polydata.SetPoints(points)
-        self._seed_polydata.GetPointData().SetScalars(rgba)
-        self._seed_polydata.Modified()
-        self._seed_actor.SetVisibility(points.GetNumberOfPoints() > 0)
-        self._update_ring()
-        return True
-
-    def _territory_rgb(self, carrier: Any, territory: str) -> list:
-        """The territory's mid-toned base colour as an ``[r, g, b]`` 0..255 list.
-
-        Pulled toward mid-tone (``HANDLE_MIDTONE_FACTOR``) so the signed-distance
-        side tint has headroom in BOTH directions (the SliceControlPolygonPipeline
-        convention).
+        Feeds the base's projection the same hover/grab targets the seeds must
+        recolour to (yellow hover / green grab): the cursor's hover seed +
+        the base's grabbed key.  ``None`` targets simply never match a
+        projected key, so no seed lights up (the base's default-off sentinel).
         """
-        try:
-            rgb = carrier.GetTerritoryColor(territory)
-            return [
-                int(max(0.0, min(1.0, c)) * 255 * HANDLE_MIDTONE_FACTOR)
-                for c in (rgb[0], rgb[1], rgb[2])
-            ]
-        except Exception:  # pragma: no cover - defensive
-            return [int(255 * HANDLE_MIDTONE_FACTOR)] * 3
+        return self._hover_target, self._drag_key
 
-    def _update_ring(self) -> None:
-        """Show the hover/grab ring on the grabbed (green) or hovered (yellow) seed."""
-        target = self._drag_target or self._hover_target
-        pts = vtk.vtkPoints()
-        show = False
-        if target is not None and target in self._projected_keys:
-            idx = self._projected_keys.index(target)
-            px, py = self._projected_xy[idx]
-            pts.InsertNextPoint(px, py, 0.0)
-            colour = HALO_GRAB_COLOR if self._drag_target is not None else HALO_HOVER_COLOR
-            self._ring_actor.GetProperty().SetColor(*colour)
-            show = True
-        self._ring_polydata.SetPoints(pts)
-        self._ring_polydata.Modified()
-        self._ring_actor.SetVisibility(show)
+    def _pick_world(self, eventData: Any):
+        """Route the base's armed add-on-click through the vessel surface snap.
 
-    # ------------------------------------------------------------------ #
-    # Interaction -- placement / slice-side edit (ADR-0032 / ADR-0033)
-    # ------------------------------------------------------------------ #
-
-    def CanProcessInteractionEvent(self, eventData: Any):  # noqa: N802 - VTK verb
-        """Return ``(canProcess, distance2)`` for the LayerDM focus logic.
-
-        Mirrors ``TerritoryPlacementPipeline`` on the slice: a press near a
-        projected seed grabs it (real squared distance); an armed press over
-        the slice claims add-on-click (pick-radius squared); a grabbed
-        move/release is claimed unconditionally; a bare move is DECLINED
-        (``(False, +inf)``) so the camera is untouched (ADR-0033).
+        Overrides the base's default pick delegate so the SINGLE snap seam is
+        ``_snap_event_to_surface`` (the unit-layer + placemode-test monkeypatch
+        target), keeping the vessel-visibility-gated surface snap the only
+        placement constraint (no straddle-snap; revised ADR-0037 slice 5).
         """
-        try:
-            if self._safe_get_renderer() is None:
-                return False, sys.float_info.max
-            etype = _event_type(eventData)
+        return self._snap_event_to_surface(eventData)
 
-            if self._drag_target is not None:
-                if etype in (
-                    vtk.vtkCommand.MouseMoveEvent,
-                    vtk.vtkCommand.LeftButtonReleaseEvent,
-                ):
-                    return True, 0.0
-                return False, sys.float_info.max
+    def _add_point(self, world: Any) -> None:
+        """Fan the armed click into the ACTIVE territory + repaint this slice.
 
-            if etype == vtk.vtkCommand.MouseMoveEvent:
-                # Bare hover (ADR-0033: repaint as a side effect, DECLINE so the
-                # camera is untouched).  Over an existing handle -> mark it the
-                # hover target (yellow ring, grab affordance) and clear the
-                # placement preview; over empty surface -> publish the adhering
-                # point so the placement preview follows the cursor in every
-                # view.  Repaint THIS slice directly -- it must not wait on the
-                # cross-view update path.
-                key, distance2 = self._nearest_seed_in_display(eventData)
-                if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
-                    self._hover_target = key
-                    self._clear_highlight()
-                else:
-                    self._hover_target = None
-                    self._publish_highlight(eventData)
-                self._reproject()
-                self._reconcile_highlight()
-                self.RequestRender()
-                return False, sys.float_info.max
+        Overrides the base's plain provider ``add_point`` only to repaint this
+        slice immediately (a carrier-observer RequestRender does not flush a
+        frame mid-interaction, so the seed would otherwise only appear on the
+        next reslice).  The per-territory grouping itself is the provider's
+        concern -- it appends into ``_placement_territory``.
+        """
+        provider = self._provider
+        if provider is not None:
+            provider.add_point((world[0], world[1], world[2]))
+        self._reproject()
+        self.RequestRender()
 
-            if etype != vtk.vtkCommand.LeftButtonPressEvent:
-                return False, sys.float_info.max
+    def _on_grab(self, key: Any) -> None:
+        """Grab an existing seed: recolour it green + ring, immediately."""
+        self._reproject()
+        self.RequestRender()
 
-            _key, distance2 = self._nearest_seed_in_display(eventData)
-            if distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
-                return True, distance2  # grab a seed for a drag (edit gesture)
+    def _on_release(self) -> None:
+        """Gesture over: drop the grab colour + ring."""
+        self._reproject()
+        self.RequestRender()
 
-            # Add-on-click requires an armed pipeline (ADR-0037 §Decision 3):
-            # a disarmed press away from any seed leaves it to the camera.
-            if not self._is_armed():
-                return False, sys.float_info.max
-            if self._snap_event_to_surface(eventData) is None:
-                return False, sys.float_info.max
-            return True, POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            return False, sys.float_info.max
+    def _move_grabbed_to(self, eventData: Any) -> None:
+        """Relocate the grabbed seed to the surface snap, then repaint.
 
-    def ProcessInteractionEvent(self, eventData: Any) -> bool:  # noqa: N802 - VTK verb
-        """Drive add-on-click / drag-to-edit from a slice view (ADR-0037 §2D)."""
-        try:
-            if self._safe_get_renderer() is None:
-                self._drag_target = None
-                return False
-            etype = _event_type(eventData)
+        The slice drag follows the cursor on the picked vessel surface (the
+        same snap the add uses), writing back through the provider so the
+        ``(territoryId, index)`` key round-trips; a missed snap keeps the grab
+        (no move).
+        """
+        world = self._snap_event_to_surface(eventData)
+        if world is None:
+            return
+        provider = self._provider
+        if provider is not None and self._drag_key is not None:
+            provider.move_point(self._drag_key, (world[0], world[1], world[2]))
+        self._reproject()
+        self.RequestRender()
 
-            if self._drag_target is None:
-                if etype != vtk.vtkCommand.LeftButtonPressEvent:
-                    return False
-                key, distance2 = self._nearest_seed_in_display(eventData)
-                if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
-                    self._drag_target = key  # grab for a drag (edit gesture)
-                    self._reproject()  # recolour the grabbed handle green + ring
-                    self.RequestRender()
-                    return True
-                if not self._is_armed():
-                    return False  # a disarmed click adds nothing
-                # Module-active gate (ADR-0037 slice-5 concern #1): decline
-                # while the owning module is inactive, beyond the armed flag.
-                if not self.IsModuleActive():
-                    return False
-                world = self._snap_event_to_surface(eventData)
-                if world is None:
-                    return False
-                # A later seed is placed WHERE THE PICK SNAPS IT, with no
-                # snap-back: a territory may straddle disjoint structures and
-                # the visibility-gated pick is the only placement constraint
-                # (revised ADR-0037 slice 5, no straddle-snap).
-                self._add_point(world)
-                # Repaint THIS slice immediately: a RequestRender from the
-                # carrier observer does not flush a frame mid-interaction (the
-                # seed would otherwise only appear on the next reslice).
-                self._reproject()
-                self.RequestRender()
-                return True
+    def _on_bare_move_decline(self, eventData: Any) -> None:
+        """Raise the cross-view hover cue on a declined bare move (ADR-0033).
 
-            if etype == vtk.vtkCommand.LeftButtonReleaseEvent:
-                self._drag_target = None
-                self._reproject()  # drop the grab colour + ring
-                self.RequestRender()
-                return False  # gesture over -- release the focus
-
-            if etype == vtk.vtkCommand.MouseMoveEvent:
-                world = self._snap_event_to_surface(eventData)
-                if world is None:
-                    return True  # keep the grab; this move just didn't resolve
-                self._relocate_grabbed_point(world)
-                self._reproject()
-                self.RequestRender()
-                return True
-
-            return False
-        except Exception:  # pragma: no cover - C++ boundary must never raise
-            return False
+        Over an existing handle -> mark it the hover target (yellow ring, grab
+        affordance) + clear the placement preview; over empty surface -> publish
+        the adhering point so the placement preview follows the cursor in every
+        view.  Repaints THIS slice directly -- it must not wait on the
+        cross-view update path.  A declined bare move, so the camera is
+        untouched.
+        """
+        key, distance2 = self._nearest_handle_in_display(eventData)
+        if key is not None and distance2 <= POINT_PICK_RADIUS_PX * POINT_PICK_RADIUS_PX:
+            self._hover_target = key
+            self._clear_highlight()
+        else:
+            self._hover_target = None
+            self._publish_highlight(eventData)
+        self._reproject()
+        self._reconcile_highlight()
+        self.RequestRender()
 
     def DeleteAnnotationPoint(self, territoryId: str, index: int) -> bool:  # noqa: N802 - VTK verb
         """Remove EXACTLY ONE seed via the carrier (the shared deletion path)."""
@@ -681,7 +529,7 @@ class TerritorySlicePipeline(_PipelineBase):
         return bool(carrier.RemoveNthAnnotationPoint(territoryId, int(index)))
 
     # ------------------------------------------------------------------ #
-    # Snap + carrier writes
+    # Snap (the vessel surface pick along the slice normal)
     # ------------------------------------------------------------------ #
 
     def _snap_event_to_surface(self, eventData: Any, use_fallback: bool = True):
@@ -713,21 +561,6 @@ class TerritorySlicePipeline(_PipelineBase):
             return None
         p1, p2 = ray
         return pick.pick(p1, p2, fallback_point=(ras if use_fallback else None))
-
-    def _add_point(self, world: Any) -> None:
-        carrier = self._get_carrier()
-        territory = self._placement_territory()
-        if carrier is None or territory is None:
-            return
-        carrier.AddAnnotationPoint(territory, float(world[0]), float(world[1]), float(world[2]))
-
-    def _relocate_grabbed_point(self, world: Any) -> None:
-        carrier = self._get_carrier()
-        target = self._drag_target
-        if carrier is None or target is None:
-            return
-        territory, index = target
-        carrier.SetNthAnnotationPoint(territory, int(index), float(world[0]), float(world[1]), float(world[2]))
 
     # ------------------------------------------------------------------ #
     # Cross-view adhering highlight (publish on hover / render the marker)
@@ -776,14 +609,11 @@ class TerritorySlicePipeline(_PipelineBase):
         """Project the shared adhering point into this slice as the hover marker.
 
         Reads the data-only display node (the adhering point + flags any view
-        published) and shows a hollow-circle handle PREVIEW (solid yellow, the
-        hover colour, set on the actor) at its projection.  Unlike the seeds,
-        the preview is a TRANSIENT cue and is NOT distance-culled: the surface
-        point under the cursor sits at the vessel's depth (a radius OFF the
-        slice plane along the normal), so a presence cutoff would hide it in
-        the very slice being hovered.  It shows in every slice whenever
-        adhering, so the cue is present in 2D and 3D regardless of where the
-        cursor is.
+        published) and shows a hollow-circle handle PREVIEW (yellow, the hover
+        colour) at its projection.  Unlike the seeds, the preview is a TRANSIENT
+        cue and is NOT distance-culled: the surface point under the cursor sits
+        at the vessel's depth (a radius OFF the slice plane along the normal),
+        so a presence cutoff would hide it in the very slice being hovered.
         """
         display = self._display_node
         slice_node = self._slice_node
@@ -808,27 +638,6 @@ class TerritorySlicePipeline(_PipelineBase):
         self._highlight_polydata.Modified()
         self._highlight_actor.SetVisibility(show)
 
-    def _nearest_seed_in_display(self, eventData: Any):
-        """``((territoryId, index) | None, distance2)`` of the nearest projected seed.
-
-        Slice-view display coordinates coincide with the XY projection space
-        (the slice renderer convention), so the arbitration compares the
-        event pixel against ``_projected_xy``.  A seed at / beyond the
-        presence cutoff is not projected, so it is inherently unpickable.
-        """
-        try:
-            ex, ey = eventData.GetDisplayPosition()
-        except Exception:  # pragma: no cover - defensive (fake events)
-            return None, sys.float_info.max
-        best_key = None
-        best_d2 = sys.float_info.max
-        for key, (px, py) in zip(self._projected_keys, self._projected_xy):
-            d2 = (px - ex) ** 2 + (py - ey) ** 2
-            if d2 < best_d2:
-                best_d2 = d2
-                best_key = key
-        return best_key, best_d2
-
     # ------------------------------------------------------------------ #
     # Introspection (unit seams)
     # ------------------------------------------------------------------ #
@@ -839,33 +648,10 @@ class TerritorySlicePipeline(_PipelineBase):
     def GetSeedPolyData(self) -> Any:  # noqa: N802 - VTK verb
         return self._seed_polydata
 
-    def GetProjectedKeys(self) -> list:  # noqa: N802 - VTK verb
-        return list(self._projected_keys)
-
     # ------------------------------------------------------------------ #
-    # Observers
+    # Observers -- reproject on a carrier / slice Modified; repaint the marker
+    # only on a display-node Modified (the cross-view adhering channel).
     # ------------------------------------------------------------------ #
-
-    def _attach_observer(self, node: Any) -> None:
-        if node is None or not hasattr(node, "AddObserver"):
-            return
-        tag = node.AddObserver("ModifiedEvent", self._on_node_modified)
-        self._observer_tags.setdefault(id(node), []).append(tag)
-        if node not in self._observed_node_refs:
-            self._observed_node_refs.append(node)
-
-    def _detach_observer(self, node: Any) -> None:
-        if node is None:
-            return
-        for tag in self._observer_tags.pop(id(node), []):
-            try:
-                node.RemoveObserver(tag)
-            except Exception:  # pragma: no cover - defensive
-                pass
-        try:
-            self._observed_node_refs.remove(node)
-        except ValueError:
-            pass
 
     def _on_node_modified(self, caller: Any, event: str) -> None:
         """Reconcile on a carrier / slice ``Modified`` -- reproject + render.
@@ -873,14 +659,13 @@ class TerritorySlicePipeline(_PipelineBase):
         The Pipeline holds no shadow copy of the seed set: the carrier IS the
         source of truth, so a reconcile driven by an unrelated ``Modified``
         (a table repaint, a colour change) reprojects without adding / moving
-        / dropping any seed (ADR-0037 §Conformance no-drift).
+        / dropping any seed (ADR-0037 §Conformance no-drift).  A display-node
+        Modified is (almost always) an adhering-point / visibility change from
+        a hover in SOME view: repaint the marker only, keeping the per-hover
+        cost off the full seed reprojection.
         """
         del event
         try:
-            # A display-node Modified is (almost always) an adhering-point /
-            # visibility change from a hover in SOME view: repaint the marker
-            # only, keeping the per-hover cost off the full seed reprojection.
-            # A carrier / slice Modified reprojects the seeds too.
             if caller is not self._display_node:
                 self._reproject()
             self._reconcile_highlight()
@@ -889,9 +674,24 @@ class TerritorySlicePipeline(_PipelineBase):
             pass
 
 
-def _event_type(eventData: Any) -> int:  # noqa: N803 - VTK arg name
-    """The VTK event-type id off ``eventData``."""
-    return int(eventData.GetType())
+class _TerritorySlicePick:
+    """The base's pick provider, delegating to the pipeline's surface snap.
+
+    The base places a click at whatever world the pick returns (ADR-0038
+    §"Base extension" -- no surface-vs-volume branch).  Territories' pick is
+    the vessel-visibility-gated surface snap, which also stays the unit-layer +
+    placemode-test monkeypatch seam (``_snap_event_to_surface``): this adapter
+    forwards the base's ``pick_for_event`` to it so both the production pick and
+    the injected test double flow through one place.
+    """
+
+    def __init__(self, pipeline) -> None:
+        self._pipeline = pipeline
+
+    def pick_for_event(self, eventData: Any):
+        # Re-read through the pipeline so a unit-layer monkeypatch of
+        # ``_snap_event_to_surface`` is always honoured.
+        return self._pipeline._snap_event_to_surface(eventData)
 
 
 def registerTerritorySlicePipelineCreator() -> None:  # noqa: N802 - project convention

--- a/VascularTerritories/VascularTerritoriesLib/TerritorySliceProjection.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritorySliceProjection.py
@@ -1,188 +1,61 @@
 # Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
 # Distributed under the OSI-approved BSD 3-Clause License.
-"""Pure-math slice projection for territory annotation seeds (ADR-0037).
+"""Compatibility re-export of the shared ``SlicePointProjection`` math.
 
-The 2D-slice territory placement (``TerritorySlicePipeline``) projects the
-carrier's annotation points into a slice view's XY space, fades them by
-their distance to the slice plane, and casts a snap ray along the slice
-normal.  Those operations are pure geometry given a slice node exposing
-``GetXYToRAS`` / ``GetSliceToRAS`` (4x4 ``vtkMatrix4x4``) -- no LayerDM, no
-GL, no Slicer scene -- so they live here as module-level functions the
-bare unit layer can exercise directly (the ``VesselSurfacePick`` /
-``VesselHighlightWiring`` pure-VTK-helper split precedent).
+ADR-0038 §Context named the slice projection into XY (``inverse(XYToRAS)``),
+the distance-graded alpha, the signed above/below side tint, and the HARD
+presence cutoff as duplicated surface -- carried near-verbatim here and in
+``LiverResectionsLib.SliceControlPolygonPipeline``.  The extraction hoisted
+that math into ``SlicerLiverInteractionLib.SlicePointProjection``; this
+module now re-exports it so existing call sites (``TerritorySlicePipeline``)
+and the territory characterization suite keep working unchanged (the
+extraction is behaviour-preserving -- ADR-0038 [review]).
 
-The fade / side-tint / presence-cutoff constants MIRROR the slice control
-polygon (``LiverResectionsLib.SliceControlPolygonPipeline``, ADR-0033) so
-the two slice-projected annotation surfaces read consistently: short fade
-distance (only points NEAR the plane are present), a signed above/below
-side tint, and a HARD presence cutoff because 2D alpha is unreliable.
-
-Imports ``vtk`` only (for the matrix arithmetic); the slice node is passed
-in and duck-typed.
+The dual import mirrors the ``<Module>Lib`` idiom: the installed/built tree
+stages ``SlicerLiverInteractionLib`` alongside this package; the bare unit
+layer sets ``sys.path`` to the individual Lib dir, so a sibling-directory
+fallback keeps the shared core importable there too.
 """
 
 from __future__ import annotations
 
-from typing import Any
+try:
+    from SlicerLiverInteractionLib.SlicePointProjection import (  # noqa: F401
+        FADE_DISTANCE_MM,
+        PICK_RANGE_MM,
+        SIDE_TINT_MAX,
+        apply_matrix_xy,
+        fade_alpha,
+        inverse_xy_to_ras,
+        is_present,
+        normal_ray,
+        project_ras_to_xy,
+        side_tint,
+        signed_distance,
+        signed_distance_to_slice,
+        slice_frame,
+        xy_to_ras_on_plane,
+    )
+except ImportError:  # bare unit layer: add the sibling Lib dir to sys.path
+    import pathlib
+    import sys
 
-#: Distance (mm) over which the projection fades to fully transparent --
-#: the above/below-the-plane cue.  Short by design: only annotation seeds
-#: NEAR the plane are present in a slice at all (mirrors
-#: ``SliceControlPolygonPipeline.FADE_DISTANCE_MM``).
-FADE_DISTANCE_MM = 15.0
-
-#: Presence == visibility: a seed at / beyond ``FADE_DISTANCE_MM`` is
-#: absent (2D alpha is unreliable, so presence is a HARD cutoff, not a
-#: faded-to-zero alpha -- the ADR-0033 slice-polygon rule).
-PICK_RANGE_MM = FADE_DISTANCE_MM
-
-#: Maximum lightness shift for the above/below-plane cue: seeds ABOVE the
-#: plane tint toward white, below toward black, graded by distance.
-#: Sign-neutral, so it composes with any per-territory colour and stays
-#: colourblind-legible (mirrors ``SliceControlPolygonPipeline.SIDE_TINT_MAX``).
-SIDE_TINT_MAX = 0.55
-
-
-def slice_frame(slice_node: Any):
-    """``(origin, unit_normal)`` of the slice plane in RAS, or ``None``.
-
-    Reads the slice-to-RAS matrix's translation (origin) + normalized
-    third column (plane normal).  ``None`` when no slice node / matrix.
-    """
-    if slice_node is None:
-        return None
-    try:
-        to_ras = slice_node.GetSliceToRAS()
-    except Exception:  # pragma: no cover - defensive (fake nodes)
-        return None
-    if to_ras is None:
-        return None
-    origin = [to_ras.GetElement(r, 3) for r in range(3)]
-    normal = [to_ras.GetElement(r, 2) for r in range(3)]
-    norm = sum(n * n for n in normal) ** 0.5 or 1.0
-    normal = [n / norm for n in normal]
-    return origin, normal
-
-
-def signed_distance(origin, normal, point) -> float:
-    """Signed distance (mm) from ``point`` to a plane ``(origin, unit normal)``.
-
-    Positive on the ``+normal`` side, negative on the other.  The per-seed
-    primitive the reproject loop calls after resolving the frame ONCE.
-    """
-    return sum(n * (p - o) for n, p, o in zip(normal, point, origin))
-
-
-def signed_distance_to_slice(slice_node: Any, point) -> float:
-    """Signed distance (mm) from ``point`` (RAS) to the slice plane.
-
-    Positive ABOVE the plane (along the slice normal), negative below.
-    ``+inf`` when the slice frame cannot be resolved.  Convenience wrapper
-    resolving the frame per call -- for a loop, resolve ``slice_frame`` once
-    and call :func:`signed_distance`.
-    """
-    frame = slice_frame(slice_node)
-    if frame is None:
-        return float("inf")
-    return signed_distance(frame[0], frame[1], point)
-
-
-def inverse_xy_to_ras(slice_node: Any):
-    """The slice's ``inverse(XYToRAS)`` as a ``vtkMatrix4x4``, or ``None``.
-
-    Resolved ONCE per reproject and reused for every seed (the
-    ``SliceControlPolygonPipeline`` convention).
-    """
-    if slice_node is None:
-        return None
-    try:
-        import vtk
-
-        ras_to_xy = vtk.vtkMatrix4x4()
-        ras_to_xy.DeepCopy(slice_node.GetXYToRAS())
-        ras_to_xy.Invert()
-    except Exception:  # pragma: no cover - defensive (fake nodes)
-        return None
-    return ras_to_xy
-
-
-def apply_matrix_xy(ras_to_xy, point):
-    """Map an RAS ``point`` through a pre-built ``inverse(XYToRAS)`` to XY."""
-    xy = ras_to_xy.MultiplyPoint((point[0], point[1], point[2], 1.0))
-    w = xy[3] or 1.0
-    return xy[0] / w, xy[1] / w
-
-
-def project_ras_to_xy(slice_node: Any, point):
-    """Project an RAS ``point`` into the slice view's XY space, or ``None``.
-
-    Uses ``inverse(XYToRAS)`` -- the slice-view display coordinates coincide
-    with this XY space (the slice renderer convention, shared with
-    ``SliceControlPolygonPipeline``).  Convenience wrapper building the
-    inverse per call -- for a loop, build it once via
-    :func:`inverse_xy_to_ras` and call :func:`apply_matrix_xy`.
-    """
-    ras_to_xy = inverse_xy_to_ras(slice_node)
-    if ras_to_xy is None:
-        return None
-    return apply_matrix_xy(ras_to_xy, point)
-
-
-def xy_to_ras_on_plane(slice_node: Any, ex: float, ey: float):
-    """Resolve a slice-view pixel ``(ex, ey)`` to its RAS point ON the plane.
-
-    ``XYToRAS`` maps the in-plane pixel (z=0) straight onto the slice
-    plane, so this is the click's landing point before the normal-ray snap.
-    ``None`` when the matrix cannot be read.
-    """
-    if slice_node is None:
-        return None
-    try:
-        xy_to_ras = slice_node.GetXYToRAS()
-        ras = xy_to_ras.MultiplyPoint((float(ex), float(ey), 0.0, 1.0))
-    except Exception:  # pragma: no cover - defensive (fake nodes)
-        return None
-    w = ras[3] or 1.0
-    return ras[0] / w, ras[1] / w, ras[2] / w
-
-
-def normal_ray(slice_node: Any, ras_point, extent_mm: float = 1000.0):
-    """A world ray ``(p1, p2)`` through ``ras_point`` ALONG the slice normal.
-
-    Casts from ``ras_point + extent * normal`` to ``ras_point - extent *
-    normal`` so ``VesselSurfacePick`` can snap the seed onto the vessel
-    surface the slice cuts (ADR-0037 §2D snap).  ``None`` when the slice
-    frame cannot be resolved.
-    """
-    frame = slice_frame(slice_node)
-    if frame is None:
-        return None
-    _origin, normal = frame
-    p1 = tuple(ras_point[i] + normal[i] * extent_mm for i in range(3))
-    p2 = tuple(ras_point[i] - normal[i] * extent_mm for i in range(3))
-    return p1, p2
-
-
-def is_present(distance_mm: float) -> bool:
-    """True iff a seed at ``|distance_mm|`` is present in the slice.
-
-    The HARD presence cutoff (2D alpha unreliable): a seed at / beyond
-    ``PICK_RANGE_MM`` is absent -- not faded-to-zero (ADR-0033).
-    """
-    return abs(distance_mm) < PICK_RANGE_MM
-
-
-def fade_alpha(distance_mm: float) -> float:
-    """Linear fade [0, 1] of a seed by ``|distance_mm|`` to the plane."""
-    return max(0.0, 1.0 - abs(distance_mm) / FADE_DISTANCE_MM)
-
-
-def side_tint(rgb, signed_distance: float):
-    """Blend ``rgb`` toward white (above the plane) or black (below).
-
-    Mirrors ``SliceControlPolygonPipeline._side_tint`` so the two
-    slice-projected surfaces share the signed above/below cue.
-    """
-    fraction = min(1.0, abs(signed_distance) / FADE_DISTANCE_MM) * SIDE_TINT_MAX
-    target = 255 if signed_distance > 0 else 0
-    return [int(c + (target - c) * fraction) for c in rgb]
+    _shared_lib = pathlib.Path(__file__).resolve().parents[2] / "SlicerLiverInteractionLib"
+    if str(_shared_lib) not in sys.path:
+        sys.path.insert(0, str(_shared_lib))
+    from SlicePointProjection import (  # type: ignore[no-redef]  # noqa: F401
+        FADE_DISTANCE_MM,
+        PICK_RANGE_MM,
+        SIDE_TINT_MAX,
+        apply_matrix_xy,
+        fade_alpha,
+        inverse_xy_to_ras,
+        is_present,
+        normal_ray,
+        project_ras_to_xy,
+        side_tint,
+        signed_distance,
+        signed_distance_to_slice,
+        slice_frame,
+        xy_to_ras_on_plane,
+    )


### PR DESCRIPTION
> **WIP / Draft — stacked on #604.** This is the ADR-0038 pipeline
> extraction, landing one client at a time. So far: the shared 3D
> placement base + seam, and resection's 3D pipeline refactored onto it.
> The slice pipeline base + resection slice client + the vascular-territory
> clients are follow-up increments on this branch. Do not merge before #604.

## Summary

Implements the **ADR-0038** extraction: a shared 3D control-point
placement/interaction base in `SlicerLiverInteractionLib`, with the concrete
modules as thin clients over a `PointProvider` seam. This is the
behaviour-preserving refactor the ADR deferred; it is driven now by
LiverVolumetry needing to be a third consumer (issue #570).

### What lands in this increment

- **`SurfacePointPlacementPipeline3D`** — the shared 3D base. It owns the
  generic interaction: add-on-click / drag-to-edit-nearest / delete /
  bare-move-decline arbitration (ADR-0033), the display-space pick-radius
  grab, the provider write-backs, the swappable click→world pick (no
  surface-vs-volume branch in the base — ADR-0038 §"Base extension"), and the
  no-drift reconcile. It carries **no** data-model knowledge; it exposes five
  empty extension hooks (`_admissible`, `_on_grab/_drag/_release`,
  `_on_bare_move_decline`) the clients fill.
- **`PointProvider`** seam + **`SlicePointProjection`** (the slice-projection
  math, extracted for the upcoming slice base).
- **Resection** `ControlPolygonPipeline` is now a genuine thin client: the
  copied arbitration bodies are deleted and the base drives interaction;
  resection-specifics (the ADR-0035 Init/Planning state machine, the grid
  edges, the control-point-depth drag) stay in the client as narrow
  overrides and a `ResectionControlPolygonProvider`. Verified neither the
  state machine nor the edges leak into the base.

### Tests

- New bare provider suite (8) + the resection bare unit scaffold (120 pass /
  30 pre-existing build-dependent skips) green.
- The launched resection interaction characterization suites
  (`test_control_polygon_pipeline.py`, `test_pipeline_control_point_edit.py`)
  and the base 3D suite are LayerDM-gated — they run in CI here. Their green
  is the behaviour-preservation gate for this refactor.

### Follow-up increments on this branch

- Slice placement base + resection slice client.
- Vascular-territory 3D + slice clients over the seam.
- Neutralize the `PointPlacementState` active-key suffix.

Relates to ADR-0038, ADR-0037, ADR-0035, ADR-0033/0032, ADR-0013, ADR-0004;
issue #570.

---

*Drafted with the assistance of Claude Code (model: claude-opus-4-8);
reviewed by the author.*
