### PR TITLE
ENH: Carry group-drag hover and grab state on the control-polygon display node (#505 slice 2)

### DIFF
--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
@@ -82,6 +82,8 @@ int testDefaults()
   // Transient cross-view interaction state: nothing hovered/grabbed.
   CHECK_INT(node->GetHoveredControlPoint(), -1);
   CHECK_INT(node->GetGrabbedControlPoint(), -1);
+  CHECK_INT(node->GetHoveredGroup(), vtkMRMLControlPolygonDisplayNode::GroupNone);
+  CHECK_INT(node->GetGrabbedGroup(), vtkMRMLControlPolygonDisplayNode::GroupNone);
 
   CHECK_STRING(node->GetNodeTagName(), "ControlPolygonDisplay");
   return EXIT_SUCCESS;
@@ -111,6 +113,15 @@ int testSettersAndGetters()
   CHECK_INT(node->GetHoveredControlPoint(), 5);
   node->SetGrabbedControlPoint(7);
   CHECK_INT(node->GetGrabbedControlPoint(), 7);
+
+  // Group-drag targets.  Frame and ring 0 span the same boundary points
+  // but are DISTINCT targets -- the frame drag moves the whole polygon,
+  // ring 0 moves only the boundary -- so the node must keep them apart.
+  node->SetHoveredGroup(vtkMRMLControlPolygonDisplayNode::GroupFrame);
+  CHECK_INT(node->GetHoveredGroup(), vtkMRMLControlPolygonDisplayNode::GroupFrame);
+  node->SetGrabbedGroup(vtkMRMLControlPolygonDisplayNode::GroupRing0 + 1);
+  CHECK_INT(node->GetGrabbedGroup(), vtkMRMLControlPolygonDisplayNode::GroupRing0 + 1);
+  CHECK_BOOL(vtkMRMLControlPolygonDisplayNode::GroupFrame != vtkMRMLControlPolygonDisplayNode::GroupRing0, true);
   return EXIT_SUCCESS;
 }
 
@@ -217,10 +228,14 @@ int testCopyContent()
   // just as the fields are excluded from the XML round-trip.
   source->SetHoveredControlPoint(5);
   source->SetGrabbedControlPoint(7);
+  source->SetHoveredGroup(vtkMRMLControlPolygonDisplayNode::GroupFrame);
+  source->SetGrabbedGroup(vtkMRMLControlPolygonDisplayNode::GroupRing0);
   vtkNew<vtkMRMLControlPolygonDisplayNode> transientSink;
   transientSink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
   CHECK_INT(transientSink->GetHoveredControlPoint(), -1);
   CHECK_INT(transientSink->GetGrabbedControlPoint(), -1);
+  CHECK_INT(transientSink->GetHoveredGroup(), vtkMRMLControlPolygonDisplayNode::GroupNone);
+  CHECK_INT(transientSink->GetGrabbedGroup(), vtkMRMLControlPolygonDisplayNode::GroupNone);
   return EXIT_SUCCESS;
 }
 

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
@@ -60,6 +60,8 @@ vtkMRMLControlPolygonDisplayNode::vtkMRMLControlPolygonDisplayNode()
   // Transient cross-view interaction state (not serialized).
   , HoveredControlPoint(-1)
   , GrabbedControlPoint(-1)
+  , HoveredGroup(GroupNone)
+  , GrabbedGroup(GroupNone)
 {
 }
 
@@ -102,10 +104,11 @@ void vtkMRMLControlPolygonDisplayNode::CopyContent(vtkMRMLNode* anode, bool deep
   MRMLNodeModifyBlocker blocker(this);
   Superclass::CopyContent(anode, deepCopy);
 
-  // HoveredControlPoint / GrabbedControlPoint are TRANSIENT interaction
-  // state (the markups ActiveComponent precedent): copying a node must not
-  // clone a live hover/grab onto the copy, so they are excluded here just
-  // as they are from the XML round-trip.
+  // HoveredControlPoint / GrabbedControlPoint and the group-drag pair
+  // HoveredGroup / GrabbedGroup are TRANSIENT interaction state (the
+  // markups ActiveComponent precedent): copying a node must not clone a
+  // live hover/grab onto the copy, so all four are excluded here just as
+  // they are from the XML round-trip.
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyFloatMacro(HandleRadius);
   vtkMRMLCopyVectorMacro(HandleColor, double, 3);
@@ -126,5 +129,7 @@ void vtkMRMLControlPolygonDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(EdgeWidth);
   vtkMRMLPrintIntMacro(HoveredControlPoint);
   vtkMRMLPrintIntMacro(GrabbedControlPoint);
+  vtkMRMLPrintIntMacro(HoveredGroup);
+  vtkMRMLPrintIntMacro(GrabbedGroup);
   vtkMRMLPrintEndMacro();
 }

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
@@ -135,6 +135,44 @@ public:
   vtkSetMacro(GrabbedControlPoint, int);
   vtkGetMacro(GrabbedControlPoint, int);
 
+  /// Group-drag targets.  A GROUP translates rigidly: every member
+  /// control point is displaced by the SAME delta and the surface is
+  /// recomputed.
+  ///
+  ///  - ``GroupNone``  — nothing hovered/grabbed.
+  ///  - ``GroupFrame`` — the polygon BORDER, whose drag moves the WHOLE
+  ///    control polygon (every point, not only the boundary).  The frame
+  ///    is the affordance; its action is global.
+  ///  - ``GroupRing0`` and up — one ring from
+  ///    ``vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups``,
+  ///    whose drag moves ONLY that ring's points.  Ring ``k`` is
+  ///    ``GroupRing0 + k``.
+  ///
+  /// Frame and ring 0 cover the same boundary points but are distinct
+  /// targets: the frame moves everything, ring 0 moves only the
+  /// boundary.  They are separated here so the highlight can say which
+  /// gesture is armed.
+  enum GroupTarget
+  {
+    GroupNone = -1,
+    GroupFrame = 0,
+    GroupRing0 = 1
+  };
+
+  /// The HOVERED group (see GroupTarget; ``GroupNone`` = none).
+  /// TRANSIENT interaction state shared across views, not serialized --
+  /// the same reasoning as HoveredControlPoint: every pipeline observing
+  /// this display node highlights the same group, whichever view the
+  /// cursor is in.  A Python pipeline instance could not do this,
+  /// because LayerDM does not drive it.
+  vtkSetMacro(HoveredGroup, int);
+  vtkGetMacro(HoveredGroup, int);
+
+  /// The GRABBED group (see GroupTarget; ``GroupNone`` = none).
+  /// TRANSIENT, cross-view, not serialized (see HoveredGroup).
+  vtkSetMacro(GrabbedGroup, int);
+  vtkGetMacro(GrabbedGroup, int);
+
 protected:
   vtkMRMLControlPolygonDisplayNode();
   ~vtkMRMLControlPolygonDisplayNode() override;
@@ -149,6 +187,8 @@ private:
   double EdgeWidth;
   int HoveredControlPoint;
   int GrabbedControlPoint;
+  int HoveredGroup;
+  int GrabbedGroup;
 };
 
 #endif //__vtkmrmlcontrolpolygondisplaynode_h_


### PR DESCRIPTION
Slice 2 of the control-polygon group-drag epic (#505). Data-only MRML change — no interaction, no rendering, no behaviour change yet.

**Independent of #636** (slice 1): that one touches `LiverResections/Algorithm/`, this one touches `LiverResections/MRML/`. Disjoint files, based directly on `preview`, so the two can review and merge in either order.

## Why this state lives on the display node

The frame and ring gestures need highlight state at **group** granularity. The node carried only single-int `HoveredControlPoint` / `GrabbedControlPoint`.

It has to live on the shared MRML display node rather than on a Python pipeline instance, for exactly the reason the per-point fields do: **LayerDM does not drive a Python pipeline's own attributes**, so a hover armed in one view would never light the group in the others. With it on the node, every pipeline observing it highlights the same group, whichever view the cursor is in — the cross-view coherence comes for free rather than being re-plumbed per view.

## Frame and ring 0 are deliberately distinct

They span the same boundary points, so it is tempting to collapse them. The encoding keeps them apart because their **actions differ**:

- `GroupFrame` — dragging the border moves the **whole** control polygon, every point, and the derived surface. The frame is the affordance; its action is global.
- `GroupRing0` — dragging ring 0 moves **only** the boundary points, deforming the surface.

Ring *k* is `GroupRing0 + k`, matching `BuildRingGroups`' ordering, so a pipeline can index straight from one to the other.

## Transient, like its siblings

Both fields are excluded from the XML round-trip and from `CopyContent`, so a copied node never inherits a live hover or grab (the markups `ActiveComponent` precedent). **The test pins that exclusion rather than trusting omission** — a future `vtkMRMLCopyIntMacro` added without thought would otherwise start cloning live interaction state silently.

## Verification

`vtkMRMLControlPolygonDisplayNodeTest1` — **passed**, extended in three places:

- defaults: both fields start at `GroupNone`;
- setters/getters round-trip, including a ring index above `GroupRing0`, plus an explicit assertion that `GroupFrame != GroupRing0` so a future refactor cannot quietly merge the two targets;
- `CopyContent` leaves both at `GroupNone` on the sink even when the source holds a live frame hover and ring grab.

Built and run in the warm Qt6 tree; the borrowed tree was restored clean.

## Note on branch structure

Slice 2 was initially committed onto #636's branch, which would have silently grown that PR past its frozen scope. It has been moved to its own branch based on `preview` and #636 re-verified as unchanged (1 commit, 4 files). Flagging it because the ≤400-LOC frozen-PR discipline only holds if that kind of drift gets caught.

## Next

3. Edge-segment picking — `CanProcessInteractionEvent` measures distance to handles only today — plus widening the base's left-button-only dispatch.
4. Frame drag + frame highlight.
5. Ring right-drag + ring highlight.

Slices 4 and 5 will want a `:0` eyeball; LayerDM render-and-interaction work is where the harnesses stayed green through five invisible defects during #620.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
