### PR TITLE
ENH: VascularTerritories usability batch (eyeball round)

### DIFF
--- a/Docs/adr/0037-vascular-territories-off-markups.md
+++ b/Docs/adr/0037-vascular-territories-off-markups.md
@@ -386,3 +386,94 @@ the 3D vessel render, not the territory palette), paired with the structure name
 - [review] Re-extraction is idempotent: a territory's prior centerlines are
   cleared once before its structure loop, so re-running replaces rather than
   accrues.
+
+## Amendment — per-territory status + derived edit-lock
+
+- **Status:** Accepted
+- **Date:** 2026-07-30
+- **Cross-references:** [ADR-0034](0034-stage2-segments-table.md) (the shared
+  status vocabulary + demote-on-edit rule), [ADR-0010](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0010-accessibility-and-i18n.md)
+  (glyph + text, never colour alone).  Design study:
+  `Docs/design/territory-protection-validation-plan.md` (Option B).
+
+The maintainer's ask — *"editing seeds risks accidental changes; today the
+only protection is hiding the territory … a lock icon … the same logic as for
+segmentations, with validation of territories?"* — is answered by **Option B**
+of the design study: a per-territory **review status** mirroring Slicer's
+per-segment status, with the edit-lock **derived** from it.  The three states
+visibility / lock / validation are orthogonal; hiding a territory is no longer
+overloaded as "protect it" (and in this module hiding also removes the vessel
+from the pick surface — §slice 5 — so hide was doubly wrong as protection).
+
+### Decision
+
+1. **Carrier status slot.** `vtkMRMLCustomTerritoriesNode` carries a
+   per-territory `std::map<std::string, int> TerritoryStatuses` mirroring the
+   `TerritoryVisibilities` idiom: `SetTerritoryStatus` / `GetTerritoryStatus` /
+   `GetStatusTerritoryIds`, one `ModifiedEvent` per write, XML + `.vta.json`
+   round-trip (persisted as the machine string).  The enum reuses Slicer's
+   segment-status vocabulary **exactly** — the same ordinals (`NotStarted 0` /
+   `InProgress 1` / `Completed 2` / `Flagged 3`) and machine strings as
+   `vtkSlicerSegmentationsModuleLogic` / [ADR-0034](0034-stage2-segments-table.md)
+   / the #574 segment `structureStatus` — so the territories table and the
+   Stage-2 segments table speak one language.  The full 4-state enum ships;
+   the only load-bearing transition is reaching / leaving `Completed`.
+
+2. **Lock is DERIVED.** `GetTerritoryLocked(id)` returns
+   `GetTerritoryStatus(id) == Completed` — there is no separate stored bool
+   (the minimalism choice, byte-parallel to #574).  A status write never
+   touches `AnnotationPoints` (display-vs-geometry independence,
+   [ADR-0014](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0014-livermarkups-dissolution.md)
+   §"Fourth layer"), and the lock is **independent of visibility** (a hidden
+   territory is not thereby locked; a locked one stays visibility-toggleable).
+
+3. **Table status cell.** Each territory row carries a click-cycle status
+   `qt.QToolButton` (`NotStarted → InProgress → Completed → Flagged →
+   NotStarted`) rendered as glyph + text ([ADR-0010](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0010-accessibility-and-i18n.md)),
+   like `qMRMLSegmentsTableView`.  The derived completeness glyph folds into
+   the status cell's tooltip — one authoritative row indicator.  A locked
+   (`Completed`) territory shows a lock glyph + "Locked" and DISABLES the row's
+   Place-arm, colour, label, seed-delete, and Remove controls with an
+   explaining tooltip; the visibility toggle stays enabled.
+
+4. **Interaction guards.** A locked territory refuses geometry edits at the
+   existing seams: the Place toggle cannot arm into it and the placement
+   Pipeline checks status before `AddAnnotationPoint` (defence in depth since
+   the arm state lives on the display node); the drag hit-test excludes a
+   locked territory's seeds (a press leaves the hover highlight); per-seed
+   delete and territory Remove refuse.  **Demote-on-edit** (the #574 staleness
+   rule, locally scoped): a **geometry** edit reaching a `Completed` territory
+   through the provider (seed add / move / delete) demotes it to `InProgress`,
+   clearing the derived lock; colour / label edits are cosmetic and do **not**
+   demote.
+
+### Out of scope (explicitly deferred)
+
+Coupling validation to **compute-gating** (Extract keeps its existing ≥2-seed
+gate) and any **cross-stage invalidation cascade** are **#440 (v2.1,
+ADR-gated)** territory and must not be pulled into this amendment.
+
+### No conflict with the dissolution ADRs
+
+The guards live on the carrier status + the existing Pipeline seam, so there
+is no custom displayable manager ([ADR-0013](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0013-layerdm-pipeline-pattern.md)
+§5); the status is a display-layer attribute leaving the geometry untouched
+([ADR-0014](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0014-livermarkups-dissolution.md));
+the status cell is Python-widget composition ([ADR-0004](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0004-python-cpp-boundary.md)).
+
+### Conformance
+
+- [test] The status click-cycle wraps `NotStarted → InProgress → Completed →
+  Flagged → NotStarted`.
+- [test] A locked (`Completed`) territory refuses each edit path — placement,
+  drag-grab, seed-delete, territory-delete, colour, label.
+- [test] A geometry edit demotes `Completed → InProgress`; a colour / label
+  edit does not.
+- [test] The status survives the `.vta.json` storage round-trip; the derived
+  lock is back on read.
+- [test] The lock is independent of visibility: hiding a territory does not
+  lock it, and a locked territory stays visibility-toggleable.
+- [review] The enum ordinals + machine strings are byte-identical to Slicer's
+  segment-status vocabulary (ADR-0034), so the two tables render status the
+  same.
+- [future] Compute-gating and cross-stage invalidation — #440.

--- a/Docs/design/territory-protection-validation-plan.md
+++ b/Docs/design/territory-protection-validation-plan.md
@@ -1,0 +1,319 @@
+# Design plan — VascularTerritories protect-from-edits + validation
+
+- **Status:** Design proposal (no code) — for maintainer decision
+- **Date:** 2026-07-30
+- **Scope:** VascularTerritories annotation table + carrier
+  (`vtkMRMLCustomTerritoriesNode`), the `feature/territory-usability`
+  batch, ADR-0037.
+- **Maintainer intent (verbatim):** *"editing seeds risks accidental
+  changes; today the only protection is hiding the territory … a lock
+  icon in the territory … would it make sense to have the same logic as
+  for segmentations? with validation of territories?"*
+
+This plan grounds the ask in (a) how core Slicer actually treats
+per-segment protection and status, (b) the current territories code and
+ADRs, and (c) named UX heuristics, then lands a staged recommendation.
+No code is written here.
+
+## 1. What Slicer actually does (verified against 5.8 source)
+
+Verified in `Modules/Loadable/Segmentations/…` of the pinned Slicer
+5.8.1 tree.
+
+### 1a. `qMRMLSegmentsTableView` per-segment controls
+Columns are visibility (eye toggle), colour swatch, opacity, name, and
+an optional **status** column (plus an optional layer column, off by
+default). Visibility and status are **single-click cells**; colour and
+opacity open editors; name is inline-editable.
+
+### 1b. Per-segment STATUS — real, and the model to mirror
+- Stored as a **`vtkSegment` tag `Segmentation.Status`** (machine-readable
+  string), read/written via
+  `vtkSlicerSegmentationsModuleLogic::{Get,Set}SegmentStatus`.
+- Exhaustive enum: **`NotStarted, InProgress, Completed, Flagged`**
+  (`LastStatus` sentinel).
+- Surfaced as a status column with **icons**
+  (`:Icons/{NotStarted,InProgress,Completed,Flagged}.png`),
+  **single-click-to-cycle** (`onSegmentsTableClicked`: `++status`
+  wrapping at `LastStatus`; `Flagged → Completed`), and **per-status
+  filter buttons** (`setStatusShown`).
+- The Segment Editor **auto-sets status** when adding a segment
+  (`SetSegmentStatus(addedSegment, status)`); editing an existing segment
+  drives the `NotStarted → InProgress` progression through the same tag.
+
+### 1c. Is there a per-segment EDIT-LOCK in core Slicer? **No.**
+This is the load-bearing finding. There is **no per-segment lock
+affordance** anywhere in `vtkSegment`, `vtkSegmentation`, or
+`qMRMLSegmentsTableView`. The only "lock" is a **whole-widget**
+read-only flag on `qMRMLSegmentEditorWidget` (`d->Locked`) that disables
+add/remove and calls `SegmentsTableView->setReadOnly(true)` for the
+*entire* segmentation — with a source comment: *"In the future locked
+state may be read from the Segmentation node."* i.e. per-segment lock is
+explicitly a **not-yet-existing** idea in Slicer.
+
+What actually protects a segment from accidental edits in Slicer is the
+**Segment Editor masking model**, not a lock: `vtkMRMLSegmentEditorNode`
+carries `MaskMode` / `MaskSegmentID` / `OverwriteMode` and
+`EditAllowedInsideSingleSegment` — you edit the *selected* segment, and
+masking constrains where paint lands. Protection is a **consequence of
+selection + masking**, plus visibility, plus (advisory) status.
+
+**Conclusion for our ask:** "same logic as segmentations" cleanly gives
+us **STATUS** (real, click-to-cycle, icon+text) and **validation**
+(status == a Completed-like terminal state). A per-territory **LOCK** is
+NOT a Slicer segment affordance — it would be **novel**. That does not
+forbid it, but it means the honest "just like Slicer" answer is
+*status/validation*, and lock is an *addition* we justify on our own UX
+grounds (below), not by appeal to Slicer precedent.
+
+## 2. The three orthogonal states (the core model distinction)
+
+The maintainer already spotted the anti-pattern: **hiding a territory is
+being overloaded as "protect it."** Visibility, lock, and
+validation-status are three **orthogonal** concepts and must not be
+collapsed:
+
+| Concept | Question it answers | Slicer precedent | Today in territories |
+|---|---|---|---|
+| **Visibility** | Is it drawn / pickable? | eye toggle (real) | exists: `SetTerritoryVisibility`; also gates the pick surface (ADR-0037 slice 5) |
+| **Lock (edit-protect)** | Can seeds be added/moved/deleted? | **none per-segment** (novel) | absent — no protection except hide |
+| **Validation / status** | Has the surgeon signed this territory off as ready? | per-segment status tag (real) | absent — only a *derived* completeness glyph (⚠/Ready) |
+
+Overloading is a **consistency-with-platform-conventions** and
+**recognition-over-recall** failure: a Slicer user reads the eye as "show/
+hide," never as "protect." Using hide as protection also has a nasty
+coupling in *this* module — ADR-0037 slice 5 makes visibility **gate the
+pick surface**, so hiding a territory to protect it *also removes its
+vessel system from picking for every other territory's placement*. Hide
+is doubly wrong as a protection mechanism here. That is the strongest
+argument that lock (or status-as-protect) must be its own axis.
+
+### 2a. Should "validated" imply lock, and/or gate compute?
+Three sub-decisions, kept explicit:
+- **validated ⇒ auto-lock?** A soft coupling is good UX (error
+  prevention + reversibility): reaching the terminal status flips an
+  edit-guard that a later edit clears, exactly Slicer's *demote-on-edit*
+  rule (#574 / ADR-0034 Decision 2). This gives "protect" for free
+  without a separate manual lock gesture — the minimalism win.
+- **validated ⇒ gate compute?** The completeness glyph already exists and
+  the ≥2-seed-per-structure gate already governs extraction (ADR-0037
+  slice 5). Making *validation* (a human attestation) additionally
+  required to compute is a **positioning-level** change — that is #440
+  territory (IEC 62366, ADR-0009). Do **not** couple validation to
+  compute-gating in this batch.
+- **lock ⇒ refuse edits.** Whatever carries the guard, the interaction
+  consequence is uniform: placement (add-on-click into a locked/validated
+  territory), drag-edit of its seeds, per-seed delete, and territory
+  delete all **refuse** (with an explaining tooltip, never a silent
+  no-op).
+
+## 3. Data-model shape (carrier + storage)
+
+`vtkMRMLCustomTerritoriesNode` already carries independent per-territory
+display maps (`TerritoryColors`, `TerritoryLabels`, `TerritoryVisibilities`)
+each with a `Get/Set…` pair, XML + `.vta.json` round-trip, and a single
+`ModifiedEvent` per write (the pattern is settled; ADR-0037 §Decision 3).
+A protection/validation flag follows the **same idiom exactly**:
+
+- **Preferred (mirror Slicer's status tag):** one
+  `std::map<std::string,int> TerritoryStatuses` keyed on territory id,
+  storing the enum ordinal, defaulting to `NotStarted`. Add
+  `SetTerritoryStatus(id,int)` / `GetTerritoryStatus(id)->int`,
+  `GetStatusTerritoryIds()`, XML attribute + `.vta.json` field, one
+  `ModifiedEvent` per write. **Lock is DERIVED** from status (`Completed
+  ⇒ locked`), so no separate stored bool — the minimalism choice, and the
+  one that stays byte-for-byte parallel to #574.
+- **Alternative (explicit lock bool):** add `TerritoryLocked` bool map
+  alongside status. Only needed if the maintainer wants lock *independent*
+  of validation (lock a still-incomplete territory). Costs a second
+  orthogonal flag and a second storage field.
+
+Both keep the geometry map (`AnnotationPoints`) untouched by a
+status/lock write (the display-vs-geometry independence ADR-0014 §Fourth
+layer requires). Enum values and the machine-readable strings should
+**reuse Slicer's own vocabulary** (`NotStarted/InProgress/Completed/
+Flagged`) so the territories table and the #574 segments table speak one
+language.
+
+## 4. Table UX (icons/columns, a11y)
+
+The territories panel is a single-column, header-less `QTreeWidget` of
+composite row strips (ADR-0037 slice-4). The territory strip today is:
+Place · eye · colour · label(QLineEdit, stretch) · completeness-status ·
+Remove. Additions:
+
+- A **status control** on the territory strip: a `QToolButton` rendered
+  as **icon + short text** (ADR-0010 — never colour/icon alone), whose
+  click **cycles** the status exactly like Slicer's status cell
+  (`NotStarted → InProgress → Completed → Flagged → …`). Reuse Slicer's
+  status icons where the resource resolves, glyph fallback otherwise
+  (the existing `_applyEyeIcon` pattern).
+- The **derived completeness glyph** stays but is **subordinated** to
+  status: completeness (⚠/Ready) is a *machine* readiness hint; status is
+  the *human* attestation. Keep both, but the row's authoritative state
+  is status. (Consider folding the completeness text into the status
+  button's tooltip to avoid two competing indicators — a minimalism
+  refinement to review.)
+- When a territory is **locked** (derived from `Completed`, per §2a), the
+  strip shows a **lock glyph + "Locked"** and the Place toggle, colour,
+  label edit, seed deletes, and Remove are **disabled** (greyed, with a
+  tooltip: "Territory validated — unlock to edit"). Unlock = cycle status
+  off `Completed`. This is Slicer's demote-on-edit made explicit.
+- a11y: every state is glyph/icon **plus text** and a tooltip; disabled
+  controls keep their label so the state is announced, not merely dimmed
+  (ADR-0010, and #574's "never colour alone" conformance).
+
+## 5. Interaction consequences (who refuses what)
+
+The lock guard lives on the **carrier status** and is read at the same
+seams that already exist:
+
+- **Placement (add-on-click).** `TerritoryPlacementPipeline` appends to
+  the *active* territory via the display-node arm state. A locked active
+  territory must refuse the append. The clean guard point: the Place
+  toggle **cannot arm** into a locked territory (disabled in the strip),
+  and the pipeline additionally checks status before `AddAnnotationPoint`
+  (defence in depth, since arm state lives on the display node).
+- **Drag-edit / pick.** ADR-0037 §Decision 2 makes drag edit the nearest
+  point. The pipeline's drag path must consult the point's territory
+  status and decline the relocate on a locked territory (leaving the
+  hover highlight, like a declined bare move).
+- **Per-seed delete & territory Remove.** `deleteSeed` / `deleteTerritory`
+  in the table refuse (button disabled) for a locked territory.
+- **Already-handled hygiene (do not re-solve):** deleted-territory and
+  active-territory disarm hygiene already exist (`deleteTerritory` clears
+  arm state; module-active gate on `exit()`). Locking rides on top of
+  these, it does not replace them.
+
+## 6. Design options
+
+### Option A — Lock-only binary (no status vocabulary)
+A single per-territory `locked` bool + a lock/unlock toggle in the strip;
+locked ⇒ all edits refuse. Simplest; directly answers "a lock icon in the
+territory."
+- **UX:** strong error-prevention, trivially reversible, minimal states.
+- **Cost:** small (one bool map + storage + guards).
+- **Against:** does **not** match Slicer ("same logic as segmentations"
+  is status, not lock), and does **not** give the *validation* the
+  maintainer also asked for. Diverges from #574's status language, so the
+  two tables feel like two products.
+- **ADR:** an ADR-0037 amendment suffices (no positioning change).
+
+### Option B — Slicer-style 4-state status, `Completed ⇒ locked` (recommended core)
+Mirror `qMRMLSegmentsTableView`: per-territory status
+(`NotStarted/InProgress/Completed/Flagged`) stored on the carrier,
+click-to-cycle icon+text cell, **lock derived** from `Completed`, edits
+on a `Completed` territory refuse and demote-on-edit clears it.
+- **UX:** best consistency-with-platform (a Slicer user recognises the
+  status cell instantly), visibility-of-system-status (review state is
+  explicit and persistent), error-prevention via the derived lock,
+  reversibility via cycle-off, minimalism (one axis buys both protect and
+  validate). Matches #574 exactly so the segments table and territories
+  table are one product.
+- **Cost:** moderate (status map + storage + status cell + guards +
+  invariant tests). Reuses the display-map idiom and Slicer's own
+  icons/vocabulary.
+- **Against:** four states may be more than territories need (do surgeons
+  use `Flagged` on a territory?). Mitigation: ship the full enum for
+  #574-consistency but the *only load-bearing* transition is
+  reach-`Completed`-to-validate/lock; `Flagged` is a defer marker, free
+  to carry.
+- **ADR:** an ADR-0037 amendment (status/lock is a display-layer
+  attribute + interaction guard, not a positioning change). Cross-
+  reference ADR-0034's status vocabulary as the shared source of truth.
+
+### Option C — Lock + separate accept/validate contract tied to #440
+Per-territory lock as in A, **plus** a distinct human-attestation
+"validate" that participates in the shell-wide phase-contract cascade
+(invalidation when upstream anatomy changes, DAG unlock, IEC 62366
+positioning).
+- **UX:** most powerful; a true clinical review contract.
+- **Against:** #440 is **v2.1**, **ADR-gated**, with five unresolved
+  questions (invalidation cascade, optional-stage DAG, positioning
+  re-open, verification fatigue, persistence). Pulling territory
+  validation into that contract is a positioning-level move that
+  **cannot** ride the current usability batch (violates
+  check-milestone-before-dispatching; #440 stays v2.1 per the 2026-07-09
+  re-baseline note).
+- **ADR:** requires the #440 ADR, not an amendment. Out of scope for this
+  batch.
+
+## 7. Recommendation + staging
+
+**Adopt Option B**, staged so the usability batch ships the protection
+the maintainer needs *now* without straying into #440's positioning
+change.
+
+- **Ship in the current `feature/territory-usability` batch:**
+  1. Carrier `TerritoryStatuses` map (enum reusing Slicer's
+     `NotStarted/InProgress/Completed/Flagged`) with XML + `.vta.json`
+     round-trip and one `ModifiedEvent` per write — test-first, mirroring
+     the existing display-map tests (ADR-0027).
+  2. Status cell on the territory strip: click-to-cycle, icon **+** text,
+     Slicer status icons with glyph fallback (ADR-0010).
+  3. **Derived lock** (`Completed ⇒ locked`): disable Place-arm, colour,
+     label, seed-delete, territory-Remove on a locked territory, each with
+     an explaining tooltip; pipeline placement/drag guards as defence in
+     depth. **Demote-on-edit** clears `Completed → InProgress` (the #574
+     staleness rule, locally scoped to this territory).
+  4. Invariant tests: cycle order; `Completed` refuses each edit path;
+     demote-on-edit; storage round-trip; visibility remains independent of
+     lock (the anti-overload pin).
+
+- **Explicitly defer to v2.1 / #440 (do NOT build now):**
+  - Coupling validation to **compute-gating** (extraction already gates
+    on ≥2 seeds/structure; making human validation a compute
+    precondition is positioning-level).
+  - Any **cross-stage invalidation cascade** (upstream anatomy change
+    demoting a validated territory) — that is #440's dependency-tracking
+    question, not a per-territory local rule.
+  - A separate `Flagged`-driven senior-review workflow.
+
+- **Consistency with #574 (make the two tables one product):** reuse the
+  **same status enum, the same machine-readable strings, and the same
+  icons** as `qMRMLSegmentsTableView` / ADR-0034. Where practical, factor
+  the status-cell rendering (icon+text+cycle) into a shared helper so the
+  segments table and the territories tree render status identically. The
+  demote-on-edit rule should read the same in both ADRs.
+
+**Why not A:** it answers "lock icon" literally but abandons the
+"validation … same as segmentations" half and drifts from #574's
+language. **Why not C now:** it is v2.1, ADR-gated, positioning-level.
+
+## 8. ADR impact
+
+- **ADR-0037 amendment** (new): "Per-territory status + derived edit-lock,"
+  recording the carrier status slot, the click-to-cycle status cell, the
+  `Completed ⇒ locked` derivation, the edit-refusal seams, and
+  demote-on-edit. New ADRs are authored `Status: Accepted` (repo
+  convention). Cross-reference ADR-0034 as the status-vocabulary source
+  and ADR-0010 for the icon+text rule.
+- **No conflict** with ADR-0013 (no custom DM — guards live on the
+  carrier + existing Pipeline seam), ADR-0014 (status is a display-layer
+  attribute, geometry untouched), or ADR-0004 (the cell is Python-widget
+  composition).
+- **Boundary flag:** compute-gating and cross-stage invalidation belong to
+  **#440 (v2.1, ADR-gated)** and must not be pulled into this amendment.
+
+## 9. Open questions for the maintainer (each with a default)
+
+1. **Lock derived from status, or an independent lock bool?**
+   *Default: derived (`Completed ⇒ locked`), Option B* — minimal, matches
+   Slicer's demote-on-edit. Choose independent only if you want to lock an
+   incomplete territory.
+2. **Full 4-state enum, or a 2-state (`Draft/Validated`) subset?**
+   *Default: full enum reusing Slicer's* — costs nothing extra and keeps
+   the territories and #574 segment tables identical. `Flagged` rides
+   along as a defer marker.
+3. **Does reaching the status also gate Extract/Compute?**
+   *Default: no* — extraction keeps its existing ≥2-seed gate; validation-
+   as-compute-gate is #440 positioning-level. Revisit in v2.1.
+4. **Keep the derived completeness glyph AND the status cell, or fold
+   completeness into the status tooltip?**
+   *Default: fold completeness into the status button tooltip* — one
+   authoritative row indicator (minimalism); revisit if surgeons want both
+   visible.
+5. **Should demote-on-edit fire on any edit, or only on geometry edits
+   (add/move/delete seed), not on colour/label?**
+   *Default: geometry edits only* — colour/label are cosmetic and should
+   not invalidate a surgeon's sign-off.

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -73,6 +73,7 @@ design/resection-plan-architecture/06-pattern-and-audit.md
 design/connected-tree-seeding-plan.md
 design/multi-system-territory-plan.md
 design/volumetry-seeds-layerdm-plan.md
+design/territory-protection-validation-plan.md
 ```
 
 ```{toctree}

--- a/SlicerLiverInteractionLib/PointPlacementState.py
+++ b/SlicerLiverInteractionLib/PointPlacementState.py
@@ -43,6 +43,7 @@ class PointPlacementState:
         self._armed_attr = f"{namespace}.Armed"
         self._active_attr = f"{namespace}.{active_suffix}"
         self._module_active_attr = f"{namespace}.ModuleActive"
+        self._grabbing_attr = f"{namespace}.Grabbing"
         self._carrier_role = f"{namespace}.carrier"
 
     # ------------------------------------------------------------------ #
@@ -85,6 +86,29 @@ class PointPlacementState:
         return (
             displayNode is None
             or displayNode.GetAttribute(self._module_active_attr) != "0"
+        )
+
+    # ------------------------------------------------------------------ #
+    # Grab (drag-in-flight) flag
+    # ------------------------------------------------------------------ #
+    def set_grabbing(self, displayNode: Any, grabbing: bool) -> None:
+        """Publish that a point-drag gesture is IN FLIGHT on the display node.
+
+        The manager-driven Pipeline sets this on a grab and clears it on
+        release; a widget/table observing the CARRIER reads it to defer its
+        expensive full rebuild until the drag ends (a drag relocates one
+        point per mouse-move, each firing the carrier's ``Modified``, so a
+        naive observer would rebuild the whole view per frame).  Rides as a
+        cheap string attribute on the display node -- NOT the carrier -- so
+        setting/clearing it never itself fires the carrier observer.
+        """
+        if displayNode is not None:
+            displayNode.SetAttribute(self._grabbing_attr, "1" if grabbing else "0")
+
+    def is_grabbing(self, displayNode: Any) -> bool:
+        return (
+            displayNode is not None
+            and displayNode.GetAttribute(self._grabbing_attr) == "1"
         )
 
     # ------------------------------------------------------------------ #

--- a/SlicerLiverInteractionLib/Testing/Python/test_point_placement_state.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_point_placement_state.py
@@ -211,6 +211,27 @@ def test_carrier_binds_as_node_ref_and_fires_modified():
     )
 
 
+def test_grabbing_flag_round_trips_and_defaults_off():
+    """The drag-in-flight (grabbing) flag round-trips; a fresh node reads OFF.
+
+    A point drag relocates the grabbed point on every mouse-move, each firing
+    the carrier's ``Modified``; a widget/table observing the carrier reads
+    this flag off the SHARED display node to defer its expensive full rebuild
+    until the drag ends (ADR-0037 §Decision 3 performance).  The Pipeline sets
+    it on grab and clears it on release, so like the arm flag it MUST live on
+    the display node, not the pipeline instance.
+    """
+    PointPlacementState = _import_state()
+    state = PointPlacementState("Volumetry")
+    node = _FakeDisplayNode()
+
+    assert state.is_grabbing(node) is False, "a fresh node must read NOT grabbing."
+    state.set_grabbing(node, True)
+    assert state.is_grabbing(node) is True
+    state.set_grabbing(node, False)
+    assert state.is_grabbing(node) is False
+
+
 # --------------------------------------------------------------------------- #
 # Namespace parameterization -- two consumers, independent keys/nodes
 # --------------------------------------------------------------------------- #

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.cxx
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.cxx
@@ -236,6 +236,7 @@ void vtkMRMLCustomTerritoriesNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "TerritoryColors: " << this->TerritoryColors.size() << " entries\n";
   os << indent << "TerritoryLabels: " << this->TerritoryLabels.size() << " entries\n";
   os << indent << "TerritoryVisibilities: " << this->TerritoryVisibilities.size() << " entries\n";
+  os << indent << "TerritoryStatuses: " << this->TerritoryStatuses.size() << " entries\n";
 }
 
 //------------------------------------------------------------------------------
@@ -288,6 +289,15 @@ void vtkMRMLCustomTerritoriesNode::ReadXMLAttributes(const char** atts)
     {
       this->TerritoryVisibilities.clear();
       walkEncodedMap(attValue, [this](const std::string& key, const std::string& value) { this->TerritoryVisibilities[key] = (value != "0"); });
+    }
+    else if (!std::strcmp(attName, "territoryStatuses"))
+    {
+      this->TerritoryStatuses.clear();
+      // The XML value stores the machine-readable status STRING (matching
+      // Slicer's segment-status strings, ADR-0034), decoded back to the enum
+      // ordinal, so a hand-inspected scene reads the surgeon-facing state.
+      walkEncodedMap(attValue,
+                     [this](const std::string& key, const std::string& value) { this->TerritoryStatuses[key] = vtkMRMLCustomTerritoriesNode::GetStatusFromMachineString(value); });
     }
     else if (!std::strcmp(attName, "segmentNames"))
     {
@@ -348,6 +358,18 @@ void vtkMRMLCustomTerritoriesNode::WriteXML(ostream& of, int nIndent)
     }
     of << " territoryVisibilities=\"" << this->XMLAttributeEncodeString(encodeMap(encodedVis).c_str()) << "\"";
   }
+  if (!this->TerritoryStatuses.empty())
+  {
+    // Persist the machine-readable status STRING (not the raw ordinal) so the
+    // scene XML reads the surgeon-facing state and stays byte-parallel to
+    // Slicer's segment-status strings (ADR-0034).
+    std::map<std::string, std::string> encodedStatuses;
+    for (const auto& kv : this->TerritoryStatuses)
+    {
+      encodedStatuses[kv.first] = vtkMRMLCustomTerritoriesNode::GetStatusAsMachineString(kv.second);
+    }
+    of << " territoryStatuses=\"" << this->XMLAttributeEncodeString(encodeMap(encodedStatuses).c_str()) << "\"";
+  }
   if (this->SegmentNames && this->SegmentNames->GetNumberOfValues() > 0)
   {
     std::ostringstream names;
@@ -381,6 +403,7 @@ void vtkMRMLCustomTerritoriesNode::CopyContent(vtkMRMLNode* anode, bool deepCopy
   this->TerritoryColors = other->TerritoryColors;
   this->TerritoryLabels = other->TerritoryLabels;
   this->TerritoryVisibilities = other->TerritoryVisibilities;
+  this->TerritoryStatuses = other->TerritoryStatuses;
   if (other->SegmentNames)
   {
     this->SegmentNames->DeepCopy(other->SegmentNames);
@@ -555,6 +578,7 @@ bool vtkMRMLCustomTerritoriesNode::RemoveTerritory(const std::string& territoryI
   removed |= (this->TerritoryColors.erase(territoryId) > 0);
   removed |= (this->TerritoryLabels.erase(territoryId) > 0);
   removed |= (this->TerritoryVisibilities.erase(territoryId) > 0);
+  removed |= (this->TerritoryStatuses.erase(territoryId) > 0);
   if (removed)
   {
     this->Modified();
@@ -656,7 +680,86 @@ std::vector<std::string> vtkMRMLCustomTerritoriesNode::GetDisplayTerritoryIds() 
   {
     ids.insert(kv.first);
   }
+  for (const auto& kv : this->TerritoryStatuses)
+  {
+    ids.insert(kv.first);
+  }
   return std::vector<std::string>(ids.begin(), ids.end());
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLCustomTerritoriesNode::SetTerritoryStatus(const std::string& territoryId, int status)
+{
+  if (status < NotStarted || status >= LastStatus)
+  {
+    // Out-of-range ordinal: refuse the write (no event) so a bad value never
+    // lands and the derived lock stays well-defined.
+    return;
+  }
+  this->TerritoryStatuses[territoryId] = status;
+  this->Modified();
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLCustomTerritoriesNode::GetTerritoryStatus(const std::string& territoryId) const
+{
+  auto it = this->TerritoryStatuses.find(territoryId);
+  if (it == this->TerritoryStatuses.end())
+  {
+    return NotStarted;
+  }
+  return it->second;
+}
+
+//------------------------------------------------------------------------------
+std::string vtkMRMLCustomTerritoriesNode::GetStatusAsMachineString(int status)
+{
+  switch (status)
+  {
+    case InProgress: return "InProgress";
+    case Completed: return "Completed";
+    case Flagged: return "Flagged";
+    case NotStarted:
+    default: return "NotStarted";
+  }
+}
+
+//------------------------------------------------------------------------------
+int vtkMRMLCustomTerritoriesNode::GetStatusFromMachineString(const std::string& machineString)
+{
+  if (machineString == "InProgress")
+  {
+    return InProgress;
+  }
+  if (machineString == "Completed")
+  {
+    return Completed;
+  }
+  if (machineString == "Flagged")
+  {
+    return Flagged;
+  }
+  return NotStarted;
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLCustomTerritoriesNode::GetTerritoryLocked(const std::string& territoryId) const
+{
+  // The lock is DERIVED from the status — a Completed territory is locked; no
+  // separate stored bool (ADR-0037 Amendment "Per-territory status + derived
+  // edit-lock").  Independent of visibility.
+  return this->GetTerritoryStatus(territoryId) == Completed;
+}
+
+//------------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLCustomTerritoriesNode::GetStatusTerritoryIds() const
+{
+  std::vector<std::string> ids;
+  for (const auto& kv : this->TerritoryStatuses)
+  {
+    ids.push_back(kv.first);
+  }
+  return ids;
 }
 
 //------------------------------------------------------------------------------

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.cxx
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.cxx
@@ -545,6 +545,24 @@ void vtkMRMLCustomTerritoriesNode::ClearAnnotationPoints(const std::string& terr
 }
 
 //------------------------------------------------------------------------------
+bool vtkMRMLCustomTerritoriesNode::RemoveTerritory(const std::string& territoryId)
+{
+  // A territory is present if it carries geometry OR any display slot; an
+  // empty (zero-seed) territory lives only in the display maps, so the erase
+  // spans every per-territory map keyed on the surgeon-named id.
+  bool removed = false;
+  removed |= (this->AnnotationPoints.erase(territoryId) > 0);
+  removed |= (this->TerritoryColors.erase(territoryId) > 0);
+  removed |= (this->TerritoryLabels.erase(territoryId) > 0);
+  removed |= (this->TerritoryVisibilities.erase(territoryId) > 0);
+  if (removed)
+  {
+    this->Modified();
+  }
+  return removed;
+}
+
+//------------------------------------------------------------------------------
 std::vector<std::string> vtkMRMLCustomTerritoriesNode::GetAnnotationTerritoryIds() const
 {
   std::vector<std::string> ids;

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.h
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.h
@@ -249,6 +249,68 @@ public:
   std::vector<std::string> GetDisplayTerritoryIds() const;
 
   //--------------------------------------------------------------------------
+  // Per-territory review status + derived edit-lock (ADR-0037 Amendment
+  // "Per-territory status + derived edit-lock" / the territory-usability plan)
+  //--------------------------------------------------------------------------
+  //
+  // The surgeon signs a territory off through a per-territory review status
+  // mirroring Slicer's per-segment status (ADR-0034, the #574 segment
+  // structureStatus): the enum reuses ``vtkSlicerSegmentationsModuleLogic``'s
+  // vocabulary EXACTLY — same int values (NotStarted 0 / InProgress 1 /
+  // Completed 2 / Flagged 3) and the same machine-readable strings — so the
+  // territories table and the Stage-2 segments table speak one language.
+  // Stored as a ``std::map<std::string, int>`` keyed on the surgeon-named
+  // territory id, mirroring the ``TerritoryVisibilities`` idiom (own slot, one
+  // ModifiedEvent per write, XML + ``.vta.json`` round-trip).  The LOCK is
+  // DERIVED from the status (``Completed`` ⇒ locked) — no separate stored bool.
+  // The status is a DISPLAY-layer attribute: a status write never touches
+  // ``AnnotationPoints`` (ADR-0014 §"Fourth layer" display-vs-geometry
+  // independence), and it is INDEPENDENT of visibility (a hidden territory is
+  // not thereby locked; a locked one stays visibility-toggleable).
+
+  /// The per-territory review-status vocabulary.  Reuses Slicer's own segment
+  /// status enum values (``vtkSlicerSegmentationsModuleLogic``) so the ordinals
+  /// and the machine strings match ADR-0034 / the #574 segment table exactly.
+  enum TerritoryStatus
+  {
+    NotStarted = 0,
+    InProgress = 1,
+    Completed = 2,
+    Flagged = 3,
+    LastStatus = 4
+  };
+
+  /// Set territory ``territoryId``'s review status (one of the
+  /// ``TerritoryStatus`` ordinals).  An out-of-range value is a no-op (no
+  /// event).  Fires ONE ModifiedEvent.  Does NOT touch the annotation-point
+  /// geometry.
+  void SetTerritoryStatus(const std::string& territoryId, int status);
+
+  /// Territory ``territoryId``'s review status ordinal.  An unset territory
+  /// defaults to ``NotStarted``.
+  int GetTerritoryStatus(const std::string& territoryId) const;
+
+  /// The machine-readable string for a status ordinal
+  /// (``"NotStarted"`` / ``"InProgress"`` / ``"Completed"`` / ``"Flagged"``),
+  /// matching Slicer's segment-status strings.  An out-of-range ordinal maps
+  /// to ``"NotStarted"``.
+  static std::string GetStatusAsMachineString(int status);
+
+  /// The status ordinal for a machine-readable string (the inverse of
+  /// ``GetStatusAsMachineString``); an unknown string maps to ``NotStarted``.
+  static int GetStatusFromMachineString(const std::string& machineString);
+
+  /// Whether territory ``territoryId`` is edit-LOCKED.  The lock is DERIVED
+  /// from the status (``Completed`` ⇒ locked) — there is no separate stored
+  /// bool.  Independent of visibility.
+  bool GetTerritoryLocked(const std::string& territoryId) const;
+
+  /// The territory ids that currently carry a review status, in a
+  /// deterministic (sorted) order.  Used by the storage node to enumerate the
+  /// per-territory status slots.
+  std::vector<std::string> GetStatusTerritoryIds() const;
+
+  //--------------------------------------------------------------------------
   // Storage
   //--------------------------------------------------------------------------
 
@@ -285,6 +347,14 @@ protected:
   std::map<std::string, std::array<double, 3>> TerritoryColors;
   std::map<std::string, std::string> TerritoryLabels;
   std::map<std::string, bool> TerritoryVisibilities;
+
+  /// Per-territory review status (ADR-0037 Amendment "Per-territory status +
+  /// derived edit-lock").  Keyed on the same surgeon-named territory id as the
+  /// other display maps but kept SEPARATE so a status write cannot perturb the
+  /// geometry or the other display slots.  A territory with no entry defaults
+  /// to ``NotStarted``.  The edit-lock is derived (``Completed`` ⇒ locked), so
+  /// no lock bool is stored.
+  std::map<std::string, int> TerritoryStatuses;
 
   /// Scratch buffer backing the ``GetTerritoryColor`` size-hinted return
   /// (same idiom as ``AnnotationPointScratch``).

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.h
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesNode.h
@@ -193,6 +193,14 @@ public:
   /// ONE ModifiedEvent for a non-empty territory.
   void ClearAnnotationPoints(const std::string& territoryId);
 
+  /// Remove ``territoryId`` wholesale — its annotation points AND its
+  /// per-territory display slot (colour / label / visibility) — leaving
+  /// siblings intact.  Fires ONE ModifiedEvent iff something was removed.
+  /// Returns true iff the territory carried any geometry or display slot.
+  /// A territory with zero seeds is still removable (its display slot alone
+  /// makes it present), which is the affordance an empty territory needs.
+  bool RemoveTerritory(const std::string& territoryId);
+
   /// The surgeon-named territory ids that currently carry at least one
   /// annotation point, in a deterministic (sorted) order.  Used by the
   /// storage node to enumerate the per-territory point lists.

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.cxx
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.cxx
@@ -211,6 +211,11 @@ int vtkMRMLCustomTerritoriesStorageNode::WriteJson(const std::string& filePath, 
       writer->WriteVectorProperty("color", rgb, 3);
       writer->WriteStringProperty("label", carrier->GetTerritoryLabel(territoryId));
       writer->WriteBoolProperty("visibility", carrier->GetTerritoryVisibility(territoryId));
+      // Per-territory review status (ADR-0037 Amendment "Per-territory status +
+      // derived edit-lock"): the machine-readable status STRING, matching
+      // Slicer's segment-status strings (ADR-0034).  The lock is derived from
+      // it on read, so no separate lock field is persisted.
+      writer->WriteStringProperty("status", vtkMRMLCustomTerritoriesNode::GetStatusAsMachineString(carrier->GetTerritoryStatus(territoryId)));
       writer->WriteObjectPropertyEnd();
     }
   }
@@ -346,6 +351,14 @@ void vtkMRMLCustomTerritoriesStorageNode::ReadDisplay(vtkMRMLJsonElement* root, 
     if (entry->HasMember("visibility"))
     {
       carrier->SetTerritoryVisibility(territoryId, entry->GetBoolProperty("visibility"));
+    }
+    if (entry->HasMember("status"))
+    {
+      // Decode the machine-readable status STRING back to the enum ordinal
+      // (ADR-0037 Amendment "Per-territory status + derived edit-lock").  A
+      // document without a status field reads back the carrier default
+      // (NotStarted), which is additive to the pre-status schema.
+      carrier->SetTerritoryStatus(territoryId, vtkMRMLCustomTerritoriesNode::GetStatusFromMachineString(entry->GetStringProperty("status")));
     }
   }
 }

--- a/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.h
+++ b/VascularTerritories/MRML/vtkMRMLCustomTerritoriesStorageNode.h
@@ -74,15 +74,19 @@ class vtkMRMLJsonElement;
  *     "SegmentVIII": [ { "xyz": [x, y, z] }, ... ]
  *   },
  *   "territoryDisplay": {
- *     "SegmentVII": { "color": [r, g, b], "label": "…", "visibility": true }
+ *     "SegmentVII": { "color": [r, g, b], "label": "…", "visibility": true,
+ *                     "status": "Completed" }
  *   }
  * }
  * \endcode
  *
  * The ``territoryDisplay`` object carries the per-territory display slot
- * (colour / label / visibility) ADR-0037 §Decision 3 adds; it is optional
+ * (colour / label / visibility / status) ADR-0037 §Decision 3 + the
+ * "Per-territory status + derived edit-lock" amendment add; it is optional
  * and additive to the v1 schema (a document without it reads back with the
- * carrier's display defaults).
+ * carrier's display defaults, and a document without the ``status`` field
+ * reads back ``NotStarted``).  The edit-lock is DERIVED from the status on
+ * read, so no lock field is persisted.
  *
  * The per-territory arrays are ORDERED — placement order round-trips
  * identically (ADR-0037 §Conformance [test]).  The storage node is typed

--- a/VascularTerritories/Testing/Python/test_territories_action_enablement.py
+++ b/VascularTerritories/Testing/Python/test_territories_action_enablement.py
@@ -305,6 +305,125 @@ def test_compute_gated_on_centerline_and_reference_volume(qt_widgets):
 
 
 # =========================================================================== #
+# REQUIREMENTS MESSAGE — the affirmative "what's missing" surface
+# =========================================================================== #
+#
+# ADR-0037 §Decision 4 affirmative requirements surface: when Extract / Compute
+# are disabled the panel enumerates the UNMET preconditions (a status line + the
+# button tooltips), so a disabled action always explains what to do next.  The
+# message reads the SAME live state as the enablement gates, so the two cannot
+# diverge (an empty unmet list == the action can run).
+
+
+def _require_requirements_seam_or_skip(widget):
+    if not hasattr(widget, "_actionRequirements"):
+        pytest.skip(
+            "widget has no _actionRequirements -- the ADR-0037 §Decision 4 "
+            "requirements-message surface has not landed (ADR-0027)."
+        )
+
+
+def test_requirements_message_lists_missing_items_with_no_input(qt_widgets):
+    """With NO input selected both actions list "Select an input segmentation".
+
+    ADR-0037 §Decision 4: the unmet-precondition list drives the messaging.  A
+    fresh widget with no input, no reference volume, and no centerline lists the
+    input requirement for BOTH actions and the volume + centerline for Compute.
+    Launched (widget); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+    _require_requirements_seam_or_skip(widget)
+
+    widget.ui.inputSurfaceSelector.setCurrentNode(None)
+    extractUnmet, computeUnmet = widget._actionRequirements()
+
+    assert "Select an input segmentation" in extractUnmet, (
+        "with no input, Extract must list the input requirement."
+    )
+    assert "Select an input segmentation" in computeUnmet, (
+        "with no input, Compute must list the input requirement."
+    )
+    assert "Load a reference volume" in computeUnmet, (
+        "with no reference volume, Compute must list the volume requirement."
+    )
+    assert "Extract centerlines first" in computeUnmet, (
+        "with no extracted centerline, Compute must list the centerline "
+        "requirement."
+    )
+
+
+def test_requirements_message_flags_vmtk_absence(qt_widgets):
+    """When SlicerVMTK is absent, Extract lists the VMTK install requirement.
+
+    ADR-0037 §Decision 4: the VMTK wording is preserved for the extractor-
+    absent case.  Off the VMTK image the requirement is present; on it, it is
+    not.  Launched (widget); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+    _require_requirements_seam_or_skip(widget)
+
+    seg, _segId = _vessel_segmentation(slicer)
+    widget.ui.inputSurfaceSelector.setCurrentNode(seg)
+    extractUnmet, _computeUnmet = widget._actionRequirements()
+
+    vmtk_msg = "SlicerVMTK (ExtractCenterline) is not installed"
+    if widget.logic.extractionActionEnabled():
+        assert vmtk_msg not in extractUnmet, (
+            "with SlicerVMTK present the VMTK requirement must not be listed."
+        )
+    else:
+        assert vmtk_msg in extractUnmet, (
+            "with SlicerVMTK absent the VMTK requirement must be listed."
+        )
+
+
+def test_requirements_message_empties_when_compute_ready(qt_widgets):
+    """Compute's unmet list EMPTIES once input + volume + centerline are present.
+
+    ADR-0037 §Decision 4: an empty unmet list is exactly the enablement gate --
+    the messaging cannot diverge from the button state.  Populated via the
+    stub-centerline idiom (no SlicerVMTK).  Launched (widget); SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+    _require_requirements_seam_or_skip(widget)
+
+    seg, _segId = _vessel_segmentation(slicer)
+    widget.ui.inputSurfaceSelector.setCurrentNode(seg)
+    carrier = widget._ensureAnnotationCarrier()
+
+    ref_volume = slicer.mrmlScene.AddNewNodeByClass(
+        "vtkMRMLScalarVolumeNode", "ReqMsgRefVolume")
+    image = vtk.vtkImageData()
+    image.SetDimensions(4, 4, 4)
+    image.AllocateScalars(vtk.VTK_SHORT, 1)
+    ref_volume.SetAndObserveImageData(image)
+
+    # No centerline yet: Compute lists the centerline requirement.
+    _extractUnmet, computeUnmet = widget._actionRequirements()
+    assert "Extract centerlines first" in computeUnmet
+
+    # A centerline in CenterlineRefs empties Compute's unmet list.
+    _attach_stub_centerline(slicer, widget.logic, carrier, "T1")
+    _extractUnmet2, computeUnmet2 = widget._actionRequirements()
+    assert computeUnmet2 == [], (
+        "with input + reference volume + an extracted centerline, Compute's "
+        "unmet list must be empty (mirrors the enabled button)."
+    )
+    assert widget.ui.calculateVascularTerritoryMapButton.enabled is True, (
+        "an empty Compute unmet list must coincide with an enabled button."
+    )
+
+
+# =========================================================================== #
 # POST-REVIEW REFINEMENT — Extract + Compute both DISARM placement
 # =========================================================================== #
 #

--- a/VascularTerritories/Testing/Python/test_territories_annotation_carrier.py
+++ b/VascularTerritories/Testing/Python/test_territories_annotation_carrier.py
@@ -286,6 +286,100 @@ def test_clear_fires_exactly_one_modified():
     )
 
 
+def _require_remove_territory_or_skip(node):
+    """Skip-pend unless the carrier exposes the territory-level delete seam."""
+    if not hasattr(node, "RemoveTerritory"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no RemoveTerritory -- the "
+            "territory-level delete seam has not landed (ADR-0037 §Decision 3)."
+        )
+
+
+def test_remove_territory_drops_it_and_its_points():
+    """RemoveTerritory removes the territory + all its annotation points.
+
+    A territory-level delete (the affordance for removing a whole territory,
+    including an empty one) drops the territory from
+    ``GetAnnotationTerritoryIds`` and clears its point count, leaving siblings
+    intact (ADR-0037 §Decision 3).
+    """
+    slicer = _slicer_or_skip()
+    node = _make_custom_territories_or_skip(slicer)
+    _require_remove_territory_or_skip(node)
+
+    node.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
+    node.AddAnnotationPoint(TERRITORY_A, 2.0, 0.0, 0.0)
+    node.AddAnnotationPoint(TERRITORY_B, 0.0, 1.0, 0.0)
+
+    assert node.RemoveTerritory(TERRITORY_A) is True, (
+        "RemoveTerritory must report having removed a populated territory."
+    )
+    assert TERRITORY_A not in list(node.GetAnnotationTerritoryIds()), (
+        "the removed territory must be gone from GetAnnotationTerritoryIds."
+    )
+    assert node.GetNumberOfAnnotationPoints(TERRITORY_A) == 0, (
+        "RemoveTerritory must drop every one of the territory's points."
+    )
+    assert node.GetNumberOfAnnotationPoints(TERRITORY_B) == 1, (
+        "RemoveTerritory must NOT touch a sibling territory."
+    )
+
+
+def test_remove_empty_territory_is_removable():
+    """An EMPTY (zero-seed) territory is still removable via its display slot.
+
+    An empty territory has no seeds, so it lives only in the per-territory
+    display maps; RemoveTerritory must still remove it (the affordance an
+    empty territory needs, ADR-0037 §Decision 3).  A never-seen id removes
+    nothing.
+    """
+    slicer = _slicer_or_skip()
+    node = _make_custom_territories_or_skip(slicer)
+    _require_remove_territory_or_skip(node)
+    if not hasattr(node, "SetTerritoryColor"):
+        pytest.skip(
+            f"{CUSTOM_TERRITORIES_CLASS} has no display slot -- cannot mint an "
+            "empty (display-only) territory (ADR-0027)."
+        )
+
+    # Mint an empty territory the way the table does: a display slot, no seeds.
+    node.SetTerritoryColor(TERRITORY_A, 0.5, 0.5, 0.5)
+    node.SetTerritoryVisibility(TERRITORY_A, True)
+    assert node.GetNumberOfAnnotationPoints(TERRITORY_A) == 0
+
+    assert node.RemoveTerritory(TERRITORY_A) is True, (
+        "an empty territory (display slot, no seeds) must be removable."
+    )
+    assert TERRITORY_A not in list(node.GetDisplayTerritoryIds()), (
+        "RemoveTerritory must clear the empty territory's display slot too."
+    )
+    assert node.RemoveTerritory("NeverAdded") is False, (
+        "removing a never-seen territory must report False (removed nothing)."
+    )
+
+
+def test_remove_territory_fires_exactly_one_modified():
+    """RemoveTerritory fires exactly ONE ModifiedEvent when it removes one."""
+    import vtk
+
+    slicer = _slicer_or_skip()
+    node = _make_custom_territories_or_skip(slicer)
+    _require_remove_territory_or_skip(node)
+
+    node.AddAnnotationPoint(TERRITORY_A, 1.0, 2.0, 3.0)
+
+    events = []
+    tag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, lambda c, e: events.append(1))
+    try:
+        node.RemoveTerritory(TERRITORY_A)
+    finally:
+        node.RemoveObserver(tag)
+
+    assert len(events) == 1, (
+        f"RemoveTerritory must fire exactly ONE ModifiedEvent; got {len(events)}."
+    )
+
+
 def test_no_markups_fiducial_reference_role_on_the_carrier():
     """i1: the annotation path adds NO markups-fiducial node reference.
 

--- a/VascularTerritories/Testing/Python/test_territories_annotation_carrier.py
+++ b/VascularTerritories/Testing/Python/test_territories_annotation_carrier.py
@@ -627,6 +627,205 @@ def test_display_attributes_round_trip_through_storage():
             os.remove(path)
 
 
+# --------------------------------------------------------------------------- #
+# i6 (Amendment) — per-territory review status + derived edit-lock (launched)
+#
+# ADR-0037 Amendment "Per-territory status + derived edit-lock": the carrier
+# carries a per-territory review status reusing Slicer's segment-status enum
+# (NotStarted 0 / InProgress 1 / Completed 2 / Flagged 3); the edit-lock is
+# DERIVED (Completed => locked), independent of geometry and of visibility;
+# the status round-trips through storage.
+# --------------------------------------------------------------------------- #
+
+_STATUS_METHODS = (
+    "SetTerritoryStatus",
+    "GetTerritoryStatus",
+    "GetTerritoryLocked",
+    "GetStatusTerritoryIds",
+)
+
+
+def _make_carrier_with_status_or_skip(slicer, name="StatusCarrierTest"):
+    """Mint a carrier exposing the status slot, or skip-pend (ADR-0027)."""
+    node = _make_custom_territories_or_skip(slicer, name)
+    for method in _STATUS_METHODS:
+        if not hasattr(node, method):
+            pytest.skip(
+                f"{CUSTOM_TERRITORIES_CLASS} has no {method} -- the ADR-0037 "
+                "per-territory status + derived edit-lock amendment has not "
+                "landed.  The skip lifts at the implementation commit (ADR-0027)."
+            )
+    return node
+
+
+def test_status_defaults_to_not_started_and_is_unlocked():
+    """i6: an unset territory reads NotStarted (0) and is NOT locked."""
+    slicer = _slicer_or_skip()
+    node = _make_carrier_with_status_or_skip(slicer)
+
+    assert node.GetTerritoryStatus(TERRITORY_A) == 0, (
+        "an unset territory must default to NotStarted (0)."
+    )
+    assert bool(node.GetTerritoryLocked(TERRITORY_A)) is False, (
+        "a NotStarted territory must not be locked."
+    )
+
+
+def test_lock_is_derived_from_completed_status():
+    """i6: the edit-lock is DERIVED from the status (Completed => locked).
+
+    Only ``Completed`` locks; NotStarted / InProgress / Flagged do not.  There
+    is no separate lock bool -- cycling off Completed unlocks.
+    """
+    slicer = _slicer_or_skip()
+    node = _make_carrier_with_status_or_skip(slicer)
+    cls = node.__class__
+
+    node.SetTerritoryStatus(TERRITORY_A, cls.Completed)
+    assert bool(node.GetTerritoryLocked(TERRITORY_A)) is True, (
+        "a Completed territory must be locked (the derived lock)."
+    )
+    for status in (cls.NotStarted, cls.InProgress, cls.Flagged):
+        node.SetTerritoryStatus(TERRITORY_A, status)
+        assert bool(node.GetTerritoryLocked(TERRITORY_A)) is False, (
+            f"status {status} must NOT lock the territory (only Completed does)."
+        )
+
+
+def test_status_write_leaves_geometry_untouched():
+    """i6: a status write is a display-layer edit -- geometry is byte-identical."""
+    slicer = _slicer_or_skip()
+    node = _make_carrier_with_status_or_skip(slicer)
+
+    pts = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)]
+    for x, y, z in pts:
+        node.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    before = [_nth(node, TERRITORY_A, i) for i in range(len(pts))]
+
+    node.SetTerritoryStatus(TERRITORY_A, node.__class__.Completed)
+
+    assert node.GetNumberOfAnnotationPoints(TERRITORY_A) == len(pts), (
+        "a status write must not change the annotation-point count."
+    )
+    for i, expected in enumerate(before):
+        assert _nth(node, TERRITORY_A, i) == pytest.approx(expected, abs=1e-9), (
+            f"point {i} must not move on a status write."
+        )
+
+
+def test_lock_is_independent_of_visibility():
+    """i6: the lock and visibility are ORTHOGONAL (the anti-overload pin).
+
+    A hidden territory is NOT thereby locked, and a locked territory stays
+    visibility-toggleable (ADR-0037 Amendment §2 the three orthogonal states).
+    """
+    slicer = _slicer_or_skip()
+    node = _make_carrier_with_status_or_skip(slicer)
+
+    # Hiding a territory must not lock it.
+    node.SetTerritoryVisibility(TERRITORY_A, False)
+    assert bool(node.GetTerritoryLocked(TERRITORY_A)) is False, (
+        "hiding a territory must NOT lock it (visibility != lock)."
+    )
+
+    # A locked territory stays visibility-toggleable in BOTH directions.
+    node.SetTerritoryStatus(TERRITORY_A, node.__class__.Completed)
+    assert bool(node.GetTerritoryLocked(TERRITORY_A)) is True
+    node.SetTerritoryVisibility(TERRITORY_A, True)
+    assert bool(node.GetTerritoryVisibility(TERRITORY_A)) is True, (
+        "a locked territory must remain visibility-toggleable (to visible)."
+    )
+    node.SetTerritoryVisibility(TERRITORY_A, False)
+    assert bool(node.GetTerritoryVisibility(TERRITORY_A)) is False, (
+        "a locked territory must remain visibility-toggleable (to hidden)."
+    )
+    assert bool(node.GetTerritoryLocked(TERRITORY_A)) is True, (
+        "toggling visibility must not change the lock."
+    )
+
+
+def test_status_fires_exactly_one_modified():
+    """i6: a status write fires exactly ONE ModifiedEvent."""
+    import vtk
+
+    slicer = _slicer_or_skip()
+    node = _make_carrier_with_status_or_skip(slicer)
+
+    events = []
+    tag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, lambda c, e: events.append(1))
+    try:
+        node.SetTerritoryStatus(TERRITORY_A, node.__class__.Completed)
+    finally:
+        node.RemoveObserver(tag)
+
+    assert len(events) == 1, (
+        f"SetTerritoryStatus must fire exactly ONE ModifiedEvent; got {len(events)}."
+    )
+
+
+def test_status_round_trips_through_storage():
+    """i6: the review status survives a .vta.json write + read.
+
+    A Completed territory read back on a fresh sink carrier is Completed (and
+    hence locked); the status is persisted as its machine string alongside the
+    display slot (ADR-0037 Amendment).
+    """
+    import os
+
+    slicer = _slicer_or_skip()
+    source = _make_carrier_with_status_or_skip(slicer, "StatusSource")
+    storage = _make_storage_or_skip(slicer)
+
+    source.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
+    source.SetTerritoryStatus(TERRITORY_A, source.__class__.Completed)
+    source.AddAnnotationPoint(TERRITORY_B, 0.0, 1.0, 0.0)
+    source.SetTerritoryStatus(TERRITORY_B, source.__class__.Flagged)
+
+    path = _temp_path(slicer, "json")
+    storage.SetFileName(path)
+    assert storage.WriteData(source) == 1, "storage WriteData must succeed."
+
+    try:
+        sink = _make_carrier_with_status_or_skip(slicer, "StatusSink")
+        read_storage = _make_storage_or_skip(slicer)
+        read_storage.SetFileName(path)
+        assert read_storage.ReadData(sink) == 1, "storage ReadData must succeed."
+
+        assert sink.GetTerritoryStatus(TERRITORY_A) == sink.__class__.Completed, (
+            "a Completed status must round-trip through storage."
+        )
+        assert bool(sink.GetTerritoryLocked(TERRITORY_A)) is True, (
+            "the derived lock must be back after the round-trip."
+        )
+        assert sink.GetTerritoryStatus(TERRITORY_B) == sink.__class__.Flagged, (
+            "a Flagged status must round-trip through storage."
+        )
+    finally:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def test_status_machine_strings_match_slicer_segment_vocabulary():
+    """i6: the status machine strings match Slicer's segment-status strings.
+
+    ADR-0034 shares the vocabulary with the #574 segment table; the carrier's
+    machine strings must be byte-identical so the two tables speak one language.
+    """
+    slicer = _slicer_or_skip()
+    node = _make_carrier_with_status_or_skip(slicer)
+    cls = node.__class__
+
+    expected = {
+        cls.NotStarted: "NotStarted",
+        cls.InProgress: "InProgress",
+        cls.Completed: "Completed",
+        cls.Flagged: "Flagged",
+    }
+    for ordinal, machine in expected.items():
+        assert cls.GetStatusAsMachineString(ordinal) == machine
+        assert cls.GetStatusFromMachineString(machine) == ordinal
+
+
 def test_storage_can_write_custom_territories_only():
     """i2: the storage node accepts the custom-territories carrier; rejects others.
 

--- a/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
+++ b/VascularTerritories/Testing/Python/test_territories_placement_pipeline.py
@@ -332,6 +332,45 @@ def test_bare_move_is_declined_and_adds_nothing(monkeypatch):
     )
 
 
+def test_bare_move_decline_requests_a_render(monkeypatch):
+    """i3: a declined bare move REQUESTS A RENDER so the hover cue paints.
+
+    The bare hover is DECLINED (camera untouched, ADR-0033), and its whole
+    point is the adhering-highlight / glow-halo SIDE EFFECT.  The base's
+    arbitration returns without a render, and a bare hover mutates no observed
+    node, so the hover cue is computed onto the marker/halo actors but never
+    flushed to the screen unless the client's bare-move-decline hook requests
+    a render itself (the same mid-interaction RequestRender the sibling
+    ControlPolygonPipeline hover path follows).  This pins the render request
+    that the ADR-0038 base extraction dropped -- the regression where "the
+    highlight does not even come" -- and which the FakeRenderer-mocked
+    ``test_click_adds...`` path never exercised.
+    """
+    slicer = _slicer_or_skip()
+    TerritoryPlacementPipeline = _import_pipeline_or_skip()
+    pipeline = TerritoryPlacementPipeline()
+    carrier = _make_carrier_or_skip(slicer)
+    _wire_pipeline_or_skip(slicer, pipeline, carrier, monkeypatch)
+    if not hasattr(pipeline, "_on_bare_move_decline"):
+        pytest.skip(
+            "TerritoryPlacementPipeline has no _on_bare_move_decline hook -- "
+            "the ADR-0033 bare-move hover cue seam is unavailable (ADR-0027)."
+        )
+
+    renders = []
+    monkeypatch.setattr(pipeline, "RequestRender", lambda: renders.append(1))
+
+    move = _Event(vtk.vtkCommand.MouseMoveEvent)
+    can, _distance2 = pipeline.CanProcessInteractionEvent(move)
+
+    assert can is False, "a bare move must still be DECLINED (camera untouched)."
+    assert renders, (
+        "a declined bare move must REQUEST A RENDER so the adhering vessel "
+        "highlight / glow halo actually paints -- without it the hover cue is "
+        "computed but never flushed (ADR-0037 §Decision 2 hover side effect)."
+    )
+
+
 # --------------------------------------------------------------------------- #
 # i4 — edit (drag) + delete + no drift on unrelated Modified
 # --------------------------------------------------------------------------- #

--- a/VascularTerritories/Testing/Python/test_territories_structure_visibility.py
+++ b/VascularTerritories/Testing/Python/test_territories_structure_visibility.py
@@ -746,5 +746,81 @@ def test_centerline_hides_when_its_structure_is_hidden(qt_widgets):
     )
 
 
+def test_centerline_hides_when_its_territory_is_hidden(qt_widgets):
+    """i3: a centerline hides when its TERRITORY is hidden, reappears on show.
+
+    ADR-0037 slice 5: hiding a TERRITORY (the carrier's per-territory
+    visibility) hides not only its seeds but also its centerline(s).  The
+    centerline->territory association is the carrier's ``Groupings`` map
+    (centerline node ID -> territory id) the extraction wired via
+    ``SetGrouping``; ``_syncCenterlineVisibility`` gates each centerline on
+    BOTH its territory visibility AND its structure visibility, re-firing on
+    the annotation-carrier ``Modified`` a territory-visibility toggle emits.
+    A widget-level Python observer (ADR-0013 §5 -- no displayable manager).
+    Launched-only; SKIPS bare.
+    """
+    slicer = _slicer_or_skip()
+    widget = _make_widget_or_skip(slicer)
+    qt_widgets.append(widget)
+    _detach_scene_observers(slicer, widget)
+
+    if not hasattr(widget, "_syncCenterlineVisibility"):
+        pytest.skip(
+            "the ADR-0037 slice-5 centerline-visibility follow "
+            "(_syncCenterlineVisibility) has not landed (ADR-0027)."
+        )
+
+    seg, segA, segB = _two_structure_segmentation(slicer)
+    widget.ui.inputSurfaceSelector.setCurrentNode(seg)
+    carrier = widget._ensureAnnotationCarrier()
+    if not hasattr(carrier, "GetGrouping") or not hasattr(carrier, "SetTerritoryVisibility"):
+        pytest.skip(
+            "vtkMRMLCustomTerritoriesNode lacks GetGrouping / "
+            "SetTerritoryVisibility -- the territory-gate seam has not landed "
+            "(ADR-0027)."
+        )
+
+    # A centerline on structure B, grouped under TERRITORY (SetGrouping in the
+    # helper wires the Groupings map the territory gate reads).
+    model = _attach_stub_centerline(
+        slicer, widget.logic, carrier, TERRITORY, segB, "TerritoryGateCenterline")
+    modelDisplay = model.GetDisplayNode()
+    assert modelDisplay is not None
+
+    # Both structure B and TERRITORY start visible -> the centerline shows.
+    seg.GetDisplayNode().SetSegmentVisibility(segB, True)
+    carrier.SetTerritoryVisibility(TERRITORY, True)
+    widget._syncCenterlineVisibility()
+    assert bool(modelDisplay.GetVisibility()) is True, (
+        "a centerline shows when both its territory and its structure are "
+        "visible."
+    )
+
+    # Hiding the TERRITORY hides the centerline (even though its structure is
+    # still shown) -- via the carrier Modified the visibility toggle emits.
+    carrier.SetTerritoryVisibility(TERRITORY, False)
+    carrier.Modified()
+    assert bool(modelDisplay.GetVisibility()) is False, (
+        "hiding the TERRITORY must hide its centerline, not just its seeds "
+        "(ADR-0037 slice 5)."
+    )
+
+    # Showing the territory again restores it (its structure is still visible).
+    carrier.SetTerritoryVisibility(TERRITORY, True)
+    carrier.Modified()
+    assert bool(modelDisplay.GetVisibility()) is True, (
+        "showing the territory must restore its centerline (structure still "
+        "visible)."
+    )
+
+    # And the structure gate still composes: with the territory visible, hiding
+    # the STRUCTURE hides the centerline (both gates must pass to show).
+    seg.GetDisplayNode().SetSegmentVisibility(segB, False)
+    assert bool(modelDisplay.GetVisibility()) is False, (
+        "with the territory visible, hiding the structure must still hide the "
+        "centerline -- the two gates compose (ADR-0037 slice 5)."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -1500,5 +1500,287 @@ def test_no_endpoints_selector_and_no_persisted_fiducial(qt_widgets):
     widget.cleanup()
 
 
+# --------------------------------------------------------------------------- #
+# REVIEW STATUS + DERIVED EDIT-LOCK (ADR-0037 Amendment)
+#
+# The territory-usability plan §3-§5 / §8: a per-territory click-cycle status
+# cell (NotStarted -> InProgress -> Completed -> Flagged -> NotStarted); a
+# LOCKED (Completed) territory refuses each edit path (place / drag / seed-
+# delete / territory-delete); a GEOMETRY edit demotes a Completed territory to
+# InProgress, but a colour / label edit does NOT.
+# --------------------------------------------------------------------------- #
+
+_STATUS_NOT_STARTED = 0
+_STATUS_IN_PROGRESS = 1
+_STATUS_COMPLETED = 2
+_STATUS_FLAGGED = 3
+
+
+def _require_status_seam(table):
+    """Skip-pend unless the table exposes the review-status seam (ADR-0027)."""
+    for method in (
+        "territoryStatus",
+        "setTerritoryStatus",
+        "cycleTerritoryStatus",
+        "territoryIsLocked",
+    ):
+        if not hasattr(table, method):
+            pytest.skip(
+                f"TerritoriesTableWidget has no {method} -- the ADR-0037 "
+                "per-territory status + derived edit-lock has not landed (ADR-0027)."
+            )
+
+
+def _require_carrier_status_or_skip(carrier):
+    if not hasattr(carrier, "SetTerritoryStatus") or not hasattr(carrier, "GetTerritoryLocked"):
+        pytest.skip(
+            "vtkMRMLCustomTerritoriesNode has no status slot -- the ADR-0037 "
+            "status amendment carrier has not landed (ADR-0027)."
+        )
+
+
+def test_status_cell_click_cycles_through_the_four_states(qt_widgets):
+    """The status cell click-cycles NotStarted -> InProgress -> Completed -> Flagged -> NotStarted."""
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    _require_carrier_status_or_skip(carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    _require_status_seam(table)
+
+    territory = table.addTerritory()  # NotStarted by default
+    assert table.territoryStatus(territory) == _STATUS_NOT_STARTED
+
+    expected = [_STATUS_IN_PROGRESS, _STATUS_COMPLETED, _STATUS_FLAGGED, _STATUS_NOT_STARTED]
+    for want in expected:
+        table.cycleTerritoryStatus(territory)
+        assert table.territoryStatus(territory) == want, (
+            f"the status cell must cycle to {want}; got {table.territoryStatus(territory)}."
+        )
+
+
+def test_status_button_click_advances_the_status(qt_widgets):
+    """Clicking the status QToolButton advances the review status one step."""
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    _require_carrier_status_or_skip(carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    _require_status_seam(table)
+    if not hasattr(table, "statusButton"):
+        pytest.skip("TerritoriesTableWidget has no statusButton getter (ADR-0027).")
+
+    territory = table.addTerritory()
+    button = table.statusButton(territory)
+    assert button is not None, "the territory row must carry a status button."
+
+    button.click()
+    assert table.territoryStatus(territory) == _STATUS_IN_PROGRESS, (
+        "a status-button click must advance the review status one step."
+    )
+
+
+def test_locked_territory_disables_the_row_edit_controls(qt_widgets):
+    """A locked (Completed) territory disables place / colour / label / Remove.
+
+    The visibility toggle stays ENABLED (lock is independent of visibility).
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    _require_carrier_status_or_skip(carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    _require_status_seam(table)
+
+    territory = table.addTerritory()
+    table.setTerritoryStatus(territory, _STATUS_COMPLETED)  # -> rebuild, locked
+
+    assert table.territoryIsLocked(territory) is True
+    assert table.placeButton(territory).enabled is False, "Place must be disabled when locked."
+    assert table.colourButton(territory).enabled is False, "colour must be disabled when locked."
+    assert table.territoryDeleteButton(territory).enabled is False, "Remove must be disabled when locked."
+    # Visibility stays usable -- lock is orthogonal to visibility.
+    assert table.visibilityButton(territory).enabled is True, (
+        "visibility must stay enabled on a locked territory (lock != visibility)."
+    )
+
+
+def test_locked_territory_refuses_seed_and_territory_delete(qt_widgets):
+    """A locked territory refuses delete-by-seed AND territory-delete (§5)."""
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    _require_carrier_status_or_skip(carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_status_seam(table)
+    if not hasattr(table, "deleteSeed") or not hasattr(table, "deleteTerritory"):
+        pytest.skip("TerritoriesTableWidget lacks deleteSeed / deleteTerritory (ADR-0027).")
+
+    for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]:
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    carrier.Modified()
+    table.setTerritoryStatus(TERRITORY_A, _STATUS_COMPLETED)
+    assert table.territoryIsLocked(TERRITORY_A) is True
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    table.deleteSeed(TERRITORY_A, 0)
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "a locked territory must refuse delete-by-seed (§5)."
+    )
+
+    table.deleteTerritory(TERRITORY_A)
+    assert TERRITORY_A in list(carrier.GetAnnotationTerritoryIds()), (
+        "a locked territory must refuse territory-delete (§5)."
+    )
+
+
+def test_locked_territory_refuses_colour_and_label_edits(qt_widgets):
+    """A locked territory refuses colour + label edits through the table (§2/§4)."""
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    _require_carrier_status_or_skip(carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_status_seam(table)
+
+    carrier.SetTerritoryColor(TERRITORY_A, 0.1, 0.2, 0.3)
+    carrier.SetTerritoryLabel(TERRITORY_A, "Before")
+    table.setTerritoryStatus(TERRITORY_A, _STATUS_COMPLETED)
+
+    table.setTerritoryColor(TERRITORY_A, 0.9, 0.9, 0.9)
+    table.setTerritoryLabel(TERRITORY_A, "After")
+
+    colour = carrier.GetTerritoryColor(TERRITORY_A)
+    assert (colour[0], colour[1], colour[2]) == pytest.approx((0.1, 0.2, 0.3), abs=1e-6), (
+        "a locked territory must refuse a colour edit through the table."
+    )
+    assert carrier.GetTerritoryLabel(TERRITORY_A) == "Before", (
+        "a locked territory must refuse a label edit through the table."
+    )
+
+
+def test_locked_active_territory_refuses_placement(qt_widgets, monkeypatch):
+    """An armed click into a locked active territory appends NO seed (§5).
+
+    The Pipeline's defence-in-depth status check refuses the AddAnnotationPoint
+    even when the shared display node still carries an armed flag.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    _require_carrier_status_or_skip(carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    pipeline = _import_pipeline_or_skip()()
+    _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
+    _require_arm_seam(pipeline)
+
+    # Arm into a territory, then lock it (Completed) and fire a click.
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    pipeline.Arm()
+    carrier.SetTerritoryStatus(TERRITORY_A, _STATUS_COMPLETED)
+
+    before = carrier.GetNumberOfAnnotationPoints(TERRITORY_A)
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonPressEvent))
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == before, (
+        "a locked active territory must refuse the placement append (§5)."
+    )
+
+
+def test_locked_territory_declines_the_drag_grab(qt_widgets, monkeypatch):
+    """A press over a locked territory's seed does NOT grab it for a drag (§5)."""
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    _require_carrier_status_or_skip(carrier)
+    displayNode = _make_display_node_or_skip(slicer)
+    pipeline = _import_pipeline_or_skip()()
+    _wire_pipeline_through_display_or_skip(pipeline, displayNode, carrier, monkeypatch)
+    _require_arm_seam(pipeline)
+    if not hasattr(pipeline, "_nearest_key_in_display"):
+        pytest.skip("TerritoryPlacementPipeline lacks the grab hit-test seam (ADR-0027).")
+
+    pipeline.SetActiveTerritory(TERRITORY_A)
+    # A seed on the pick surface (the unit sphere the wiring injected snaps to).
+    carrier.AddAnnotationPoint(TERRITORY_A, 0.0, 0.0, 1.0)
+    carrier.SetTerritoryStatus(TERRITORY_A, _STATUS_COMPLETED)
+
+    key, _distance2 = pipeline._nearest_key_in_display(
+        pipeline._safe_get_renderer(), _Event(vtk.vtkCommand.LeftButtonPressEvent)
+    )
+    assert key is None, (
+        "a locked territory's seeds must not be drag-grab targets (§5)."
+    )
+
+
+def test_geometry_edit_demotes_completed_but_colour_label_does_not(qt_widgets):
+    """A GEOMETRY edit demotes Completed -> InProgress; colour/label does NOT.
+
+    The demote-on-edit rule (plan §9 default 5): a seed add / move / delete on
+    a Completed territory (reaching the carrier directly, e.g. via the provider)
+    demotes it to InProgress; a colour / label edit is cosmetic and never
+    demotes.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    _require_carrier_status_or_skip(carrier)
+    try:
+        from VascularTerritoriesLib.TerritoryPointProvider import TerritoryPointProvider
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"TerritoryPointProvider not importable ({exc!r}) (ADR-0027).")
+    if not hasattr(carrier, "SetTerritoryStatus"):
+        pytest.skip("carrier has no status slot (ADR-0027).")
+
+    provider = TerritoryPointProvider(
+        carrier_getter=lambda: carrier,
+        territory_getter=lambda: TERRITORY_A,
+    )
+
+    # A colour / label edit does NOT demote.
+    carrier.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
+    carrier.SetTerritoryStatus(TERRITORY_A, _STATUS_COMPLETED)
+    carrier.SetTerritoryColor(TERRITORY_A, 0.4, 0.4, 0.4)
+    carrier.SetTerritoryLabel(TERRITORY_A, "Cosmetic")
+    assert carrier.GetTerritoryStatus(TERRITORY_A) == _STATUS_COMPLETED, (
+        "a colour / label edit must NOT demote a Completed territory."
+    )
+
+    # A GEOMETRY edit (provider add) demotes to InProgress.
+    provider.add_point((2.0, 0.0, 0.0))
+    assert carrier.GetTerritoryStatus(TERRITORY_A) == _STATUS_IN_PROGRESS, (
+        "a geometry edit (seed add) must demote Completed -> InProgress."
+    )
+
+    # And move / delete demote too (re-lock, then edit).
+    carrier.SetTerritoryStatus(TERRITORY_A, _STATUS_COMPLETED)
+    provider.move_point((TERRITORY_A, 0), (3.0, 0.0, 0.0))
+    assert carrier.GetTerritoryStatus(TERRITORY_A) == _STATUS_IN_PROGRESS, (
+        "a geometry edit (seed move) must demote Completed -> InProgress."
+    )
+    carrier.SetTerritoryStatus(TERRITORY_A, _STATUS_COMPLETED)
+    provider.delete_point((TERRITORY_A, 0))
+    assert carrier.GetTerritoryStatus(TERRITORY_A) == _STATUS_IN_PROGRESS, (
+        "a geometry edit (seed delete) must demote Completed -> InProgress."
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -502,6 +502,77 @@ def test_carrier_modified_event_rebuilds_the_tree(qt_widgets):
     )
 
 
+def test_seed_drag_defers_full_rebuild_until_release(qt_widgets):
+    """A seed drag does NOT rebuild the tree per move; ONE rebuild on release.
+
+    ADR-0037 §Decision 3 performance: a drag relocates the grabbed seed on
+    every mouse-move (``SetNthAnnotationPoint`` -> carrier ``Modified``), so a
+    naive observer rebuilds the whole tree (every composite row widget
+    destroyed + recreated) per frame -- the drag lag.  The placement Pipeline
+    publishes a drag-in-flight flag on the shared display node on grab and
+    clears it + fires ONE carrier ``Modified`` on release; the table observer
+    reads the flag and defers its full ``_rebuild`` until the drag ends.  This
+    pins: (1) carrier ``Modified``s WHILE grabbing trigger no full rebuild;
+    (2) the release rebuild runs once; (3) the final positions are consistent.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    state = _import_interaction_state_or_skip()
+    if not hasattr(state, "set_grabbing"):
+        pytest.skip(
+            "TerritoryInteractionState has no set_grabbing -- the drag-defer "
+            "seam has not landed (ADR-0027)."
+        )
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+
+    # A seed to drag.
+    carrier.AddAnnotationPoint(TERRITORY_A, 1.0, 0.0, 0.0)
+
+    # Spy on the full rebuild.
+    rebuild_calls = {"n": 0}
+    real_rebuild = table._rebuild
+
+    def _counting_rebuild():
+        rebuild_calls["n"] += 1
+        real_rebuild()
+
+    table._rebuild = _counting_rebuild
+
+    # Grab: the Pipeline sets the drag-in-flight flag on the display node.
+    state.set_grabbing(displayNode, True)
+
+    # Many drag moves relocate the grabbed seed -- each fires carrier Modified.
+    for step in range(1, 11):
+        carrier.SetNthAnnotationPoint(TERRITORY_A, 0, float(step), 0.0, 0.0)
+    assert rebuild_calls["n"] == 0, (
+        "a drag in flight must NOT trigger a full tree rebuild per move -- the "
+        f"drag lag (got {rebuild_calls['n']} rebuilds across 10 moves)."
+    )
+
+    # Release: the Pipeline clears the flag, then fires ONE carrier Modified.
+    state.set_grabbing(displayNode, False)
+    carrier.Modified()
+    assert rebuild_calls["n"] == 1, (
+        "the release must run EXACTLY ONE full rebuild reflecting the final "
+        f"positions (got {rebuild_calls['n']})."
+    )
+
+    # Final state consistent: the seed row exists at the dragged-to position.
+    final = carrier.GetNthAnnotationPoint(TERRITORY_A, 0)
+    assert (final[0], final[1], final[2]) == (10.0, 0.0, 0.0), (
+        "the carrier must hold the final dragged-to seed position after release."
+    )
+    assert len(table.seedItems(TERRITORY_A)) == 1, (
+        "the tree must show exactly the one seed after the release rebuild -- "
+        "no stale / duplicated rows."
+    )
+
+
 # --------------------------------------------------------------------------- #
 # ARMING — click appends to the ACTIVE territory
 # --------------------------------------------------------------------------- #

--- a/VascularTerritories/Testing/Python/test_territories_table.py
+++ b/VascularTerritories/Testing/Python/test_territories_table.py
@@ -754,6 +754,134 @@ def test_delete_by_seed_and_by_pick_share_one_carrier_path(qt_widgets):
 
 
 # --------------------------------------------------------------------------- #
+# TERRITORY-LEVEL DELETE — remove a whole territory (incl. an EMPTY one)
+# --------------------------------------------------------------------------- #
+
+
+def test_territory_delete_button_removes_the_whole_territory(qt_widgets):
+    """The territory header row carries a delete button that removes it wholly.
+
+    ADR-0037 §Decision 3: a territory-HEADER delete affordance removes the
+    territory and all its seeds via the carrier's ``RemoveTerritory`` -- so a
+    populated territory drops from ``GetAnnotationTerritoryIds`` and its points
+    go, while a sibling is untouched.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "territoryDeleteButton") or not hasattr(carrier, "RemoveTerritory"):
+        pytest.skip(
+            "TerritoriesTableWidget/carrier lack the territory-level delete seam "
+            "(territoryDeleteButton / RemoveTerritory) (ADR-0027)."
+        )
+
+    for x, y, z in [(1.0, 0.0, 0.0), (2.0, 0.0, 0.0)]:
+        carrier.AddAnnotationPoint(TERRITORY_A, x, y, z)
+    carrier.AddAnnotationPoint(TERRITORY_B, 0.0, 1.0, 0.0)
+    carrier.Modified()
+
+    delete = table.territoryDeleteButton(TERRITORY_A)
+    assert delete is not None, "the territory header row must carry a delete button."
+    delete.click()
+
+    assert TERRITORY_A not in list(carrier.GetAnnotationTerritoryIds()), (
+        "deleting a territory must drop it from GetAnnotationTerritoryIds."
+    )
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_A) == 0, (
+        "deleting a territory must drop all its seeds."
+    )
+    assert carrier.GetNumberOfAnnotationPoints(TERRITORY_B) == 1, (
+        "deleting a territory must NOT touch a sibling."
+    )
+
+
+def test_empty_territory_is_deletable_via_the_header_button(qt_widgets):
+    """An EMPTY (zero-seed) minted territory is removable via its header button.
+
+    ADR-0037 §Decision 3: the failure mode this fixes -- a territory with no
+    seeds has no seed rows, so the per-seed delete never appears; the header
+    delete affordance must still remove it.  Mints an empty territory via
+    ``addTerritory`` and clicks its header delete.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "territoryDeleteButton") or not hasattr(carrier, "RemoveTerritory"):
+        pytest.skip(
+            "TerritoriesTableWidget/carrier lack the territory-level delete seam "
+            "(ADR-0027)."
+        )
+
+    territoryId = table.addTerritory()
+    assert carrier.GetNumberOfAnnotationPoints(territoryId) == 0, (
+        "precondition: the minted territory has no seeds (the empty case)."
+    )
+    assert territoryId in table.territoryIds(), (
+        "precondition: the empty territory has a top-level (header) item."
+    )
+
+    delete = table.territoryDeleteButton(territoryId)
+    assert delete is not None, "an empty territory's header row must carry a delete button."
+    delete.click()
+
+    assert territoryId not in table.territoryIds(), (
+        "deleting an empty territory must drop its top-level item."
+    )
+    assert territoryId not in list(carrier.GetDisplayTerritoryIds()), (
+        "deleting an empty territory must clear its display slot too."
+    )
+
+
+def test_deleting_the_active_territory_clears_the_arm_state(qt_widgets):
+    """Deleting the ACTIVE (armed) territory disarms placement (hygiene).
+
+    ADR-0037 §Decision 3: if the deleted territory is the display node's active
+    territory, the arm state is cleared so a subsequent surface click does not
+    append to a territory that is gone.
+    """
+    slicer = _slicer_or_skip()
+    _qt_or_skip()
+    carrier = _make_carrier_or_skip(slicer)
+    displayNode = _make_display_node_or_skip(slicer)
+    table = _make_table_or_skip(slicer, carrier, displayNode)
+    qt_widgets.append(table)
+    _require_tree_model(table)
+    _require_composite_rows_or_skip(table)
+    if not hasattr(table, "deleteTerritory") or not hasattr(carrier, "RemoveTerritory"):
+        pytest.skip(
+            "TerritoriesTableWidget/carrier lack the territory-level delete seam "
+            "(ADR-0027)."
+        )
+    state = _import_interaction_state_or_skip()
+
+    # Mint + arm into a territory (addTerritory arms into the new territory).
+    territoryId = table.addTerritory()
+    assert state.is_armed(displayNode) is True, (
+        "precondition: minting a territory arms placement into it."
+    )
+    assert state.get_active_territory(displayNode) == territoryId, (
+        "precondition: the minted territory is the active one."
+    )
+
+    table.deleteTerritory(territoryId)
+
+    assert state.is_armed(displayNode) is False, (
+        "deleting the active territory must clear the arm state so placement "
+        "does not target a gone territory (ADR-0037 §Decision 3)."
+    )
+
+
+# --------------------------------------------------------------------------- #
 # DISPLAY EDITS — write the carrier display slot without touching geometry
 # --------------------------------------------------------------------------- #
 

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -245,6 +245,12 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     # Pipeline (Python-widget composition, ADR-0004).
     self._setupTerritoriesTable()
 
+    # ADR-0037 §Decision 4: an always-visible affirmative requirements surface
+    # under the Extract / Compute buttons (Python-composed, ADR-0004; legible
+    # a11y text, ADR-0010).  It enumerates the UNMET preconditions live so a
+    # disabled action always tells the surgeon what to do next.
+    self._setupRequirementsLabel()
+
     #TODO: Store all GUI settings
     # These connections ensure that whenever user changes some settings on the GUI, that is saved in the MRML scene
     # (in the selected parameter node).
@@ -527,6 +533,26 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     self._annotationCarrier = node
     return node
 
+  def _setupRequirementsLabel(self):
+    """Compose the always-visible action-requirements status line (ADR-0004).
+
+    A wrapping ``qt.QLabel`` under the Extract / Compute buttons that
+    ``_updateRequirementsMessage`` fills with the live unmet-precondition list.
+    Legible plain text (ADR-0010) -- never colour alone.  Degrades gracefully
+    (the panel loads without it) if label construction is unavailable.
+    """
+    self._requirementsLabel = None
+    try:
+      label = qt.QLabel()
+    except Exception as exc:  # noqa: BLE001 - Qt unavailable in this launch
+      logging.warning(
+        "VascularTerritories: requirements status line unavailable (%s).", exc)
+      return
+    label.setWordWrap(True)
+    label.setObjectName("VascularTerritoriesRequirementsLabel")
+    self._requirementsLabel = label
+    self.layout.addWidget(label)
+
   def enableWidgetButtons(self, state):
     # The extraction action additionally requires SlicerVMTK (ADR-0037
     # §Decision 4): never enable it when the extractor is absent, even if the
@@ -555,26 +581,16 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     Re-evaluated on input-surface change, a carrier ``Modified`` (seeds
     added/deleted), and the end of the extract / compute handlers.
     """
-    segmentationNode = self.ui.inputSurfaceSelector.currentNode()
-    hasInput = segmentationNode is not None
+    extractUnmet, computeUnmet = self._actionRequirements()
 
-    vmtkPresent = self.logic.extractionActionEnabled()
-    extractEnabled = hasInput and vmtkPresent and self._hasExtractableStructure(segmentationNode)
-    self.ui.addCenterlineSegmentButton.setEnabled(extractEnabled)
-    # Keep the VMTK explanation tooltip when the extractor is absent.
-    self.ui.addCenterlineSegmentButton.setToolTip(
-      "" if vmtkPresent else (
-        "Centerline extraction needs the SlicerVMTK extension "
-        "(ExtractCenterline), which is not installed."))
+    self.ui.addCenterlineSegmentButton.setEnabled(not extractUnmet)
+    self.ui.calculateVascularTerritoryMapButton.setEnabled(not computeUnmet)
 
-    carrier = getattr(self, "_annotationCarrier", None)
-    hasVolume = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLScalarVolumeNode") is not None
-    hasCenterline = (
-      carrier is not None
-      and len(self.logic.getCenterlineReferenceIDs(carrier)) > 0
-    )
-    self.ui.calculateVascularTerritoryMapButton.setEnabled(
-      hasInput and hasVolume and hasCenterline)
+    # Affirmative "what's missing" surface (ADR-0037 §Decision 4, ADR-0010):
+    # a live status line under the buttons + a comprehensive tooltip on BOTH
+    # buttons enumerate the unmet preconditions, so a disabled action always
+    # explains itself rather than reading dead.
+    self._updateRequirementsMessage(extractUnmet, computeUnmet)
 
   def _hasExtractableStructure(self, segmentationNode):
     """True iff some territory has a structure with >=2 seeds (extractable).
@@ -591,6 +607,79 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
       if any(count >= 2 for count in counts.values()):
         return True
     return False
+
+  def _actionRequirements(self):
+    """The UNMET preconditions for Extract + Compute, as two message lists.
+
+    Reads the SAME live state the enablement gates read (ADR-0037 §Decision 4)
+    so the messaging and the enablement cannot diverge -- the enablement is
+    simply "the list is empty".  Each entry is a short, actionable,
+    platform-neutral instruction (ADR-0010 legible text).
+
+    Returns ``(extractUnmet, computeUnmet)`` -- lists of human-readable
+    strings; an empty list means the action can run.
+    """
+    segmentationNode = self.ui.inputSurfaceSelector.currentNode()
+    hasInput = segmentationNode is not None
+    vmtkPresent = self.logic.extractionActionEnabled()
+    carrier = getattr(self, "_annotationCarrier", None)
+    hasVolume = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLScalarVolumeNode") is not None
+    hasCenterline = (
+      carrier is not None
+      and len(self.logic.getCenterlineReferenceIDs(carrier)) > 0
+    )
+
+    extractUnmet = []
+    if not hasInput:
+      extractUnmet.append("Select an input segmentation")
+    if not vmtkPresent:
+      # Keep the existing VMTK wording (the surgeon may need to install it).
+      extractUnmet.append(
+        "SlicerVMTK (ExtractCenterline) is not installed")
+    if hasInput and not self._hasExtractableStructure(segmentationNode):
+      extractUnmet.append("Place at least 2 seeds in a structure")
+
+    computeUnmet = []
+    if not hasInput:
+      computeUnmet.append("Select an input segmentation")
+    if not hasVolume:
+      computeUnmet.append("Load a reference volume")
+    if not hasCenterline:
+      computeUnmet.append("Extract centerlines first")
+
+    return extractUnmet, computeUnmet
+
+  def _updateRequirementsMessage(self, extractUnmet, computeUnmet):
+    """Surface the unmet preconditions on the status line + both button tooltips.
+
+    ADR-0037 §Decision 4 affirmative requirements surface (ADR-0004 Python-
+    composed, ADR-0010 legible a11y text): an always-visible label under the
+    two buttons enumerates what is missing for each action, and BOTH buttons
+    carry the same per-action unmet list as a tooltip.  Called on every
+    ``_updateActionEnablement`` so the message tracks input / carrier /
+    extract-compute changes live.
+    """
+    extractTip = (
+      "Extract centerlines is ready." if not extractUnmet
+      else "Extract centerlines needs:\n- " + "\n- ".join(extractUnmet))
+    computeTip = (
+      "Compute territory map is ready." if not computeUnmet
+      else "Compute territory map needs:\n- " + "\n- ".join(computeUnmet))
+    self.ui.addCenterlineSegmentButton.setToolTip(extractTip)
+    self.ui.calculateVascularTerritoryMapButton.setToolTip(computeTip)
+
+    label = getattr(self, "_requirementsLabel", None)
+    if label is None:
+      return
+    if not extractUnmet and not computeUnmet:
+      label.setText("All requirements met -- extract centerlines, then compute the map.")
+      return
+    lines = []
+    if extractUnmet:
+      lines.append("To extract centerlines: " + "; ".join(extractUnmet) + ".")
+    if computeUnmet:
+      lines.append("To compute the territory map: " + "; ".join(computeUnmet) + ".")
+    label.setText("\n".join(lines))
 
   def _onAnnotationCarrierModified(self, caller, event):
     """Re-evaluate the action enablement on a carrier edit (seeds add/delete)."""

--- a/VascularTerritories/VascularTerritories.py
+++ b/VascularTerritories/VascularTerritories.py
@@ -414,29 +414,50 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
       highlight.Modified()
 
   def _syncCenterlineVisibility(self):
-    """Set each ``CenterlineRefs`` model's visibility to its structure's visibility.
+    """Gate each ``CenterlineRefs`` model on its TERRITORY and STRUCTURE visibility.
 
-    Reads the input segmentation display node's per-segment visibility
-    (``GetSegmentVisibility``) and applies it to every extracted centerline
-    tagged with that segment id (``CENTERLINE_STRUCTURE_ATTRIBUTE``).  A
-    centerline with no structure tag (single-model input) is left alone
-    (ADR-0037 slice 5).
+    A centerline shows only if BOTH its owning TERRITORY is visible AND its
+    STRUCTURE (input segment) is visible -- hiding either hides the centerline
+    (ADR-0037 slice 5):
+
+    * TERRITORY -- the carrier's per-territory ``GetTerritoryVisibility``,
+      resolved from the ``Groupings`` map (centerline node ID -> territory id)
+      the extraction wired via ``SetGrouping``.  A hidden territory hides all
+      of its centerlines (a territory can span structures, so this is keyed on
+      the centerline's owning territory, not the structure).
+    * STRUCTURE -- the input segmentation display node's per-segment
+      visibility (``GetSegmentVisibility``), read off the centerline's
+      ``CENTERLINE_STRUCTURE_ATTRIBUTE`` tag.  A centerline with no structure
+      tag (single-model input) is not gated on a segment.
+
+    Fires on the segmentation-display-node observer (structure show/hide) and
+    the annotation-carrier ``Modified`` (territory show/hide + extraction).
     """
     carrier = getattr(self, "_annotationCarrier", None)
-    displayNode = self._observedSegmentationDisplayNode
-    if carrier is None or displayNode is None:
+    if carrier is None:
       return
+    displayNode = self._observedSegmentationDisplayNode
     attribute = self.logic.CENTERLINE_STRUCTURE_ATTRIBUTE
     for centerlineId in self.logic.getCenterlineReferenceIDs(carrier):
       model = slicer.mrmlScene.GetNodeByID(centerlineId)
       if model is None:
         continue
-      structureId = model.GetAttribute(attribute)
-      if not structureId:
-        continue
       modelDisplay = model.GetDisplayNode()
-      if modelDisplay is not None:
-        modelDisplay.SetVisibility(bool(displayNode.GetSegmentVisibility(structureId)))
+      if modelDisplay is None:
+        continue
+      # Territory gate: hide the centerline when its owning territory is hidden.
+      territoryId = carrier.GetGrouping(centerlineId)
+      territoryVisible = (
+        bool(carrier.GetTerritoryVisibility(territoryId)) if territoryId else True
+      )
+      # Structure gate: hide the centerline when its input segment is hidden.
+      structureId = model.GetAttribute(attribute)
+      structureVisible = (
+        bool(displayNode.GetSegmentVisibility(structureId))
+        if (displayNode is not None and structureId)
+        else True
+      )
+      modelDisplay.SetVisibility(territoryVisible and structureVisible)
 
   def _setupStructuresTable(self):
     """Compose a stock ``qMRMLSegmentsTableView`` for input-structure show/hide.
@@ -682,9 +703,24 @@ class VascularTerritoriesWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
     label.setText("\n".join(lines))
 
   def _onAnnotationCarrierModified(self, caller, event):
-    """Re-evaluate the action enablement on a carrier edit (seeds add/delete)."""
+    """React to a carrier edit (seeds add/delete, territory show/hide).
+
+    Re-evaluates the Extract/Compute enablement (seed state) AND re-syncs the
+    centerline visibility -- a per-territory visibility toggle writes the
+    carrier's display slot, so a hidden TERRITORY must hide its centerline(s)
+    too (ADR-0037 slice 5).  Deferred while a seed drag is in flight (the same
+    grabbing flag the table reads): a drag relocates the grabbed seed per
+    mouse-move, and none of this reacts to a coordinate change, so it runs once
+    on release -- keeping the drag frame free of scan work (ADR-0037 §Decision 3).
+    """
     del caller, event
+    node = getattr(self, "_highlightDisplayNode", None)
+    if node is not None:
+      from VascularTerritoriesLib import TerritoryInteractionState as _territoryState
+      if _territoryState.is_grabbing(node):
+        return
     self._updateActionEnablement()
+    self._syncCenterlineVisibility()
 
   def segmentationNodeSelected(self):
     self.ui.SegmentationShow3DButton.setEnabled(True)

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -94,6 +94,53 @@ _INCOMPLETE_GLYPH = "⚠"  # WARNING SIGN
 _INCOMPLETE_TEXT = "Incomplete — needs at least two seeds"
 _COMPLETE_TEXT = "Ready"
 
+#: The per-territory review-status vocabulary (ADR-0037 Amendment
+#: "Per-territory status + derived edit-lock").  Reuses Slicer's own segment
+#: status enum ordinals (``vtkSlicerSegmentationsModuleLogic`` /
+#: ``vtkMRMLCustomTerritoriesNode``: NotStarted 0 / InProgress 1 / Completed 2 /
+#: Flagged 3) and the SAME machine strings + glyphs as the Stage-2 segments
+#: table (ADR-0034), so the two tables render status identically.  Kept factored
+#: here as a module-level table so a later increment can extract a shared
+#: status-cell helper (plan §4); do not over-engineer a shared module now.
+_STATUS_NOT_STARTED = 0
+_STATUS_IN_PROGRESS = 1
+_STATUS_COMPLETED = 2
+_STATUS_FLAGGED = 3
+_STATUS_LAST = 4  # sentinel: the cycle wraps at this ordinal (Flagged -> NotStarted)
+
+#: (glyph, short text) per ordinal — glyph + text, never colour alone
+#: (ADR-0010).  The glyphs mirror the #574 segment-table vocabulary
+#: (○ Missing / ● Review / ✓ Confirmed / ⚑ Flagged), mapped onto the status
+#: names so a Slicer user recognises the cell instantly.
+_STATUS_LABELS = {
+    _STATUS_NOT_STARTED: ("○", "Not started"),
+    _STATUS_IN_PROGRESS: ("●", "In progress"),
+    _STATUS_COMPLETED: ("✓", "Completed"),
+    _STATUS_FLAGGED: ("⚑", "Flagged"),
+}
+
+#: The lock affordance shown on a locked (Completed) territory (ADR-0037
+#: Amendment; glyph + text per ADR-0010).
+_LOCK_GLYPH = "🔒"
+_LOCK_TEXT = "Locked"
+_LOCK_TOOLTIP = "Territory validated (Completed) — cycle status off Completed to edit"
+
+
+def _status_cell_text(status: int) -> str:
+    """The status cell's GLYPH + TEXT for a status ordinal (ADR-0010)."""
+    glyph, text = _STATUS_LABELS.get(status, _STATUS_LABELS[_STATUS_NOT_STARTED])
+    return f"{glyph} {text}"
+
+
+def _next_status(status: int) -> int:
+    """The next status in the click-cycle, wrapping Flagged -> NotStarted.
+
+    Mirrors ``qMRMLSegmentsTableView``'s ``++status`` wrap at ``LastStatus``
+    (the plan's "Flagged→Completed wrap" phrasing describes the same
+    full-cycle advance: from Flagged the cycle returns to NotStarted).
+    """
+    return (int(status) + 1) % _STATUS_LAST
+
 
 class TerritoriesTableWidget(qt.QWidget):
     """Custom composite-row tree over the annotation carrier (ADR-0037).
@@ -256,9 +303,15 @@ class TerritoriesTableWidget(qt.QWidget):
         return [parent.child(j) for j in range(parent.childCount())]
 
     def territoryStatusText(self, territoryId: str) -> str:
-        """The completeness status TEXT shown on the territory's row widget."""
-        status = self._territoryControl(territoryId, "status")
-        return status.text if status is not None else ""
+        """The completeness (readiness) TEXT for the territory (ADR-0010).
+
+        This is the MACHINE readiness hint (≥2-seed / per-structure gate), now
+        folded into the status button's tooltip and SUBORDINATED to the human
+        review status (plan §4).  Kept as a reader so the completeness
+        invariants still pin the glyph + text.
+        """
+        completeness = self._territoryControl(territoryId, "completeness")
+        return completeness if completeness is not None else ""
 
     def territoryHasIncompleteGlyph(self, territoryId: str) -> bool:
         """Whether the territory carries the incomplete GLYPH (ADR-0010)."""
@@ -301,6 +354,10 @@ class TerritoriesTableWidget(qt.QWidget):
     def territoryDeleteButton(self, territoryId: str) -> Any:
         """The delete ``qt.QToolButton`` on the territory HEADER row."""
         return self._territoryControl(territoryId, "delete")
+
+    def statusButton(self, territoryId: str) -> Any:
+        """The click-cycle status ``qt.QToolButton`` on the territory row."""
+        return self._territoryControl(territoryId, "status_button")
 
     def seedRowWidget(self, territoryId: str, pointIndex: int) -> Any:
         """The composite ``QWidget`` on the seed child item (col 0)."""
@@ -538,6 +595,19 @@ class TerritoriesTableWidget(qt.QWidget):
         self.setTerritoryVisibility(territoryId, checked)
         self._applyEyeIcon(button, checked)
 
+    def _onStatusClicked(self, territoryId: str) -> None:
+        """Cycle the territory's review status one step (the status-cell click).
+
+        ``NotStarted → InProgress → Completed → Flagged → NotStarted``, exactly
+        like Slicer's segment status cell.  The carrier ``Modified`` observer
+        rebuilds the row so the cell text + the derived lock re-derive.  A
+        colour/label edit does NOT reach here; this is a status (not geometry)
+        edit, so it never demotes on its own -- it IS the edit.
+        """
+        if self._rebuilding:
+            return
+        self.cycleTerritoryStatus(territoryId)
+
     def _onLabelEdited(self, territoryId: str, edit: Any) -> None:
         """Write an edited label ``QLineEdit`` back to the carrier's display slot.
 
@@ -580,12 +650,57 @@ class TerritoriesTableWidget(qt.QWidget):
             self._carrier.SetTerritoryVisibility(territoryId, bool(visible))
 
     def setTerritoryColor(self, territoryId: str, r: float, g: float, b: float) -> None:
-        if self._carrier is not None:
+        # A locked territory refuses colour edits (the swatch is disabled in the
+        # row; this refuses the programmatic path too).  A colour edit is
+        # cosmetic and never demotes -- but it does not apply while locked.
+        if self._carrier is not None and not self.territoryIsLocked(territoryId):
             self._carrier.SetTerritoryColor(territoryId, float(r), float(g), float(b))
 
     def setTerritoryLabel(self, territoryId: str, label: str) -> None:
-        if self._carrier is not None:
+        if self._carrier is not None and not self.territoryIsLocked(territoryId):
             self._carrier.SetTerritoryLabel(territoryId, str(label))
+
+    # ------------------------------------------------------------------ #
+    # Review status + derived edit-lock (ADR-0037 Amendment)
+    # ------------------------------------------------------------------ #
+
+    def territoryStatus(self, territoryId: str) -> int:
+        """The territory's review-status ordinal (``NotStarted`` when unset)."""
+        if self._carrier is not None and hasattr(self._carrier, "GetTerritoryStatus"):
+            return int(self._carrier.GetTerritoryStatus(territoryId))
+        return _STATUS_NOT_STARTED
+
+    def setTerritoryStatus(self, territoryId: str, status: int) -> None:
+        """Write the territory's review status back to the carrier's slot.
+
+        A status write is a display-layer edit (never touches the geometry) and
+        drives the derived edit-lock (``Completed`` ⇒ locked).  The carrier
+        ``Modified`` observer rebuilds the row so the status cell + the locked
+        controls re-derive.
+        """
+        if self._carrier is not None and hasattr(self._carrier, "SetTerritoryStatus"):
+            self._carrier.SetTerritoryStatus(territoryId, int(status))
+
+    def cycleTerritoryStatus(self, territoryId: str) -> None:
+        """Advance the territory's status one step (the status-cell click).
+
+        Cycles ``NotStarted → InProgress → Completed → Flagged → NotStarted``
+        exactly like Slicer's ``qMRMLSegmentsTableView`` status cell.  This is
+        the ONE gesture that toggles the derived edit-lock (reaching / leaving
+        ``Completed``).
+        """
+        self.setTerritoryStatus(territoryId, _next_status(self.territoryStatus(territoryId)))
+
+    def territoryIsLocked(self, territoryId: str) -> bool:
+        """Whether the territory is edit-LOCKED (derived from status).
+
+        Prefers the carrier's own derivation (``GetTerritoryLocked``) so the
+        table and the interaction guards read one source of truth; falls back
+        to the ``Completed`` comparison when that accessor is absent.
+        """
+        if self._carrier is not None and hasattr(self._carrier, "GetTerritoryLocked"):
+            return bool(self._carrier.GetTerritoryLocked(territoryId))
+        return self.territoryStatus(territoryId) == _STATUS_COMPLETED
 
     def deleteTerritory(self, territoryId: str) -> None:
         """Remove a whole territory (its seeds + display slot) via the carrier.
@@ -600,6 +715,10 @@ class TerritoriesTableWidget(qt.QWidget):
         not resurrect it.
         """
         if not territoryId or self._carrier is None:
+            return
+        # A LOCKED territory refuses removal (the Remove button is disabled in
+        # the row; this refuses the programmatic path too -- ADR-0037 Amendment).
+        if self.territoryIsLocked(territoryId):
             return
         # Active-territory hygiene: disarm if the doomed territory is armed, so a
         # subsequent surface click does not append to a territory that is gone.
@@ -697,10 +816,16 @@ class TerritoriesTableWidget(qt.QWidget):
         """Compose a territory row's horizontal control STRIP (ADR-0037 slice-4).
 
         Order: Place toggle -> eye-icon visibility toggle -> colour button ->
-        label QLineEdit (stretch) -> completeness status label.  Controls are
-        registered by NAME in ``_territory_rows`` so the getters resolve them
-        without any column index.
+        label QLineEdit (stretch) -> click-cycle STATUS button -> Remove.  The
+        status button folds the completeness hint into its tooltip (one
+        authoritative row indicator, plan §4), and when the territory is LOCKED
+        (status Completed) it shows a lock glyph + "Locked" and the Place /
+        colour / label / seed-delete / Remove controls are DISABLED with an
+        explaining tooltip (ADR-0037 Amendment "Per-territory status + derived
+        edit-lock").  Controls are registered by NAME in ``_territory_rows`` so
+        the getters resolve them without any column index.
         """
+        locked = self.territoryIsLocked(territoryId)
         rowWidget = qt.QWidget()
         rowLayout = qt.QHBoxLayout(rowWidget)
         rowLayout.setContentsMargins(2, 1, 2, 1)
@@ -723,6 +848,11 @@ class TerritoriesTableWidget(qt.QWidget):
             "toggled(bool)",
             lambda checked, t=territoryId: self._onPlaceToggled(t, checked),
         )
+        if locked:
+            # A locked territory refuses placement: the Place toggle cannot arm
+            # into it (the pipeline checks status as defence in depth).
+            placeButton.setEnabled(False)
+            placeButton.setToolTip(_LOCK_TOOLTIP)
         rowLayout.addWidget(placeButton)
 
         # Visibility: a Slicer-idiomatic eye-on / eye-off ``QToolButton`` (the
@@ -755,6 +885,9 @@ class TerritoriesTableWidget(qt.QWidget):
                 t, c.redF(), c.greenF(), c.blueF()
             ),
         )
+        if locked:
+            colourButton.setEnabled(False)
+            colourButton.setToolTip(_LOCK_TOOLTIP)
         rowLayout.addWidget(colourButton)
 
         # Editable label: a ``QLineEdit`` (the composite-row replacement for the
@@ -766,31 +899,61 @@ class TerritoriesTableWidget(qt.QWidget):
             "editingFinished()",
             lambda t=territoryId, e=labelEdit: self._onLabelEdited(t, e),
         )
+        if locked:
+            labelEdit.setReadOnly(True)
+            labelEdit.setToolTip(_LOCK_TOOLTIP)
         rowLayout.addWidget(labelEdit, 1)
 
-        # Completeness indicator: GLYPH + TEXT (ADR-0010, never colour alone).
-        # The check is PER STRUCTURE (revised ADR-0037 slice 5, §B6): a
-        # territory that touches any structure with <2 seeds is flagged, because
-        # that structure cannot yield a centerline -- even when the flat seed
-        # count reads complete (e.g. 2 on the vein + 1 on the artery).  The flat
+        # Completeness hint: GLYPH + TEXT (ADR-0010, never colour alone).  The
+        # check is PER STRUCTURE (revised ADR-0037 slice 5, §B6): a territory
+        # that touches any structure with <2 seeds is flagged, because that
+        # structure cannot yield a centerline -- even when the flat seed count
+        # reads complete (e.g. 2 on the vein + 1 on the artery).  The flat
         # <2-seed check remains as the fallback when no segmentation is bound.
+        # This is now a MACHINE readiness hint SUBORDINATED to the human review
+        # status (plan §4): it is FOLDED into the status button's tooltip, so
+        # there is ONE authoritative row indicator.
         underSeeded = self._underSeededStructures(territoryId)
         if underSeeded:
             names = ", ".join(
                 self._segmentName(segId) or str(segId) for segId in underSeeded
             )
-            statusText = f"{_INCOMPLETE_GLYPH} {names} needs at least two seeds"
+            completenessText = f"{_INCOMPLETE_GLYPH} {names} needs at least two seeds"
         elif seedCount < _MIN_SEEDS_FOR_COMPLETE:
-            statusText = f"{_INCOMPLETE_GLYPH} {_INCOMPLETE_TEXT}"
+            completenessText = f"{_INCOMPLETE_GLYPH} {_INCOMPLETE_TEXT}"
         else:
-            statusText = _COMPLETE_TEXT
-        statusLabel = qt.QLabel(statusText)
-        rowLayout.addWidget(statusLabel)
+            completenessText = _COMPLETE_TEXT
+
+        # Review-status cell: a click-cycle ``QToolButton`` rendered as GLYPH +
+        # TEXT (ADR-0010), exactly like Slicer's segment status cell.  When the
+        # territory is LOCKED (status Completed) the button reads the lock glyph
+        # + "Locked" (the human sign-off is explicit + persistent); a click
+        # cycles the status one step (the ONE gesture that reaches / leaves the
+        # locked state).  The completeness hint lives in the tooltip so the row
+        # carries one authoritative indicator (plan §4).
+        status = self.territoryStatus(territoryId)
+        statusButton = qt.QToolButton()
+        statusButton.setAutoRaise(True)
+        statusButton.setToolButtonStyle(qt.Qt.ToolButtonTextOnly)
+        if locked:
+            statusButton.setText(f"{_LOCK_GLYPH} {_LOCK_TEXT}")
+        else:
+            statusButton.setText(_status_cell_text(status))
+        statusButton.setToolTip(
+            f"{_status_cell_text(status)} — click to change review status.\n"
+            f"Readiness: {completenessText}"
+        )
+        statusButton.connect(
+            "clicked(bool)",
+            lambda _checked, t=territoryId: self._onStatusClicked(t),
+        )
+        rowLayout.addWidget(statusButton)
 
         # Territory-level delete: removes the WHOLE territory (seeds + display
         # slot) via the carrier's RemoveTerritory, so an EMPTY territory -- which
         # has no seed rows and thus no per-seed delete button -- is still
-        # removable (ADR-0037 §Decision 3).  a11y: explicit text + tooltip.
+        # removable (ADR-0037 §Decision 3).  a11y: explicit text + tooltip.  A
+        # LOCKED territory refuses removal (disabled with an explaining tooltip).
         deleteButton = qt.QToolButton()
         deleteButton.setAutoRaise(True)
         deleteButton.setText("Remove")
@@ -799,6 +962,9 @@ class TerritoriesTableWidget(qt.QWidget):
             "clicked(bool)",
             lambda _checked, t=territoryId: self.deleteTerritory(t),
         )
+        if locked:
+            deleteButton.setEnabled(False)
+            deleteButton.setToolTip(_LOCK_TOOLTIP)
         rowLayout.addWidget(deleteButton)
 
         self._territory_rows[territoryId] = {
@@ -807,7 +973,14 @@ class TerritoriesTableWidget(qt.QWidget):
             "visibility": visibilityButton,
             "colour": colourButton,
             "label": labelEdit,
-            "status": statusLabel,
+            # ``status`` keeps returning the completeness GLYPH+TEXT the existing
+            # ``territoryStatusText`` / ``territoryHasIncompleteGlyph`` readers
+            # consult (the readiness hint), now sourced from the status button's
+            # tooltip so those invariants stay green; ``status_button`` is the
+            # new review-status cell.
+            "status": statusButton,
+            "status_button": statusButton,
+            "completeness": completenessText,
             "delete": deleteButton,
         }
         return rowWidget
@@ -865,6 +1038,10 @@ class TerritoriesTableWidget(qt.QWidget):
             "clicked(bool)",
             lambda _checked, t=territoryId, i=pointIndex: self._removePoint(t, i),
         )
+        if self.territoryIsLocked(territoryId):
+            # Seed-delete is a geometry edit; a locked territory refuses it.
+            deleteButton.setEnabled(False)
+            deleteButton.setToolTip(_LOCK_TOOLTIP)
         rowLayout.addWidget(deleteButton)
 
         self._seed_rows[(territoryId, pointIndex)] = {
@@ -882,6 +1059,8 @@ class TerritoriesTableWidget(qt.QWidget):
         carrier method the placement Pipeline's pick-delete
         (``DeleteAnnotationPoint``) reaches, so delete-by-seed and
         delete-by-pick converge on one deletion path (ADR-0037 §Decision 3).
+        A LOCKED territory refuses the seed delete (a geometry edit; the row
+        button is disabled, this refuses the programmatic path too).
         """
-        if self._carrier is not None:
+        if self._carrier is not None and not self.territoryIsLocked(territoryId):
             self._carrier.RemoveNthAnnotationPoint(territoryId, pointIndex)

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -214,6 +214,17 @@ class TerritoriesTableWidget(qt.QWidget):
         del caller, event
         if self._rebuilding:
             return
+        # Defer the full tree rebuild while a seed drag is in flight: each
+        # drag move relocates the grabbed seed (``SetNthAnnotationPoint`` ->
+        # carrier ``Modified``), so a per-frame full rebuild (every row widget
+        # destroyed + recreated) is the drag lag.  The placement Pipeline
+        # publishes the drag-in-flight flag on the shared display node on grab
+        # and clears it + fires ONE carrier ``Modified`` on release, so exactly
+        # one rebuild lands at the end with the final positions (ADR-0037
+        # §Decision 3).  The row content is structural (Seed N + structure),
+        # not the live coordinate, so nothing visible drifts while deferred.
+        if _state.is_grabbing(self._displayNode):
+            return
         self._rebuild()
 
     # ------------------------------------------------------------------ #

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -973,12 +973,10 @@ class TerritoriesTableWidget(qt.QWidget):
             "visibility": visibilityButton,
             "colour": colourButton,
             "label": labelEdit,
-            # ``status`` keeps returning the completeness GLYPH+TEXT the existing
-            # ``territoryStatusText`` / ``territoryHasIncompleteGlyph`` readers
-            # consult (the readiness hint), now sourced from the status button's
-            # tooltip so those invariants stay green; ``status_button`` is the
-            # new review-status cell.
-            "status": statusButton,
+            # ``status_button`` is the review-status cell; ``completeness`` is the
+            # readiness GLYPH+TEXT the ``territoryStatusText`` /
+            # ``territoryHasIncompleteGlyph`` readers consult (folded into the
+            # status button's tooltip, plan §4).
             "status_button": statusButton,
             "completeness": completenessText,
             "delete": deleteButton,

--- a/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoriesTableWidget.py
@@ -287,6 +287,10 @@ class TerritoriesTableWidget(qt.QWidget):
         """The editable label ``qt.QLineEdit`` on the territory row."""
         return self._territoryControl(territoryId, "label")
 
+    def territoryDeleteButton(self, territoryId: str) -> Any:
+        """The delete ``qt.QToolButton`` on the territory HEADER row."""
+        return self._territoryControl(territoryId, "delete")
+
     def seedRowWidget(self, territoryId: str, pointIndex: int) -> Any:
         """The composite ``QWidget`` on the seed child item (col 0)."""
         return self._seedControl(territoryId, pointIndex, "widget")
@@ -572,6 +576,27 @@ class TerritoriesTableWidget(qt.QWidget):
         if self._carrier is not None:
             self._carrier.SetTerritoryLabel(territoryId, str(label))
 
+    def deleteTerritory(self, territoryId: str) -> None:
+        """Remove a whole territory (its seeds + display slot) via the carrier.
+
+        The territory-HEADER-row delete affordance: routes through the carrier's
+        ``RemoveTerritory`` so an EMPTY territory (no seed rows, hence no
+        per-seed delete button) is still removable (ADR-0037 §Decision 3).  If
+        the removed territory was the display node's ACTIVE (armed) territory,
+        the arm state is cleared first so placement does not target a gone
+        territory.  The carrier ``Modified`` observer refreshes the tree; the
+        local first-seen order list is pruned so a later ``addTerritory`` does
+        not resurrect it.
+        """
+        if not territoryId or self._carrier is None:
+            return
+        # Active-territory hygiene: disarm if the doomed territory is armed, so a
+        # subsequent surface click does not append to a territory that is gone.
+        if _state.get_active_territory(self._displayNode) == territoryId:
+            self.done()
+        self._territory_order = [t for t in self._territory_order if t != territoryId]
+        self._carrier.RemoveTerritory(territoryId)
+
     def deleteSeed(self, territoryId: str, pointIndex: int) -> None:
         """Delete-from-tree entry point — converges on the shared removal path.
 
@@ -751,6 +776,20 @@ class TerritoriesTableWidget(qt.QWidget):
         statusLabel = qt.QLabel(statusText)
         rowLayout.addWidget(statusLabel)
 
+        # Territory-level delete: removes the WHOLE territory (seeds + display
+        # slot) via the carrier's RemoveTerritory, so an EMPTY territory -- which
+        # has no seed rows and thus no per-seed delete button -- is still
+        # removable (ADR-0037 §Decision 3).  a11y: explicit text + tooltip.
+        deleteButton = qt.QToolButton()
+        deleteButton.setAutoRaise(True)
+        deleteButton.setText("Remove")
+        deleteButton.setToolTip("Remove this territory and its seeds")
+        deleteButton.connect(
+            "clicked(bool)",
+            lambda _checked, t=territoryId: self.deleteTerritory(t),
+        )
+        rowLayout.addWidget(deleteButton)
+
         self._territory_rows[territoryId] = {
             "widget": rowWidget,
             "place": placeButton,
@@ -758,6 +797,7 @@ class TerritoriesTableWidget(qt.QWidget):
             "colour": colourButton,
             "label": labelEdit,
             "status": statusLabel,
+            "delete": deleteButton,
         }
         return rowWidget
 

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryInteractionState.py
@@ -48,6 +48,7 @@ _STATE = PointPlacementState(_NAMESPACE, active_suffix="ActiveTerritory")
 ARMED_ATTR = f"{_NAMESPACE}.Armed"
 ACTIVE_TERRITORY_ATTR = f"{_NAMESPACE}.ActiveTerritory"
 MODULE_ACTIVE_ATTR = f"{_NAMESPACE}.ModuleActive"
+GRABBING_ATTR = f"{_NAMESPACE}.Grabbing"
 CARRIER_REFERENCE_ROLE = f"{_NAMESPACE}.carrier"
 
 
@@ -68,6 +69,15 @@ def set_module_active(displayNode: Any, active: bool) -> None:
 def is_module_active(displayNode: Any) -> bool:
     """True unless the module has EXPLICITLY closed the gate."""
     return _STATE.is_module_active(displayNode)
+
+
+def set_grabbing(displayNode: Any, grabbing: bool) -> None:
+    """Publish that a seed-drag gesture is in flight on the display node."""
+    _STATE.set_grabbing(displayNode, grabbing)
+
+
+def is_grabbing(displayNode: Any) -> bool:
+    return _STATE.is_grabbing(displayNode)
 
 
 def set_active_territory(displayNode: Any, territoryId: str | None) -> None:

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -438,6 +438,22 @@ class TerritoryPlacementPipeline(_PipelineBase):
             return active
         return self._territory_id
 
+    def _territory_locked(self, territoryId: str | None) -> bool:
+        """Whether ``territoryId`` is edit-LOCKED (derived from Completed status).
+
+        The interaction guard reads the carrier's own derivation
+        (``GetTerritoryLocked``) so the pipeline, the table, and the carrier
+        agree on one source of truth (ADR-0037 Amendment "Per-territory status +
+        derived edit-lock").  A carrier without the status slot (pre-amendment)
+        is never locked.
+        """
+        if territoryId is None:
+            return False
+        carrier = self._get_carrier()
+        if carrier is None or not hasattr(carrier, "GetTerritoryLocked"):
+            return False
+        return bool(carrier.GetTerritoryLocked(territoryId))
+
     # ------------------------------------------------------------------ #
     # LayerDM lifecycle
     # ------------------------------------------------------------------ #
@@ -670,7 +686,15 @@ class TerritoryPlacementPipeline(_PipelineBase):
         also reslices the 2D views onto the placed seed (ADR-0025 mirror) --
         the per-territory grouping itself is the provider's concern (it appends
         into ``_placement_territory``).
+
+        A LOCKED active territory REFUSES the append (ADR-0037 Amendment
+        "Per-territory status + derived edit-lock" §5): the Place toggle cannot
+        arm into it, and this is the placement pipeline's defence-in-depth
+        status check before ``AddAnnotationPoint`` (the arm state lives on the
+        display node, so a stale armed flag could still route a click here).
         """
+        if self._territory_locked(self._placement_territory()):
+            return
         provider = self._provider
         if provider is not None:
             provider.add_point((world[0], world[1], world[2]))
@@ -751,7 +775,13 @@ class TerritoryPlacementPipeline(_PipelineBase):
         in order.  Returns True iff a point was removed.  Routes through the
         provider's delete write-back (the base's ``DeletePoint`` seam) so the
         key contract matches the grab / drag path.
+
+        A LOCKED territory REFUSES the delete (ADR-0037 Amendment
+        "Per-territory status + derived edit-lock" §5): a per-seed delete on a
+        validated territory is declined.
         """
+        if self._territory_locked(territoryId):
+            return False
         return bool(self.DeletePoint((territoryId, int(index))))
 
     # ------------------------------------------------------------------ #
@@ -789,6 +819,13 @@ class TerritoryPlacementPipeline(_PipelineBase):
         carrier = self._get_carrier()
         territory = self._placement_territory()
         if carrier is None or territory is None:
+            return None, None, sys.float_info.max
+        # A LOCKED territory declines drag-edit of its points (ADR-0037 Amendment
+        # "Per-territory status + derived edit-lock" §5): its seeds are not
+        # grab targets, so the base's grab arbitration finds nothing near and a
+        # press over a locked seed leaves the hover highlight (a declined bare
+        # move) instead of relocating the point.
+        if self._territory_locked(territory):
             return None, None, sys.float_info.max
         count = carrier.GetNumberOfAnnotationPoints(territory)
         if count == 0:

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -717,6 +717,13 @@ class TerritoryPlacementPipeline(_PipelineBase):
             self._set_hover(None)
             self._raise_highlight(renderer, eventData)
         self._reconcile_highlight()
+        # The base's bare-move arbitration DECLINES (returns without a render),
+        # and a bare hover mutates no observed node, so nothing else flushes a
+        # frame: request one HERE or the adhering marker / glow halo is computed
+        # but never painted (the mid-interaction RequestRender discipline the
+        # sibling ControlPolygonPipeline hover path also follows).  Without it
+        # the vessel highlight never appears on hover.
+        self.RequestRender()
 
     def DeleteAnnotationPoint(self, territoryId: str, index: int) -> bool:  # noqa: N802 - VTK verb
         """Remove EXACTLY ONE annotation point (delete-from-table end).

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPlacementPipeline.py
@@ -684,7 +684,16 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._rebuild_seed_actor()
 
     def _on_grab(self, key: Any, renderer: Any, eventData: Any) -> None:
-        """Grab an existing seed: swap the glow halo + seed to green."""
+        """Grab an existing seed: swap the glow halo + seed to green.
+
+        Publish a "drag in flight" flag on the shared display node so the
+        table observer defers its expensive full rebuild until the drag ends
+        (each drag move relocates the seed via ``SetNthAnnotationPoint``, which
+        fires the carrier ``Modified`` -- without the flag the whole tree would
+        rebuild per frame; ADR-0037 §Decision 3).
+        """
+        if self._display_node is not None:
+            _state.set_grabbing(self._display_node, True)
         self._position_halo()
         self._rebuild_seed_actor()
 
@@ -694,9 +703,19 @@ class TerritoryPlacementPipeline(_PipelineBase):
         self._rebuild_seed_actor()
 
     def _on_release(self) -> None:
-        """Gesture over: drop the grab colour (fall back to hover/none)."""
+        """Gesture over: drop the grab colour (fall back to hover/none).
+
+        Clear the "drag in flight" flag FIRST, then fire ONE carrier
+        ``Modified`` so the table's deferred observer runs a single full
+        rebuild reflecting the final seed positions (ADR-0037 §Decision 3).
+        """
+        if self._display_node is not None:
+            _state.set_grabbing(self._display_node, False)
         self._position_halo()
         self._rebuild_seed_actor()
+        carrier = _state.get_carrier(self._display_node)
+        if carrier is not None:
+            carrier.Modified()
 
     def _on_bare_move_decline(self, renderer: Any, eventData: Any) -> None:
         """Raise the hover cue on a declined bare move (ADR-0033 side effect).

--- a/VascularTerritories/VascularTerritoriesLib/TerritoryPointProvider.py
+++ b/VascularTerritories/VascularTerritoriesLib/TerritoryPointProvider.py
@@ -44,6 +44,12 @@ class TerritoryPointProvider:
     thin fan-out with no state of its own beyond those callables.
     """
 
+    #: The status ordinals the demote-on-edit rule reads.  Kept as module-scoped
+    #: constants mirroring ``vtkMRMLCustomTerritoriesNode``'s enum (Completed 2 /
+    #: InProgress 1) so the provider stays free of the wrapped-C++ import.
+    _STATUS_IN_PROGRESS = 1
+    _STATUS_COMPLETED = 2
+
     def __init__(self, carrier_getter, territory_getter, visible_getter=None) -> None:
         self._carrier_getter = carrier_getter
         self._territory_getter = territory_getter
@@ -104,12 +110,33 @@ class TerritoryPointProvider:
         """Territory seeds are unordered per-territory points -- no edges."""
         return False
 
+    def _demote_on_geometry_edit(self, carrier, territory) -> None:
+        """Demote a ``Completed`` territory to ``InProgress`` on a GEOMETRY edit.
+
+        The #574 demote-on-edit staleness rule (ADR-0034 Decision 2), locally
+        scoped to this territory: a seed add / move / delete on a Completed
+        (locked) territory is a geometry change, so its sign-off is stale --
+        drop it to InProgress, which also clears the derived edit-lock.  A
+        colour / label edit does NOT reach here (it goes through the carrier's
+        display setters), so cosmetic edits never demote (plan §9 default 5).
+        A no-op when the carrier has no status slot (pre-amendment carrier).
+        """
+        if territory is None or not hasattr(carrier, "GetTerritoryStatus"):
+            return
+        if int(carrier.GetTerritoryStatus(territory)) == self._STATUS_COMPLETED:
+            carrier.SetTerritoryStatus(territory, self._STATUS_IN_PROGRESS)
+
     def add_point(self, world) -> Any:
-        """Append one seed to the ACTIVE territory; return its key."""
+        """Append one seed to the ACTIVE territory; return its key.
+
+        Demotes the active territory on this geometry edit if it was Completed
+        (the demote-on-edit rule) before the append lands.
+        """
         carrier = self._carrier()
         territory = self._territory()
         if carrier is None or territory is None:
             return None
+        self._demote_on_geometry_edit(carrier, territory)
         carrier.AddAnnotationPoint(
             territory, float(world[0]), float(world[1]), float(world[2])
         )
@@ -117,19 +144,27 @@ class TerritoryPointProvider:
         return (territory, index)
 
     def move_point(self, key, world) -> None:
-        """Relocate the ``(territoryId, index)`` seed to ``world``."""
+        """Relocate the ``(territoryId, index)`` seed to ``world``.
+
+        Demotes the seed's territory on this geometry edit if it was Completed.
+        """
         carrier = self._carrier()
         if carrier is None or key is None:
             return
         territory, index = key
+        self._demote_on_geometry_edit(carrier, territory)
         carrier.SetNthAnnotationPoint(
             territory, int(index), float(world[0]), float(world[1]), float(world[2])
         )
 
     def delete_point(self, key) -> bool:
-        """Remove the ``(territoryId, index)`` seed; True iff one was removed."""
+        """Remove the ``(territoryId, index)`` seed; True iff one was removed.
+
+        Demotes the seed's territory on this geometry edit if it was Completed.
+        """
         carrier = self._carrier()
         if carrier is None or key is None:
             return False
         territory, index = key
+        self._demote_on_geometry_edit(carrier, territory)
         return bool(carrier.RemoveNthAnnotationPoint(territory, int(index)))


### PR DESCRIPTION
## Summary

Usability batch for VascularTerritories, driven by a live eyeball session on
real anatomy after the ADR-0038 migration. Every fix was verified live on a
real GL display in addition to the test suites.

- **Hover cue restored on placement** — the territory placement pipeline's
  bare-move decline now requests a render, so the adhering marker/halo shows
  while placing (the ADR-0038 extraction had dropped the flush; a regression
  test pins it).
- **Territory-level delete** — the carrier gains `RemoveTerritory` and each
  territory row a Remove control, so an empty territory is no longer
  undeletable; deleting the active territory disarms placement.
- **Affirmative requirements messaging** — Extract centerlines / Compute map
  gained a live "what's missing" line + tooltips (input, SlicerVMTK, seeds,
  reference volume, centerlines) instead of silently disabled buttons.
- **Seed-drag performance** — the seeds table defers its full rebuild while a
  drag is in flight (a `Grabbing` flag on the shared display node, set by the
  pipeline), removing the per-frame tree rebuild that made editing crawl.
- **Centerline visibility follows the territory** — hiding a territory now
  hides its extracted centerline(s) too (gated on territory AND structure
  visibility, associated via the carrier's groupings).
- **Per-territory review status + derived edit-lock** (ADR-0037 amendment) —
  a click-to-cycle status cell reusing Slicer's segment-status vocabulary
  (NotStarted/InProgress/Completed/Flagged); `Completed` derives a lock that
  refuses placement/drag/delete with explaining tooltips, and a geometry edit
  demotes to InProgress. Status round-trips through storage.

Docs: the ADR-0037 amendment + the protection/validation design study, both
in the toctree.

Tests: carrier, table, pipeline, and enablement invariants extended in both
harnesses; the launched suites are the behaviour gate in CI.

---

*Drafted with the assistance of Claude Code (model: claude-opus-4-8);
reviewed by the author.*
