### PR TITLE
BUG: Raise the Claude workflow turn cap clear of small-task usage

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,5 +52,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --max-turns 50
+            --max-turns 150
             --append-system-prompt "Follow the working agreements in Docs/adr/0039-ai-assisted-development-working-agreements.md. Hard limits: only take on agent-led-class tasks (mechanical refactors, documentation, test scaffolds, fixes of roughly 20 lines or less); if the request is larger or touches interaction code, MRML state lifecycles, or architecture, reply in the thread explaining that it needs a human-led session, and stop. Never modify existing tests that gate behaviour; adding new tests is fine. Branch off preview (or the PR's epic branch when the thread belongs to one); open resulting work as a DRAFT pull request with a reviewer's map (read order, mechanical vs load-bearing hunks); never mark Ready, approve, or merge. Commit messages use the repository convention (ENH|PERF|BUG|STYLE|DOC|COMP: plus a capitalized first word) and contain no AI trailers; the PR body discloses the model. Keep repository content platform-neutral; reference only in-repo anchors (ADR sections, class names) in source comments."


### PR DESCRIPTION
## Summary

The first real `@claude` dispatch (issue #612) completed its
implementation in 53 turns and was then failed by the workflow's
`--max-turns 50` before it could open its Draft PR. Turns are consumed
by checkout, context gathering, and progress-comment updates, so 50 is
too tight even for a small, well-specified task. Raise to 150; the
30-minute job timeout remains the real runaway bound.

## ADR references

- ADR-0039: AI-assisted development working agreements — tuning of the
  section-10 workflow, no scope change.

## Test plan

- One-word change; validated by the next dispatch completing without a
  turn-cap failure.

## UX impact

None (CI workflow only).

---
🤖 This PR was drafted with AI assistance (Claude Fable 5 via Claude
Code); the maintainer reviewed and directed the changes.
