### PR TITLE
ENH: Add BuildRingGroups to the control-polygon geometry SSOT (#505 slice 1)

### DIFF
--- a/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
@@ -18,6 +18,7 @@ set(KIT_TEST_SRCS
   vtkLiverSpheroidRingExtractorEdgeCasesTest.cxx
   vtkLiverSpheroidRingExtractorConsistencyTest.cxx
   vtkSlicerLiverBezierControlPolygonGeometryTest1.cxx
+  vtkSlicerLiverBezierRingGroupsTest.cxx
   vtkLiverResectogramAspectRatioTest.cxx
   vtkLiverResectogramPixelMappingTest.cxx
   )
@@ -43,6 +44,7 @@ SIMPLE_TEST(vtkLiverContourParameterizerEdgeCasesTest)
 SIMPLE_TEST(vtkLiverPlaneRingExtractorEdgeCasesTest)
 SIMPLE_TEST(vtkLiverSpheroidRingExtractorEdgeCasesTest)
 SIMPLE_TEST(vtkSlicerLiverBezierControlPolygonGeometryTest1)
+SIMPLE_TEST(vtkSlicerLiverBezierRingGroupsTest)
 
 # Stack-4 ring-extraction wiring — Constraint 1 (shader/extractor
 # parameter consistency) + Constraint 2 (extraction-granularity bound).

--- a/LiverResections/Algorithm/Testing/Cxx/vtkSlicerLiverBezierRingGroupsTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkSlicerLiverBezierRingGroupsTest.cxx
@@ -1,0 +1,172 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, Oslo University Hospital. All rights reserved.
+
+  Tests for
+  ``vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups``
+  — the ring decomposition the control-polygon group-drag gestures
+  consume (frame translation and per-ring translation).
+
+  Per ADR-0008 §2 these are C++ low-level ctkTest-driver tests with no
+  Slicer scene, no Qt, no rendering, no on-screen interactor.  The
+  builder is a pure index helper; the test exercises the static method
+  directly.
+
+  The load-bearing property is that the rings PARTITION the control
+  grid: a ring translates rigidly, so an id appearing in two rings
+  would be displaced twice and an id appearing in none would be left
+  behind, tearing the surface.  Every case below asserts the partition
+  explicitly rather than only checking sizes.
+
+  Coverage:
+
+   - ``(4, 4)``: two rings — outer 12 ids, inner 4 — and the outer ring
+     emitted as a CONTIGUOUS closed-path walk, so a caller can draw the
+     ring highlight straight from the id order.
+   - ``(3, 3)``: two rings — outer 8 ids, and an inner group holding the
+     SINGLE centre id.  A one-element rigid-translation group is well
+     defined even though it is not a ring geometrically; this pins the
+     degenerate shape so a caller presenting a ring affordance cannot be
+     surprised by it.
+   - Invalid shapes: the ADR-0018 §1 closed-set check rejects them and
+     returns an empty ring list, mirroring the sibling
+     ``BuildControlPolygonCells``.
+
+==============================================================================*/
+
+// LiverResections Algorithm includes
+#include "vtkSlicerLiverBezierControlPolygonGeometry.h"
+
+// VTK includes
+#include <vtkTestingOutputWindow.h>
+#include <vtkType.h>
+
+// STD includes
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+
+#define LIVER_CHECK_INT(actual, expected)                                                                    \
+  do                                                                                                         \
+  {                                                                                                          \
+    const long long _a = static_cast<long long>(actual);                                                     \
+    const long long _e = static_cast<long long>(expected);                                                   \
+    if (_a != _e)                                                                                            \
+    {                                                                                                        \
+      std::fprintf(stderr, "[%s:%d] FAIL: %s = %lld; expected %lld\n", __FILE__, __LINE__, #actual, _a, _e); \
+      return EXIT_FAILURE;                                                                                   \
+    }                                                                                                        \
+  } while (0)
+
+//----------------------------------------------------------------------------
+// The rings must be a partition of [0, rows * cols): every control point
+// in exactly one rigid-translation group.
+int CheckPartitions(const std::vector<std::vector<vtkIdType>>& rings, unsigned int rows, unsigned int cols)
+{
+  std::vector<vtkIdType> flat;
+  for (const auto& ring : rings)
+  {
+    flat.insert(flat.end(), ring.begin(), ring.end());
+  }
+  std::sort(flat.begin(), flat.end());
+
+  LIVER_CHECK_INT(flat.size(), rows * cols);
+  for (unsigned int i = 0; i < rows * cols; ++i)
+  {
+    LIVER_CHECK_INT(flat[i], i);
+  }
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestFourByFour()
+{
+  const auto rings = vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups(4, 4);
+
+  LIVER_CHECK_INT(rings.size(), 2);
+  LIVER_CHECK_INT(rings[0].size(), 12);
+  LIVER_CHECK_INT(rings[1].size(), 4);
+
+  if (CheckPartitions(rings, 4, 4) != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+
+  // The outer ring walks the boundary clockwise from the top-left, so a
+  // highlight can consume the order directly as a closed path.
+  const std::vector<vtkIdType> expectedOuter = { 0, 1, 2, 3, 7, 11, 15, 14, 13, 12, 8, 4 };
+  for (size_t i = 0; i < expectedOuter.size(); ++i)
+  {
+    LIVER_CHECK_INT(rings[0][i], expectedOuter[i]);
+  }
+
+  const std::vector<vtkIdType> expectedInner = { 5, 6, 10, 9 };
+  for (size_t i = 0; i < expectedInner.size(); ++i)
+  {
+    LIVER_CHECK_INT(rings[1][i], expectedInner[i]);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestThreeByThree()
+{
+  const auto rings = vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups(3, 3);
+
+  LIVER_CHECK_INT(rings.size(), 2);
+  LIVER_CHECK_INT(rings[0].size(), 8);
+
+  // The degenerate case: the 3x3 "inner ring" is the single centre point.
+  LIVER_CHECK_INT(rings[1].size(), 1);
+  LIVER_CHECK_INT(rings[1][0], 4);
+
+  return CheckPartitions(rings, 3, 3);
+}
+
+//----------------------------------------------------------------------------
+int TestInvalidShapesAreRejected()
+{
+  const unsigned int invalid[][2] = { { 2, 2 }, { 5, 5 }, { 3, 4 }, { 4, 3 }, { 0, 0 }, { 1, 1 } };
+  for (const auto& shape : invalid)
+  {
+    TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+    const auto rings = vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups(shape[0], shape[1]);
+    TESTING_OUTPUT_ASSERT_WARNINGS_END();
+    if (!rings.empty())
+    {
+      std::fprintf(stderr, "[%s:%d] FAIL: (%u, %u) is outside the ADR-0018 closed set but produced %zu rings\n", __FILE__, __LINE__, shape[0], shape[1], rings.size());
+      return EXIT_FAILURE;
+    }
+  }
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//----------------------------------------------------------------------------
+int vtkSlicerLiverBezierRingGroupsTest(int, char*[])
+{
+  if (TestFourByFour() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestThreeByThree() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestInvalidShapesAreRejected() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "vtkSlicerLiverBezierRingGroupsTest passed." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/Algorithm/vtkSlicerLiverBezierControlPolygonGeometry.cxx
+++ b/LiverResections/Algorithm/vtkSlicerLiverBezierControlPolygonGeometry.cxx
@@ -100,3 +100,38 @@ vtkSmartPointer<vtkCellArray> vtkSlicerLiverBezierControlPolygonGeometry::BuildC
 
   return planeCells;
 }
+
+//------------------------------------------------------------------------------
+std::vector<std::vector<vtkIdType>> vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups(unsigned int rows, unsigned int cols)
+{
+  // ADR-0018 §1 admits exactly two control-polygon shapes, and each has
+  // exactly two rings.  The memberships are therefore constants, written
+  // out rather than peeled off the lattice by a loop: a general
+  // decomposition would carry depth arithmetic and degenerate
+  // single-row / single-column branches for shapes this project does not
+  // allow.  Should ADR-0018 ever widen the set (a NURBS control net of
+  // arbitrary m x n is the plausible case), this body grows a general
+  // walk -- the signature and the callers do not change.
+  //
+  // Row-major ids (i * cols + j), matching BuildControlPolygonCells.
+  // The OUTER ring is listed as a contiguous clockwise walk from the
+  // top-left corner so a ring highlight can consume the order directly
+  // as a closed path.
+  switch (rows == cols ? rows : 0u)
+  {
+    case 4u: return { { 0, 1, 2, 3, 7, 11, 15, 14, 13, 12, 8, 4 }, { 5, 6, 10, 9 } };
+    case 3u:
+      // The 3x3 inner "ring" is the SINGLE centre point.  A one-element
+      // rigid-translation group is well defined, but it is not a ring in
+      // any geometric sense, and a caller presenting a ring affordance
+      // should expect it.
+      return { { 0, 1, 2, 5, 8, 7, 6, 3 }, { 4 } };
+    default:
+      vtkGenericWarningMacro("vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups:"
+                             " (rows, cols) = ("
+                             << rows << ", " << cols
+                             << ") is outside the"
+                                " ADR-0018 §1 closed set {(3, 3), (4, 4)}; returning empty ring list.");
+      return {};
+  }
+}

--- a/LiverResections/Algorithm/vtkSlicerLiverBezierControlPolygonGeometry.h
+++ b/LiverResections/Algorithm/vtkSlicerLiverBezierControlPolygonGeometry.h
@@ -48,6 +48,8 @@
 #include <vtkObject.h>
 #include <vtkSmartPointer.h>
 
+#include <vector>
+
 class vtkCellArray;
 
 /**
@@ -103,6 +105,33 @@ public:
   /// of the ``(i, j)`` lattice cell.  The number of cells is
   /// ``(rows - 1) * (cols - 1)`` — four for 3×3, nine for 4×4.
   static vtkSmartPointer<vtkCellArray> BuildControlPolygonCells(unsigned int rows, unsigned int cols);
+
+  /// Ring decomposition of a ``rows × cols`` control polygon, indexed
+  /// row-major (``i * cols + j``) to match
+  /// :func:`BuildControlPolygonCells`.  Ring 0 is the OUTER ring (the
+  /// lattice boundary), ring 1 the interior.  Both legal shapes have
+  /// exactly two rings, so the memberships are constants rather than a
+  /// computed decomposition.
+  ///
+  /// The group-drag gestures consume this: a ring translates rigidly
+  /// (every member displaced by the SAME delta), so the caller needs
+  /// the membership, not the geometry.
+  ///
+  /// Per ADR-0018 §1 the closed set of valid shapes is
+  /// ``{(3, 3), (4, 4)}``; any other ``(rows, cols)`` emits a
+  /// ``vtkGenericWarningMacro`` and returns an empty vector.
+  ///
+  /// Shapes differ in a way callers must handle:
+  ///   - 4×4 → two rings: outer holds 12 ids, inner holds 4.
+  ///   - 3×3 → two rings: outer holds 8 ids, inner holds the SINGLE
+  ///     centre id.  A one-element "ring" is still a valid rigid
+  ///     translation group, but it is not a ring in any geometric
+  ///     sense — callers presenting a ring affordance should expect it.
+  ///
+  /// Every control-point id appears in exactly one ring, and the
+  /// concatenation of all rings is a permutation of
+  /// ``[0, rows * cols)``.
+  static std::vector<std::vector<vtkIdType>> BuildRingGroups(unsigned int rows, unsigned int cols);
 
 protected:
   vtkSlicerLiverBezierControlPolygonGeometry();


### PR DESCRIPTION
> [!IMPORTANT]
> **CLOSED — not merged. Superseded by #639.**
>
> **Reason:** the API in this PR is not callable from Python, which is where both of its consumers live.
>
> `BuildRingGroups` returned `std::vector<std::vector<vtkIdType>>`. VTK's Python wrapper handles a flat
> `std::vector<T>` of scalars but **not a nested one**, so it skipped the method silently — no error, no
> warning, a green build. Verified against the generated wrapper in a real build:
>
> | Method | Return type | In `vtkSlicerLiverBezierControlPolygonGeometryPython.cxx` |
> |---|---|---|
> | `BuildControlPolygonCells` | `vtkSmartPointer<vtkCellArray>` | **yes** — registered in the method table |
> | `BuildRingGroups` | `std::vector<std::vector<vtkIdType>>` | **zero occurrences** |
>
> The C++ tests below all passed precisely because they are C++; they could not detect this. Both intended
> callers — `ControlPolygonPipeline` and `SliceControlPolygonPipeline` — are Python, so the method would have
> been unreachable, surfacing in slice 4 as "no such method".
>
> Fixing the signature alone (`vtkIdList` out-parameters wrap cleanly) was rejected on a second ground raised
> in review: ADR-0018 §1 admits only `{(3,3), (4,4)}`, each has exactly two rings, and the init re-fit only
> ever produces 4×4 — so the memberships are two fixed arrays. A wrapped C++ API plus an out-parameter loop
> to hand Python two constants is machinery without a payer.
>
> **#639** replaces this with module-level constants in `LiverResectionsLib`, where both pipelines import
> them: +159 lines of Python instead of +238 of C++ and generated wrapper surface, 10 tests passing **bare**,
> and packaging parity asserted so it is installed at runtime rather than merely present in the tree.
>
> Should a NURBS control net of arbitrary *m*×*n* ever need computed rings (#630), that is a C++ API designed
> against a real requirement — with a wrappable signature chosen deliberately and a Python consumer proving
> reachability.
>
> The branch is retained for reference; nothing here was merged.

---

Slice 1 of the control-polygon group-drag epic (#505). Pure geometry — no interaction, no rendering, no behaviour change. The gestures in later slices consume this.

## What and why

The two requested gestures both translate a **set** of control points by a single delta and recompute the surface:

- dragging the polygon **frame** moves the whole control polygon, its points, and the derived surface;
- right-dragging a **ring** moves that ring's points — all by the same direction and magnitude, not to the same place.

Both need ring **membership**, which nothing exposed. The Algorithm library carried `BuildControlPolygonCells` for the edge topology but no equivalent for the ring decomposition, so every caller would have rolled its own index arithmetic.

`BuildRingGroups(rows, cols)` goes beside its sibling per ADR-0018, which requires control-polygon geometry be shared with NURBS rather than reimplemented as a Bézier-only Python helper. Same row-major indexing (`i * cols + j`), same ADR-0018 §1 closed-shape rejection.

## The property that matters

**The rings partition the grid.** A ring translates rigidly, so an id appearing in two rings would be displaced twice, and an id in none would be left behind — either tears the surface. The test asserts the partition explicitly for both shapes rather than only checking ring sizes.

| Shape | Rings | Sizes |
|---|---|---|
| 4×4 | 2 | outer 12, inner 4 |
| 3×3 | 2 | outer 8, inner **1** |

Two details later slices depend on:

**The outer ring is a contiguous clockwise walk** from the top-left (`0,1,2,3,7,11,15,14,13,12,8,4`), so a ring highlight can consume the id order directly as a closed path instead of re-deriving the traversal. The test pins the exact sequence, not just the membership.

**A 3×3 grid's inner "ring" is the single centre point.** A one-element rigid-translation group is well defined, but it is not a ring in any geometric sense, and a caller presenting a ring affordance should expect it. The UI only ever produces 4×4 today (init always re-fits to it), but the shape is legal under ADR-0018 and the library must be correct for it. Flagging it here so it does not surface later as a crash in a gesture handler.

## Verification

- `vtkSlicerLiverBezierRingGroupsTest` — **passed**. Covers 4×4, 3×3, the exact outer-ring traversal order, the partition invariant, and rejection of `(2,2)`, `(5,5)`, `(3,4)`, `(4,3)`, `(0,0)`, `(1,1)` with the expected warning.
- `vtkSlicerLiverBezierControlPolygonGeometryTest1` (sibling) — **still passed**, so the shared header change did not disturb it.
- Built and run in the warm Qt6 tree; re-verified after clang-format reflowed two lines, so what is committed is what was tested. The borrowed tree was restored clean.

## Sequencing note — a correction

An earlier read of this epic had **#583** (folding `LiverBezierSurfacePipeline`'s grab grammar into the shared base) as a hard prerequisite, on the grounds that both touch `SurfacePointPlacementPipeline3D`'s dispatch.

That is wrong. `LiverBezierSurfacePipeline` has **zero** imports of `SlicerLiverInteractionLib`, and its grab grammar operates on the two auto-seeded **Init-handles** in `STATE_INIT` — a different data model from the control grid, and in `Planning` it declines outright because ADR-0033 re-sited per-point editing onto `ControlPolygonPipeline`. Widening the base cannot disturb it. #583 remains worth doing and will fold into the wider grammar, but it does not gate this work.

## Remaining slices

2. Group hover/grab state on `vtkMRMLControlPolygonDisplayNode` (it carries only single-int `HoveredControlPoint` / `GrabbedControlPoint` today; group state must live on the display node for the highlight to stay coherent across views).
3. Edge-segment picking — `CanProcessInteractionEvent` currently measures distance to handles only — plus widening the base's left-button-only dispatch.
4. Frame drag + frame highlight.
5. Ring right-drag + ring highlight.

Slices 4 and 5 will want a `:0` eyeball: LayerDM render-and-interaction work is exactly where the harnesses stayed green through five invisible defects during #620.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._

