### PR TITLE
ENH: Thread margin band style onto the resectogram 2D mapper

### DIFF
--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -218,6 +218,13 @@ class FlattenedSurfaceRepresentation:
         # which live on the carrier (ADR-0014 §"Fourth layer").
         self._resection_plan_node: Any | None = None
 
+        # The SHARED ``vtkMRMLParametricSurfaceDisplayNode`` -- the carrier's
+        # sibling display aspect carrying the band STYLE (margin colours +
+        # InterpolatedMargins).  One source of truth with the 3D surface
+        # (Docs/architecture/target-mrml-node-hierarchy.md: the display node
+        # carries margin COLORS only; the scalars stay on the plan wrapper).
+        self._surface_display_node: Any | None = None
+
         # The cross-view ``vtkMRMLLocatorNode`` (ADR-0025), threaded by the
         # ResectogramPipeline like the plan node; drives the 2D mapper's
         # uLocatorPosition / uLocatorRadius marker uniforms.
@@ -264,6 +271,18 @@ class FlattenedSurfaceRepresentation:
         no-distance-map fallback).
         """
         self._resection_plan_node = plan_node
+
+    def SetSurfaceDisplayNode(self, display_node: Any | None) -> None:  # noqa: N802 - VTK verb
+        """Attach the shared ``vtkMRMLParametricSurfaceDisplayNode``.
+
+        The ResectogramPipeline resolves the carrier's parametric-surface
+        display aspect and threads it here so the strip's band STYLE (margin
+        colours + InterpolatedMargins) reads from the SAME node the 3D
+        ``BezierPlanningRepresentation`` reads -- 2D and 3D bands can never
+        diverge.  ``None`` clears it; the 2D mapper's compiled-in defaults
+        then stand untouched.
+        """
+        self._surface_display_node = display_node
 
     def SetLocatorNode(self, locator_node: Any | None) -> None:  # noqa: N802 - VTK verb
         """Attach the cross-view locator node (ADR-0025); ``None`` clears."""
@@ -352,6 +371,7 @@ class FlattenedSurfaceRepresentation:
         self._distance_map_volume = None
         self._effective_texture_num_comps = 0
         self._locator_node = None
+        self._surface_display_node = None
 
         # Detach BEFORE dropping the actor handles: nulling the marker actor
         # first would make _detach_actors skip it and leak it into the
@@ -658,6 +678,36 @@ class FlattenedSurfaceRepresentation:
         if risk is not None and set_uncertainty is not None:
             set_uncertainty(float(risk()))
 
+    def _apply_band_style(self, mapper: Any) -> None:
+        """Thread the shared display node's band STYLE onto the 2D mapper.
+
+        Margin COLOURS + the InterpolatedMargins flag live on the carrier's
+        ``vtkMRMLParametricSurfaceDisplayNode`` -- the same node the 3D
+        ``BezierPlanningRepresentation`` reads -- so both views classify their
+        bands with identical style from one source of truth
+        (Docs/architecture/target-mrml-node-hierarchy.md).  A no-op when no
+        display node is wired: the mapper's compiled-in defaults stand, so
+        carriers without the parametric aspect keep the historic appearance.
+        """
+        display = self._surface_display_node
+        if display is None:
+            return
+        _push_color3(
+            mapper,
+            "SetResectionMarginColor",
+            getattr(display, "GetResectionMarginColor", None),
+        )
+        _push_color3(
+            mapper,
+            "SetUncertaintyMarginColor",
+            getattr(display, "GetUncertaintyMarginColor", None),
+        )
+        _push_bool(
+            mapper,
+            "SetInterpolatedMargins",
+            getattr(display, "GetInterpolatedMargins", None),
+        )
+
     def _apply_distance_map_texture(
         self, display_node: Any | None, data_node: Any | None
     ) -> None:
@@ -688,6 +738,9 @@ class FlattenedSurfaceRepresentation:
         # texture is bound), so they must be set even on the no-distance-map /
         # deferred-GL paths below.  Mirrors BezierPlanningRepresentation.
         self._apply_resection_margins(mapper)
+        # Band STYLE (colours + interpolation) rides the same early slot for
+        # the same reason: display state, valid without any texture bound.
+        self._apply_band_style(mapper)
 
         bind = getattr(mapper, "SetDistanceMapTextureObject", None)
         if bind is None:
@@ -1275,6 +1328,39 @@ def _safe_get_sampled_surface(data_node: Any | None) -> Any | None:
         if value is not None:
             return value
     return None
+
+
+def _push_color3(mapper: Any, setter_name: str, getter: Any | None) -> None:
+    """Read a 3-vector from ``getter`` and push it to ``mapper.<setter_name>``.
+
+    No-op when either side is absent (partial display nodes / the generic
+    fallback mapper).  Local twin of the BezierPlanningRepresentation helper
+    -- Representations stay independently importable, so no cross-module
+    import (module docstring contract).
+    """
+    if getter is None:
+        return
+    setter = getattr(mapper, setter_name, None)
+    if setter is None:
+        return
+    try:
+        c = getter()
+        setter(float(c[0]), float(c[1]), float(c[2]))
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _push_bool(mapper: Any, setter_name: str, getter: Any | None) -> None:
+    """Read a bool from ``getter`` and push it to ``mapper.<setter_name>``."""
+    if getter is None:
+        return
+    setter = getattr(mapper, setter_name, None)
+    if setter is None:
+        return
+    try:
+        setter(bool(getter()))
+    except Exception:  # pragma: no cover - defensive
+        pass
 
 
 def _safe_get_bool(node: Any | None, getter_name: str, *, default: bool) -> bool:

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -136,6 +136,12 @@ class ResectogramPipeline(_PipelineBase):
         self._resection_node: Any | None = None
         self._last_resection_scan_mtime: int | None = None
 
+        # The carrier's sibling ``vtkMRMLParametricSurfaceDisplayNode`` -- the
+        # band-style source shared with the 3D path.  Re-resolved every
+        # reconcile (a walk over the data node's own display-node list, no
+        # scene scan), so it carries no cache-invalidation obligations.
+        self._surface_display_node: Any | None = None
+
         # Whether a press-grabbed drag-reslice gesture is in flight: a
         # left-button press starts it, mouse moves keep producing picks
         # while it holds, the release ends it (see
@@ -206,6 +212,15 @@ class ResectogramPipeline(_PipelineBase):
                 self._resection_node = self._resolve_resection_node()
         if self._flattened_surface is not None:
             self._flattened_surface.SetResectionPlanNode(self._resection_node)
+            # Thread the carrier's SIBLING parametric-surface display node --
+            # the band-style source (margin colours + InterpolatedMargins)
+            # shared with the 3D path.  Resolved every reconcile: the walk is
+            # over the data node's own display-node list (no scene scan), so
+            # it is cheap and needs no cache invalidation.
+            self._surface_display_node = self._resolve_surface_display_node()
+            self._flattened_surface.SetSurfaceDisplayNode(
+                self._surface_display_node
+            )
             # Thread the cross-view locator (ADR-0025) so the strip's 2D
             # mapper paints the 1:1 correspondence marker.
             self._flattened_surface.SetLocatorNode(
@@ -535,6 +550,34 @@ class ResectogramPipeline(_PipelineBase):
             return (u, v)
         except Exception:  # pragma: no cover - defensive (stub renderers)
             return None
+
+    def _resolve_surface_display_node(self) -> Any | None:
+        """The carrier's sibling ``vtkMRMLParametricSurfaceDisplayNode``.
+
+        The carrier holds two display aspects -- the resectogram display node
+        (ours) and the parametric-surface display node the 3D path renders
+        from.  The latter carries the band STYLE (margin colours +
+        InterpolatedMargins -- Docs/architecture/target-mrml-node-hierarchy.md
+        keeps margin colours on the display node, scalars on the plan), so the
+        strip must read it too for the 2D and 3D bands to match.  Returns the
+        first parametric aspect on the data node, or ``None`` (compiled-in
+        mapper defaults then stand).  Same walk as the Stage-4 widget's
+        display-node resolution.
+        """
+        data_node = self._data_node
+        if data_node is None:
+            return None
+        try:
+            count = data_node.GetNumberOfDisplayNodes()
+            for i in range(count):
+                candidate = data_node.GetNthDisplayNode(i)
+                if candidate is not None and candidate.IsA(
+                    "vtkMRMLParametricSurfaceDisplayNode"
+                ):
+                    return candidate
+        except Exception:  # pragma: no cover - defensive (stub data nodes)
+            return None
+        return None
 
     @staticmethod
     def _resolve_locator_node(surface: Any) -> Any | None:

--- a/LiverResections/Testing/Python/test_flattened_surface_band_style.py
+++ b/LiverResections/Testing/Python/test_flattened_surface_band_style.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Resectogram-margins slice 1 -- band STYLE reaches the 2D mapper.
+
+The resectogram's flattened strip classifies its two margin bands in the
+``vtkOpenGLResection2DPolyDataMapper`` fragment shader from three STYLE
+inputs -- ``uResectionMarginColor``, ``uUncertaintyMarginColor``,
+``uInterpolatedMargins``.  Per the target node hierarchy
+(Docs/architecture/target-mrml-node-hierarchy.md, "display node carries
+margin colors only") these live on the SHARED
+``vtkMRMLParametricSurfaceDisplayNode`` -- the same node the 3D
+``BezierPlanningRepresentation`` reads -- so the 3D surface and the
+resectogram always show identical band colours from one source of truth.
+
+The gap this pins: ``FlattenedSurfaceRepresentation`` threads the margin
+SCALARS off the plan wrapper (``_apply_resection_margins``) but pushes NO
+style -- the 2D mapper silently rides its compiled-in defaults, and a
+user-edited colour or the InterpolatedMargins flag never reaches the strip.
+
+-- GL-FREE VIA A FAKE MAPPER --
+
+Same idiom as ``test_flattened_surface_plan_shading.py``: a fake mapper
+records the style setter calls so the threading is asserted without a GL
+context.  The actual band render stays on the :0 eyeball checklist of the
+resectogram-margins epic.
+
+-- WHY LAUNCHED-SLICER (soft) --
+
+The positive path reads a wrapped ``vtkMRMLParametricSurfaceDisplayNode``;
+skips cleanly under bare pytest via the shared ``slicer_pytest_support``
+guards + the ``SetSurfaceDisplayNode`` seam gate.
+
+-- WHY RED NOW --
+
+``FlattenedSurfaceRepresentation`` has no ``SetSurfaceDisplayNode`` seam, so
+every test SKIPS cleanly.  The skip lifts when slice 1 lands
+(ADR-0027 §Conformance).
+
+See also:
+  * Docs/adr/0031-distance-map-input-on-resection-plan.md (margins cluster)
+  * Docs/architecture/target-mrml-node-hierarchy.md (colour placement)
+  * LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+  * LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+    (the 3D style-threading precedent this ports)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+RESECTOGRAM_DISPLAY_NODE_CLASS = "vtkMRMLResectogramDisplayNode"
+SURFACE_DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+
+
+class _FakeResection2DMapper:
+    """GL-free stand-in recording the band-STYLE setter calls.
+
+    ``None`` recorders distinguish "never touched" from an explicit push --
+    the defaults invariant below relies on that: with no surface display
+    node threaded, NO style setter may fire, so the mapper's compiled-in
+    defaults stand and the pre-slice appearance is unchanged.
+    """
+
+    def __init__(self):
+        self.resection_margin_color = None
+        self.uncertainty_margin_color = None
+        self.interpolated_margins = None
+        self.resection_margin = None
+        self.uncertainty_margin = None
+        self.distance_map_texture = "sentinel"
+
+    def SetResectionMarginColor(self, r, g, b):  # noqa: N802 - VTK verb
+        self.resection_margin_color = (float(r), float(g), float(b))
+
+    def SetUncertaintyMarginColor(self, r, g, b):  # noqa: N802 - VTK verb
+        self.uncertainty_margin_color = (float(r), float(g), float(b))
+
+    def SetInterpolatedMargins(self, flag):  # noqa: N802 - VTK verb
+        self.interpolated_margins = bool(flag)
+
+    def SetResectionMargin(self, value):  # noqa: N802 - VTK verb
+        self.resection_margin = float(value)
+
+    def SetUncertaintyMargin(self, value):  # noqa: N802 - VTK verb
+        self.uncertainty_margin = float(value)
+
+    def SetDistanceMapTextureObject(self, texture):  # noqa: N802 - VTK verb
+        self.distance_map_texture = texture
+
+    def GetDistanceMapTextureObject(self):  # noqa: N802 - VTK verb
+        return None if self.distance_map_texture == "sentinel" else self.distance_map_texture
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_representation_or_skip():
+    try:
+        from LiverResectionsLib.Representations.FlattenedSurfaceRepresentation import (
+            FlattenedSurfaceRepresentation,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            "FlattenedSurfaceRepresentation not importable "
+            f"({exc!r}) -- not reachable in this environment."
+        )
+    return FlattenedSurfaceRepresentation()
+
+
+def _require_band_style_seam_or_skip(rep):
+    """Skip unless the band-style seam (resectogram-margins slice 1) landed.
+
+    RED == the Representation has no ``SetSurfaceDisplayNode`` -- the seam
+    that threads the shared parametric-surface display node's margin
+    colours + InterpolatedMargins onto the 2D mapper.
+    """
+    if not hasattr(rep, "SetSurfaceDisplayNode"):
+        pytest.skip(
+            "FlattenedSurfaceRepresentation has no SetSurfaceDisplayNode -- "
+            "the resectogram-margins band-style seam has not landed."
+        )
+
+
+def _inject_fake_mapper(rep):
+    fake = _FakeResection2DMapper()
+    rep._resection_mapper_2d = fake
+    return fake
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def test_band_style_threads_from_surface_display_node():
+    """Non-default colours + the interpolated flag reach the 2D mapper.
+
+    Deliberately NON-default values (green / blue, interpolated on) so the
+    assertion cannot pass by the mapper's compiled-in red / yellow defaults.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_band_style_seam_or_skip(rep)
+
+    fake = _inject_fake_mapper(rep)
+
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+    surface_display = _add_or_skip(slicer, SURFACE_DISPLAY_NODE_CLASS)
+    if not hasattr(surface_display, "SetResectionMarginColor"):
+        pytest.skip(f"{SURFACE_DISPLAY_NODE_CLASS} has no margin-colour fields.")
+
+    surface_display.SetResectionMarginColor(0.0, 1.0, 0.0)
+    surface_display.SetUncertaintyMarginColor(0.0, 0.0, 1.0)
+    surface_display.SetInterpolatedMargins(True)
+
+    rep.SetSurfaceDisplayNode(surface_display)
+    rep.update(display, data)
+
+    assert fake.resection_margin_color is not None, (
+        "the shared display node's ResectionMarginColor must reach the 2D "
+        "mapper's SetResectionMarginColor -- no colour was threaded."
+    )
+    assert all(
+        abs(a - b) < 1e-5
+        for a, b in zip(fake.resection_margin_color, (0.0, 1.0, 0.0))
+    ), f"expected (0,1,0); got {fake.resection_margin_color}."
+    assert fake.uncertainty_margin_color is not None and all(
+        abs(a - b) < 1e-5
+        for a, b in zip(fake.uncertainty_margin_color, (0.0, 0.0, 1.0))
+    ), f"expected (0,0,1); got {fake.uncertainty_margin_color}."
+    assert fake.interpolated_margins is True, (
+        "the shared display node's InterpolatedMargins must reach the 2D "
+        f"mapper; got {fake.interpolated_margins!r}."
+    )
+
+
+def test_band_style_untouched_without_surface_display_node():
+    """No surface display node -> NO style setter fires.
+
+    The mapper's compiled-in defaults must stand (red / yellow, hard band),
+    keeping the pre-slice appearance byte-identical for carriers that have no
+    parametric-surface display node (resectogram-only fixtures).
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_band_style_seam_or_skip(rep)
+
+    fake = _inject_fake_mapper(rep)
+
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+
+    rep.SetSurfaceDisplayNode(None)
+    rep.update(display, data)
+
+    assert fake.resection_margin_color is None, (
+        "with no surface display node the Representation must NOT touch "
+        "SetResectionMarginColor (compiled-in defaults stand); got "
+        f"{fake.resection_margin_color!r}."
+    )
+    assert fake.uncertainty_margin_color is None
+    assert fake.interpolated_margins is None
+
+
+def test_band_style_is_orthogonal_to_the_plan_wrapper():
+    """Style threads even with NO plan wrapper wired.
+
+    Colours / interpolation are display state, margins are plan state
+    (ADR-0031); a carrier whose plan is not yet resolved must still show the
+    user-chosen band style the moment the shader has a band to draw.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_band_style_seam_or_skip(rep)
+
+    fake = _inject_fake_mapper(rep)
+
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+    surface_display = _add_or_skip(slicer, SURFACE_DISPLAY_NODE_CLASS)
+    if not hasattr(surface_display, "SetResectionMarginColor"):
+        pytest.skip(f"{SURFACE_DISPLAY_NODE_CLASS} has no margin-colour fields.")
+
+    surface_display.SetResectionMarginColor(1.0, 0.0, 1.0)
+
+    rep.SetResectionPlanNode(None)
+    rep.SetSurfaceDisplayNode(surface_display)
+    rep.update(display, data)
+
+    assert fake.resection_margin_color is not None and all(
+        abs(a - b) < 1e-5
+        for a, b in zip(fake.resection_margin_color, (1.0, 0.0, 1.0))
+    ), (
+        "band style must thread independently of the plan wrapper; got "
+        f"{fake.resection_margin_color!r}."
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/LiverResections/Testing/Python/test_resectogram_pipeline_resolves_surface_display.py
+++ b/LiverResections/Testing/Python/test_resectogram_pipeline_resolves_surface_display.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Resectogram-margins slice 1 -- the Pipeline resolves the style display node.
+
+The band STYLE (margin colours + InterpolatedMargins) lives on the shared
+``vtkMRMLParametricSurfaceDisplayNode`` that hangs off the carrier as a
+SIBLING of the resectogram display node (one carrier, two display aspects --
+Docs/architecture/current-mrml-node-hierarchy.md).  For the strip to show
+user-chosen colours, the ``ResectogramPipeline`` must resolve that sibling
+and hand it to the ``FlattenedSurfaceRepresentation`` via
+``SetSurfaceDisplayNode`` -- mirroring how it already reverse-resolves the
+plan wrapper (``test_resectogram_pipeline_resolves_resection_plan.py``).
+
+-- WHY LAUNCHED-SLICER --
+
+Needs the wrapped display nodes + the ``ResectogramPipeline`` whose base
+``vtkMRMLLayerDMScriptedPipeline`` is constructible only inside a Slicer
+process with SlicerLayerDM loaded.  Skips cleanly under bare pytest.
+
+-- WHY RED NOW --
+
+The Pipeline has no surface-display resolution seam and the Representation
+has no ``SetSurfaceDisplayNode``, so the tests SKIP cleanly.  The skip lifts
+when resectogram-margins slice 1 lands (ADR-0027 §Conformance).
+
+See also:
+  * Docs/architecture/target-mrml-node-hierarchy.md (colour placement)
+  * LiverResections/LiverResectionsLib/ResectogramPipeline.py
+  * LiverResections/Testing/Python/test_resectogram_pipeline_resolves_resection_plan.py
+    (the plan-wrapper resolution precedent this mirrors)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+RESECTOGRAM_DISPLAY_NODE_CLASS = "vtkMRMLResectogramDisplayNode"
+SURFACE_DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_pipeline_or_skip():
+    pytest.importorskip(
+        "LayerDMLib",
+        reason="ResectogramPipeline's base vtkMRMLLayerDMScriptedPipeline is "
+        "only constructible inside a Slicer process with SlicerLayerDM loaded "
+        "(the launched pytest_launched row); skipping under bare pytest.",
+    )
+    try:
+        from LiverResectionsLib.ResectogramPipeline import ResectogramPipeline
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"ResectogramPipeline not importable ({exc!r}).")
+    return ResectogramPipeline()
+
+
+def _require_style_seam_or_skip(pipeline):
+    """Skip unless the surface-display resolution seam (slice 1) landed."""
+    try:
+        from LiverResectionsLib.Representations.FlattenedSurfaceRepresentation import (
+            FlattenedSurfaceRepresentation,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"FlattenedSurfaceRepresentation not importable ({exc!r}).")
+    if not hasattr(FlattenedSurfaceRepresentation, "SetSurfaceDisplayNode"):
+        pytest.skip(
+            "FlattenedSurfaceRepresentation has no SetSurfaceDisplayNode -- "
+            "resectogram-margins slice 1 has not landed."
+        )
+    if not hasattr(pipeline, "_resolve_surface_display_node"):
+        pytest.skip(
+            "ResectogramPipeline has no _resolve_surface_display_node -- "
+            "resectogram-margins slice 1 has not landed."
+        )
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+class _RecordingRepresentation:
+    """Spy standing in for the FlattenedSurfaceRepresentation.
+
+    Records the display node handed through ``SetSurfaceDisplayNode`` --
+    "never called" (sentinel) is distinct from an explicit ``None``.
+    """
+
+    def __init__(self):
+        self.surface_display_node = "sentinel"
+
+    def SetSurfaceDisplayNode(self, node):  # noqa: N802 - VTK verb
+        self.surface_display_node = node
+
+    def SetResectionPlanNode(self, node):  # noqa: N802 - VTK verb
+        pass
+
+    def SetLocatorNode(self, node):  # noqa: N802 - VTK verb
+        pass
+
+    def update(self, display_node, data_node):
+        pass
+
+
+def _wire_carrier(slicer):
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+    data.SetAndObserveDisplayNodeID(display.GetID())
+    if display.GetDisplayableNode() is not data:
+        pytest.skip(
+            "display.GetDisplayableNode() does not resolve the carrier in "
+            "this build -- cannot exercise the Pipeline's data-node derivation."
+        )
+    return data, display
+
+
+def _spy_flattened_representation(pipeline):
+    """Dispatch once so the Representations exist, then swap in the spy."""
+    pipeline.UpdatePipeline()
+    spy = _RecordingRepresentation()
+    pipeline._flattened_surface = spy
+    # Invalidate the memo so the next dispatch re-threads into the spy.
+    pipeline._last_update_key = None
+    return spy
+
+
+def test_pipeline_threads_sibling_surface_display_node():
+    """Carrier with BOTH display aspects -> the parametric one is threaded.
+
+    Wire ``data <--displayable-- {resectogram-display, surface-display}``;
+    after a dispatch the flattened Representation must have received the
+    PARAMETRIC display node (the style source) via ``SetSurfaceDisplayNode``.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_style_seam_or_skip(pipeline)
+
+    data, display = _wire_carrier(slicer)
+    surface_display = _add_or_skip(slicer, SURFACE_DISPLAY_NODE_CLASS)
+    data.AddAndObserveDisplayNodeID(surface_display.GetID())
+
+    pipeline.SetDisplayNode(display)
+    spy = _spy_flattened_representation(pipeline)
+    pipeline.UpdatePipeline()
+
+    assert spy.surface_display_node is surface_display, (
+        "the Pipeline must resolve the carrier's sibling "
+        "vtkMRMLParametricSurfaceDisplayNode and thread it via "
+        "SetSurfaceDisplayNode (the band-style source); got "
+        f"{spy.surface_display_node!r}."
+    )
+
+
+def test_pipeline_threads_none_without_sibling_display_node():
+    """Resectogram-only carrier -> explicit ``SetSurfaceDisplayNode(None)``.
+
+    Pins the graceful default: no parametric sibling means the Representation
+    is told so (not left stale), and the mapper's compiled-in colours stand.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_style_seam_or_skip(pipeline)
+
+    data, display = _wire_carrier(slicer)
+
+    pipeline.SetDisplayNode(display)
+    spy = _spy_flattened_representation(pipeline)
+    pipeline.UpdatePipeline()
+
+    assert spy.surface_display_node is None, (
+        "a carrier with no parametric-surface display node must thread an "
+        "explicit None (never leave the spy untouched at the sentinel); got "
+        f"{spy.surface_display_node!r}."
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Slice 1 of the resectogram-margins epic (plan-approved 2026-08-20): the
2D resectogram mapper classifies its margin bands from
`uResectionMarginColor` / `uUncertaintyMarginColor` /
`uInterpolatedMargins`, but nothing pushed them — user-chosen band style
never reached the strip. The `FlattenedSurfaceRepresentation` gains a
`SetSurfaceDisplayNode` seam + `_apply_band_style`, and the
`ResectogramPipeline` resolves the carrier's sibling
`vtkMRMLParametricSurfaceDisplayNode` each reconcile and threads it.
One style source shared with the 3D path, no new MRML fields.

## ADR references

- ADR-0031: distance-map input on resection plan — realises the colour
  half of its margin cluster; scalars-on-plan / colours-on-display
  discipline upheld (target-mrml-node-hierarchy).
- ADR-0027: invariant-test-first — both suites landed red-as-skip in the
  first commit.
- ADR-0039: working agreements — sub-PR on the `feature/resectogram-margins`
  epic branch, ≤400 lines.

## Reviewer's map

Read order: (1) `test_flattened_surface_band_style.py` — the contract;
(2) `test_resectogram_pipeline_resolves_surface_display.py` — the
resolution contract; (3) `FlattenedSurfaceRepresentation.py` —
load-bearing: the seam, `_apply_band_style`, its call site right after
`_apply_resection_margins`; (4) `ResectogramPipeline.py` —
load-bearing: `_resolve_surface_display_node` + the pre-memo threading.
Mechanical: the `_push_color3`/`_push_bool` module helpers (local twins
of the BezierPlanningRepresentation ones — Representations stay
independently importable), the `cleanup()` null, the init members.

## Test plan

- Bare harness: all new tests skip cleanly (verified locally, 11 skips
  across new + sentinel files).
- Launched (CI): both new suites run; sentinels
  `test_resectogram_pipeline_memo_key.py` (unmodified) and
  `test_flattened_surface_plan_shading.py` must stay green.
- On-screen band colours are eyeball-verified at the end of the epic
  (checklist in the epic's final PR).

## UX impact

None yet — behaviour is identical until something writes non-default
colours (slice 3 adds the UI).

---
🤖 This PR was drafted with AI assistance (Claude Fable 5 via Claude
Code); the maintainer reviewed and directed the changes.
