### PR TITLE
ENH: Add Stage-4 margin controls to the resection planning panel

### DIFF
--- a/Docs/architecture/ui-stage-4-resection-planning.md
+++ b/Docs/architecture/ui-stage-4-resection-planning.md
@@ -113,7 +113,7 @@ For volumes + verification → continue to Stage 5.
 [Open resectogram view ▶]
 ```
 
-No numeric readouts in any state. Volume / margin / vessel-cut numbers live in Stage 5 per the 2026-05-21 compute-on-stable-state pushback.
+No numeric readouts in any state. Volume / margin / vessel-cut numbers live in Stage 5 per the 2026-05-21 compute-on-stable-state pushback. Margin *inputs* are the exception: the "Resection margins" group (Safety / Risk spinboxes, total-margin label, interpolated-margins toggle) is authored here per ADR-0023 §Stage-4 / §Persistence, gated on the distance map like the drawer; computed *readouts* remain Stage 5.
 
 ### Resectogram view button
 

--- a/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
+++ b/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
@@ -432,10 +432,16 @@ class ResectionPlanningWidget(qt.QWidget):
             return
         plan.SetRiskMargin(float(value))
         # v1 floor-clamp: safety >= risk keeps the shader's
-        # ``lowMargin = safety - risk`` non-negative.  Raising the minimum can
-        # clamp the safety value, whose valueChanged then writes the plan --
-        # deliberately, so the visible value and the node never diverge.
+        # ``lowMargin = safety - risk`` non-negative.  The SetRiskMargin above
+        # already routed through the plan observer into _syncMarginControls,
+        # which floors the minimum UNDER blockSignals -- so the spinbox may
+        # have clamped its value with the valueChanged suppressed.  Write the
+        # resulting value through explicitly: the visible value and the node
+        # must never diverge, regardless of which path did the clamping.
         self._safetyMarginSpinBox.minimum = float(value)
+        clamped = float(self._safetyMarginSpinBox.value)
+        if abs(plan.GetSafetyMargin() - clamped) > 1e-9:
+            plan.SetSafetyMargin(clamped)
         self._updateTotalMarginLabel()
 
     def onInterpolatedMarginsToggled(self, checked):  # noqa: N802 - Slicer/Qt verb convention

--- a/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
+++ b/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
@@ -106,6 +106,7 @@ _RESECTOGRAM_BACKGROUND_RGB = (1.0, 1.0, 1.0)
 _RESECTION_PLAN_CLASS = "vtkMRMLResectionPlanNode"
 _BEZIER_CARRIER_CLASS = "vtkMRMLBezierSurfaceNode"
 _RESECTOGRAM_DISPLAY_CLASS = "vtkMRMLResectogramDisplayNode"
+_SURFACE_DISPLAY_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
 _VIEW_NODE_CLASS = "vtkMRMLViewNode"
 # The logic module whose create-API (``CreateResectionPlan``) the Place button
 # calls to mint a fresh plan + carrier + display triad (ADR-0032).
@@ -208,10 +209,59 @@ class ResectionPlanningWidget(qt.QWidget):
         self._placeButton = placeButton
         placeButton.connect("clicked()", self.onPlaceResection)
 
+        # Margin inputs (ADR-0023 §Stage-4): the plan wrapper's Safety / Risk
+        # scalars (millimetres, ADR-0031) plus the display node's
+        # InterpolatedMargins band-style flag.  Disabled until the selected
+        # plan carries a distance map -- the same gate as the drawer, since
+        # without the map the shader has no band to draw.  Computed READOUTS
+        # (achieved margins, volumes) stay in Stage 5; these are inputs.
+        marginsGroup = ctk.ctkCollapsibleGroupBox()
+        marginsGroup.setObjectName("ResectionMarginsGroupBox")
+        marginsGroup.title = "Resection margins"
+        marginsGroup.enabled = False
+        planningLayout.addWidget(marginsGroup, 2, 0, 1, 2)
+        self._marginsGroup = marginsGroup
+
+        marginsForm = qt.QFormLayout(marginsGroup)
+
+        safetySpinBox = slicer.qMRMLSpinBox()
+        safetySpinBox.setObjectName("SafetyMarginSpinBox")
+        safetySpinBox.quantity = "millimeters"
+        safetySpinBox.minimum = 0.0
+        safetySpinBox.maximum = 100.0
+        safetySpinBox.singleStep = 1.0
+        marginsForm.addRow("Safety margin:", safetySpinBox)
+        self._safetyMarginSpinBox = safetySpinBox
+
+        riskSpinBox = slicer.qMRMLSpinBox()
+        riskSpinBox.setObjectName("RiskMarginSpinBox")
+        riskSpinBox.quantity = "millimeters"
+        riskSpinBox.minimum = 0.0
+        riskSpinBox.maximum = 100.0
+        riskSpinBox.singleStep = 0.5
+        marginsForm.addRow("Risk margin (±):", riskSpinBox)
+        self._riskMarginSpinBox = riskSpinBox
+
+        totalMarginLabel = qt.QLabel("0.00 mm")
+        totalMarginLabel.setObjectName("TotalMarginLabel")
+        marginsForm.addRow("Total margin:", totalMarginLabel)
+        self._totalMarginLabel = totalMarginLabel
+
+        interpolatedCheckBox = qt.QCheckBox("Interpolated margins")
+        interpolatedCheckBox.setObjectName("InterpolatedMarginsCheckBox")
+        marginsForm.addRow(interpolatedCheckBox)
+        self._interpolatedMarginsCheckBox = interpolatedCheckBox
+
+        safetySpinBox.connect("valueChanged(double)", self.onSafetyMarginChanged)
+        riskSpinBox.connect("valueChanged(double)", self.onRiskMarginChanged)
+        interpolatedCheckBox.connect(
+            "toggled(bool)", self.onInterpolatedMarginsToggled
+        )
+
         drawer = ctk.ctkCollapsibleButton()
         drawer.setObjectName("ResectogramDrawer")
         drawer.text = "Resectogram"
-        planningLayout.addWidget(drawer, 2, 0, 1, 2)
+        planningLayout.addWidget(drawer, 3, 0, 1, 2)
         self._drawer = drawer
 
         drawerLayout = qt.QGridLayout(drawer)
@@ -236,6 +286,10 @@ class ResectionPlanningWidget(qt.QWidget):
     def setMRMLScene(self, scene):  # noqa: N802 - Slicer/Qt verb convention
         self._mrmlScene = scene
         self._comboBox.setMRMLScene(scene)
+        # The margin spinboxes need the scene for the unit framework (the mm
+        # suffix comes from the scene's unit nodes).
+        self._safetyMarginSpinBox.setMRMLScene(scene)
+        self._riskMarginSpinBox.setMRMLScene(scene)
         self._updateLocatorReslicer(scene)
         self.refreshResectogramDrawer()
 
@@ -269,6 +323,21 @@ class ResectionPlanningWidget(qt.QWidget):
 
     def resectogramHintLabel(self):  # noqa: N802 - Slicer/Qt verb convention
         return self._hintLabel
+
+    def marginsGroupBox(self):  # noqa: N802 - Slicer/Qt verb convention
+        return self._marginsGroup
+
+    def safetyMarginSpinBox(self):  # noqa: N802 - Slicer/Qt verb convention
+        return self._safetyMarginSpinBox
+
+    def riskMarginSpinBox(self):  # noqa: N802 - Slicer/Qt verb convention
+        return self._riskMarginSpinBox
+
+    def totalMarginLabel(self):  # noqa: N802 - Slicer/Qt verb convention
+        return self._totalMarginLabel
+
+    def interpolatedMarginsCheckBox(self):  # noqa: N802 - Slicer/Qt verb convention
+        return self._interpolatedMarginsCheckBox
 
     def placeResectionButton(self):  # noqa: N802 - Slicer/Qt verb convention
         return self._placeButton
@@ -343,6 +412,84 @@ class ResectionPlanningWidget(qt.QWidget):
     def _onActiveResectionModified(self, caller, event):
         self.refreshResectogramDrawer()
 
+    # ----------------------------------------------------------------------- #
+    # Margin controls (ADR-0023 §Stage-4; scalars on the plan wrapper per
+    # ADR-0031, InterpolatedMargins on the carrier's parametric display node).
+    # The slices' pipeline observers make every write repaint both views, so
+    # these slots only author MRML state -- no render plumbing here.
+    # ----------------------------------------------------------------------- #
+
+    def onSafetyMarginChanged(self, value):  # noqa: N802 - Slicer/Qt verb convention
+        plan = self._activeResectionNode
+        if plan is None:
+            return
+        plan.SetSafetyMargin(float(value))
+        self._updateTotalMarginLabel()
+
+    def onRiskMarginChanged(self, value):  # noqa: N802 - Slicer/Qt verb convention
+        plan = self._activeResectionNode
+        if plan is None:
+            return
+        plan.SetRiskMargin(float(value))
+        # v1 floor-clamp: safety >= risk keeps the shader's
+        # ``lowMargin = safety - risk`` non-negative.  Raising the minimum can
+        # clamp the safety value, whose valueChanged then writes the plan --
+        # deliberately, so the visible value and the node never diverge.
+        self._safetyMarginSpinBox.minimum = float(value)
+        self._updateTotalMarginLabel()
+
+    def onInterpolatedMarginsToggled(self, checked):  # noqa: N802 - Slicer/Qt verb convention
+        plan = self._activeResectionNode
+        carrier = plan.GetGeometryNode() if plan is not None else None
+        display = self._parametricSurfaceDisplayNode(carrier)
+        if display is not None:
+            display.SetInterpolatedMargins(bool(checked))
+
+    def _updateTotalMarginLabel(self):
+        plan = self._activeResectionNode
+        total = (
+            plan.GetSafetyMargin() + plan.GetRiskMargin()
+            if plan is not None
+            else 0.0
+        )
+        self._totalMarginLabel.text = f"{total:.2f} mm"
+
+    def _syncMarginControls(self, plan, hasDistanceMap):  # noqa: N802 - internal
+        """Pull the selected plan's margin state into the controls.
+
+        blockSignals discipline: the sync must never echo a write back onto
+        the node (an external / scripted margin edit routes here through the
+        active-plan observer, and a write-back would ping-pong).  Cheap and
+        idempotent, so it runs on every drawer refresh -- including the
+        edge-trigger-short-circuited ones, which is exactly what keeps the
+        controls current when only the margins changed.
+        """
+        controls = (
+            self._safetyMarginSpinBox,
+            self._riskMarginSpinBox,
+            self._interpolatedMarginsCheckBox,
+        )
+        for control in controls:
+            control.blockSignals(True)
+        try:
+            if plan is not None:
+                # Floor before value, so the value never clamps spuriously.
+                self._safetyMarginSpinBox.minimum = plan.GetRiskMargin()
+                self._safetyMarginSpinBox.setValue(plan.GetSafetyMargin())
+                self._riskMarginSpinBox.setValue(plan.GetRiskMargin())
+            display = self._parametricSurfaceDisplayNode(
+                plan.GetGeometryNode() if plan is not None else None
+            )
+            if display is not None:
+                self._interpolatedMarginsCheckBox.setChecked(
+                    bool(display.GetInterpolatedMargins())
+                )
+        finally:
+            for control in controls:
+                control.blockSignals(False)
+        self._marginsGroup.enabled = bool(hasDistanceMap)
+        self._updateTotalMarginLabel()
+
     def _onDrawerCollapsed(self, collapsed):
         self.scheduleResectogramRender()
 
@@ -369,6 +516,12 @@ class ResectionPlanningWidget(qt.QWidget):
             hasPlan and carrier is not None and plan.GetDistanceMapVolumeNode() is not None
         )
         scene = self._mrmlScene
+
+        # Margin controls sync BEFORE the edge-trigger short-circuit below:
+        # a margin-only edit (spinbox, script, undo) changes neither the plan
+        # identity nor the distance-map presence, yet the controls + total
+        # label must still track it.
+        self._syncMarginControls(plan, hasDistanceMap)
 
         # Edge-trigger on the populate-relevant state only.  The active-plan
         # ModifiedEvent observer fires this on EVERY wrapper modification --
@@ -836,6 +989,22 @@ class ResectionPlanningWidget(qt.QWidget):
         """Return ``node`` if it is a resection-plan wrapper node, else ``None``."""
         if node is not None and node.IsA(_RESECTION_PLAN_CLASS):
             return node
+        return None
+
+    @staticmethod
+    def _parametricSurfaceDisplayNode(carrier):
+        """The carrier's parametric-surface display aspect, or ``None``.
+
+        The band-style home (InterpolatedMargins, margin colours) shared with
+        the 3D path -- the sibling of the resectogram display node on the same
+        carrier (Docs/architecture/target-mrml-node-hierarchy.md).
+        """
+        if carrier is None:
+            return None
+        for index in range(carrier.GetNumberOfDisplayNodes()):
+            candidate = carrier.GetNthDisplayNode(index)
+            if candidate is not None and candidate.IsA(_SURFACE_DISPLAY_CLASS):
+                return candidate
         return None
 
     @staticmethod

--- a/LiverResections/Testing/Python/test_resection_planning_widget_margin_controls.py
+++ b/LiverResections/Testing/Python/test_resection_planning_widget_margin_controls.py
@@ -1,0 +1,314 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+"""Resectogram-margins slice 3 -- Stage-4 margin controls author the plan.
+
+ADR-0023 §Stage-4 puts the margin INPUTS on the resection-planning panel
+(margin-dependent controls disable without a distance map, §"UI elements
+that depend on the distance maps"); the plan wrapper carries the values
+(``SafetyMargin`` / ``RiskMargin``, millimetres -- ADR-0031) and the
+carrier's ``vtkMRMLParametricSurfaceDisplayNode`` carries the
+``InterpolatedMargins`` band-style flag.  Slices 1-2 made every write
+repaint both views; this slice adds the authoring surface: two mm
+spinboxes (Safety / Risk), a total-margin readout, and an "Interpolated
+margins" checkbox, with the v1 floor-clamp (safety >= risk keeps the
+shader's ``lowMargin = safety - risk`` non-negative) and blockSignals
+pull-back discipline.
+
+All invariants are widget/MRML state, GPU-free, runnable under the
+``--no-main-window`` launched harness.
+
+-- WHY LAUNCHED-SLICER + SKIP-PENDING --
+
+Same harness shape as ``test_resection_planning_widget_v2_repoint.py``
+(the guards + teardown registration are shared).  Every test is guarded
+on the margin-controls' PRESENCE (``hasattr(widget,
+"safetyMarginSpinBox")``), so this lands RED-as-skip and turns green at
+the implementation commit (ADR-0027 §Conformance).  Verify run-vs-skip
+in the CI log; never trust overall green.
+
+-- NOT PINNED HERE --
+
+The bands actually recolouring on screen is the epic's :0 eyeball
+checklist (items 3-6); this file pins only the widget <-> node contract.
+
+See also:
+  * Docs/adr/0023-unified-gui-stage-workflow.md §Stage-4 (margin inputs)
+  * Docs/adr/0031-distance-map-input-on-resection-plan.md (+ Amendment:
+    the field rename this file's API calls follow)
+  * Docs/architecture/ui-stage-4-resection-planning.md (inputs-here,
+    computed-readouts-in-Stage-5 split)
+  * LiverResections/Testing/Python/test_resection_planning_widget_v2_repoint.py
+    (the harness shape this clones)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+MODULE_NAME = "liverresections"
+PLAN_NODE_CLASS = "vtkMRMLResectionPlanNode"
+BEZIER_CARRIER_CLASS = "vtkMRMLBezierSurfaceNode"
+SURFACE_DISPLAY_CLASS = "vtkMRMLParametricSurfaceDisplayNode"
+VOLUME_NODE_CLASS = "vtkMRMLScalarVolumeNode"
+VIEW_NODE_CLASS = "vtkMRMLViewNode"
+
+
+# --------------------------------------------------------------------------- #
+# Test isolation -- reclaim the resectogram singleton view node after each
+# test (the distance-map-present fixtures run the auto-populate branch, which
+# mints the singleton view + camera; both survive scene Clear by design).
+# Mirrors test_resection_planning_widget_v2_repoint.py.
+# --------------------------------------------------------------------------- #
+
+
+def _purge_resectogram_singleton_view():
+    try:
+        import slicer  # type: ignore[import-not-found]
+        from LiverResectionsLib.ResectogramViewManager import (  # type: ignore[import-not-found]
+            RESECTOGRAM_VIEW_SINGLETON_TAG,
+        )
+    except Exception:  # pragma: no cover - bare-pytest / import-env dependent
+        return
+    scene = getattr(slicer, "mrmlScene", None)
+    if scene is None:
+        return
+    stale_views, stale_ids = [], set()
+    for index in range(scene.GetNumberOfNodesByClass(VIEW_NODE_CLASS)):
+        node = scene.GetNthNodeByClass(index, VIEW_NODE_CLASS)
+        if node is not None and node.GetSingletonTag() == RESECTOGRAM_VIEW_SINGLETON_TAG:
+            stale_views.append(node)
+            stale_ids.add(node.GetID())
+    for index in range(scene.GetNumberOfNodesByClass("vtkMRMLCameraNode")):
+        camera = scene.GetNthNodeByClass(index, "vtkMRMLCameraNode")
+        if camera is not None and camera.GetActiveTag() in stale_ids:
+            scene.RemoveNode(camera)
+    for node in stale_views:
+        scene.RemoveNode(node)
+
+
+@pytest.fixture(autouse=True)
+def _drop_resectogram_singleton_view():
+    _purge_resectogram_singleton_view()
+    yield
+    _purge_resectogram_singleton_view()
+
+
+# --------------------------------------------------------------------------- #
+# Skip-guards
+# --------------------------------------------------------------------------- #
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()
+
+
+def _widget_or_skip(slicer):
+    from slicer_pytest_support import require_qt_widget, register_widget_for_teardown
+
+    require_qt_widget()
+    if getattr(slicer.modules, MODULE_NAME, None) is None:
+        pytest.skip(f"'{MODULE_NAME}' module not registered.")
+    try:
+        from LiverResectionsLib.ResectionPlanningWidget import (  # type: ignore[import-not-found]
+            ResectionPlanningWidget,
+        )
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"ResectionPlanningWidget not importable ({exc!r}).")
+    widget = ResectionPlanningWidget()
+    widget.setMRMLScene(slicer.mrmlScene)
+    return register_widget_for_teardown(widget)
+
+
+def _require_margin_controls_or_skip(widget):
+    """RED gate: the margin controls have not landed yet."""
+    if not hasattr(widget, "safetyMarginSpinBox"):
+        pytest.skip(
+            "ResectionPlanningWidget has no safetyMarginSpinBox() accessor -- "
+            "resectogram-margins slice 3 (Stage-4 margin controls) has not "
+            "landed."
+        )
+
+
+def _add_or_skip(slicer, node_class):
+    node = slicer.mrmlScene.AddNewNodeByClass(node_class)
+    if node is None:
+        pytest.skip(f"{node_class} not registered in this build.")
+    return node
+
+
+def _wire_plan(slicer, *, with_distance_map, with_surface_display=False):
+    """plan --geometry--> carrier (+ optional distance map / display aspect)."""
+    plan = _add_or_skip(slicer, PLAN_NODE_CLASS)
+    carrier = _add_or_skip(slicer, BEZIER_CARRIER_CLASS)
+    if not hasattr(plan, "SetAndObserveGeometryNode"):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no SetAndObserveGeometryNode.")
+    plan.SetAndObserveGeometryNode(carrier)
+    if not (hasattr(plan, "SetSafetyMargin") and hasattr(plan, "SetRiskMargin")):
+        pytest.skip(f"{PLAN_NODE_CLASS} has no Safety/Risk margin setters.")
+    if with_distance_map:
+        volume = _add_or_skip(slicer, VOLUME_NODE_CLASS)
+        if not hasattr(plan, "SetAndObserveDistanceMapVolumeNode"):
+            pytest.skip(f"{PLAN_NODE_CLASS} has no distance-map reference API.")
+        plan.SetAndObserveDistanceMapVolumeNode(volume)
+    display = None
+    if with_surface_display:
+        display = _add_or_skip(slicer, SURFACE_DISPLAY_CLASS)
+        carrier.AddAndObserveDisplayNodeID(display.GetID())
+    return plan, carrier, display
+
+
+def _select(widget, plan):
+    widget.resectionSurfaceComboBox().setCurrentNode(plan)
+
+
+def test_margins_group_gates_on_distance_map():
+    """The group enables iff the selected plan carries a distance map.
+
+    Three states: no selection -> disabled; plan without map -> disabled;
+    attaching the map (the wrapper Modified re-refresh path) -> enabled.
+    ADR-0023 §Stage-4 distance-map gate.
+    """
+    slicer = _slicer_or_skip()
+    widget = _widget_or_skip(slicer)
+    _require_margin_controls_or_skip(widget)
+
+    group = widget.marginsGroupBox()
+    assert not group.enabled, "no selection -> margin controls disabled."
+
+    plan, carrier, _ = _wire_plan(slicer, with_distance_map=False)
+    _select(widget, plan)
+    assert not group.enabled, "plan without distance map -> still disabled."
+
+    volume = _add_or_skip(slicer, VOLUME_NODE_CLASS)
+    plan.SetAndObserveDistanceMapVolumeNode(volume)
+    assert group.enabled, (
+        "attaching the distance map fires the active-plan observer and must "
+        "enable the margin controls."
+    )
+
+
+def test_spinboxes_write_the_plan_margins():
+    """The real integrated path: spinbox edits land on the wrapper."""
+    slicer = _slicer_or_skip()
+    widget = _widget_or_skip(slicer)
+    _require_margin_controls_or_skip(widget)
+
+    plan, carrier, _ = _wire_plan(slicer, with_distance_map=True)
+    _select(widget, plan)
+
+    widget.safetyMarginSpinBox().setValue(10.0)
+    assert abs(plan.GetSafetyMargin() - 10.0) < 1e-9, (
+        "the Safety spinbox must write plan.SetSafetyMargin."
+    )
+    widget.riskMarginSpinBox().setValue(2.0)
+    assert abs(plan.GetRiskMargin() - 2.0) < 1e-9, (
+        "the Risk spinbox must write plan.SetRiskMargin."
+    )
+
+
+def test_risk_floor_clamps_safety():
+    """v1 parity: raising risk floors the safety spinbox and writes through.
+
+    Keeps the shader's ``lowMargin = safety - risk`` non-negative: safety 5
+    then risk 8 -> safety minimum climbs to 8, its value clamps to 8, and the
+    clamp-raised valueChanged writes the plan.
+    """
+    slicer = _slicer_or_skip()
+    widget = _widget_or_skip(slicer)
+    _require_margin_controls_or_skip(widget)
+
+    plan, carrier, _ = _wire_plan(slicer, with_distance_map=True)
+    _select(widget, plan)
+
+    widget.safetyMarginSpinBox().setValue(5.0)
+    widget.riskMarginSpinBox().setValue(8.0)
+
+    assert abs(widget.safetyMarginSpinBox().minimum - 8.0) < 1e-9, (
+        "the safety spinbox minimum must floor at the risk value."
+    )
+    assert abs(widget.safetyMarginSpinBox().value - 8.0) < 1e-9, (
+        "the safety value must clamp up to the floor."
+    )
+    assert abs(plan.GetSafetyMargin() - 8.0) < 1e-9, (
+        "the clamp-raised value must write through to the plan."
+    )
+
+
+def test_total_margin_label_tracks_the_sum():
+    slicer = _slicer_or_skip()
+    widget = _widget_or_skip(slicer)
+    _require_margin_controls_or_skip(widget)
+
+    plan, carrier, _ = _wire_plan(slicer, with_distance_map=True)
+    _select(widget, plan)
+
+    widget.safetyMarginSpinBox().setValue(10.0)
+    widget.riskMarginSpinBox().setValue(2.0)
+    assert widget.totalMarginLabel().text == "12.00 mm", (
+        "total label must show safety + risk with the v1 two-decimal format; "
+        f"got {widget.totalMarginLabel().text!r}."
+    )
+
+
+def test_interpolated_checkbox_writes_the_display_node():
+    """The checkbox writes InterpolatedMargins on the carrier's parametric
+    display node -- and the plan gains no new field (colours-on-display
+    discipline, target-mrml-node-hierarchy)."""
+    slicer = _slicer_or_skip()
+    widget = _widget_or_skip(slicer)
+    _require_margin_controls_or_skip(widget)
+
+    plan, carrier, display = _wire_plan(
+        slicer, with_distance_map=True, with_surface_display=True
+    )
+    if not hasattr(display, "SetInterpolatedMargins"):
+        pytest.skip(f"{SURFACE_DISPLAY_CLASS} has no InterpolatedMargins.")
+    _select(widget, plan)
+
+    widget.interpolatedMarginsCheckBox().setChecked(True)
+    assert display.GetInterpolatedMargins() is True, (
+        "the checkbox must write InterpolatedMargins on the carrier's "
+        "parametric-surface display node."
+    )
+    assert not hasattr(plan, "GetInterpolatedMargins"), (
+        "the plan wrapper must NOT grow an InterpolatedMargins field."
+    )
+
+
+def test_selection_pull_back_syncs_without_writing():
+    """Selecting a plan pulls its values into the controls with blockSignals
+    discipline: the sync itself must not echo a write back (plan MTime
+    unchanged by the selection)."""
+    slicer = _slicer_or_skip()
+    widget = _widget_or_skip(slicer)
+    _require_margin_controls_or_skip(widget)
+
+    plan, carrier, display = _wire_plan(
+        slicer, with_distance_map=True, with_surface_display=True
+    )
+    plan.SetSafetyMargin(9.0)
+    plan.SetRiskMargin(3.0)
+    if hasattr(display, "SetInterpolatedMargins"):
+        display.SetInterpolatedMargins(True)
+    mtime_before = plan.GetMTime()
+
+    _select(widget, plan)
+
+    assert abs(widget.safetyMarginSpinBox().value - 9.0) < 1e-9
+    assert abs(widget.riskMarginSpinBox().value - 3.0) < 1e-9
+    if hasattr(display, "GetInterpolatedMargins"):
+        assert widget.interpolatedMarginsCheckBox().checked is True
+    assert plan.GetMTime() == mtime_before, (
+        "the pull-back sync must not write the plan (blockSignals "
+        "discipline) -- the plan MTime advanced during selection."
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Slice 3 of the resectogram-margins epic — the authoring surface. A
"Resection margins" group on the Stage-4 panel (between Place and the
drawer): Safety / Risk `qMRMLSpinBox`es (millimetres), a total-margin
readout, and an "Interpolated margins" checkbox. Scalars write the plan
wrapper (`SetSafetyMargin`/`SetRiskMargin`, ADR-0031 + its rename
amendment); the flag writes the carrier's parametric-surface display
node; slices 1–2 make every write repaint both views, so the slots
author MRML state only. The group shares the drawer's distance-map
gate; risk edits floor the safety spinbox (v1 parity — keeps the
shader's `lowMargin = safety − risk` non-negative); selection pull-back
runs under blockSignals and never echoes a write.

## ADR references

- ADR-0023 §Stage-4 / §Persistence — the margin-input contract this
  realises (margin-dependent controls disable without distance maps).
- ADR-0031 (+ Amendment) — scalars on the plan wrapper.
- ADR-0004 — widget composed in Python code (the orphaned v1 `.ui` was
  the naming/quantity reference only).
- ADR-0027 / ADR-0039 — tests-first; sub-PR on the epic.

## Reviewer's map

Read order: (1) `test_resection_planning_widget_margin_controls.py` —
the six pinned invariants (gate, write path, floor clamp, total label,
display-node flag + no-new-plan-field, MTime-neutral pull-back);
(2) `ResectionPlanningWidget.py` — load-bearing: the three slots,
`_syncMarginControls` (called at the top of `refreshResectogramDrawer`
BEFORE its edge-trigger short-circuit — that placement is what keeps
the controls tracking margin-only edits), `_parametricSurfaceDisplayNode`.
Mechanical: the `_setupUi` group construction, accessors, the drawer's
grid row shifting 2→3, the `setMRMLScene` spinbox wiring, the one-line
Stage-4 spec amendment.

## Test plan

- Bare harness: all 6 new tests skip cleanly (verified locally; the
  sibling repoint suite unchanged).
- Launched (CI): the new suite runs; verify run-vs-skip in the log.
- On-screen band behaviour is the epic's :0 eyeball checklist, which
  this slice completes the prerequisites for.

## UX impact

Yes — this is the user-facing piece: margins become configurable from
Stage 4. Disabled-state behaviour follows the existing drawer hint
pattern.

---
🤖 This PR was drafted with AI assistance (Claude Fable 5 via Claude
Code); the maintainer reviewed and directed the changes.
