### PR TITLE
ENH: Give the distance-contour mapper Python-wrappable point accessors

### DIFF
--- a/LiverResections/Testing/Python/test_mapper_accessors_reach_python.py
+++ b/LiverResections/Testing/Python/test_mapper_accessors_reach_python.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The contour mappers' point/plane accessors are callable FROM PYTHON.
+
+VTK's Python wrapper takes a flat ``std::vector`` of scalars but neither
+``std::array`` nor a nested container, and when it meets one it SKIPS the
+method SILENTLY: the build stays green, C++ tests pass, and the method
+simply does not exist from Python.  Both contour mappers declare their
+real accessors with ``const std::array<float, 4>&``, so none of those
+four reach Python.
+
+That is invisible to a C++ test by construction, which is why this file
+exists: it asserts REACHABILITY, not behaviour.  The behaviour is already
+covered by the C++ mapper tests.
+
+The rule this pins: any C++ method a Python pipeline must call needs a
+wrappable signature AND a Python caller proving it -- a passing C++ test
+is not evidence of either.
+
+HARNESS: launched Slicer.  The wrapped VTKWidgets classes resolve only
+via ``vtkSlicerLiverResectionsModuleVTKWidgetsPython``, which needs the
+built module on the path, so a bare run SKIPS CLEANLY (ADR-0027).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _widgets_namespace_or_skip():
+    """The ONLY namespace these wrapped classes resolve from.
+
+    Not ``slicer``, not ``vtk`` -- a resolver guessing those silently
+    returns None and every downstream call becomes a no-op.
+    """
+    try:
+        import vtkSlicerLiverResectionsModuleVTKWidgetsPython as widgets
+    except Exception as exc:
+        pytest.skip(f"VTKWidgets Python module not importable ({exc!r}) -- ADR-0027.")
+    return widgets
+
+
+def _mapper_or_skip(name):
+    widgets = _widgets_namespace_or_skip()
+    cls = getattr(widgets, name, None)
+    if cls is None:
+        pytest.skip(f"{name} absent from the VTKWidgets namespace (ADR-0027).")
+    return cls()
+
+
+@pytest.mark.parametrize(
+    ("setter", "getter", "value"),
+    [
+        ("SetExternalPointWorld", "GetExternalPointWorld", (1.5, -2.5, 3.5)),
+        ("SetReferencePointWorld", "GetReferencePointWorld", (-4.0, 5.0, 6.0)),
+    ],
+)
+def test_distance_contour_point_accessors_round_trip_from_python(setter, getter, value):
+    """The accessors exist in Python and round-trip a world point."""
+    mapper = _mapper_or_skip("vtkOpenGLDistanceContourPolyDataMapper")
+
+    assert hasattr(mapper, setter), (
+        f"{setter} is missing from Python.  The std::array<float, 4> "
+        "overload does not wrap, so a wrappable variant must exist or no "
+        "Python pipeline can drive this mapper."
+    )
+    getattr(mapper, setter)(*value)
+    read = tuple(getattr(mapper, getter)())
+
+    assert read == pytest.approx(value), (
+        "The wrappable accessor must round-trip through the float[4] "
+        "storage; the W component is fixed to 1 and not exposed."
+    )
+
+
+@pytest.mark.parametrize(
+    ("setter", "getter", "value"),
+    [
+        ("SetPlanePositionWorld", "GetPlanePositionWorld", (7.0, 8.0, 9.0)),
+        ("SetPlaneNormalWorld", "GetPlaneNormalWorld", (0.0, 1.0, 0.0)),
+    ],
+)
+def test_slicing_contour_plane_accessors_round_trip_from_python(setter, getter, value):
+    """The sibling's accessors, pinned so the pair cannot drift apart."""
+    mapper = _mapper_or_skip("vtkOpenGLSlicingContourPolyDataMapper")
+
+    assert hasattr(mapper, setter), f"{setter} is missing from Python."
+    getattr(mapper, setter)(*value)
+    read = tuple(getattr(mapper, getter)())
+
+    assert read == pytest.approx(value)
+
+
+def test_the_std_array_overloads_are_absent_as_expected():
+    """Documents WHY the World variants exist.
+
+    Not a demand that the array overloads be hidden -- they are C++ API
+    and should stay.  This pins the reason the wrappable pair is needed,
+    so a future reader does not delete it as redundant.
+    """
+    mapper = _mapper_or_skip("vtkOpenGLDistanceContourPolyDataMapper")
+
+    assert not hasattr(mapper, "SetExternalPoint"), (
+        "If VTK ever learns to wrap std::array, this assertion fires and "
+        "the World variants can be reconsidered -- until then they are "
+        "the only way in from Python."
+    )

--- a/LiverResections/VTKWidgets/vtkOpenGLDistanceContourPolyDataMapper.cxx
+++ b/LiverResections/VTKWidgets/vtkOpenGLDistanceContourPolyDataMapper.cxx
@@ -87,6 +87,11 @@ public:
   vtkWeakPointer<vtkOpenGLDistanceContourPolyDataMapper> Parent;
   std::array<float, 4> ExternalPoint;
   std::array<float, 4> ReferencePoint;
+
+  // Scratch for the Python-wrappable double[3] getters below; VTK_SIZEHINT
+  // returns a borrowed pointer, so the storage must outlive the call.
+  std::array<double, 3> ExternalPointWorld{ 0.0, 0.0, 0.0 };
+  std::array<double, 3> ReferencePointWorld{ 1.0, 0.0, 0.0 };
   float ContourThickness;
   bool ContourVisibility;
   // a0..a9 coefficients of the triaxial-ellipsoid quadric, derived from
@@ -297,6 +302,34 @@ void vtkOpenGLDistanceContourPolyDataMapper::SetReferencePoint(const std::array<
 {
   this->Impl->ReferencePoint = referencePoint;
   this->Modified();
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLDistanceContourPolyDataMapper::SetExternalPointWorld(double x, double y, double z)
+{
+  this->SetExternalPoint({ static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), 1.0f });
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenGLDistanceContourPolyDataMapper::SetReferencePointWorld(double x, double y, double z)
+{
+  this->SetReferencePoint({ static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), 1.0f });
+}
+
+//------------------------------------------------------------------------------
+double* vtkOpenGLDistanceContourPolyDataMapper::GetExternalPointWorld()
+{
+  const auto& point = this->Impl->ExternalPoint;
+  this->Impl->ExternalPointWorld = { static_cast<double>(point[0]), static_cast<double>(point[1]), static_cast<double>(point[2]) };
+  return this->Impl->ExternalPointWorld.data();
+}
+
+//------------------------------------------------------------------------------
+double* vtkOpenGLDistanceContourPolyDataMapper::GetReferencePointWorld()
+{
+  const auto& point = this->Impl->ReferencePoint;
+  this->Impl->ReferencePointWorld = { static_cast<double>(point[0]), static_cast<double>(point[1]), static_cast<double>(point[2]) };
+  return this->Impl->ReferencePointWorld.data();
 }
 
 //------------------------------------------------------------------------------

--- a/LiverResections/VTKWidgets/vtkOpenGLDistanceContourPolyDataMapper.h
+++ b/LiverResections/VTKWidgets/vtkOpenGLDistanceContourPolyDataMapper.h
@@ -70,6 +70,18 @@ public:
   /// Set the slicing plane normal
   void SetReferencePoint(const std::array<float, 4>& referencePoint);
 
+  /// Python-wrappable point accessors (the std::array signatures above do
+  /// not wrap -- VTK's wrapper takes a flat std::vector of scalars but no
+  /// std::array and no nested container, and it SKIPS such a method
+  /// silently, leaving a green build with the method absent from Python).
+  /// Mirrors the sibling vtkOpenGLSlicingContourPolyDataMapper, whose
+  /// plane accessors carry the same pair for the same reason.  The
+  /// homogeneous W component is fixed to 1.
+  void SetExternalPointWorld(double x, double y, double z);
+  void SetReferencePointWorld(double x, double y, double z);
+  double* GetExternalPointWorld() VTK_SIZEHINT(3);
+  double* GetReferencePointWorld() VTK_SIZEHINT(3);
+
   /// Get the contour thickness
   float GetContourThickness() const;
 


### PR DESCRIPTION
Follow-up to the wrapping defect found in #636: a sweep for the same failure elsewhere in the codebase, and a fix for the only place it could plausibly bite.

## The sweep

I diffed every public method declared in a C++ header against what the VTK wrapper actually generated, across all 37 wrapped classes, then checked whether any Python code calls the misses. That is the only reliable detector — the failure is silent by construction.

**No active instance: nothing in Python calls an unwrapped method.** Three categories of miss, all benign:

| Category | Why unwrapped | Verdict |
|---|---|---|
| `ReadXMLAttributes` / `WriteXML` on all 8 MRML nodes | `const char**` / `ostream&` | By design — Slicer core is identical; the scene calls them, never Python |
| `vtkLabelMapHelper` (8 methods) | `itk::Image::Pointer` in signatures | By design — C++-internal, driven by `vtkLiverVolumetryLogic` |
| `VTK_SIZEHINT` | a macro, not a method | Artifact of my parser |

I also re-checked the related silent-`None` failure mode — resolvers guessing the wrong namespace. All resolvers use the correct `vtkSlicerLiverResectionsModule*Python` namespaces; the known-bad `("slicer", "vtk")` pattern is gone from the tree.

## What this PR fixes

Four accessors on `vtkOpenGLDistanceContourPolyDataMapper` — `SetExternalPoint`, `GetExternalPoint`, `SetReferencePoint`, `GetReferencePoint` — take `const std::array<float, 4>&` and are silently skipped by the wrapper.

Nothing calls them from Python today, so **nothing is broken**. But ADR-0013 is moving rendering onto Python-driven LayerDM pipelines, so the first pipeline needing to drive this mapper would have hit the same wall as #636, with no diagnostic and a green build.

**The sibling already solved this.** `vtkOpenGLSlicingContourPolyDataMapper` carries `SetPlanePositionWorld` / `SetPlaneNormalWorld` / `GetPlanePositionWorld` / `GetPlaneNormalWorld` for exactly this reason — its header says so. This adds the matching pair to the distance-contour mapper, bringing the two back into line rather than inventing a pattern.

The `std::array` overloads stay: they are the C++ API and the C++ tests use them. The `…World` variants are additive.

## Verification — red then green, launched

| | Result |
|---|---|
| **Without** the accessors | **2 failed** — both distance-contour round-trips |
| **With** them | **160 passed**, 15 skipped |

Baseline without the new test file was 155 passed, so all **5** new tests ran and passed — I checked rather than inferring it from the progress dots, which wrap.

Confirmed directly in the generated wrapper that all four now appear as registered methods, where previously there were zero occurrences.

## A note on the test

It asserts **reachability, not behaviour**. Behaviour is already covered by the C++ mapper tests — and a C++ test cannot detect a wrapping gap by construction, which is exactly how #636 got as far as review.

It also pins that the `std::array` overloads remain *absent* from Python. That is not a demand they stay hidden; it documents why the `…World` pair exists, so a future reader does not delete it as redundant. If VTK ever learns to wrap `std::array`, that assertion fires and the question can be revisited deliberately.

The rule worth carrying forward: **a C++ method a Python pipeline must call needs a wrappable signature and a Python caller proving it.** A passing C++ test is evidence of neither.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
