### PR TITLE
BUG: Repaint the resectogram on margin and band-style edits

### DIFF
--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -1402,6 +1402,14 @@ class LiverBezierSurfacePipeline(_PipelineBase):
                 _machine.phase_token(self._data_node),
                 _safe_get_picked_position(self._locator_node),
                 _safe_get_locator_visibility(self._locator_node),
+                # Margin scalars + band style are visible dispatch inputs
+                # too: a spinbox edit re-threads the mapper uniforms via the
+                # MTime-keyed reconcile above, but without these VALUE
+                # components the view stayed stale until an unrelated
+                # repaint (a camera orbit).  Values, never MTimes -- same
+                # feedback-loop guard as every other component.
+                _safe_get_plan_margins(self._resection_node),
+                _safe_get_band_style(self._display_node),
             )
             if render_key == self._last_render_key:
                 return
@@ -1443,6 +1451,37 @@ def _safe_get_mtime(node: Any) -> int:
     if node is None:
         return 0
     return int(node.GetMTime())
+
+
+def _safe_get_plan_margins(node: Any) -> tuple | None:
+    """The plan wrapper's ``(SafetyMargin_mm, RiskMargin_mm)``; None sans node.
+
+    A render-key VALUE component: a margin edit changes it (one coalesced
+    repaint), render-induced ``Modified`` churn does not.
+    """
+    if node is None:
+        return None
+    try:
+        return (float(node.GetSafetyMargin_mm()), float(node.GetRiskMargin_mm()))
+    except Exception:  # pragma: no cover - defensive (stub plans)
+        return None
+
+
+def _safe_get_band_style(node: Any) -> tuple | None:
+    """The display node's ``(marginRGB, uncertaintyRGB, interpolated)``.
+
+    ``None`` sans node; a render-key VALUE component like the margins.
+    """
+    if node is None:
+        return None
+    try:
+        return (
+            tuple(float(c) for c in node.GetResectionMarginColor()),
+            tuple(float(c) for c in node.GetUncertaintyMarginColor()),
+            bool(node.GetInterpolatedMargins()),
+        )
+    except Exception:  # pragma: no cover - defensive (stub displays)
+        return None
 
 
 def _safe_get_locator_visibility(node: Any) -> bool | None:

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -550,10 +550,11 @@ class BezierPlanningRepresentation:
         Ports ``vtkSlicerBezierSurfaceRepresentation3D::UpdateBezierSurfaceDisplay``.
         A no-op on the generic fallback mapper, which has no ``SetResection*``
         surface — there the colour rides on the actor property set by the
-        caller.  Margin scalars (``SetResectionMargin`` / ``SetUncertaintyMargin``)
-        are intentionally left at the mapper defaults: the v2 node hierarchy
-        carries no margin field yet, and the margins only bias the distance
-        field, which is not bound in this slice.
+        caller.  Margin SCALARS (``SetResectionMargin`` / ``SetUncertaintyMargin``)
+        are not pushed here — they are plan-wrapper state
+        (``SafetyMargin_mm`` / ``RiskMargin_mm``, ADR-0031) threaded by
+        ``_apply_resection_plan``; this method pushes only the display node's
+        decoration (colours, flags, grid).
         """
         mapper = self._surface_mapper
         if mapper is None:

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -218,6 +218,13 @@ class FlattenedSurfaceRepresentation:
         # which live on the carrier (ADR-0014 §"Fourth layer").
         self._resection_plan_node: Any | None = None
 
+        # The SHARED ``vtkMRMLParametricSurfaceDisplayNode`` -- the carrier's
+        # sibling display aspect carrying the band STYLE (margin colours +
+        # InterpolatedMargins).  One source of truth with the 3D surface
+        # (Docs/architecture/target-mrml-node-hierarchy.md: the display node
+        # carries margin COLORS only; the scalars stay on the plan wrapper).
+        self._surface_display_node: Any | None = None
+
         # The cross-view ``vtkMRMLLocatorNode`` (ADR-0025), threaded by the
         # ResectogramPipeline like the plan node; drives the 2D mapper's
         # uLocatorPosition / uLocatorRadius marker uniforms.
@@ -264,6 +271,18 @@ class FlattenedSurfaceRepresentation:
         no-distance-map fallback).
         """
         self._resection_plan_node = plan_node
+
+    def SetSurfaceDisplayNode(self, display_node: Any | None) -> None:  # noqa: N802 - VTK verb
+        """Attach the shared ``vtkMRMLParametricSurfaceDisplayNode``.
+
+        The ResectogramPipeline resolves the carrier's parametric-surface
+        display aspect and threads it here so the strip's band STYLE (margin
+        colours + InterpolatedMargins) reads from the SAME node the 3D
+        ``BezierPlanningRepresentation`` reads -- 2D and 3D bands can never
+        diverge.  ``None`` clears it; the 2D mapper's compiled-in defaults
+        then stand untouched.
+        """
+        self._surface_display_node = display_node
 
     def SetLocatorNode(self, locator_node: Any | None) -> None:  # noqa: N802 - VTK verb
         """Attach the cross-view locator node (ADR-0025); ``None`` clears."""
@@ -352,6 +371,7 @@ class FlattenedSurfaceRepresentation:
         self._distance_map_volume = None
         self._effective_texture_num_comps = 0
         self._locator_node = None
+        self._surface_display_node = None
 
         # Detach BEFORE dropping the actor handles: nulling the marker actor
         # first would make _detach_actors skip it and leak it into the
@@ -658,6 +678,36 @@ class FlattenedSurfaceRepresentation:
         if risk is not None and set_uncertainty is not None:
             set_uncertainty(float(risk()))
 
+    def _apply_band_style(self, mapper: Any) -> None:
+        """Thread the shared display node's band STYLE onto the 2D mapper.
+
+        Margin COLOURS + the InterpolatedMargins flag live on the carrier's
+        ``vtkMRMLParametricSurfaceDisplayNode`` -- the same node the 3D
+        ``BezierPlanningRepresentation`` reads -- so both views classify their
+        bands with identical style from one source of truth
+        (Docs/architecture/target-mrml-node-hierarchy.md).  A no-op when no
+        display node is wired: the mapper's compiled-in defaults stand, so
+        carriers without the parametric aspect keep the historic appearance.
+        """
+        display = self._surface_display_node
+        if display is None:
+            return
+        _push_color3(
+            mapper,
+            "SetResectionMarginColor",
+            getattr(display, "GetResectionMarginColor", None),
+        )
+        _push_color3(
+            mapper,
+            "SetUncertaintyMarginColor",
+            getattr(display, "GetUncertaintyMarginColor", None),
+        )
+        _push_bool(
+            mapper,
+            "SetInterpolatedMargins",
+            getattr(display, "GetInterpolatedMargins", None),
+        )
+
     def _apply_distance_map_texture(
         self, display_node: Any | None, data_node: Any | None
     ) -> None:
@@ -688,6 +738,9 @@ class FlattenedSurfaceRepresentation:
         # texture is bound), so they must be set even on the no-distance-map /
         # deferred-GL paths below.  Mirrors BezierPlanningRepresentation.
         self._apply_resection_margins(mapper)
+        # Band STYLE (colours + interpolation) rides the same early slot for
+        # the same reason: display state, valid without any texture bound.
+        self._apply_band_style(mapper)
 
         bind = getattr(mapper, "SetDistanceMapTextureObject", None)
         if bind is None:
@@ -1275,6 +1328,39 @@ def _safe_get_sampled_surface(data_node: Any | None) -> Any | None:
         if value is not None:
             return value
     return None
+
+
+def _push_color3(mapper: Any, setter_name: str, getter: Any | None) -> None:
+    """Read a 3-vector from ``getter`` and push it to ``mapper.<setter_name>``.
+
+    No-op when either side is absent (partial display nodes / the generic
+    fallback mapper).  Local twin of the BezierPlanningRepresentation helper
+    -- Representations stay independently importable, so no cross-module
+    import (module docstring contract).
+    """
+    if getter is None:
+        return
+    setter = getattr(mapper, setter_name, None)
+    if setter is None:
+        return
+    try:
+        c = getter()
+        setter(float(c[0]), float(c[1]), float(c[2]))
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+def _push_bool(mapper: Any, setter_name: str, getter: Any | None) -> None:
+    """Read a bool from ``getter`` and push it to ``mapper.<setter_name>``."""
+    if getter is None:
+        return
+    setter = getattr(mapper, setter_name, None)
+    if setter is None:
+        return
+    try:
+        setter(bool(getter()))
+    except Exception:  # pragma: no cover - defensive
+        pass
 
 
 def _safe_get_bool(node: Any | None, getter_name: str, *, default: bool) -> bool:

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -176,8 +176,9 @@ class ResectogramPipeline(_PipelineBase):
         is a no-op observationally — the memoised key short-circuits the work
         (`ADR-0013`_ §3).
 
-        The key is the data node's control-point GEOMETRY digest ALONE.  It
-        deliberately does NOT fold in ``GetMTime`` of the data or display node:
+        The key is ``(control-point geometry digest, band-state digest)`` --
+        both VALUE digests.  It deliberately does NOT fold in ``GetMTime`` of
+        any node:
         a maximize binds the resectogram view node to two live qMRMLThreeDViews
         whose renders re-``Modified()`` the surface AND the resectogram display
         node every frame, advancing those MTimes WITHOUT any geometry change.
@@ -188,7 +189,10 @@ class ResectogramPipeline(_PipelineBase):
         churn at fixed geometry leaves the digest unchanged → short-circuit →
         the loop is broken.  A markups control-point DRAG also advances only
         the control-point structure, not the node ``GetMTime``, so the digest
-        is the correct reactivity signal on both counts.
+        is the correct reactivity signal on both counts.  The band-state half
+        extends the same discipline to the plan's margins and the shared
+        display node's colours / InterpolatedMargins: an EDIT changes the
+        digested values (re-thread + repaint), churn does not.
         """
         try:
             self._reconcile()
@@ -210,14 +214,25 @@ class ResectogramPipeline(_PipelineBase):
             if scene_mtime != self._last_resection_scan_mtime:
                 self._last_resection_scan_mtime = scene_mtime
                 self._resection_node = self._resolve_resection_node()
+        # Resolve the carrier's SIBLING parametric-surface display node -- the
+        # band-style source (margin colours + InterpolatedMargins) shared with
+        # the 3D path.  Resolved every reconcile: the walk is over the data
+        # node's own display-node list (no scene scan), so it is cheap and
+        # needs no cache invalidation.  Resolved BEFORE the memo key so the
+        # band-state digest below always sees the current node.
+        self._surface_display_node = self._resolve_surface_display_node()
+
+        # Observe the resolved STATE nodes (ADR-0013 §4: the observation set
+        # includes nodes the displayed concept depends on) so a margin or
+        # band-style edit reaches ``UpdatePipeline`` with no external caller.
+        # Membership-guarded: ``_reattach_node_observers`` drains the set on
+        # renderer churn and the next reconcile re-attaches exactly once.
+        for state_node in (self._resection_node, self._surface_display_node):
+            if state_node is not None and state_node not in self._observed_node_refs:
+                self._attach_observer(state_node)
+
         if self._flattened_surface is not None:
             self._flattened_surface.SetResectionPlanNode(self._resection_node)
-            # Thread the carrier's SIBLING parametric-surface display node --
-            # the band-style source (margin colours + InterpolatedMargins)
-            # shared with the 3D path.  Resolved every reconcile: the walk is
-            # over the data node's own display-node list (no scene scan), so
-            # it is cheap and needs no cache invalidation.
-            self._surface_display_node = self._resolve_surface_display_node()
             self._flattened_surface.SetSurfaceDisplayNode(
                 self._surface_display_node
             )
@@ -227,7 +242,12 @@ class ResectogramPipeline(_PipelineBase):
                 self._resolve_locator_node(self._data_node)
             )
 
-        key = _safe_get_control_points_digest(self._data_node)
+        key = (
+            _safe_get_control_points_digest(self._data_node),
+            _safe_get_band_state_digest(
+                self._resection_node, self._surface_display_node
+            ),
+        )
         if key == self._last_update_key:
             return  # idempotent short-circuit
         self._last_update_key = key
@@ -803,11 +823,51 @@ def _safe_get_scene_mtime(node: Any) -> int | None:
     return int(scene.GetMTime())
 
 
+def _safe_get_band_state_digest(plan: Any, surface_display: Any) -> tuple:
+    """Return a VALUE digest of the margin band state.
+
+    The second half of ``UpdatePipeline``'s memo key: the plan wrapper's
+    margin scalars and the shared parametric-surface display node's band
+    style.  VALUES, never MTimes — render-induced ``Modified`` churn at
+    fixed state leaves the digest unchanged (the render-storm guard extends
+    over the band state), while a real margin / colour / interpolation edit
+    changes it and re-threads the mappers.  ``None`` nodes contribute
+    nothing, so a bare surface digests to a constant.
+    """
+    digest = []
+    if plan is not None:
+        try:
+            digest.append(
+                (
+                    float(plan.GetSafetyMargin_mm()),
+                    float(plan.GetRiskMargin_mm()),
+                )
+            )
+        except Exception:  # pragma: no cover - defensive (stub plans)
+            pass
+    if surface_display is not None:
+        try:
+            digest.append(
+                (
+                    tuple(float(c) for c in surface_display.GetResectionMarginColor()),
+                    tuple(
+                        float(c)
+                        for c in surface_display.GetUncertaintyMarginColor()
+                    ),
+                    bool(surface_display.GetInterpolatedMargins()),
+                )
+            )
+        except Exception:  # pragma: no cover - defensive (stub displays)
+            pass
+    return tuple(digest)
+
+
 def _safe_get_control_points_digest(node: Any) -> tuple:
     """Return a digest of the data node's control-point positions.
 
-    This digest is the SOLE memoisation key for ``UpdatePipeline`` (it does
-    NOT fold in ``GetMTime``): a control-point edit changes the digest, while
+    The geometry half of ``UpdatePipeline``'s memo key (paired with
+    ``_safe_get_band_state_digest``; neither folds in ``GetMTime``): a
+    control-point edit changes the digest, while
     a render-induced ``Modified`` at fixed geometry does not, which is exactly
     the discrimination that keeps edits reactive while breaking the maximize
     render storm.  A control-point edit advances the geometry digest (so

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -136,6 +136,12 @@ class ResectogramPipeline(_PipelineBase):
         self._resection_node: Any | None = None
         self._last_resection_scan_mtime: int | None = None
 
+        # The carrier's sibling ``vtkMRMLParametricSurfaceDisplayNode`` -- the
+        # band-style source shared with the 3D path.  Re-resolved every
+        # reconcile (a walk over the data node's own display-node list, no
+        # scene scan), so it carries no cache-invalidation obligations.
+        self._surface_display_node: Any | None = None
+
         # Whether a press-grabbed drag-reslice gesture is in flight: a
         # left-button press starts it, mouse moves keep producing picks
         # while it holds, the release ends it (see
@@ -206,6 +212,15 @@ class ResectogramPipeline(_PipelineBase):
                 self._resection_node = self._resolve_resection_node()
         if self._flattened_surface is not None:
             self._flattened_surface.SetResectionPlanNode(self._resection_node)
+            # Thread the carrier's SIBLING parametric-surface display node --
+            # the band-style source (margin colours + InterpolatedMargins)
+            # shared with the 3D path.  Resolved every reconcile: the walk is
+            # over the data node's own display-node list (no scene scan), so
+            # it is cheap and needs no cache invalidation.
+            self._surface_display_node = self._resolve_surface_display_node()
+            self._flattened_surface.SetSurfaceDisplayNode(
+                self._surface_display_node
+            )
             # Thread the cross-view locator (ADR-0025) so the strip's 2D
             # mapper paints the 1:1 correspondence marker.
             self._flattened_surface.SetLocatorNode(
@@ -535,6 +550,34 @@ class ResectogramPipeline(_PipelineBase):
             return (u, v)
         except Exception:  # pragma: no cover - defensive (stub renderers)
             return None
+
+    def _resolve_surface_display_node(self) -> Any | None:
+        """The carrier's sibling ``vtkMRMLParametricSurfaceDisplayNode``.
+
+        The carrier holds two display aspects -- the resectogram display node
+        (ours) and the parametric-surface display node the 3D path renders
+        from.  The latter carries the band STYLE (margin colours +
+        InterpolatedMargins -- Docs/architecture/target-mrml-node-hierarchy.md
+        keeps margin colours on the display node, scalars on the plan), so the
+        strip must read it too for the 2D and 3D bands to match.  Returns the
+        first parametric aspect on the data node, or ``None`` (compiled-in
+        mapper defaults then stand).  Same walk as the Stage-4 widget's
+        display-node resolution.
+        """
+        data_node = self._data_node
+        if data_node is None:
+            return None
+        try:
+            count = data_node.GetNumberOfDisplayNodes()
+            for i in range(count):
+                candidate = data_node.GetNthDisplayNode(i)
+                if candidate is not None and candidate.IsA(
+                    "vtkMRMLParametricSurfaceDisplayNode"
+                ):
+                    return candidate
+        except Exception:  # pragma: no cover - defensive (stub data nodes)
+            return None
+        return None
 
     @staticmethod
     def _resolve_locator_node(surface: Any) -> Any | None:

--- a/LiverResections/Testing/Python/test_bezier_planning_margin_render_key.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_margin_render_key.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Resectogram-margins slice 2 -- the 3D view repaints on margin edits.
+
+The 3D twin of ``test_resectogram_pipeline_margin_repaint.py``.  The
+``LiverBezierSurfacePipeline`` already OBSERVES the plan wrapper and its
+display node, and its reconcile key already folds their MTimes -- so a
+margin write re-threads the mapper uniforms.  What it does NOT do is
+request a render: ``_on_node_modified``'s ``render_key`` digests only the
+visible dispatch inputs (state / geometry / slicing plane / phase /
+locator) and has no margin or band-style component, so the surface shows
+stale bands until an unrelated repaint (a camera orbit).  Slice 2 extends
+the render key with the margin + band-style VALUES -- values, never
+MTimes, keeping the documented render feedback-loop guard intact.
+
+-- WHY LAUNCHED-SLICER --
+
+Needs the wrapped plan / carrier / display nodes + a constructible
+``LiverBezierSurfacePipeline``.  Skips cleanly under bare pytest.
+
+-- WHY RED NOW --
+
+The pipeline module has no ``_safe_get_plan_margins`` accessor, so the
+tests SKIP cleanly.  The skip lifts when slice 2 lands
+(ADR-0027 §Conformance).
+
+See also:
+  * LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+    (_on_node_modified -- the render_key this extends)
+  * LiverResections/Testing/Python/test_pipeline_resolves_resection_plan.py
+    (the construction idiom this clones)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_pipeline_or_skip():
+    try:
+        from LiverResectionsLib.LiverBezierSurfacePipeline import (
+            LiverBezierSurfacePipeline,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            f"LiverBezierSurfacePipeline not importable ({exc!r}) -- LayerDMLib "
+            "not reachable in this environment."
+        )
+    return LiverBezierSurfacePipeline()
+
+
+def _require_margin_render_seam_or_skip():
+    """Skip unless the margin render-key extension (slice 2) has landed."""
+    import LiverResectionsLib.LiverBezierSurfacePipeline as module
+
+    if not hasattr(module, "_safe_get_plan_margins"):
+        pytest.skip(
+            "LiverBezierSurfacePipeline has no _safe_get_plan_margins -- "
+            "resectogram-margins slice 2 has not landed."
+        )
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def _wire_pipeline(slicer, pipeline):
+    """plan --geometry--> data <--displayable-- display; dispatched once."""
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, DISPLAY_NODE_CLASS)
+    data.SetAndObserveDisplayNodeID(display.GetID())
+    if display.GetDisplayableNode() is not data:
+        pytest.skip(
+            "display.GetDisplayableNode() does not resolve the carrier in "
+            "this build."
+        )
+    plan = _add_or_skip(slicer, PLAN_NODE_CLASS)
+    if not hasattr(plan, "SetAndObserveGeometryNode"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveGeometryNode.")
+    plan.SetAndObserveGeometryNode(data)
+    if not hasattr(plan, "SetSafetyMargin_mm"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetSafetyMargin_mm.")
+
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+    # Settle the render key: drive the observer once so _last_render_key
+    # holds the current state before the margin edit under test.
+    pipeline._on_node_modified(None, None)
+    return data, display, plan
+
+
+def _count_renders(pipeline, action):
+    calls = []
+    original = pipeline.RequestRender
+    pipeline.RequestRender = lambda: calls.append(1)  # wrap: count only
+    try:
+        action()
+    finally:
+        pipeline.RequestRender = original
+    return len(calls)
+
+
+def test_margin_write_requests_exactly_one_render():
+    """A margin edit at fixed geometry repaints the 3D surface -- once.
+
+    The plan observer routes the write into ``_on_node_modified``; the
+    extended render key sees new margin VALUES -> exactly one coalesced
+    ``RequestRender``.  Without the extension the bands stay stale until a
+    camera orbit.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_margin_render_seam_or_skip()
+
+    data, display, plan = _wire_pipeline(slicer, pipeline)
+
+    renders = _count_renders(pipeline, lambda: plan.SetSafetyMargin_mm(9.0))
+
+    assert renders == 1, (
+        "a SafetyMargin_mm write at fixed geometry must request exactly one "
+        f"render through the extended render key; got {renders}."
+    )
+
+
+def test_noop_modified_requests_no_render():
+    """A ``Modified`` with nothing changed stays silent.
+
+    Values-not-MTimes: firing the plan's ``Modified`` without changing any
+    digested value must not re-request -- the render feedback-loop guard the
+    key extension must not weaken.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_margin_render_seam_or_skip()
+
+    data, display, plan = _wire_pipeline(slicer, pipeline)
+    plan.SetSafetyMargin_mm(9.0)  # settle a non-default value first
+
+    renders = _count_renders(pipeline, plan.Modified)
+
+    assert renders == 0, (
+        "a no-op Modified (no digested value changed) must not request a "
+        f"render; got {renders} -- the feedback-loop guard regressed."
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/LiverResections/Testing/Python/test_bezier_planning_margin_render_key.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_margin_render_key.py
@@ -66,12 +66,20 @@ def _make_pipeline_or_skip():
 
 def _require_margin_render_seam_or_skip():
     """Skip unless the margin render-key extension (slice 2) has landed."""
-    import LiverResectionsLib.LiverBezierSurfacePipeline as module
+    import importlib
+
+    # importlib.import_module returns the real submodule from
+    # sys.modules; a plain ``import X.Y as module`` resolves through
+    # the package ATTRIBUTE, which the package __init__'s
+    # ``from .Y import Y`` re-binds to the CLASS -- hasattr on that
+    # never sees module-level functions.
+    module = importlib.import_module("LiverResectionsLib.LiverBezierSurfacePipeline")
 
     if not hasattr(module, "_safe_get_plan_margins"):
         pytest.skip(
             "LiverBezierSurfacePipeline has no _safe_get_plan_margins -- "
-            "resectogram-margins slice 2 has not landed."
+            "resectogram-margins slice 2 has not landed (imported from "
+            f"{getattr(module, '__file__', '?')})."
         )
 
 

--- a/LiverResections/Testing/Python/test_flattened_surface_band_style.py
+++ b/LiverResections/Testing/Python/test_flattened_surface_band_style.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Resectogram-margins slice 1 -- band STYLE reaches the 2D mapper.
+
+The resectogram's flattened strip classifies its two margin bands in the
+``vtkOpenGLResection2DPolyDataMapper`` fragment shader from three STYLE
+inputs -- ``uResectionMarginColor``, ``uUncertaintyMarginColor``,
+``uInterpolatedMargins``.  Per the target node hierarchy
+(Docs/architecture/target-mrml-node-hierarchy.md, "display node carries
+margin colors only") these live on the SHARED
+``vtkMRMLParametricSurfaceDisplayNode`` -- the same node the 3D
+``BezierPlanningRepresentation`` reads -- so the 3D surface and the
+resectogram always show identical band colours from one source of truth.
+
+The gap this pins: ``FlattenedSurfaceRepresentation`` threads the margin
+SCALARS off the plan wrapper (``_apply_resection_margins``) but pushes NO
+style -- the 2D mapper silently rides its compiled-in defaults, and a
+user-edited colour or the InterpolatedMargins flag never reaches the strip.
+
+-- GL-FREE VIA A FAKE MAPPER --
+
+Same idiom as ``test_flattened_surface_plan_shading.py``: a fake mapper
+records the style setter calls so the threading is asserted without a GL
+context.  The actual band render stays on the :0 eyeball checklist of the
+resectogram-margins epic.
+
+-- WHY LAUNCHED-SLICER (soft) --
+
+The positive path reads a wrapped ``vtkMRMLParametricSurfaceDisplayNode``;
+skips cleanly under bare pytest via the shared ``slicer_pytest_support``
+guards + the ``SetSurfaceDisplayNode`` seam gate.
+
+-- WHY RED NOW --
+
+``FlattenedSurfaceRepresentation`` has no ``SetSurfaceDisplayNode`` seam, so
+every test SKIPS cleanly.  The skip lifts when slice 1 lands
+(ADR-0027 §Conformance).
+
+See also:
+  * Docs/adr/0031-distance-map-input-on-resection-plan.md (margins cluster)
+  * Docs/architecture/target-mrml-node-hierarchy.md (colour placement)
+  * LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+  * LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+    (the 3D style-threading precedent this ports)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+RESECTOGRAM_DISPLAY_NODE_CLASS = "vtkMRMLResectogramDisplayNode"
+SURFACE_DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+
+
+class _FakeResection2DMapper:
+    """GL-free stand-in recording the band-STYLE setter calls.
+
+    ``None`` recorders distinguish "never touched" from an explicit push --
+    the defaults invariant below relies on that: with no surface display
+    node threaded, NO style setter may fire, so the mapper's compiled-in
+    defaults stand and the pre-slice appearance is unchanged.
+    """
+
+    def __init__(self):
+        self.resection_margin_color = None
+        self.uncertainty_margin_color = None
+        self.interpolated_margins = None
+        self.resection_margin = None
+        self.uncertainty_margin = None
+        self.distance_map_texture = "sentinel"
+
+    def SetResectionMarginColor(self, r, g, b):  # noqa: N802 - VTK verb
+        self.resection_margin_color = (float(r), float(g), float(b))
+
+    def SetUncertaintyMarginColor(self, r, g, b):  # noqa: N802 - VTK verb
+        self.uncertainty_margin_color = (float(r), float(g), float(b))
+
+    def SetInterpolatedMargins(self, flag):  # noqa: N802 - VTK verb
+        self.interpolated_margins = bool(flag)
+
+    def SetResectionMargin(self, value):  # noqa: N802 - VTK verb
+        self.resection_margin = float(value)
+
+    def SetUncertaintyMargin(self, value):  # noqa: N802 - VTK verb
+        self.uncertainty_margin = float(value)
+
+    def SetDistanceMapTextureObject(self, texture):  # noqa: N802 - VTK verb
+        self.distance_map_texture = texture
+
+    def GetDistanceMapTextureObject(self):  # noqa: N802 - VTK verb
+        return None if self.distance_map_texture == "sentinel" else self.distance_map_texture
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_representation_or_skip():
+    try:
+        from LiverResectionsLib.Representations.FlattenedSurfaceRepresentation import (
+            FlattenedSurfaceRepresentation,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(
+            "FlattenedSurfaceRepresentation not importable "
+            f"({exc!r}) -- not reachable in this environment."
+        )
+    return FlattenedSurfaceRepresentation()
+
+
+def _require_band_style_seam_or_skip(rep):
+    """Skip unless the band-style seam (resectogram-margins slice 1) landed.
+
+    RED == the Representation has no ``SetSurfaceDisplayNode`` -- the seam
+    that threads the shared parametric-surface display node's margin
+    colours + InterpolatedMargins onto the 2D mapper.
+    """
+    if not hasattr(rep, "SetSurfaceDisplayNode"):
+        pytest.skip(
+            "FlattenedSurfaceRepresentation has no SetSurfaceDisplayNode -- "
+            "the resectogram-margins band-style seam has not landed."
+        )
+
+
+def _inject_fake_mapper(rep):
+    fake = _FakeResection2DMapper()
+    rep._resection_mapper_2d = fake
+    return fake
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def test_band_style_threads_from_surface_display_node():
+    """Non-default colours + the interpolated flag reach the 2D mapper.
+
+    Deliberately NON-default values (green / blue, interpolated on) so the
+    assertion cannot pass by the mapper's compiled-in red / yellow defaults.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_band_style_seam_or_skip(rep)
+
+    fake = _inject_fake_mapper(rep)
+
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+    surface_display = _add_or_skip(slicer, SURFACE_DISPLAY_NODE_CLASS)
+    if not hasattr(surface_display, "SetResectionMarginColor"):
+        pytest.skip(f"{SURFACE_DISPLAY_NODE_CLASS} has no margin-colour fields.")
+
+    surface_display.SetResectionMarginColor(0.0, 1.0, 0.0)
+    surface_display.SetUncertaintyMarginColor(0.0, 0.0, 1.0)
+    surface_display.SetInterpolatedMargins(True)
+
+    rep.SetSurfaceDisplayNode(surface_display)
+    rep.update(display, data)
+
+    assert fake.resection_margin_color is not None, (
+        "the shared display node's ResectionMarginColor must reach the 2D "
+        "mapper's SetResectionMarginColor -- no colour was threaded."
+    )
+    assert all(
+        abs(a - b) < 1e-5
+        for a, b in zip(fake.resection_margin_color, (0.0, 1.0, 0.0))
+    ), f"expected (0,1,0); got {fake.resection_margin_color}."
+    assert fake.uncertainty_margin_color is not None and all(
+        abs(a - b) < 1e-5
+        for a, b in zip(fake.uncertainty_margin_color, (0.0, 0.0, 1.0))
+    ), f"expected (0,0,1); got {fake.uncertainty_margin_color}."
+    assert fake.interpolated_margins is True, (
+        "the shared display node's InterpolatedMargins must reach the 2D "
+        f"mapper; got {fake.interpolated_margins!r}."
+    )
+
+
+def test_band_style_untouched_without_surface_display_node():
+    """No surface display node -> NO style setter fires.
+
+    The mapper's compiled-in defaults must stand (red / yellow, hard band),
+    keeping the pre-slice appearance byte-identical for carriers that have no
+    parametric-surface display node (resectogram-only fixtures).
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_band_style_seam_or_skip(rep)
+
+    fake = _inject_fake_mapper(rep)
+
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+
+    rep.SetSurfaceDisplayNode(None)
+    rep.update(display, data)
+
+    assert fake.resection_margin_color is None, (
+        "with no surface display node the Representation must NOT touch "
+        "SetResectionMarginColor (compiled-in defaults stand); got "
+        f"{fake.resection_margin_color!r}."
+    )
+    assert fake.uncertainty_margin_color is None
+    assert fake.interpolated_margins is None
+
+
+def test_band_style_is_orthogonal_to_the_plan_wrapper():
+    """Style threads even with NO plan wrapper wired.
+
+    Colours / interpolation are display state, margins are plan state
+    (ADR-0031); a carrier whose plan is not yet resolved must still show the
+    user-chosen band style the moment the shader has a band to draw.
+    """
+    slicer = _slicer_or_skip()
+    rep = _make_representation_or_skip()
+    _require_band_style_seam_or_skip(rep)
+
+    fake = _inject_fake_mapper(rep)
+
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+    surface_display = _add_or_skip(slicer, SURFACE_DISPLAY_NODE_CLASS)
+    if not hasattr(surface_display, "SetResectionMarginColor"):
+        pytest.skip(f"{SURFACE_DISPLAY_NODE_CLASS} has no margin-colour fields.")
+
+    surface_display.SetResectionMarginColor(1.0, 0.0, 1.0)
+
+    rep.SetResectionPlanNode(None)
+    rep.SetSurfaceDisplayNode(surface_display)
+    rep.update(display, data)
+
+    assert fake.resection_margin_color is not None and all(
+        abs(a - b) < 1e-5
+        for a, b in zip(fake.resection_margin_color, (1.0, 0.0, 1.0))
+    ), (
+        "band style must thread independently of the plan wrapper; got "
+        f"{fake.resection_margin_color!r}."
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/LiverResections/Testing/Python/test_resectogram_pipeline_margin_repaint.py
+++ b/LiverResections/Testing/Python/test_resectogram_pipeline_margin_repaint.py
@@ -75,12 +75,20 @@ def _make_pipeline_or_skip():
 
 def _require_band_digest_seam_or_skip():
     """Skip unless the band-state digest (slice 2) has landed."""
-    import LiverResectionsLib.ResectogramPipeline as module
+    import importlib
+
+    # importlib.import_module returns the real submodule from
+    # sys.modules; a plain ``import X.Y as module`` resolves through
+    # the package ATTRIBUTE, which the package __init__'s
+    # ``from .Y import Y`` re-binds to the CLASS -- hasattr on that
+    # never sees module-level functions.
+    module = importlib.import_module("LiverResectionsLib.ResectogramPipeline")
 
     if not hasattr(module, "_safe_get_band_state_digest"):
         pytest.skip(
             "ResectogramPipeline has no _safe_get_band_state_digest -- "
-            "resectogram-margins slice 2 has not landed."
+            "resectogram-margins slice 2 has not landed (imported from "
+            f"{getattr(module, '__file__', '?')})."
         )
 
 

--- a/LiverResections/Testing/Python/test_resectogram_pipeline_margin_repaint.py
+++ b/LiverResections/Testing/Python/test_resectogram_pipeline_margin_repaint.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Resectogram-margins slice 2 -- margin edits repaint the strip.
+
+The Pipeline memoises ``UpdatePipeline`` on the control-point geometry
+digest, so a ``SafetyMargin_mm`` / ``RiskMargin_mm`` write on the plan
+wrapper -- or a band-style edit on the parametric-surface display node --
+at FIXED geometry never re-threads the mappers and never repaints: the
+strip shows stale bands until an unrelated render.  Slice 2 widens the
+memo key to ``(geometry digest, band-state digest)`` -- the band digest
+being VALUES, never MTimes, so render-induced ``Modified`` churn at fixed
+geometry + fixed band state still short-circuits (the maximize render
+storm cannot regress; ``test_resectogram_pipeline_memo_key.py`` stays
+green UNMODIFIED as the sentinel) -- and observes the resolved plan +
+parametric-surface display nodes through the Pipeline's EXISTING Python
+observer route, so the edits arrive with no external caller.
+
+The framework's own ``UpdatePipeline`` dispatch fires on ResetDisplay, not
+plain ``Modified`` (the LayerDM dispatch caveat) -- which is exactly why
+the Pipeline's own observers carry this, as they already do for the
+display + data nodes.
+
+-- WHY LAUNCHED-SLICER --
+
+Needs the wrapped plan / carrier / display nodes + a constructible
+``ResectogramPipeline``.  Skips cleanly under bare pytest.
+
+-- WHY RED NOW --
+
+The Pipeline has no band-state digest (``_safe_get_band_state_digest``
+absent), so every test SKIPS cleanly.  The skip lifts when slice 2 lands
+(ADR-0027 §Conformance).
+
+See also:
+  * Docs/adr/0031-distance-map-input-on-resection-plan.md (margins cluster)
+  * Docs/adr/0013-layerdm-pipeline-pattern.md §4 (observing state nodes)
+  * LiverResections/Testing/Python/test_resectogram_pipeline_memo_key.py
+    (the render-storm sentinel this must not regress)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+RESECTOGRAM_DISPLAY_NODE_CLASS = "vtkMRMLResectogramDisplayNode"
+SURFACE_DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_pipeline_or_skip():
+    pytest.importorskip(
+        "LayerDMLib",
+        reason="ResectogramPipeline's base vtkMRMLLayerDMScriptedPipeline is "
+        "only constructible inside a Slicer process with SlicerLayerDM loaded "
+        "(the launched pytest_launched row); skipping under bare pytest.",
+    )
+    try:
+        from LiverResectionsLib.ResectogramPipeline import ResectogramPipeline
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"ResectogramPipeline not importable ({exc!r}).")
+    return ResectogramPipeline()
+
+
+def _require_band_digest_seam_or_skip():
+    """Skip unless the band-state digest (slice 2) has landed."""
+    import LiverResectionsLib.ResectogramPipeline as module
+
+    if not hasattr(module, "_safe_get_band_state_digest"):
+        pytest.skip(
+            "ResectogramPipeline has no _safe_get_band_state_digest -- "
+            "resectogram-margins slice 2 has not landed."
+        )
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def _wire_full_margin_fixture(slicer):
+    """plan --geometry--> data <--displayable-- {resectogram, surface} displays."""
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+    data.SetAndObserveDisplayNodeID(display.GetID())
+    if display.GetDisplayableNode() is not data:
+        pytest.skip(
+            "display.GetDisplayableNode() does not resolve the carrier in "
+            "this build."
+        )
+    surface_display = _add_or_skip(slicer, SURFACE_DISPLAY_NODE_CLASS)
+    data.AddAndObserveDisplayNodeID(surface_display.GetID())
+    plan = _add_or_skip(slicer, PLAN_NODE_CLASS)
+    if not hasattr(plan, "SetAndObserveGeometryNode"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveGeometryNode.")
+    plan.SetAndObserveGeometryNode(data)
+    if not (hasattr(plan, "SetSafetyMargin_mm") and hasattr(plan, "SetRiskMargin_mm")):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no Safety/Risk margin setters.")
+    return data, display, surface_display, plan
+
+
+def test_margin_write_at_fixed_geometry_does_real_work():
+    """A margin edit with static geometry re-reconciles -- the slice-2 gap.
+
+    No explicit ``UpdatePipeline`` call after the write: the plan node's
+    ``ModifiedEvent`` must reach the Pipeline through its own observer (the
+    plan is resolved, so it must be observed) and the widened memo key must
+    treat the new margin VALUES as a fresh key.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_band_digest_seam_or_skip()
+
+    data, display, surface_display, plan = _wire_full_margin_fixture(slicer)
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+    settled = pipeline.GetUpdateCount()
+    assert settled >= 1, "the first dispatch must do real work."
+
+    plan.SetSafetyMargin_mm(7.0)
+
+    assert pipeline.GetUpdateCount() > settled, (
+        "a SafetyMargin_mm write at fixed geometry must re-reconcile through "
+        "the Pipeline's own plan observer + the widened memo key; the count "
+        "did not advance -- the margin edit was swallowed."
+    )
+
+
+def test_margin_key_is_idempotent_after_the_edit():
+    """A second dispatch after the margin write short-circuits.
+
+    The widened key must stay a stable VALUE digest: same margins, same
+    geometry -> same key -> no repeated work (the storm guard, extended).
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_band_digest_seam_or_skip()
+
+    data, display, surface_display, plan = _wire_full_margin_fixture(slicer)
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    plan.SetSafetyMargin_mm(7.0)
+    after_edit = pipeline.GetUpdateCount()
+
+    pipeline.UpdatePipeline()
+    assert pipeline.GetUpdateCount() == after_edit, (
+        "an explicit UpdatePipeline with margins + geometry both unchanged "
+        "must short-circuit; the count advanced -- the band digest is not a "
+        "stable value digest."
+    )
+
+
+def test_unchanged_state_requests_no_render():
+    """``_on_node_modified`` at fixed geometry AND fixed band state is silent.
+
+    Render-induced ``Modified`` churn advances MTimes but not the VALUES the
+    widened key digests, so no render may be requested -- the maximize
+    render-storm guard extended over the new key components.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_band_digest_seam_or_skip()
+
+    data, display, surface_display, plan = _wire_full_margin_fixture(slicer)
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    calls = []
+    original = pipeline.RequestRender
+    pipeline.RequestRender = lambda: calls.append(1)  # wrap: count only
+    try:
+        pipeline._on_node_modified(None, None)
+    finally:
+        pipeline.RequestRender = original
+
+    assert calls == [], (
+        "a Modified at fixed geometry + fixed band state must not request a "
+        f"render; got {len(calls)} request(s) -- the storm guard regressed."
+    )
+
+
+def test_resolved_state_nodes_are_observed():
+    """The resolved plan + surface display node land in the observed set.
+
+    Without observers a margin / style edit only takes effect on the next
+    unrelated dispatch -- the edit must reach the Pipeline with NO external
+    caller (ADR-0013 §4: the observation set includes state nodes the
+    displayed concept depends on).
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_band_digest_seam_or_skip()
+
+    data, display, surface_display, plan = _wire_full_margin_fixture(slicer)
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+
+    assert plan in pipeline._observed_node_refs, (
+        "the resolved plan wrapper must be observed so margin writes reach "
+        "the Pipeline without an external caller."
+    )
+    assert surface_display in pipeline._observed_node_refs, (
+        "the resolved parametric-surface display node must be observed so "
+        "band-style edits reach the Pipeline without an external caller."
+    )
+
+
+def test_interpolated_flip_does_real_work():
+    """An ``InterpolatedMargins`` flip on the style node re-reconciles."""
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_band_digest_seam_or_skip()
+
+    data, display, surface_display, plan = _wire_full_margin_fixture(slicer)
+    if not hasattr(surface_display, "SetInterpolatedMargins"):
+        pytest.skip(f"{SURFACE_DISPLAY_NODE_CLASS} has no InterpolatedMargins.")
+    pipeline.SetDisplayNode(display)
+    pipeline.UpdatePipeline()
+    settled = pipeline.GetUpdateCount()
+
+    surface_display.SetInterpolatedMargins(True)
+
+    assert pipeline.GetUpdateCount() > settled, (
+        "an InterpolatedMargins flip must re-reconcile through the style "
+        "node's observer + the widened memo key; the count did not advance."
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/LiverResections/Testing/Python/test_resectogram_pipeline_resolves_surface_display.py
+++ b/LiverResections/Testing/Python/test_resectogram_pipeline_resolves_surface_display.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Resectogram-margins slice 1 -- the Pipeline resolves the style display node.
+
+The band STYLE (margin colours + InterpolatedMargins) lives on the shared
+``vtkMRMLParametricSurfaceDisplayNode`` that hangs off the carrier as a
+SIBLING of the resectogram display node (one carrier, two display aspects --
+Docs/architecture/current-mrml-node-hierarchy.md).  For the strip to show
+user-chosen colours, the ``ResectogramPipeline`` must resolve that sibling
+and hand it to the ``FlattenedSurfaceRepresentation`` via
+``SetSurfaceDisplayNode`` -- mirroring how it already reverse-resolves the
+plan wrapper (``test_resectogram_pipeline_resolves_resection_plan.py``).
+
+-- WHY LAUNCHED-SLICER --
+
+Needs the wrapped display nodes + the ``ResectogramPipeline`` whose base
+``vtkMRMLLayerDMScriptedPipeline`` is constructible only inside a Slicer
+process with SlicerLayerDM loaded.  Skips cleanly under bare pytest.
+
+-- WHY RED NOW --
+
+The Pipeline has no surface-display resolution seam and the Representation
+has no ``SetSurfaceDisplayNode``, so the tests SKIP cleanly.  The skip lifts
+when resectogram-margins slice 1 lands (ADR-0027 §Conformance).
+
+See also:
+  * Docs/architecture/target-mrml-node-hierarchy.md (colour placement)
+  * LiverResections/LiverResectionsLib/ResectogramPipeline.py
+  * LiverResections/Testing/Python/test_resectogram_pipeline_resolves_resection_plan.py
+    (the plan-wrapper resolution precedent this mirrors)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BEZIER_NODE_CLASS = "vtkMRMLBezierSurfaceNode"
+RESECTOGRAM_DISPLAY_NODE_CLASS = "vtkMRMLResectogramDisplayNode"
+SURFACE_DISPLAY_NODE_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import (
+        import_slicer_or_skip as _import_slicer_or_skip,
+        require_mrml_scene as _require_mrml_scene,
+    )
+
+    _require_mrml_scene()
+    return _import_slicer_or_skip()
+
+
+def _make_pipeline_or_skip():
+    pytest.importorskip(
+        "LayerDMLib",
+        reason="ResectogramPipeline's base vtkMRMLLayerDMScriptedPipeline is "
+        "only constructible inside a Slicer process with SlicerLayerDM loaded "
+        "(the launched pytest_launched row); skipping under bare pytest.",
+    )
+    try:
+        from LiverResectionsLib.ResectogramPipeline import ResectogramPipeline
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"ResectogramPipeline not importable ({exc!r}).")
+    return ResectogramPipeline()
+
+
+def _require_style_seam_or_skip(pipeline):
+    """Skip unless the surface-display resolution seam (slice 1) landed."""
+    try:
+        from LiverResectionsLib.Representations.FlattenedSurfaceRepresentation import (
+            FlattenedSurfaceRepresentation,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"FlattenedSurfaceRepresentation not importable ({exc!r}).")
+    if not hasattr(FlattenedSurfaceRepresentation, "SetSurfaceDisplayNode"):
+        pytest.skip(
+            "FlattenedSurfaceRepresentation has no SetSurfaceDisplayNode -- "
+            "resectogram-margins slice 1 has not landed."
+        )
+    if not hasattr(pipeline, "_resolve_surface_display_node"):
+        pytest.skip(
+            "ResectogramPipeline has no _resolve_surface_display_node -- "
+            "resectogram-margins slice 1 has not landed."
+        )
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+class _RecordingRepresentation:
+    """Spy standing in for the FlattenedSurfaceRepresentation.
+
+    Records the display node handed through ``SetSurfaceDisplayNode`` --
+    "never called" (sentinel) is distinct from an explicit ``None``.
+    """
+
+    def __init__(self):
+        self.surface_display_node = "sentinel"
+
+    def SetSurfaceDisplayNode(self, node):  # noqa: N802 - VTK verb
+        self.surface_display_node = node
+
+    def SetResectionPlanNode(self, node):  # noqa: N802 - VTK verb
+        pass
+
+    def SetLocatorNode(self, node):  # noqa: N802 - VTK verb
+        pass
+
+    def update(self, display_node, data_node):
+        pass
+
+
+def _wire_carrier(slicer):
+    data = _add_or_skip(slicer, BEZIER_NODE_CLASS)
+    display = _add_or_skip(slicer, RESECTOGRAM_DISPLAY_NODE_CLASS)
+    data.SetAndObserveDisplayNodeID(display.GetID())
+    if display.GetDisplayableNode() is not data:
+        pytest.skip(
+            "display.GetDisplayableNode() does not resolve the carrier in "
+            "this build -- cannot exercise the Pipeline's data-node derivation."
+        )
+    return data, display
+
+
+def _spy_flattened_representation(pipeline):
+    """Dispatch once so the Representations exist, then swap in the spy."""
+    pipeline.UpdatePipeline()
+    spy = _RecordingRepresentation()
+    pipeline._flattened_surface = spy
+    # Invalidate the memo so the next dispatch re-threads into the spy.
+    pipeline._last_update_key = None
+    return spy
+
+
+def test_pipeline_threads_sibling_surface_display_node():
+    """Carrier with BOTH display aspects -> the parametric one is threaded.
+
+    Wire ``data <--displayable-- {resectogram-display, surface-display}``;
+    after a dispatch the flattened Representation must have received the
+    PARAMETRIC display node (the style source) via ``SetSurfaceDisplayNode``.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_style_seam_or_skip(pipeline)
+
+    data, display = _wire_carrier(slicer)
+    surface_display = _add_or_skip(slicer, SURFACE_DISPLAY_NODE_CLASS)
+    data.AddAndObserveDisplayNodeID(surface_display.GetID())
+
+    pipeline.SetDisplayNode(display)
+    spy = _spy_flattened_representation(pipeline)
+    pipeline.UpdatePipeline()
+
+    assert spy.surface_display_node is surface_display, (
+        "the Pipeline must resolve the carrier's sibling "
+        "vtkMRMLParametricSurfaceDisplayNode and thread it via "
+        "SetSurfaceDisplayNode (the band-style source); got "
+        f"{spy.surface_display_node!r}."
+    )
+
+
+def test_pipeline_threads_none_without_sibling_display_node():
+    """Resectogram-only carrier -> explicit ``SetSurfaceDisplayNode(None)``.
+
+    Pins the graceful default: no parametric sibling means the Representation
+    is told so (not left stale), and the mapper's compiled-in colours stand.
+    """
+    slicer = _slicer_or_skip()
+    pipeline = _make_pipeline_or_skip()
+    _require_style_seam_or_skip(pipeline)
+
+    data, display = _wire_carrier(slicer)
+
+    pipeline.SetDisplayNode(display)
+    spy = _spy_flattened_representation(pipeline)
+    pipeline.UpdatePipeline()
+
+    assert spy.surface_display_node is None, (
+        "a carrier with no parametric-surface display node must thread an "
+        "explicit None (never leave the spy untouched at the sentinel); got "
+        f"{spy.surface_display_node!r}."
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Slice 2 of the resectogram-margins epic: a `SafetyMargin_mm` /
`RiskMargin_mm` write — or a band-style edit — at fixed geometry never
repainted. The resectogram pipeline memoised on the control-point
geometry digest alone; the 3D pipeline re-threaded its uniforms but its
render key had no margin component, so the view stayed stale until a
camera orbit. Fix: widen the resectogram memo key to
`(geometry digest, band-state digest)` — **values, never MTimes**, so
render-induced Modified churn still short-circuits — observe the
resolved plan + parametric-surface display nodes through the pipeline's
existing observer route, and extend the 3D `render_key` with the margin
and band-style values.

## ADR references

- ADR-0013 §4: the pipeline's observation set includes state nodes the
  displayed concept depends on — realised for plan + style nodes.
- ADR-0031: margins as plan-wrapper state — edit-reactivity completed.
- ADR-0027: invariant-test-first — both suites landed red-as-skip first.
- ADR-0039: sub-PR on the epic branch.

## Reviewer's map

Read order: (1) `test_resectogram_pipeline_margin_repaint.py` — the five
pinned invariants, incl. the extended render-storm guard; (2)
`test_bezier_planning_margin_render_key.py` — 3D exactly-one-render /
zero-on-noop; (3) `ResectogramPipeline.py` — load-bearing:
`_safe_get_band_state_digest`, the widened key, the observer loop
(membership-guarded against `_reattach_node_observers` drain); (4)
`LiverBezierSurfacePipeline.py` — the two value accessors + render_key
extension. Mechanical: docstring updates (UpdatePipeline, the digest
helper, and the stale margin note in `BezierPlanningRepresentation`).

**Storm-guard sentinel:** `test_resectogram_pipeline_memo_key.py` is
UNMODIFIED and must stay green — its stub scene digests band state to a
constant `()`, so its behaviour contract is unchanged by construction.

## Test plan

- Bare harness: clean skips verified locally.
- Launched (CI): 7 new tests run; sentinel memo-key suite green
  unmodified.
- Live repaint-on-drag is item 3-4 of the epic's eyeball checklist.

## UX impact

None yet — margin edits only come from scripts until slice 3's UI.

---
🤖 This PR was drafted with AI assistance (Claude Fable 5 via Claude
Code); the maintainer reviewed and directed the changes.
