### PR TITLE
BUG: Require liver voxels, not just a liver tag, to unlock Place

### DIFF
--- a/LiverResections/LiverResectionsLib/TargetModel.py
+++ b/LiverResections/LiverResectionsLib/TargetModel.py
@@ -35,15 +35,28 @@ _TARGET_MODEL_ATTRIBUTE = "LiverResections.TargetModel"
 
 
 def has_canonical_liver() -> bool:
-    """True iff a canonical segmentation holds an SCT-tagged liver segment.
+    """True iff a canonical segmentation holds a liver segment WITH VOXELS.
 
     The Place guard's predicate: without it there is no target mesh, no
     auto-seed, and no contour -- Place must refuse instead of minting a
     dead resection (v1 parity: AddResectionPlane errored on a missing
     target organ model).
+
+    The tag alone does not carry that guarantee.  Stage 2 pre-seeds its
+    checklist with ``AddEmptySegment`` rows that already carry their
+    terminology tags, and the Liver shell builds every stage panel on
+    module open -- so a liver-tagged but EMPTY segment exists from the
+    first frame, before anything has been segmented.  Matching on the tag
+    alone unlocked Place immediately and minted exactly the dead
+    resection this guard exists to prevent: ``ensure_target_model``
+    returned ``None``, the auto-seed bailed on zero points, and the user
+    was left with a selected plan that rendered nothing and reported
+    nothing.
     """
-    node, _segment_id = _find_canonical_liver_segment()
-    return node is not None
+    node, segment_id = _find_canonical_liver_segment()
+    if node is None:
+        return False
+    return not _segment_is_empty(node, segment_id)
 
 
 def ensure_target_model(plan_node: Any) -> Any | None:
@@ -95,6 +108,50 @@ def _find_canonical_liver_segment() -> tuple:
             if f"^{_SCT_LIVER_CODE}^" in str(text):
                 return node, segment_id
     return None, None
+
+
+def _segment_is_empty(segmentation_node: Any, segment_id: str) -> bool:
+    """True when ``segment_id`` carries no voxel of its OWN label value.
+
+    Emptiness must be LABEL-AWARE.  Stage 2's pre-seeded segments SHARE a
+    single binary-labelmap layer (the stock ``AddEmptySegment`` shape), so
+    landing content on one sharer grows the shared image's extent for
+    every sharer.  The object-level extent therefore says nothing about
+    whether THIS segment holds anything -- only a scan for its own label
+    value does.
+
+    Cheap by construction: the binary labelmap is the segmentation's
+    master representation, so this reads what is already in memory.  It
+    deliberately does NOT go through ``_liver_closed_surface``, which
+    would run a closed-surface conversion on every enablement check.
+
+    The Stage-2 sibling (``LiverSegmentation._segmentIsEmpty``) applies
+    the same rule; per this module's cross-module contract note the
+    shared vocabulary is scene data, not a Python import, so the logic is
+    restated here rather than imported.
+    """
+    if segmentation_node is None or not segment_id:
+        return True
+    segment = segmentation_node.GetSegmentation().GetSegment(segment_id)
+    if segment is None:
+        return True
+
+    name = slicer.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName()
+    labelmap = segment.GetRepresentation(name)
+    if labelmap is None:
+        return True
+    if hasattr(labelmap, "IsEmpty") and labelmap.IsEmpty():
+        return True
+    extent = labelmap.GetExtent()
+    if extent[0] > extent[1] or extent[2] > extent[3] or extent[4] > extent[5]:
+        return True
+    scalars = labelmap.GetPointData().GetScalars()
+    if scalars is None:
+        return True
+
+    from vtk.util.numpy_support import vtk_to_numpy
+
+    return not bool((vtk_to_numpy(scalars) == segment.GetLabelValue()).any())
 
 
 def _liver_closed_surface(segmentation_node: Any, segment_id: str) -> Any | None:

--- a/LiverResections/Testing/Python/test_place_gate_requires_liver_voxels.py
+++ b/LiverResections/Testing/Python/test_place_gate_requires_liver_voxels.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The Place gate demands liver VOXELS, not just a liver-tagged row.
+
+``has_canonical_liver()`` is the Place button's enablement predicate, and
+its docstring states the contract it must honour: *"without it there is
+no target mesh, no auto-seed, and no contour -- Place must refuse instead
+of minting a dead resection"*.
+
+Matching on the SCT terminology tag alone does not honour it.  Stage 2
+pre-seeds its checklist with ``AddEmptySegment`` rows that ALREADY carry
+their terminology tags (``ensureExpectedStructures``), and the Liver
+shell builds every stage panel on module open -- so a liver-tagged but
+EMPTY segment exists from the first frame, before anything is segmented.
+A tag-only predicate therefore unlocks Place immediately;
+``ensure_target_model`` then finds no polydata and returns ``None``, the
+auto-seed bails on zero points, and the user gets a created, selected
+plan with no handles, no contour and no message.
+
+Emptiness is LABEL-AWARE: pre-seeded segments SHARE one binary-labelmap
+layer, so writing content to one sharer grows the shared extent for all
+of them.  A segment is empty iff NO voxel carries its own label value --
+the object-level extent says nothing about a single sharer.  (The Stage-2
+sibling ``_segmentIsEmpty`` documents the same trap; the contract between
+the modules is scene data, not a Python import.)
+
+HARNESS: launched Slicer.  Needs a live scene plus the segmentations
+logic, so a bare ``PythonSlicer -m pytest`` SKIPS CLEANLY (ADR-0027).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+SCT_LIVER_CODE = "10200004"
+
+_TERMINOLOGY = (
+    "Segmentation category and type - DICOM master list"
+    "~SCT^85756007^Tissue"
+    f"~SCT^{SCT_LIVER_CODE}^Liver"
+    "~^^~Anatomic codes - DICOM master list~^^~^^"
+)
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()
+
+
+def _target_model_module():
+    try:
+        from LiverResectionsLib import TargetModel
+    except Exception:
+        pytest.skip("LiverResectionsLib.TargetModel not importable (pending impl).")
+    return TargetModel
+
+
+def _canonical_node(slicer):
+    """A canonical-role segmentation with no segments yet."""
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+    node.SetAttribute("LiverSegmentation.Role", "canonical")
+    return node
+
+
+def _add_tagged_empty_liver(node):
+    """Stage 2's pre-seeded placeholder: tagged, no voxels."""
+    segment_id = node.GetSegmentation().AddEmptySegment("", "Liver parenchyma")
+    node.GetSegmentation().GetSegment(segment_id).SetTag(
+        "TerminologyEntry", _TERMINOLOGY
+    )
+    return segment_id
+
+
+def _fill_liver_voxels(slicer, node, segment_id):
+    """Land real voxels on an existing tagged segment."""
+    import numpy as np
+
+    labelmap = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode")
+    array = np.zeros((16, 16, 16), dtype="uint8")
+    array[4:12, 4:12, 4:12] = 1
+    slicer.util.updateVolumeFromArray(labelmap, array)
+    slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(
+        labelmap, node
+    )
+    slicer.mrmlScene.RemoveNode(labelmap)
+    # The import lands a NEW segment; move the tag onto it and drop the
+    # placeholder, which is what a real Stage-2 landing does.
+    segmentation = node.GetSegmentation()
+    for candidate in list(segmentation.GetSegmentIDs()):
+        if candidate == segment_id:
+            continue
+        segmentation.GetSegment(candidate).SetTag("TerminologyEntry", _TERMINOLOGY)
+        segmentation.RemoveSegment(segment_id)
+        return candidate
+    return segment_id
+
+
+def test_tagged_but_empty_liver_does_not_unlock_place():
+    """The Stage-2 placeholder must NOT satisfy the Place gate.
+
+    This is the whole bug: the checklist row exists from module open, so
+    a tag-only predicate mints a dead resection on the first click.
+    """
+    slicer = _slicer_or_skip()
+    target_model = _target_model_module()
+
+    node = _canonical_node(slicer)
+    _add_tagged_empty_liver(node)
+
+    assert target_model.has_canonical_liver() is False, (
+        "A liver-tagged segment with NO voxels is Stage 2's pre-seeded "
+        "placeholder, not a segmented liver.  Place must stay disabled: "
+        "ensure_target_model would return None and the auto-seed would "
+        "bail, leaving a selected plan that renders nothing."
+    )
+
+
+def test_liver_with_voxels_unlocks_place():
+    """Once the row holds voxels the gate opens (the positive case)."""
+    slicer = _slicer_or_skip()
+    target_model = _target_model_module()
+
+    node = _canonical_node(slicer)
+    segment_id = _add_tagged_empty_liver(node)
+    _fill_liver_voxels(slicer, node, segment_id)
+
+    assert target_model.has_canonical_liver() is True, (
+        "A liver-tagged segment holding voxels is exactly what Place "
+        "needs; the gate must not over-tighten and refuse real anatomy."
+    )
+
+
+def test_no_canonical_segmentation_keeps_place_shut():
+    """The pre-existing refusal path is unchanged by the emptiness rule."""
+    slicer = _slicer_or_skip()
+    target_model = _target_model_module()
+    assert slicer is not None
+
+    assert target_model.has_canonical_liver() is False


### PR DESCRIPTION
Closes #634.

## The bug

**Place resection** was enabled from the first frame, before anything had been segmented. Clicking it created a plan that rendered nothing and reported nothing — Stage 4 looked broken rather than ungated, and clicking again just minted a second dead plan.

The guard's own docstring states the contract it was failing:

> *"without it there is no target mesh, no auto-seed, and no contour — Place must refuse instead of minting a dead resection"*

## Why the tag was not enough

1. The Liver shell builds every stage panel on module open, so `LiverSegmentation.setup()` runs and calls `getOrCreateCanonicalSegmentation()`.
2. That calls `ensureExpectedStructures()`, which does `AddEmptySegment(...)` + `tagSegmentWithSct(...)` for all four structures. **Four empty segments now carry their SCT tags.**
3. `has_canonical_liver()` matched purely on `"^10200004^" in TerminologyEntry` — no voxel check — and returned `True`.
4. `ensure_target_model()` found no polydata and returned `None` ("a graceful no-op").
5. `_auto_seed_slicing_plane()` hit `if polydata is None or polydata.GetNumberOfPoints() == 0: return False` and bailed.

Every layer degraded gracefully, and the silence composed into a dead feature — the same shape as the five render defects the #620 eyeball caught.

## The fix

`has_canonical_liver()` now requires voxels.

**Emptiness is label-aware, and this is the part worth reviewing.** Stage 2's pre-seeded segments **share one binary-labelmap layer**, so landing content on any one sharer grows the shared image's extent for *all* of them. An object-level extent check would therefore report an untouched placeholder as non-empty — the naive fix is wrong. Only a scan for the segment's own label value is correct.

I found that rule by reading the Stage-2 sibling `_segmentIsEmpty`, which documents the same trap. The logic is **restated rather than imported**: `TargetModel.py`'s header explicitly records that "LiverResections does not import LiverSegmentationLib — the contract is the scene data".

**On cost:** #634 floated closed-surface conversion as the obvious predicate. That would run a full representation build on every enablement check. The binary labelmap is the segmentation's master representation, so this reads what is already in memory.

## Verification — red then green, launched

The invariant test was written first and proven to catch the bug:

| | Result |
|---|---|
| **Without** the fix | **1 failed**, 157 passed, 15 skipped — the failure is exactly `test_tagged_but_empty_liver_does_not_unlock_place` |
| **With** the fix | **158 passed**, 15 skipped, 0 failed |

The positive-case test (`test_liver_with_voxels_unlocks_place`) passed in **both** runs, so the gate is not over-tightened — it still admits real anatomy. The third test pins that the pre-existing no-segmentation refusal is unchanged.

Run in the warm Qt6 build tree via the launched harness (the tree was restored to clean afterwards; nothing was committed there). Bare: skips cleanly with the standard harness message.

**No CMakeLists entry needed** — LiverResections' launched row sweeps the directory, which is why the new file ran without registration, and why its sibling `test_target_model_wiring.py` is likewise unregistered. This is *not* the #628 situation, where the omitted files were in a list that drives the bare sweep and so ran nowhere.

## What the user sees now

With the gate honest, the **existing** refusal path fires for the common case and names the missing hand-off — *"Accept a liver segmentation in Anatomy (Stage 2) first."* — instead of silently minting a dead plan.

**Worth a follow-up, not fixed here:** that hint is written into the *Resectogram* section's label, which any later refresh overwrites. The message is right; its home is fragile.

## Reviewer's map

- `TargetModel.py` — **load-bearing**: `has_canonical_liver()` now delegates to the new `_segment_is_empty()`. Read the probe's docstring for the shared-layer reasoning.
- `test_place_gate_requires_liver_voxels.py` — three invariants; the first is the bug.

## Eyeball worth doing

Open the Liver module on a fresh scene and confirm Place refuses with the hint instead of creating an invisible plan; then segment a liver and confirm it proceeds normally.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
