### PR TITLE
DOC: ADR-0039 AI-assisted development working agreements + GitHub-dialog agent workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,73 @@
+# GitHub-dialog agent — see Docs/adr/0039-ai-assisted-development-working-agreements.md
+#
+# Mentioning @claude in an issue or PR thread dispatches Claude Code on
+# a runner.  Scope (ADR-0039 §10): write-access users only; agent-led
+# task class only (mechanical refactors, docs, test scaffolds, small
+# fixes); work is opened as Draft PRs; the agent never merges, approves,
+# or flips Ready — merge authority stays human.  Commits are authored by
+# the bot identity, keeping attribution truthful.
+#
+# Setup: the Claude GitHub App must be installed on the repository and
+# the CLAUDE_CODE_OAUTH_TOKEN secret configured (claude setup-token).
+
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    # Trigger: an @claude mention by a user with repo write access.
+    # author_association is the first gate; the action re-validates
+    # actor permissions server-side.
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+               github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Follow the working agreements in
+            Docs/adr/0039-ai-assisted-development-working-agreements.md.
+            Hard limits for this dispatch:
+            - Only take on agent-led-class tasks: mechanical refactors,
+              documentation, test scaffolds, fixes of roughly 20 lines
+              or less.  If the request is larger or touches interaction
+              code, MRML state lifecycles, or architecture, reply in the
+              thread explaining that it needs a human-led session, and
+              stop.
+            - Never modify existing tests that gate behaviour; adding
+              new tests is fine.
+            - Branch off preview (or the PR's epic branch when the
+              thread belongs to one); open resulting work as a DRAFT
+              pull request with a reviewer's map (read order, mechanical
+              vs load-bearing hunks).  Never mark Ready, approve, or
+              merge.
+            - Commit messages use the repository convention
+              (ENH|PERF|BUG|STYLE|DOC|COMP: + capitalized first word)
+              and contain no AI trailers; the PR body discloses the
+              model.
+            - Keep repository content platform-neutral; reference only
+              in-repo anchors (ADR sections, class names) in source
+              comments.
+          claude_args: --max-turns 50

--- a/Docs/adr/0039-ai-assisted-development-working-agreements.md
+++ b/Docs/adr/0039-ai-assisted-development-working-agreements.md
@@ -1,0 +1,139 @@
+# 0039. AI-assisted development working agreements
+
+- **Status:** Accepted
+- **Date:** 2026-08-20
+- **Deciders:** Rafael Palomar
+- **Relates to:**
+  [ADR-0006](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0006-branch-model.md)
+  (branch model — this ADR adds the integration-branch/sub-PR shape on
+  top of it),
+  [ADR-0005](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0005-github-actions-ci.md)
+  (CI — whose unfiltered `pull_request` triggers already cover sub-PRs),
+  and [ADR-0021](0021-coverage-measurement.md) (measurement posture).
+- **PR:** _filled in on merge_
+
+## Context
+
+The Jul–Aug 2026 development campaign was our largest AI-assisted
+effort to date and produced a measurable pathology alongside real
+throughput: one review unit ballooned to ~15.6k changed lines across
+84 commits as findings were appended to an open PR; ~23% of the
+campaign's commits were `BUG:` fixes for code introduced by the same
+campaign; and every consequential defect was caught by the maintainer
+exercising the live application, not by the test suites or by review.
+The maintainer's summary of the risk: *we do not want a repository
+that can only be faced with the use of AI*.
+
+The external evidence base points the same direction.  Review
+effectiveness collapses beyond 200–400 changed lines
+([SmartBear/Cisco study](https://static0.smartbear.co/support/media/resources/cc/book/code-review-cisco-case-study.pdf));
+Google's review culture holds the median change near 24 lines
+([Sadowski et al., ICSE-SEIP 2018](https://sback.it/publications/icse2018seip.pdf));
+DORA finds AI adoption inflates batch size and taxes delivery
+stability, and that AI *amplifies* the surrounding system rather than
+fixing it ([DORA 2024/2025](https://dora.dev/research/));
+a randomized trial found experienced maintainers on their own mature
+repositories 19% *slower* with AI while believing themselves faster
+([METR 2025](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/));
+corpus data shows duplication and churn rising in the AI era
+([GitClear 2025](https://www.gitclear.com/ai_assistant_code_quality_2025_research));
+and passive delegation to AI measurably costs code comprehension
+([arXiv:2601.20245](https://arxiv.org/abs/2601.20245)).  Peter Naur's
+[*Programming as Theory Building*](https://pages.cs.wisc.edu/~remzi/Naur.pdf)
+names the underlying failure mode: the program is the theory the team
+holds, and generated text builds no theory in any human head.
+
+Peer projects have already converged on policy: Ghostty requires AI
+disclosure and holds that *the approver must be able to explain the
+code*; QEMU scopes agent autonomy by change size and risk class.
+
+## Decision
+
+1. **Reviewable unit.**  A non-mechanical PR targets ≤ ~400 changed
+   lines.  A PR freezes when opened: review and verification findings
+   open a follow-up PR, never append to the one under review.
+   (Mechanical sweeps — formatting, renames, generated files — are
+   exempt when declared as such.)
+
+2. **Integration branches replace stacked PRs.**  A multi-step feature
+   opens `feature/<epic>` off `preview`.  Each increment is a sub-PR
+   *based on the epic branch*, reviewed and merged there at the size
+   above.  One final PR merges `feature/<epic>` into `preview`,
+   rebase-merged so the reviewed structure survives; by then every
+   hunk has been reviewed piecewise and the final PR carries a
+   reviewer's map, not a wall.  Squash-merging members of a
+   hand-stacked PR chain is what this replaces — it rewrites history
+   under the remaining members.
+
+3. **Cycle shape.**  Design → human sign-off → tests pinned →
+   implementation.  For behaviour with a computable ground truth, a
+   synthetic fixture with analytic expected values is built *before*
+   the algorithm.  Design reviews run before v1, not after.
+
+4. **Test integrity.**  An agent may not modify the tests that gate
+   its own change.  Every behavioural feature carries at least one
+   test on the real integrated path; suites that mock the integration
+   surface are necessary but not sufficient.
+
+5. **Merge bar (the Ghostty standard).**  A PR is mergeable only when
+   a human can explain every hunk.  Agent-drafted PRs include a
+   reviewer's map: suggested read order, and which hunks are
+   mechanical versus load-bearing.
+
+6. **Comment discipline.**  Comments state invariants, reasons, and
+   ADR anchors.  Narrative retellings of change history belong in
+   commit messages and PR bodies, not source files.
+
+7. **ADR bar.**  New ADRs meet Nygard's criterion — the decision is
+   contested and costly to reverse.  Design studies live under
+   `Docs/design/` and may be marked superseded once code and tests
+   carry the decision.
+
+8. **Instrumentation.**  Each campaign records: largest PR size,
+   rework ratio (`BUG:` commits fixing same-campaign code / total),
+   and CI failures per PR.  Baseline (Jul–Aug 2026): 15.6k / 23% / 3.
+   The next campaign must move all three.
+
+9. **Autonomy by risk class.**
+   - *Agent-led* (agent authors, human reviews): mechanical
+     refactors, documentation, test scaffolds, fixes ≤ ~20 lines.
+   - *Agent-drafted, human-walked-through*: UI and interaction code,
+     MRML state lifecycles.
+   - *Human-led* (agent assists only): architecture and
+     safety-relevant semantics.
+
+10. **Agent identity and attribution.**  Repository-resident agents
+    commit under their own bot identity (the Claude GitHub App commits
+    as `claude[bot]`), so authorship in history and the contributor
+    graph is truthful.  Human-authored commits carry no AI trailers;
+    AI-drafted PR bodies disclose the model used.  The
+    GitHub-dialog agent (`@claude` in issues and PR threads) is
+    triggerable only by users with write access, operates only within
+    the *agent-led* risk class, opens its work as Draft PRs, and never
+    flips Ready, approves, or merges — merge authority stays human.
+
+## Consequences
+
+- More PRs and more branch bookkeeping per feature; this is the
+  deliberate price of keeping every reviewed unit inside the band
+  where human review works.
+- History and the contributor graph become honest about who wrote
+  what; other developers can dispatch bounded agent work from GitHub
+  without local tooling.
+- Some raw generation throughput is given back.  The campaign data
+  says a quarter of it was being repaid as rework anyway.
+
+## Conformance
+
+- [review] Reviewers bounce non-mechanical PRs over ~400 changed
+  lines and appended-scope pushes to an open PR.
+- [review] Sub-PRs target their epic branch; the epic→`preview` PR is
+  rebase-merged.
+- [review] Agent-drafted PR bodies name the model and include a
+  reviewer's map; commit messages carry no AI trailers.
+- [review] The `claude.yml` workflow keeps its scope: write-access
+  trigger gate, agent-led task class, Draft PRs only, no edits to
+  gating tests, no merge authority.
+- [future] Automate the §8 metrics as a scheduled report.
+- [future] Audit the existing ADR corpus against §7; migrate
+  design-study ADRs to `Docs/design/`.

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -57,6 +57,7 @@ adr/0035-resection-init-state-machine.md
 adr/0036-vessel-highlight-separate-instance.md
 adr/0037-vascular-territories-off-markups.md
 adr/0038-unify-control-point-interaction.md
+adr/0039-ai-assisted-development-working-agreements.md
 ```
 
 ```{toctree}


### PR DESCRIPTION
## Summary

Codifies the operating model from the 2026-08-20 development-process
retrospective as ADR-0039, and adds the `claude.yml` workflow that
implements its §10 (GitHub-dialog agent): `@claude` mentions by
write-access users dispatch bounded, bot-attributed agent work as
Draft PRs, scoped to the agent-led risk class. Doc + workflow only —
no runtime code touched.

## ADR references

- ADR-0039: AI-assisted development working agreements — introduced by
  this PR.
- ADR-0006: branch model — extended (not amended) with the
  integration-branch/sub-PR shape for multi-step features.
- ADR-0005: GitHub Actions CI — unchanged; its unfiltered
  `pull_request` triggers already give sub-PRs CI coverage.

## Conformance

- The workflow enforces ADR-0039 §10 mechanically where it can
  (write-access `if` gate, Draft-only instructions, no merge
  permissions used) and by prompt where it cannot; the residue is
  [review]-tagged in the ADR.

## Test plan

- Docs: joins the `Docs/index.md` toctree (sphinx orphan check);
  internal links resolve under lychee `--offline`.
- Workflow: YAML validated; inert until the Claude GitHub App is
  installed and `CLAUDE_CODE_OAUTH_TOKEN` is configured, so merging is
  safe before the app setup completes.

## UX impact

None (process/infrastructure only).

<details><summary>Detailed rationale</summary>

The retrospective measured a ~15.6k-line review unit, ~23%
self-inflicted rework, and defect discovery landing entirely on manual
GUI verification. The ADR's Context section carries the external
evidence base (SmartBear/Cisco, Sadowski et al. ICSE 2018, DORA
2024/2025, METR 2025, GitClear 2025, arXiv:2601.20245, Naur) and the
peer-project policy precedents (Ghostty, QEMU). Note: this PR will
show a trivial `Docs/index.md` conflict once #609 (which adds
ADR-0036–0038 to the same toctree block) merges; a one-line rebase
resolves it.

</details>

---
🤖 This PR was drafted with AI assistance (Claude Fable 5 via Claude
Code); the maintainer reviewed and directed the changes.
