### PR TITLE
ENH: Open a group-gesture seam on the shared placement base (#505 slice 3)

### DIFF
--- a/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
+++ b/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
@@ -89,6 +89,14 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
         # None when no drag is in flight.
         self._drag_key: Any | None = None
 
+        # The GROUP gesture in flight (a client-defined id), or None.  A
+        # group translates its members rigidly; the base holds only the
+        # gesture's identity, never its meaning.
+        self._group_drag: Any | None = None
+        # Which release event ends it: a group gesture may be right-button,
+        # while the point drag is always left.
+        self._group_drag_release_event: Any | None = None
+
     # ------------------------------------------------------------------ #
     # Seam wiring
     # ------------------------------------------------------------------ #
@@ -162,13 +170,27 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
         """
         try:
             if not self._admissible():
-                self._drag_key = None  # a state flip mid-gesture drops the grab
+                # A state flip mid-gesture drops BOTH grabs.
+                self._drag_key = None
+                self._group_drag = None
+                self._group_drag_release_event = None
                 return False, sys.float_info.max
             renderer = self._safe_get_renderer()
             if renderer is None:
                 self._drag_key = None
                 return False, sys.float_info.max
             etype = _event_type(eventData)
+
+            # A group drag in flight owns move + the release of ITS OWN
+            # button (a group gesture may be right-button; the point drag
+            # is always left).
+            if self._group_drag is not None:
+                if etype in (
+                    vtk.vtkCommand.MouseMoveEvent,
+                    self._group_drag_release_event,
+                ):
+                    return True, 0.0
+                return False, sys.float_info.max
 
             if self._drag_key is not None:
                 if etype in (
@@ -183,6 +205,19 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
                 # client's hover cue is a side effect of this declined call.
                 self._on_bare_move_decline(renderer, eventData)
                 return False, sys.float_info.max
+
+            # A client that opts into group gestures may claim a press of
+            # EITHER button.  Asked before the point pick so a frame or
+            # ring target wins over a handle that merely happens to be
+            # near the cursor; a client that does not opt in returns None
+            # and the arbitration below is untouched.
+            if etype in (
+                vtk.vtkCommand.LeftButtonPressEvent,
+                vtk.vtkCommand.RightButtonPressEvent,
+            ):
+                claim = self._group_pick(renderer, eventData, etype)
+                if claim is not None:
+                    return True, claim[1]
 
             if etype != vtk.vtkCommand.LeftButtonPressEvent:
                 return False, sys.float_info.max
@@ -219,7 +254,40 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
                 return False
             etype = _event_type(eventData)
 
+            if self._group_drag is not None:
+                if etype == self._group_drag_release_event:
+                    group = self._group_drag
+                    self._group_drag = None
+                    self._group_drag_release_event = None
+                    self._on_group_release(group)
+                    self.RequestRender()
+                    return False  # gesture over -- release the focus
+                if etype == vtk.vtkCommand.MouseMoveEvent:
+                    world = self._event_world(renderer, eventData)
+                    if world is None:
+                        return True  # keep the grab; this move didn't resolve
+                    self._on_group_drag(self._group_drag, world)
+                    self.RequestRender()
+                    return True
+                return False
+
             if self._drag_key is None:
+                if etype in (
+                    vtk.vtkCommand.LeftButtonPressEvent,
+                    vtk.vtkCommand.RightButtonPressEvent,
+                ):
+                    claim = self._group_pick(renderer, eventData, etype)
+                    if claim is not None:
+                        self._group_drag = claim[0]
+                        self._group_drag_release_event = (
+                            vtk.vtkCommand.RightButtonReleaseEvent
+                            if etype == vtk.vtkCommand.RightButtonPressEvent
+                            else vtk.vtkCommand.LeftButtonReleaseEvent
+                        )
+                        self._on_group_grab(claim[0], renderer, eventData)
+                        self.RequestRender()
+                        return True
+
                 if etype != vtk.vtkCommand.LeftButtonPressEvent:
                     return False
                 key, distance2 = self._nearest_key_in_display(renderer, eventData)
@@ -273,6 +341,41 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
         such gate.
         """
         return True
+
+    # -- group gestures (opt-in; the flat clients never override these) -- #
+
+    def _group_pick(self, renderer: Any, eventData: Any, etype: Any):
+        """Claim a press as a GROUP gesture, or decline.
+
+        Return ``(group_id, distance2)`` to claim, or ``None`` to leave
+        the press to the ordinary point arbitration.  ``group_id`` is
+        opaque to the base -- it is handed back verbatim to the group
+        hooks below, so a client chooses its own encoding (the resection
+        control polygon uses its display node's ``GroupTarget``).
+
+        Default declines every press, which is what keeps this change
+        inert for clients that do not opt in: the territories, volumetry
+        and slice-polygon pipelines never override it and see exactly the
+        dispatch they saw before.
+
+        A group gesture translates its members RIGIDLY -- the base moves
+        nothing itself, because the delta's meaning is the client's.
+        """
+        return None
+
+    def _on_group_grab(self, group: Any, renderer: Any, eventData: Any) -> None:
+        """A group gesture began (default: no-op)."""
+
+    def _on_group_drag(self, group: Any, world: Any) -> None:
+        """The cursor moved to ``world`` during a group gesture.
+
+        The base does NOT apply a displacement: what a group means, and
+        what a delta does to it, is data-model knowledge the base does not
+        carry (ADR-0038 §"What is not shared").
+        """
+
+    def _on_group_release(self, group: Any) -> None:
+        """A group gesture ended (default: no-op)."""
 
     def _on_grab(self, key: Any, renderer: Any, eventData: Any) -> None:
         """Called right after the base grabs ``key`` on a press (default no-op)."""

--- a/SlicerLiverInteractionLib/Testing/Python/test_group_gesture_seam.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_group_gesture_seam.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The group-gesture seam on the shared placement base (ADR-0038).
+
+A GROUP gesture translates a set of control points rigidly -- every
+member displaced by the same delta -- as opposed to the per-point drag
+the base already arbitrates.  The control polygon needs two of them: a
+frame drag moving the whole polygon, and a ring drag moving one ring.
+
+The base carries the ARBITRATION only.  What a group is, and what a
+delta does to it, is data-model knowledge that stays with the client
+(ADR-0038 §"What is not shared") -- so the base hands a client-defined
+id straight back to the client's hooks and never moves a point itself.
+
+The load-bearing property here is that the seam is INERT for clients
+that do not opt in.  Three modules sit on this base (resection control
+polygon, vascular territories, volumetry seeds); a widening that leaked
+into their dispatch would change interaction everywhere at once.  The
+default ``_group_pick`` declines every press, so those clients see the
+dispatch they always saw.
+
+HARNESS: launched Slicer.  The renderer, scene and GL are all stubbed
+out here -- the arbitration under test is pure Python -- but the base
+class itself derives from ``vtkMRMLLayerDMPipelineI``, which is
+reachable only inside a launched Slicer with LayerDM loaded.  A bare
+``PythonSlicer -m pytest`` SKIPS CLEANLY (ADR-0027).
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+# The lib ships flat into qt-scripted-modules, so its modules are imported
+# by bare name; put the source dir on the path the same way the sibling
+# base tests do.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+def _base_or_skip():
+    try:
+        module = importlib.import_module("SurfacePointPlacementPipeline3D")
+    except Exception as exc:
+        pytest.skip(f"placement base not importable ({exc!r}) -- ADR-0027.")
+    if not hasattr(module, "SurfacePointPlacementPipeline3D"):
+        pytest.skip("SurfacePointPlacementPipeline3D absent (ADR-0027).")
+    return module
+
+
+class _Event:
+    """Minimal eventData stand-in: only the event type is read here."""
+
+    def __init__(self, etype):
+        self._etype = etype
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+
+def _make_pipeline(base_module, group_claim=None):
+    """A pipeline whose renderer/admissibility are stubbed out.
+
+    ``group_claim`` is what ``_group_pick`` returns; ``None`` models a
+    client that never opted in.
+    """
+    cls = base_module.SurfacePointPlacementPipeline3D
+
+    class _Probe(cls):
+        def __init__(self):
+            super().__init__("test")
+            self.grabs = []
+            self.drags = []
+            self.releases = []
+
+        # Stub the environment the base would otherwise reach for.
+        def _safe_get_renderer(self):
+            return object()
+
+        def _admissible(self):
+            return True
+
+        def _nearest_key_in_display(self, renderer, eventData):
+            return None, float("inf")
+
+        def _pick_world(self, renderer, eventData):
+            return None
+
+        def _event_world(self, renderer, eventData):
+            return (1.0, 2.0, 3.0)
+
+        def RequestRender(self):  # noqa: N802 - VTK verb
+            pass
+
+        def _group_pick(self, renderer, eventData, etype):
+            return group_claim
+
+        def _on_group_grab(self, group, renderer, eventData):
+            self.grabs.append(group)
+
+        def _on_group_drag(self, group, world):
+            self.drags.append((group, world))
+
+        def _on_group_release(self, group):
+            self.releases.append(group)
+
+    try:
+        return _Probe()
+    except Exception as exc:  # pragma: no cover - construction needs the C++ base
+        pytest.skip(f"placement base not constructible here ({exc!r}) -- ADR-0027.")
+
+
+def test_default_group_pick_declines_every_press():
+    """The seam is inert for a client that does not opt in."""
+    base_module = _base_or_skip()
+    pipeline = _make_pipeline(base_module, group_claim=None)
+
+    for etype in (
+        vtk.vtkCommand.LeftButtonPressEvent,
+        vtk.vtkCommand.RightButtonPressEvent,
+    ):
+        claimed, _distance = pipeline.CanProcessInteractionEvent(_Event(etype))
+        assert claimed is False, (
+            "A client that never overrides _group_pick must see the "
+            "dispatch it always saw; three modules depend on this."
+        )
+
+
+def test_right_press_is_claimed_only_when_a_client_opts_in():
+    """A right press reaches the group seam and can be claimed."""
+    base_module = _base_or_skip()
+    pipeline = _make_pipeline(base_module, group_claim=("ring0", 0.0))
+
+    claimed, _distance = pipeline.CanProcessInteractionEvent(
+        _Event(vtk.vtkCommand.RightButtonPressEvent)
+    )
+    assert claimed is True, (
+        "The base filtered to LeftButtonPress only, so a right-drag "
+        "gesture could never be routed; the ring gesture needs it."
+    )
+
+
+def test_group_gesture_runs_grab_drag_release_and_ends_on_its_own_button():
+    """A right-button group drag ends on the RIGHT release, not the left."""
+    base_module = _base_or_skip()
+    pipeline = _make_pipeline(base_module, group_claim=("ring0", 0.0))
+
+    assert pipeline.ProcessInteractionEvent(
+        _Event(vtk.vtkCommand.RightButtonPressEvent)
+    )
+    assert pipeline.grabs == ["ring0"]
+
+    assert pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.MouseMoveEvent))
+    assert pipeline.drags == [("ring0", (1.0, 2.0, 3.0))]
+
+    # A LEFT release must not end a RIGHT gesture.
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonReleaseEvent))
+    assert pipeline.releases == [], (
+        "A group gesture must end on the release of the button that "
+        "started it, or a stray left click would strand the drag."
+    )
+
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.RightButtonReleaseEvent))
+    assert pipeline.releases == ["ring0"]
+
+
+def test_group_drag_never_moves_a_point_in_the_base():
+    """The base holds the gesture's identity, never its meaning."""
+    base_module = _base_or_skip()
+    pipeline = _make_pipeline(base_module, group_claim=("frame", 0.0))
+
+    moved = []
+    pipeline._move_point = lambda key, world: moved.append((key, world))
+
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.RightButtonPressEvent))
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.MouseMoveEvent))
+
+    assert moved == [], (
+        "What a delta does to a group is the client's data model "
+        "(ADR-0038 §'What is not shared'); the base must not displace "
+        "anything itself."
+    )


### PR DESCRIPTION
Slice 3 of the control-polygon group-drag epic (#505). Opens the seam the two gestures ride on. No gesture is wired up yet — this PR changes no observable behaviour.

**Independent of #636 and #637.** Those touch `Algorithm/` and `MRML/`; this touches `SlicerLiverInteractionLib/`. All three are based on `preview` and can merge in any order.

## What the base could not express

The frame and ring gestures translate a **set** of control points rigidly — every member displaced by the same delta. The base arbitrated a single grabbed point, and filtered presses to `LeftButtonPressEvent`, so **a right-drag gesture could never be routed at all**.

## The seam is opt-in, and that is the load-bearing property

Three modules already sit on this base: the resection control polygon, vascular territories, and volumetry seeds. A widening that leaked into their arbitration would change interaction in all three at once.

`_group_pick` declines every press by default, so a client that does not override it sees exactly the dispatch it saw before. **That inertness is asserted, not assumed** — `test_default_group_pick_declines_every_press` drives both button presses through a non-opting client and requires a decline.

## The base learns identity, never meaning

It hands a client-defined `group_id` straight back to `_on_group_grab` / `_on_group_drag` / `_on_group_release` and **displaces nothing itself**. What a group is, and what a delta does to it, is data-model knowledge that stays with the client (ADR-0038 §"What is not shared"). `test_group_drag_never_moves_a_point_in_the_base` pins that by monkeypatching `_move_point` and requiring it is never called during a group drag.

Two details that will matter once the gestures land:

**A group gesture ends on the release of the button that started it**, tracked per gesture rather than assumed. The point drag is always left; a ring gesture is right. Without this a stray left release would strand the drag, leaving the polygon following the cursor. The test drives a left release mid-right-gesture and requires it be ignored.

**The group pick is asked before the point pick**, so a frame or ring target wins over a handle that merely happens to be near the cursor — otherwise grabbing the frame near a corner would silently become a single-point edit.

## Verification — red then green, launched

| | Result |
|---|---|
| **Without** the widening | **2 failed** — `test_right_press_is_claimed_only_when_a_client_opts_in` and `test_group_gesture_runs_grab_drag_release_and_ends_on_its_own_button` |
| **With** it | **30 passed**, 4 skipped |

The other two tests pass in *both* runs, by design: the inertness test must pass on the old base — that is precisely what it asserts — and no group drag can start there for the no-displacement test to observe.

Also run bare across every client of the base, all unchanged: `SlicerLiverInteractionLib` 20 passed, `LiverResections` 39, `LiverVolumetry` 64, `VascularTerritories` 11, `Testing/Python/unit` 120.

The new test is launched-only and says so: its arbitration is pure Python over stubs, but the base class derives from `vtkMRMLLayerDMPipelineI`, reachable only inside a launched Slicer with LayerDM loaded. It skips cleanly bare.

## Reviewer's map

- `SurfacePointPlacementPipeline3D.py` — **load-bearing**: the `_group_drag` branch in `CanProcessInteractionEvent` and `ProcessInteractionEvent`, and the per-gesture release-event tracking. The four hooks at the bottom are all no-ops.
- `test_group_gesture_seam.py` — four invariants; the first is the inertness guarantee for the other three modules.

## Next

4. Frame drag — rigid translation of the whole polygon + surface, frame highlight.
5. Ring right-drag — same delta on the ring's points, ring highlight.

Both consume `BuildRingGroups` (#636) and the group state on the display node (#637), and both want a `:0` eyeball before merge.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
