### PR TITLE
ENH: Drag the control polygon by its wireframe to translate it (#505 slice 4)

### DIFF
--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -24,6 +24,7 @@
 set(LiverResectionsLib_PYTHON_SCRIPTS
   __init__.py
   ControlPolygonPipeline.py
+  ControlPolygonRings.py
   DistanceMaps.py
   LiverBezierSurfacePipeline.py
   LocatorReslicer.py

--- a/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonPipeline.py
@@ -88,6 +88,28 @@ CONTROL_POINT_PICK_RADIUS_PX = 20.0
 #: not by a larger halo -- the glow blur washes a halo hue out.
 HALO_HOVER_COLOR = (1.0, 0.9, 0.2)
 HALO_GRAB_COLOR = (0.3, 1.0, 0.4)
+#: Pick radius (display pixels) within which a press grabs the FRAME.
+#: Wider than the handle radius: the frame is a thin tube, and the
+#: gesture is coarse (translate everything) so a generous target costs
+#: nothing -- the group pick is asked BEFORE the point pick, but only
+#: claims when no handle is closer (see _group_pick).
+FRAME_PICK_RADIUS_PX = 10.0
+
+#: Border colour while the frame is hovered / held.
+#:
+#: COOL against a warm resting border.  The edge's default is pure RED
+#: and the handle cues are warm too (halo hover yellow, halo grab green),
+#: so a warm highlight is nearly invisible: the first attempt used orange
+#: (1.0, 0.55, 0.0) against that red and read as no change at all --
+#: the cue was firing correctly and simply could not be seen.
+#:
+#: Cyan and blue are the two hues no other element in this pipeline uses,
+#: and both differ from the resting red in hue AND luminance, so the
+#: change survives a glance.  They also stay distinct from the white
+#: handles and from each other.
+FRAME_HOVER_COLOR = (0.25, 0.9, 1.0)
+FRAME_GRAB_COLOR = (0.1, 0.45, 1.0)
+
 #: Halo radius scale vs the handle sphere.
 HALO_HOVER_SCALE = 1.35
 
@@ -100,6 +122,42 @@ DASH_LENGTH_MM = 7.0
 GAP_LENGTH_MM = 7.0
 
 _REGISTERED = False
+
+
+def _ring_groups(rows: int, cols: int):
+    """Ring membership for the group gestures, or ``()`` when unavailable.
+
+    Imported lazily and defensively: the Representations stay
+    independently importable, and a missing module must degrade to "no
+    group affordance" rather than breaking an interaction callback.
+    """
+    try:
+        from ControlPolygonRings import ring_groups
+    except Exception:
+        try:
+            from LiverResectionsLib.ControlPolygonRings import ring_groups
+        except Exception:
+            return ()
+    return ring_groups(int(rows), int(cols))
+
+
+def _point_segment_distance2(px: float, py: float, start, end) -> float:
+    """Squared distance from ``(px, py)`` to the SEGMENT ``start``-``end``.
+
+    Clamped to the segment, so the ends do not attract picks that belong
+    to the neighbouring edge.  A degenerate (zero-length) segment reduces
+    to the point distance.
+    """
+    ax, ay = start
+    bx, by = end
+    vx, vy = bx - ax, by - ay
+    length2 = vx * vx + vy * vy
+    if length2 <= 0.0:
+        return (px - ax) ** 2 + (py - ay) ** 2
+    t = ((px - ax) * vx + (py - ay) * vy) / length2
+    t = max(0.0, min(1.0, t))
+    cx, cy = ax + t * vx, ay + t * vy
+    return (px - cx) ** 2 + (py - cy) ** 2
 
 
 def _resolve_control_polygon_geometry() -> Any | None:
@@ -156,6 +214,10 @@ class ControlPolygonPipeline(_PipelineBase):
         self._control_polygon_geometry: Any | None = None
         #: Edge topology from the Algorithm builder + the (rows, cols) it
         #: was built for.
+        #: Cursor world position the running frame drag is anchored at.
+        self._group_anchor_world: Any | None = None
+        #: Whether the cursor last sat on the frame (render-change gate).
+        self._frame_hovered = False
         self._edge_cells: Any | None = None
         self._edge_cells_shape: tuple | None = None
 
@@ -446,6 +508,15 @@ class ControlPolygonPipeline(_PipelineBase):
         the picked surface (ADR-0033).  ``None`` (no grab / unresolved)
         keeps the grab alive without moving anything.
         """
+        # A GROUP drag has no grabbed point: the gesture translates the
+        # whole set, so it follows the cursor on the plane through the
+        # grid's CENTROID.  Without this the base resolves no world
+        # position, claims the move (the camera stays put, which is why the
+        # gesture looks dead rather than absent) and never calls the drag
+        # hook.
+        if self._group_drag is not None:
+            return self._event_world_at_grid_centroid(renderer, eventData)
+
         idx = self._drag_key
         if idx is None:
             return None
@@ -459,6 +530,30 @@ class ControlPolygonPipeline(_PipelineBase):
             and distance2 <= CONTROL_POINT_PICK_RADIUS_PX * CONTROL_POINT_PICK_RADIUS_PX
         )
         self._set_hover(idx if within else None)
+
+        # Frame hover: only when no handle owns the cursor, mirroring the
+        # pick arbitration so the cue cannot promise a gesture the press
+        # would not deliver.
+        frame_hovered = False
+        if not within and self._interaction_admissible():
+            frame_d2 = self._frame_distance2_in_display(renderer, eventData)
+            frame_hovered = (
+                frame_d2 is not None and frame_d2 <= FRAME_PICK_RADIUS_PX**2
+            )
+        display_node = self._display_node
+        group = (
+            getattr(display_node, "GroupFrame", 0) if display_node is not None else 0
+        )
+        # Request a render when the frame hover CHANGES.  _set_hover
+        # early-returns on an unchanged handle index and renders nothing,
+        # so leaving the frame (with no handle involved) restyled the actor
+        # and never flushed it -- the border stayed lit after the cursor
+        # had gone.
+        if frame_hovered != self._frame_hovered:
+            self._frame_hovered = frame_hovered
+            self._publish_group_state(hovered=group if frame_hovered else None)
+            self._apply_frame_style()
+            self.RequestRender()
 
     def _on_grab(self, key: Any, renderer: Any, eventData: Any) -> None:
         """The resection grab: Init->Planning commit + grab colour + halo.
@@ -485,6 +580,224 @@ class ControlPolygonPipeline(_PipelineBase):
         """The halo follows the grabbed handle during the drag."""
         self._hover_index = None
         self._set_hover(key)
+
+    # ------------------------------------------------------------------ #
+    # Group gestures (ADR-0038 seam).  The FRAME drag translates the whole
+    # control polygon rigidly -- every control point by the same delta --
+    # and the surface follows because it is regenerated from the grid.
+    # ------------------------------------------------------------------ #
+
+    def _group_pick(self, renderer: Any, eventData: Any, etype: Any):
+        """Claim a LEFT press on the polygon FRAME (the boundary edges).
+
+        Declines when a handle is nearer than the frame: the base asks
+        this before the point pick, so without that check grabbing a
+        corner would translate the whole polygon instead of editing the
+        point under the cursor.
+        """
+
+        if etype != vtk.vtkCommand.LeftButtonPressEvent:
+            return None
+        if not self._interaction_admissible():
+            return None
+
+        frame_d2 = self._frame_distance2_in_display(renderer, eventData)
+        if frame_d2 is None or frame_d2 > FRAME_PICK_RADIUS_PX**2:
+            return None
+
+        # PRECEDENCE, not proximity.  Boundary control points lie ON the
+        # frame, so near a handle both distances are ~0 and comparing them
+        # raw let sub-pixel noise decide -- a press on a corner handle
+        # sometimes translated the whole polygon.  A handle owns any press
+        # inside ITS OWN radius, full stop; the frame is only consulted
+        # when no handle is in range.  This is the same rule the hover cue
+        # applies, so the highlight can no longer promise a gesture the
+        # press would not deliver.
+        _idx, handle_d2 = self._nearest_control_point_in_display(renderer, eventData)
+        if handle_d2 <= CONTROL_POINT_PICK_RADIUS_PX**2:
+            return None  # a handle owns this press
+
+        display_node = self._display_node
+        group = (
+            display_node.GroupFrame
+            if display_node is not None and hasattr(display_node, "GroupFrame")
+            else 0
+        )
+        return group, frame_d2
+
+    def _on_group_grab(self, group: Any, renderer: Any, eventData: Any) -> None:
+        """Anchor the drag at the cursor's world position."""
+        self._group_anchor_world = self._event_world(renderer, eventData)
+        self._publish_group_state(grabbed=group)
+        self._apply_frame_style()
+        self.RequestRender()
+
+    def _on_group_drag(self, group: Any, world: Any) -> None:
+        """Translate every control point by the cursor's delta.
+
+        The anchor advances each move, so the delta is incremental: the
+        polygon tracks the cursor without accumulating the rounding that
+        an absolute origin would.
+        """
+        anchor = getattr(self, "_group_anchor_world", None)
+        if anchor is None or world is None:
+            return
+        delta = (world[0] - anchor[0], world[1] - anchor[1], world[2] - anchor[2])
+        if self._translate_control_grid(delta):
+            self._group_anchor_world = world
+
+    def _on_group_release(self, group: Any) -> None:
+        """End the gesture; the grid keeps the translation."""
+        self._group_anchor_world = None
+        # Drop the hover flag too: the cursor may have left the frame during
+        # the drag, and the next bare move must be free to re-evaluate
+        # rather than compare against a stale True.
+        self._frame_hovered = False
+        self._publish_group_state(grabbed=None, hovered=None)
+        self._apply_frame_style()
+        self.RequestRender()
+
+    def _translate_control_grid(self, delta) -> bool:
+        """Displace EVERY control point by ``delta`` (the rigid move).
+
+        One write per point through the carrier's own setter, so the
+        carrier raises its usual modified events and the surface, the
+        slice projection and the resectogram all follow from one gesture.
+        """
+        carrier = self._data_node
+        if carrier is None or _safe_get_state(carrier) != STATE_PLANNING:
+            return False
+        rows = int(carrier.GetRows())
+        cols = int(carrier.GetCols())
+        grid = carrier.GetControlGridVector()
+
+        # ONE Modified for the whole translation.  SetControlPoint fires its
+        # own Modified, so writing 16 points unbatched re-tessellated the
+        # surface and reconciled every pipeline 16 times PER MOUSE MOVE --
+        # the drag tracked the cursor correctly but crawled.  The batch is
+        # the same idiom the state machine uses for its re-fit.
+        was_modifying = carrier.StartModify()
+        try:
+            for i in range(rows * cols):
+                carrier.SetControlPoint(
+                    i // cols,
+                    i % cols,
+                    grid[i * 3 + 0] + delta[0],
+                    grid[i * 3 + 1] + delta[1],
+                    grid[i * 3 + 2] + delta[2],
+                )
+        finally:
+            carrier.EndModify(was_modifying)
+        return True
+
+    def _frame_distance2_in_display(self, renderer: Any, eventData: Any):
+        """Squared display distance from the event pixel to ANY polygon edge.
+
+        Every lattice segment counts, interior ones included: the polygon
+        reads as a single object, so grabbing any part of its wireframe
+        translates the whole thing.  Restricting this to the outer ring
+        left the interior segments inert and, with handles owning a 20px
+        radius, squeezed the grabbable band to the middle of each boundary
+        edge.
+
+        Distance is to the SEGMENTS, not the vertices -- measuring to
+        vertices would leave the middle of a long edge unpickable.
+        """
+        carrier = self._data_node
+        if carrier is None:
+            return None
+        rows = int(carrier.GetRows())
+        cols = int(carrier.GetCols())
+        if rows <= 0 or cols <= 0:
+            return None
+
+        grid = carrier.GetControlGridVector()
+        ex, ey = eventData.GetDisplayPosition()
+
+        # Project the whole grid once; the segment walk below reuses it.
+        screen = []
+        for i in range(rows * cols):
+            renderer.SetWorldPoint(
+                grid[i * 3 + 0], grid[i * 3 + 1], grid[i * 3 + 2], 1.0
+            )
+            renderer.WorldToDisplay()
+            dx, dy, _dz = renderer.GetDisplayPoint()
+            screen.append((dx, dy))
+
+        best = None
+        for r in range(rows):
+            for c in range(cols):
+                here = screen[r * cols + c]
+                if c + 1 < cols:  # segment to the right
+                    d2 = _point_segment_distance2(
+                        float(ex), float(ey), here, screen[r * cols + c + 1]
+                    )
+                    if best is None or d2 < best:
+                        best = d2
+                if r + 1 < rows:  # segment downward
+                    d2 = _point_segment_distance2(
+                        float(ex), float(ey), here, screen[(r + 1) * cols + c]
+                    )
+                    if best is None or d2 < best:
+                        best = d2
+        return best
+
+    def _apply_frame_style(self) -> None:
+        """Colour the polygon border from the SHARED group state.
+
+        Read off the display node, not a local flag, so every view paints
+        the same frame: hovering the border in one view lights it in all
+        of them, which is the coherence the gesture was asked for.
+        """
+        display_node = self._display_node
+        if display_node is None or not hasattr(display_node, "GetHoveredGroup"):
+            return
+        none_value = getattr(display_node, "GroupNone", -1)
+        frame = getattr(display_node, "GroupFrame", 0)
+
+        grabbed = display_node.GetGrabbedGroup() == frame
+        hovered = display_node.GetHoveredGroup() == frame
+
+        if grabbed:
+            colour = FRAME_GRAB_COLOR
+        elif hovered:
+            colour = FRAME_HOVER_COLOR
+        else:
+            colour = None
+
+        prop = self._edges_actor.GetProperty()
+        if colour is None:
+            # Restore the display node's own edge colour.
+            getter = getattr(display_node, "GetEdgeColor", None)
+            if getter is not None:
+                try:
+                    c = getter()
+                    prop.SetColor(float(c[0]), float(c[1]), float(c[2]))
+                except Exception:  # pragma: no cover - defensive
+                    pass
+        else:
+            prop.SetColor(*colour)
+        _ = none_value  # documented sentinel; comparisons above are explicit
+
+    def _publish_group_state(self, hovered=..., grabbed=...) -> None:
+        """Write group hover/grab onto the SHARED display node.
+
+        On the node, not this instance: LayerDM does not drive a Python
+        pipeline's attributes, so a frame hovered in one view would not
+        light the frame in the others.
+        """
+        display_node = self._display_node
+        if display_node is None or not hasattr(display_node, "SetHoveredGroup"):
+            return
+        none_value = getattr(display_node, "GroupNone", -1)
+        if hovered is not ...:
+            value = none_value if hovered is None else int(hovered)
+            if display_node.GetHoveredGroup() != value:
+                display_node.SetHoveredGroup(value)
+        if grabbed is not ...:
+            value = none_value if grabbed is None else int(grabbed)
+            if display_node.GetGrabbedGroup() != value:
+                display_node.SetGrabbedGroup(value)
 
     def _on_release(self) -> None:
         """Drop the grab colour + halo when the base clears the grab."""
@@ -671,6 +984,42 @@ class ControlPolygonPipeline(_PipelineBase):
                 best_idx = i
         return best_idx, best_d2
 
+    def _event_world_at_grid_centroid(self, renderer: Any, eventData: Any):
+        """Back-project the event pixel onto the control grid's centroid depth.
+
+        The depth reference for a GROUP gesture.  A rigid translation has
+        no single grabbed point to take depth from, and picking one member
+        arbitrarily would make the polygon swing differently depending on
+        which edge was grabbed.  The centroid keeps the motion the same
+        whichever part of the frame the cursor holds.
+        """
+        carrier = self._data_node
+        if carrier is None:
+            return None
+        try:
+            rows = int(carrier.GetRows())
+            cols = int(carrier.GetCols())
+            grid = carrier.GetControlGridVector()
+            count = rows * cols
+            if count <= 0:
+                return None
+            cx = sum(grid[i * 3 + 0] for i in range(count)) / count
+            cy = sum(grid[i * 3 + 1] for i in range(count)) / count
+            cz = sum(grid[i * 3 + 2] for i in range(count)) / count
+
+            ex, ey = eventData.GetDisplayPosition()
+            renderer.SetWorldPoint(cx, cy, cz, 1.0)
+            renderer.WorldToDisplay()
+            _dx, _dy, dz = renderer.GetDisplayPoint()
+            renderer.SetDisplayPoint(float(ex), float(ey), dz)
+            renderer.DisplayToWorld()
+            wx, wy, wz, ww = renderer.GetWorldPoint()
+        except Exception:  # pragma: no cover - defensive
+            return None
+        if ww == 0.0:
+            return None
+        return (wx / ww, wy / ww, wz / ww)
+
     def _event_world_at_control_point(self, renderer: Any, eventData: Any, idx: int):
         """Back-project the event pixel onto control point ``idx``'s depth.
 
@@ -835,6 +1184,12 @@ class ControlPolygonPipeline(_PipelineBase):
                 self._edges_tube.SetRadius(float(edge_width()))
             except Exception:  # pragma: no cover - defensive
                 pass
+
+        # Re-assert the group highlight LAST.  The block above restores the
+        # display node's own edge colour on every reconcile, and a drag
+        # reconciles on each move -- so without this the highlight was
+        # repainted away the moment the gesture it belongs to did any work.
+        self._apply_frame_style()
 
     # ------------------------------------------------------------------ #
     # Introspection (unit tests) + plumbing

--- a/LiverResections/LiverResectionsLib/ControlPolygonRings.py
+++ b/LiverResections/LiverResectionsLib/ControlPolygonRings.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Ring membership of a Bezier control polygon, for the group-drag gestures.
+
+A group gesture translates a SET of control points rigidly -- every
+member displaced by the same delta, then the surface recomputed.  Two
+pipelines need the same memberships: ``ControlPolygonPipeline`` (3D) and
+``SliceControlPolygonPipeline`` (its slice-view projection).  They live
+here so the two cannot drift apart.
+
+WHY CONSTANTS, NOT A COMPUTED DECOMPOSITION
+-------------------------------------------
+ADR-0018 §1 admits exactly two control-polygon shapes, ``(3, 3)`` and
+``(4, 4)``, and each has exactly two rings -- so the memberships are
+fixed.  A general peel-the-lattice algorithm would carry depth
+arithmetic and degenerate single-row / single-column branches for shapes
+this project does not allow.
+
+WHY PYTHON, NOT THE ALGORITHM LIBRARY
+-------------------------------------
+The first attempt put this in ``vtkSlicerLiverBezierControlPolygonGeometry``
+beside ``BuildControlPolygonCells``.  It returned
+``std::vector<std::vector<vtkIdType>>``, which VTK's Python wrapper
+SILENTLY SKIPS -- a flat ``std::vector<T>`` of scalars wraps, a nested
+one does not.  The build stayed green, the C++ tests passed, and the
+method simply did not exist from Python, where both consumers live.
+(The same trap as the ``void*`` distance-map upload: compiles, links,
+tests green, invisible from Python.)
+
+Should a NURBS control net of arbitrary ``m x n`` ever need computed
+rings, that is a C++ API designed against a real requirement -- with a
+wrappable signature (``vtkIdList`` out-parameters) and a Python consumer
+to prove it.
+
+INDEXING
+--------
+Row-major, ``(i, j) -> i * cols + j``, matching
+``vtkSlicerLiverBezierControlPolygonGeometry::BuildControlPolygonCells``.
+
+Ring 0 is the OUTER ring, listed as a contiguous CLOCKWISE WALK from the
+top-left corner, so a ring highlight can consume the order directly as a
+closed path instead of re-deriving the traversal.  Ring 1 is the
+interior.
+
+A 3x3 grid's inner "ring" is the SINGLE centre point.  A one-element
+rigid-translation group is well defined, but it is not a ring in any
+geometric sense; a caller presenting a ring affordance should expect it.
+The UI only ever produces 4x4 today (the init re-fit always does), but
+3x3 is legal under ADR-0018.
+"""
+
+from __future__ import annotations
+
+#: (rows, cols) -> tuple of rings, each a tuple of flat row-major ids.
+#: Every id appears in exactly one ring: a group translates rigidly, so
+#: an id in two rings would be displaced twice and an id in none would be
+#: left behind -- either tears the surface.
+RING_GROUPS: dict[tuple[int, int], tuple[tuple[int, ...], ...]] = {
+    (4, 4): (
+        (0, 1, 2, 3, 7, 11, 15, 14, 13, 12, 8, 4),
+        (5, 6, 10, 9),
+    ),
+    (3, 3): (
+        (0, 1, 2, 5, 8, 7, 6, 3),
+        (4,),
+    ),
+}
+
+
+def ring_groups(rows: int, cols: int) -> tuple[tuple[int, ...], ...]:
+    """Rings for a ``rows x cols`` control polygon, outermost first.
+
+    Returns an empty tuple for any shape outside the ADR-0018 §1 closed
+    set, mirroring ``BuildControlPolygonCells``' rejection rather than
+    raising: a pipeline asking about an out-of-spec grid should render no
+    group affordance, not fail an interaction callback.
+    """
+    return RING_GROUPS.get((rows, cols), ())

--- a/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
+++ b/LiverResections/MRML/Testing/Cxx/vtkMRMLControlPolygonDisplayNodeTest1.cxx
@@ -82,6 +82,8 @@ int testDefaults()
   // Transient cross-view interaction state: nothing hovered/grabbed.
   CHECK_INT(node->GetHoveredControlPoint(), -1);
   CHECK_INT(node->GetGrabbedControlPoint(), -1);
+  CHECK_INT(node->GetHoveredGroup(), vtkMRMLControlPolygonDisplayNode::GroupNone);
+  CHECK_INT(node->GetGrabbedGroup(), vtkMRMLControlPolygonDisplayNode::GroupNone);
 
   CHECK_STRING(node->GetNodeTagName(), "ControlPolygonDisplay");
   return EXIT_SUCCESS;
@@ -111,6 +113,15 @@ int testSettersAndGetters()
   CHECK_INT(node->GetHoveredControlPoint(), 5);
   node->SetGrabbedControlPoint(7);
   CHECK_INT(node->GetGrabbedControlPoint(), 7);
+
+  // Group-drag targets.  Frame and ring 0 span the same boundary points
+  // but are DISTINCT targets -- the frame drag moves the whole polygon,
+  // ring 0 moves only the boundary -- so the node must keep them apart.
+  node->SetHoveredGroup(vtkMRMLControlPolygonDisplayNode::GroupFrame);
+  CHECK_INT(node->GetHoveredGroup(), vtkMRMLControlPolygonDisplayNode::GroupFrame);
+  node->SetGrabbedGroup(vtkMRMLControlPolygonDisplayNode::GroupRing0 + 1);
+  CHECK_INT(node->GetGrabbedGroup(), vtkMRMLControlPolygonDisplayNode::GroupRing0 + 1);
+  CHECK_BOOL(vtkMRMLControlPolygonDisplayNode::GroupFrame != vtkMRMLControlPolygonDisplayNode::GroupRing0, true);
   return EXIT_SUCCESS;
 }
 
@@ -217,10 +228,14 @@ int testCopyContent()
   // just as the fields are excluded from the XML round-trip.
   source->SetHoveredControlPoint(5);
   source->SetGrabbedControlPoint(7);
+  source->SetHoveredGroup(vtkMRMLControlPolygonDisplayNode::GroupFrame);
+  source->SetGrabbedGroup(vtkMRMLControlPolygonDisplayNode::GroupRing0);
   vtkNew<vtkMRMLControlPolygonDisplayNode> transientSink;
   transientSink->CopyContent(source.GetPointer(), /*deepCopy=*/true);
   CHECK_INT(transientSink->GetHoveredControlPoint(), -1);
   CHECK_INT(transientSink->GetGrabbedControlPoint(), -1);
+  CHECK_INT(transientSink->GetHoveredGroup(), vtkMRMLControlPolygonDisplayNode::GroupNone);
+  CHECK_INT(transientSink->GetGrabbedGroup(), vtkMRMLControlPolygonDisplayNode::GroupNone);
   return EXIT_SUCCESS;
 }
 

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.cxx
@@ -60,6 +60,8 @@ vtkMRMLControlPolygonDisplayNode::vtkMRMLControlPolygonDisplayNode()
   // Transient cross-view interaction state (not serialized).
   , HoveredControlPoint(-1)
   , GrabbedControlPoint(-1)
+  , HoveredGroup(GroupNone)
+  , GrabbedGroup(GroupNone)
 {
 }
 
@@ -102,10 +104,11 @@ void vtkMRMLControlPolygonDisplayNode::CopyContent(vtkMRMLNode* anode, bool deep
   MRMLNodeModifyBlocker blocker(this);
   Superclass::CopyContent(anode, deepCopy);
 
-  // HoveredControlPoint / GrabbedControlPoint are TRANSIENT interaction
-  // state (the markups ActiveComponent precedent): copying a node must not
-  // clone a live hover/grab onto the copy, so they are excluded here just
-  // as they are from the XML round-trip.
+  // HoveredControlPoint / GrabbedControlPoint and the group-drag pair
+  // HoveredGroup / GrabbedGroup are TRANSIENT interaction state (the
+  // markups ActiveComponent precedent): copying a node must not clone a
+  // live hover/grab onto the copy, so all four are excluded here just as
+  // they are from the XML round-trip.
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyFloatMacro(HandleRadius);
   vtkMRMLCopyVectorMacro(HandleColor, double, 3);
@@ -126,5 +129,7 @@ void vtkMRMLControlPolygonDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(EdgeWidth);
   vtkMRMLPrintIntMacro(HoveredControlPoint);
   vtkMRMLPrintIntMacro(GrabbedControlPoint);
+  vtkMRMLPrintIntMacro(HoveredGroup);
+  vtkMRMLPrintIntMacro(GrabbedGroup);
   vtkMRMLPrintEndMacro();
 }

--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
@@ -135,6 +135,44 @@ public:
   vtkSetMacro(GrabbedControlPoint, int);
   vtkGetMacro(GrabbedControlPoint, int);
 
+  /// Group-drag targets.  A GROUP translates rigidly: every member
+  /// control point is displaced by the SAME delta and the surface is
+  /// recomputed.
+  ///
+  ///  - ``GroupNone``  — nothing hovered/grabbed.
+  ///  - ``GroupFrame`` — the polygon BORDER, whose drag moves the WHOLE
+  ///    control polygon (every point, not only the boundary).  The frame
+  ///    is the affordance; its action is global.
+  ///  - ``GroupRing0`` and up — one ring from
+  ///    ``vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups``,
+  ///    whose drag moves ONLY that ring's points.  Ring ``k`` is
+  ///    ``GroupRing0 + k``.
+  ///
+  /// Frame and ring 0 cover the same boundary points but are distinct
+  /// targets: the frame moves everything, ring 0 moves only the
+  /// boundary.  They are separated here so the highlight can say which
+  /// gesture is armed.
+  enum GroupTarget
+  {
+    GroupNone = -1,
+    GroupFrame = 0,
+    GroupRing0 = 1
+  };
+
+  /// The HOVERED group (see GroupTarget; ``GroupNone`` = none).
+  /// TRANSIENT interaction state shared across views, not serialized --
+  /// the same reasoning as HoveredControlPoint: every pipeline observing
+  /// this display node highlights the same group, whichever view the
+  /// cursor is in.  A Python pipeline instance could not do this,
+  /// because LayerDM does not drive it.
+  vtkSetMacro(HoveredGroup, int);
+  vtkGetMacro(HoveredGroup, int);
+
+  /// The GRABBED group (see GroupTarget; ``GroupNone`` = none).
+  /// TRANSIENT, cross-view, not serialized (see HoveredGroup).
+  vtkSetMacro(GrabbedGroup, int);
+  vtkGetMacro(GrabbedGroup, int);
+
 protected:
   vtkMRMLControlPolygonDisplayNode();
   ~vtkMRMLControlPolygonDisplayNode() override;
@@ -149,6 +187,8 @@ private:
   double EdgeWidth;
   int HoveredControlPoint;
   int GrabbedControlPoint;
+  int HoveredGroup;
+  int GrabbedGroup;
 };
 
 #endif //__vtkmrmlcontrolpolygondisplaynode_h_

--- a/LiverResections/Testing/Python/test_control_polygon_frame_highlight.py
+++ b/LiverResections/Testing/Python/test_control_polygon_frame_highlight.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The frame highlight survives the gesture that owns it.
+
+The border lights while the frame is hovered or held.  A drag translates
+the control grid, which fires Modified, which reconciles the pipeline --
+and the reconcile restores the display node's own edge colour.  If the
+highlight is not re-asserted after that restore, the gesture repaints
+away its own cue: the border lights on grab and goes dark the instant the
+drag does any work.
+
+That is exactly what the eyeball caught, and it is invisible to a test
+that only checks the colour right after the grab.  So the sequence here
+is grab -> RECONCILE -> assert, not grab -> assert.
+
+HARNESS: launched Slicer.  The pipeline derives from a LayerDMLib base
+reachable only inside a launched Slicer, so a bare run SKIPS CLEANLY
+(ADR-0027).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _pipeline_module_or_skip():
+    """The MODULE, not the class.
+
+    ``from LiverResectionsLib import ControlPolygonPipeline`` yields the
+    CLASS: the package __init__ does ``from .ControlPolygonPipeline import
+    ControlPolygonPipeline``, rebinding the module attribute to the class.
+    importlib reaches the module itself, which is what the constants below
+    live on.
+    """
+    import importlib
+
+    try:
+        return importlib.import_module("LiverResectionsLib.ControlPolygonPipeline")
+    except Exception as exc:
+        pytest.skip(f"ControlPolygonPipeline not importable ({exc!r}) -- ADR-0027.")
+
+
+def _display_node_or_skip(slicer):
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLControlPolygonDisplayNode")
+    if node is None or not hasattr(node, "SetGrabbedGroup"):
+        pytest.skip("control-polygon display node lacks group state (ADR-0027).")
+    return node
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()
+
+
+def _pipeline_with_display(module, slicer):
+    try:
+        pipeline = module.ControlPolygonPipeline()
+    except Exception as exc:
+        pytest.skip(f"pipeline not constructible ({exc!r}) -- ADR-0027.")
+    display = _display_node_or_skip(slicer)
+    display.SetEdgeColor(0.2, 0.2, 0.9)  # a resting colour unlike the cues
+    pipeline.SetDisplayNode(display)
+    return pipeline, display
+
+
+def test_grab_highlight_survives_a_reconcile():
+    """The bug the eyeball found: a drag repainted away its own highlight."""
+    slicer = _slicer_or_skip()
+    module = _pipeline_module_or_skip()
+    pipeline, display = _pipeline_with_display(module, slicer)
+
+    display.SetGrabbedGroup(display.GroupFrame)
+    pipeline._apply_frame_style()
+    held = pipeline._edges_actor.GetProperty().GetColor()
+    assert held == pytest.approx(module.FRAME_GRAB_COLOR, abs=1e-3)
+
+    # The reconcile a drag triggers: it restores the display node's own
+    # edge colour and must NOT leave it there while the frame is held.
+    pipeline._apply_display_node()
+
+    after = pipeline._edges_actor.GetProperty().GetColor()
+    assert after == pytest.approx(module.FRAME_GRAB_COLOR, abs=1e-3), (
+        "The reconcile restored the resting edge colour over the grab "
+        "highlight.  A drag reconciles on every move, so the border goes "
+        "dark the moment the gesture does any work."
+    )
+
+
+def test_hover_highlight_survives_a_reconcile():
+    """Same guarantee for the hover cue."""
+    slicer = _slicer_or_skip()
+    module = _pipeline_module_or_skip()
+    pipeline, display = _pipeline_with_display(module, slicer)
+
+    display.SetHoveredGroup(display.GroupFrame)
+    pipeline._apply_frame_style()
+    pipeline._apply_display_node()
+
+    after = pipeline._edges_actor.GetProperty().GetColor()
+    assert after == pytest.approx(module.FRAME_HOVER_COLOR, abs=1e-3)
+
+
+def test_resting_polygon_keeps_the_display_node_colour():
+    """With no group cue the border is the display node's own colour.
+
+    Guards the other direction: a highlight that never cleared would be
+    just as wrong as one that never held.
+    """
+    slicer = _slicer_or_skip()
+    module = _pipeline_module_or_skip()
+    pipeline, display = _pipeline_with_display(module, slicer)
+
+    display.SetHoveredGroup(display.GroupNone)
+    display.SetGrabbedGroup(display.GroupNone)
+    pipeline._apply_display_node()
+
+    after = pipeline._edges_actor.GetProperty().GetColor()
+    assert after == pytest.approx((0.2, 0.2, 0.9), abs=1e-3)

--- a/LiverResections/Testing/Python/test_control_polygon_rings.py
+++ b/LiverResections/Testing/Python/test_control_polygon_rings.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Ring membership for the control-polygon group-drag gestures.
+
+A group translates RIGIDLY -- every member displaced by the same delta,
+then the surface recomputed.  The load-bearing property is therefore
+that the rings PARTITION the control grid: an id in two rings would be
+displaced twice, an id in none would be left behind, and either tears
+the surface.  Sizes alone do not catch that, so the partition is
+asserted directly.
+
+HARNESS: pure Python, no Slicer, no VTK, no scene.  RUNS BARE (ADR-0027).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+LIB_DIR = REPO_ROOT / "LiverResections" / "LiverResectionsLib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+
+def _rings_or_skip():
+    try:
+        import ControlPolygonRings
+    except Exception as exc:  # pragma: no cover - import-environment dependent
+        pytest.skip(f"ControlPolygonRings not importable ({exc!r}) -- ADR-0027.")
+    return ControlPolygonRings
+
+
+@pytest.mark.parametrize(("rows", "cols"), [(4, 4), (3, 3)])
+def test_rings_partition_the_control_grid(rows, cols):
+    """Every control point belongs to exactly one rigid-translation group."""
+    module = _rings_or_skip()
+    rings = module.ring_groups(rows, cols)
+    flat = [index for ring in rings for index in ring]
+
+    assert sorted(flat) == list(range(rows * cols)), (
+        "The rings must partition the grid: a duplicated id is displaced "
+        "twice and a missing id is left behind -- either tears the surface."
+    )
+
+
+def test_four_by_four_outer_ring_is_a_clockwise_closed_walk():
+    """The order is load-bearing: a highlight draws straight from it."""
+    module = _rings_or_skip()
+    outer, inner = module.ring_groups(4, 4)
+
+    assert outer == (0, 1, 2, 3, 7, 11, 15, 14, 13, 12, 8, 4), (
+        "The outer ring is consumed as a closed path by the ring "
+        "highlight; a membership-only change would break the drawing."
+    )
+    assert inner == (5, 6, 10, 9)
+
+
+def test_three_by_three_inner_group_is_the_single_centre_point():
+    """The degenerate shape, pinned so a ring affordance expects it."""
+    module = _rings_or_skip()
+    outer, inner = module.ring_groups(3, 3)
+
+    assert len(outer) == 8
+    assert inner == (4,), (
+        "A 3x3 has no interior ring -- only its centre point.  A "
+        "one-element rigid-translation group is valid, but a caller "
+        "presenting a ring affordance must expect it."
+    )
+
+
+@pytest.mark.parametrize(
+    ("rows", "cols"), [(2, 2), (5, 5), (3, 4), (4, 3), (0, 0), (1, 1)]
+)
+def test_shapes_outside_the_adr_0018_set_yield_no_rings(rows, cols):
+    """Out-of-spec grids render no group affordance rather than raising."""
+    module = _rings_or_skip()
+    assert module.ring_groups(rows, cols) == ()

--- a/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
+++ b/SlicerLiverInteractionLib/SurfacePointPlacementPipeline3D.py
@@ -89,6 +89,14 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
         # None when no drag is in flight.
         self._drag_key: Any | None = None
 
+        # The GROUP gesture in flight (a client-defined id), or None.  A
+        # group translates its members rigidly; the base holds only the
+        # gesture's identity, never its meaning.
+        self._group_drag: Any | None = None
+        # Which release event ends it: a group gesture may be right-button,
+        # while the point drag is always left.
+        self._group_drag_release_event: Any | None = None
+
     # ------------------------------------------------------------------ #
     # Seam wiring
     # ------------------------------------------------------------------ #
@@ -162,13 +170,27 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
         """
         try:
             if not self._admissible():
-                self._drag_key = None  # a state flip mid-gesture drops the grab
+                # A state flip mid-gesture drops BOTH grabs.
+                self._drag_key = None
+                self._group_drag = None
+                self._group_drag_release_event = None
                 return False, sys.float_info.max
             renderer = self._safe_get_renderer()
             if renderer is None:
                 self._drag_key = None
                 return False, sys.float_info.max
             etype = _event_type(eventData)
+
+            # A group drag in flight owns move + the release of ITS OWN
+            # button (a group gesture may be right-button; the point drag
+            # is always left).
+            if self._group_drag is not None:
+                if etype in (
+                    vtk.vtkCommand.MouseMoveEvent,
+                    self._group_drag_release_event,
+                ):
+                    return True, 0.0
+                return False, sys.float_info.max
 
             if self._drag_key is not None:
                 if etype in (
@@ -183,6 +205,19 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
                 # client's hover cue is a side effect of this declined call.
                 self._on_bare_move_decline(renderer, eventData)
                 return False, sys.float_info.max
+
+            # A client that opts into group gestures may claim a press of
+            # EITHER button.  Asked before the point pick so a frame or
+            # ring target wins over a handle that merely happens to be
+            # near the cursor; a client that does not opt in returns None
+            # and the arbitration below is untouched.
+            if etype in (
+                vtk.vtkCommand.LeftButtonPressEvent,
+                vtk.vtkCommand.RightButtonPressEvent,
+            ):
+                claim = self._group_pick(renderer, eventData, etype)
+                if claim is not None:
+                    return True, claim[1]
 
             if etype != vtk.vtkCommand.LeftButtonPressEvent:
                 return False, sys.float_info.max
@@ -219,7 +254,40 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
                 return False
             etype = _event_type(eventData)
 
+            if self._group_drag is not None:
+                if etype == self._group_drag_release_event:
+                    group = self._group_drag
+                    self._group_drag = None
+                    self._group_drag_release_event = None
+                    self._on_group_release(group)
+                    self.RequestRender()
+                    return False  # gesture over -- release the focus
+                if etype == vtk.vtkCommand.MouseMoveEvent:
+                    world = self._event_world(renderer, eventData)
+                    if world is None:
+                        return True  # keep the grab; this move didn't resolve
+                    self._on_group_drag(self._group_drag, world)
+                    self.RequestRender()
+                    return True
+                return False
+
             if self._drag_key is None:
+                if etype in (
+                    vtk.vtkCommand.LeftButtonPressEvent,
+                    vtk.vtkCommand.RightButtonPressEvent,
+                ):
+                    claim = self._group_pick(renderer, eventData, etype)
+                    if claim is not None:
+                        self._group_drag = claim[0]
+                        self._group_drag_release_event = (
+                            vtk.vtkCommand.RightButtonReleaseEvent
+                            if etype == vtk.vtkCommand.RightButtonPressEvent
+                            else vtk.vtkCommand.LeftButtonReleaseEvent
+                        )
+                        self._on_group_grab(claim[0], renderer, eventData)
+                        self.RequestRender()
+                        return True
+
                 if etype != vtk.vtkCommand.LeftButtonPressEvent:
                     return False
                 key, distance2 = self._nearest_key_in_display(renderer, eventData)
@@ -273,6 +341,41 @@ class SurfacePointPlacementPipeline3D(_PipelineBase):
         such gate.
         """
         return True
+
+    # -- group gestures (opt-in; the flat clients never override these) -- #
+
+    def _group_pick(self, renderer: Any, eventData: Any, etype: Any):
+        """Claim a press as a GROUP gesture, or decline.
+
+        Return ``(group_id, distance2)`` to claim, or ``None`` to leave
+        the press to the ordinary point arbitration.  ``group_id`` is
+        opaque to the base -- it is handed back verbatim to the group
+        hooks below, so a client chooses its own encoding (the resection
+        control polygon uses its display node's ``GroupTarget``).
+
+        Default declines every press, which is what keeps this change
+        inert for clients that do not opt in: the territories, volumetry
+        and slice-polygon pipelines never override it and see exactly the
+        dispatch they saw before.
+
+        A group gesture translates its members RIGIDLY -- the base moves
+        nothing itself, because the delta's meaning is the client's.
+        """
+        return None
+
+    def _on_group_grab(self, group: Any, renderer: Any, eventData: Any) -> None:
+        """A group gesture began (default: no-op)."""
+
+    def _on_group_drag(self, group: Any, world: Any) -> None:
+        """The cursor moved to ``world`` during a group gesture.
+
+        The base does NOT apply a displacement: what a group means, and
+        what a delta does to it, is data-model knowledge the base does not
+        carry (ADR-0038 §"What is not shared").
+        """
+
+    def _on_group_release(self, group: Any) -> None:
+        """A group gesture ended (default: no-op)."""
 
     def _on_grab(self, key: Any, renderer: Any, eventData: Any) -> None:
         """Called right after the base grabs ``key`` on a press (default no-op)."""

--- a/SlicerLiverInteractionLib/Testing/Python/test_group_gesture_seam.py
+++ b/SlicerLiverInteractionLib/Testing/Python/test_group_gesture_seam.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""The group-gesture seam on the shared placement base (ADR-0038).
+
+A GROUP gesture translates a set of control points rigidly -- every
+member displaced by the same delta -- as opposed to the per-point drag
+the base already arbitrates.  The control polygon needs two of them: a
+frame drag moving the whole polygon, and a ring drag moving one ring.
+
+The base carries the ARBITRATION only.  What a group is, and what a
+delta does to it, is data-model knowledge that stays with the client
+(ADR-0038 §"What is not shared") -- so the base hands a client-defined
+id straight back to the client's hooks and never moves a point itself.
+
+The load-bearing property here is that the seam is INERT for clients
+that do not opt in.  Three modules sit on this base (resection control
+polygon, vascular territories, volumetry seeds); a widening that leaked
+into their dispatch would change interaction everywhere at once.  The
+default ``_group_pick`` declines every press, so those clients see the
+dispatch they always saw.
+
+HARNESS: launched Slicer.  The renderer, scene and GL are all stubbed
+out here -- the arbitration under test is pure Python -- but the base
+class itself derives from ``vtkMRMLLayerDMPipelineI``, which is
+reachable only inside a launched Slicer with LayerDM loaded.  A bare
+``PythonSlicer -m pytest`` SKIPS CLEANLY (ADR-0027).
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+# The lib ships flat into qt-scripted-modules, so its modules are imported
+# by bare name; put the source dir on the path the same way the sibling
+# base tests do.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PY_DIR = REPO_ROOT / "SlicerLiverInteractionLib"
+if str(PY_DIR) not in sys.path:
+    sys.path.insert(0, str(PY_DIR))
+
+
+def _base_or_skip():
+    try:
+        module = importlib.import_module("SurfacePointPlacementPipeline3D")
+    except Exception as exc:
+        pytest.skip(f"placement base not importable ({exc!r}) -- ADR-0027.")
+    if not hasattr(module, "SurfacePointPlacementPipeline3D"):
+        pytest.skip("SurfacePointPlacementPipeline3D absent (ADR-0027).")
+    return module
+
+
+class _Event:
+    """Minimal eventData stand-in: only the event type is read here."""
+
+    def __init__(self, etype):
+        self._etype = etype
+
+    def GetType(self):  # noqa: N802 - VTK verb
+        return self._etype
+
+
+def _make_pipeline(base_module, group_claim=None):
+    """A pipeline whose renderer/admissibility are stubbed out.
+
+    ``group_claim`` is what ``_group_pick`` returns; ``None`` models a
+    client that never opted in.
+    """
+    cls = base_module.SurfacePointPlacementPipeline3D
+
+    class _Probe(cls):
+        def __init__(self):
+            super().__init__("test")
+            self.grabs = []
+            self.drags = []
+            self.releases = []
+
+        # Stub the environment the base would otherwise reach for.
+        def _safe_get_renderer(self):
+            return object()
+
+        def _admissible(self):
+            return True
+
+        def _nearest_key_in_display(self, renderer, eventData):
+            return None, float("inf")
+
+        def _pick_world(self, renderer, eventData):
+            return None
+
+        def _event_world(self, renderer, eventData):
+            return (1.0, 2.0, 3.0)
+
+        def RequestRender(self):  # noqa: N802 - VTK verb
+            pass
+
+        def _group_pick(self, renderer, eventData, etype):
+            return group_claim
+
+        def _on_group_grab(self, group, renderer, eventData):
+            self.grabs.append(group)
+
+        def _on_group_drag(self, group, world):
+            self.drags.append((group, world))
+
+        def _on_group_release(self, group):
+            self.releases.append(group)
+
+    try:
+        return _Probe()
+    except Exception as exc:  # pragma: no cover - construction needs the C++ base
+        pytest.skip(f"placement base not constructible here ({exc!r}) -- ADR-0027.")
+
+
+def test_default_group_pick_declines_every_press():
+    """The seam is inert for a client that does not opt in."""
+    base_module = _base_or_skip()
+    pipeline = _make_pipeline(base_module, group_claim=None)
+
+    for etype in (
+        vtk.vtkCommand.LeftButtonPressEvent,
+        vtk.vtkCommand.RightButtonPressEvent,
+    ):
+        claimed, _distance = pipeline.CanProcessInteractionEvent(_Event(etype))
+        assert claimed is False, (
+            "A client that never overrides _group_pick must see the "
+            "dispatch it always saw; three modules depend on this."
+        )
+
+
+def test_right_press_is_claimed_only_when_a_client_opts_in():
+    """A right press reaches the group seam and can be claimed."""
+    base_module = _base_or_skip()
+    pipeline = _make_pipeline(base_module, group_claim=("ring0", 0.0))
+
+    claimed, _distance = pipeline.CanProcessInteractionEvent(
+        _Event(vtk.vtkCommand.RightButtonPressEvent)
+    )
+    assert claimed is True, (
+        "The base filtered to LeftButtonPress only, so a right-drag "
+        "gesture could never be routed; the ring gesture needs it."
+    )
+
+
+def test_group_gesture_runs_grab_drag_release_and_ends_on_its_own_button():
+    """A right-button group drag ends on the RIGHT release, not the left."""
+    base_module = _base_or_skip()
+    pipeline = _make_pipeline(base_module, group_claim=("ring0", 0.0))
+
+    assert pipeline.ProcessInteractionEvent(
+        _Event(vtk.vtkCommand.RightButtonPressEvent)
+    )
+    assert pipeline.grabs == ["ring0"]
+
+    assert pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.MouseMoveEvent))
+    assert pipeline.drags == [("ring0", (1.0, 2.0, 3.0))]
+
+    # A LEFT release must not end a RIGHT gesture.
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.LeftButtonReleaseEvent))
+    assert pipeline.releases == [], (
+        "A group gesture must end on the release of the button that "
+        "started it, or a stray left click would strand the drag."
+    )
+
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.RightButtonReleaseEvent))
+    assert pipeline.releases == ["ring0"]
+
+
+def test_group_drag_never_moves_a_point_in_the_base():
+    """The base holds the gesture's identity, never its meaning."""
+    base_module = _base_or_skip()
+    pipeline = _make_pipeline(base_module, group_claim=("frame", 0.0))
+
+    moved = []
+    pipeline._move_point = lambda key, world: moved.append((key, world))
+
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.RightButtonPressEvent))
+    pipeline.ProcessInteractionEvent(_Event(vtk.vtkCommand.MouseMoveEvent))
+
+    assert moved == [], (
+        "What a delta does to a group is the client's data model "
+        "(ADR-0038 §'What is not shared'); the base must not displace "
+        "anything itself."
+    )


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #639, #637 and #638.** This branch carries those three commits until they merge; review only the last commit, *"Drag the control polygon by its wireframe to translate it"*. Once the three land, this diff reduces to that commit alone.

Slice 4 of #505, and the first slice with visible behaviour. **Eyeball-verified on `:0` — maintainer approved.**

## What it does

A press on **any** polygon edge — boundary or interior — translates the whole control polygon rigidly: every control point by the same delta, surface following because it is regenerated from the grid.

## What the eyeball found that CI could not

Five defects, every one of them through a green suite. This is the value of the loop, so they are worth listing:

**1. The drag was dead, and looked it in a specific way.** The maintainer's report — *"I can drag the world and rotate, but when I try to drag the border nothing happens; there is a difference"* — was the whole diagnosis. The camera *not* rotating proved the press was being claimed, so the pick worked and the failure was downstream. `_event_world` back-projects onto the **grabbed control point's** depth and returns `None` when there is no grabbed point, which is exactly a group drag. The base then took its "move didn't resolve, keep the grab" branch: held focus, moved nothing. A group drag now takes depth from the grid **centroid** — not an arbitrary member, which would make the polygon swing differently depending on which edge was held.

**2. The drag crawled.** `SetControlPoint` fires its own `Modified`, so sixteen unbatched writes re-tessellated the surface and reconciled every pipeline **sixteen times per mouse move**. It tracked the cursor correctly and was unusable. Now one `StartModify`/`EndModify` batch — the idiom `ResectionStateMachine` already uses. The bulk `SetControlGrid` would be the natural single call, but it is one of the signatures that does not cross the Python wrap (see #636), so batched per-point writes are the correct Python-side answer.

**3. Grabbing a handle sometimes moved everything** — *"does not happen always"*, which was the clue. Boundary control points lie **on** the frame, so near a handle both distances are ≈ 0 and my `handle_d2 < frame_d2` let sub-pixel geometry decide; the same click behaved differently after a camera nudge. Worse, the **hover cue already used the correct rule** while the press used nearest-wins, so the highlight promised one gesture and the press delivered another. Now both use precedence: a handle owns any press inside its radius, full stop.

**4. The highlight died mid-gesture.** The styling pass restores the display node's own edge colour on every reconcile, and a drag reconciles on every move — so the gesture repainted away its own cue. Re-asserted last in that pass. Separately, leaving the frame left the border lit: `_set_hover` owns the render request and early-returns on an unchanged handle index, so the restyle never flushed. Frame hover now requests a render when it **changes**.

**5. The cue was invisible.** The resting border is **pure red** and both handle cues are warm; I picked orange for the grab. Adjacent hue, identical luminance. The highlight was firing correctly the whole time and simply could not be seen — I chased three code-level hypotheses (enum wrapping, colour-write ordering, reconcile clobbering) and **all three were wrong**, each ruled out by instrumentation rather than argument. The maintainer identified it by eye in one sentence. Cues are now cyan (hover) and blue (grab): the only hues nothing else in this pipeline uses, differing from red in luminance as well as hue.

## Interior segments

Grabbable, by request — raised twice during the eyeball. The polygon reads as one object, so any part of its wireframe moving the whole thing is unsurprising; it also relieves a reachability squeeze, since handles own a 20 px radius and restricting targets to the outer ring left only the middle of each boundary edge usable.

Consequence to keep in mind for slice 5: left-dragging an interior segment moves everything, while right-dragging the inner **ring** will move only its four points. Same pixels, two gestures, distinguished by button.

## Verification

- Bare: **49 passed**. Launched: **158 passed**, 15 skipped.
- New `test_control_polygon_frame_highlight.py` pins that the highlight survives a reconcile in both the grab and hover cases, and that a resting polygon returns to the display node's own colour — a highlight that never cleared would be as wrong as one that never held.
- Eyeball on `:0`: hover, drag, handle-drag-near-corner, and re-grab all confirmed by the maintainer.

All debug instrumentation used during diagnosis has been removed (0 occurrences remain).

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
