### PR TITLE
ENH: Extract an oriented point cloud from a labelmap for PSR (ADR-0040 phase 2)

### DIFF
--- a/LiverResections/Algorithm/CMakeLists.txt
+++ b/LiverResections/Algorithm/CMakeLists.txt
@@ -62,6 +62,8 @@ set(${KIT}_SRCS
   vtkLiverResectogramAspectRatio.cxx
   vtkLiverResectogramPixelMapping.h
   vtkLiverResectogramPixelMapping.cxx
+  vtkLiverOrientedPointCloudExtractor.h
+  vtkLiverOrientedPointCloudExtractor.cxx
   )
 
 #

--- a/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
@@ -18,6 +18,7 @@ set(KIT_TEST_SRCS
   vtkLiverSpheroidRingExtractorEdgeCasesTest.cxx
   vtkLiverSpheroidRingExtractorConsistencyTest.cxx
   vtkSlicerLiverBezierControlPolygonGeometryTest1.cxx
+  vtkLiverOrientedPointCloudExtractorTest.cxx
   vtkLiverResectogramAspectRatioTest.cxx
   vtkLiverResectogramPixelMappingTest.cxx
   )
@@ -43,6 +44,7 @@ SIMPLE_TEST(vtkLiverContourParameterizerEdgeCasesTest)
 SIMPLE_TEST(vtkLiverPlaneRingExtractorEdgeCasesTest)
 SIMPLE_TEST(vtkLiverSpheroidRingExtractorEdgeCasesTest)
 SIMPLE_TEST(vtkSlicerLiverBezierControlPolygonGeometryTest1)
+SIMPLE_TEST(vtkLiverOrientedPointCloudExtractorTest)
 
 # Stack-4 ring-extraction wiring — Constraint 1 (shader/extractor
 # parameter consistency) + Constraint 2 (extraction-granularity bound).

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverOrientedPointCloudExtractorTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverOrientedPointCloudExtractorTest.cxx
@@ -1,0 +1,286 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, Oslo University Hospital. All rights reserved.
+
+  Tests for ``vtkLiverOrientedPointCloudExtractor`` — the oriented point
+  cloud PSR consumes (ADR-0040 §Decision 2).
+
+  The load-bearing property is the NORMAL DIRECTION.  PSR reconstructs
+  from orientation; a cloud whose normals point inward reconstructs the
+  complement of the object, and a cloud with the right positions but
+  wrong orientations fails in a way position-only assertions cannot see.
+  So the sphere case checks every normal against the analytic outward
+  direction, not merely that normals exist.
+
+  Per ADR-0008 §2: C++ low-level ctkTest-driver tests, no Slicer scene,
+  no Qt, no rendering.
+
+==============================================================================*/
+
+#include "vtkLiverOrientedPointCloudExtractor.h"
+
+// VTK includes
+#include <vtkDataArray.h>
+#include <vtkImageData.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+
+// STD includes
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+namespace
+{
+
+#define LIVER_CHECK(cond, msg)                                             \
+  do                                                                       \
+  {                                                                        \
+    if (!(cond))                                                           \
+    {                                                                      \
+      std::fprintf(stderr, "[%s:%d] FAIL: %s\n", __FILE__, __LINE__, msg); \
+      return EXIT_FAILURE;                                                 \
+    }                                                                      \
+  } while (0)
+
+//----------------------------------------------------------------------------
+// A solid sphere of `label`, centred in a dim^3 volume.
+vtkSmartPointer<vtkImageData> MakeSphere(int dim, double radius, int label)
+{
+  vtkSmartPointer<vtkImageData> image = vtkSmartPointer<vtkImageData>::New();
+  image->SetDimensions(dim, dim, dim);
+  image->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+  const double c = (dim - 1) / 2.0;
+  for (int k = 0; k < dim; ++k)
+  {
+    for (int j = 0; j < dim; ++j)
+    {
+      for (int i = 0; i < dim; ++i)
+      {
+        const double d2 = (i - c) * (i - c) + (j - c) * (j - c) + (k - c) * (k - c);
+        unsigned char* v = static_cast<unsigned char*>(image->GetScalarPointer(i, j, k));
+        *v = (d2 <= radius * radius) ? static_cast<unsigned char>(label) : 0;
+      }
+    }
+  }
+  return image;
+}
+
+//----------------------------------------------------------------------------
+int TestNormalsPointOutward()
+{
+  const int dim = 32;
+  const double radius = 10.0;
+  vtkSmartPointer<vtkImageData> sphere = MakeSphere(dim, radius, 1);
+  vtkNew<vtkMatrix4x4> identity;
+  vtkNew<vtkPolyData> cloud;
+
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, 0, cloud), "extraction of a solid sphere must succeed");
+
+  vtkPoints* pts = cloud->GetPoints();
+  vtkDataArray* normals = cloud->GetPointData()->GetNormals();
+  LIVER_CHECK(pts && normals, "the cloud carries points and normals");
+  LIVER_CHECK(pts->GetNumberOfPoints() > 0, "the cloud is not empty");
+  LIVER_CHECK(normals->GetNumberOfTuples() == pts->GetNumberOfPoints(), "one normal per point");
+
+  // Every normal must agree with the analytic outward radial direction.
+  // A cloud oriented inward reconstructs the complement of the object.
+  const double c = (dim - 1) / 2.0;
+  double worstDot = 1.0;
+  double meanDot = 0.0;
+  for (vtkIdType i = 0; i < pts->GetNumberOfPoints(); ++i)
+  {
+    double p[3];
+    pts->GetPoint(i, p);
+    double n[3];
+    normals->GetTuple(i, n);
+
+    double r[3] = { p[0] - c, p[1] - c, p[2] - c };
+    const double rl = std::sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
+    if (rl < 1e-6)
+    {
+      continue;
+    }
+    for (int d = 0; d < 3; ++d)
+    {
+      r[d] /= rl;
+    }
+    const double dot = n[0] * r[0] + n[1] * r[1] + n[2] * r[2];
+    worstDot = std::min(worstDot, dot);
+    meanDot += dot;
+
+    const double len = std::sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+    LIVER_CHECK(std::fabs(len - 1.0) < 1e-3, "normals are unit length");
+  }
+  meanDot /= static_cast<double>(pts->GetNumberOfPoints());
+
+  std::cout << "  sphere: " << pts->GetNumberOfPoints() << " points, mean dot " << meanDot << ", worst " << worstDot << std::endl;
+
+  // Sobel on a voxelised sphere cannot be exact; the mean must be close
+  // to 1 and NO normal may point inward.
+  LIVER_CHECK(meanDot > 0.95, "normals agree with the analytic outward direction");
+  LIVER_CHECK(worstDot > 0.0, "NO normal points inward");
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestSubsamplingIsDeterministicAndBounded()
+{
+  vtkSmartPointer<vtkImageData> sphere = MakeSphere(32, 10.0, 1);
+  vtkNew<vtkMatrix4x4> identity;
+
+  vtkNew<vtkPolyData> full;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, 0, full), "full");
+  const vtkIdType n = full->GetNumberOfPoints();
+
+  const vtkIdType cap = n / 4;
+  vtkNew<vtkPolyData> a;
+  vtkNew<vtkPolyData> b;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, cap, a), "capped a");
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, cap, b), "capped b");
+
+  LIVER_CHECK(a->GetNumberOfPoints() <= cap, "the cap is respected");
+  LIVER_CHECK(a->GetNumberOfPoints() == b->GetNumberOfPoints(), "same count twice");
+  for (vtkIdType i = 0; i < a->GetNumberOfPoints(); ++i)
+  {
+    double pa[3];
+    double pb[3];
+    a->GetPoint(i, pa);
+    b->GetPoint(i, pb);
+    LIVER_CHECK(pa[0] == pb[0] && pa[1] == pb[1] && pa[2] == pb[2], "the subsample is DETERMINISTIC -- a test could not assert on it otherwise");
+  }
+  std::cout << "  subsample: " << a->GetNumberOfPoints() << " of " << n << " (cap " << cap << ")" << std::endl;
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestGeometryIsAppliedFromTheMatrix()
+{
+  vtkSmartPointer<vtkImageData> sphere = MakeSphere(32, 10.0, 1);
+
+  vtkNew<vtkMatrix4x4> identity;
+  vtkNew<vtkPolyData> plain;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, 0, plain), "plain");
+
+  // Anisotropic spacing plus a translation: positions must scale and
+  // shift, normals must NOT pick up the translation and must stay unit.
+  vtkNew<vtkMatrix4x4> geom;
+  geom->Identity();
+  geom->SetElement(0, 0, 2.0);
+  geom->SetElement(1, 1, 0.5);
+  geom->SetElement(2, 2, 1.0);
+  geom->SetElement(0, 3, 100.0);
+  vtkNew<vtkPolyData> shifted;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, geom, 1, 0, shifted), "shifted");
+
+  LIVER_CHECK(plain->GetNumberOfPoints() == shifted->GetNumberOfPoints(), "geometry changes coordinates, not membership");
+
+  double pb[6];
+  shifted->GetBounds(pb);
+  LIVER_CHECK(pb[0] > 90.0, "the translation reached the points");
+
+  vtkDataArray* normals = shifted->GetPointData()->GetNormals();
+  for (vtkIdType i = 0; i < normals->GetNumberOfTuples(); ++i)
+  {
+    double n[3];
+    normals->GetTuple(i, n);
+    const double len = std::sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+    LIVER_CHECK(std::fabs(len - 1.0) < 1e-3,
+                "normals stay unit under anisotropic spacing -- a translation or a "
+                "scale leaking in would skew every one of them");
+  }
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestDegenerateInputsYieldAnEmptyCloud()
+{
+  vtkNew<vtkMatrix4x4> identity;
+  vtkNew<vtkPolyData> out;
+
+  LIVER_CHECK(!vtkLiverOrientedPointCloudExtractor::Extract(nullptr, identity, 1, 0, out), "a null image is refused");
+  LIVER_CHECK(out->GetNumberOfPoints() == 0, "and leaves the output empty, not stale");
+
+  vtkSmartPointer<vtkImageData> sphere = MakeSphere(16, 5.0, 1);
+  vtkNew<vtkPolyData> absent;
+  LIVER_CHECK(!vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 7, 0, absent), "a label that is not present has no boundary");
+  LIVER_CHECK(absent->GetNumberOfPoints() == 0, "and yields an empty cloud, not an exception");
+
+  vtkNew<vtkPolyData> noMatrix;
+  LIVER_CHECK(!vtkLiverOrientedPointCloudExtractor::Extract(sphere, nullptr, 1, 0, noMatrix), "a null matrix is refused");
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestOtherLabelsDoNotBleedIn()
+{
+  // Two concentric shells with different labels.  Extracting the inner
+  // one must not see the outer one's boundary: the indicator is built
+  // from voxels EQUAL to the label, not merely non-zero.
+  const int dim = 40;
+  vtkSmartPointer<vtkImageData> image = MakeSphere(dim, 8.0, 1);
+  const double c = (dim - 1) / 2.0;
+  for (int k = 0; k < dim; ++k)
+  {
+    for (int j = 0; j < dim; ++j)
+    {
+      for (int i = 0; i < dim; ++i)
+      {
+        const double d2 = (i - c) * (i - c) + (j - c) * (j - c) + (k - c) * (k - c);
+        unsigned char* v = static_cast<unsigned char*>(image->GetScalarPointer(i, j, k));
+        if (d2 > 8.0 * 8.0 && d2 <= 14.0 * 14.0)
+        {
+          *v = 2;
+        }
+      }
+    }
+  }
+
+  vtkNew<vtkMatrix4x4> identity;
+  vtkNew<vtkPolyData> inner;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(image, identity, 1, 0, inner), "inner");
+
+  double b[6];
+  inner->GetBounds(b);
+  const double maxR = std::max(std::fabs(b[1] - c), std::fabs(b[0] - c));
+  std::cout << "  two-label: inner cloud max radius " << maxR << " (inner r=8, outer r=14)" << std::endl;
+  LIVER_CHECK(maxR < 12.0,
+              "the inner label's cloud must not reach the outer label's boundary -- "
+              "a non-zero test instead of an equality test would merge them");
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//----------------------------------------------------------------------------
+int vtkLiverOrientedPointCloudExtractorTest(int, char*[])
+{
+  if (TestNormalsPointOutward() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestSubsamplingIsDeterministicAndBounded() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestGeometryIsAppliedFromTheMatrix() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestDegenerateInputsYieldAnEmptyCloud() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestOtherLabelsDoNotBleedIn() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  std::cout << "vtkLiverOrientedPointCloudExtractorTest passed." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverOrientedPointCloudExtractorTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverOrientedPointCloudExtractorTest.cxx
@@ -73,6 +73,77 @@ vtkSmartPointer<vtkImageData> MakeSphere(int dim, double radius, int label)
 }
 
 //----------------------------------------------------------------------------
+/// The same sphere, but in an image whose EXTENT STARTS AWAY FROM ZERO.
+///
+/// This is the shape the class is actually given in production: a
+/// segment's binary labelmap is cropped to its own bounding box, so its
+/// extent begins wherever that box does.  A zero-based fixture cannot
+/// tell a correct index mapping from one that ignores the offset.
+vtkSmartPointer<vtkImageData> MakeSphereAtExtent(int dim, double radius, int label, const int origin[3])
+{
+  vtkSmartPointer<vtkImageData> image = vtkSmartPointer<vtkImageData>::New();
+  image->SetExtent(origin[0], origin[0] + dim - 1, origin[1], origin[1] + dim - 1, origin[2], origin[2] + dim - 1);
+  image->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+  const double c = (dim - 1) / 2.0;
+  for (int k = 0; k < dim; ++k)
+  {
+    for (int j = 0; j < dim; ++j)
+    {
+      for (int i = 0; i < dim; ++i)
+      {
+        const double d2 = (i - c) * (i - c) + (j - c) * (j - c) + (k - c) * (k - c);
+        unsigned char* v = static_cast<unsigned char*>(image->GetScalarPointer(i + origin[0], j + origin[1], k + origin[2]));
+        *v = (d2 <= radius * radius) ? static_cast<unsigned char>(label) : 0;
+      }
+    }
+  }
+  return image;
+}
+
+//----------------------------------------------------------------------------
+/// The cloud must land at the voxels' ABSOLUTE index position.
+///
+/// Slicer's image-to-world matrix maps absolute voxel indices, so an
+/// extractor that reports indices relative to the extent produces a
+/// cloud that is intact, correctly shaped, correctly oriented -- and
+/// translated by the extent origin.  Every other assertion in this file
+/// still passes in that state, which is exactly how it reached a real
+/// liver before being caught by eye.
+int TestExtentOriginIsHonoured()
+{
+  const int dim = 30;
+  const double radius = 9.0;
+  const int origin[3] = { 100, 50, 20 };
+
+  vtkSmartPointer<vtkImageData> shifted = MakeSphereAtExtent(dim, radius, 1, origin);
+  vtkNew<vtkMatrix4x4> identity; // IJK == RAS, so the answer is exact.
+  vtkNew<vtkPolyData> cloud;
+  if (!vtkLiverOrientedPointCloudExtractor::Extract(shifted, identity, 1, 0, cloud))
+  {
+    std::cerr << "FAIL: extraction failed on a shifted-extent image" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  double bounds[6];
+  cloud->GetBounds(bounds);
+  const double centre[3] = { (bounds[0] + bounds[1]) / 2.0, (bounds[2] + bounds[3]) / 2.0, (bounds[4] + bounds[5]) / 2.0 };
+  const double expected[3] = { origin[0] + (dim - 1) / 2.0, origin[1] + (dim - 1) / 2.0, origin[2] + (dim - 1) / 2.0 };
+
+  std::cout << "extent origin: centre (" << centre[0] << ", " << centre[1] << ", " << centre[2] << "), expected (" << expected[0] << ", " << expected[1] << ", " << expected[2]
+            << ")" << std::endl;
+
+  for (int axis = 0; axis < 3; ++axis)
+  {
+    if (std::abs(centre[axis] - expected[axis]) > 1.0)
+    {
+      std::cerr << "FAIL: axis " << axis << " off by " << (expected[axis] - centre[axis]) << " -- the extent origin was dropped" << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
 int TestNormalsPointOutward()
 {
   const int dim = 32;
@@ -278,6 +349,10 @@ int vtkLiverOrientedPointCloudExtractorTest(int, char*[])
     return EXIT_FAILURE;
   }
   if (TestOtherLabelsDoNotBleedIn() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestExtentOriginIsHonoured() != EXIT_SUCCESS)
   {
     return EXIT_FAILURE;
   }

--- a/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.cxx
+++ b/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.cxx
@@ -163,6 +163,17 @@ bool vtkLiverOrientedPointCloudExtractor::Extract(vtkImageData* labelMap, vtkMat
   int dims[3] = { 0, 0, 0 };
   labelMap->GetDimensions(dims);
 
+  // The EXTENT ORIGIN, which is rarely zero for the images this class is
+  // actually given.  A segment's binary labelmap is cropped to its own
+  // bounding box, so its extent starts wherever that box does, while the
+  // ITK image built above is indexed from 0.  Slicer's image-to-world
+  // matrix maps ABSOLUTE voxel indices, so the offset has to be added
+  // back before the matrix is applied -- otherwise every point is
+  // translated by the extent origin and the cloud lands, intact and
+  // correctly shaped, in the wrong place.
+  int extent[6] = { 0, 0, 0, 0, 0, 0 };
+  labelMap->GetExtent(extent);
+
   // The normal rotates by the direction part only; translation would
   // move it and scale would skew it.  Columns are normalised so a
   // non-uniform voxel size does not bias the direction.
@@ -231,7 +242,7 @@ bool vtkLiverOrientedPointCloudExtractor::Extract(vtkImageData* labelMap, vtkMat
     }
 
     const FloatImageType::IndexType idx = itX.GetIndex();
-    double ijk[4] = { static_cast<double>(idx[0]), static_cast<double>(idx[1]), static_cast<double>(idx[2]), 1.0 };
+    double ijk[4] = { static_cast<double>(idx[0] + extent[0]), static_cast<double>(idx[1] + extent[2]), static_cast<double>(idx[2] + extent[4]), 1.0 };
     double ras[4] = { 0.0, 0.0, 0.0, 0.0 };
     ijkToRAS->MultiplyPoint(ijk, ras);
     points->InsertNextPoint(ras[0], ras[1], ras[2]);

--- a/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.cxx
+++ b/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.cxx
@@ -1,0 +1,258 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+==============================================================================*/
+
+#include "vtkLiverOrientedPointCloudExtractor.h"
+
+// VTK includes
+#include <vtkFloatArray.h>
+#include <vtkImageData.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+
+// ITK includes
+#include <itkImage.h>
+#include <itkImageRegionConstIterator.h>
+#include <itkNeighborhoodOperatorImageFilter.h>
+#include <itkSobelOperator.h>
+
+// STD includes
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace
+{
+using FloatImageType = itk::Image<float, 3>;
+
+//------------------------------------------------------------------------------
+// Copy the label's indicator function into a float ITK image.
+//
+// A copy rather than an itk::ImportImageFilter over the VTK buffer: the
+// Sobel convolution needs a float field, the input may be any scalar
+// type, and only voxels EQUAL to `label` belong to the object -- a
+// multi-label volume must not have its other labels bleed into the
+// gradient.
+template <typename T>
+void FillIndicator(vtkImageData* image, int label, std::vector<float>& out)
+{
+  const T* src = static_cast<const T*>(image->GetScalarPointer());
+  const size_t n = out.size();
+  const T wanted = static_cast<T>(label);
+  for (size_t i = 0; i < n; ++i)
+  {
+    out[i] = (src[i] == wanted) ? 1.0f : 0.0f;
+  }
+}
+
+//------------------------------------------------------------------------------
+FloatImageType::Pointer MakeIndicatorImage(vtkImageData* image, int label, bool& ok)
+{
+  ok = false;
+  int dims[3] = { 0, 0, 0 };
+  image->GetDimensions(dims);
+  if (dims[0] <= 0 || dims[1] <= 0 || dims[2] <= 0)
+  {
+    return nullptr;
+  }
+  const size_t count = static_cast<size_t>(dims[0]) * static_cast<size_t>(dims[1]) * static_cast<size_t>(dims[2]);
+
+  // Unit spacing and zero origin deliberately: the gradient is taken in
+  // VOXEL space and the caller's ijkToRAS carries the geometry.  Baking
+  // spacing in here would scale the normals twice.
+  FloatImageType::RegionType region;
+  FloatImageType::SizeType size;
+  size[0] = dims[0];
+  size[1] = dims[1];
+  size[2] = dims[2];
+  FloatImageType::IndexType start;
+  start.Fill(0);
+  region.SetSize(size);
+  region.SetIndex(start);
+
+  FloatImageType::Pointer indicator = FloatImageType::New();
+  indicator->SetRegions(region);
+  indicator->Allocate();
+
+  std::vector<float> buffer(count, 0.0f);
+  switch (image->GetScalarType())
+  {
+    vtkTemplateMacro(FillIndicator<VTK_TT>(image, label, buffer));
+    default: return nullptr;
+  }
+  std::copy(buffer.begin(), buffer.end(), indicator->GetBufferPointer());
+
+  ok = true;
+  return indicator;
+}
+
+//------------------------------------------------------------------------------
+FloatImageType::Pointer SobelAlong(FloatImageType::Pointer input, unsigned int direction)
+{
+  itk::SobelOperator<float, 3> sobel;
+  sobel.SetDirection(direction);
+  itk::Size<3> radius;
+  radius.Fill(1);
+  sobel.CreateToRadius(radius);
+
+  using FilterType = itk::NeighborhoodOperatorImageFilter<FloatImageType, FloatImageType>;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetOperator(sobel);
+  filter->SetInput(input);
+  filter->Update();
+  FloatImageType::Pointer out = filter->GetOutput();
+  out->DisconnectPipeline();
+  return out;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+vtkStandardNewMacro(vtkLiverOrientedPointCloudExtractor);
+
+//------------------------------------------------------------------------------
+vtkLiverOrientedPointCloudExtractor::vtkLiverOrientedPointCloudExtractor() = default;
+
+//------------------------------------------------------------------------------
+vtkLiverOrientedPointCloudExtractor::~vtkLiverOrientedPointCloudExtractor() = default;
+
+//------------------------------------------------------------------------------
+void vtkLiverOrientedPointCloudExtractor::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//------------------------------------------------------------------------------
+bool vtkLiverOrientedPointCloudExtractor::Extract(vtkImageData* labelMap, vtkMatrix4x4* ijkToRAS, int label, vtkIdType maxPoints, vtkPolyData* output)
+{
+  if (!output)
+  {
+    return false;
+  }
+  vtkNew<vtkPoints> points;
+  vtkNew<vtkFloatArray> normals;
+  normals->SetNumberOfComponents(3);
+  normals->SetName("Normals");
+  output->SetPoints(points);
+  output->GetPointData()->SetNormals(normals);
+
+  if (!labelMap || !ijkToRAS)
+  {
+    return false;
+  }
+
+  bool ok = false;
+  FloatImageType::Pointer indicator = MakeIndicatorImage(labelMap, label, ok);
+  if (!ok || indicator.IsNull())
+  {
+    return false;
+  }
+
+  FloatImageType::Pointer gx = SobelAlong(indicator, 0);
+  FloatImageType::Pointer gy = SobelAlong(indicator, 1);
+  FloatImageType::Pointer gz = SobelAlong(indicator, 2);
+
+  int dims[3] = { 0, 0, 0 };
+  labelMap->GetDimensions(dims);
+
+  // The normal rotates by the direction part only; translation would
+  // move it and scale would skew it.  Columns are normalised so a
+  // non-uniform voxel size does not bias the direction.
+  double rot[3][3];
+  for (int c = 0; c < 3; ++c)
+  {
+    double norm = 0.0;
+    for (int r = 0; r < 3; ++r)
+    {
+      rot[r][c] = ijkToRAS->GetElement(r, c);
+      norm += rot[r][c] * rot[r][c];
+    }
+    norm = std::sqrt(norm);
+    if (norm > 0.0)
+    {
+      for (int r = 0; r < 3; ++r)
+      {
+        rot[r][c] /= norm;
+      }
+    }
+  }
+
+  // Two passes: count the boundary, then emit with a stride.  A stride
+  // keeps the subsample DETERMINISTIC -- the same labelmap yields the
+  // same cloud, so a test can assert on it.
+  const float kGradientEpsilon = 1e-3f;
+  vtkIdType boundaryCount = 0;
+  itk::ImageRegionConstIterator<FloatImageType> itX(gx, gx->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<FloatImageType> itY(gy, gy->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<FloatImageType> itZ(gz, gz->GetLargestPossibleRegion());
+  for (itX.GoToBegin(), itY.GoToBegin(), itZ.GoToBegin(); !itX.IsAtEnd(); ++itX, ++itY, ++itZ)
+  {
+    const float m = std::sqrt(itX.Get() * itX.Get() + itY.Get() * itY.Get() + itZ.Get() * itZ.Get());
+    if (m > kGradientEpsilon)
+    {
+      ++boundaryCount;
+    }
+  }
+  if (boundaryCount == 0)
+  {
+    return false;
+  }
+
+  vtkIdType stride = 1;
+  if (maxPoints > 0 && boundaryCount > maxPoints)
+  {
+    stride = (boundaryCount + maxPoints - 1) / maxPoints;
+  }
+
+  vtkIdType seen = 0;
+  for (itX.GoToBegin(), itY.GoToBegin(), itZ.GoToBegin(); !itX.IsAtEnd(); ++itX, ++itY, ++itZ)
+  {
+    const float dx = itX.Get();
+    const float dy = itY.Get();
+    const float dz = itZ.Get();
+    const float m = std::sqrt(dx * dx + dy * dy + dz * dz);
+    if (m <= kGradientEpsilon)
+    {
+      continue;
+    }
+    const bool keep = (seen % stride) == 0;
+    ++seen;
+    if (!keep)
+    {
+      continue;
+    }
+
+    const FloatImageType::IndexType idx = itX.GetIndex();
+    double ijk[4] = { static_cast<double>(idx[0]), static_cast<double>(idx[1]), static_cast<double>(idx[2]), 1.0 };
+    double ras[4] = { 0.0, 0.0, 0.0, 0.0 };
+    ijkToRAS->MultiplyPoint(ijk, ras);
+    points->InsertNextPoint(ras[0], ras[1], ras[2]);
+
+    // Negated: the indicator RISES from 0 outside to 1 inside, so its
+    // gradient points INWARD.  PSR wants the outward normal.
+    const double nIjk[3] = { -dx / m, -dy / m, -dz / m };
+    double nRas[3] = { 0.0, 0.0, 0.0 };
+    for (int r = 0; r < 3; ++r)
+    {
+      nRas[r] = rot[r][0] * nIjk[0] + rot[r][1] * nIjk[1] + rot[r][2] * nIjk[2];
+    }
+    const double len = std::sqrt(nRas[0] * nRas[0] + nRas[1] * nRas[1] + nRas[2] * nRas[2]);
+    if (len > 0.0)
+    {
+      nRas[0] /= len;
+      nRas[1] /= len;
+      nRas[2] /= len;
+    }
+    normals->InsertNextTuple3(nRas[0], nRas[1], nRas[2]);
+  }
+
+  return points->GetNumberOfPoints() > 0;
+}

--- a/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.h
+++ b/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.h
@@ -1,0 +1,80 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  This file was originally developed for the Slicer-Liver extension as
+  the Algorithm-library home of the oriented-point-cloud extraction that
+  feeds Poisson Surface Reconstruction (ADR-0040; ADR-0015 §1 — a pure
+  computation helper with no MRML or VTKWidgets linkage).
+
+==============================================================================*/
+
+#ifndef __vtkliverorientedpointcloudextractor_h_
+#define __vtkliverorientedpointcloudextractor_h_
+
+#include "vtkSlicerLiverResectionsModuleAlgorithmExport.h"
+
+// VTK includes
+#include <vtkObject.h>
+
+class vtkImageData;
+class vtkMatrix4x4;
+class vtkPolyData;
+
+/// \brief Oriented point cloud from a binary labelmap, for PSR input.
+///
+/// Poisson Surface Reconstruction consumes points carrying OUTWARD
+/// NORMALS.  The normals come from the labelmap's own intensity
+/// gradient, not from a triangulated surface: at a labelmap boundary the
+/// gradient IS the outward normal, so no intermediate marching-cubes
+/// surface is built and the normals do not inherit the staircase
+/// artefacts PSR exists to remove (ADR-0040 §Decision 2).
+///
+/// The gradient is an ITK Sobel operator rather than a raw central
+/// difference.  Sobel's built-in smoothing matters on a BINARY mask,
+/// where a bare difference gives normals quantised to a handful of
+/// lattice directions.
+class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverOrientedPointCloudExtractor : public vtkObject
+{
+public:
+  static vtkLiverOrientedPointCloudExtractor* New();
+  vtkTypeMacro(vtkLiverOrientedPointCloudExtractor, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Extract oriented points from ``labelMap`` into ``output``.
+  ///
+  /// \param labelMap    binary or multi-label volume; voxels equal to
+  ///                    ``label`` form the object.
+  /// \param ijkToRAS    voxel-to-world matrix; points are emitted in
+  ///                    world millimetres and normals are rotated by its
+  ///                    direction part (translation and scale removed),
+  ///                    so a caller never has to fix them up.
+  /// \param label       the label value to extract.
+  /// \param maxPoints   upper bound on emitted points; a stride keeps
+  ///                    the subsample DETERMINISTIC, so a test asserting
+  ///                    on the output is reproducible.  Zero means no
+  ///                    limit.
+  /// \param output      receives the points plus a float "Normals" array
+  ///                    on its point data.
+  ///
+  /// \return false (leaving ``output`` empty) on a null argument, an
+  /// unsupported scalar type, or a label with no boundary — a caller
+  /// gets an empty cloud rather than an exception.
+  ///
+  /// Signature is deliberately wrappable: VTK objects and scalars only.
+  /// A PSR entry point unreachable from Python would be useless here,
+  /// and this project has shipped that mistake twice (#636, #640).
+  static bool Extract(vtkImageData* labelMap, vtkMatrix4x4* ijkToRAS, int label, vtkIdType maxPoints, vtkPolyData* output);
+
+protected:
+  vtkLiverOrientedPointCloudExtractor();
+  ~vtkLiverOrientedPointCloudExtractor() override;
+
+private:
+  vtkLiverOrientedPointCloudExtractor(const vtkLiverOrientedPointCloudExtractor&) = delete;
+  void operator=(const vtkLiverOrientedPointCloudExtractor&) = delete;
+};
+
+#endif // __vtkliverorientedpointcloudextractor_h_


### PR DESCRIPTION
**ADR-0040 phase 2.** The oriented point cloud PSR consumes, extracted straight from a segmentation. Relates to **#310**; ADR in **#644**.

Lands nothing user-visible — an Algorithm-library entry point and its tests.

## What it does, and why this way

PSR reconstructs from points carrying **outward normals**. The normals here come from the labelmap's own **intensity gradient**, not from a triangulated surface: at a labelmap boundary the gradient *is* the outward normal.

That's the whole point of the approach, and the reason PSR is worth having rather than smoothing an existing mesh — normals estimated off a marching-cubes surface would already carry the staircase artefacts PSR exists to remove. It ports the 2018 method from `RafaelPalomar/PoissonSurfaceReconstruction`.

The gradient is an **ITK Sobel operator**, not a raw central difference. On a *binary* mask that matters: a bare difference quantises normals to a handful of lattice directions, where Sobel's built-in smoothing gives usable orientations. ADR-0040 required ITK here for exactly this reason, and phase 1's probe (which used `numpy.gradient`) was explicitly flagged as needing this.

## Four decisions worth review

**Equality, not non-zero.** The indicator is built from voxels **equal to** the label. In a multi-label volume, testing non-zero would merge a neighbouring structure into the gradient and put phantom boundary points between them. A test with two concentric labelled shells pins this — extracting the inner label yields a cloud of max radius 8.5 against an inner radius of 8, nowhere near the outer shell at 14.

**Geometry is applied after, not baked in.** The gradient is taken in **voxel space** with unit spacing; the caller's `ijkToRAS` supplies geometry afterwards. Baking spacing into the ITK image would scale the normals twice. Normals rotate by the matrix's direction part with columns normalised, so anisotropic voxels don't skew them and a translation can't leak in — tested with 2.0/0.5/1.0 spacing plus a 100 mm shift.

**Stride, not random draw.** Subsampling is deterministic, so the same labelmap yields the same cloud — which is what makes the output assertable at all. Tested by extracting twice and comparing point-for-point.

**Degenerate inputs yield an empty cloud.** Null image, null matrix, or a label that isn't present return `false` and leave the output **empty rather than stale**, never throwing.

## Verification

`vtkLiverOrientedPointCloudExtractorTest` — **passed**. Measured values:

```
sphere:    3808 points, mean dot 0.971, worst 0.758
subsample: 952 of 3808 (cap 952), identical across runs
two-label: inner cloud max radius 8.5 (inner r=8, outer r=14)
```

**The sphere test checks every normal against the analytic outward direction**, not merely that normals exist. A cloud with correct positions and inverted orientations reconstructs the *complement* of the object, and position-only assertions cannot see that. `worst > 0` asserts no normal points inward at all.

## Python reachability, proven a phase early

ADR-0040 makes this conformance for phase 3. I checked it now, because this project has shipped the opposite twice (#636, #640) — signatures that compiled, linked, passed C++ tests, and were invisible from Python.

A real call inside a launched Slicer:

```
class present: True
Extract present: True
Extract returned: True
points: 2512    normals: 2512
first normal . outward = 0.837
```

Not "the symbol is in the generated wrapper" — an actual invocation returning an actual cloud.

## Next

Phase 3 is the PSR adapter itself: `vtkPolyData` in → reconstruction → `vtkPolyData` out, with depth defaulting to **7** per ADR-0040's phase-1 finding. Phase 2's conformance debt is noted there too — the phase-1 comparison was PSR→marching-cubes only, and phase 3's tests must use a **symmetric** measure.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
