### PR TITLE
STYLE: Remove the dormant hover-preview highlight channel

### DIFF
--- a/LiverVolumetry/LiverVolumetryLib/CarvedRegionStripes.py
+++ b/LiverVolumetry/LiverVolumetryLib/CarvedRegionStripes.py
@@ -69,18 +69,6 @@ except ImportError:  # bare fallback: vtkCommand::UserEvent is the stable 1000
     _USER_EVENT = 1000
 STRIPE_TICK_EVENT = _USER_EVENT + 61
 
-#: The hover-PREVIEW marker on the shared ``HighlightSeedID`` member: while
-#: the surgeon hovers an UNPINNED seed's Pin button, the widget publishes
-#: ``preview:<seedID>`` instead of the bare ID.  The slice pipelines parse
-#: the marker and render the preview STATIC (phase frozen -- the widget
-#: also stops ticking) and DIMMED, so a glance never reads as the pin.
-#: One transient member carries both states (a second member was overkill);
-#: hover-out restores the pinned ID (or clears).
-PREVIEW_PREFIX = "preview:"
-
-#: The preview stripes' dimmed opacity (the pinned stripes render opaque).
-PREVIEW_STRIPE_OPACITY = 0.4
-
 #: LEGACY display-node ATTRIBUTES from the retired attribute-borne highlight
 #: channel.  Node attributes serialize into the scene XML, so an old scene can
 #: carry a frozen highlight/phase; ``clear_legacy_highlight_attributes``
@@ -107,32 +95,11 @@ def set_highlight_seed_id(displayNode: Any, seedID: str) -> None:
 
 
 def get_highlight_seed_id(displayNode: Any) -> str:
-    """The raw highlight member value (empty string when none).
-
-    May carry the ``preview:`` marker; renderers go through
-    ``parse_highlight_value`` to split the seed ID from the preview flag.
-    """
+    """The raw highlight member value (empty string when none)."""
     getter = getattr(displayNode, "GetHighlightSeedID", None)
     if getter is None:
         return ""
     return getter() or ""
-
-
-def set_preview_seed_id(displayNode: Any, seedID: str) -> None:
-    """Publish a hover-PREVIEW highlight for ``seedID`` (static + dimmed).
-
-    Writes ``preview:<seedID>`` onto the same transient member the pin
-    uses; an empty / ``None`` seed clears the member entirely.
-    """
-    set_highlight_seed_id(displayNode, f"{PREVIEW_PREFIX}{seedID}" if seedID else "")
-
-
-def parse_highlight_value(value: str) -> tuple:
-    """Split a raw highlight member value into ``(seedID, is_preview)``."""
-    value = value or ""
-    if value.startswith(PREVIEW_PREFIX):
-        return value[len(PREVIEW_PREFIX):], True
-    return value, False
 
 
 def invoke_stripe_tick(displayNode: Any) -> None:

--- a/LiverVolumetry/LiverVolumetryLib/VolumetrySeedPipeline.py
+++ b/LiverVolumetry/LiverVolumetryLib/VolumetrySeedPipeline.py
@@ -92,11 +92,9 @@ try:  # pragma: no cover - exercised once per import path
         write_seed_context,
     )
     from .CarvedRegionStripes import (
-        PREVIEW_STRIPE_OPACITY,
         STRIPE_PERIOD_PX,
         STRIPE_TICK_EVENT,
         get_highlight_seed_id,
-        parse_highlight_value,
         resample_mask_to_plane,
         stripe_segments,
     )
@@ -114,11 +112,9 @@ except ImportError:  # top-level import path (the unit layer's sys.path setup)
         write_seed_context,
     )
     from CarvedRegionStripes import (  # type: ignore[no-redef]
-        PREVIEW_STRIPE_OPACITY,
         STRIPE_PERIOD_PX,
         STRIPE_TICK_EVENT,
         get_highlight_seed_id,
-        parse_highlight_value,
         resample_mask_to_plane,
         stripe_segments,
     )
@@ -556,8 +552,7 @@ class VolumetrySeedPipelineSlice(_PipelineSliceBase):
         # On-slice identity text (ADR-0010 -- never colour/animation alone
         # IN THE VIEW either): while a seed is PINNED, a corner annotation
         # names the pinned seed + its volume in text right where the
-        # stripes render.  Cleared with the pin; a hover preview shows no
-        # annotation (transient by design).
+        # stripes render.  Cleared with the pin.
         self._pin_annotation = vtk.vtkCornerAnnotation()
         self._pin_annotation.SetLinearFontScaleFactor(2)
         self._pin_annotation.SetNonlinearFontScaleFactor(1)
@@ -700,12 +695,8 @@ class VolumetrySeedPipelineSlice(_PipelineSliceBase):
         """
         del caller, event
         try:
-            seedID, isPreview = parse_highlight_value(
-                get_highlight_seed_id(self._display_node)
-            )
-            if not seedID or isPreview:
-                # A hover PREVIEW is STATIC by contract: the widget stops
-                # ticking, and a straggler tick must not march it either.
+            seedID = get_highlight_seed_id(self._display_node)
+            if not seedID:
                 return
             self._stripe_phase = (self._stripe_phase + 1) % STRIPE_PERIOD_PX
             self._update_stripes()
@@ -909,37 +900,29 @@ class VolumetrySeedPipelineSlice(_PipelineSliceBase):
             self.ClearPinAnnotation()
             return
         show = False
-        raw = get_highlight_seed_id(self._display_node)
-        seedID, isPreview = parse_highlight_value(raw)
-        if raw != self._stripe_highlight_id:
-            self._stripe_highlight_id = raw
+        seedID = get_highlight_seed_id(self._display_node)
+        if seedID != self._stripe_highlight_id:
+            self._stripe_highlight_id = seedID
             self._stripe_phase = 0
         if seedID:
             index = self._resolve_seed_index(seedID)
             if index >= 0:
                 mask2d = self._carved_mask_2d(index)
                 if mask2d is not None:
-                    # A hover preview renders STATIC (phase frozen at zero;
-                    # no tick marches it) and DIMMED, so it never reads as
-                    # the pinned highlight.
-                    phase = 0 if isPreview else self._stripe_phase
-                    segments = stripe_segments(mask2d, STRIPE_PERIOD_PX, phase)
+                    segments = stripe_segments(mask2d, STRIPE_PERIOD_PX, self._stripe_phase)
                     if segments:
                         self._build_stripe_lines(segments)
                         prop = self._stripes_actor.GetProperty()
                         prop.SetColor(*self._stripe_rgb(index))
-                        prop.SetOpacity(
-                            PREVIEW_STRIPE_OPACITY if isPreview else 1.0
-                        )
+                        prop.SetOpacity(1.0)
                         show = True
         self._stripes_actor.SetVisibility(show)
-        self._update_pin_annotation(seedID if not isPreview else "")
+        self._update_pin_annotation(seedID)
 
     def _update_pin_annotation(self, seedID: str) -> None:
         """Name the pinned seed + volume in the slice corner (text identity).
 
-        Empty / unresolvable clears the annotation.  Preview never annotates
-        (the caller passes "" for a preview).
+        Empty / unresolvable clears the annotation.
         """
         text = ""
         if seedID:

--- a/LiverVolumetry/Testing/Python/test_volumetry_carved_stripes.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_carved_stripes.py
@@ -30,15 +30,12 @@ if str(_LIB) not in sys.path:
     sys.path.insert(0, str(_LIB))
 
 from CarvedRegionStripes import (  # noqa: E402
-    PREVIEW_PREFIX,
     STRIPE_TICK_EVENT,
     clear_legacy_highlight_attributes,
     get_highlight_seed_id,
     invoke_stripe_tick,
-    parse_highlight_value,
     resample_mask_to_plane,
     set_highlight_seed_id,
-    set_preview_seed_id,
     stripe_segments,
 )
 
@@ -204,28 +201,6 @@ def test_highlight_helpers_never_touch_the_attribute_channel():
         "the highlight helpers must NEVER write a node attribute -- "
         "attributes persist into the scene XML."
     )
-
-
-def test_preview_channel_rides_the_same_transient_member():
-    """The hover-preview marks the ONE transient member with ``preview:`` --
-    no second member, no attribute channel -- and parses back losslessly."""
-    display = _FakeDisplayNode()
-
-    set_preview_seed_id(display, "seed_7")
-
-    assert get_highlight_seed_id(display) == f"{PREVIEW_PREFIX}seed_7"
-    assert parse_highlight_value(get_highlight_seed_id(display)) == ("seed_7", True)
-    assert display.attribute_writes == []
-
-    set_preview_seed_id(display, "")
-    assert get_highlight_seed_id(display) == "", "an empty preview clears."
-
-
-def test_parse_highlight_value_splits_pin_and_preview():
-    assert parse_highlight_value("seed_3") == ("seed_3", False)
-    assert parse_highlight_value(f"{PREVIEW_PREFIX}seed_3") == ("seed_3", True)
-    assert parse_highlight_value("") == ("", False)
-    assert parse_highlight_value(None) == ("", False)
 
 
 def test_stripe_tick_fires_the_custom_event_with_no_mrml_write():


### PR DESCRIPTION
## Summary

Removes the dormant hover-preview highlight channel from the volumetry stripes: `set_preview_seed_id` had no production callers after row hover was made inert, so its plumbing (`PREVIEW_PREFIX`, `parse_highlight_value`, the pipeline's `isPreview` branches, and the now-unused `PREVIEW_STRIPE_OPACITY`) is removed. Mechanical, no behaviour change; the live pin/placement highlight channel is untouched.

Closes #612.

## Changes
- `CarvedRegionStripes.py`: removed `PREVIEW_PREFIX`, `set_preview_seed_id`, `parse_highlight_value`, `PREVIEW_STRIPE_OPACITY`, and the related docstring paragraphs.
- `VolumetrySeedPipeline.py`: both call sites now consume the bare highlight seed ID directly; dropped the preview branches and unused import.
- `test_volumetry_carved_stripes.py`: deleted the two tests pinning the retired channel (explicitly authorized by the issue) plus unused imports. All other tests in the file are untouched.

## Reviewer's map
- Mechanical: import-list edits, the deleted constant/function block, docstring trims, test deletions.
- Load-bearing (read closely): `_on_stripe_tick` and `_update_stripes` in `VolumetrySeedPipeline.py` — verify the collapsed control flow reproduces the old non-preview path exactly.

## Test plan
- [ ] Run `test_volumetry_carved_stripes.py` (could not execute in this session — no Python execution permission)
- [ ] Run `test_volumetry_hover_preview.py` to confirm it's unaffected

Generated with [Claude Code](https://claude.ai/code)
