### PR TITLE
ENH: Add control-polygon ring membership for the group-drag gestures (#505 slice 1, replaces #636)

### DIFF
--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -24,6 +24,7 @@
 set(LiverResectionsLib_PYTHON_SCRIPTS
   __init__.py
   ControlPolygonPipeline.py
+  ControlPolygonRings.py
   DistanceMaps.py
   LiverBezierSurfacePipeline.py
   LocatorReslicer.py

--- a/LiverResections/LiverResectionsLib/ControlPolygonRings.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonRings.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Ring membership of a Bezier control polygon, for the group-drag gestures.
+
+A group gesture translates a SET of control points rigidly -- every
+member displaced by the same delta, then the surface recomputed.  Two
+pipelines need the same memberships: ``ControlPolygonPipeline`` (3D) and
+``SliceControlPolygonPipeline`` (its slice-view projection).  They live
+here so the two cannot drift apart.
+
+WHY CONSTANTS, NOT A COMPUTED DECOMPOSITION
+-------------------------------------------
+ADR-0018 §1 admits exactly two control-polygon shapes, ``(3, 3)`` and
+``(4, 4)``, and each has exactly two rings -- so the memberships are
+fixed.  A general peel-the-lattice algorithm would carry depth
+arithmetic and degenerate single-row / single-column branches for shapes
+this project does not allow.
+
+WHY PYTHON, NOT THE ALGORITHM LIBRARY
+-------------------------------------
+The first attempt put this in ``vtkSlicerLiverBezierControlPolygonGeometry``
+beside ``BuildControlPolygonCells``.  It returned
+``std::vector<std::vector<vtkIdType>>``, which VTK's Python wrapper
+SILENTLY SKIPS -- a flat ``std::vector<T>`` of scalars wraps, a nested
+one does not.  The build stayed green, the C++ tests passed, and the
+method simply did not exist from Python, where both consumers live.
+(The same trap as the ``void*`` distance-map upload: compiles, links,
+tests green, invisible from Python.)
+
+Should a NURBS control net of arbitrary ``m x n`` ever need computed
+rings, that is a C++ API designed against a real requirement -- with a
+wrappable signature (``vtkIdList`` out-parameters) and a Python consumer
+to prove it.
+
+INDEXING
+--------
+Row-major, ``(i, j) -> i * cols + j``, matching
+``vtkSlicerLiverBezierControlPolygonGeometry::BuildControlPolygonCells``.
+
+Ring 0 is the OUTER ring, listed as a contiguous CLOCKWISE WALK from the
+top-left corner, so a ring highlight can consume the order directly as a
+closed path instead of re-deriving the traversal.  Ring 1 is the
+interior.
+
+A 3x3 grid's inner "ring" is the SINGLE centre point.  A one-element
+rigid-translation group is well defined, but it is not a ring in any
+geometric sense; a caller presenting a ring affordance should expect it.
+The UI only ever produces 4x4 today (the init re-fit always does), but
+3x3 is legal under ADR-0018.
+"""
+
+from __future__ import annotations
+
+#: (rows, cols) -> tuple of rings, each a tuple of flat row-major ids.
+#: Every id appears in exactly one ring: a group translates rigidly, so
+#: an id in two rings would be displaced twice and an id in none would be
+#: left behind -- either tears the surface.
+RING_GROUPS: dict[tuple[int, int], tuple[tuple[int, ...], ...]] = {
+    (4, 4): (
+        (0, 1, 2, 3, 7, 11, 15, 14, 13, 12, 8, 4),
+        (5, 6, 10, 9),
+    ),
+    (3, 3): (
+        (0, 1, 2, 5, 8, 7, 6, 3),
+        (4,),
+    ),
+}
+
+
+def ring_groups(rows: int, cols: int) -> tuple[tuple[int, ...], ...]:
+    """Rings for a ``rows x cols`` control polygon, outermost first.
+
+    Returns an empty tuple for any shape outside the ADR-0018 §1 closed
+    set, mirroring ``BuildControlPolygonCells``' rejection rather than
+    raising: a pipeline asking about an out-of-spec grid should render no
+    group affordance, not fail an interaction callback.
+    """
+    return RING_GROUPS.get((rows, cols), ())

--- a/LiverResections/Testing/Python/test_control_polygon_rings.py
+++ b/LiverResections/Testing/Python/test_control_polygon_rings.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Ring membership for the control-polygon group-drag gestures.
+
+A group translates RIGIDLY -- every member displaced by the same delta,
+then the surface recomputed.  The load-bearing property is therefore
+that the rings PARTITION the control grid: an id in two rings would be
+displaced twice, an id in none would be left behind, and either tears
+the surface.  Sizes alone do not catch that, so the partition is
+asserted directly.
+
+HARNESS: pure Python, no Slicer, no VTK, no scene.  RUNS BARE (ADR-0027).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+LIB_DIR = REPO_ROOT / "LiverResections" / "LiverResectionsLib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+
+def _rings_or_skip():
+    try:
+        import ControlPolygonRings
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"ControlPolygonRings not importable ({exc!r}) -- ADR-0027.")
+    return ControlPolygonRings
+
+
+@pytest.mark.parametrize(("rows", "cols"), [(4, 4), (3, 3)])
+def test_rings_partition_the_control_grid(rows, cols):
+    """Every control point belongs to exactly one rigid-translation group."""
+    module = _rings_or_skip()
+    rings = module.ring_groups(rows, cols)
+    flat = [index for ring in rings for index in ring]
+
+    assert sorted(flat) == list(range(rows * cols)), (
+        "The rings must partition the grid: a duplicated id is displaced "
+        "twice and a missing id is left behind -- either tears the surface."
+    )
+
+
+def test_four_by_four_outer_ring_is_a_clockwise_closed_walk():
+    """The order is load-bearing: a highlight draws straight from it."""
+    module = _rings_or_skip()
+    outer, inner = module.ring_groups(4, 4)
+
+    assert outer == (0, 1, 2, 3, 7, 11, 15, 14, 13, 12, 8, 4), (
+        "The outer ring is consumed as a closed path by the ring "
+        "highlight; a membership-only change would break the drawing."
+    )
+    assert inner == (5, 6, 10, 9)
+
+
+def test_three_by_three_inner_group_is_the_single_centre_point():
+    """The degenerate shape, pinned so a ring affordance expects it."""
+    module = _rings_or_skip()
+    outer, inner = module.ring_groups(3, 3)
+
+    assert len(outer) == 8
+    assert inner == (4,), (
+        "A 3x3 has no interior ring -- only its centre point.  A "
+        "one-element rigid-translation group is valid, but a caller "
+        "presenting a ring affordance must expect it."
+    )
+
+
+@pytest.mark.parametrize(
+    ("rows", "cols"), [(2, 2), (5, 5), (3, 4), (4, 3), (0, 0), (1, 1)]
+)
+def test_shapes_outside_the_adr_0018_set_yield_no_rings(rows, cols):
+    """Out-of-spec grids render no group affordance rather than raising."""
+    module = _rings_or_skip()
+    assert module.ring_groups(rows, cols) == ()


### PR DESCRIPTION
> [!NOTE]
> **Supersedes #636** (closed, not merged). That PR placed this in C++ on
> `vtkSlicerLiverBezierControlPolygonGeometry`; its return type was not Python-wrappable, so the method was
> invisible from the two pipelines that need it. Full reasoning in #636's description and closing comments.
>
> Part of #505. Siblings: #637 (group state on the display node), #638 (group-gesture seam on the shared base).
> All three are independent, based on current `preview`, and merge in any order.

---

Slice 1 of the control-polygon group-drag epic (#505), redone in Python.

## Why #636 had to go — it was invisible from Python

`BuildRingGroups` returned `std::vector<std::vector<vtkIdType>>`. VTK's Python wrapper handles a flat `std::vector<T>` of scalars but **not a nested one**, so it skipped the method silently. Verified against the generated wrapper in a real build:

| Method | Return type | In the generated `…GeometryPython.cxx` |
|---|---|---|
| `BuildControlPolygonCells` | `vtkSmartPointer<vtkCellArray>` | **yes** — registered in the method table |
| `BuildRingGroups` | `std::vector<std::vector<vtkIdType>>` | **zero occurrences** |

Both consumers are Python, so neither could ever have called it. The build was green and the C++ tests passed — they could not detect this, being C++. It would have surfaced in slice 4 as "the method doesn't exist".

**This is the same trap as the `void*` distance-map upload in #620**: a signature that compiles, links, tests green, and is invisible from the language that needs it. Worth naming as a recurring failure mode, not a one-off.

## Why not just fix the signature

`vtkIdList` out-parameters would wrap cleanly and are the idiomatic VTK answer. But ADR-0018 §1 admits only `{(3,3), (4,4)}`, each has exactly two rings, and the init re-fit only ever produces 4×4 — the memberships are two fixed arrays. A wrapped C++ API plus an out-parameter loop to hand Python two constants is machinery without a payer.

Both consumers — `ControlPolygonPipeline` and `SliceControlPolygonPipeline` — live in `LiverResectionsLib`, so the constants live there too, in one module so the two cannot drift apart.

## What is asserted

**The partition.** A group translates rigidly, so an id in two rings is displaced twice and an id in none is left behind; either tears the surface. The test asserts the partition directly for both shapes, not just ring sizes.

**The exact outer-ring order.** It is a contiguous clockwise walk from the top-left (`0,1,2,3,7,11,15,14,13,12,8,4`), so the ring highlight can consume it as a closed path. A membership-only refactor would silently break the drawing, so the sequence is pinned.

**The 3×3 degenerate shape.** Its inner "ring" is the single centre point — legal under ADR-0018, unreachable from today's UI, pinned so a ring affordance expects it.

**Out-of-spec shapes return empty** rather than raising, mirroring `BuildControlPolygonCells`' rejection: a pipeline asking about an illegal grid should render no group affordance, not fail an interaction callback.

## Verification

- 10 tests, **all passing bare** — no build required, unlike the C++ version. That is itself the point: the code is now reachable from where it is used.
- `test_liverresectionslib_packaging_parity` passes, confirming the new module is registered in `LiverResectionsLib_PYTHON_SCRIPTS` and will actually be installed. Omitting that would have reproduced the original defect in a different form — present in the source tree, absent at runtime.

## Net effect versus #636

+159 lines of Python replacing +238 of C++ and generated-wrapper surface, and it can actually be called.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._

