### PR TITLE
ENH: LiverVolumetry seeds off markups onto the ADR-0038 base (#570)

### DIFF
--- a/LiverVolumetry/CMakeLists.txt
+++ b/LiverVolumetry/CMakeLists.txt
@@ -14,6 +14,12 @@ set(MODULE_PYTHON_RESOURCES
   Resources/UI/${MODULE_NAME}Widget.ui
   )
 
+# v2.0.0 MRML kit -- the ADR-0038-amendment seeds-off-markups carrier /
+# storage / display node (volumetry-seeds-layerdm-plan.md §3a).  Library
+# name is ``vtkSlicerLiverVolumetryModuleMRML`` (matches MODULE_NAME).
+# Built first so downstream consumers can link + Python-wrap it (mirrors
+# VascularTerritories/CMakeLists.txt).
+add_subdirectory(MRML)
 add_subdirectory(Logic)
 #-----------------------------------------------------------------------------
 slicerMacroBuildScriptedModule(

--- a/LiverVolumetry/CMakeLists.txt
+++ b/LiverVolumetry/CMakeLists.txt
@@ -21,6 +21,12 @@ set(MODULE_PYTHON_RESOURCES
 # VascularTerritories/CMakeLists.txt).
 add_subdirectory(MRML)
 add_subdirectory(Logic)
+
+# ADR-0038 client Python Lib: the carrier->transient-fiducial adapter, the flat
+# PointProvider adapter, the in-volume slice-click pick, and the LayerDM
+# Pipeline creators (volumetry-seeds-layerdm-plan.md §3).  Mirrors
+# VascularTerritoriesLib.
+add_subdirectory(LiverVolumetryLib)
 #-----------------------------------------------------------------------------
 slicerMacroBuildScriptedModule(
   NAME ${MODULE_NAME}

--- a/LiverVolumetry/LiverVolumetry.py
+++ b/LiverVolumetry/LiverVolumetry.py
@@ -47,6 +47,15 @@ import slicer
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 
+# The seed carrier / display node the placement writes to (ADR-0038-amendment
+# seeds-off-markups migration); the interaction state rides the display node via
+# the shared PointPlacementState namespaced ``LiverVolumetry.*``
+# (feedback_layerdm_state_on_display_node).
+SEEDS_NODE_CLASS = "vtkMRMLVolumetrySeedsNode"
+SEEDS_DISPLAY_NODE_CLASS = "vtkMRMLVolumetrySeedsDisplayNode"
+SEEDS_STORAGE_NODE_CLASS = "vtkMRMLVolumetrySeedsStorageNode"
+VOLUMETRY_NAMESPACE = "LiverVolumetry"
+
 
 #
 # LiverVolumetry
@@ -73,11 +82,50 @@ class LiverVolumetry(ScriptedLoadableModule):
     self.parent.acknowledgementText = """
     """  # TODO: replace with organization, grant and thanks.
 
-    # Additional initialization step after application startup is complete
-    #slicer.app.connect("startupCompleted()", registerSampleData)
+    # Register the seed-carrier MRML node classes at module-discovery time
+    # (ADR-0013 §5 call 1) so ``slicer.mrmlScene.AddNewNodeByClass(
+    # "vtkMRMLVolumetrySeedsNode", ...)`` works from any test, batch-mode
+    # script, or other module's setup callback -- not only after the widget is
+    # first opened.  The generic ``vtkLiverVolumetryLogic`` is a plain
+    # vtkObject with no scene observer (ADR-0015 keeps it unchanged), so the
+    # registration lives here in Python, not in a C++ RegisterNodes.
+    if not slicer.app.commandOptions().noMainWindow:
+      slicer.app.connect("startupCompleted()", self._registerSeedNodeClasses)
+    else:
+      # ``--no-main-window`` skips Slicer's normal startup sequence so the
+      # ``startupCompleted`` signal never fires; register immediately so
+      # headless / test invocations still have the classes available.
+      self._registerSeedNodeClasses()
 
     #Hide module, so that it only shows up in the Liver module, and not as a separate module
     parent.hidden = True
+
+  def _registerSeedNodeClasses(self):
+    """Register the seed carrier / display / storage node classes (ADR-0013 §5 call 1).
+
+    Instantiates each wrapped C++ prototype and hands it to
+    ``RegisterNodeClass`` so ``AddNewNodeByClass`` resolves it.  A launch
+    without the module's MRML library on the path (the class import fails)
+    degrades gracefully -- the placement feature is disabled that session.
+    """
+    try:
+      from slicer import (
+        vtkMRMLVolumetrySeedsNode,
+        vtkMRMLVolumetrySeedsDisplayNode,
+        vtkMRMLVolumetrySeedsStorageNode,
+      )
+    except ImportError as exc:
+      logging.warning(
+        "LiverVolumetry: seed MRML node classes unavailable (%s) -- seed "
+        "placement is disabled this session.  This usually means the module "
+        "MRML library failed to build or its Python wrapping is not on the "
+        "launcher's --additional-module-paths.", exc)
+      return
+    scene = slicer.mrmlScene
+    for cls in (vtkMRMLVolumetrySeedsNode,
+                vtkMRMLVolumetrySeedsDisplayNode,
+                vtkMRMLVolumetrySeedsStorageNode):
+      scene.RegisterNodeClass(cls())
 
 
 #
@@ -95,6 +143,13 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.logic = None
     self._parameterNode = None
     self._updatingGUIFromParameterNode = False
+    # The scene-resident seed carrier + its shared data-only display node
+    # (ADR-0038-amendment): the arm state / carrier binding / pick-surface ride
+    # the display node, and the LayerDM-driven placement Pipelines read them
+    # back (feedback_layerdm_state_on_display_node).  Created lazily; dropped on
+    # scene close.
+    self._seedsCarrier = None
+    self._seedsDisplayNode = None
     ScriptedLoadableModuleWidget.__init__(self, parent)
     VTKObservationMixin.__init__(self)  # needed for parameter node observation
 
@@ -103,6 +158,13 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     Called when the user opens the module the first time and the widget is initialized.
     """
     ScriptedLoadableModuleWidget.setup(self)
+
+    # Register the LayerDM Pipeline creators (ADR-0013 §5 call 3): ONE 3D +
+    # ONE slice pipeline for the seed display-node type, each wired to the flat
+    # volumetry provider + the in-volume pick.  No custom displayable manager
+    # (ADR-0013 §5 / feedback_layerdm_no_custom_dm).  Idempotent; guarded
+    # against an unreachable LayerDMLib.
+    self._registerSeedPlacementPipelines()
 
     # Load widget from .ui file (created by Qt Designer)
     liverVolumetryWidget = slicer.util.loadUI(self.resourcePath('UI/LiverVolumetryWidget.ui'))
@@ -141,26 +203,142 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.ui.ComputeVolumePushButton.connect('clicked(bool)', self.onComputeAdvancedVolumeButtonClicked)
     self.ui.GenerateSegmentsPushButton.connect('clicked(bool)', self.onGenerateSegmentsButtonClicked)
     self.ui.ResectionTargetNodeComboBox.connect('currentNodeChanged(vtkMRMLNode*)', self.onGenerateSegmentsParameterChanged)
-    self.ui.ROIMarkersListSelector.connect('currentNodeChanged(vtkMRMLNode*)', self.onGenerateSegmentsParameterChanged)
+    # ADR-0038-amendment: the ROIMarkersList fiducial selector + place widget
+    # are RETIRED; placement is the arm toggle below, driving the seed carrier
+    # through the shared base pipeline.
+    self.ui.AddSeedsButton.connect('toggled(bool)', self.onAddSeedsToggled)
 
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
     self.initializeParameterNode()
 
+  def _registerSeedPlacementPipelines(self):
+    """Register the seed placement LayerDM Pipeline creators (ADR-0013 §5 call 3).
+
+    ONE 3D + ONE slice creator for ``vtkMRMLVolumetrySeedsDisplayNode``, each
+    returning the shared ``SurfacePointPlacementPipeline*`` base wired to the
+    flat volumetry provider + the in-volume pick.  Idempotent; a missing
+    LayerDMLib is a real configuration error under ADR-0002 so it logs at
+    ``critical``, but the rest of widget setup continues.
+    """
+    try:
+      from LiverVolumetryLib import (
+        registerVolumetrySeedPipeline3DCreator,
+        registerVolumetrySeedPipelineSliceCreator,
+      )
+      if registerVolumetrySeedPipeline3DCreator is None:
+        raise ImportError("volumetry seed Pipeline creators unavailable")
+      registerVolumetrySeedPipeline3DCreator()
+      registerVolumetrySeedPipelineSliceCreator()
+    except ImportError as exc:
+      logging.critical(
+        "LiverVolumetry: seed placement LayerDM Pipeline creators not "
+        "registered (%s) -- seed placement is disabled in this session.  "
+        "Loading the SlicerLayerDisplayableManager extension is required for "
+        "the Pipeline path (ADR-0013/0038).", exc)
+
+  # ------------------------------------------------------------------ #
+  # Seed carrier + placement arming (ADR-0038-amendment)
+  # ------------------------------------------------------------------ #
+
+  def _ensureSeedsCarrier(self):
+    """Return the scene-resident seed carrier, creating it once.
+
+    ``None`` when the C++ node class is unavailable (a launch without the
+    module's MRML library on the path) -- the caller degrades gracefully.
+    """
+    node = self._seedsCarrier
+    if node is not None and slicer.mrmlScene.IsNodePresent(node):
+      return node
+    try:
+      node = slicer.mrmlScene.AddNewNodeByClass(SEEDS_NODE_CLASS, "Volumetry Seeds")
+    except Exception:  # noqa: BLE001 - node class not registered in this launch
+      node = None
+    if node is None:
+      logging.warning(
+        "LiverVolumetry: %s unavailable -- seed placement disabled this "
+        "session.", SEEDS_NODE_CLASS)
+      return None
+    self._seedsCarrier = node
+    return node
+
+  def _ensureSeedsDisplayNode(self):
+    """Return the scene-resident seed display node, creating + binding it once.
+
+    Configures the carrier binding + the pick surface BEFORE AddNode: LayerDM
+    consults the Pipeline creators the moment the node enters the scene, and
+    each created Pipeline resolves the carrier + labelmap at creation -- so the
+    carrier reference (and the pickSurface) must already be on the node
+    (the configure-before-AddNode LayerDM discipline).
+    """
+    node = self._seedsDisplayNode
+    if node is not None and slicer.mrmlScene.IsNodePresent(node):
+      return node
+    try:
+      node = slicer.mrmlScene.CreateNodeByClass(SEEDS_DISPLAY_NODE_CLASS)
+    except Exception:  # noqa: BLE001 - node class not registered in this launch
+      node = None
+    if node is None:
+      logging.warning(
+        "LiverVolumetry: %s unavailable -- seed placement disabled this "
+        "session.", SEEDS_DISPLAY_NODE_CLASS)
+      return None
+    node.UnRegister(None)
+    node.SetName("Volumetry Seeds Display")
+    node.SetVisibility(True)
+    carrier = self._ensureSeedsCarrier()
+    if carrier is not None:
+      from SlicerLiverInteractionLib.PointPlacementState import PointPlacementState
+      PointPlacementState(VOLUMETRY_NAMESPACE).set_carrier(node, carrier)
+    self._aimPickSurface(node)
+    node = slicer.mrmlScene.AddNode(node)
+    self._seedsDisplayNode = node
+    return node
+
+  def _aimPickSurface(self, displayNode):
+    """Aim the seed display node's pickSurface at the target labelmap surface.
+
+    The in-volume pick resolves interior voxels against the target region's
+    labelmap.  The v2.0 target region is the currently selected input
+    segmentation; a segmentation node satisfies the pick's labelmap read via
+    its binary labelmap representation.  ``None`` clears the reference.
+    """
+    if displayNode is None or not hasattr(displayNode, "SetAndObservePickSurfaceNodeID"):
+      return
+    segmentation = self.ui.InputSegmentationSelector.currentNode()
+    displayNode.SetAndObservePickSurfaceNodeID(
+      segmentation.GetID() if segmentation is not None else None)
+
+  def onAddSeedsToggled(self, armed):
+    """Arm / disarm interior seed placement through the shared base pipeline.
+
+    Arming publishes the armed flag onto the shared display node so the
+    LayerDM-driven placement Pipelines add an interior seed on the next click;
+    disarming clears it.  The state rides the display node, not a Python
+    pipeline instance (feedback_layerdm_state_on_display_node).
+    """
+    node = self._ensureSeedsDisplayNode()
+    if node is None:
+      return
+    self._aimPickSurface(node)
+    from SlicerLiverInteractionLib.PointPlacementState import PointPlacementState
+    state = PointPlacementState(VOLUMETRY_NAMESPACE)
+    state.set_module_active(node, True)
+    state.set_armed(node, bool(armed))
 
   def onGenerateSegmentsParameterChanged(self):
-    node2 = self.ui.ROIMarkersListSelector.currentNode()
     node3 = self.ui.ReferenceVolumeSelector.currentNode()
     node4 = self.ui.InputSegmentationSelector.currentNode()
     node5 = self.ui.InputSegmentSelectorWidget.selectedSegmentIDs()
     if len(self.ui.InputSegmentSelectorWidget.selectedSegmentIDs()) == 0:
       node5 = None
-    self.ui.GenerateSegmentsPushButton.setEnabled(None not in [ node2, node3, node4, node5])
+    hasSeeds = self._seedsCarrier is not None and self._seedsCarrier.GetNumberOfSeeds() > 0
+    self.ui.GenerateSegmentsPushButton.setEnabled(hasSeeds and None not in [ node3, node4, node5])
 
   def onGenerateSegmentsButtonClicked(self):
     resectionNodes = self.getResectionNodes()
-    ROIMarkersList = self.ui.ROIMarkersListSelector.currentNode()
+    seedsCarrier = self._ensureSeedsCarrier()
     segmentsVolumeNode = slicer.mrmlScene.GetFirstNodeByName("segmentVolumeNode")
     if not segmentsVolumeNode:
       segmentsVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode", "segmentVolumeNode")
@@ -170,7 +348,7 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       slicer.modules.segmentations.logic().ExportSegmentsToLabelmapNode(segmentationNode, segmentationIds,
                                                                         segmentsVolumeNode, refVolumeNode)
 
-    self.logic.generateSegments(resectionNodes, ROIMarkersList, segmentsVolumeNode)
+    self.logic.generateSegments(resectionNodes, seedsCarrier, segmentsVolumeNode)
     slicer.mrmlScene.RemoveNode(segmentsVolumeNode)
 
   def onVolumetryParameterChanged(self):
@@ -224,10 +402,10 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       slicer.modules.segmentations.logic().ExportSegmentsToLabelmapNode(segmentationNode, segmentationIds,
                                                                         targetSegmentVolumeNode, refVolumeNode)
 
-    ROIMarkersList = self.ui.ROIMarkersListSelector.currentNode()
+    seedsCarrier = self._ensureSeedsCarrier()
     outputTable = self.ui.VolumeTableSelectorWidget.currentNode()
 
-    self.logic.computeVolume(segmentsVolumeNode, targetSegmentVolumeNode, self.ui.InputSegmentationSelector.currentNode(), outputTable, ROIMarkersList, resectionNodes)
+    self.logic.computeVolume(segmentsVolumeNode, targetSegmentVolumeNode, self.ui.InputSegmentationSelector.currentNode(), outputTable, seedsCarrier, resectionNodes)
 
     # The wait cursor (set above) is the in-progress feedback; the
     # populated volumetry table is the result, so no blocking completion
@@ -289,6 +467,11 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     Called each time the user opens this module.
     """
+    # Open the module-active add-on-click gate (ADR-0038): the LayerDM-created
+    # placement Pipelines read this off the shared display node, so an armed
+    # click only lands while LiverVolumetry is active.  Entering auto-arms
+    # NOTHING -- placement is the explicit Add-seeds toggle.
+    self._setModuleActive(True)
     # Make sure parameter node exists and observed
     self.initializeParameterNode()
 
@@ -296,8 +479,26 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     Called each time the user opens a different module.
     """
+    # Disarm placement + close the module-active gate on the way out so no view
+    # claims an add-on-click while LiverVolumetry is inactive (ADR-0038).
+    node = getattr(self, "_seedsDisplayNode", None)
+    if node is not None and slicer.mrmlScene.IsNodePresent(node):
+      from SlicerLiverInteractionLib.PointPlacementState import PointPlacementState
+      state = PointPlacementState(VOLUMETRY_NAMESPACE)
+      state.set_armed(node, False)
+      state.set_module_active(node, False)
+    if hasattr(self.ui, "AddSeedsButton"):
+      self.ui.AddSeedsButton.setChecked(False)
     # Do not react to parameter node changes (GUI wlil be updated when the user enters into the module)
     self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
+
+  def _setModuleActive(self, active):
+    """Open/close the shared display node's module-active add-on-click gate."""
+    node = getattr(self, "_seedsDisplayNode", None)
+    if node is None or not slicer.mrmlScene.IsNodePresent(node):
+      return
+    from SlicerLiverInteractionLib.PointPlacementState import PointPlacementState
+    PointPlacementState(VOLUMETRY_NAMESPACE).set_module_active(node, bool(active))
 
   def onSceneStartClose(self, caller, event):
     """
@@ -310,6 +511,10 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     Called just after the scene is closed.
     """
+    # The seed carrier + display node were cleared with the scene; drop the
+    # stale handles so the next placement re-creates fresh ones.
+    self._seedsCarrier = None
+    self._seedsDisplayNode = None
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
     self.initializeParameterNode()
 
@@ -441,7 +646,23 @@ class LiverVolumetryLogic(ScriptedLoadableModuleLogic):
     Initialize parameter node with default settings.
     """
 
-  def computeVolume(self, segmentsVolumeNode, targetSegmentVolumeNode, segmentationNode, outputTable, ROIMarkersList, resectionNodes):
+  def transientFiducialFromSeeds(self, seedsNode):
+    """Build a TRANSIENT fiducial from the seed carrier (ADR-0038 §3c).
+
+    Keeps the C++ ``vtkLiverVolumetryLogic`` signatures unchanged (ADR-0015):
+    they take a ``vtkMRMLMarkupsFiducialNode*``, so the seeds-off-markups path
+    feeds them a transient fiducial built INSIDE the call from the seed carrier,
+    with the per-seed LABEL round-tripping into each control-point label so
+    ``GenerateSegmentsLabelMap`` still names generated segments correctly.  The
+    caller REMOVES the returned node -- no persistent markups survive
+    (ADR-0014 §"Fourth layer").  ``None`` when there is no carrier.
+    """
+    if seedsNode is None:
+      return None
+    from LiverVolumetryLib import build_transient_fiducial
+    return build_transient_fiducial(slicer.mrmlScene, seedsNode)
+
+  def computeVolume(self, segmentsVolumeNode, targetSegmentVolumeNode, segmentationNode, outputTable, seedsNode, resectionNodes):
     statistics = {}
     if outputTable is None:
       raise ValueError("Missing outputTable")
@@ -455,52 +676,66 @@ class LiverVolumetryLogic(ScriptedLoadableModuleLogic):
       voxel_count = numpy.count_nonzero(scalars)
       targetSegmentVolume = voxel_count*spacing[0]*spacing[1]*spacing[2]*0.001
 
-    if resectionNodes is None:
-      if ROIMarkersList is None:
-        import SegmentStatistics
-        segStatLogic = SegmentStatistics.SegmentStatisticsLogic()
-        segStatLogic.getParameterNode().SetParameter("Segmentation", segmentationNode.GetID())
-        segStatLogic.computeStatistics()
-        stats = segStatLogic.getStatistics()
-        for segmentId in stats["SegmentIDs"]:
-          voxel_count = 0
-          volume_cm3 = 0
-          if stats[segmentId,"LabelmapSegmentStatisticsPlugin.voxel_count"]:
-            voxel_count = stats[segmentId,"LabelmapSegmentStatisticsPlugin.voxel_count"]
-            volume_cm3 = stats[segmentId,"LabelmapSegmentStatisticsPlugin.volume_cm3"]
-          elif stats[segmentId,"ScalarVolumeSegmentStatisticsPlugin.voxel_count"]:
-            voxel_count = stats[segmentId,"ScalarVolumeSegmentStatisticsPlugin.voxel_count"]
-            volume_cm3 = stats[segmentId,"ScalarVolumeSegmentStatisticsPlugin.volume_cm3"]
-          segmentName = segmentationNode.GetSegmentation().GetSegment(segmentId).GetName()
-          statistics[segmentId] = [segmentName, voxel_count, volume_cm3]
-          self.scl.VolumetryTable(segmentName, targetSegmentVolume, voxel_count, volume_cm3,outputTable)
+    # Build the transient fiducial from the seed carrier once and feed it to the
+    # unchanged C++ logic (ADR-0038 §3c); remove it afterwards.
+    hasSeeds = seedsNode is not None and seedsNode.GetNumberOfSeeds() > 0
+    ROIMarkersList = self.transientFiducialFromSeeds(seedsNode) if hasSeeds else None
+    try:
+      if resectionNodes is None:
+        if ROIMarkersList is None:
+          import SegmentStatistics
+          segStatLogic = SegmentStatistics.SegmentStatisticsLogic()
+          segStatLogic.getParameterNode().SetParameter("Segmentation", segmentationNode.GetID())
+          segStatLogic.computeStatistics()
+          stats = segStatLogic.getStatistics()
+          for segmentId in stats["SegmentIDs"]:
+            voxel_count = 0
+            volume_cm3 = 0
+            if stats[segmentId,"LabelmapSegmentStatisticsPlugin.voxel_count"]:
+              voxel_count = stats[segmentId,"LabelmapSegmentStatisticsPlugin.voxel_count"]
+              volume_cm3 = stats[segmentId,"LabelmapSegmentStatisticsPlugin.volume_cm3"]
+            elif stats[segmentId,"ScalarVolumeSegmentStatisticsPlugin.voxel_count"]:
+              voxel_count = stats[segmentId,"ScalarVolumeSegmentStatisticsPlugin.voxel_count"]
+              volume_cm3 = stats[segmentId,"ScalarVolumeSegmentStatisticsPlugin.volume_cm3"]
+            segmentName = segmentationNode.GetSegmentation().GetSegment(segmentId).GetName()
+            statistics[segmentId] = [segmentName, voxel_count, volume_cm3]
+            self.scl.VolumetryTable(segmentName, targetSegmentVolume, voxel_count, volume_cm3,outputTable)
+        else:
+          import vtk
+          import numpy
+          ROIvalues = self.scl.GetROIPointsLabelValue(segmentsVolumeNode, ROIMarkersList)
+          scalars = vtk.util.numpy_support.vtk_to_numpy(segmentsVolumeNode.GetImageData().GetPointData().GetScalars())
+          spacing = segmentsVolumeNode.GetSpacing()
+          for i, values in enumerate(ROIvalues):
+            voxel_count = numpy.count_nonzero(scalars == values)
+            volume_cm3 = voxel_count*spacing[0]*spacing[1]*spacing[2]*0.001
+            pointLabel = ROIMarkersList.GetNthControlPointLabel(i)
+            statistics[pointLabel] = [pointLabel, voxel_count, volume_cm3]
+            self.scl.VolumetryTable(pointLabel, targetSegmentVolume, voxel_count, volume_cm3, outputTable)
       else:
-        import vtk
-        import numpy
-        ROIvalues = self.scl.GetROIPointsLabelValue(segmentsVolumeNode, ROIMarkersList)
-        scalars = vtk.util.numpy_support.vtk_to_numpy(segmentsVolumeNode.GetImageData().GetPointData().GetScalars())
-        spacing = segmentsVolumeNode.GetSpacing()
-        for i, values in enumerate(ROIvalues):
-          voxel_count = numpy.count_nonzero(scalars == values)
-          volume_cm3 = voxel_count*spacing[0]*spacing[1]*spacing[2]*0.001
-          pointLabel = ROIMarkersList.GetNthControlPointLabel(i)
-          statistics[pointLabel] = [pointLabel, voxel_count, volume_cm3]
-          self.scl.VolumetryTable(pointLabel, targetSegmentVolume, voxel_count, volume_cm3, outputTable)
-    else:
-      self.scl.ComputeAdvancedPlanningVolumetry(segmentsVolumeNode, outputTable, ROIMarkersList, resectionNodes, targetSegmentVolume)
+        self.scl.ComputeAdvancedPlanningVolumetry(segmentsVolumeNode, outputTable, ROIMarkersList, resectionNodes, targetSegmentVolume)
+    finally:
+      if ROIMarkersList is not None:
+        slicer.mrmlScene.RemoveNode(ROIMarkersList)
 
-  def generateSegments(self, resectionNodes, ROIMarkersList, segmentsVolumeNode):
-    generatedSegmentsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
-    generatedSegmentsNode.CreateDefaultDisplayNodes()
+  def generateSegments(self, resectionNodes, seedsNode, segmentsVolumeNode):
+    ROIMarkersList = self.transientFiducialFromSeeds(seedsNode)
+    if ROIMarkersList is None:
+      return
+    try:
+      generatedSegmentsNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
+      generatedSegmentsNode.CreateDefaultDisplayNodes()
 
-    self.scl.GenerateSegmentsLabelMap(segmentsVolumeNode, generatedSegmentsNode, resectionNodes, ROIMarkersList)
+      self.scl.GenerateSegmentsLabelMap(segmentsVolumeNode, generatedSegmentsNode, resectionNodes, ROIMarkersList)
 
-    seg = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
-    slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(generatedSegmentsNode, seg)
+      seg = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+      slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(generatedSegmentsNode, seg)
 
-    ##set segments label
-    seg.GetSegmentation().GetNthSegment(0).SetName("Remnant")
-    for i in range(ROIMarkersList.GetNumberOfControlPoints()):
-      seg.GetSegmentation().GetNthSegment(i+1).SetName(ROIMarkersList.GetNthFiducialLabel(i))
+      ##set segments label
+      seg.GetSegmentation().GetNthSegment(0).SetName("Remnant")
+      for i in range(ROIMarkersList.GetNumberOfControlPoints()):
+        seg.GetSegmentation().GetNthSegment(i+1).SetName(ROIMarkersList.GetNthFiducialLabel(i))
 
-    slicer.mrmlScene.RemoveNode(generatedSegmentsNode)
+      slicer.mrmlScene.RemoveNode(generatedSegmentsNode)
+    finally:
+      slicer.mrmlScene.RemoveNode(ROIMarkersList)

--- a/LiverVolumetry/LiverVolumetry.py
+++ b/LiverVolumetry/LiverVolumetry.py
@@ -150,6 +150,11 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # scene close.
     self._seedsCarrier = None
     self._seedsDisplayNode = None
+    # The carrier-backed seeds table (ADR-0038 §Conformance): one row per seed
+    # with an editable label (the generated segment name), a colour swatch, and
+    # a delete affordance.  Composed into the panel in ``setup`` and bound to
+    # the carrier once it exists; dropped on scene close.
+    self._seedsTable = None
     ScriptedLoadableModuleWidget.__init__(self, parent)
     VTKObservationMixin.__init__(self)  # needed for parameter node observation
 
@@ -208,6 +213,12 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # through the shared base pipeline.
     self.ui.AddSeedsButton.connect('toggled(bool)', self.onAddSeedsToggled)
 
+    # Compose the carrier-backed seeds table into the panel (ADR-0004: the
+    # panel is Python).  It is bound to the seed carrier lazily -- the carrier
+    # is created on first placement -- so it starts empty and repaints on the
+    # carrier's ModifiedEvent once bound.
+    self._composeSeedsTable(liverVolumetryWidget)
+
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
@@ -238,6 +249,40 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         "Loading the SlicerLayerDisplayableManager extension is required for "
         "the Pipeline path (ADR-0013/0038).", exc)
 
+  def _composeSeedsTable(self, panelWidget):
+    """Compose the carrier-backed seeds table into the panel grid (ADR-0004).
+
+    Placed on the free grid row between the Add-seeds toggle and the
+    Generate-segments button (the seed list belongs with the seed controls).
+    A missing widget class (a launch without the Lib on the path) degrades
+    gracefully -- the panel simply omits the table.
+    """
+    # The package guards the widget import (Qt/ctk unreachable bare), exposing
+    # ``None`` when the class could not be built -- degrade to no table.
+    from LiverVolumetryLib import VolumetrySeedsTableWidget
+    if VolumetrySeedsTableWidget is None:
+      logging.warning(
+        "LiverVolumetry: VolumetrySeedsTableWidget unavailable -- the seeds "
+        "table is omitted this session.")
+      return
+    self._seedsTable = VolumetrySeedsTableWidget(carrier=None)
+    grid = self.ui.ResectionVolumetryGroupWidget.layout()
+    if grid is not None and hasattr(grid, "addWidget"):
+      # Row 6, colspan 4: between AddSeedsButton (row 5) and
+      # GenerateSegmentsPushButton (row 7) in the .ui grid.
+      grid.addWidget(self._seedsTable, 6, 0, 1, 4)
+    else:
+      panelWidget.layout().addWidget(self._seedsTable)
+
+  def _bindSeedsTable(self, carrier):
+    """Rebind the seeds table over ``carrier`` (drops the prior observer).
+
+    Re-parents nothing -- only the carrier binding changes -- so the future
+    unified planning table can adopt the same rebind seam.
+    """
+    if self._seedsTable is not None:
+      self._seedsTable.setCarrier(carrier)
+
   # ------------------------------------------------------------------ #
   # Seed carrier + placement arming (ADR-0038-amendment)
   # ------------------------------------------------------------------ #
@@ -261,6 +306,9 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         "session.", SEEDS_NODE_CLASS)
       return None
     self._seedsCarrier = node
+    # Bind the freshly-created carrier into the panel's seeds table so labels /
+    # colours / deletes edit the same carrier the placement writes to.
+    self._bindSeedsTable(node)
     return node
 
   def _ensureSeedsDisplayNode(self):
@@ -461,6 +509,11 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     Called when the application closes and the module widget is destroyed.
      """
+    # Tear down the seeds table's carrier observer so the parentless widget
+    # does not survive to app shutdown holding a MRML observer
+    # (feedback_launched_widget_teardown_crash).
+    if self._seedsTable is not None:
+      self._seedsTable.cleanup()
     self.removeObservers()
 
   def enter(self):
@@ -515,6 +568,9 @@ class LiverVolumetryWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # stale handles so the next placement re-creates fresh ones.
     self._seedsCarrier = None
     self._seedsDisplayNode = None
+    # Unbind the table from the now-invalid carrier (drops its observer) so it
+    # empties and does not observe a scene-cleared node.
+    self._bindSeedsTable(None)
     # If this module is shown while the scene is closed then recreate a new parameter node immediately
     self.initializeParameterNode()
 

--- a/LiverVolumetry/LiverVolumetryLib/CMakeLists.txt
+++ b/LiverVolumetry/LiverVolumetryLib/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LiverVolumetryLib_PYTHON_SCRIPTS
   VolumetrySeedProvider.py
   InVolumePick.py
   VolumetrySeedPipeline.py
+  VolumetrySeedsTableWidget.py
   )
 
 set(LiverVolumetryLib_PYTHON_RESOURCES

--- a/LiverVolumetry/LiverVolumetryLib/CMakeLists.txt
+++ b/LiverVolumetry/LiverVolumetryLib/CMakeLists.txt
@@ -1,0 +1,39 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+#
+# LiverVolumetry seeds-off-markups client — Python install rules for the
+# pure carrier->transient-fiducial adapter, the flat PointProvider adapter,
+# the in-volume slice-click pick, and the LayerDM Pipeline creators (ADR-0038
+# implementation amendment; volumetry-seeds-layerdm-plan.md §3).
+#
+# Mirrors the ``<Module>Lib`` convention used by ``VascularTerritoriesLib``
+# and ``LiverResectionsLib``: a Python sub-package staged alongside the
+# scripted module so it is importable at runtime and from the bare unit layer.
+#
+# EVERY runtime module MUST be listed below: ctkMacroCompilePythonScript
+# stages ONLY the listed scripts into the build/install tree, and the
+# package ``__init__`` swallows a missing-module ImportError (degrading the
+# feature to silently disabled).  A file present on disk but absent here
+# works in the source tree yet vanishes in an installed build.
+#-----------------------------------------------------------------------------
+
+set(LiverVolumetryLib_PYTHON_SCRIPTS
+  __init__.py
+  TransientVolumetrySeeds.py
+  VolumetrySeedProvider.py
+  InVolumePick.py
+  VolumetrySeedPipeline.py
+  )
+
+set(LiverVolumetryLib_PYTHON_RESOURCES
+  )
+
+ctkMacroCompilePythonScript(
+  TARGET_NAME LiverVolumetryLib
+  SCRIPTS "${LiverVolumetryLib_PYTHON_SCRIPTS}"
+  RESOURCES "${LiverVolumetryLib_PYTHON_RESOURCES}"
+  DESTINATION_DIR ${CMAKE_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}/LiverVolumetryLib
+  INSTALL_DIR ${Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR}/LiverVolumetryLib
+  NO_INSTALL_SUBDIR
+  )

--- a/LiverVolumetry/LiverVolumetryLib/InVolumePick.py
+++ b/LiverVolumetry/LiverVolumetryLib/InVolumePick.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The volumetry in-volume / slice-click pick provider (ADR-0038 §"Base extension").
+
+ADR-0038's implementation amendment (2026-07-27, OQ4) makes the pick step a
+SEAM-INJECTED provider on the base, not a fixed surface snap.  LiverVolumetry
+seeds are REGION-GROWING seeds: ``vtkLiverVolumetryLogic`` converts each seed
+to a voxel index (``TransformPhysicalPointToIndex``) and grows a
+``ConnectedThreshold`` from it (ADR-0015), so the seed must land INSIDE the
+target region -- on a labelled voxel with labelled neighbours -- not on the
+region's surface.  A surface snap would place the seed on the boundary and can
+mis-seed the grow.
+
+So the surface consumers (resection, vascular territories) inject a
+``SurfacePick``; LiverVolumetry injects THIS in-volume pick.  It resolves a
+slice-view click to the interior RAS point of a labelmap volume:
+
+* the pixel is projected to RAS on the slice plane (``XYToRAS``);
+* that RAS is mapped to the labelmap's voxel index (``RASToIJK``);
+* the index is snapped to the nearest STRICTLY-INTERIOR labelled voxel (a
+  labelled voxel whose six axis neighbours are all labelled), so the returned
+  RAS lands on a voxel the region-grow can seed.
+
+The base carries NO surface-vs-volume branch (ADR-0038 §"Base extension") -- it
+places at whatever world point this provider returns; ``None`` declines the
+placement (the click was outside any labelled region).
+
+References
+----------
+* ADR-0038 -- §"Base extension: the pick step is swappable (surface vs
+  in-volume)".
+* ADR-0015 -- the region-grow C++ (TransformPhysicalPointToIndex ->
+  ConnectedThreshold) the interior seed feeds, unchanged.
+* SlicerLiverInteractionLib/SurfacePick.py -- the surface variant this parallels.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class InVolumePick:
+    """Resolve a slice-view click to an interior labelled voxel's RAS point.
+
+    Bound to a ``vtkMRMLLabelMapVolumeNode``; keeps no cursor state, so a
+    (re)aimed labelmap is a fresh binding.  Satisfies both the volumetry
+    slice-click seam (``pick_for_slice_event``) and the base's generic pick
+    seam (``pick_for_event``), which routes a 3D/slice event through the same
+    interior-voxel resolution.
+    """
+
+    def __init__(self, labelmap) -> None:
+        self._labelmap = labelmap
+
+    # ------------------------------------------------------------------ #
+    # The base's generic pick seam (ADR-0038 PickProvider)
+    # ------------------------------------------------------------------ #
+
+    def pick_for_event(self, renderer: Any, eventData: Any):
+        """The base's click->world seam: return an interior RAS point or ``None``.
+
+        The base calls this for a click; the volumetry pick ignores the
+        renderer (the seed is resolved against the labelmap, not the camera)
+        and returns the region's interior point.  A slice-aware caller may use
+        ``pick_for_slice_event`` directly to honour the clicked pixel.
+        """
+        del renderer, eventData
+        return self._interior_ras()
+
+    # ------------------------------------------------------------------ #
+    # The volumetry slice-click seam
+    # ------------------------------------------------------------------ #
+
+    def pick_for_slice_event(self, slice_node, display_xy):
+        """Resolve a slice-view click to a strictly-interior labelled voxel's RAS.
+
+        With ``display_xy`` set, projects the pixel to RAS on the slice plane
+        and snaps to the nearest strictly-interior labelled voxel; with
+        ``display_xy`` None (or no slice geometry), returns the region's
+        interior centroid.  ``None`` when there is no labelled region.
+        """
+        seed_ras = None
+        if display_xy is not None and slice_node is not None:
+            seed_ras = self._xy_to_ras_on_plane(slice_node, display_xy)
+        return self._interior_ras(near_ras=seed_ras)
+
+    # ------------------------------------------------------------------ #
+    # Interior-voxel resolution
+    # ------------------------------------------------------------------ #
+
+    def _interior_ras(self, near_ras=None):
+        """The RAS of a strictly-interior labelled voxel, nearest ``near_ras``.
+
+        Scans the labelmap for labelled voxels whose six axis neighbours are
+        ALSO labelled (strictly inside, not a boundary face -- ADR-0038
+        §"Base extension"), and returns the one whose IJK index is nearest the
+        seed index derived from ``near_ras`` (or nearest the labelled bounding-
+        box centre when no seed is given).  ``None`` when the region has no
+        strictly-interior voxel.
+        """
+        import vtk
+
+        labelmap = self._labelmap
+        if labelmap is None:
+            return None
+        image = labelmap.GetImageData()
+        if image is None:
+            return None
+        dims = image.GetDimensions()
+
+        # The target seed index: the clicked pixel's voxel, or the labelled
+        # bounding-box centre when no pixel is supplied.
+        target = None
+        if near_ras is not None:
+            ras_to_ijk = vtk.vtkMatrix4x4()
+            labelmap.GetRASToIJKMatrix(ras_to_ijk)
+            ijk = ras_to_ijk.MultiplyPoint([near_ras[0], near_ras[1], near_ras[2], 1.0])
+            target = (int(round(ijk[0])), int(round(ijk[1])), int(round(ijk[2])))
+
+        best_index = None
+        best_d2 = None
+        centre_accum = [0, 0, 0]
+        interior_count = 0
+        for k in range(1, dims[2] - 1):
+            for j in range(1, dims[1] - 1):
+                for i in range(1, dims[0] - 1):
+                    if image.GetScalarComponentAsDouble(i, j, k, 0) == 0:
+                        continue
+                    if not self._is_strict_interior(image, i, j, k):
+                        continue
+                    centre_accum[0] += i
+                    centre_accum[1] += j
+                    centre_accum[2] += k
+                    interior_count += 1
+                    if target is not None:
+                        d2 = (
+                            (i - target[0]) ** 2
+                            + (j - target[1]) ** 2
+                            + (k - target[2]) ** 2
+                        )
+                        if best_d2 is None or d2 < best_d2:
+                            best_d2 = d2
+                            best_index = (i, j, k)
+        if interior_count == 0:
+            return None
+
+        if best_index is None:
+            # No click supplied: use the interior centroid, snapped back to a
+            # labelled strictly-interior voxel if the raw centroid missed one.
+            centroid = (
+                centre_accum[0] // interior_count,
+                centre_accum[1] // interior_count,
+                centre_accum[2] // interior_count,
+            )
+            best_index = centroid
+            if (
+                image.GetScalarComponentAsDouble(*centroid, 0) == 0
+                or not self._is_strict_interior(image, *centroid)
+            ):
+                best_index = self._nearest_interior(image, dims, centroid)
+                if best_index is None:
+                    return None
+
+        ijk_to_ras = vtk.vtkMatrix4x4()
+        labelmap.GetIJKToRASMatrix(ijk_to_ras)
+        ras = ijk_to_ras.MultiplyPoint(
+            [float(best_index[0]), float(best_index[1]), float(best_index[2]), 1.0]
+        )
+        return (ras[0], ras[1], ras[2])
+
+    @staticmethod
+    def _is_strict_interior(image, i, j, k) -> bool:
+        """True iff voxel ``(i, j, k)`` is labelled with all six neighbours labelled."""
+        if image.GetScalarComponentAsDouble(i, j, k, 0) == 0:
+            return False
+        for di, dj, dk in (
+            (1, 0, 0),
+            (-1, 0, 0),
+            (0, 1, 0),
+            (0, -1, 0),
+            (0, 0, 1),
+            (0, 0, -1),
+        ):
+            if image.GetScalarComponentAsDouble(i + di, j + dj, k + dk, 0) == 0:
+                return False
+        return True
+
+    def _nearest_interior(self, image, dims, target):
+        """The strictly-interior labelled voxel nearest ``target`` (or ``None``)."""
+        best_index = None
+        best_d2 = None
+        for k in range(1, dims[2] - 1):
+            for j in range(1, dims[1] - 1):
+                for i in range(1, dims[0] - 1):
+                    if not self._is_strict_interior(image, i, j, k):
+                        continue
+                    d2 = (
+                        (i - target[0]) ** 2
+                        + (j - target[1]) ** 2
+                        + (k - target[2]) ** 2
+                    )
+                    if best_d2 is None or d2 < best_d2:
+                        best_d2 = d2
+                        best_index = (i, j, k)
+        return best_index
+
+    @staticmethod
+    def _xy_to_ras_on_plane(slice_node, display_xy):
+        """Project a slice-view pixel to RAS on the slice plane (``XYToRAS``)."""
+        import vtk
+
+        xy_to_ras = slice_node.GetXYToRAS()
+        if xy_to_ras is None:
+            return None
+        homog = vtk.vtkMatrix4x4()
+        homog.DeepCopy(xy_to_ras)
+        ras = homog.MultiplyPoint([float(display_xy[0]), float(display_xy[1]), 0.0, 1.0])
+        return (ras[0], ras[1], ras[2])

--- a/LiverVolumetry/LiverVolumetryLib/TransientVolumetrySeeds.py
+++ b/LiverVolumetry/LiverVolumetryLib/TransientVolumetrySeeds.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment) -- the carrier->transient-fiducial adapter.
+
+``vtkLiverVolumetryLogic`` keeps its C++ signatures unchanged (ADR-0015): it
+takes a ``vtkMRMLMarkupsFiducialNode*``.  The seeds-off-markups migration
+feeds it a TRANSIENT fiducial built INSIDE the call from the seed carrier
+(``vtkMRMLVolumetrySeedsNode``), mirroring ADR-0037 §Decision 4 /
+``VascularTerritoriesLib.TransientVmtkSeeds``.
+
+Two layers, split on the ADR-0004 Python/C++ boundary:
+
+* ``build_fiducial_payload`` -- a DEPENDENCY-FREE core mapping ordered
+  ``(x, y, z, label)`` seeds to a fiducial-shaped payload, preserving
+  coordinate + LABEL + order.  It imports neither ``slicer`` nor ``vtk`` nor
+  Qt, so the mapping invariant is bare-unit-testable
+  (``test_volumetry_seed_transient_fiducial.py``).
+* ``build_transient_fiducial`` -- a thin Logic wrapper over the core that
+  creates the transient ``vtkMRMLMarkupsFiducialNode`` in a live scene from a
+  carrier node (positions + per-seed labels as control-point labels), returning
+  the node the caller feeds the logic and later removes.  Pinned end to end by
+  ``test_volumetry_compute_from_carrier.py``.
+
+The per-seed LABEL must round-trip into the transient fiducial's control-point
+label so ``GenerateSegmentsLabelMap`` still names generated segments correctly
+(ADR-0038 §Conformance).
+
+References
+----------
+* ADR-0038 -- §Conformance (per-seed labels round-trip so generated segments
+  keep their names).
+* ADR-0004 -- Python/C++ boundary; keep the mapping pure Python.
+* ADR-0015 -- the C++ region-grow logic is unchanged (transient adapter, not a
+  signature rewrite).
+* VascularTerritoriesLib/TransientVmtkSeeds.py -- the transient-builder idiom
+  this mirrors.
+"""
+
+from __future__ import annotations
+
+
+def build_fiducial_payload(seeds):
+    """Map ordered ``(x, y, z, label)`` seeds to a fiducial-shaped payload.
+
+    Reproduces ``seeds`` 1:1 in placement ORDER as ``((x, y, z), label)``
+    pairs, preserving each seed's coordinate and its LABEL (the generated
+    segment name).  Pure -- no live scene, no markups, no wrapped node -- so
+    the mapping invariant is bare-unit-testable (ADR-0038 §Conformance).
+
+    :param seeds: iterable of ``(x, y, z, label)`` tuples in placement order.
+    :returns: list of ``((x, y, z), label)`` pairs, one per input seed, in the
+        SAME order.
+    """
+    payload = []
+    for x, y, z, label in seeds:
+        payload.append(((float(x), float(y), float(z)), label))
+    return payload
+
+
+def seeds_from_carrier(seedsNode):
+    """Read a ``vtkMRMLVolumetrySeedsNode`` into ordered ``(x, y, z, label)``.
+
+    The carrier read the pure core consumes: walks the carrier in placement
+    order (``GetNumberOfSeeds`` / ``GetNthSeed`` / ``GetNthSeedLabel``) so the
+    label stays bound to its coordinate.  Kept separate from
+    ``build_fiducial_payload`` so the pure core never touches a wrapped node.
+    """
+    seeds = []
+    if seedsNode is None:
+        return seeds
+    for i in range(seedsNode.GetNumberOfSeeds()):
+        coord = seedsNode.GetNthSeed(i)
+        seeds.append(
+            (float(coord[0]), float(coord[1]), float(coord[2]), seedsNode.GetNthSeedLabel(i))
+        )
+    return seeds
+
+
+def build_transient_fiducial(scene, seedsNode):
+    """Build a transient ``vtkMRMLMarkupsFiducialNode`` from the seed carrier.
+
+    The thin Logic wrapper over ``build_fiducial_payload`` (ADR-0004): adds a
+    fiducial node to ``scene``, sets each control point's position + LABEL from
+    the carrier's seeds in placement ORDER, and returns it.  The caller feeds it
+    to the unchanged ``vtkLiverVolumetryLogic`` and REMOVES it afterwards -- no
+    persistent markups survive (ADR-0014 §"Fourth layer").
+
+    The control-point LABEL round-trip is the segment-name fidelity
+    ``GenerateSegmentsLabelMap`` reads (ADR-0038 §Conformance).
+    """
+    import vtk
+
+    node = scene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    payload = build_fiducial_payload(seeds_from_carrier(seedsNode))
+    for (x, y, z), label in payload:
+        index = node.AddControlPoint(vtk.vtkVector3d(x, y, z))
+        node.SetNthControlPointLabel(index, label)
+    return node

--- a/LiverVolumetry/LiverVolumetryLib/VolumetrySeedPipeline.py
+++ b/LiverVolumetry/LiverVolumetryLib/VolumetrySeedPipeline.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""LayerDM Pipeline creators for volumetry seed placement (ADR-0038 / ADR-0013 §5).
+
+ADR-0038 §Decision makes LiverVolumetry a thin CLIENT of the shared
+control-point base: the base DRIVES the generic add-on-click / drag-to-edit-
+nearest / delete / bare-move-decline arbitration
+(``SurfacePointPlacementPipeline3D`` / ``...Slice``), and this module supplies
+ONLY the volumetry-specific wiring through the base's injected seams -- the
+flat ``VolumetrySeedProvider`` (data model) + the ``InVolumePick``
+(``ADR-0038 §"Base extension"`` -- the in-volume/slice pick, not a surface
+snap).  There is NO territory grouping and NO vessel gating (ADR-0038 §"What
+is not shared"): volumetry is the simplest of the three clients.
+
+The interaction state (arm / carrier / pick-surface) rides the SHARED
+``vtkMRMLVolumetrySeedsDisplayNode`` via the base's ``PointPlacementState``
+(namespaced ``LiverVolumetry.*``), NOT the Python pipeline instance LayerDM
+does not drive (``feedback_layerdm_state_on_display_node``).  So the LayerDM-
+created pipelines resolve the carrier + the labelmap from the display node at
+creation and re-resolve on ``UpdatePipeline`` (the display node is added to the
+scene before the widget binds the carrier reference).
+
+Two creators, keyed disjointly (ADR-0013 §1 -- one pipeline per (view, type)):
+
+* ``(vtkMRMLViewNode, vtkMRMLVolumetrySeedsDisplayNode)`` -> the 3D pipeline;
+* ``(vtkMRMLSliceNode, vtkMRMLVolumetrySeedsDisplayNode)`` -> the slice pipeline.
+
+Rendering + interaction route through these scripted Pipelines + their
+creators, NEVER a custom displayable manager (ADR-0013 §5 /
+``feedback_layerdm_no_custom_dm``).
+
+References
+----------
+* ADR-0038 -- §Decision (client-of-the-base seam) + §"Base extension"
+  (in-volume pick) + §"Consumers ledger" (LiverVolumetry client).
+* ADR-0013 §1/§5 -- one pipeline per (view, type); the 3 registration calls;
+  no custom displayable manager.
+* VascularTerritoriesLib/TerritoryPlacementPipeline.py -- the client-of-the-base
+  wiring idiom this mirrors (minus the territory grouping + vessel gating).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The shared 3D + slice placement/edit bases (ADR-0038 §Decision): volumetry is
+# the flat, ungated client over the PointProvider + swappable-pick seam.
+try:  # pragma: no cover - exercised once per import path
+    from SlicerLiverInteractionLib.SurfacePointPlacementPipeline3D import (
+        SurfacePointPlacementPipeline3D as _Pipeline3DBase,
+    )
+    from SlicerLiverInteractionLib.SurfacePointPlacementPipelineSlice import (
+        SurfacePointPlacementPipelineSlice as _PipelineSliceBase,
+    )
+    from SlicerLiverInteractionLib.PointPlacementState import PointPlacementState
+except ImportError:  # bare / top-level path: add the sibling Lib dir to sys.path
+    import pathlib
+    import sys as _sys
+
+    _shared_lib = pathlib.Path(__file__).resolve().parents[2] / "SlicerLiverInteractionLib"
+    if str(_shared_lib) not in _sys.path:
+        _sys.path.insert(0, str(_shared_lib))
+    from SurfacePointPlacementPipeline3D import (  # type: ignore[no-redef]
+        SurfacePointPlacementPipeline3D as _Pipeline3DBase,
+    )
+    from SurfacePointPlacementPipelineSlice import (  # type: ignore[no-redef]
+        SurfacePointPlacementPipelineSlice as _PipelineSliceBase,
+    )
+    from PointPlacementState import PointPlacementState  # type: ignore[no-redef]
+
+try:  # pragma: no cover - exercised once per import path
+    from .VolumetrySeedProvider import VolumetrySeedProvider
+    from .InVolumePick import InVolumePick
+except ImportError:  # top-level import path (the unit layer's sys.path setup)
+    from VolumetrySeedProvider import VolumetrySeedProvider  # type: ignore[no-redef]
+    from InVolumePick import InVolumePick  # type: ignore[no-redef]
+
+#: The base namespace for the volumetry arm/carrier/pick state on the shared
+#: display node (matches the display node's ``LiverVolumetry.*`` attribute
+#: channel; vtkMRMLVolumetrySeedsDisplayNode header §"Field roster").
+VOLUMETRY_NAMESPACE = "LiverVolumetry"
+
+_REGISTERED_3D = False
+_REGISTERED_SLICE = False
+
+
+def _carrier_from_display(displayNode: Any):
+    """The seed carrier the shared display node binds (``LiverVolumetry.carrier``)."""
+    state = PointPlacementState(VOLUMETRY_NAMESPACE)
+    return state.get_carrier(displayNode)
+
+
+def _labelmap_from_display(displayNode: Any):
+    """The target labelmap the in-volume pick resolves against (``pickSurface``)."""
+    if displayNode is None or not hasattr(displayNode, "GetPickSurfaceNode"):
+        return None
+    return displayNode.GetPickSurfaceNode()
+
+
+def _wire_provider_and_pick(pipeline: Any, displayNode: Any) -> None:
+    """(Re)resolve the flat provider + the in-volume pick from the display node.
+
+    Shared by the 3D + slice pipelines: the display node enters the scene
+    before the widget binds the carrier reference, so both re-run this on
+    ``UpdatePipeline`` (fired when the reference is set) to pick up the bound
+    carrier + labelmap.
+    """
+    provider = VolumetrySeedProvider(_carrier_from_display(displayNode))
+    provider.SetDisplayNode(displayNode)
+    pipeline.SetProvider(provider)
+    labelmap = _labelmap_from_display(displayNode)
+    pipeline.SetPickProvider(InVolumePick(labelmap) if labelmap is not None else None)
+
+
+class VolumetrySeedPipeline3D(_Pipeline3DBase):
+    """The 3D volumetry seed placement pipeline (a thin base client).
+
+    Created by LayerDM's manager for ``(vtkMRMLViewNode,
+    vtkMRMLVolumetrySeedsDisplayNode)``.  Wires the flat volumetry provider +
+    the in-volume pick from the shared display node; the base drives the
+    add/grab/drag/delete arbitration.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(namespace=VOLUMETRY_NAMESPACE)
+
+    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
+        super().SetDisplayNode(displayNode)
+        self._display_node = displayNode
+        self._rewire()
+
+    def OnRendererAdded(self, renderer: Any) -> None:  # noqa: N802 - VTK verb
+        try:
+            self._renderer = renderer
+            if self._display_node is None:
+                display = self.GetDisplayNode()
+                if display is not None:
+                    self.SetDisplayNode(display)
+            self._rewire()
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def UpdatePipeline(self) -> None:  # noqa: N802 - VTK verb
+        try:
+            self._rewire()
+            self.RequestRender()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            pass
+
+    def _rewire(self) -> None:
+        """(Re)resolve the provider + pick from the shared display node."""
+        _wire_provider_and_pick(self, self._display_node)
+
+
+class VolumetrySeedPipelineSlice(_PipelineSliceBase):
+    """The slice volumetry seed placement pipeline (a thin base client).
+
+    Created by LayerDM's manager for ``(vtkMRMLSliceNode,
+    vtkMRMLVolumetrySeedsDisplayNode)``.  The slice analogue of the 3D pipeline:
+    an armed slice click routes through the in-volume pick's slice-click seam so
+    the seed lands on an interior labelled voxel of the target region.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(namespace=VOLUMETRY_NAMESPACE)
+
+    def _after_display_node_set(self) -> None:
+        _wire_provider_and_pick(self, self._display_node)
+
+    def _pick_world(self, eventData: Any):
+        """Route the armed slice click through the in-volume slice-click pick.
+
+        The base's default calls ``pick_for_event(eventData)``, but the
+        in-volume pick resolves a slice click against the labelmap
+        (``pick_for_slice_event(slice_node, display_xy)``), so this override
+        supplies the slice node + the event pixel -- keeping the interior-voxel
+        seed the only placement (ADR-0038 §"Base extension").
+        """
+        pick = self._pick_provider
+        if pick is None:
+            return None
+        try:
+            display_xy = eventData.GetDisplayPosition()
+        except Exception:  # pragma: no cover - defensive (fake events)
+            display_xy = None
+        return pick.pick_for_slice_event(self._slice_node, display_xy)
+
+
+def registerVolumetrySeedPipeline3DCreator() -> None:  # noqa: N802 - project convention
+    """Register the 3D volumetry seed placement creator with LayerDM (ADR-0013 §5).
+
+    Idempotent (module-level flag).  Matches ``(vtkMRMLViewNode,
+    vtkMRMLVolumetrySeedsDisplayNode)`` -- the 3D views only; the slice creator
+    accepts only ``vtkMRMLSliceNode``, so the (view-type, display-type) keying
+    stays disjoint (ADR-0013 §1).  No custom displayable manager (ADR-0013 §5).
+    """
+    global _REGISTERED_3D
+    if _REGISTERED_3D:
+        return
+
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLLayerDMPipelineFactory,
+        vtkMRMLLayerDMPipelineScriptedCreator,
+        vtkMRMLVolumetrySeedsDisplayNode,
+        vtkMRMLViewNode,
+    )
+
+    def tryCreate(viewNode, node):
+        try:
+            if not isinstance(viewNode, vtkMRMLViewNode):
+                return None
+            if not isinstance(node, vtkMRMLVolumetrySeedsDisplayNode):
+                return None
+            return VolumetrySeedPipeline3D()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return None
+
+    creator = vtkMRMLLayerDMPipelineScriptedCreator()
+    creator.SetPythonCallback(tryCreate)
+    vtkMRMLLayerDMPipelineFactory.GetInstance().AddPipelineCreator(creator)
+    _REGISTERED_3D = True
+
+
+def registerVolumetrySeedPipelineSliceCreator() -> None:  # noqa: N802 - project convention
+    """Register the slice volumetry seed placement creator with LayerDM (ADR-0013 §5).
+
+    Idempotent (module-level flag).  Matches ``(vtkMRMLSliceNode,
+    vtkMRMLVolumetrySeedsDisplayNode)`` -- the slice views only; the 3D creator
+    accepts only ``vtkMRMLViewNode`` (ADR-0013 §1).  No custom displayable
+    manager (ADR-0013 §5).
+    """
+    global _REGISTERED_SLICE
+    if _REGISTERED_SLICE:
+        return
+
+    from slicer import (  # type: ignore[import-not-found]
+        vtkMRMLLayerDMPipelineFactory,
+        vtkMRMLLayerDMPipelineScriptedCreator,
+        vtkMRMLVolumetrySeedsDisplayNode,
+    )
+
+    def tryCreate(viewNode, node):
+        try:
+            if viewNode is None or not viewNode.IsA("vtkMRMLSliceNode"):
+                return None
+            if not isinstance(node, vtkMRMLVolumetrySeedsDisplayNode):
+                return None
+            return VolumetrySeedPipelineSlice()
+        except Exception:  # pragma: no cover - C++ boundary must never raise
+            return None
+
+    creator = vtkMRMLLayerDMPipelineScriptedCreator()
+    creator.SetPythonCallback(tryCreate)
+    vtkMRMLLayerDMPipelineFactory.GetInstance().AddPipelineCreator(creator)
+    _REGISTERED_SLICE = True

--- a/LiverVolumetry/LiverVolumetryLib/VolumetrySeedProvider.py
+++ b/LiverVolumetry/LiverVolumetryLib/VolumetrySeedProvider.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The LiverVolumetry ``PointProvider`` adapter (ADR-0038 seam).
+
+ADR-0038 §Decision makes LiverVolumetry the THIRD client of the shared
+control-point base over a ``PointProvider`` seam.  Volumetry seeds are a FLAT,
+ORDERED, no-edges point set (region-growing seeds; no grouping, no polygon):
+so this adapter is the simplest of the three clients -- a thin fan-out over
+``vtkMRMLVolumetrySeedsNode`` with the add / drag / delete write-backs
+targeting the carrier's ``AddSeed`` / ``SetNthSeed`` / ``RemoveNthSeed`` and
+the per-seed colour read from ``GetNthSeedColor``.
+
+There is NO territory grouping and NO vessel-visibility gate here (ADR-0038
+§"What is not shared"): the volumetry client contributes only the flat data
+model.  The drag / delete key is the placement INDEX (a flat int), which is
+exactly what the base's default enumerate-keyed hit-test and slice projection
+expect, so this client needs no key-seam override.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: The seed marker's default display colour when the carrier reports none
+#: (opaque white matches the carrier's own out-of-range default).
+_DEFAULT_SEED_RGB = (1.0, 1.0, 1.0)
+
+
+class VolumetrySeedProvider:
+    """Flat, no-edges ``PointProvider`` over a volumetry seed carrier.
+
+    Bound to a ``vtkMRMLVolumetrySeedsNode`` carrier; keeps no state of its
+    own beyond that reference, so the carrier stays the single source of
+    truth (the base holds no shadow copy -- ADR-0038 no-drift).
+    """
+
+    def __init__(self, carrier: Any) -> None:
+        self._carrier = carrier
+        # The shared display node the base's arm/hover/grab state rides
+        # (feedback_layerdm_state_on_display_node).  The provider itself does
+        # not read it, but the placement wiring binds it here for symmetry
+        # with the territory client's SetDisplayNode seam.
+        self._display_node: Any | None = None
+
+    def SetDisplayNode(self, displayNode: Any) -> None:  # noqa: N802 - VTK verb
+        """Bind the shared display node the interaction state rides."""
+        self._display_node = displayNode
+
+    def iter_points(self):
+        """Yield ``(world, base_rgb)`` per seed, flat in placement order.
+
+        The enumeration order IS the carrier's placement order, so the base's
+        enumerate-keyed grab hit-test + slice projection key each seed by its
+        placement index -- the key the add / move / delete write-backs expect.
+        """
+        carrier = self._carrier
+        if carrier is None:
+            return
+        for i in range(carrier.GetNumberOfSeeds()):
+            coord = carrier.GetNthSeed(i)
+            world = (float(coord[0]), float(coord[1]), float(coord[2]))
+            rgb = carrier.GetNthSeedColor(i)
+            base_rgb = (float(rgb[0]), float(rgb[1]), float(rgb[2]))
+            yield world, base_rgb
+
+    def has_edges(self) -> bool:
+        """Volumetry seeds are unordered region-grow seeds -- no edges."""
+        return False
+
+    def add_point(self, world) -> Any:
+        """Append one seed at ``world``; return its placement index (the key)."""
+        carrier = self._carrier
+        if carrier is None:
+            return None
+        return carrier.AddSeed(float(world[0]), float(world[1]), float(world[2]))
+
+    def move_point(self, key, world) -> None:
+        """Relocate the index-``key`` seed to ``world`` (a drag edit)."""
+        carrier = self._carrier
+        if carrier is None or key is None:
+            return
+        carrier.SetNthSeed(int(key), float(world[0]), float(world[1]), float(world[2]))
+
+    def delete_point(self, key) -> bool:
+        """Remove the index-``key`` seed; True iff one was removed."""
+        carrier = self._carrier
+        if carrier is None or key is None:
+            return False
+        return bool(carrier.RemoveNthSeed(int(key)))

--- a/LiverVolumetry/LiverVolumetryLib/VolumetrySeedsTableWidget.py
+++ b/LiverVolumetry/LiverVolumetryLib/VolumetrySeedsTableWidget.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment) -- the LiverVolumetry seeds table widget.
+
+A thin, carrier-backed table over the FLAT ``vtkMRMLVolumetrySeedsNode`` seed
+carrier (ADR-0038 §"Consumers ledger"), the volumetry sibling of the
+VascularTerritories ``TerritoriesTableWidget``.  It is a Python-composed
+``qt.QWidget`` (ADR-0004: Slicer-Liver panels are Python, not C++
+``qSlicer*ModuleWidget``) that OWNS a ``qt.QTableWidget``, one ROW per seed.
+
+Unlike the territories tree (a two-level territory/seed hierarchy), the
+volumetry seed carrier is a FLAT ORDERED list with no grouping and no edges,
+so this is a plain flat table, not a ``QTreeWidget``.
+
+Each row carries a horizontal strip of controls addressed by NAME through the
+per-row getters (never by column index):
+
+* COLOUR swatch -- a ``ctk.ctkColorPickerButton`` that renders the seed's
+  display colour and opens the picker on click, writing ``SetNthSeedColor``.
+* LABEL -- an editable ``qt.QLineEdit`` whose committed text writes
+  ``SetNthSeedLabel``.  This label becomes the generated segment name that
+  ``GenerateSegmentsLabelMap`` reads (ADR-0038 §Conformance), so it is the
+  load-bearing per-seed field.
+* DELETE -- a ``qt.QToolButton`` that removes the seed via ``RemoveNthSeed``.
+
+The table has NO per-seed VISIBILITY column: the flat seed carrier and the
+data-only ``vtkMRMLVolumetrySeedsDisplayNode`` expose only a single shared
+``Visibility`` (inherited from ``vtkMRMLDisplayNode``), not a per-seed toggle,
+so a per-row eye toggle would be a fake affordance -- the column is OMITTED
+rather than faked (the segmentation-table precedent + the "no colour of the
+sky" discipline).  The visibility column can be added later if the carrier
+grows a per-seed visibility slot.
+
+CARRIER IS THE MODEL.  The table reads/writes the carrier
+(``GetNumberOfSeeds`` / ``GetNthSeedColor`` / ``GetNthSeedLabel`` for the
+read; ``SetNthSeedColor`` / ``SetNthSeedLabel`` / ``RemoveNthSeed`` for the
+edits) and OBSERVES its ``vtkCommand::ModifiedEvent`` to rebuild.  It detaches
+the observer on ``cleanup()``: a parentless Qt widget holding a MRML observer
+must tear down cleanly (cleanup + deleteLater) so it does not survive to
+app shutdown (``feedback_launched_widget_teardown_crash``).
+
+Kept THIN and re-parentable so the future unified planning table -- the one
+that composes seeds, resections, and territories into a single panel -- can
+absorb the same carrier binding without a rewrite.
+
+a11y: every icon-only control also carries text + a tooltip (ADR-0010: never
+an icon / colour alone).  The colour swatch is paired with the label text.
+
+See also:
+  * Docs/adr/0038 -- the seeds-off-markups migration + §Conformance (labels
+    become generated segment names).
+  * Docs/adr/0014-*.md §"Fourth layer" -- the wrapper/carrier/display/storage
+    split (a display edit must not touch geometry).
+  * Docs/adr/0010-accessibility-and-i18n.md -- glyph/text pairing.
+  * Docs/adr/0004-*.md -- panels are Python.
+  * VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+    -- the carrier-backed table idiom this mirrors (hierarchical variant).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import ctk
+import qt
+import vtk
+
+#: The seed default display colour (opaque white), mirroring the carrier's
+#: ``SeedColorScratch`` default so an unedited row reads the same swatch the
+#: carrier reports for an out-of-range index.
+_DEFAULT_SEED_COLOR = (1.0, 1.0, 1.0)
+
+
+class VolumetrySeedsTableWidget(qt.QWidget):
+    """Flat carrier-backed table over ``vtkMRMLVolumetrySeedsNode`` (ADR-0038).
+
+    Constructed over the seed carrier::
+
+        VolumetrySeedsTableWidget(carrier=<vtkMRMLVolumetrySeedsNode>)
+
+    The carrier is the model: the table renders one row per seed, edits write
+    back to the carrier, and a carrier ``ModifiedEvent`` rebuilds the rows.
+    Controls are addressed by NAME through the per-row getters
+    (``colourButton`` / ``labelEdit`` / ``deleteButton``), never by column
+    index.
+    """
+
+    def __init__(self, carrier: Any = None, parent: Any = None) -> None:
+        super().__init__(parent)
+
+        self._carrier = carrier
+        self._carrier_observer_tag: int | None = None
+        # Guards against the write-back edits re-triggering a rebuild mid-edit.
+        self._rebuilding = False
+        # rowIndex -> the named controls parsed out of the row (rebuilt every
+        # repaint).
+        self._rows: dict[int, dict[str, Any]] = {}
+
+        layout = qt.QVBoxLayout(self)
+
+        self._table = qt.QTableWidget()
+        self._table.setColumnCount(3)
+        self._table.setHorizontalHeaderLabels(["Colour", "Label", ""])
+        self._table.verticalHeader().setVisible(False)
+        self._table.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
+        self._table.setSelectionMode(qt.QAbstractItemView.SingleSelection)
+        self._table.horizontalHeader().setStretchLastSection(False)
+        # The label column takes the row's slack; the colour + delete cells stay
+        # tight to their controls.
+        header = self._table.horizontalHeader()
+        header.setSectionResizeMode(0, qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(1, qt.QHeaderView.Stretch)
+        header.setSectionResizeMode(2, qt.QHeaderView.ResizeToContents)
+        layout.addWidget(self._table)
+
+        self._attachCarrierObserver()
+        self._rebuild()
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def cleanup(self) -> None:
+        """Drop the carrier observer (called by the test teardown fixture).
+
+        A parentless Qt widget holding a MRML observer must tear down cleanly
+        so it does not survive to app shutdown
+        (``feedback_launched_widget_teardown_crash``).
+        """
+        self._detachCarrierObserver()
+
+    def setCarrier(self, carrier: Any) -> None:
+        """Rebind the table to ``carrier`` (drops the prior observer, rebuilds).
+
+        The rebind seam the module widget uses once the scene-resident carrier
+        is created (or re-created after a scene close); the same seam the future
+        unified planning table can adopt to adopt this carrier.
+        """
+        if carrier is self._carrier:
+            return
+        self._detachCarrierObserver()
+        self._carrier = carrier
+        self._attachCarrierObserver()
+        self._rebuild()
+
+    def _attachCarrierObserver(self) -> None:
+        if self._carrier is None or not hasattr(self._carrier, "AddObserver"):
+            return
+        self._carrier_observer_tag = self._carrier.AddObserver(
+            vtk.vtkCommand.ModifiedEvent, self._onCarrierModified
+        )
+
+    def _detachCarrierObserver(self) -> None:
+        if self._carrier is None or self._carrier_observer_tag is None:
+            return
+        try:
+            self._carrier.RemoveObserver(self._carrier_observer_tag)
+        except Exception:  # noqa: BLE001 - teardown is best-effort
+            pass
+        self._carrier_observer_tag = None
+
+    def _onCarrierModified(self, caller: Any, event: str) -> None:
+        del caller, event
+        if self._rebuilding:
+            return
+        self._rebuild()
+
+    # ------------------------------------------------------------------ #
+    # Item-model reader seams
+    # ------------------------------------------------------------------ #
+
+    def table(self) -> Any:
+        """The underlying ``qt.QTableWidget``."""
+        return self._table
+
+    def rowCount(self) -> int:
+        """The number of rows currently rendered (one per seed)."""
+        return self._table.rowCount
+
+    def _control(self, rowIndex: int, key: str) -> Any:
+        """The named control from a row (or ``None`` for an out-of-range row)."""
+        row = self._rows.get(int(rowIndex))
+        return row[key] if row is not None else None
+
+    def colourButton(self, rowIndex: int) -> Any:
+        """The ``ctk.ctkColorPickerButton`` on the row."""
+        return self._control(rowIndex, "colour")
+
+    def labelEdit(self, rowIndex: int) -> Any:
+        """The editable label ``qt.QLineEdit`` on the row."""
+        return self._control(rowIndex, "label")
+
+    def deleteButton(self, rowIndex: int) -> Any:
+        """The delete ``qt.QToolButton`` on the row."""
+        return self._control(rowIndex, "delete")
+
+    # ------------------------------------------------------------------ #
+    # Edits (write back to the carrier)
+    # ------------------------------------------------------------------ #
+
+    def setSeedColor(self, rowIndex: int, r: float, g: float, b: float) -> None:
+        if self._carrier is not None:
+            self._carrier.SetNthSeedColor(int(rowIndex), float(r), float(g), float(b))
+
+    def setSeedLabel(self, rowIndex: int, label: str) -> None:
+        if self._carrier is not None:
+            self._carrier.SetNthSeedLabel(int(rowIndex), str(label))
+
+    def deleteSeed(self, rowIndex: int) -> None:
+        """Remove the seed at ``rowIndex`` via the carrier's ``RemoveNthSeed``.
+
+        The single seed-removal path both the delete button and any external
+        caller reach -- the same carrier method the placement pipeline's
+        pick-delete uses, so delete-by-row and delete-by-pick converge.
+        """
+        if self._carrier is not None:
+            self._carrier.RemoveNthSeed(int(rowIndex))
+
+    def _onLabelEdited(self, rowIndex: int, edit: Any) -> None:
+        if self._rebuilding:
+            return
+        self.setSeedLabel(rowIndex, edit.text)
+
+    def _onColourChanged(self, rowIndex: int, colour: Any) -> None:
+        if self._rebuilding:
+            return
+        self.setSeedColor(rowIndex, colour.redF(), colour.greenF(), colour.blueF())
+
+    # ------------------------------------------------------------------ #
+    # Repaint
+    # ------------------------------------------------------------------ #
+
+    def _seedCount(self) -> int:
+        if self._carrier is None:
+            return 0
+        return self._carrier.GetNumberOfSeeds()
+
+    def _rebuild(self) -> None:
+        self._rebuilding = True
+        try:
+            self._rows = {}
+            count = self._seedCount()
+            self._table.setRowCount(count)
+            for rowIndex in range(count):
+                self._buildRow(rowIndex)
+        finally:
+            self._rebuilding = False
+
+    def _seedColor(self, rowIndex: int) -> tuple[float, float, float]:
+        if self._carrier is None:
+            return _DEFAULT_SEED_COLOR
+        rgb = self._carrier.GetNthSeedColor(rowIndex)
+        return (rgb[0], rgb[1], rgb[2])
+
+    def _seedLabel(self, rowIndex: int) -> str:
+        if self._carrier is None:
+            return ""
+        return self._carrier.GetNthSeedLabel(rowIndex)
+
+    def _buildRow(self, rowIndex: int) -> None:
+        """Compose one seed row's controls: colour swatch, label, delete.
+
+        Controls are registered by NAME in ``_rows`` so the getters resolve
+        them without any column index.
+        """
+        color = self._seedColor(rowIndex)
+        label = self._seedLabel(rowIndex)
+
+        # Colour swatch: the Slicer-idiomatic ``ctkColorPickerButton`` (the
+        # segmentation / resection convention) -- it renders its own colour
+        # square, opens the picker on click, and emits ``colorChanged``.
+        # ``setColor`` BEFORE ``connect`` so seeding the initial colour does
+        # not fire the write-back.  The button text names the seed so the
+        # colour is never the only cue (ADR-0010, colour never alone).
+        colourButton = ctk.ctkColorPickerButton()
+        colourButton.displayColorName = False
+        colourButton.setColor(
+            qt.QColor(int(color[0] * 255), int(color[1] * 255), int(color[2] * 255))
+        )
+        colourButton.setToolTip(f"Seed {rowIndex + 1} colour")
+        colourButton.connect(
+            "colorChanged(QColor)",
+            lambda c, i=rowIndex: self._onColourChanged(i, c),
+        )
+        self._table.setCellWidget(rowIndex, 0, colourButton)
+
+        # Editable label: a ``QLineEdit`` whose committed text becomes the
+        # generated segment name (ADR-0038 §Conformance).  ``editingFinished``
+        # writes ``SetNthSeedLabel``.
+        labelEdit = qt.QLineEdit()
+        labelEdit.setText(label)
+        labelEdit.setPlaceholderText(f"Seed {rowIndex + 1} label")
+        labelEdit.setToolTip("Label for this seed (becomes the generated segment name)")
+        labelEdit.connect(
+            "editingFinished()",
+            lambda i=rowIndex, e=labelEdit: self._onLabelEdited(i, e),
+        )
+        self._table.setCellWidget(rowIndex, 1, labelEdit)
+
+        # Delete: an icon-only button paired with text + a tooltip (ADR-0010).
+        deleteButton = qt.QToolButton()
+        deleteButton.setAutoRaise(True)
+        deleteButton.setText("Delete")
+        deleteButton.setToolTip("Remove this seed")
+        deleteButton.connect(
+            "clicked(bool)",
+            lambda _checked, i=rowIndex: self.deleteSeed(i),
+        )
+        self._table.setCellWidget(rowIndex, 2, deleteButton)
+
+        self._rows[rowIndex] = {
+            "colour": colourButton,
+            "label": labelEdit,
+            "delete": deleteButton,
+        }

--- a/LiverVolumetry/LiverVolumetryLib/__init__.py
+++ b/LiverVolumetry/LiverVolumetryLib/__init__.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""LiverVolumetry Python sub-package (ADR-0038 seeds-off-markups client).
+
+Hosts the pure-Python pieces of the volumetry seeds-off-markups migration:
+the carrier->transient-fiducial adapter (the C++ compute is fed a transient
+fiducial built from the seed carrier, ADR-0015 unchanged), the flat
+``VolumetrySeedProvider`` (the ADR-0038 PointProvider adapter), the in-volume
+slice-click pick (ADR-0038 §"Base extension"), and the LayerDM Pipeline creator
+registrations (ADR-0013 §5, no custom displayable manager).
+"""
+
+from __future__ import annotations
+
+# The pure carrier->transient-fiducial adapter (ADR-0038 §Conformance) is
+# dependency-free at the mapping core (no slicer/vtk/Qt at import), so it imports
+# unconditionally -- the bare unit layer reaches ``build_fiducial_payload``.
+from .TransientVolumetrySeeds import (
+    build_fiducial_payload,
+    build_transient_fiducial,
+    seeds_from_carrier,
+)
+
+# The flat PointProvider adapter + the in-volume pick are pure Python (vtk is
+# imported lazily inside the pick's methods), so they import unconditionally too.
+from .VolumetrySeedProvider import VolumetrySeedProvider
+from .InVolumePick import InVolumePick
+
+# The LayerDM Pipeline creators depend on the shared base (LayerDMLib, reachable
+# only from a launched Slicer with the SlicerLayerDisplayableManager extension on
+# the path); guard them so the bare unit layer can still import the package for
+# the pure cores alone (the VascularTerritoriesLib precedent).
+try:
+    from .VolumetrySeedPipeline import (
+        VolumetrySeedPipeline3D,
+        VolumetrySeedPipelineSlice,
+        registerVolumetrySeedPipeline3DCreator,
+        registerVolumetrySeedPipelineSliceCreator,
+    )
+except ImportError:  # pragma: no cover - LayerDMLib unreachable bare
+    VolumetrySeedPipeline3D = None
+    VolumetrySeedPipelineSlice = None
+    registerVolumetrySeedPipeline3DCreator = None
+    registerVolumetrySeedPipelineSliceCreator = None
+
+__all__ = [
+    "build_fiducial_payload",
+    "build_transient_fiducial",
+    "seeds_from_carrier",
+    "VolumetrySeedProvider",
+    "InVolumePick",
+    "VolumetrySeedPipeline3D",
+    "VolumetrySeedPipelineSlice",
+    "registerVolumetrySeedPipeline3DCreator",
+    "registerVolumetrySeedPipelineSliceCreator",
+]

--- a/LiverVolumetry/LiverVolumetryLib/__init__.py
+++ b/LiverVolumetry/LiverVolumetryLib/__init__.py
@@ -43,6 +43,20 @@ except ImportError:  # pragma: no cover - LayerDMLib unreachable bare
     registerVolumetrySeedPipeline3DCreator = None
     registerVolumetrySeedPipelineSliceCreator = None
 
+# The carrier-backed seeds table (ADR-0038 §Conformance) is a Python-composed
+# Qt widget (ADR-0004), so it imports ``qt`` / ``ctk`` at module load; those
+# resolve only inside a launched Slicer.  Guard the import so the bare unit
+# layer can still reach the pure cores above (the VolumetrySeedPipeline
+# precedent).
+try:
+    from .VolumetrySeedsTableWidget import VolumetrySeedsTableWidget
+except (ImportError, AttributeError):  # pragma: no cover - Qt/ctk unreachable bare
+    # Bare ``qt`` imports but lacks ``qt.QWidget`` (no qSlicerApplication), so
+    # the class body raises AttributeError, not ImportError -- catch both so
+    # the pure cores above stay importable bare (the VascularTerritoriesLib
+    # precedent).
+    VolumetrySeedsTableWidget = None
+
 __all__ = [
     "build_fiducial_payload",
     "build_transient_fiducial",
@@ -53,4 +67,5 @@ __all__ = [
     "VolumetrySeedPipelineSlice",
     "registerVolumetrySeedPipeline3DCreator",
     "registerVolumetrySeedPipelineSliceCreator",
+    "VolumetrySeedsTableWidget",
 ]

--- a/LiverVolumetry/MRML/CMakeLists.txt
+++ b/LiverVolumetry/MRML/CMakeLists.txt
@@ -1,0 +1,46 @@
+# ==============================================================================
+#
+#  Distributed under the OSI-approved BSD 3-Clause License.
+#
+#   Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+#
+# ==============================================================================
+#
+# MRML kit for the ADR-0038-amendment LiverVolumetry seeds-off-markups
+# migration (volumetry-seeds-layerdm-plan.md §3a): the seed data carrier,
+# its storage node, and the data-only seed-placement display node.
+#
+# The kit name ``vtkSlicerLiverVolumetryModuleMRML`` follows the project's
+# per-module kit-library convention (matches MODULE_NAME = ``LiverVolumetry``).
+#
+# Sibling-of-source layout matches VascularTerritories/MRML/CMakeLists.txt.
+
+project(vtkSlicerLiverVolumetryModuleMRML)
+
+set(KIT ${PROJECT_NAME})
+
+set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_LIVERVOLUMETRY_MODULE_MRML_EXPORT")
+
+set(${KIT}_INCLUDE_DIRECTORIES)
+
+set(${KIT}_SRCS
+  vtkMRMLVolumetrySeedsNode.h
+  vtkMRMLVolumetrySeedsNode.cxx
+  vtkMRMLVolumetrySeedsStorageNode.h
+  vtkMRMLVolumetrySeedsStorageNode.cxx
+  vtkMRMLVolumetrySeedsDisplayNode.h
+  vtkMRMLVolumetrySeedsDisplayNode.cxx
+  )
+
+set(${KIT}_TARGET_LIBRARIES
+  ${MRML_LIBRARIES}
+  )
+
+#-----------------------------------------------------------------------------
+SlicerMacroBuildModuleMRML(
+  NAME ${KIT}
+  EXPORT_DIRECTIVE ${${KIT}_EXPORT_DIRECTIVE}
+  INCLUDE_DIRECTORIES ${${KIT}_INCLUDE_DIRECTORIES}
+  SRCS ${${KIT}_SRCS}
+  TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
+)

--- a/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsDisplayNode.cxx
+++ b/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsDisplayNode.cxx
@@ -1,0 +1,114 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Implementation of vtkMRMLVolumetrySeedsDisplayNode — the data-only
+  interaction-state carrier for the ADR-0038-amendment volumetry seed
+  placement (ADR-0025 display-node template, ADR-0033 hover discipline).
+  See the class docstring in the header for the field roster.
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLVolumetrySeedsDisplayNode.h"
+
+// MRML includes
+#include <vtkMRMLNodePropertyMacros.h>
+
+// VTK includes
+#include <vtkObjectFactory.h>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLVolumetrySeedsDisplayNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLVolumetrySeedsDisplayNode::vtkMRMLVolumetrySeedsDisplayNode()
+  // 3 mm reads clearly as a seed marker on a liver-scale surface without
+  // occluding the anatomy under it (mirrors the territories highlight node).
+  : Radius(3.0)
+{
+  this->TransientPoint[0] = 0.0;
+  this->TransientPoint[1] = 0.0;
+  this->TransientPoint[2] = 0.0;
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLVolumetrySeedsDisplayNode::~vtkMRMLVolumetrySeedsDisplayNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsDisplayNode::SetTransientPoint(double x, double y, double z)
+{
+  // Guard against a redundant Modified() so a hover that lands on the same
+  // sub-pixel point does not churn the Pipeline.
+  if (this->TransientPoint[0] == x && this->TransientPoint[1] == y && this->TransientPoint[2] == z)
+  {
+    return;
+  }
+  this->TransientPoint[0] = x;
+  this->TransientPoint[1] = y;
+  this->TransientPoint[2] = z;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsDisplayNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of, nIndent);
+
+  // TransientPoint is TRANSIENT (re-derived from the cursor every hover) and
+  // is deliberately absent here; only the marker Radius round-trips (Color /
+  // Visibility persist on the base).
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLFloatMacro(radius, Radius);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsDisplayNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+
+  Superclass::ReadXMLAttributes(atts);
+
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLFloatMacro(radius, Radius);
+  vtkMRMLReadXMLEndMacro();
+
+  this->EndModify(disabledModify);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyFloatMacro(Radius);
+  vtkMRMLCopyEndMacro();
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsDisplayNode::SetAndObservePickSurfaceNodeID(const char* surfaceNodeID)
+{
+  this->SetAndObserveNodeReferenceID(this->GetPickSurfaceReferenceRole(), surfaceNodeID);
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLNode* vtkMRMLVolumetrySeedsDisplayNode::GetPickSurfaceNode()
+{
+  return this->GetNodeReference(this->GetPickSurfaceReferenceRole());
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintVectorMacro(TransientPoint, double, 3);
+  vtkMRMLPrintFloatMacro(Radius);
+  vtkMRMLPrintEndMacro();
+}

--- a/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsDisplayNode.h
+++ b/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsDisplayNode.h
@@ -1,0 +1,144 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was developed for the Slicer-Liver extension as part of the
+  ADR-0038-amendment volumetry seeds-off-markups migration (ADR-0013
+  Pipeline pattern, ADR-0025 display-node/pipeline template, ADR-0033 hover
+  discipline; volumetry-seeds-layerdm-plan.md §3a).
+
+==============================================================================*/
+
+#ifndef __vtkmrmlvolumetryseedsdisplaynode_h_
+#define __vtkmrmlvolumetryseedsdisplaynode_h_
+
+#include "vtkSlicerLiverVolumetryModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLDisplayNode.h>
+
+// VTK includes
+#include <vtkSetGet.h>
+
+/**
+ * \class vtkMRMLVolumetrySeedsDisplayNode
+ *
+ * \brief Data-only MRML display node carrying the volumetry seed-placement
+ *        interaction state (ADR-0038-amendment §3a).
+ *
+ * Following the ADR-0025/0033 data-only display-node shape, this node
+ * CARRIES the seed-placement interaction state but does NO rendering
+ * itself: the LayerDM Pipeline renders (ADR-0013 §5 forbids a per-module
+ * displayable manager).  The arm / hover / grab state living on the SHARED
+ * display node — not on a Python pipeline instance LayerDM does not drive —
+ * is the hard-won LayerDM lesson (``feedback_layerdm_state_on_display_node``);
+ * the shared base's ``PointPlacementState`` accessors read/write that state
+ * through the generic ``SetAttribute`` / ``GetAttribute`` channel
+ * (namespaced ``LiverVolumetry.*``), so this class does not re-declare it.
+ *
+ * \par Field roster
+ *
+ *   - ``TransientPoint`` — TRANSIENT adhering point (RAS) under the cursor
+ *     (the hover preview the Pipeline renders without a carrier mutation).
+ *     Get/Set; NOT persisted.
+ *   - ``Radius`` — marker glyph radius (mm).  Persisted.
+ *   - the surface the pick resolves against is referenced through the
+ *     ``pickSurface`` node-reference role (generic
+ *     ``SetNodeReferenceID`` / ``GetNodeReference``).
+ *   - ``Color`` and ``Visibility`` inherited from ``vtkMRMLDisplayNode``.
+ *
+ * The node exposes NO rendering machinery (no actor, no mapper, no
+ * displayable-manager class of its own) — an absence pinned by the
+ * data-only conformance test because the v1 markups display node DID
+ * render.
+ */
+class VTK_SLICER_LIVERVOLUMETRY_MODULE_MRML_EXPORT vtkMRMLVolumetrySeedsDisplayNode : public vtkMRMLDisplayNode
+{
+public:
+  static vtkMRMLVolumetrySeedsDisplayNode* New();
+  vtkTypeMacro(vtkMRMLVolumetrySeedsDisplayNode, vtkMRMLDisplayNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+  vtkMRMLNode* CreateNodeInstance() override;
+  const char* GetNodeTagName() override { return "VolumetrySeedsDisplay"; }
+
+  void ReadXMLAttributes(const char** atts) override;
+  void WriteXML(ostream& of, int indent) override;
+  void CopyContent(vtkMRMLNode* anode, bool deepCopy = true) override;
+
+  //--------------------------------------------------------------------------
+  // Interaction-state fields (ADR-0025/0033 data-only shape)
+  //--------------------------------------------------------------------------
+
+  /// TRANSIENT adhering point (RAS) under the cursor (the hover preview).
+  /// Deliberately NOT persisted — re-derived from interaction every hover.
+  void SetTransientPoint(double x, double y, double z);
+  vtkGetVector3Macro(TransientPoint, double);
+
+  /// Marker glyph radius (mm).  Persisted.  Colour and visibility are
+  /// inherited from vtkMRMLDisplayNode (Get/SetColor, Get/SetVisibility).
+  vtkSetMacro(Radius, double);
+  vtkGetMacro(Radius, double);
+
+  //--------------------------------------------------------------------------
+  // Pick-surface reference (the surface the pick resolves against; ADR-0025
+  // data-only reference).
+  //--------------------------------------------------------------------------
+
+  /// Reference role name for the surface the seed pick resolves against.
+  /// Namespaced ``LiverVolumetry.*`` to match the interaction-state attribute
+  /// channel.
+  static const char* GetPickSurfaceReferenceRole() { return "LiverVolumetry.pickSurface"; }
+
+  /// Reference the surface the pick resolves against.  ``nullptr`` clears
+  /// the reference.
+  void SetAndObservePickSurfaceNodeID(const char* surfaceNodeID);
+
+  /// Resolve the referenced pick surface, or ``nullptr`` when none is wired.
+  vtkMRMLNode* GetPickSurfaceNode();
+
+protected:
+  vtkMRMLVolumetrySeedsDisplayNode();
+  ~vtkMRMLVolumetrySeedsDisplayNode() override;
+
+private:
+  vtkMRMLVolumetrySeedsDisplayNode(const vtkMRMLVolumetrySeedsDisplayNode&) = delete;
+  void operator=(const vtkMRMLVolumetrySeedsDisplayNode&) = delete;
+
+  double TransientPoint[3];
+  double Radius;
+};
+
+#endif // __vtkmrmlvolumetryseedsdisplaynode_h_

--- a/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsNode.cxx
+++ b/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsNode.cxx
@@ -1,0 +1,192 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Implementation of vtkMRMLVolumetrySeedsNode — the flat, ordered
+  region-growing seed carrier for the ADR-0038-amendment seeds-off-markups
+  migration (volumetry-seeds-layerdm-plan.md §3a).  See the class docstring
+  in the header for the field roster.
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLVolumetrySeedsNode.h"
+#include "vtkMRMLVolumetrySeedsStorageNode.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLVolumetrySeedsNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLVolumetrySeedsNode::vtkMRMLVolumetrySeedsNode() = default;
+
+//------------------------------------------------------------------------------
+vtkMRMLVolumetrySeedsNode::~vtkMRMLVolumetrySeedsNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "Seeds: " << this->Seeds.size() << " points\n";
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsNode::WriteXML(ostream& of, int nIndent)
+{
+  // The ordered seeds + labels + colours round-trip through the
+  // vtkMRMLVolumetrySeedsStorageNode ``.vsd.json`` document (ADR-0014
+  // §"Fourth layer"), not the scene XML; only the base storable
+  // attributes persist here.
+  Superclass::WriteXML(of, nIndent);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+  Superclass::ReadXMLAttributes(atts);
+  this->EndModify(disabledModify);
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLVolumetrySeedsNode* other = vtkMRMLVolumetrySeedsNode::SafeDownCast(anode);
+  if (other == nullptr)
+  {
+    return;
+  }
+  this->Seeds = other->Seeds;
+  this->SeedLabels = other->SeedLabels;
+  this->SeedColors = other->SeedColors;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLVolumetrySeedsNode::IsValidIndex(int i) const
+{
+  return i >= 0 && i < static_cast<int>(this->Seeds.size());
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLVolumetrySeedsNode::AddSeed(double x, double y, double z)
+{
+  this->Seeds.push_back({ x, y, z });
+  this->SeedLabels.emplace_back();
+  // Module default swatch: opaque white until the caller picks a colour.
+  this->SeedColors.push_back({ 1.0, 1.0, 1.0 });
+  const int index = static_cast<int>(this->Seeds.size()) - 1;
+  this->Modified();
+  return index;
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLVolumetrySeedsNode::GetNumberOfSeeds()
+{
+  return static_cast<int>(this->Seeds.size());
+}
+
+//------------------------------------------------------------------------------
+const double* vtkMRMLVolumetrySeedsNode::GetNthSeed(int i)
+{
+  this->SeedScratch[0] = 0.0;
+  this->SeedScratch[1] = 0.0;
+  this->SeedScratch[2] = 0.0;
+  if (this->IsValidIndex(i))
+  {
+    const std::array<double, 3>& p = this->Seeds[static_cast<std::size_t>(i)];
+    this->SeedScratch[0] = p[0];
+    this->SeedScratch[1] = p[1];
+    this->SeedScratch[2] = p[2];
+  }
+  return this->SeedScratch;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsNode::SetNthSeed(int i, double x, double y, double z)
+{
+  if (!this->IsValidIndex(i))
+  {
+    return;
+  }
+  this->Seeds[static_cast<std::size_t>(i)] = { x, y, z };
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLVolumetrySeedsNode::RemoveNthSeed(int i)
+{
+  if (!this->IsValidIndex(i))
+  {
+    return false;
+  }
+  const std::size_t idx = static_cast<std::size_t>(i);
+  // The three parallel vectors shift in lockstep so a seed's label + colour
+  // stay bound to its coordinate.
+  this->Seeds.erase(this->Seeds.begin() + idx);
+  this->SeedLabels.erase(this->SeedLabels.begin() + idx);
+  this->SeedColors.erase(this->SeedColors.begin() + idx);
+  this->Modified();
+  return true;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsNode::SetNthSeedLabel(int i, const std::string& label)
+{
+  if (!this->IsValidIndex(i))
+  {
+    return;
+  }
+  this->SeedLabels[static_cast<std::size_t>(i)] = label;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+std::string vtkMRMLVolumetrySeedsNode::GetNthSeedLabel(int i)
+{
+  if (!this->IsValidIndex(i))
+  {
+    return std::string();
+  }
+  return this->SeedLabels[static_cast<std::size_t>(i)];
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsNode::SetNthSeedColor(int i, double r, double g, double b)
+{
+  if (!this->IsValidIndex(i))
+  {
+    return;
+  }
+  this->SeedColors[static_cast<std::size_t>(i)] = { r, g, b };
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+const double* vtkMRMLVolumetrySeedsNode::GetNthSeedColor(int i)
+{
+  this->SeedColorScratch[0] = 1.0;
+  this->SeedColorScratch[1] = 1.0;
+  this->SeedColorScratch[2] = 1.0;
+  if (this->IsValidIndex(i))
+  {
+    const std::array<double, 3>& c = this->SeedColors[static_cast<std::size_t>(i)];
+    this->SeedColorScratch[0] = c[0];
+    this->SeedColorScratch[1] = c[1];
+    this->SeedColorScratch[2] = c[2];
+  }
+  return this->SeedColorScratch;
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLStorageNode* vtkMRMLVolumetrySeedsNode::CreateDefaultStorageNode()
+{
+  return vtkMRMLVolumetrySeedsStorageNode::New();
+}

--- a/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsNode.h
+++ b/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsNode.h
@@ -1,0 +1,188 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==============================================================================*/
+
+#ifndef __vtkmrmlvolumetryseedsnode_h_
+#define __vtkmrmlvolumetryseedsnode_h_
+
+#include "vtkSlicerLiverVolumetryModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLStorableNode.h>
+
+// VTK includes
+#include <vtkWrappingHints.h>
+
+// STD includes
+#include <array>
+#include <string>
+#include <vector>
+
+class vtkMRMLStorageNode;
+
+/**
+ * \class vtkMRMLVolumetrySeedsNode
+ *
+ * \brief Data carrier for the LiverVolumetry region-growing seeds, moved
+ *        OFF Slicer markups per the ADR-0038-amendment seeds-off-markups
+ *        migration (``volumetry-seeds-layerdm-plan.md`` §3a).
+ *
+ * A volumetry seed is a labelled in-volume point.  Each seed carries:
+ *
+ *   - a RAS coordinate (the interior voxel the surgeon dropped);
+ *   - a LABEL string that becomes the generated segment name
+ *     (``GenerateSegmentsLabelMap`` reads it, ADR-0038 §Conformance); and
+ *   - an RGB display colour.
+ *
+ * The seeds are FLAT and ORDERED: no grouping, no edges.  The three
+ * per-seed attributes ride PARALLEL vectors keyed by placement index so a
+ * label / colour write never perturbs a coordinate and vice versa (the
+ * geometry slot is independent of the display / label slot).  This node
+ * replaces the v1 ``vtkMRMLMarkupsFiducialNode`` ``ROIMarkersList``; it
+ * holds NO markups reference anywhere (ADR-0014 §"Fourth layer", the
+ * off-markups invariant).
+ *
+ * The carrier is storable via ``vtkMRMLVolumetrySeedsStorageNode`` (a
+ * ``.vsd.json`` document), mirroring the resection-plan / territory-carrier
+ * rooted-persistence wiring (ADR-0014 §"Fourth layer").
+ *
+ * \par Field roster (parallel per-seed vectors)
+ *
+ *   - ``Seeds``       — ordered RAS coordinates.
+ *   - ``SeedLabels``  — per-seed segment-name label.
+ *   - ``SeedColors``  — per-seed RGB display colour.
+ */
+class VTK_SLICER_LIVERVOLUMETRY_MODULE_MRML_EXPORT vtkMRMLVolumetrySeedsNode : public vtkMRMLStorableNode
+{
+public:
+  static vtkMRMLVolumetrySeedsNode* New();
+  vtkTypeMacro(vtkMRMLVolumetrySeedsNode, vtkMRMLStorableNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+  vtkMRMLNode* CreateNodeInstance() override;
+  const char* GetNodeTagName() override { return "VolumetrySeeds"; }
+
+  void ReadXMLAttributes(const char** atts) override;
+  void WriteXML(ostream& of, int indent) override;
+  void CopyContent(vtkMRMLNode* anode, bool deepCopy = true) override;
+
+  //--------------------------------------------------------------------------
+  // Ordered seed carrier (ADR-0038 §"Consumers ledger", flat/no-edges)
+  //--------------------------------------------------------------------------
+
+  /// Append a seed at RAS ``(x, y, z)`` with an empty label + the module
+  /// default colour; returns its placement index.  Fires ONE ModifiedEvent.
+  int AddSeed(double x, double y, double z);
+
+  /// Number of seeds currently carried.
+  int GetNumberOfSeeds();
+
+  /// The i-th seed's RAS coordinate (placement order), returned as a
+  /// 3-tuple in Python (``VTK_SIZEHINT``).  An out-of-range index returns
+  /// the origin.  The pointer aliases an internal scratch buffer valid
+  /// until the next call — copy before re-calling.
+  const double* GetNthSeed(int i) VTK_SIZEHINT(3);
+
+  /// Relocate the i-th seed in place.  Fires ONE ModifiedEvent; a no-op
+  /// (no event) for an out-of-range index.
+  void SetNthSeed(int i, double x, double y, double z);
+
+  /// Remove the i-th seed; the tail (coordinate + label + colour) shifts up
+  /// in order.  Fires ONE ModifiedEvent; a no-op for an out-of-range index.
+  /// Returns true iff a seed was removed.
+  bool RemoveNthSeed(int i);
+
+  //--------------------------------------------------------------------------
+  // Per-seed label (becomes the generated segment name, ADR-0038 §Conformance)
+  //--------------------------------------------------------------------------
+
+  /// Set the i-th seed's LABEL (the generated segment name).  Fires ONE
+  /// ModifiedEvent; a no-op for an out-of-range index.  Does NOT touch the
+  /// coordinate.
+  void SetNthSeedLabel(int i, const std::string& label);
+
+  /// The i-th seed's LABEL (empty string for an out-of-range index).
+  std::string GetNthSeedLabel(int i);
+
+  //--------------------------------------------------------------------------
+  // Per-seed display colour
+  //--------------------------------------------------------------------------
+
+  /// Set the i-th seed's RGB display colour (components in [0, 1]).  Fires
+  /// ONE ModifiedEvent; a no-op for an out-of-range index.  Does NOT touch
+  /// the coordinate.
+  void SetNthSeedColor(int i, double r, double g, double b);
+
+  /// The i-th seed's RGB display colour as a 3-tuple in Python
+  /// (``VTK_SIZEHINT``).  An out-of-range index returns the module default
+  /// (opaque white).  The pointer aliases an internal scratch buffer valid
+  /// until the next call — copy before re-calling.
+  const double* GetNthSeedColor(int i) VTK_SIZEHINT(3);
+
+  //--------------------------------------------------------------------------
+  // Storage
+  //--------------------------------------------------------------------------
+
+  /// The seed carrier's default storage node
+  /// (``vtkMRMLVolumetrySeedsStorageNode``), mirroring the resection plan's
+  /// rooted-persistence wiring (ADR-0014 §"Fourth layer").
+  vtkMRMLStorageNode* CreateDefaultStorageNode() override;
+
+protected:
+  vtkMRMLVolumetrySeedsNode();
+  ~vtkMRMLVolumetrySeedsNode() override;
+  vtkMRMLVolumetrySeedsNode(const vtkMRMLVolumetrySeedsNode&) = delete;
+  void operator=(const vtkMRMLVolumetrySeedsNode&) = delete;
+
+  /// True iff ``i`` indexes an existing seed.
+  bool IsValidIndex(int i) const;
+
+  /// Ordered per-seed attributes on PARALLEL vectors keyed by placement
+  /// index: a remove shifts all three in lockstep so the label + colour
+  /// stay bound to their coordinate (ADR-0038 §"Consumers ledger").
+  std::vector<std::array<double, 3>> Seeds;
+  std::vector<std::string> SeedLabels;
+  std::vector<std::array<double, 3>> SeedColors;
+
+  /// Scratch buffers backing the size-hinted 3-tuple returns (the
+  /// ``GetNthAnnotationPoint`` idiom): a stable address to alias so the
+  /// wrapped 3-tuple does not point at a temporary.
+  double SeedScratch[3] = { 0.0, 0.0, 0.0 };
+  double SeedColorScratch[3] = { 1.0, 1.0, 1.0 };
+};
+
+#endif // __vtkmrmlvolumetryseedsnode_h_

--- a/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsStorageNode.cxx
+++ b/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsStorageNode.cxx
@@ -1,0 +1,275 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Implementation of vtkMRMLVolumetrySeedsStorageNode — the ``.vsd.json``
+  storage layer for the volumetry seed carrier (ADR-0038-amendment §3a).
+  Mirrors vtkMRMLCustomTerritoriesStorageNode (ADR-0014 §"Fourth layer").
+  See the class docstring in the header for the schema.
+
+==============================================================================*/
+
+// This module MRML includes
+#include "vtkMRMLVolumetrySeedsStorageNode.h"
+#include "vtkMRMLVolumetrySeedsNode.h"
+
+// MRML includes
+#include <vtkMRMLJsonElement.h>
+#include <vtkMRMLMessageCollection.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkSmartPointer.h>
+#include <vtkStringArray.h>
+
+// STD includes
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLVolumetrySeedsStorageNode);
+
+//------------------------------------------------------------------------------
+vtkMRMLVolumetrySeedsStorageNode::vtkMRMLVolumetrySeedsStorageNode()
+{
+  this->DefaultWriteFileExtension = "vsd.json";
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLVolumetrySeedsStorageNode::~vtkMRMLVolumetrySeedsStorageNode() = default;
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsStorageNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os, indent);
+  os << indent << "SchemaVersion: " << SchemaVersion << "\n";
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLVolumetrySeedsStorageNode::CanReadInReferenceNode(vtkMRMLNode* refNode)
+{
+  return refNode != nullptr && refNode->IsA("vtkMRMLVolumetrySeedsNode");
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLVolumetrySeedsStorageNode::CanWriteFromReferenceNode(vtkMRMLNode* refNode)
+{
+  return refNode != nullptr && refNode->IsA("vtkMRMLVolumetrySeedsNode");
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsStorageNode::InitializeSupportedReadFileTypes()
+{
+  this->SupportedReadFileTypes->InsertNextValue("Volumetry seeds (.vsd.json)");
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLVolumetrySeedsStorageNode::InitializeSupportedWriteFileTypes()
+{
+  this->SupportedWriteFileTypes->InsertNextValue("Volumetry seeds (.vsd.json)");
+}
+
+//------------------------------------------------------------------------------
+namespace
+{
+std::string toLower(std::string s)
+{
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return s;
+}
+
+bool endsWithLower(const std::string& path, const std::string& suffix)
+{
+  if (path.size() < suffix.size())
+  {
+    return false;
+  }
+  return toLower(path.substr(path.size() - suffix.size())) == suffix;
+}
+} // namespace
+
+//------------------------------------------------------------------------------
+int vtkMRMLVolumetrySeedsStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
+{
+  if (refNode == nullptr)
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::ReadDataInternal", "Reading seed carrier failed: null reference node");
+    return 0;
+  }
+  vtkMRMLVolumetrySeedsNode* carrier = vtkMRMLVolumetrySeedsNode::SafeDownCast(refNode);
+  if (carrier == nullptr)
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
+                                     "vtkMRMLVolumetrySeedsStorageNode::ReadDataInternal",
+                                     "Reading seed carrier failed: reference node is not a vtkMRMLVolumetrySeedsNode (got '" << refNode->GetClassName() << "')");
+    return 0;
+  }
+
+  const std::string fullName = this->GetFullNameFromFileName();
+  if (fullName.empty())
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::ReadDataInternal", "Reading seed carrier failed: file name not specified");
+    return 0;
+  }
+  if (!endsWithLower(fullName, ".vsd.json") && !endsWithLower(fullName, ".json"))
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
+                                     "vtkMRMLVolumetrySeedsStorageNode::ReadDataInternal",
+                                     "Reading seed carrier failed: unsupported file extension for '" << fullName << "' (expected .vsd.json)");
+    return 0;
+  }
+  return this->ReadJson(fullName, carrier);
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLVolumetrySeedsStorageNode::WriteDataInternal(vtkMRMLNode* refNode)
+{
+  if (refNode == nullptr)
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::WriteDataInternal", "Writing seed carrier failed: null reference node");
+    return 0;
+  }
+  vtkMRMLVolumetrySeedsNode* carrier = vtkMRMLVolumetrySeedsNode::SafeDownCast(refNode);
+  if (carrier == nullptr)
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
+                                     "vtkMRMLVolumetrySeedsStorageNode::WriteDataInternal",
+                                     "Writing seed carrier failed: reference node is not a vtkMRMLVolumetrySeedsNode (got '" << refNode->GetClassName() << "')");
+    return 0;
+  }
+
+  const std::string fullName = this->GetFullNameFromFileName();
+  if (fullName.empty())
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::WriteDataInternal", "Writing seed carrier failed: file name not specified");
+    return 0;
+  }
+  if (!endsWithLower(fullName, ".vsd.json") && !endsWithLower(fullName, ".json"))
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
+                                     "vtkMRMLVolumetrySeedsStorageNode::WriteDataInternal",
+                                     "Writing seed carrier failed: unsupported file extension for '" << fullName << "' (expected .vsd.json)");
+    return 0;
+  }
+  return this->WriteJson(fullName, carrier);
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLVolumetrySeedsStorageNode::WriteJson(const std::string& filePath, vtkMRMLVolumetrySeedsNode* carrier)
+{
+  vtkNew<vtkMRMLJsonWriter> writer;
+  if (!writer->WriteToFileBegin(filePath.c_str(), nullptr))
+  {
+    vtkErrorToMessageCollectionMacro(
+      this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::WriteJson", "Writing seed carrier failed: failed to open '" << filePath << "' for writing");
+    return 0;
+  }
+
+  writer->WriteIntProperty("schemaVersion", SchemaVersion);
+
+  // seeds -- an ORDERED array; each element carries the RAS coordinate, the
+  // per-seed LABEL (the generated segment name, ADR-0038 §Conformance), and
+  // the per-seed display colour.
+  writer->WriteArrayPropertyStart("seeds");
+  const int nSeeds = carrier->GetNumberOfSeeds();
+  for (int i = 0; i < nSeeds; ++i)
+  {
+    const double* src = carrier->GetNthSeed(i);
+    double xyz[3] = { src[0], src[1], src[2] };
+    const std::string label = carrier->GetNthSeedLabel(i);
+    const double* colorSrc = carrier->GetNthSeedColor(i);
+    double color[3] = { colorSrc[0], colorSrc[1], colorSrc[2] };
+
+    writer->WriteObjectStart();
+    writer->WriteVectorProperty("xyz", xyz, 3);
+    writer->WriteStringProperty("label", label);
+    writer->WriteVectorProperty("color", color, 3);
+    writer->WriteObjectEnd();
+  }
+  writer->WriteArrayPropertyEnd();
+
+  if (!writer->WriteToFileEnd())
+  {
+    vtkErrorToMessageCollectionMacro(
+      this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::WriteJson", "Writing seed carrier failed: failed to close '" << filePath << "' after write");
+    return 0;
+  }
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLVolumetrySeedsStorageNode::ReadJson(const std::string& filePath, vtkMRMLVolumetrySeedsNode* carrier)
+{
+  vtkNew<vtkMRMLJsonReader> reader;
+  vtkSmartPointer<vtkMRMLJsonElement> root = vtkSmartPointer<vtkMRMLJsonElement>::Take(reader->ReadFromFile(filePath.c_str()));
+  if (root == nullptr)
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::ReadJson", "Reading seed carrier failed: failed to parse '" << filePath << "'");
+    return 0;
+  }
+  if (!root->HasMember("schemaVersion"))
+  {
+    vtkErrorToMessageCollectionMacro(
+      this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::ReadJson", "Reading seed carrier failed: missing required 'schemaVersion' field in '" << filePath << "'");
+    return 0;
+  }
+  const int schemaVersion = root->GetIntProperty("schemaVersion");
+  if (schemaVersion < MinReadableSchemaVersion || schemaVersion > SchemaVersion)
+  {
+    vtkErrorToMessageCollectionMacro(this->GetUserMessages(),
+                                     "vtkMRMLVolumetrySeedsStorageNode::ReadJson",
+                                     "Reading seed carrier failed: unsupported schemaVersion " << schemaVersion << " in '" << filePath << "' (this build understands "
+                                                                                               << MinReadableSchemaVersion << " through " << SchemaVersion << ")");
+    return 0;
+  }
+
+  // The read REPLACES the carrier's seed state under a single ModifyBlocker:
+  // drop every existing seed so a re-read into a reused sink does not
+  // accumulate, then repopulate in document order.
+  MRMLNodeModifyBlocker blocker(carrier);
+  for (int i = carrier->GetNumberOfSeeds() - 1; i >= 0; --i)
+  {
+    carrier->RemoveNthSeed(i);
+  }
+
+  if (!root->HasMember("seeds"))
+  {
+    return 1;
+  }
+  vtkSmartPointer<vtkMRMLJsonElement> list = vtkSmartPointer<vtkMRMLJsonElement>::Take(root->GetArrayProperty("seeds"));
+  if (list == nullptr)
+  {
+    vtkWarningToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLVolumetrySeedsStorageNode::ReadJson", "'seeds' present but unreadable in '" << filePath << "'");
+    return 1;
+  }
+
+  const int nSeeds = list->GetArraySize();
+  for (int i = 0; i < nSeeds; ++i)
+  {
+    vtkSmartPointer<vtkMRMLJsonElement> item = vtkSmartPointer<vtkMRMLJsonElement>::Take(list->GetArrayItem(i));
+    if (item == nullptr)
+    {
+      continue;
+    }
+    double xyz[3] = { 0.0, 0.0, 0.0 };
+    if (!item->GetVectorProperty("xyz", xyz, 3))
+    {
+      continue;
+    }
+    const int index = carrier->AddSeed(xyz[0], xyz[1], xyz[2]);
+    if (item->HasMember("label"))
+    {
+      carrier->SetNthSeedLabel(index, item->GetStringProperty("label"));
+    }
+    double color[3] = { 1.0, 1.0, 1.0 };
+    if (item->GetVectorProperty("color", color, 3))
+    {
+      carrier->SetNthSeedColor(index, color[0], color[1], color[2]);
+    }
+  }
+  return 1;
+}

--- a/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsStorageNode.h
+++ b/LiverVolumetry/MRML/vtkMRMLVolumetrySeedsStorageNode.h
@@ -1,0 +1,131 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  * Neither the name of Oslo University Hospital nor the names
+    of Contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  This file was developed for the Slicer-Liver extension as the seed-carrier
+  storage layer of the ADR-0038-amendment seeds-off-markups migration
+  (volumetry-seeds-layerdm-plan.md §3a), mirroring
+  vtkMRMLCustomTerritoriesStorageNode (ADR-0014 §"Fourth layer").
+
+==============================================================================*/
+
+#ifndef __vtkmrmlvolumetryseedsstoragenode_h_
+#define __vtkmrmlvolumetryseedsstoragenode_h_
+
+#include "vtkSlicerLiverVolumetryModuleMRMLExport.h"
+
+// MRML includes
+#include <vtkMRMLStorageNode.h>
+
+// STD includes
+#include <string>
+
+class vtkMRMLVolumetrySeedsNode;
+
+/**
+ * \class vtkMRMLVolumetrySeedsStorageNode
+ *
+ * \brief ``.vsd.json`` storage node for the volumetry seed carrier — the
+ *        flat, ORDERED per-seed coordinate + label + colour on
+ *        ``vtkMRMLVolumetrySeedsNode`` (ADR-0038-amendment §3a).
+ *
+ * Mirrors ``vtkMRMLCustomTerritoriesStorageNode``: a rooted persistence
+ * target for a carrier node moved off Slicer markups (ADR-0014 §"Fourth
+ * layer").
+ *
+ * Schema shape (v1):
+ *
+ * \code
+ * {
+ *   "schemaVersion": 1,
+ *   "seeds": [
+ *     { "xyz": [x, y, z], "label": "SegmentV",  "color": [r, g, b] },
+ *     { "xyz": [x, y, z], "label": "SegmentVI", "color": [r, g, b] }
+ *   ]
+ * }
+ * \endcode
+ *
+ * The ``seeds`` array is ORDERED — placement order + per-seed labels +
+ * per-seed colours round-trip identically (ADR-0038 §Conformance, the
+ * segment-name fidelity).  The storage node is typed to
+ * ``vtkMRMLVolumetrySeedsNode`` and rejects any other node.
+ */
+class VTK_SLICER_LIVERVOLUMETRY_MODULE_MRML_EXPORT vtkMRMLVolumetrySeedsStorageNode : public vtkMRMLStorageNode
+{
+public:
+  static vtkMRMLVolumetrySeedsStorageNode* New();
+  vtkTypeMacro(vtkMRMLVolumetrySeedsStorageNode, vtkMRMLStorageNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Current JSON schema version emitted by ``WriteDataInternal``.
+  static constexpr int SchemaVersion = 1;
+
+  /// Lowest schema version the reader admits.
+  static constexpr int MinReadableSchemaVersion = 1;
+
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  const char* GetNodeTagName() override { return "VolumetrySeedsStorage"; }
+
+  /// Returns true iff ``refNode`` is a ``vtkMRMLVolumetrySeedsNode``.
+  bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
+
+  /// Returns true iff ``refNode`` is a ``vtkMRMLVolumetrySeedsNode``.
+  bool CanWriteFromReferenceNode(vtkMRMLNode* refNode) override;
+
+  const char* GetDefaultWriteFileExtension() override { return "vsd.json"; }
+
+protected:
+  void InitializeSupportedReadFileTypes() override;
+  void InitializeSupportedWriteFileTypes() override;
+
+  int ReadDataInternal(vtkMRMLNode* refNode) override;
+  int WriteDataInternal(vtkMRMLNode* refNode) override;
+
+protected:
+  vtkMRMLVolumetrySeedsStorageNode();
+  ~vtkMRMLVolumetrySeedsStorageNode() override;
+
+private:
+  vtkMRMLVolumetrySeedsStorageNode(const vtkMRMLVolumetrySeedsStorageNode&) = delete;
+  void operator=(const vtkMRMLVolumetrySeedsStorageNode&) = delete;
+
+  /// Write the v1 ``.vsd.json`` for ``carrier`` to ``filePath``.  Returns
+  /// 1 on success, 0 on failure.
+  int WriteJson(const std::string& filePath, vtkMRMLVolumetrySeedsNode* carrier);
+
+  /// Read the v1 ``.vsd.json`` from ``filePath`` into ``carrier``.
+  /// Returns 1 on success, 0 on failure.
+  int ReadJson(const std::string& filePath, vtkMRMLVolumetrySeedsNode* carrier);
+};
+
+#endif // __vtkmrmlvolumetryseedsstoragenode_h_

--- a/LiverVolumetry/Resources/UI/LiverVolumetryWidget.ui
+++ b/LiverVolumetry/Resources/UI/LiverVolumetryWidget.ui
@@ -63,19 +63,6 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="3">
-       <widget class="qSlicerMarkupsPlaceWidget" name="ROIMarkersListPlaceWidget">
-        <property name="maximumSize">
-         <size>
-          <width>15000</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="placeMultipleMarkups">
-         <enum>qSlicerMarkupsPlaceWidget::ForcePlaceMultipleMarkups</enum>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="2">
        <widget class="qMRMLNodeComboBox" name="VolumeTableSelectorWidget">
         <property name="toolTip">
@@ -249,30 +236,16 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="2">
-       <widget class="qMRMLNodeComboBox" name="ROIMarkersListSelector">
+      <item row="5" column="0" colspan="4">
+       <widget class="QPushButton" name="AddSeedsButton">
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of fiducial seeds that used for volume calculation&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Arm placement of region-growing seeds: click inside a target region in a slice view to drop an interior seed; click again to add more; toggle off when done.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
-        <property name="nodeTypes">
-         <stringlist>
-          <string>vtkMRMLMarkupsFiducialNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="baseName">
-         <string>ROIMarkersList</string>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="editEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="renameEnabled">
-         <bool>true</bool>
+        <property name="text">
+         <string>Add region-growing seeds</string>
         </property>
        </widget>
       </item>
@@ -282,7 +255,7 @@
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Generate segments based on selected resections and ROI markers</string>
+         <string>Generate segments based on selected resections and region-growing seeds</string>
         </property>
        </widget>
       </item>
@@ -320,11 +293,6 @@
    <extends>QWidget</extends>
    <header>qSlicerWidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerMarkupsPlaceWidget</class>
-   <extends>qSlicerWidget</extends>
-   <header>qSlicerMarkupsPlaceWidget.h</header>
   </customwidget>
   <customwidget>
    <class>qMRMLSegmentSelectorWidget</class>
@@ -399,38 +367,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>ROIMarkersListSelector</sender>
-   <signal>currentNodeChanged(vtkMRMLNode*)</signal>
-   <receiver>ROIMarkersListPlaceWidget</receiver>
-   <slot>setCurrentNode(vtkMRMLNode*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>422</x>
-     <y>686</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>762</x>
-     <y>686</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>LiverVolumetryWidget</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>ROIMarkersListSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>428</x>
-     <y>490</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>422</x>
-     <y>686</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>LiverVolumetryWidget</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
    <receiver>InputSegmentSelectorWidget</receiver>
@@ -443,22 +379,6 @@
     <hint type="destinationlabel">
      <x>422</x>
      <y>631</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>LiverVolumetryWidget</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>ROIMarkersListPlaceWidget</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>428</x>
-     <y>490</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>762</x>
-     <y>686</y>
     </hint>
    </hints>
   </connection>

--- a/LiverVolumetry/Testing/Python/CMakeLists.txt
+++ b/LiverVolumetry/Testing/Python/CMakeLists.txt
@@ -66,6 +66,11 @@ set(_volumetry_pytest_files
   # node with NO custom displayable manager.  Node registration + LayerDM
   # factory -> SKIPS bare, RUNS launched (ADR-0027).
   test_volumetry_registration_smoke.py
+  # ADR-0038 §Conformance -- the carrier-backed seeds table: one row per seed,
+  # label edit -> SetNthSeedLabel (the generated segment name), colour edit ->
+  # SetNthSeedColor, delete -> RemoveNthSeed, observer rebuild + teardown.  Qt
+  # + wrapped carrier -> SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_seeds_table.py
 )
 
 foreach(_pytest_file IN LISTS _volumetry_pytest_files)

--- a/LiverVolumetry/Testing/Python/conftest.py
+++ b/LiverVolumetry/Testing/Python/conftest.py
@@ -58,3 +58,33 @@ def _launched_scene_cleanup():
 
     yield
     scene.Clear(0)
+
+
+@pytest.fixture
+def qt_widgets():
+    """Register launched-Slicer Qt widgets for disposal after the test.
+
+    A widget-building test appends each widget it constructs; teardown drops
+    the widget's VTK observers via ``cleanup()`` and disposes the Qt tree so
+    no widget survives to shutdown holding a MRML observer (mirrors the
+    VascularTerritories idiom; feedback_launched_widget_teardown_crash).
+    """
+    registered: list = []
+
+    yield registered
+
+    for widget in registered:
+        try:
+            cleanup = getattr(widget, "cleanup", None)
+            if callable(cleanup):
+                cleanup()
+            parent = getattr(widget, "parent", None)
+            target = parent if parent is not None else widget
+            if hasattr(target, "setParent"):
+                target.setParent(None)
+            if hasattr(target, "delete"):
+                target.delete()
+            elif hasattr(target, "deleteLater"):
+                target.deleteLater()
+        except Exception:  # noqa: BLE001 — teardown is best-effort across versions
+            pass

--- a/LiverVolumetry/Testing/Python/test_volumetry_compute_from_carrier.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_compute_from_carrier.py
@@ -62,7 +62,7 @@ import pytest
 
 vtk = pytest.importorskip("vtk")
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 for candidate in (
     REPO_ROOT / "LiverVolumetry" / "LiverVolumetryLib",
     REPO_ROOT / "LiverVolumetry",

--- a/LiverVolumetry/Testing/Python/test_volumetry_in_volume_pick.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_in_volume_pick.py
@@ -154,7 +154,11 @@ def test_slice_click_inside_region_yields_a_labelled_interior_voxel():
     # strictly interior to the 6..14 block).  The slice node + display xy are
     # resolved by the harness against the labelmap centre; the invariant is
     # the RESULT (a labelled interior voxel), not the pixel arithmetic.
-    slice_node = slicer.app.layoutManager().sliceWidget("Red").mrmlSliceNode()
+    # Headless-safe slice node: --no-main-window has no layout manager, so
+    # create the slice node directly in the scene.  With display_xy=None the
+    # pick ignores the slice geometry and returns the interior centroid, so a
+    # scene-resident slice node is sufficient to pin the result invariant.
+    slice_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSliceNode", "Red")
     world = pick.pick_for_slice_event(slice_node, display_xy=None)
     if world is None:
         pytest.skip(
@@ -194,7 +198,11 @@ def test_in_volume_pick_is_not_surface_snapped():
     if not hasattr(pick, "pick_for_slice_event"):
         pytest.skip("InVolumePick has no pick_for_slice_event seam (ADR-0027).")
 
-    slice_node = slicer.app.layoutManager().sliceWidget("Red").mrmlSliceNode()
+    # Headless-safe slice node: --no-main-window has no layout manager, so
+    # create the slice node directly in the scene.  With display_xy=None the
+    # pick ignores the slice geometry and returns the interior centroid, so a
+    # scene-resident slice node is sufficient to pin the result invariant.
+    slice_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSliceNode", "Red")
     world = pick.pick_for_slice_event(slice_node, display_xy=None)
     if world is None:
         pytest.skip("the pick could not resolve a slice click in this harness (ADR-0027).")

--- a/LiverVolumetry/Testing/Python/test_volumetry_in_volume_pick.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_in_volume_pick.py
@@ -57,7 +57,7 @@ import pytest
 
 vtk = pytest.importorskip("vtk")
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 for candidate in (
     REPO_ROOT / "LiverVolumetry" / "LiverVolumetryLib",
     REPO_ROOT / "LiverVolumetry",

--- a/LiverVolumetry/Testing/Python/test_volumetry_seed_placement.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_seed_placement.py
@@ -49,7 +49,7 @@ import pytest
 
 vtk = pytest.importorskip("vtk")
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 for candidate in (
     REPO_ROOT / "SlicerLiverInteractionLib",
     REPO_ROOT / "LiverVolumetry" / "LiverVolumetryLib",

--- a/LiverVolumetry/Testing/Python/test_volumetry_seed_transient_fiducial.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_seed_transient_fiducial.py
@@ -55,7 +55,7 @@ import sys
 
 import pytest
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 # The pure builder core lives in the module's Lib (proposed
 # ``LiverVolumetryLib`` following the VascularTerritoriesLib precedent); the
 # path-insert lets the bare layer import it before the Lib packaging lands.

--- a/LiverVolumetry/Testing/Python/test_volumetry_seeds_table.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_seeds_table.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""ADR-0038 (amendment) -- the LiverVolumetry seeds table widget.
+
+Pins the carrier-backed seeds table (the volumetry sibling of the
+VascularTerritories ``TerritoriesTableWidget``, simplified for the FLAT seed
+carrier):
+
+* ROW-PER-SEED -- the table has one row per carrier seed, in placement order,
+  matching ``GetNumberOfSeeds`` (the carrier is the model).
+* CARRIER MODIFIED REBUILD -- adding a seed to the carrier (outside the table)
+  grows the row count without an explicit refresh (the table observes the
+  carrier's ``ModifiedEvent``).
+* LABEL EDIT -- committing the row's ``QLineEdit`` writes ``SetNthSeedLabel``
+  on the carrier (the label becomes the generated segment name, ADR-0038
+  §Conformance) without touching the seed coordinate.
+* COLOUR EDIT -- the row's colour picker writes ``SetNthSeedColor`` without
+  touching the coordinate.
+* DELETE -- the row's delete button calls ``RemoveNthSeed``, dropping exactly
+  that seed; the ``deleteSeed`` entry point converges on the same carrier
+  method.
+* OBSERVER TEARDOWN -- ``cleanup`` detaches the carrier observer so a
+  parentless widget does not survive to app shutdown holding a MRML observer
+  (feedback_launched_widget_teardown_crash).
+
+HARNESS: launched Slicer.  The table needs Qt (``qt.QTableWidget`` +
+``ctk.ctkColorPickerButton``) + the wrapped ``vtkMRMLVolumetrySeedsNode``
+carrier, so a bare ``PythonSlicer -m pytest`` (``slicer.mrmlScene is None``,
+no Qt) SKIPS CLEANLY via the shared ``slicer_pytest_support`` guards; the CTest
+row collects + skips bare and RUNS launched (ADR-0027).
+
+References
+----------
+* ADR-0038 -- §"Consumers ledger" + §Conformance (per-seed labels become
+  generated segment names).
+* ADR-0014 -- the four-layer split (a display edit must not touch geometry).
+* ADR-0010 -- glyph/text pairing (icon controls carry text + tooltip).
+* ADR-0027 -- invariant-test-first (red->skip lifecycle).
+* VascularTerritories/Testing/Python/test_territories_table.py -- the
+  carrier-backed table idiom this mirrors (hierarchical variant).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+SEEDS_NODE_CLASS = "vtkMRMLVolumetrySeedsNode"
+
+
+def _slicer_or_skip():
+    from conftest import _import_slicer_or_skip, _require_mrml_scene
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _qt_or_skip():
+    from conftest import _require_qt_widget
+
+    _require_qt_widget()
+
+
+def _make_carrier_or_skip(slicer, name="SeedsTableCarrierTest"):
+    """Mint a seed carrier exposing the flat seed API, or skip-pend (ADR-0027)."""
+    node = slicer.mrmlScene.AddNewNodeByClass(SEEDS_NODE_CLASS, name)
+    if node is None:
+        pytest.skip(
+            f"{SEEDS_NODE_CLASS} not registered -- the ADR-0038-amendment "
+            "volumetry seed carrier has not landed (launched build; ADR-0027)."
+        )
+    for method in ("AddSeed", "GetNumberOfSeeds", "GetNthSeed"):
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{SEEDS_NODE_CLASS} has no {method} -- the seed carrier API "
+                "has not landed (ADR-0027)."
+            )
+    return node
+
+
+def _import_table_or_skip():
+    """Import the seeds table widget class, or skip-pend (ADR-0027)."""
+    try:
+        from LiverVolumetryLib.VolumetrySeedsTableWidget import (
+            VolumetrySeedsTableWidget,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"VolumetrySeedsTableWidget not importable ({exc!r}) -- the ADR-0038 "
+            "seeds table has not landed OR Qt/ctk is not reachable here.  The "
+            "skip lifts at the implementation commit (ADR-0027)."
+        )
+    return VolumetrySeedsTableWidget
+
+
+def _make_table_or_skip(slicer, carrier):
+    """Construct the table over the carrier, or skip-pend the seam (ADR-0027)."""
+    VolumetrySeedsTableWidget = _import_table_or_skip()
+    try:
+        table = VolumetrySeedsTableWidget(carrier=carrier)
+    except TypeError as exc:
+        pytest.skip(
+            f"VolumetrySeedsTableWidget(carrier=) seam absent ({exc!r}) -- the "
+            "ADR-0038 widget constructor has not landed (ADR-0027)."
+        )
+    for method in ("table", "rowCount"):
+        if not hasattr(table, method):
+            pytest.skip(
+                f"VolumetrySeedsTableWidget has no {method} seam (ADR-0027)."
+            )
+    return table
+
+
+# --------------------------------------------------------------------------- #
+# ROW-PER-SEED + carrier-modified rebuild
+# --------------------------------------------------------------------------- #
+
+
+def test_table_has_one_row_per_seed(qt_widgets):
+    """The table renders one row per carrier seed, matching the seed count."""
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+
+    for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0), (3.0, 0.0, 0.0)]:
+        carrier.AddSeed(x, y, z)
+    carrier.Modified()
+
+    assert table.rowCount() == carrier.GetNumberOfSeeds() == 3, (
+        "the table must render one row per carrier seed."
+    )
+    assert table.table().rowCount == 3
+
+
+def test_carrier_modified_event_rebuilds_the_table(qt_widgets):
+    """A carrier ``ModifiedEvent`` rebuilds the table (the carrier is the model).
+
+    Adding a seed to the carrier (outside the table) grows the row count with
+    no explicit refresh -- the table observes the carrier.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+
+    carrier.AddSeed(1.0, 0.0, 0.0)
+    before = table.rowCount()
+
+    carrier.AddSeed(2.0, 0.0, 0.0)  # fires ModifiedEvent
+
+    after = table.rowCount()
+    assert after == before + 1, (
+        "a carrier ModifiedEvent must rebuild the table (row count grows with "
+        "the seed count) -- the carrier is the model, no manual refresh."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# LABEL edit -- writes SetNthSeedLabel without touching geometry
+# --------------------------------------------------------------------------- #
+
+
+def test_editing_the_label_line_edit_writes_set_nth_seed_label(qt_widgets):
+    """Committing the row's ``QLineEdit`` writes ``SetNthSeedLabel`` on the carrier.
+
+    ADR-0038 §Conformance: the per-seed label becomes the generated segment
+    name.  Committing an edit (setting the text + emitting ``editingFinished``)
+    routes through ``setSeedLabel`` and writes the carrier -- without moving the
+    seed coordinate.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    if not hasattr(carrier, "SetNthSeedLabel"):
+        pytest.skip(f"{SEEDS_NODE_CLASS} has no SetNthSeedLabel (ADR-0027).")
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    if not hasattr(table, "labelEdit"):
+        pytest.skip("VolumetrySeedsTableWidget has no labelEdit seam (ADR-0027).")
+
+    carrier.AddSeed(1.0, 2.0, 3.0)
+    carrier.Modified()
+
+    edit = table.labelEdit(0)
+    assert edit is not None, "the seed row must carry an editable label QLineEdit."
+
+    edit.setText("SegmentV")
+    edit.editingFinished()  # commit the edit
+
+    assert carrier.GetNthSeedLabel(0) == "SegmentV", (
+        "committing the label QLineEdit must write SetNthSeedLabel on the "
+        "carrier (the generated segment name; ADR-0038 §Conformance)."
+    )
+    # The display edit must not move the seed.
+    assert tuple(carrier.GetNthSeed(0)) == pytest.approx((1.0, 2.0, 3.0), abs=1e-9), (
+        "a label edit must NOT move the seed coordinate (ADR-0014 four-layer)."
+    )
+
+
+def test_set_seed_color_writes_carrier_without_touching_geometry(qt_widgets):
+    """``setSeedColor`` writes ``SetNthSeedColor`` without moving the seed.
+
+    ADR-0014 §"Fourth layer": a display edit writes the display slot only; the
+    seed coordinate stays byte-identical.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    if not hasattr(carrier, "SetNthSeedColor"):
+        pytest.skip(f"{SEEDS_NODE_CLASS} has no SetNthSeedColor (ADR-0027).")
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    if not hasattr(table, "setSeedColor"):
+        pytest.skip("VolumetrySeedsTableWidget has no setSeedColor seam (ADR-0027).")
+
+    carrier.AddSeed(4.0, 5.0, 6.0)
+    carrier.Modified()
+
+    table.setSeedColor(0, 0.3, 0.6, 0.9)
+
+    color = carrier.GetNthSeedColor(0)
+    assert (color[0], color[1], color[2]) == pytest.approx((0.3, 0.6, 0.9), abs=1e-6)
+    assert tuple(carrier.GetNthSeed(0)) == pytest.approx((4.0, 5.0, 6.0), abs=1e-9), (
+        "a colour edit must NOT move the seed coordinate (ADR-0014 four-layer)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# DELETE -- drops exactly that seed via RemoveNthSeed
+# --------------------------------------------------------------------------- #
+
+
+def test_delete_seed_removes_exactly_one_point(qt_widgets):
+    """``deleteSeed`` removes EXACTLY ONE carrier seed; survivors keep order."""
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    if not hasattr(carrier, "RemoveNthSeed"):
+        pytest.skip(f"{SEEDS_NODE_CLASS} has no RemoveNthSeed (ADR-0027).")
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    if not hasattr(table, "deleteSeed"):
+        pytest.skip("VolumetrySeedsTableWidget has no deleteSeed seam (ADR-0027).")
+
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    for x, y, z in pts:
+        carrier.AddSeed(x, y, z)
+    carrier.Modified()
+
+    table.deleteSeed(1)
+
+    assert carrier.GetNumberOfSeeds() == len(pts) - 1, (
+        "delete-by-row must remove EXACTLY ONE carrier seed."
+    )
+    assert tuple(carrier.GetNthSeed(0)) == pytest.approx(pts[0], abs=1e-6)
+    assert tuple(carrier.GetNthSeed(1)) == pytest.approx(pts[2], abs=1e-6)
+
+
+def test_delete_button_removes_exactly_that_seed(qt_widgets):
+    """Clicking a row's delete button removes exactly that seed via the carrier."""
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    if not hasattr(carrier, "RemoveNthSeed"):
+        pytest.skip(f"{SEEDS_NODE_CLASS} has no RemoveNthSeed (ADR-0027).")
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    if not hasattr(table, "deleteButton"):
+        pytest.skip("VolumetrySeedsTableWidget has no deleteButton seam (ADR-0027).")
+
+    pts = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    for x, y, z in pts:
+        carrier.AddSeed(x, y, z)
+    carrier.Modified()
+
+    delete = table.deleteButton(1)
+    assert delete is not None, "the seed row must carry a delete button."
+    delete.click()
+
+    assert carrier.GetNumberOfSeeds() == len(pts) - 1, (
+        "clicking a row's delete button must remove EXACTLY ONE carrier seed."
+    )
+    assert tuple(carrier.GetNthSeed(0)) == pytest.approx(pts[0], abs=1e-6)
+    assert tuple(carrier.GetNthSeed(1)) == pytest.approx(pts[2], abs=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# OBSERVER teardown
+# --------------------------------------------------------------------------- #
+
+
+def test_cleanup_detaches_the_carrier_observer(qt_widgets):
+    """``cleanup`` detaches the carrier observer so nothing survives shutdown.
+
+    A parentless Qt widget holding a MRML observer crashes SlicerApp on
+    shutdown (feedback_launched_widget_teardown_crash).  After ``cleanup``, a
+    carrier ``ModifiedEvent`` no longer rebuilds the table.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier)
+    qt_widgets.append(table)
+    if not hasattr(table, "cleanup"):
+        pytest.skip("VolumetrySeedsTableWidget has no cleanup seam (ADR-0027).")
+
+    carrier.AddSeed(1.0, 0.0, 0.0)
+    before = table.rowCount()
+
+    table.cleanup()
+    carrier.AddSeed(2.0, 0.0, 0.0)  # fires ModifiedEvent; observer is detached
+
+    assert table.rowCount() == before, (
+        "after cleanup, a carrier ModifiedEvent must NOT rebuild the table -- "
+        "the observer was detached (feedback_launched_widget_teardown_crash)."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Moves LiverVolumetry's region-growing seed points off Slicer markups onto the
LayerDM architecture (issue #570), as the **third consumer** of the shared
ADR-0038 point-placement base. Stacked on the base + resection/territory
migration.

### What lands

- **New C++ MRML layer** (`LiverVolumetry/MRML/`, mirroring
  `VascularTerritories/MRML/`): `vtkMRMLVolumetrySeedsNode` (carrier — ordered
  in-volume seed points, each with a label and colour), a `.vsd.json` storage
  node, and a data-only `vtkMRMLVolumetrySeedsDisplayNode` (arm/hover/grab +
  pickSurface ref + transient point). `Liver` prefix dropped per T2.7.
- **Volumetry as a placement client** of `SlicerLiverInteractionLib`: a flat,
  no-edges `VolumetrySeedProvider` over the carrier, and — the one place
  volumetry diverges from the surface consumers — an **in-volume / slice-click
  pick** that resolves a click to a strictly-interior labelled voxel (region-
  growing seeds live inside the parenchyma, not on a surface). The shared base
  drives the placement/edit/delete interaction; the swappable pick is injected.
- **3 registration calls** (ADR-0013 §5) for the display-node-typed pipeline
  creators; no custom displayable manager.
- The region-grow C++ (`vtkLiverVolumetryLogic`) is **unchanged** (ADR-0015):
  it is fed a transient `vtkMRMLMarkupsFiducialNode` built from the carrier
  inside the compute call, with per-seed labels round-tripped so generated
  segments keep their names.
- The `ROIMarkersList` markups place-widget + node selector are **retired** from
  the module and its `.ui`.

### Tests

- The pure carrier→transient-fiducial mapping test passes bare (position,
  label, order). The wrapped-node, in-volume-pick, compute-preservation,
  placement, and registration-smoke suites are launched-gated and run in CI.
- The shared-base and resection/territory characterization suites remain green
  (regression check that the new consumer did not perturb the base).

Relates to ADR-0038, ADR-0014, ADR-0015, ADR-0013, ADR-0025, ADR-0012, ADR-0004;
issue #570. Follow-up: a minimal carrier-backed seeds table (the #417 seam).

---

*Drafted with the assistance of Claude Code (model: claude-opus-4-8);
reviewed by the author.*
