### PR TITLE
ENH: Drop the _mm suffix from the resection-plan margin API and keys

### DIFF
--- a/Docs/adr/0031-distance-map-input-on-resection-plan.md
+++ b/Docs/adr/0031-distance-map-input-on-resection-plan.md
@@ -183,3 +183,13 @@ after this reference + its binding.
 - v1 source for the port:
   `LiverMarkups/VTKWidgets/vtkSlicerBezierSurfaceRepresentation3D.cxx`
   (distance-map texture upload + RAS/IJK matrices).
+
+## Amendment (2026-08-21): margin field rename
+
+The margin fields this ADR placed on the plan wrapper dropped their
+unit suffix to match the VTK/Slicer accessor idiom: the API is now
+`SetSafetyMargin` / `GetRiskMargin` (units documented as millimetres
+in the header), and the serialized keys are `safetyMargin` /
+`riskMargin` in scene XML and `.lrp.json` alike, with readers
+accepting the legacy unit-suffixed keys.  The placement decision is
+unchanged; body text above keeps the original names as written.

--- a/Docs/architecture/current-mrml-node-hierarchy.md
+++ b/Docs/architecture/current-mrml-node-hierarchy.md
@@ -45,7 +45,7 @@ classDiagram
     %% =======================================================
     class vtkMRMLResectionPlanNode {
         +State : Init / Planning / Confirmed
-        +SafetyMargin_mm, RiskMargin_mm : double
+        +SafetyMargin, RiskMargin : double
         +SetAndObserveGeometryNode(surface)
         +SetAndObserveDistanceMapVolumeNode(volume)
     }

--- a/Docs/architecture/target-mrml-node-hierarchy.md
+++ b/Docs/architecture/target-mrml-node-hierarchy.md
@@ -81,8 +81,8 @@ classDiagram
     class vtkMRMLResectionPlanNode {
         <<NEW v2.0 — clinical wrapper>>
         +string Name
-        +double SafetyMargin_mm
-        +double RiskMargin_mm
+        +double SafetyMargin
+        +double RiskMargin
         +int OrderIndex
         +PlanState State : Init | Planning | Confirmed
         --node refs--

--- a/Docs/design/resection-plan-architecture/01-class-hierarchy.md
+++ b/Docs/design/resection-plan-architecture/01-class-hierarchy.md
@@ -30,8 +30,8 @@ classDiagram
     class vtkMRMLResectionPlanNode {
         <<NEW v2.0>>
         +string Name
-        +double SafetyMargin_mm
-        +double RiskMargin_mm
+        +double SafetyMargin
+        +double RiskMargin
         +int OrderIndex
         +PlanState State : Init | Planning | Confirmed
         --node refs--

--- a/Docs/design/resection-plan-architecture/03-storage-ownership.md
+++ b/Docs/design/resection-plan-architecture/03-storage-ownership.md
@@ -43,8 +43,8 @@ flowchart LR
 | Field | `.mrml` (WriteXML) | `.lrp.json` (storage) |
 |---|---|---|
 | `Name` (MRML primitive) | ✓ (Superclass) | ✓ (mirrored for standalone-load) |
-| `SafetyMargin_mm` |   | ✓ |
-| `RiskMargin_mm` |   | ✓ |
+| `SafetyMargin` |   | ✓ |
+| `RiskMargin` |   | ✓ |
 | `OrderIndex` | ✓ (lightweight scalar, scene-relevant) | ✓ |
 | `State` | ✓ (lightweight scalar) | ✓ |
 | Node refs (`geometry`, storage) | ✓ (Superclass) |   |

--- a/Docs/design/resection-plan-architecture/05-lrp-json-schema.md
+++ b/Docs/design/resection-plan-architecture/05-lrp-json-schema.md
@@ -1,5 +1,11 @@
 # 05 — `.lrp.json` v2 schema shape (trimmed)
 
+> **Key rename note (2026-08-21).** The margin keys were renamed from
+> `safetyMargin_mm` / `riskMargin_mm` to `safetyMargin` / `riskMargin`
+> (values remain millimetres).  Readers accept both spellings; writers
+> emit only the current keys.  `schemaVersion` stays `2`.
+
+
 The shipped v2 schema (PR #430) was reshaped after the 2026-05-25
 maintainer review. Two refinements landed:
 
@@ -19,8 +25,8 @@ graph TB
     root["root JSON object"]
     sv["schemaVersion: 2"]
     name["name: string"]
-    sm["safetyMargin_mm: double"]
-    rm["riskMargin_mm: double"]
+    sm["safetyMargin: double"]
+    rm["riskMargin: double"]
     oi["orderIndex: int (sentinel -1)"]
     state["state: 'Init' | 'Planning' | 'Confirmed'"]
 
@@ -74,8 +80,8 @@ distanceSpheroid                                              → moved into sur
 metadata: {}                            metadata: {}          (reserved)
 
 resection: {                            name                  (root — plan IS the resection)
-  name, safetyMargin_mm,                safetyMargin_mm
-  riskMargin_mm, orderIndex             riskMargin_mm
+  name, safetyMargin,                safetyMargin
+  riskMargin, orderIndex             riskMargin
 }                                       orderIndex
 
 scene: {                                ─────────────────────  REMOVED
@@ -119,7 +125,7 @@ scene-local node ID would reintroduce exactly the cross-machine breakage
 the trim above removed. Re-linking the distance map on load rides on the
 same v2.1 stable-ID resolution (#415) as the other node references; until
 then the plan re-establishes / recomputes it rather than carrying a
-fragile ID. The two margins (`safetyMargin_mm`, `riskMargin_mm`), being
+fragile ID. The two margins (`safetyMargin`, `riskMargin`), being
 plain scalars, **do** round-trip — the rest of the distance-shading input
 set is persisted; only the volume reference waits for v2.1. A guard test
 (`LiverResections/Testing/Python/test_resection_plan_distance_map_not_persisted.py`)
@@ -141,8 +147,8 @@ fragile persistence early.
 {
   "schemaVersion": 2,
   "name": "Right hemihepatectomy",
-  "safetyMargin_mm": 10.0,
-  "riskMargin_mm": 5.0,
+  "safetyMargin": 10.0,
+  "riskMargin": 5.0,
   "orderIndex": 0,
   "state": "Planning",
   "surface": {

--- a/Docs/migrations/v1-to-v2.md
+++ b/Docs/migrations/v1-to-v2.md
@@ -17,8 +17,8 @@ The v2 plan format (`.lrp.json`, schema version 2) is rooted on the
 resection **plan**, with the surface persisted as a polymorphic
 `surface` block. Beyond the control polygon, the plan carries:
 
-- `safetyMargin_mm` — clinical safety margin (mm).
-- `riskMargin_mm` — clinical risk margin (mm).
+- `safetyMargin` — clinical safety margin (mm).
+- `riskMargin` — clinical risk margin (mm).
 - `orderIndex` — zero-based position in the operative sequence.
 - `state` — plan-level state machine (`Init` / `Planning` /
   `Confirmed`).
@@ -34,8 +34,8 @@ migration applies the documented v2 reader defaults:
 
 | Field             | Default on migration |
 | ----------------- | -------------------- |
-| `safetyMargin_mm` | `0.0`                |
-| `riskMargin_mm`   | `0.0`                |
+| `safetyMargin` | `0.0`                |
+| `riskMargin`   | `0.0`                |
 | `orderIndex`      | `-1`                 |
 | `state`           | `Init`               |
 
@@ -63,3 +63,12 @@ path routes it to `vtkMRMLResectionPlanStorageNode::ReadFcsv`, which:
 Saving a migrated plan always writes the v2 `.lrp.json`. The
 `.lrp.fcsv` format is **read-only** in v2; there is no v2 writer for
 it.
+
+## Margin key rename (2026-08-21)
+
+The plan margins were renamed from `safetyMargin_mm` / `riskMargin_mm`
+to `safetyMargin` / `riskMargin` in both the C++ API
+(`SetSafetyMargin` etc.) and the serialized forms (scene XML +
+`.lrp.json`).  Values remain millimetres.  Readers accept the legacy
+unit-suffixed keys, so scenes and plan files written before the rename
+load unchanged; anything re-saved uses the current keys.

--- a/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
+++ b/LiverResections/LiverResectionsLib/LiverBezierSurfacePipeline.py
@@ -1454,7 +1454,7 @@ def _safe_get_mtime(node: Any) -> int:
 
 
 def _safe_get_plan_margins(node: Any) -> tuple | None:
-    """The plan wrapper's ``(SafetyMargin_mm, RiskMargin_mm)``; None sans node.
+    """The plan wrapper's ``(SafetyMargin, RiskMargin)``; None sans node.
 
     A render-key VALUE component: a margin edit changes it (one coalesced
     repaint), render-induced ``Modified`` churn does not.
@@ -1462,7 +1462,7 @@ def _safe_get_plan_margins(node: Any) -> tuple | None:
     if node is None:
         return None
     try:
-        return (float(node.GetSafetyMargin_mm()), float(node.GetRiskMargin_mm()))
+        return (float(node.GetSafetyMargin()), float(node.GetRiskMargin()))
     except Exception:  # pragma: no cover - defensive (stub plans)
         return None
 

--- a/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/BezierPlanningRepresentation.py
@@ -552,7 +552,7 @@ class BezierPlanningRepresentation:
         surface — there the colour rides on the actor property set by the
         caller.  Margin SCALARS (``SetResectionMargin`` / ``SetUncertaintyMargin``)
         are not pushed here — they are plan-wrapper state
-        (``SafetyMargin_mm`` / ``RiskMargin_mm``, ADR-0031) threaded by
+        (``SafetyMargin`` / ``RiskMargin``, ADR-0031) threaded by
         ``_apply_resection_plan``; this method pushes only the display node's
         decoration (colours, flags, grid).
         """
@@ -641,8 +641,8 @@ class BezierPlanningRepresentation:
         # Margins are plan fields, meaningful independent of the distance map
         # (the shader simply has no band to draw without a bound texture).
         if plan_node is not None:
-            safety = getattr(plan_node, "GetSafetyMargin_mm", None)
-            risk = getattr(plan_node, "GetRiskMargin_mm", None)
+            safety = getattr(plan_node, "GetSafetyMargin", None)
+            risk = getattr(plan_node, "GetRiskMargin", None)
             if safety is not None:
                 mapper.SetResectionMargin(float(safety()))
             if risk is not None:

--- a/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
+++ b/LiverResections/LiverResectionsLib/Representations/FlattenedSurfaceRepresentation.py
@@ -662,15 +662,15 @@ class FlattenedSurfaceRepresentation:
         by the ``vtkMRMLResectionPlanNode`` wrapper, alongside the distance-map
         volume, as one distance-shading input set.  Ports the margin block of
         the 3D ``BezierPlanningRepresentation._apply_resection_plan``: push
-        ``GetSafetyMargin_mm`` -> ``SetResectionMargin`` and ``GetRiskMargin_mm``
+        ``GetSafetyMargin`` -> ``SetResectionMargin`` and ``GetRiskMargin``
         -> ``SetUncertaintyMargin``.  A no-op when no plan is wired or on the
         generic fallback mapper (the getattr guards).
         """
         plan = self._resection_plan_node
         if plan is None:
             return
-        safety = getattr(plan, "GetSafetyMargin_mm", None)
-        risk = getattr(plan, "GetRiskMargin_mm", None)
+        safety = getattr(plan, "GetSafetyMargin", None)
+        risk = getattr(plan, "GetRiskMargin", None)
         set_resection = getattr(mapper, "SetResectionMargin", None)
         set_uncertainty = getattr(mapper, "SetUncertaintyMargin", None)
         if safety is not None and set_resection is not None:

--- a/LiverResections/LiverResectionsLib/ResectogramPipeline.py
+++ b/LiverResections/LiverResectionsLib/ResectogramPipeline.py
@@ -839,8 +839,8 @@ def _safe_get_band_state_digest(plan: Any, surface_display: Any) -> tuple:
         try:
             digest.append(
                 (
-                    float(plan.GetSafetyMargin_mm()),
-                    float(plan.GetRiskMargin_mm()),
+                    float(plan.GetSafetyMargin()),
+                    float(plan.GetRiskMargin()),
                 )
             )
         except Exception:  # pragma: no cover - defensive (stub plans)

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanNodeTest1.cxx
@@ -26,7 +26,7 @@
  *      class is concrete and instantiable, unlike the carrier
  *      hierarchy base.)
  *   2. Defaults match the design's documented sentinels:
- *      ``SafetyMargin_mm = 0.0``, ``RiskMargin_mm = 0.0``,
+ *      ``SafetyMargin = 0.0``, ``RiskMargin = 0.0``,
  *      ``OrderIndex = -1`` (sentinel), ``State = Init``,
  *      ``Name = ""``.
  *      (Design doc 01-class-hierarchy.md ``vtkMRMLResectionPlanNode``
@@ -43,7 +43,7 @@
  *   4. XML round-trip of every plan field through WriteXML +
  *      ReadXMLAttributes (Markups precedent -- light scalars in
  *      .mrml; storage carries the heavy fields).  Includes ``Name``,
- *      ``SafetyMargin_mm``, ``RiskMargin_mm``, ``OrderIndex``,
+ *      ``SafetyMargin``, ``RiskMargin``, ``OrderIndex``,
  *      ``State``.
  *      (Design doc 03-storage-ownership.md §"Plan node
  *      (vtkMRMLResectionPlanNode)" table -- the WriteXML column for
@@ -183,8 +183,8 @@ int testInstantiable()
 int testDefaults()
 {
   vtkNew<vtkMRMLResectionPlanNode> node;
-  CHECK_DOUBLE(node->GetSafetyMargin_mm(), 0.0);
-  CHECK_DOUBLE(node->GetRiskMargin_mm(), 0.0);
+  CHECK_DOUBLE(node->GetSafetyMargin(), 0.0);
+  CHECK_DOUBLE(node->GetRiskMargin(), 0.0);
   CHECK_INT(node->GetOrderIndex(), -1);
   CHECK_INT(node->GetState(), vtkMRMLResectionPlanNode::Init);
   // ``Name`` is a Slicer-core MRML primitive (GetName / SetName on
@@ -243,8 +243,8 @@ int testXMLRoundTrip()
   vtkNew<vtkMRMLResectionPlanNode> source;
   source->SetScene(scene.GetPointer());
   source->SetName("Right hemihepatectomy");
-  source->SetSafetyMargin_mm(10.0);
-  source->SetRiskMargin_mm(5.0);
+  source->SetSafetyMargin(10.0);
+  source->SetRiskMargin(5.0);
   source->SetOrderIndex(2);
   source->SetState(vtkMRMLResectionPlanNode::Planning);
 
@@ -253,12 +253,16 @@ int testXMLRoundTrip()
   const std::string xml = out.str();
 
   // Spot-check: the serialised text mentions one of the plan-
-  // specific attributes.  vtkMRMLWriteXMLDoubleMacro emits
-  // lower-camelCase attribute names; check both casings for
-  // robustness.
-  if (xml.find("safetyMargin_mm") == std::string::npos && xml.find("SafetyMargin_mm") == std::string::npos)
+  // specific attributes (lower-camelCase per vtkMRMLWriteXMLDoubleMacro)
+  // and no longer emits the retired unit-suffixed name.
+  if (xml.find("safetyMargin") == std::string::npos)
   {
-    std::cerr << "WriteXML output missing safetyMargin_mm attribute:\n" << xml << "\n";
+    std::cerr << "WriteXML output missing safetyMargin attribute:\n" << xml << "\n";
+    return EXIT_FAILURE;
+  }
+  if (xml.find("safetyMargin_mm") != std::string::npos)
+  {
+    std::cerr << "WriteXML must not emit the legacy safetyMargin_mm attribute:\n" << xml << "\n";
     return EXIT_FAILURE;
   }
 
@@ -268,10 +272,19 @@ int testXMLRoundTrip()
   std::vector<const char*> atts = buildAttsFromXML(xml, storage);
   sink->ReadXMLAttributes(atts.data());
 
-  CHECK_DOUBLE_TOLERANCE(sink->GetSafetyMargin_mm(), source->GetSafetyMargin_mm(), 1e-9);
-  CHECK_DOUBLE_TOLERANCE(sink->GetRiskMargin_mm(), source->GetRiskMargin_mm(), 1e-9);
+  CHECK_DOUBLE_TOLERANCE(sink->GetSafetyMargin(), source->GetSafetyMargin(), 1e-9);
+  CHECK_DOUBLE_TOLERANCE(sink->GetRiskMargin(), source->GetRiskMargin(), 1e-9);
   CHECK_INT(sink->GetOrderIndex(), source->GetOrderIndex());
   CHECK_INT(sink->GetState(), source->GetState());
+
+  // Legacy-scene compatibility: attributes written before the margin
+  // rename (unit-suffixed names) still populate the fields on read.
+  vtkNew<vtkMRMLResectionPlanNode> legacySink;
+  legacySink->SetScene(scene.GetPointer());
+  const char* legacyAtts[] = { "safetyMargin_mm", "12.5", "riskMargin_mm", "4.5", nullptr };
+  legacySink->ReadXMLAttributes(legacyAtts);
+  CHECK_DOUBLE_TOLERANCE(legacySink->GetSafetyMargin(), 12.5, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(legacySink->GetRiskMargin(), 4.5, 1e-9);
   return EXIT_SUCCESS;
 }
 
@@ -346,16 +359,16 @@ int testCopyContent()
 {
   vtkNew<vtkMRMLResectionPlanNode> source;
   source->SetName("Source plan");
-  source->SetSafetyMargin_mm(7.5);
-  source->SetRiskMargin_mm(3.25);
+  source->SetSafetyMargin(7.5);
+  source->SetRiskMargin(3.25);
   source->SetOrderIndex(4);
   source->SetState(vtkMRMLResectionPlanNode::Confirmed);
 
   vtkNew<vtkMRMLResectionPlanNode> sink;
   sink->CopyContent(source.GetPointer());
 
-  CHECK_DOUBLE_TOLERANCE(sink->GetSafetyMargin_mm(), 7.5, 1e-9);
-  CHECK_DOUBLE_TOLERANCE(sink->GetRiskMargin_mm(), 3.25, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(sink->GetSafetyMargin(), 7.5, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(sink->GetRiskMargin(), 3.25, 1e-9);
   CHECK_INT(sink->GetOrderIndex(), 4);
   CHECK_INT(sink->GetState(), vtkMRMLResectionPlanNode::Confirmed);
   return EXIT_SUCCESS;

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanStorageNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLResectionPlanStorageNodeTest1.cxx
@@ -224,8 +224,8 @@ void populateSurface(vtkMRMLBezierSurfaceNode* node)
 void populatePlan(vtkMRMLResectionPlanNode* plan)
 {
   plan->SetName("Right hemihepatectomy");
-  plan->SetSafetyMargin_mm(10.0);
-  plan->SetRiskMargin_mm(5.0);
+  plan->SetSafetyMargin(10.0);
+  plan->SetRiskMargin(5.0);
   plan->SetOrderIndex(2);
   plan->SetState(vtkMRMLResectionPlanNode::Planning);
 }
@@ -332,8 +332,8 @@ int testSchemaVersionBoundary()
       ofs << "{\n";
       ofs << "  \"schemaVersion\": " << version << ",\n";
       ofs << "  \"name\": \"v" << version << "\",\n";
-      ofs << "  \"safetyMargin_mm\": 5.0,\n";
-      ofs << "  \"riskMargin_mm\": 2.5,\n";
+      ofs << "  \"safetyMargin\": 5.0,\n";
+      ofs << "  \"riskMargin\": 2.5,\n";
       ofs << "  \"orderIndex\": 0,\n";
       ofs << "  \"state\": \"Init\",\n";
       ofs << "  \"surface\": { \"type\": \"Bezier\", \"rows\": 4, \"cols\": 4, "
@@ -403,8 +403,8 @@ int testPlanRootedRoundTrip()
   CHECK_INT(readStorage->ReadData(sinkPlan.GetPointer()), 1);
 
   // Plan field round-trip.
-  CHECK_DOUBLE_TOLERANCE(sinkPlan->GetSafetyMargin_mm(), source->GetSafetyMargin_mm(), 1e-9);
-  CHECK_DOUBLE_TOLERANCE(sinkPlan->GetRiskMargin_mm(), source->GetRiskMargin_mm(), 1e-9);
+  CHECK_DOUBLE_TOLERANCE(sinkPlan->GetSafetyMargin(), source->GetSafetyMargin(), 1e-9);
+  CHECK_DOUBLE_TOLERANCE(sinkPlan->GetRiskMargin(), source->GetRiskMargin(), 1e-9);
   CHECK_INT(sinkPlan->GetOrderIndex(), source->GetOrderIndex());
   CHECK_INT(sinkPlan->GetState(), source->GetState());
 
@@ -576,8 +576,8 @@ int testOptionalFieldsDefaults()
   storage->SetFileName(path.c_str());
   CHECK_INT(storage->ReadData(plan.GetPointer()), 1);
 
-  CHECK_DOUBLE(plan->GetSafetyMargin_mm(), 0.0);
-  CHECK_DOUBLE(plan->GetRiskMargin_mm(), 0.0);
+  CHECK_DOUBLE(plan->GetSafetyMargin(), 0.0);
+  CHECK_DOUBLE(plan->GetRiskMargin(), 0.0);
   CHECK_INT(plan->GetOrderIndex(), -1);
   CHECK_INT(plan->GetState(), vtkMRMLResectionPlanNode::Init);
 
@@ -601,8 +601,8 @@ int testSceneBlockForwardCompat()
     ofs << "{\n";
     ofs << "  \"schemaVersion\": 2,\n";
     ofs << "  \"name\": \"plan-with-scene-block\",\n";
-    ofs << "  \"safetyMargin_mm\": 7.0,\n";
-    ofs << "  \"riskMargin_mm\": 3.0,\n";
+    ofs << "  \"safetyMargin\": 7.0,\n";
+    ofs << "  \"riskMargin\": 3.0,\n";
     ofs << "  \"orderIndex\": 1,\n";
     ofs << "  \"state\": \"Planning\",\n";
     ofs << "  \"surface\": { \"type\": \"Bezier\", \"rows\": 4, \"cols\": 4, "
@@ -1136,6 +1136,58 @@ int testWriteJsonPlanWithoutGeometry()
 } // namespace
 
 //------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Legacy margin keys -- files written before the margin rename carry the
+// unit-suffixed keys; the reader must still populate the fields (writers
+// emit only the current keys, pinned by the round-trip invariants above).
+int testLegacyMarginKeysStillLoad()
+{
+  const std::string path = makeTempPath("lrp.json");
+  {
+    std::ofstream ofs(path);
+    ofs << "{\n";
+    ofs << "  \"schemaVersion\": 2,\n";
+    ofs << "  \"name\": \"legacy-margin-keys\",\n";
+    ofs << "  \"safetyMargin_mm\": 9.0,\n";
+    ofs << "  \"riskMargin_mm\": 2.0,\n";
+    ofs << "  \"orderIndex\": 0,\n";
+    ofs << "  \"state\": \"Init\",\n";
+    ofs << "  \"surface\": { \"type\": \"Bezier\", \"rows\": 4, \"cols\": 4, "
+           "\"controlGrid\": [";
+    for (int i = 0; i < 48; ++i)
+    {
+      if (i > 0)
+      {
+        ofs << ", ";
+      }
+      ofs << "0.0";
+    }
+    ofs << "] }\n";
+    ofs << "}\n";
+  }
+
+  vtkNew<vtkMRMLScene> scene;
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLBezierSurfaceNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLResectionPlanStorageNode>::New());
+
+  vtkNew<vtkMRMLResectionPlanNode> plan;
+  vtkNew<vtkMRMLBezierSurfaceNode> surface;
+  scene->AddNode(plan.GetPointer());
+  scene->AddNode(surface.GetPointer());
+  plan->SetAndObserveGeometryNode(surface.GetPointer());
+
+  vtkNew<vtkMRMLResectionPlanStorageNode> storage;
+  storage->SetFileName(path.c_str());
+
+  CHECK_INT(storage->ReadData(plan.GetPointer()), 1);
+  CHECK_DOUBLE_TOLERANCE(plan->GetSafetyMargin(), 9.0, 1e-9);
+  CHECK_DOUBLE_TOLERANCE(plan->GetRiskMargin(), 2.0, 1e-9);
+
+  vtksys::SystemTools::RemoveFile(path);
+  return EXIT_SUCCESS;
+}
+
 int vtkMRMLResectionPlanStorageNodeTest1(int, char*[])
 {
   vtkNew<vtkMRMLScene> scene;
@@ -1152,6 +1204,7 @@ int vtkMRMLResectionPlanStorageNodeTest1(int, char*[])
   CHECK_EXIT_SUCCESS(testStandaloneLoadCreatesSurface());
   CHECK_EXIT_SUCCESS(testOptionalFieldsDefaults());
   CHECK_EXIT_SUCCESS(testSceneBlockForwardCompat());
+  CHECK_EXIT_SUCCESS(testLegacyMarginKeysStillLoad());
   CHECK_EXIT_SUCCESS(testSurfaceBulkDataRoundTrip());
 
   // Phase 1 -- defensive guard + JSON dispatch coverage (closes the

--- a/LiverResections/MRML/vtkMRMLResectionPlanNode.cxx
+++ b/LiverResections/MRML/vtkMRMLResectionPlanNode.cxx
@@ -26,14 +26,15 @@
 
 // STD includes
 #include <cstring>
+#include <string>
 
 //------------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLResectionPlanNode);
 
 //------------------------------------------------------------------------------
 vtkMRMLResectionPlanNode::vtkMRMLResectionPlanNode()
-  : SafetyMargin_mm(0.0)
-  , RiskMargin_mm(0.0)
+  : SafetyMargin(0.0)
+  , RiskMargin(0.0)
   , OrderIndex(-1)
   , State(PlanState::Init)
 {
@@ -123,8 +124,8 @@ void vtkMRMLResectionPlanNode::WriteXML(ostream& of, int nIndent)
   Superclass::WriteXML(of, nIndent);
 
   vtkMRMLWriteXMLBeginMacro(of);
-  vtkMRMLWriteXMLFloatMacro(safetyMargin_mm, SafetyMargin_mm);
-  vtkMRMLWriteXMLFloatMacro(riskMargin_mm, RiskMargin_mm);
+  vtkMRMLWriteXMLFloatMacro(safetyMargin, SafetyMargin);
+  vtkMRMLWriteXMLFloatMacro(riskMargin, RiskMargin);
   vtkMRMLWriteXMLIntMacro(orderIndex, OrderIndex);
   vtkMRMLWriteXMLEnumMacro(state, State);
   vtkMRMLWriteXMLEndMacro();
@@ -137,11 +138,27 @@ void vtkMRMLResectionPlanNode::ReadXMLAttributes(const char** atts)
   Superclass::ReadXMLAttributes(atts);
 
   vtkMRMLReadXMLBeginMacro(atts);
-  vtkMRMLReadXMLFloatMacro(safetyMargin_mm, SafetyMargin_mm);
-  vtkMRMLReadXMLFloatMacro(riskMargin_mm, RiskMargin_mm);
+  vtkMRMLReadXMLFloatMacro(safetyMargin, SafetyMargin);
+  vtkMRMLReadXMLFloatMacro(riskMargin, RiskMargin);
   vtkMRMLReadXMLIntMacro(orderIndex, OrderIndex);
   vtkMRMLReadXMLEnumMacro(state, State);
   vtkMRMLReadXMLEndMacro();
+
+  // Legacy scene compatibility: scenes saved before the margin rename
+  // carry the unit-suffixed attribute names.  A scene holds either the
+  // old or the new names, never both, so order does not matter.
+  for (const char** att = atts; att && *att && *(att + 1); att += 2)
+  {
+    const std::string attName = *att;
+    if (attName == "safetyMargin_mm")
+    {
+      this->SafetyMargin = std::stod(*(att + 1));
+    }
+    else if (attName == "riskMargin_mm")
+    {
+      this->RiskMargin = std::stod(*(att + 1));
+    }
+  }
 
   this->EndModify(disabledModify);
 }
@@ -157,8 +174,8 @@ void vtkMRMLResectionPlanNode::CopyContent(vtkMRMLNode* anode, bool deepCopy)
   {
     return;
   }
-  this->SafetyMargin_mm = other->SafetyMargin_mm;
-  this->RiskMargin_mm = other->RiskMargin_mm;
+  this->SafetyMargin = other->SafetyMargin;
+  this->RiskMargin = other->RiskMargin;
   this->OrderIndex = other->OrderIndex;
   this->State = other->State;
 }
@@ -169,8 +186,8 @@ void vtkMRMLResectionPlanNode::PrintSelf(ostream& os, vtkIndent indent)
   this->Superclass::PrintSelf(os, indent);
 
   vtkMRMLPrintBeginMacro(os, indent);
-  vtkMRMLPrintFloatMacro(SafetyMargin_mm);
-  vtkMRMLPrintFloatMacro(RiskMargin_mm);
+  vtkMRMLPrintFloatMacro(SafetyMargin);
+  vtkMRMLPrintFloatMacro(RiskMargin);
   vtkMRMLPrintIntMacro(OrderIndex);
   vtkMRMLPrintEnumMacro(State);
   vtkMRMLPrintEndMacro();

--- a/LiverResections/MRML/vtkMRMLResectionPlanNode.h
+++ b/LiverResections/MRML/vtkMRMLResectionPlanNode.h
@@ -69,8 +69,8 @@ class vtkMRMLScalarVolumeNode;
  * \par Field roster
  *
  *   - ``Name`` (inherited from vtkMRMLNode) — surgeon-facing plan name.
- *   - ``SafetyMargin_mm`` — clinical safety margin in millimetres.
- *   - ``RiskMargin_mm`` — clinical risk margin in millimetres.
+ *   - ``SafetyMargin`` — clinical safety margin, in millimetres.
+ *   - ``RiskMargin`` — clinical risk margin, in millimetres.
  *   - ``OrderIndex`` — zero-based position in the operative sequence
  *     (sentinel ``-1`` = unordered).  Migrated from the surface node
  *     by the wrapper-vs-carrier landing.
@@ -133,11 +133,13 @@ public:
   // Clinical field roster
   //--------------------------------------------------------------------------
 
-  vtkGetMacro(SafetyMargin_mm, double);
-  vtkSetMacro(SafetyMargin_mm, double);
+  /// Clinical safety margin, in millimetres.
+  vtkGetMacro(SafetyMargin, double);
+  vtkSetMacro(SafetyMargin, double);
 
-  vtkGetMacro(RiskMargin_mm, double);
-  vtkSetMacro(RiskMargin_mm, double);
+  /// Clinical risk (uncertainty) margin, in millimetres.
+  vtkGetMacro(RiskMargin, double);
+  vtkSetMacro(RiskMargin, double);
 
   /// Operative-sequence position (zero-based).  Default ``-1`` =
   /// unordered.  Migrated from the surface node by the
@@ -194,8 +196,8 @@ private:
   vtkMRMLResectionPlanNode(const vtkMRMLResectionPlanNode&) = delete;
   void operator=(const vtkMRMLResectionPlanNode&) = delete;
 
-  double SafetyMargin_mm;
-  double RiskMargin_mm;
+  double SafetyMargin;
+  double RiskMargin;
   int OrderIndex;
   int State;
 };

--- a/LiverResections/MRML/vtkMRMLResectionPlanStorageNode.cxx
+++ b/LiverResections/MRML/vtkMRMLResectionPlanStorageNode.cxx
@@ -191,8 +191,8 @@ int vtkMRMLResectionPlanStorageNode::WriteJson(const std::string& filePath, vtkM
   // design 05-lrp-json-schema.md §"Why the JSON document is the plan").
   const char* mrmlName = plan->GetName();
   writer->WriteStringProperty("name", mrmlName ? mrmlName : "");
-  writer->WriteDoubleProperty("safetyMargin_mm", plan->GetSafetyMargin_mm());
-  writer->WriteDoubleProperty("riskMargin_mm", plan->GetRiskMargin_mm());
+  writer->WriteDoubleProperty("safetyMargin", plan->GetSafetyMargin());
+  writer->WriteDoubleProperty("riskMargin", plan->GetRiskMargin());
   writer->WriteIntProperty("orderIndex", plan->GetOrderIndex());
   writer->WriteStringProperty("state", vtkMRMLResectionPlanNode::GetStateAsString(plan->GetState()));
 
@@ -363,20 +363,39 @@ int vtkMRMLResectionPlanStorageNode::ReadJson(const std::string& filePath, vtkMR
       plan->SetName(name.c_str());
     }
   }
-  if (root->HasMember("safetyMargin_mm"))
+  // Margins: prefer the current keys; fall back to the legacy
+  // unit-suffixed keys written before the margin rename (a file carries
+  // one set or the other, never both).  Values are millimetres either way.
+  if (root->HasMember("safetyMargin"))
+  {
+    double value = 0.0;
+    if (root->GetDoubleProperty("safetyMargin", value))
+    {
+      plan->SetSafetyMargin(value);
+    }
+  }
+  else if (root->HasMember("safetyMargin_mm"))
   {
     double value = 0.0;
     if (root->GetDoubleProperty("safetyMargin_mm", value))
     {
-      plan->SetSafetyMargin_mm(value);
+      plan->SetSafetyMargin(value);
     }
   }
-  if (root->HasMember("riskMargin_mm"))
+  if (root->HasMember("riskMargin"))
+  {
+    double value = 0.0;
+    if (root->GetDoubleProperty("riskMargin", value))
+    {
+      plan->SetRiskMargin(value);
+    }
+  }
+  else if (root->HasMember("riskMargin_mm"))
   {
     double value = 0.0;
     if (root->GetDoubleProperty("riskMargin_mm", value))
     {
-      plan->SetRiskMargin_mm(value);
+      plan->SetRiskMargin(value);
     }
   }
   if (root->HasMember("orderIndex"))

--- a/LiverResections/MRML/vtkMRMLResectionPlanStorageNode.h
+++ b/LiverResections/MRML/vtkMRMLResectionPlanStorageNode.h
@@ -63,12 +63,16 @@ class vtkMRMLAbstractParametricSurfaceNode;
  *
  * Schema shape (trimmed v2):
  *
+ * Readers also accept the legacy unit-suffixed margin keys
+ * (``safetyMargin_mm`` / ``riskMargin_mm``) written before the margin
+ * rename; writers emit only the current keys.  Values are millimetres.
+ *
  * \code
  * {
  *   "schemaVersion": 2,
  *   "name": "Right hemihepatectomy",
- *   "safetyMargin_mm": 10.0,
- *   "riskMargin_mm": 5.0,
+ *   "safetyMargin": 10.0,
+ *   "riskMargin": 5.0,
  *   "orderIndex": 0,
  *   "state": "Planning",
  *   "surface": {

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -738,8 +738,8 @@ if(DEFINED Python3_EXECUTABLE)
 
     # #501 slice 5 -- the REPRESENTATION half: FlattenedSurfaceRepresentation
     # shades off the WRAPPER (ADR-0031), not the carrier.  With a plan wrapper
-    # set, update() threads SetResectionMargin(SafetyMargin_mm) +
-    # SetUncertaintyMargin(RiskMargin_mm) onto the 2D
+    # set, update() threads SetResectionMargin(SafetyMargin) +
+    # SetUncertaintyMargin(RiskMargin) onto the 2D
     # vtkOpenGLResection2DPolyDataMapper and sources the distance-map volume
     # from plan.GetDistanceMapVolumeNode() (present -> resolved source; absent ->
     # source cleared, graceful fallback, margins still set).  GL-free: a FAKE 2D

--- a/LiverResections/Testing/Python/scenarios/BezierSurface4x4Planning.py
+++ b/LiverResections/Testing/Python/scenarios/BezierSurface4x4Planning.py
@@ -284,8 +284,8 @@ def setup_scene() -> slicer.vtkMRMLBezierSurfaceNode:
     )
     plan.SetAndObserveGeometryNode(carrier)
     plan.SetAndObserveDistanceMapVolumeNode(distance_map)
-    plan.SetSafetyMargin_mm(10.0)
-    plan.SetRiskMargin_mm(2.0)
+    plan.SetSafetyMargin(10.0)
+    plan.SetRiskMargin(2.0)
 
     # Planning state activates the BezierPlanningRepresentation (the one
     # that threads the distance map).  Confirmed reuses this fixture and

--- a/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
+++ b/LiverResections/Testing/Python/scenarios/Resectogram4x4BlurOff.py
@@ -246,8 +246,8 @@ def _build_resectogram_bezier(
     )
     plan.SetAndObserveGeometryNode(carrier)
     plan.SetAndObserveDistanceMapVolumeNode(distance_map)
-    plan.SetSafetyMargin_mm(10.0)
-    plan.SetRiskMargin_mm(2.0)
+    plan.SetSafetyMargin(10.0)
+    plan.SetRiskMargin(2.0)
 
     carrier.SetState(1)  # vtkMRMLBezierSurfaceNode::Planning
 

--- a/LiverResections/Testing/Python/test_bezier_planning_margin_render_key.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_margin_render_key.py
@@ -104,8 +104,8 @@ def _wire_pipeline(slicer, pipeline):
     if not hasattr(plan, "SetAndObserveGeometryNode"):
         pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveGeometryNode.")
     plan.SetAndObserveGeometryNode(data)
-    if not hasattr(plan, "SetSafetyMargin_mm"):
-        pytest.skip(f"{PLAN_NODE_CLASS} has no SetSafetyMargin_mm.")
+    if not hasattr(plan, "SetSafetyMargin"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetSafetyMargin.")
 
     pipeline.SetDisplayNode(display)
     pipeline.UpdatePipeline()
@@ -140,10 +140,10 @@ def test_margin_write_requests_exactly_one_render():
 
     data, display, plan = _wire_pipeline(slicer, pipeline)
 
-    renders = _count_renders(pipeline, lambda: plan.SetSafetyMargin_mm(9.0))
+    renders = _count_renders(pipeline, lambda: plan.SetSafetyMargin(9.0))
 
     assert renders == 1, (
-        "a SafetyMargin_mm write at fixed geometry must request exactly one "
+        "a SafetyMargin write at fixed geometry must request exactly one "
         f"render through the extended render key; got {renders}."
     )
 
@@ -160,7 +160,7 @@ def test_noop_modified_requests_no_render():
     _require_margin_render_seam_or_skip()
 
     data, display, plan = _wire_pipeline(slicer, pipeline)
-    plan.SetSafetyMargin_mm(9.0)  # settle a non-default value first
+    plan.SetSafetyMargin(9.0)  # settle a non-default value first
 
     renders = _count_renders(pipeline, plan.Modified)
 

--- a/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
+++ b/LiverResections/Testing/Python/test_bezier_planning_surface_mapper_wiring.py
@@ -321,8 +321,8 @@ def test_planning_distance_map_threaded_from_plan_to_mapper():
     volume.SetSpacing(2.0, 2.0, 2.0)
 
     plan.SetAndObserveDistanceMapVolumeNode(volume)
-    plan.SetSafetyMargin_mm(10.0)
-    plan.SetRiskMargin_mm(2.0)
+    plan.SetSafetyMargin(10.0)
+    plan.SetRiskMargin(2.0)
 
     rep.SetResectionPlanNode(plan)
     rep.update(display, data)
@@ -332,11 +332,11 @@ def test_planning_distance_map_threaded_from_plan_to_mapper():
         "builds the 3D texture from it in C++ at render)."
     )
     assert abs(mapper.GetResectionMargin() - 10.0) < 1e-5, (
-        "plan SafetyMargin_mm must reach the mapper's ResectionMargin; got "
+        "plan SafetyMargin must reach the mapper's ResectionMargin; got "
         f"{mapper.GetResectionMargin()}."
     )
     assert abs(mapper.GetUncertaintyMargin() - 2.0) < 1e-5, (
-        "plan RiskMargin_mm must reach the mapper's UncertaintyMargin; got "
+        "plan RiskMargin must reach the mapper's UncertaintyMargin; got "
         f"{mapper.GetUncertaintyMargin()}."
     )
     ras_to_ijk_t = mapper.GetRasToIjkMatrixT()

--- a/LiverResections/Testing/Python/test_flattened_surface_plan_shading.py
+++ b/LiverResections/Testing/Python/test_flattened_surface_plan_shading.py
@@ -7,8 +7,8 @@ The resectogram's flattened strip shades from the same distance field the 3D
 Bezier path uses, through the SAME ``vtkOpenGLResection2DPolyDataMapper``.  Its
 band needs the three wrapper-owned inputs ADR-0031 clusters on the
 ``vtkMRMLResectionPlanNode`` wrapper: the distance-map volume,
-``SetResectionMargin(SafetyMargin_mm)``, and
-``SetUncertaintyMargin(RiskMargin_mm)``.
+``SetResectionMargin(SafetyMargin)``, and
+``SetUncertaintyMargin(RiskMargin)``.
 
 The gap this pins: today ``FlattenedSurfaceRepresentation._apply_distance_map_texture``
 reads ``GetDistanceMapVolumeNode`` off the DATA NODE (the carrier) -- the WRONG
@@ -171,7 +171,7 @@ def _resolved_distance_map_source(rep, fake):
 def test_flattened_surface_threads_margins_from_wrapper():
     """Invariant 2: safety + risk margins reach the 2D mapper from the WRAPPER.
 
-    With a plan wrapper carrying ``SafetyMargin_mm`` / ``RiskMargin_mm``, the
+    With a plan wrapper carrying ``SafetyMargin`` / ``RiskMargin``, the
     Representation's ``update`` pushes ``SetResectionMargin(safety)`` +
     ``SetUncertaintyMargin(risk)`` onto the 2D mapper -- porting
     ``BezierPlanningRepresentation._apply_resection_plan`` into the resectogram
@@ -188,27 +188,27 @@ def test_flattened_surface_threads_margins_from_wrapper():
     plan = slicer.mrmlScene.AddNewNodeByClass(PLAN_NODE_CLASS)
     if data is None or display is None or plan is None:
         pytest.skip("wrapper / carrier / display nodes not all registered.")
-    if not (hasattr(plan, "SetSafetyMargin_mm") and hasattr(plan, "SetRiskMargin_mm")):
+    if not (hasattr(plan, "SetSafetyMargin") and hasattr(plan, "SetRiskMargin")):
         pytest.skip(f"{PLAN_NODE_CLASS} has no Safety/Risk margin setters.")
 
-    plan.SetSafetyMargin_mm(10.0)
-    plan.SetRiskMargin_mm(2.0)
+    plan.SetSafetyMargin(10.0)
+    plan.SetRiskMargin(2.0)
 
     rep.SetResectionPlanNode(plan)
     rep.update(display, data)
 
     assert fake.resection_margin is not None, (
-        "the wrapper's SafetyMargin_mm must reach the 2D mapper's "
+        "the wrapper's SafetyMargin must reach the 2D mapper's "
         "SetResectionMargin (ADR-0031) -- no margin was threaded."
     )
     assert abs(fake.resection_margin - 10.0) < 1e-5, (
-        "plan SafetyMargin_mm must reach SetResectionMargin; got "
+        "plan SafetyMargin must reach SetResectionMargin; got "
         f"{fake.resection_margin}."
     )
     assert fake.uncertainty_margin is not None and abs(
         fake.uncertainty_margin - 2.0
     ) < 1e-5, (
-        "plan RiskMargin_mm must reach the 2D mapper's SetUncertaintyMargin; "
+        "plan RiskMargin must reach the 2D mapper's SetUncertaintyMargin; "
         f"got {fake.uncertainty_margin}."
     )
 
@@ -273,12 +273,12 @@ def test_flattened_surface_clears_source_when_wrapper_has_no_distance_map():
         pytest.skip("wrapper / carrier / display not all registered.")
     if not hasattr(plan, "SetAndObserveDistanceMapVolumeNode"):
         pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveDistanceMapVolumeNode.")
-    if not (hasattr(plan, "SetSafetyMargin_mm") and hasattr(plan, "SetRiskMargin_mm")):
+    if not (hasattr(plan, "SetSafetyMargin") and hasattr(plan, "SetRiskMargin")):
         pytest.skip(f"{PLAN_NODE_CLASS} has no Safety/Risk margin setters.")
 
     plan.SetAndObserveDistanceMapVolumeNode(None)
-    plan.SetSafetyMargin_mm(5.0)
-    plan.SetRiskMargin_mm(1.0)
+    plan.SetSafetyMargin(5.0)
+    plan.SetRiskMargin(1.0)
 
     rep.SetResectionPlanNode(plan)
     rep.update(display, data)

--- a/LiverResections/Testing/Python/test_resection_plan_distance_map_not_persisted.py
+++ b/LiverResections/Testing/Python/test_resection_plan_distance_map_not_persisted.py
@@ -4,8 +4,8 @@
 """#501 slice 6 -- round-trip symmetry + the distance-map non-persistence guard.
 
 The ``.lrp.json`` storage node (``vtkMRMLResectionPlanStorageNode``) already
-round-trips every PERSISTED resection-plan field -- name, ``safetyMargin_mm`` /
-``riskMargin_mm``, ``orderIndex``, ``state`` and the whole surface block (grid,
+round-trips every PERSISTED resection-plan field -- name, ``safetyMargin`` /
+``riskMargin``, ``orderIndex``, ``state`` and the whole surface block (grid,
 initMode, slicingPlane, distanceSpheroid); the C++ ``testPlanRootedRoundTrip``
 pins that symmetry field-by-field.
 
@@ -74,12 +74,12 @@ def _make_plan_with_distance_map(slicer, logic, name):
     plan = logic.CreateResectionPlan(name)
     if plan is None or not plan.IsA(PLAN_NODE_CLASS):
         pytest.skip("CreateResectionPlan did not return a resection plan.")
-    for attr in ("SetSafetyMargin_mm", "SetRiskMargin_mm", "SetAndObserveDistanceMapVolumeNode",
+    for attr in ("SetSafetyMargin", "SetRiskMargin", "SetAndObserveDistanceMapVolumeNode",
                  "GetDistanceMapVolumeNode"):
         if not hasattr(plan, attr):
             pytest.skip(f"{PLAN_NODE_CLASS} lacks {attr} in this build (ADR-0031 API absent).")
-    plan.SetSafetyMargin_mm(12.0)
-    plan.SetRiskMargin_mm(3.0)
+    plan.SetSafetyMargin(12.0)
+    plan.SetRiskMargin(3.0)
     volume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", f"{name}DMap")
     if volume is None:
         pytest.skip("vtkMRMLScalarVolumeNode not registered.")
@@ -127,11 +127,11 @@ def test_distance_map_reference_does_not_round_trip():
     assert sink_storage.ReadData(sink) == 1, "ReadData of the just-written .lrp.json failed."
 
     # Positive symmetry sanity: the margins DID round-trip.
-    assert abs(sink.GetSafetyMargin_mm() - 12.0) < 1e-6, (
-        "safetyMargin_mm must round-trip through .lrp.json."
+    assert abs(sink.GetSafetyMargin() - 12.0) < 1e-6, (
+        "safetyMargin must round-trip through .lrp.json."
     )
-    assert abs(sink.GetRiskMargin_mm() - 3.0) < 1e-6, (
-        "riskMargin_mm must round-trip through .lrp.json."
+    assert abs(sink.GetRiskMargin() - 3.0) < 1e-6, (
+        "riskMargin must round-trip through .lrp.json."
     )
 
     # The guard: the distance-map reference is DELIBERATELY not persisted in

--- a/LiverResections/Testing/Python/test_resectogram_pipeline_margin_repaint.py
+++ b/LiverResections/Testing/Python/test_resectogram_pipeline_margin_repaint.py
@@ -4,7 +4,7 @@
 """Resectogram-margins slice 2 -- margin edits repaint the strip.
 
 The Pipeline memoises ``UpdatePipeline`` on the control-point geometry
-digest, so a ``SafetyMargin_mm`` / ``RiskMargin_mm`` write on the plan
+digest, so a ``SafetyMargin`` / ``RiskMargin`` write on the plan
 wrapper -- or a band-style edit on the parametric-surface display node --
 at FIXED geometry never re-threads the mappers and never repaints: the
 strip shows stale bands until an unrelated render.  Slice 2 widens the
@@ -115,7 +115,7 @@ def _wire_full_margin_fixture(slicer):
     if not hasattr(plan, "SetAndObserveGeometryNode"):
         pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveGeometryNode.")
     plan.SetAndObserveGeometryNode(data)
-    if not (hasattr(plan, "SetSafetyMargin_mm") and hasattr(plan, "SetRiskMargin_mm")):
+    if not (hasattr(plan, "SetSafetyMargin") and hasattr(plan, "SetRiskMargin")):
         pytest.skip(f"{PLAN_NODE_CLASS} has no Safety/Risk margin setters.")
     return data, display, surface_display, plan
 
@@ -138,10 +138,10 @@ def test_margin_write_at_fixed_geometry_does_real_work():
     settled = pipeline.GetUpdateCount()
     assert settled >= 1, "the first dispatch must do real work."
 
-    plan.SetSafetyMargin_mm(7.0)
+    plan.SetSafetyMargin(7.0)
 
     assert pipeline.GetUpdateCount() > settled, (
-        "a SafetyMargin_mm write at fixed geometry must re-reconcile through "
+        "a SafetyMargin write at fixed geometry must re-reconcile through "
         "the Pipeline's own plan observer + the widened memo key; the count "
         "did not advance -- the margin edit was swallowed."
     )
@@ -161,7 +161,7 @@ def test_margin_key_is_idempotent_after_the_edit():
     pipeline.SetDisplayNode(display)
     pipeline.UpdatePipeline()
 
-    plan.SetSafetyMargin_mm(7.0)
+    plan.SetSafetyMargin(7.0)
     after_edit = pipeline.GetUpdateCount()
 
     pipeline.UpdatePipeline()


### PR DESCRIPTION
## Summary

Per the review decision on #616: the plan-margin fields drop their
unit suffix everywhere. The C++/Python API becomes `SetSafetyMargin` /
`GetRiskMargin` (values still millimetres, now documented in the
header — the VTK/Slicer idiom), and the serialized forms follow:
scene-XML attributes and `.lrp.json` keys are `safetyMargin` /
`riskMargin`. Readers keep a legacy path for the old unit-suffixed
spellings so pre-rename scenes and plan files load unchanged; writers
emit only the current names; `schemaVersion` stays 2 (v3 is reserved
by the NURBS draft).

## ADR references

- ADR-0031: distance-map input on resection plan — amended (field
  rename note appended; placement decision unchanged, body text kept
  historical).
- ADR-0039: sub-PR on the `feature/resectogram-margins` epic;
  mechanical sweep declared as such.

## Reviewer's map

Load-bearing (read first):
1. `vtkMRMLResectionPlanNode.cxx` — the XML macro renames + the legacy
   attribute read loop in `ReadXMLAttributes`.
2. `vtkMRMLResectionPlanStorageNode.cxx` — new keys + else-if legacy
   fallback per margin.
3. `vtkMRMLResectionPlanStorageNodeTest1.cxx` —
   `testLegacyMarginKeysStillLoad` (the compat pin) + fixtures moved to
   current keys.
4. `vtkMRMLResectionPlanNodeTest1.cxx` — writer emits new attr / never
   the legacy one; legacy-attribute read pin.

Mechanical (the rest): CamelCase sweep across 4 lib files + 7 test
files + living docs; Doxygen unit notes; schema-doc and migration-guide
legacy notes; ADR-0031 amendment.

## Test plan

- Bare harness green locally (39 passed / expected skips).
- Launched (CI): full suite must stay green — the rename is
  behaviour-preserving except the legacy-read additions, which the two
  new C++ pins cover. First C++ compile check happens on this PR's CI.

## UX impact

None (API/schema naming only).

---
🤖 This PR was drafted with AI assistance (Claude Fable 5 via Claude
Code); the maintainer reviewed and directed the changes.
