### PR TITLE
COMP: Volumetry post-migration hygiene — unrun tests, stale markers, absent diagrams

### DIFF
--- a/Docs/adr/0012-layerdm-migration-v2-scope.md
+++ b/Docs/adr/0012-layerdm-migration-v2-scope.md
@@ -115,10 +115,12 @@ deferred:
 - **LiverSegments** — terminology dispatch (per the forthcoming
   ADR-0011), tool integrations (TotalSegmentator, MONAILabel,
   Kumar-Oram), and LabelToSCT bridges all land in v2.0.0.  LayerDM
-  display node deferred.
+  display node deferred.  *(Superseded by the 2026-07-09 amendment: the
+  migration landed in v2.0.0 -- see #569, closed complete.)*
 - **LiverVolumetry** — generic seed-and-category partition framework
   and the Couinaud preset land in v2.0.0.  LayerDM display node
-  deferred.
+  deferred.  *(Superseded by the 2026-07-09 amendment: the migration
+  landed in v2.0.0 via PR #606 -- see #570, closed complete.)*
 - **Modeling pipelines (PSR, VMTK)** — backend modernisation and
   terminology-keyed dispatch land in v2.0.0.  LayerDM display node
   deferred (would only matter for cross-module locator unification,
@@ -212,6 +214,14 @@ alone; LiverResections is the module where LayerDM pays the most.
   temporary inconsistency until v2.1.0 and must be documented in
   the v2.0.0 architecture diagrams (one diagram shows migrated
   modules, one shows the still-legacy display path).
+
+  *Superseded by the 2026-07-09 amendment.* The split did not survive:
+  `LiverSegments` was renamed `VascularTerritories` (ADR-0023) and
+  migrated (#569); `LiverVolumetry` migrated via PR #606 (#570);
+  `Modeling/` was dropped as a top-level module by ADR-0023 and never
+  existed to migrate. All shipping modules now carry LayerDM display
+  nodes, so the two-diagram treatment this paragraph asks for is moot --
+  the single target hierarchy is the accurate picture.
 - **v2.1.0 introduces additional new display node classes** for the
   deferred modules — a MINOR bump per ADR-0007 (additive,
   scene-compatible with v2.0.0).  Each deferred module needs its

--- a/Docs/adr/0038-unify-control-point-interaction.md
+++ b/Docs/adr/0038-unify-control-point-interaction.md
@@ -108,12 +108,19 @@ state-machine integration); territories become the second, simpler client.
 
 ## Conformance
 
-- [future] A shared 3D + slice control-point interaction base exists; the
+- [test] A shared 3D + slice control-point interaction base exists; the
   resection and territory pipelines are thin clients over the
-  point-provider seam.
+  point-provider seam.  (Landed: `SlicerLiverInteractionLib/`, PR #604/#605;
+  eleven non-test client files across LiverResections, VascularTerritories
+  and LiverVolumetry.)
 - [future] The four LayerDM integration invariants (one-per-type,
   configure-before-add, ResetDisplay-drives-UpdatePipeline, render-flush in
-  the interaction handler) are asserted once on the base.
+  the interaction handler) are asserted once on the base.  **Still open**:
+  `SlicerLiverInteractionLib/Testing/Python/test_layerdm_base_invariants.py`
+  carries all four as skeletons under an unconditional `@pytest.mark.skip`.
+  The base itself has landed; what is missing is LayerDM factory
+  introspection to count pipeline instances per (view, display-node type),
+  plus the actor-ordering and render-flush probes.
 - [review] The extraction is behaviour-preserving for the resection
   interaction (characterization tests green before + after).
 - [review] Each module keeps its own display-node type + creator (ADR-0013
@@ -199,11 +206,12 @@ injected pick provider.
 
 ### Conformance (this amendment)
 
-- [future] `SlicerLiverInteractionLib` exists with the five names above; the
+- [test] `SlicerLiverInteractionLib` exists with the five names above; the
   resection and territory pipelines are thin clients over the seam.
-- [future] The pick step is a seam-injected provider; LiverVolumetry supplies
+- [test] The pick step is a seam-injected provider; LiverVolumetry supplies
   an in-volume/slice pick, surface consumers supply `SurfacePick`; the base
-  contains no surface-vs-volume branch.
+  contains no surface-vs-volume branch.  (`PointProvider.pick_for_event` is
+  the seam; the 3D base contains no labelmap/in-volume branch.)
 - [review] The refactor is behaviour-preserving for resection **and**
   vascular territories (both characterization suites green, unchanged, both
   harnesses).

--- a/Docs/architecture/gui-stage-flow.md
+++ b/Docs/architecture/gui-stage-flow.md
@@ -87,7 +87,7 @@ flowchart LR
     TER["vtkMRMLAbstractTerritoriesNode<br/>(Std or Custom) — wraps SEG via segments ref"]
     PLAN["vtkMRMLResectionPlanNode(s)<br/>(clinical wrapper — name, margins, ordering, state)"]
     SURF["vtkMRMLAbstractParametricSurfaceNode<br/>(Bezier today; NURBS v2.1)"]
-    VOL["vtkMRMLLiverVolumetryPartitionNode(s)<br/>(v2.1; seed-and-category partitions)"]
+    VOL["vtkMRMLVolumetrySeedsNode(s)<br/>(seed-and-category volumetry carrier)"]
     LRP["per-plan .lrp.json<br/>(schema v2; plan + surface only)"]
     SCN["Slicer scene<br/>(.mrml + supporting files)"]
 

--- a/Docs/architecture/target-mrml-node-hierarchy.md
+++ b/Docs/architecture/target-mrml-node-hierarchy.md
@@ -145,6 +145,24 @@ classDiagram
         <<v2.0 concrete>>
         Manual path metadata + inputs (centerlines, groupings)
     }
+    class vtkMRMLVolumetrySeedsNode {
+        <<v2.0 concrete — volumetry carrier>>
+        Ordered seeds: position + label + colour
+        Per-volume grouping (AddSeedToVolume)
+    }
+    class vtkMRMLVolumetrySeedsDisplayNode {
+        <<v2.0 — data-only>>
+        Radius, per-seed colour
+        Arm / hover / grab state (ADR-0038)
+        Transient point, HighlightSeedID (not serialized)
+        --node refs--
+        +pickSurface → vtkMRMLLabelMapVolumeNode
+        +structureSource → vtkMRMLSegmentationNode
+    }
+    class vtkMRMLVolumetrySeedsStorageNode {
+        <<v2.0>>
+        Seed round-trip
+    }
 
     vtkMRMLStorableNode <|-- vtkMRMLResectionPlanNode
     vtkMRMLStorageNode  <|-- vtkMRMLResectionPlanStorageNode
@@ -155,12 +173,17 @@ classDiagram
     vtkMRMLDisplayableNode <|-- vtkMRMLAbstractTerritoriesNode
     vtkMRMLAbstractTerritoriesNode <|-- vtkMRMLStdCouinaudTerritoriesNode
     vtkMRMLAbstractTerritoriesNode <|-- vtkMRMLCustomTerritoriesNode
+    vtkMRMLDisplayableNode <|-- vtkMRMLVolumetrySeedsNode
+    vtkMRMLDisplayNode <|-- vtkMRMLVolumetrySeedsDisplayNode
+    vtkMRMLStorageNode  <|-- vtkMRMLVolumetrySeedsStorageNode
 
     vtkMRMLResectionPlanNode --> vtkMRMLAbstractParametricSurfaceNode : geometry ref
     vtkMRMLBezierSurfaceNode --> vtkMRMLParametricSurfaceDisplayNode : display ref
     vtkMRMLNurbsSurfaceNode  --> vtkMRMLParametricSurfaceDisplayNode : display ref
     vtkMRMLAbstractTerritoriesNode --> vtkMRMLSegmentationNode : segments ref
     vtkMRMLResectionPlanNode --> vtkMRMLResectionPlanStorageNode : storage ref
+    vtkMRMLVolumetrySeedsNode --> vtkMRMLVolumetrySeedsDisplayNode : display ref
+    vtkMRMLVolumetrySeedsNode --> vtkMRMLVolumetrySeedsStorageNode : storage ref
 ```
 
 ### Notes — 2026-05-25 amendment
@@ -186,6 +209,14 @@ classDiagram
   carrier).  Segment masks persist through the segmentation's own
   `.seg.nrrd` storage, not through `.lrp.json`.  See
   [`territories-class-hierarchy.md`](territories-class-hierarchy.md).
+- **Volumetry carries its own LayerDM family** (added 2026-09-11,
+  recording PR #606 / #570).  `vtkMRMLVolumetrySeedsNode` is the seed
+  carrier; the display node is **data-only** per ADR-0033 — it holds
+  radius/colour plus the ADR-0038 arm/hover/grab interaction state, and
+  renders nothing itself.  `HighlightSeedID` and the transient placement
+  point are deliberately C++ members rather than node attributes, so they
+  never serialize.  ADR-0012's "LiverVolumetry does not carry an SLDM
+  display node" is superseded.
 - **Plan ↔ Territories**: no node reference.  Per
   [ADR-0023][adr-0023] amendment, plans do not reference
   territories or partitions or UI stage state.  Visual co-existence

--- a/Docs/architecture/ui-stage-5-volumetry.md
+++ b/Docs/architecture/ui-stage-5-volumetry.md
@@ -7,6 +7,16 @@ explicit-compute output table.
 
 [adr-0023]: https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0023-unified-gui-stage-workflow.md
 
+:::{warning}
+**Design intent, not the shipped panel.** This document records the
+2026-05-21 design; the implementation diverged. Stage 5 ships a
+per-VOLUME seeds table (`LiverVolumetryLib/VolumetrySeedsTableWidget.py`)
+over `vtkMRMLVolumetrySeedsNode` / `...SeedsDisplayNode` /
+`...SeedsStorageNode` -- there is no partition-node class and no
+partitions combobox. Read the module source for current behaviour;
+read this for the reasoning behind it.
+:::
+
 ## What this stage does
 
 Compute per-category volumes by partitioning the liver parenchyma via the seed-and-category framework (2026-05-15 decision). Categories are surgeon-defined; seeds are fiducial points; barriers are Confirmed resection surfaces from Stage 4. Pure analytical workbench — **no verification card** in v2.0 (research-tool-grade per ADR-0023).
@@ -57,7 +67,7 @@ Module home: `LiverVolumetry/`.
 
 ## Top combobox — partitions
 
-- `qMRMLNodeComboBox` filtered on `vtkMRMLLiverVolumetryNode`.
+- `qMRMLNodeComboBox` filtered on a partition node class. *(Not shipped -- see the warning above; the panel is seeds-table-based.)*
 - Multiple partitions per scene are supported (e.g., "Resected vs Remnant" + "Custom regional analysis 1" + "Right-anterior watershed").
 - `[+]` creates a new empty partition. Default name on first creation: "Resected vs Remnant" (the dominant use case). Per the 2026-05-21 settlement: **empty by default** — no auto-populated categories or seeds.
 - `[-]` deletes the current partition (confirmation; deletes the output Segmentation node alongside).

--- a/LiverVolumetry/Testing/Python/CMakeLists.txt
+++ b/LiverVolumetry/Testing/Python/CMakeLists.txt
@@ -199,6 +199,26 @@ set(_volumetry_pytest_files
   # red->green).  Wrapped C++ nodes + segmentations -> SKIPS bare, RUNS
   # launched (ADR-0027).
   test_volumetry_generation_matrix.py
+  # ADR-0038 (amendment, OQ4) -- the WIRED pickSurface is readable by
+  # InVolumePick: _aimPickSurface must bind a node exposing GetImageData +
+  # RAS<->IJK, not the vtkMRMLSegmentationNode itself (which has neither, so
+  # every armed click declined and no seed landed).  The pick-math and
+  # placement tests both fed a pick surface directly and so never covered this
+  # wiring.  Live scene + Qt -> SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_pick_surface_wiring.py
+  # territory-usability -- placement CUES: a declined bare move in the slice
+  # pipeline still requests a render so the preview cursor paints (the base
+  # declines bare moves without rendering, ADR-0033, so a hover would otherwise
+  # compute the cursor and never flush it), and the 3D pipeline declines
+  # add-on-click because in-volume seeds are placed from a slice.  Pipelines
+  # import LayerDMLib -> SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_placement_cursor.py
+  # territory-usability -- selecting a segmentation toggles ONLY per-segment
+  # VISIBILITY; per-segment colour and opacity set by the user or another
+  # module survive selection.  Complements test_volumetry_show3d_visibility.py
+  # (visibility MAY change; colour/opacity may NOT).  Wrapped segmentation node
+  # + live scene + Qt -> SKIPS bare, RUNS launched (ADR-0027).
+  test_volumetry_show3d_preserves_display.py
 )
 
 foreach(_pytest_file IN LISTS _volumetry_pytest_files)

--- a/LiverVolumetry/Testing/Python/test_volumetry_compute_from_carrier.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_compute_from_carrier.py
@@ -35,9 +35,10 @@ labelmap volume + fiducial + table nodes.  A bare
 ``PythonSlicer -m pytest`` has ``slicer.mrmlScene is None`` so it SKIPS
 CLEANLY.
 
-The carrier + the transient-fiducial adapter do not exist yet.  Per
-ADR-0027 red->skip the guards skip-pend; the skips lift at the
-implementation commit.
+The carrier + the transient-fiducial adapter landed in PR #606.  The
+guards now skip only on HARNESS, never on absence -- except the
+table-level rollup at the end of this file, which stays skipped because
+its comparison target is still undefined (see its own skip reason).
 
 References
 ----------

--- a/LiverVolumetry/Testing/Python/test_volumetry_registration_smoke.py
+++ b/LiverVolumetry/Testing/Python/test_volumetry_registration_smoke.py
@@ -8,7 +8,10 @@ uses, and hosts NO per-module displayable manager
 (``feedback_layerdm_no_custom_dm``; ADR-0013 §5):
 
 1. ``RegisterNodeClass`` for the seed carrier + display node (+ storage);
-2. the upstream LayerDM displayable-manager ``RegisterInFactory``;
+2. the upstream LayerDM displayable-manager ``RegisterInFactory`` -- hosted
+   ONCE by LiverResections, not by this module: ADR-0013 §5 marks the call
+   idempotent across modules, first-to-load wins.  Listed here for the
+   complete picture, not as a LiverVolumetry obligation;
 3. a Pipeline creator matching ``(vtkMRMLViewNode,
    vtkMRMLVolumetrySeedsDisplayNode)`` returning the shared
    ``SurfacePointPlacementPipeline3D`` wired to a volumetry provider (plus
@@ -32,8 +35,8 @@ HARNESS: launched Slicer.  Node registration + the LayerDM factory are
 reachable only inside a launched Slicer with the module loaded; a bare
 ``PythonSlicer -m pytest`` SKIPS CLEANLY.
 
-The SUT does not exist yet.  Per ADR-0027 red->skip the guards skip-pend;
-the skips lift at the implementation commit.
+The SUT landed in PR #606.  The guards now skip only on HARNESS (a bare
+run has no registered nodes and no LayerDM factory), never on absence.
 
 References
 ----------

--- a/SlicerLiverInteractionLib/Testing/Python/test_layerdm_base_invariants.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_layerdm_base_invariants.py
@@ -33,7 +33,8 @@ loaded; a bare ``PythonSlicer -m pytest`` has LayerDMLib off the path, so
 every test SKIPS CLEANLY via the ``slicer_pytest_support`` guards.  Verify
 run-vs-skip in the CI log -- never trust overall green.
 
-The SUT does not exist yet.  Per ADR-0027 red->skip the import + hasattr
+The base landed in PR #604; these four probes did not.  Per ADR-0027 the
+import + hasattr
 guards skip-pend; the skips lift at the extraction commit.
 
 References
@@ -78,7 +79,7 @@ def _import_base_or_skip():
     except Exception as exc:  # pragma: no cover - import-environment dependent
         pytest.skip(
             f"SurfacePointPlacementPipeline3D not importable ({exc!r}) -- the "
-            "ADR-0038 base has not landed OR LayerDMLib is not reachable here "
+            "LayerDMLib is not reachable in this harness "
             "(ADR-0027)."
         )
     return SurfacePointPlacementPipeline3D
@@ -92,9 +93,10 @@ def _import_base_or_skip():
 @pytest.mark.skip(
     reason=(
         "ADR-0038 trap 1 (one Pipeline per (view, display-node type)) -- the "
-        "shared base + a LayerDM factory to count instances per (view, type) "
-        "have not landed.  Skeleton pins the invariant; implementer fills the "
-        "factory-instance assertion (ADR-0027 / ADR-0013 §1)."
+        "base has landed, but LayerDM factory introspection to COUNT pipeline "
+        "instances per (view, type) is not available here.  Skeleton pins the "
+        "invariant; implementer fills the factory-instance assertion "
+        "(ADR-0027 / ADR-0013 §1)."
     )
 )
 def test_one_pipeline_instance_per_view_and_display_node_type():
@@ -124,7 +126,7 @@ def test_one_pipeline_instance_per_view_and_display_node_type():
 @pytest.mark.skip(
     reason=(
         "ADR-0038 trap 2 (configure-before-AddNode) -- the shared base's "
-        "actor-add ordering is not landed.  Skeleton pins the invariant; "
+        "actor-add ordering is not yet probed.  Skeleton pins the invariant; "
         "implementer fills the ordering assertion (ADR-0027)."
     )
 )
@@ -153,7 +155,7 @@ def test_pipeline_is_configured_before_actors_are_added():
 @pytest.mark.skip(
     reason=(
         "ADR-0038 trap 3 (UpdatePipeline on ResetDisplay, not display "
-        "Modified) -- the shared base's reconcile driver is not landed.  "
+        "Modified) -- the base's reconcile driver is not yet probed.  "
         "Skeleton pins the invariant; implementer fills the "
         "ResetDisplay-vs-Modified assertion (ADR-0027)."
     )
@@ -183,9 +185,10 @@ def test_update_pipeline_is_driven_by_reset_display_not_modified():
 @pytest.mark.skip(
     reason=(
         "ADR-0038 trap 4 (RequestRender does not flush mid-"
-        "ProcessInteractionEvent) -- the shared base's interaction handler is "
-        "not landed.  Skeleton pins the invariant; implementer fills the "
-        "coalesced-render assertion (ADR-0027)."
+        "ProcessInteractionEvent) -- the base's interaction handler has "
+        "landed, but the render-flush probe is not yet written.  Skeleton "
+        "pins the invariant; implementer fills the coalesced-render "
+        "assertion (ADR-0027)."
     )
 )
 def test_request_render_does_not_flush_inside_process_interaction_event():


### PR DESCRIPTION
Closes #628 items 1-6. Hygiene from the LiverVolumetry LayerDM migration (#570) plus the stale conformance markers around it. No behaviour changes.

## 1. Three tests CMake never ran

`test_volumetry_pick_surface_wiring`, `test_volumetry_placement_cursor` and `test_volumetry_show3d_preserves_display` were committed but omitted from `_volumetry_pytest_files`, so **neither harness has ever executed them**.

They are not incidental. The first pins the wiring contract whose breakage left volumetry placement dead in the GUI: `_aimPickSurface` must bind a node exposing `GetImageData` + RAS<->IJK, and a `vtkMRMLSegmentationNode` has neither — so every armed click declined and no seed landed. Its docstring notes that the pick-math and placement tests both fed a pick surface directly and so never covered this.

## 2. ADR-0038 conformance — three flipped, one deliberately not

| Marker | Was | Now |
|---|---|---|
| Shared base exists; pipelines are thin clients | `[future]` | `[test]` — eleven non-test client files |
| `SlicerLiverInteractionLib` exists with the five names | `[future]` | `[test]` |
| Pick is a seam-injected provider, no branch in base | `[future]` | `[test]` |
| Four LayerDM integration invariants asserted on the base | `[future]` | **stays `[future]`** |

> The issue said four markers were stale. Only three are. The fourth is genuinely unfinished: `test_layerdm_base_invariants.py` carries all four invariants as skeletons under an **unconditional `@pytest.mark.skip`**, so they never assert regardless of harness. Their skip reasons claimed the base "has not landed" — false since PR #604, and misleading about which half is outstanding. The marker now names the real gap (LayerDM factory introspection to count pipeline instances per view/type, plus the ordering and render-flush probes).

## 3. ADR-0012 deferrals marked superseded

Two per-module deferrals and the "partially migrated hierarchy" paragraph still read as current. The split they describe did not survive: `LiverSegments` was renamed `VascularTerritories` and migrated (#569), `LiverVolumetry` migrated via PR #606 (#570), and `Modeling/` was dropped by ADR-0023 and never existed to migrate. The paragraph's request for two diagrams (migrated vs legacy) is moot.

## 4. Volumetry added to the target MRML hierarchy

The diagrams had **zero** mentions of volumetry despite ADR-0012 requiring them to record which modules carry LayerDM display nodes. Adds `vtkMRMLVolumetrySeedsNode` / `...DisplayNode` / `...StorageNode` with their refs, plus a note that the display node is data-only per ADR-0033 and that `HighlightSeedID` and the transient point are C++ members precisely so they never serialize.

## 5. Stage-5 doc carries a staleness warning

`ui-stage-5-volumetry.md` describes a partition-node combobox over a class that never existed. The panel ships a per-volume seeds table. Rather than silently patching the class name — which would leave the surrounding design text just as wrong — the doc gets a warning that it records design intent the implementation diverged from, and points at the real classes. The flow diagram's volumetry node is corrected.

**Left alone deliberately:** `territories-class-hierarchy.md` mentions the same absent class, but accurately — it describes a proposal the 2026-05-21 grilling pass retracted. Correct as historical narrative.

## 6. Test prose that said the SUT was unbuilt

Red-to-skip guards from the invariant-test-first phase still told the reader the implementation did not exist. It landed in PR #606. Also: the registration smoke test listed LayerDM `RegisterInFactory` among LiverVolumetry's obligations — ADR-0013 §5 marks it idempotent, first-to-load wins, and LiverResections hosts it.

**Not touched:** the one genuinely pending assertion, the table-level comparison in `test_volumetry_compute_from_carrier` (#628 item 7). Its target is undefined — a decision, not an omission.

## Verification

- Three newly-registered tests collect and skip cleanly bare with the standard harness message (they are launched-only). CI's launched row is where they first actually run.
- Bare suite per root: LiverVolumetry 64 passed / 176 skipped, SlicerLiverInteractionLib 20 passed / 10 skipped, `Testing/Python/unit` 120 passed / 30 skipped. **204 passed, 0 failed.**
- Running those three roots *together* yields 90 failures — identical on `preview` at `4ca644a`, so it is the known multi-root conftest collision, not a regression from this branch. I baselined it rather than assume.
- Mermaid blocks balanced (17/17 and 10/10 class braces); docs-lint validates properly in CI.
- Full pre-commit green.

## Reviewer's map

- `LiverVolumetry/Testing/Python/CMakeLists.txt` — **load-bearing**: three additions, each with the list's usual bare-vs-launched note.
- `Docs/adr/0038-*.md` — **load-bearing**: read the fourth marker's wording; it is the one that stays `[future]`.
- `Docs/architecture/target-mrml-node-hierarchy.md` — new node family in the class diagram + a note.
- Everything else — prose corrections, no logic.

---

**Found but deliberately out of scope:** ~70 sites across 40 files reference private LLM-memory filenames (`feedback_launched_widget_teardown_crash`, `feedback_layerdm_state_on_display_node`, `feedback_layerdm_no_custom_dm`, …) in shipped source and test docstrings. That violates the repo's own no-local-references convention and needs per-site replacement with in-repo anchors, so it wants its own PR. Filed separately.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
