### PR TITLE
ENH: Vendor the PoissonRecon core (ADR-0040 phase 3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,11 @@ repos:
       - id: debug-statements
         exclude: "Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTestWidget.py|Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTest.py"
       - id: end-of-file-fixer
-        exclude: "\\.(md5|svg|vtk|vtp)$|^Resources\\/[^\\/]+\\.h$|\\/ColorFiles\\/.+\\.txt$|Data\\/Input\\/.+$"
+        exclude: "\\.(md5|svg|vtk|vtp)$|^Resources\\/[^\\/]+\\.h$|\\/ColorFiles\\/.+\\.txt$|Data\\/Input\\/.+$|^LiverResections\\/Algorithm\\/PoissonRecon\\/"
       - id: mixed-line-ending
-        exclude: "\\.(svg|vtk|vtp)$"
+        exclude: "\\.(svg|vtk|vtp)$|^LiverResections\\/Algorithm\\/PoissonRecon\\/"
       - id: trailing-whitespace
-        exclude: "\\.(svg|vtk|vtp)$"
+        exclude: "\\.(svg|vtk|vtp)$|^LiverResections\\/Algorithm\\/PoissonRecon\\/"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.9
@@ -37,6 +37,9 @@ repos:
         # Reference: https://github.com/pre-commit/identify/blob/main/identify/extensions.py
         types_or: [file, text]
         files: \.(cpp|cxx|h|hpp|hxx|txx)$
+        # Vendored upstream PoissonRecon is a pristine drop, never
+        # reformatted -- see LiverResections/Algorithm/PoissonRecon/README.md.
+        exclude: "^LiverResections\\/Algorithm\\/PoissonRecon\\/"
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2
@@ -79,3 +82,5 @@ repos:
         entry: Utilities/Hooks/check-copyright.sh
         language: script
         files: \.(cpp|cxx|h|hpp|hxx|txx|py)$
+        # Vendored upstream code keeps ITS OWN copyright notice.
+        exclude: "^LiverResections\\/Algorithm\\/PoissonRecon\\/"

--- a/LiverResections/Algorithm/CMakeLists.txt
+++ b/LiverResections/Algorithm/CMakeLists.txt
@@ -43,8 +43,26 @@ find_package(Eigen3 REQUIRED CONFIG
     "${ITK_DIR}/../ITK-build/ITKInternalEigen3-build"
   )
 
+#-----------------------------------------------------------------------------
+# PoissonRecon (Kazhdan), vendored header-only (ADR-0040).
+#
+# A plain include directory, deliberately: upstream is header-only, so
+# there is no library to build or link, and no find_package to fail.
+#
+# The headers are NOT added to ${KIT}_SRCS.  That matters -- this kit is
+# Python-wrapped, and SlicerMacroBuildModuleLogic hands everything in
+# SRCS to the VTK wrapper.  Upstream's templates are not wrappable and
+# have no business being offered to Python; only our own adapter class
+# is.  Keeping them out of SRCS is what draws that line.
+#
+# OpenMP is NOT required.  MultiThreading.h guards it behind #ifdef
+# _OPENMP and falls back to std::async, so the extension builds on
+# toolchains without it -- notably AppleClang.  See
+# PoissonRecon/README.md for the drop's provenance and exclusion set.
+#-----------------------------------------------------------------------------
 set(${KIT}_INCLUDE_DIRECTORIES
    ${CMAKE_CURRENT_BINARY_DIR}
+   ${CMAKE_CURRENT_SOURCE_DIR}/PoissonRecon/Src
   )
 
 set(${KIT}_SRCS

--- a/LiverResections/Algorithm/PoissonRecon/LICENSE
+++ b/LiverResections/Algorithm/PoissonRecon/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 mkazhdan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/LiverResections/Algorithm/PoissonRecon/README.md
+++ b/LiverResections/Algorithm/PoissonRecon/README.md
@@ -1,0 +1,55 @@
+# Vendored: PoissonRecon (Kazhdan)
+
+Upstream <https://github.com/mkazhdan/PoissonRecon>, commit `262b0f5`
+("Version 8.76"). MIT — see `LICENSE`, which is upstream's, unmodified.
+
+Per [ADR-0040](../../../Docs/adr/0040-poisson-surface-reconstruction.md)
+this is a **vendored drop, not a fork**: nothing under `Src/` is edited.
+Our code lives outside this directory and includes these headers. Keeping
+the drop pristine is what makes a future upstream sync a re-copy rather
+than a merge.
+
+## What is here, and what is not
+
+Upstream `Src/` holds 82 headers plus 13 `.cpp` command-line mains. We
+vendor **69 headers** and none of the mains.
+
+The exclusions are not a hand-picked minimal set — they are two whole
+upstream *variants* we do not build, which is what makes the rule
+re-derivable when upstream moves:
+
+| Excluded | Why |
+| --- | --- |
+| `Socket.{h,inl}`, `*ClientServer.h` | the **distributed** variant. These are the only files in `Src/` that reach for Boost. Dropping them is what makes the build Boost-free. |
+| `Image.h`, `PNG.h`, `JPEG.h` | the **image** path, reached only from upstream's own mains for their `--colors` CLI option. It is also the one genuinely unportable part of upstream: against a *system* libpng it fails with `invalid use of incomplete type 'png_struct'`, because it reaches into internals opaque since libpng 1.5. Upstream's vendored `PNG/` tree is load-bearing for their executable; writing our own adapter against `Reconstructors.h` sidesteps it entirely. |
+
+Consequently none of upstream's four vendored third-party trees (`PNG/`,
+`JPEG/`, `ZLIB/`, and the Boost headers) are needed, and no heavyweight
+dependency is inherited.
+
+The transitive include closure of `Reconstructors.h` is **59 headers**, a
+strict subset of the 69 here. The extra ten are the rest of the
+non-excluded upstream surface, kept so the drop is "upstream minus two
+variants" rather than "whatever the compiler happened to need on the day"
+— the latter silently rots the moment upstream adds an include.
+
+## Threading
+
+`MultiThreading.h` guards OpenMP behind `#ifdef _OPENMP` and falls back
+to `std::async` or single-threaded execution. We therefore do **not**
+make OpenMP a build requirement; it is used if the toolchain offers it.
+
+## Syncing to a newer upstream
+
+1. Check out the new upstream tag.
+2. Re-copy `Src/*.h` and `Src/*.inl` **minus the excluded set above**.
+3. Re-copy `LICENSE`; update the commit and version at the top of this file.
+4. Confirm the exclusion rule still holds — `grep -rl boost Src/` upstream
+   should still name only the socket files, and nothing we vendor should
+   include `Image.h`.
+5. Rebuild and run the adapter's tests. Reconstruction output is expected
+   to shift slightly between upstream versions; the tests assert geometric
+   agreement with a tolerance, not exact vertices.
+
+Do not apply local fixes here. If upstream needs a change, the change
+belongs upstream, and the workaround belongs in our adapter.

--- a/LiverResections/Algorithm/PoissonRecon/Src/Allocator.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Allocator.h
@@ -1,0 +1,109 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef ALLOCATOR_INCLUDED
+#define ALLOCATOR_INCLUDED
+#include <vector>
+#include "Array.h"
+
+namespace PoissonRecon
+{
+	struct AllocatorState
+	{
+		size_t index , remains;
+		AllocatorState( void ) : index(0) , remains(0) {}
+	};
+
+	/** This templated class assists in memory allocation and is well suited for instances
+	* when it is known that the sequence of memory allocations is performed in a stack-based
+	* manner, so that memory allocated last is released first. It also preallocates memory
+	* in chunks so that multiple requests for small chunks of memory do not require separate
+	* system calls to the memory manager.
+	* The allocator is templated off of the class of objects that we would like it to allocate,
+	* ensuring that appropriate constructors and destructors are called as necessary.
+	*/
+	template< class T >
+	class Allocator
+	{
+		size_t _blockSize;
+		AllocatorState _state;
+		std::vector< Pointer( T ) > _memory;
+	public:
+		Allocator( void ) : _blockSize(0) {}
+		~Allocator( void ){ reset(); }
+
+		/** This method is the allocators destructor. It frees up any of the memory that
+		* it has allocated. */
+		void reset( void )
+		{
+			for( size_t i=0 ; i<_memory.size() ; i++ ) DeletePointer( _memory[i] );
+			_memory.clear();
+			_blockSize = 0;
+			_state = AllocatorState();
+		}
+		/** This method returns the memory state of the allocator. */
+		AllocatorState getState( void ) const { return _state; }
+
+		/** This method initiallizes the constructor and the blockSize variable specifies the
+		* the number of objects that should be pre-allocated at a time. */
+		void set( size_t blockSize )
+		{
+			reset();
+			_blockSize = blockSize;
+			_state.index = -1;
+			_state.remains = 0;
+		}
+
+		/** This method returns a pointer to an array of elements objects. If there is left over pre-allocated
+		* memory, this method simply returns a pointer to the next free piece of memory, otherwise it pre-allocates
+		* more memory. Note that if the number of objects requested is larger than the value blockSize with which
+		* the allocator was initialized, the request for memory will fail.
+		*/
+		Pointer( T ) newElements( size_t elements=1 )
+		{
+			Pointer( T ) mem;
+			if( !elements ) return NullPointer( T );
+			if( elements>_blockSize ) MK_THROW( "elements bigger than block-size: " , elements , " > " , _blockSize );
+			if( _state.remains<elements )
+			{
+				if( _state.index==_memory.size()-1 )
+				{
+					mem = NewPointer< T >( _blockSize );
+					if( !mem ) MK_THROW( "Failed to allocate memory" );
+					_memory.push_back( mem );
+				}
+				_state.index++;
+				_state.remains = _blockSize;
+			}
+			mem = _memory[ _state.index ] + ( _blockSize-_state.remains );
+			_state.remains -= elements;
+			return mem;
+		}
+	};
+}
+#endif // ALLOCATOR_INCLUDE

--- a/LiverResections/Algorithm/PoissonRecon/Src/Array.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Array.h
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2011, Michael Kazhdan and Ming Chuang
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef ARRAY_INCLUDED
+#define ARRAY_INCLUDED
+
+#include <vector>
+#include "MyExceptions.h"
+
+#ifdef ARRAY_DEBUG
+#else // !ARRAY_DEBUG
+namespace PoissonRecon
+{
+#endif // ARRAY_DEBUG
+	
+	// Code from http://stackoverflow.com
+	inline void* aligned_malloc( size_t size , size_t align )
+	{
+		// Align enough for the data, the alignment padding, and room to store a pointer to the actual start of the memory
+		void*  mem = malloc( size + align + sizeof( void* ) );
+		// The position at which we could potentially start addressing
+		char* amem = ( (char*)mem ) + sizeof( void* );
+		// Add align-1 to the start of the address and then zero out at most of the first align-1 bits.
+		amem = ( char* )( ( (size_t)( ( (char*)amem ) + (align-1) ) ) & ~( align-1 ) );
+		// Pre-write the actual address
+		( ( void** ) amem )[-1] = mem;
+		return amem;
+	}
+	inline void aligned_free( void* mem ) { free( ( ( void** )mem )[-1] ); }
+
+#ifdef ARRAY_DEBUG
+#ifdef SHOW_WARNINGS
+#pragma message ( "[WARNING] Array debugging is enabled" )
+#endif // SHOW_WARNINGS
+
+#define      Pointer( ... )      Array< __VA_ARGS__ >
+#define ConstPointer( ... ) ConstArray< __VA_ARGS__ >
+#define  NullPointer( ... )      Array< __VA_ARGS__ >()
+
+#include "Array.inl"
+
+	template< class C > void        FreePointer( Array< C >& a ){ a.Free( ); }
+	template< class C > void AlignedFreePointer( Array< C >& a ){ a.Free( ); }
+	template< class C > void       VFreePointer( Array< C >& a ){ a.Free( ); }
+	template< class C > void      DeletePointer( Array< C >& a ){ a.Delete( ); }
+
+	template< class C > Array< C >          NewPointer(                  size_t size ,                    const char* name=NULL ){ return Array< C >::New         (     size ,                     name ); }
+	template< class C > Array< C >        AllocPointer(                  size_t size ,                    const char* name=NULL ){ return Array< C >::Alloc       (     size ,             false , name ); }
+	template< class C > Array< C > AlignedAllocPointer(                  size_t size , size_t alignment , const char* name=NULL ){ return Array< C >::AlignedAlloc(     size , alignment , false , name ); }
+	template< class C > Array< C >      ReAllocPointer( Array< C >&  a , size_t size ,                    const char* name=NULL ){ return Array< C >::ReAlloc     ( a , size ,             false , name ); }
+
+	template< class C >       C* PointerAddress(      Array< C > a ) { return a.pointer(); }
+	template< class C > const C* PointerAddress( ConstArray< C > a ) { return a.pointer(); }
+	template< class C >      Array< C > GetPointer(       C& c ) { return      Array< C >::FromPointer( &c , 1 ); }
+	template< class C > ConstArray< C > GetPointer( const C& c ) { return ConstArray< C >::FromPointer( &c , 1 ); }
+	template< class C >      Array< C > GetPointer(       std::vector< C >& v ){ return      Array< C >::FromPointer( &v[0] , v.size() ); }
+	template< class C > ConstArray< C > GetPointer( const std::vector< C >& v ){ return ConstArray< C >::FromPointer( &v[0] , v.size() ); }
+
+	template< class C >      Array< C > GetPointer(       C* c , size_t sz ) { return      Array< C >::FromPointer( c , sz ); }
+	template< class C > ConstArray< C > GetPointer( const C* c , size_t sz ) { return ConstArray< C >::FromPointer( c , sz ); }
+	template< class C >      Array< C > GetPointer(       C* c , std::ptrdiff_t start , std::ptrdiff_t end ) { return      Array< C >::FromPointer( c , start , end ); }
+	template< class C > ConstArray< C > GetPointer( const C* c , std::ptrdiff_t start , std::ptrdiff_t end ) { return ConstArray< C >::FromPointer( c , start , end ); }
+
+#else // !ARRAY_DEBUG
+#define      Pointer( ... )       __VA_ARGS__*
+#define ConstPointer( ... ) const __VA_ARGS__*
+#define  NullPointer( ... ) NULL
+
+#define        FreePointer( ... ) { if( __VA_ARGS__ )         free( __VA_ARGS__ ) ,                   __VA_ARGS__ = NULL; }
+#define AlignedFreePointer( ... ) { if( __VA_ARGS__ ) aligned_free( __VA_ARGS__ ) ,                   __VA_ARGS__ = NULL; }
+#define      DeletePointer( ... ) { if( __VA_ARGS__ )      delete[] __VA_ARGS__ ,                     __VA_ARGS__ = NULL; }
+
+	template< class C > C*          NewPointer(        size_t size ,                    const char* name=NULL ){ return new C[size]; }
+	template< class C > C*        AllocPointer(        size_t size ,                    const char* name=NULL ){ return (C*)        malloc(        sizeof(C) * size             ); }
+	template< class C > C* AlignedAllocPointer(        size_t size , size_t alignment , const char* name=NULL ){ return (C*)aligned_malloc(        sizeof(C) * size , alignment ); }
+	template< class C > C*      ReAllocPointer( C* c , size_t size ,                    const char* name=NULL ){ return (C*)       realloc( c    , sizeof(C) * size             ); }
+
+	//template< class C > C* NullPointer( void ){ return NULL; }
+
+	template< class C >       C* PointerAddress(       C* c ){ return c; }
+	template< class C > const C* PointerAddress( const C* c ){ return c; }
+	template< class C >       C* GetPointer(       C& c ){ return &c; }
+	template< class C > const C* GetPointer( const C& c ){ return &c; }
+	template< class C >       C* GetPointer(       std::vector< C >& v ){ return &v[0]; }
+	template< class C > const C* GetPointer( const std::vector< C >& v ){ return &v[0]; }
+
+	template< class C >       C* GetPointer(       C* c , size_t sz ) { return c; }
+	template< class C > const C* GetPointer( const C* c , size_t sz ) { return c; }
+	template< class C >       C* GetPointer(       C* c , std::ptrdiff_t start , std::ptrdiff_t end ) { return c; }
+	template< class C > const C* GetPointer( const C* c , std::ptrdiff_t start , std::ptrdiff_t end ) { return c; }
+}
+#endif // ARRAY_DEBUG
+#endif // ARRAY_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Array.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Array.inl
@@ -1,0 +1,433 @@
+/*
+Copyright (c) 2011, Michael Kazhdan and Ming Chuang
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+template< class C > class ConstArray;
+
+template< class C >
+class Array
+{
+	template< class D > friend class Array;
+	friend class ConstArray< C >;
+	void _assertBounds( std::ptrdiff_t idx ) const
+	{
+		if( idx<min || idx>=max ) PoissonRecon::MK_THROW( "Array index out-of-bounds: " , min , " <= " , idx , " < " , max );
+	}
+protected:
+	C *data , *_data;
+	std::ptrdiff_t min , max;
+
+public:
+	std::ptrdiff_t minimum( void ) const { return min; }
+	std::ptrdiff_t maximum( void ) const { return max; }
+
+	static inline Array New( size_t size , const char* name=NULL )
+	{
+		Array a;
+		a._data = a.data = new C[size];
+		a.min = 0;
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Casting unsigned to signed" )
+#endif // SHOW_WARNINGS
+		a.max = (std::ptrdiff_t)size;
+		return a;
+	}
+	static inline Array Alloc( size_t size , bool clear , const char* name=NULL )
+	{
+		Array a;
+		a._data = a.data = ( C* ) malloc( size * sizeof( C ) );
+		if( clear ) memset( a.data ,  0 , size * sizeof( C ) );
+		a.min = 0;
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Casting unsigned to signed" )
+#endif // SHOW_WARNINGS
+		a.max = (std::ptrdiff_t)size;
+		return a;
+	}
+
+	static inline Array AlignedAlloc( size_t size , size_t alignment , bool clear , const char* name=NULL )
+	{
+		Array a;
+		a.data = ( C* ) aligned_malloc( sizeof(C) * size , alignment );
+		a._data = ( C* )( ( ( void** )a.data )[-1] );
+		if( clear ) memset( a.data ,  0 , size * sizeof( C ) );
+		a.min = 0;
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Casting unsigned to signed" )
+#endif // SHOW_WARNINGS
+		a.max = (std::ptrdiff_t)size;
+		return a;
+	}
+
+	static inline Array ReAlloc( Array& a , size_t size , bool clear , const char* name=NULL )
+	{
+		Array _a;
+		_a._data = _a.data = ( C* ) realloc( a.data , size * sizeof( C ) );
+		if( clear ) memset( _a.data ,  0 , size * sizeof( C ) );
+		a._data = NULL;
+		_a.min = 0;
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Casting unsigned to signed" )
+#endif // SHOW_WARNINGS
+		_a.max = (std::ptrdiff_t)size;
+		return _a;
+	}
+
+	Array( void )
+	{
+		data = _data = NULL;
+		min = max = 0;
+	}
+	template< class D >
+	Array( Array< D > a )
+	{
+		_data = NULL;
+		if( !a )
+		{
+			data =  NULL;
+			min = max = 0;
+		}
+		else
+		{
+			// [WARNING] Changing szC and szD to size_t causes some really strange behavior.
+			std::ptrdiff_t szC = (std::ptrdiff_t)sizeof( C );
+			std::ptrdiff_t szD = (std::ptrdiff_t)sizeof( D );
+			data = (C*)a.data;
+			min = ( a.minimum() * szD ) / szC;
+			max = ( a.maximum() * szD ) / szC;
+			if( min*szC!=a.minimum()*szD || max*szC!=a.maximum()*szD ) PoissonRecon::MK_THROW( "Could not convert array [ " , a.minimum() , " , " , a.maximum() , " ] * " , szD , " => [ " , min , " , " , max , " ] * " , szC );
+		}
+	}
+	static Array FromPointer( C* data , std::ptrdiff_t max )
+	{
+		Array a;
+		a._data = NULL;
+		a.data = data;
+		a.min = 0;
+		a.max = max;
+		return a;
+	}
+	static Array FromPointer( C* data , std::ptrdiff_t min , std::ptrdiff_t max )
+	{
+		Array a;
+		a._data = NULL;
+		a.data = data;
+		a.min = min;
+		a.max = max;
+		return a;
+	}
+	inline bool operator == ( const Array< C >& a ) const { return data==a.data; }
+	inline bool operator != ( const Array< C >& a ) const { return data!=a.data; }
+	inline bool operator == ( const C* c ) const { return data==c; }
+	inline bool operator != ( const C* c ) const { return data!=c; }
+	inline C* operator -> ( void )
+	{
+		_assertBounds( 0 );
+		return data;
+	}
+	inline const C* operator -> ( void ) const
+	{
+		_assertBounds( 0 );
+		return data;
+	}
+	inline C &operator * ( void )
+	{
+		_assertBounds( 0 );
+		return data[0];
+	}
+	inline const C &operator * ( void ) const
+	{
+		_assertBounds( 0 );
+		return data[0];
+	}
+	template< typename Int >
+	inline C& operator[]( Int idx )
+	{
+		static_assert( std::is_integral< Int >::value , "Integral type expected" );
+		_assertBounds( idx );
+		return data[idx];
+	}
+
+	template< typename Int >
+	inline const C& operator[]( Int idx ) const
+	{
+		static_assert( std::is_integral< Int >::value , "Integral type expected" );
+		_assertBounds( idx );
+		return data[idx];
+	}
+
+	template< typename Int >
+	inline Array operator + ( Int idx ) const
+	{
+		static_assert( std::is_integral< Int >::value , "Integral type expected" );
+		Array a;
+		a._data = _data;
+		a.data = data+idx;
+		a.min = min-idx;
+		a.max = max-idx;
+		return a;
+	}
+	template< typename Int >
+	inline Array& operator += ( Int idx  )
+	{
+		static_assert( std::is_integral< Int >::value , "Integral type expected" );
+		min -= idx;
+		max -= idx;
+		data += idx;
+		return (*this);
+	}
+	template< typename Int > Array  operator -  ( Int idx ) const { return (*this) +  (-idx); }
+	template< typename Int > Array& operator -= ( Int idx )       { return (*this) += (-idx); }
+
+	inline Array& operator ++ ( void  ) { return (*this) += 1; }
+	inline Array operator++( int ){ Array< C > temp = (*this) ; (*this) +=1 ; return temp; }
+	inline Array operator--( int ){ Array< C > temp = (*this) ; (*this) -=1 ; return temp; }
+	std::ptrdiff_t operator - ( const Array& a ) const { return data - a.data; }
+
+	void Free( void )
+	{
+		if( _data )
+		{
+			free( _data );
+		}
+		(*this) = Array( );
+	}
+	void Delete( void )
+	{
+		if( _data )
+		{
+			delete[] _data;
+		}
+		(*this) = Array( );
+	}
+	C* pointer( void ){ return data; }
+	const C* pointer( void ) const { return data; }
+	bool operator !( void ) const { return data==NULL; }
+	operator bool( ) const { return data!=NULL; }
+};
+
+template< class C >
+class ConstArray
+{
+	template< class D > friend class ConstArray;
+	void _assertBounds( std::ptrdiff_t idx ) const
+	{
+		if( idx<min || idx>=max ) PoissonRecon::MK_THROW( "ConstArray index out-of-bounds: " , min , " <= " , idx , " < " , max );
+	}
+protected:
+	const C *data;
+	std::ptrdiff_t min , max;
+public:
+	std::ptrdiff_t minimum( void ) const { return min; }
+	std::ptrdiff_t maximum( void ) const { return max; }
+
+	inline ConstArray( void )
+	{
+		data = NULL;
+		min = max = 0;
+	}
+	inline ConstArray( const Array< C >& a )
+	{
+		// [WARNING] Changing szC and szD to size_t causes some really strange behavior.
+		data = ( const C* )a.pointer( );
+		min = a.minimum();
+		max = a.maximum();
+	}
+	template< class D >
+	inline ConstArray( Array< D > a )
+	{
+		// [WARNING] Changing szC and szD to size_t causes some really strange behavior.
+		std::ptrdiff_t szC = (std::ptrdiff_t)sizeof( C );
+		std::ptrdiff_t szD = (std::ptrdiff_t)sizeof( D );
+		data = ( const C* )a.pointer( );
+		min = ( a.minimum() * szD ) / szC;
+		max = ( a.maximum() * szD ) / szC;
+		if( min*szC!=a.minimum()*szD || max*szC!=a.maximum()*szD ) PoissonRecon::MK_THROW( "Could not convert const array [ " , a.minimum() , " , " , a.maximum() , " ] * " , szD , " => [ " , min , " , " , max , " ] * " , szC );
+	}
+	template< class D >
+	inline ConstArray( ConstArray< D > a )
+	{
+		// [WARNING] Chaning szC and szD to size_t causes some really strange behavior.
+		std::ptrdiff_t szC = (std::ptrdiff_t)sizeof( C );
+		std::ptrdiff_t szD = (std::ptrdiff_t)sizeof( D );
+		data = ( const C*)a.pointer( );
+		min = ( a.minimum() * szD ) / szC;
+		max = ( a.maximum() * szD ) / szC;
+		if( min*szC!=a.minimum()*szD || max*szC!=a.maximum()*szD ) PoissonRecon::MK_THROW( "Could not convert array [ " , a.minimum() , " , " , a.maximum() , " ] * " , szD , " => [ " , min , " , " , max , " ] * " , szC );
+	}
+	explicit operator Array< C >() const
+	{
+		Array< C > a;
+		a.data = const_cast< C * >( data );
+		a.min = minimum();
+		a.max = maximum();
+		return a;
+	}
+	static ConstArray FromPointer( const C* data , std::ptrdiff_t max )
+	{
+		ConstArray a;
+		a.data = data;
+		a.min = 0;
+		a.max = max;
+		return a;
+	}
+
+	static ConstArray FromPointer( const C* data , std::ptrdiff_t min , std::ptrdiff_t max )
+	{
+		ConstArray a;
+		a.data = data;
+		a.min = min;
+		a.max = max;
+		return a;
+	}
+
+	inline bool operator == ( const ConstArray< C >& a ) const { return data==a.data; }
+	inline bool operator != ( const ConstArray< C >& a ) const { return data!=a.data; }
+	inline bool operator == ( const C* c ) const { return data==c; }
+	inline bool operator != ( const C* c ) const { return data!=c; }
+	inline const C* operator -> ( void )
+	{
+		_assertBounds( 0 );
+		return data;
+	}
+	inline const C &operator * ( void )
+	{
+		_assertBounds( 0 );
+		return data[0];
+	}
+	template< typename Int >
+	inline const C& operator[]( Int idx ) const
+	{
+		static_assert( std::is_integral< Int >::value , "Integral type expected" );
+		_assertBounds( idx );
+		return data[idx];
+	}
+	template< typename Int >
+	inline ConstArray operator + ( Int idx ) const
+	{
+		static_assert( std::is_integral< Int >::value , "Integral type expected" );
+		ConstArray a;
+		a.data = data+idx;
+		a.min = min-idx;
+		a.max = max-idx;
+		return a;
+	}
+	template< typename  Int >
+	inline ConstArray& operator += ( Int idx  )
+	{
+		static_assert( std::is_integral< Int >::value , "Integral type expected" );
+		min -= idx;
+		max -= idx;
+		data += idx;
+		return (*this);
+	}
+	template< typename Int > ConstArray  operator -  ( Int idx ) const { return (*this) +  (-idx); }
+	template< typename Int > ConstArray& operator -= ( Int idx )       { return (*this) += (-idx); }
+	inline ConstArray& operator ++ ( void ) { return (*this) += 1; }
+	inline ConstArray operator++( int ){ ConstArray< C > temp = (*this) ; (*this) +=1 ; return temp; }
+	inline ConstArray operator--( int ){ ConstArray< C > temp = (*this) ; (*this) -=1 ; return temp; }
+	std::ptrdiff_t operator - ( const ConstArray& a ) const { return data - a.data; }
+	std::ptrdiff_t operator - ( const Array< C >& a ) const { return data - a.pointer(); }
+
+	const C* pointer( void ) const { return data; }
+	bool operator !( void ) const { return data==NULL; }
+	operator bool( ) const { return data!=NULL; }
+};
+
+template< class C >
+Array< C > memcpy( Array< C > destination , const void* source , size_t size )
+{
+	if( size>destination.maximum()*sizeof(C) ) PoissonRecon::MK_THROW( "Size of copy exceeds destination maximum: " , size , " > " , destination.maximum()*sizeof( C ) );
+	if( size ) memcpy( &destination[0] , source , size );
+	return destination;
+}
+template< class C , class D >
+Array< C > memcpy( Array< C > destination , Array< D > source , size_t size )
+{
+	if( size>destination.maximum()*sizeof( C ) ) PoissonRecon::MK_THROW( "Size of copy exceeds destination maximum: " , size , " > " , destination.maximum()*sizeof( C ) );
+	if( size>source.maximum()*sizeof( D ) ) PoissonRecon::MK_THROW( "Size of copy exceeds source maximum: " , size , " > " , source.maximum()*sizeof( D ) );
+	if( size ) memcpy( &destination[0] , &source[0] , size );
+	return destination;
+}
+template< class C , class D >
+Array< C > memcpy( Array< C > destination , ConstArray< D > source , size_t size )
+{
+	if( size>destination.maximum()*sizeof( C ) ) PoissonRecon::MK_THROW( "Size of copy exceeds destination maximum: " , size , " > " , destination.maximum()*sizeof( C ) );
+	if( size>source.maximum()*sizeof( D ) ) PoissonRecon::MK_THROW( "Size of copy exceeds source maximum: " , size , " > " , source.maximum()*sizeof( D ) );
+	if( size ) memcpy( &destination[0] , &source[0] , size );
+	return destination;
+}
+template< class D >
+void* memcpy( void* destination , Array< D > source , size_t size )
+{
+	if( size>source.maximum()*sizeof( D ) ) PoissonRecon::MK_THROW( "Size of copy exceeds source maximum: " , size , " > " , source.maximum()*sizeof( D ) );
+	if( size ) memcpy( destination , &source[0] , size );
+	return destination;
+}
+template< class D >
+void* memcpy( void* destination , ConstArray< D > source , size_t size )
+{
+	if( size>source.maximum()*sizeof( D ) ) PoissonRecon::MK_THROW( "Size of copy exceeds source maximum: " , size , " > " , source.maximum()*sizeof( D ) );
+	if( size ) memcpy( destination , &source[0] , size );
+	return destination;
+}
+template< class C >
+Array< C > memset( Array< C > destination , int value , size_t size )
+{
+	if( size>destination.maximum()*sizeof( C ) ) PoissonRecon::MK_THROW( "Size of set exceeds destination maximum: " , size , " > " , destination.maximum()*sizeof( C ) );
+	if( size ) memset( &destination[0] , value , size );
+	return destination;
+}
+
+template< class C >
+size_t fread( Array< C > destination , size_t eSize , size_t count , FILE* fp )
+{
+	if( count*eSize>destination.maximum()*sizeof( C ) ) PoissonRecon::MK_THROW( "Size of read exceeds source maximum: " , count*eSize , " > " , destination.maximum()*sizeof( C ) );
+	if( count ) return fread( &destination[0] , eSize , count , fp );
+	else return 0;
+}
+template< class C >
+size_t fwrite( Array< C > source , size_t eSize , size_t count , FILE* fp )
+{
+	if( count*eSize>source.maximum()*sizeof( C ) ) PoissonRecon::MK_THROW( "Size of write exceeds source maximum: " , count*eSize , " > " , source.maximum()*sizeof( C ) );
+	if( count ) return fwrite( &source[0] , eSize , count , fp );
+	else return 0;
+}
+template< class C >
+size_t fwrite( ConstArray< C > source , size_t eSize , size_t count , FILE* fp )
+{
+	if( count*eSize>source.maximum()*sizeof( C ) ) PoissonRecon::MK_THROW( "Size of write exceeds source maximum: " , count*eSize , " > " , source.maximum()*sizeof( C ) );
+	if( count ) return fwrite( &source[0] , eSize , count , fp );
+	else return 0;
+}
+template< class C >
+void qsort( Array< C > base , size_t numElements , size_t elementSize , int (*compareFunction)( const void* , const void* ) )
+{
+	if( sizeof(C)!=elementSize ) PoissonRecon::MK_THROW( "Element sizes differ: " , sizeof(C) , " != " , elementSize );
+	if( base.minimum()>0 || base.maximum()<numElements ) MK_THROW( "Array access out of bounds: " , base.minimum() , " <= 0 <= " , base.maximum() , " <= " , numElements );
+	qsort( base.pointer() , numElements , elementSize , compareFunction );
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/BSplineData.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/BSplineData.h
@@ -1,0 +1,574 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef BSPLINE_DATA_INCLUDED
+#define BSPLINE_DATA_INCLUDED
+
+#include <string.h>
+
+#include "BinaryNode.h"
+#include "PPolynomial.h"
+#include "Array.h"
+
+namespace PoissonRecon
+{
+	enum BoundaryType
+	{
+		BOUNDARY_FREE ,
+		BOUNDARY_DIRICHLET ,
+		BOUNDARY_NEUMANN ,
+		BOUNDARY_COUNT
+	};
+	static const char* BoundaryNames[] = { "free" , "Dirichlet" , "Neumann" };
+	template< BoundaryType BType > inline bool HasPartitionOfUnity( void ){ return BType!=BOUNDARY_DIRICHLET; }
+	inline bool HasPartitionOfUnity( BoundaryType bType ){ return bType!=BOUNDARY_DIRICHLET; }
+	template< BoundaryType BType , unsigned int D > struct DerivativeBoundary{};
+	template< unsigned int D > struct DerivativeBoundary< BOUNDARY_FREE      , D >{ static const BoundaryType BType = BOUNDARY_FREE; };
+	template< unsigned int D > struct DerivativeBoundary< BOUNDARY_DIRICHLET , D >{ static const BoundaryType BType = DerivativeBoundary< BOUNDARY_NEUMANN   , D-1 >::BType; };
+	template< unsigned int D > struct DerivativeBoundary< BOUNDARY_NEUMANN   , D >{ static const BoundaryType BType = DerivativeBoundary< BOUNDARY_DIRICHLET , D-1 >::BType; };
+	template< > struct DerivativeBoundary< BOUNDARY_FREE      , 0 >{ static const BoundaryType BType = BOUNDARY_FREE; };
+	template< > struct DerivativeBoundary< BOUNDARY_DIRICHLET , 0 >{ static const BoundaryType BType = BOUNDARY_DIRICHLET; };
+	template< > struct DerivativeBoundary< BOUNDARY_NEUMANN   , 0 >{ static const BoundaryType BType = BOUNDARY_NEUMANN; };
+
+
+	// Generate a single signature that combines the degree, boundary type, and number of supported derivatives
+	template< unsigned int Degree , BoundaryType BType=BOUNDARY_FREE > struct FEMDegreeAndBType { static const unsigned int Signature = Degree * BOUNDARY_COUNT + BType; };
+
+	// Extract the degree and boundary type from the signaure
+	template< unsigned int Signature > struct FEMSignature
+	{
+		static const unsigned int Degree = ( Signature / BOUNDARY_COUNT );
+		static const BoundaryType BType = (BoundaryType)( Signature % BOUNDARY_COUNT );
+		template< unsigned int D=1 >
+		static constexpr typename std::enable_if< (Degree>=D) , unsigned int >::type DSignature( void ){ return FEMDegreeAndBType< Degree-D , DerivativeBoundary< BType , D >::BType >::Signature; }
+	};
+
+	inline unsigned int FEMSignatureDegree( unsigned int signature ){ return signature / BOUNDARY_COUNT; }
+	inline BoundaryType FEMSignatureBType ( unsigned int signature ){ return (BoundaryType)( signature % BOUNDARY_COUNT ); }
+
+	static const unsigned int FEMTrivialSignature = FEMDegreeAndBType< 0 , BOUNDARY_FREE >::Signature;
+
+	// This class represents a function that is a linear combination of B-spline elements,
+	// with the coeff member indicating how much of each element is present.
+	// [WARNING] The ordering of B-spline elements is in the opposite order from that returned by Polynomial::BSplineComponent
+	template< unsigned int Degree >
+	struct BSplineElementCoefficients
+	{
+		int coeffs[Degree+1];
+		BSplineElementCoefficients( void ){ memset( coeffs , 0 , sizeof( coeffs ) ); }
+		int& operator[]( int idx ){ return coeffs[idx]; }
+		const int& operator[]( int idx ) const { return coeffs[idx]; }
+	};
+
+	// This class represents a function on the the interval, partitioned into "res" blocks.
+	// On each block, the function is a degree-Degree polynomial, represented by the coefficients
+	// in the associated BSplineElementCoefficients.
+	// [NOTE] This representation of a function is agnostic to the type of boundary conditions (though the constructor is not).
+	template< unsigned int Degree >
+	struct BSplineElements : public std::vector< BSplineElementCoefficients< Degree > >
+	{
+		static const bool _Primal = (Degree&1)==1;
+		static const int _Off = (Degree+1)/2;
+		static int _ReflectLeft ( int offset , int res );
+		static int _ReflectRight( int offset , int res );
+		static int _RotateLeft  ( int offset , int res );
+		static int _RotateRight ( int offset , int res );
+		template< bool Left > void _addPeriodic( int offset , bool negate );
+	public:
+		// Coefficients are ordered as "/" "-" "\"
+		// [WARNING] This is the opposite of the order in Polynomial::BSplineComponent
+		int denominator;
+
+		BSplineElements( void ) { denominator = 1; }
+		BSplineElements( int res , int offset , BoundaryType bType );
+
+		void upSample( BSplineElements& high ) const;
+		template< unsigned int D >
+		void differentiate( BSplineElements< Degree-D >& d ) const;
+
+		void print( FILE* fp=stdout ) const
+		{
+			for( int i=0 ; i<std::vector< BSplineElementCoefficients< Degree > >::size() ; i++ )
+			{
+				printf( "%d]" , i );
+				for( int j=0 ; j<=Degree ; j++ ) printf( " %d" , (*this)[i][j] );
+				printf( " (%d)\n" , denominator );
+			}
+		}
+		Polynomial< Degree > polynomial( int idx ) const
+		{
+			int res = (int)std::vector< BSplineElementCoefficients< Degree > >::size();
+			Polynomial< Degree > P;
+			if( idx>=0 && idx<res ) for( int d=0 ; d<=Degree ; d++ ) P += Polynomial< Degree >::BSplineComponent( Degree-d ).scale( 1./res ).shift( (idx+0.)/res ) * ( (*this)[idx][d] );
+			return P / denominator;
+		}
+		PPolynomial< Degree > pPolynomial( void ) const
+		{
+			int res = (int)std::vector< BSplineElementCoefficients< Degree > >::size();
+			PPolynomial< Degree > P;
+			P.polyCount = res + 1;
+			P.polys = AllocPointer< StartingPolynomial< Degree > >( P.polyCount );
+			for( int i=0 ; i<P.polyCount ; i++ ) P.polys[i].start = (i+0.) / res , P.polys[i].p = polynomial(i);
+			for( int i=res ; i>=1 ; i-- ) P.polys[i].p -= P.polys[i-1].p;
+			return P.compress(0);
+		}
+	};
+
+	template< unsigned int Degree , unsigned int DDegree > struct Differentiator                   { static void Differentiate( const BSplineElements< Degree >& bse , BSplineElements< DDegree >& dbse ); };
+	template< unsigned int Degree >                        struct Differentiator< Degree , Degree >{ static void Differentiate( const BSplineElements< Degree >& bse , BSplineElements<  Degree >& dbse ); };
+
+	// Note that these bounds are inclusive -- [s,e]
+#define PR_BSPLINE_SET_BOUNDS( name , s , e ) \
+	static const int name ## Start = (s); \
+	static const int name ## End   = (e); \
+	static const unsigned int name ## Size  = (e)-(s)+1
+
+	// Assumes that x is non-negative
+#define PR__FLOOR_OF_HALF( x ) (   (x)    >>1 )
+#define  PR__CEIL_OF_HALF( x ) ( ( (x)+1 )>>1 )
+	// Done with the assumption
+#define PR_FLOOR_OF_HALF( x ) ( (x)<0 ? -  PR__CEIL_OF_HALF( -(x) ) : PR__FLOOR_OF_HALF( x ) )
+#define  PR_CEIL_OF_HALF( x ) ( (x)<0 ? - PR__FLOOR_OF_HALF( -(x) ) :  PR__CEIL_OF_HALF( x ) )
+#define PR_SMALLEST_INTEGER_LARGER_THAN_HALF( x ) (  PR_CEIL_OF_HALF( (x)+1 ) )
+#define PR_LARGEST_INTEGER_SMALLER_THAN_HALF( x ) ( PR_FLOOR_OF_HALF( (x)-1 ) )
+#define PR_SMALLEST_INTEGER_LARGER_THAN_OR_EQUAL_TO_HALF( x ) (  PR_CEIL_OF_HALF( x ) )
+#define PR_LARGEST_INTEGER_SMALLER_THAN_OR_EQUAL_TO_HALF( x ) ( PR_FLOOR_OF_HALF( x ) )
+
+	template< unsigned int Degree >
+	struct BSplineSupportSizes
+	{
+	protected:
+		static const int _Degree = Degree;
+	public:
+		inline static int Nodes( int depth ){ return ( 1<<depth ) + ( Degree&1 ); }
+		inline static bool OutOfBounds( int depth , int offset ){ return offset>=0 || offset<Nodes(depth); }
+		// An index is interiorly supported if its support is in the range [0,1<<depth)
+		inline static void InteriorSupportedSpan( int depth , int& begin , int& end ){ begin = -SupportStart , end = (1<<depth)-SupportEnd; }
+		inline static bool IsInteriorlySupported( int depth , int offset ){ return offset+SupportStart>=0 && offset+SupportEnd<(1<<depth); }
+
+		// If the degree is even, we use a dual basis and functions are centered at the center of the interval
+		// It the degree is odd, we use a primal basis and functions are centered at the left end of the interval
+		// The function at index I is supported in:
+		//	Support( I ) = [ I - (Degree+1-Inset)/2 , I + (Degree+1+Inset)/2 ]
+		// [NOTE] The value of ( Degree + 1 +/- Inset ) is always even
+		static const int Inset = (Degree&1) ? 0 : 1;
+		PR_BSPLINE_SET_BOUNDS(      Support , -( (_Degree+1)/2 ) , _Degree/2          );
+		PR_BSPLINE_SET_BOUNDS( ChildSupport ,     2*SupportStart , 2*(SupportEnd+1)-1 );
+		PR_BSPLINE_SET_BOUNDS(       Corner ,     SupportStart+1 , SupportEnd         );
+		PR_BSPLINE_SET_BOUNDS(  ChildCorner ,   2*SupportStart+1 , 2*SupportEnd + 1   );
+		PR_BSPLINE_SET_BOUNDS(      BCorner ,      CornerStart-1 ,      CornerEnd+1 );
+		PR_BSPLINE_SET_BOUNDS( ChildBCorner , ChildCornerStart-1 , ChildCornerEnd+1 );
+
+		// Setting I=0, we are looking for the smallest/largest integers J such that:
+		//		Support( 0 ) CONTAINS Support( J )
+		// <=>	[-(Degree+1-Inset) , (Degree+1+Inset) ] CONTAINS [ J-(Degree+1-Inset)/2 , J+(Degree+1+Inset)/2 ]
+		// Which is the same as the smallest/largest integers J such that:
+		//		J - (Degree+1-Inset)/2 >= -(Degree+1-Inset)	| J + (Degree+1+Inset)/2 <= (Degree+1+Inset)
+		// <=>	J >= -(Degree+1-Inset)/2					| J <= (Degree+1+Inset)/2
+		PR_BSPLINE_SET_BOUNDS( UpSample , - ( _Degree + 1 - Inset ) / 2 , ( _Degree + 1 + Inset ) /2 );
+
+		// Setting I=0/1, we are looking for the smallest/largest integers J such that:
+		//		Support( J ) CONTAINS Support( 0/1 )
+		// <=>	[ 2*J - (Degree+1-Inset) , 2*J + (Degree+1+Inset) ] CONTAINS [ 0/1 - (Degree+1-Inset)/2 , 0/1 + (Degree+1+Inset)/2 ]
+		// Which is the same as the smallest/largest integers J such that:
+		//		2*J + (Degree+1+Inset) >= 0/1 + (Degree+1+Inset)/2	| 2*J - (Degree+1-Inset) <= 0/1 - (Degree+1-Inset)/2
+		// <=>	2*J >= 0/1 - (Degree+1+Inset)/2						| 2*J <= 0/1 + (Degree+1-Inset)/2
+		PR_BSPLINE_SET_BOUNDS( DownSample0 , PR_SMALLEST_INTEGER_LARGER_THAN_OR_EQUAL_TO_HALF( 0 - ( _Degree + 1 + Inset ) / 2 ) , PR_LARGEST_INTEGER_SMALLER_THAN_OR_EQUAL_TO_HALF( 0 + ( _Degree + 1 - Inset ) / 2 ) );
+		PR_BSPLINE_SET_BOUNDS( DownSample1 , PR_SMALLEST_INTEGER_LARGER_THAN_OR_EQUAL_TO_HALF( 1 - ( _Degree + 1 + Inset ) / 2 ) , PR_LARGEST_INTEGER_SMALLER_THAN_OR_EQUAL_TO_HALF( 1 + ( _Degree + 1 - Inset ) / 2 ) );
+		static const int DownSampleStart[] , DownSampleEnd[];
+		static const unsigned int DownSampleSize[];
+	};
+	template< unsigned int Degree > const int BSplineSupportSizes< Degree >::DownSampleStart[] = { DownSample0Start , DownSample1Start };
+	template< unsigned int Degree > const int BSplineSupportSizes< Degree >::DownSampleEnd  [] = { DownSample0End   , DownSample1End   };
+	template< unsigned int Degree > const unsigned int BSplineSupportSizes< Degree >::DownSampleSize [] = { DownSample0Size  , DownSample1Size  };
+
+	template< unsigned int Degree1 , unsigned int Degree2=Degree1 >
+	struct BSplineOverlapSizes
+	{
+	protected:
+		static const int _Degree1 = Degree1;
+		static const int _Degree2 = Degree2;
+	public:
+		typedef BSplineSupportSizes< Degree1 > EData1;
+		typedef BSplineSupportSizes< Degree2 > EData2;
+		PR_BSPLINE_SET_BOUNDS(             Overlap , EData1::     SupportStart - EData2::SupportEnd , EData1::     SupportEnd - EData2::SupportStart );
+		PR_BSPLINE_SET_BOUNDS(        ChildOverlap , EData1::ChildSupportStart - EData2::SupportEnd , EData1::ChildSupportEnd - EData2::SupportStart );
+		PR_BSPLINE_SET_BOUNDS(      OverlapSupport ,      OverlapStart + EData2::SupportStart ,      OverlapEnd + EData2::SupportEnd );
+		PR_BSPLINE_SET_BOUNDS( ChildOverlapSupport , ChildOverlapStart + EData2::SupportStart , ChildOverlapEnd + EData2::SupportEnd );
+
+		// Setting I=0/1, we are looking for the smallest/largest integers J such that:
+		//		Support( 2*J ) * 2 INTERSECTION Support( 0/1 ) NON-EMPTY
+		// <=>	[ 2*J - (Degree2+1-Inset2) , 2*J + (Degree2+1+Inset2) ] INTERSECTION [ 0/1 - (Degree1+1-Inset1)/2 , 0/1 + (Degree1+1+Inset1)/2 ] NON-EMPTY
+		// Which is the same as the smallest/largest integers J such that:
+		//		0/1 - (Degree1+1-Inset1)/2 < 2*J + (Degree2+1+Inset2)			| 0/1 + (Degree1+1+Inset1)/2 > 2*J - (Degree2+1-Inset2)	
+		// <=>	2*J > 0/1 - ( 2*Degree2 + Degree1 + 3 + 2*Inset2 - Inset1 ) / 2	| 2*J < 0/1 + ( 2*Degree2 + Degree1 + 3 - 2*Inset2 + Inset1 ) / 2
+		PR_BSPLINE_SET_BOUNDS( ParentOverlap0 , PR_SMALLEST_INTEGER_LARGER_THAN_HALF( 0 - ( 2*_Degree2 + _Degree1 + 3 + 2*EData2::Inset - EData1::Inset ) / 2 ) , PR_LARGEST_INTEGER_SMALLER_THAN_HALF( 0 + ( 2*_Degree2 + _Degree1 + 3 - 2*EData2::Inset + EData1::Inset ) / 2 ) );
+		PR_BSPLINE_SET_BOUNDS( ParentOverlap1 , PR_SMALLEST_INTEGER_LARGER_THAN_HALF( 1 - ( 2*_Degree2 + _Degree1 + 3 + 2*EData2::Inset - EData1::Inset ) / 2 ) , PR_LARGEST_INTEGER_SMALLER_THAN_HALF( 1 + ( 2*_Degree2 + _Degree1 + 3 - 2*EData2::Inset + EData1::Inset ) / 2 ) );
+		static const int ParentOverlapStart[] , ParentOverlapEnd[] , ParentOverlapSize[];
+	};
+	template< unsigned int Degree1 , unsigned int Degree2 > const int BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapStart[] = { ParentOverlap0Start , ParentOverlap1Start };
+	template< unsigned int Degree1 , unsigned int Degree2 > const int BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapEnd  [] = { ParentOverlap0End   , ParentOverlap1End   };
+	template< unsigned int Degree1 , unsigned int Degree2 > const int BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapSize [] = { ParentOverlap0Size  , ParentOverlap1Size  };
+
+	struct EvaluationData
+	{
+		struct CornerEvaluator
+		{
+			virtual double value( int fIdx , int cIdx , int d ) const = 0;
+			virtual void set( int depth ) = 0;
+			virtual ~CornerEvaluator( void ){}
+		};
+		struct CenterEvaluator
+		{
+			virtual double value( int fIdx , int cIdx , int d ) const = 0;
+			virtual void set( int depth ) = 0;
+			virtual ~CenterEvaluator( void ){}
+		};
+		struct UpSampleEvaluator
+		{
+			virtual double value( int pIdx , int cIdx ) const = 0;
+			virtual void set( int depth ) = 0;
+			virtual ~UpSampleEvaluator( void ){}
+		};
+	};
+
+	template< unsigned int FEMSig >
+	class BSplineEvaluationData
+	{
+	public:
+		static const unsigned int Degree = FEMSignature< FEMSig >::Degree;
+		static const int Pad = (FEMSignature< FEMSig >::BType==BOUNDARY_FREE ) ? BSplineSupportSizes< Degree >::SupportEnd : ( (Degree&1) && FEMSignature< FEMSig >::BType==BOUNDARY_DIRICHLET ) ? -1 : 0;
+		inline static int Begin( int depth ){ return -Pad; }
+		inline static int End  ( int depth ){ return (1<<depth) + (Degree&1) + Pad; }
+		inline static bool OutOfBounds( int depth , int offset ){ return offset<Begin(depth) || offset>=End(depth); }
+
+		static const int OffsetStart = -BSplineSupportSizes< Degree >::SupportStart , OffsetStop = BSplineSupportSizes< Degree >::SupportEnd + ( Degree&1 ) , IndexSize = OffsetStart + OffsetStop + 1 + 2 * Pad;
+		static int OffsetToIndex( int depth , int offset )
+		{
+			int dim = BSplineSupportSizes< Degree >::Nodes( depth );
+			if     ( offset<OffsetStart )     return Pad + offset;
+			else if( offset>=dim-OffsetStop ) return Pad + OffsetStart + 1 + offset - ( dim-OffsetStop );
+			else                              return Pad + OffsetStart;
+		}
+		static inline int IndexToOffset( int depth , int idx ){ return ( idx-Pad<=OffsetStart ? idx - Pad : ( BSplineSupportSizes< Degree >::Nodes(depth) + Pad - IndexSize + idx ) ); }
+
+		BSplineEvaluationData( void );
+		static double Value( int depth , int off , double s , int d );
+		static double Integral( int depth , int off , double b , double e , int d );
+
+		struct BSplineUpSamplingCoefficients
+		{
+		protected:
+			int _coefficients[ BSplineSupportSizes< Degree >::UpSampleSize ];
+		public:
+			BSplineUpSamplingCoefficients( void ){ ; }
+			BSplineUpSamplingCoefficients( int depth , int offset );
+			double operator[] ( int idx ){ return (double)_coefficients[idx] / (1<<Degree); }
+		};
+
+		template< unsigned int D >
+		struct CenterEvaluator
+		{
+			struct Evaluator : public EvaluationData::CenterEvaluator
+			{
+			protected:
+				friend BSplineEvaluationData;
+				int _depth;
+				double _ccValues[D+1][IndexSize][BSplineSupportSizes< Degree >::SupportSize];
+			public:
+				Evaluator( void ){ _depth = 0 ; memset( _ccValues , 0 , sizeof(_ccValues) ); }
+				double value( int fIdx , int cIdx , int d ) const;
+				int depth( void ) const { return _depth; }
+				void set( int depth ){ BSplineEvaluationData< FEMSig >::template SetCenterEvaluator< D >( *this , depth ); }
+			};
+			struct ChildEvaluator : public EvaluationData::CenterEvaluator
+			{
+			protected:
+				friend BSplineEvaluationData;
+				int _parentDepth;
+				double _pcValues[D+1][IndexSize][BSplineSupportSizes< Degree >::ChildSupportSize];
+			public:
+				ChildEvaluator( void ){ _parentDepth = 0 ; memset( _pcValues , 0 , sizeof(_pcValues) ); }
+				double value( int fIdx , int cIdx , int d ) const;
+				int parentDepth( void ) const { return _parentDepth; }
+				int childDepth( void ) const { return _parentDepth+1; }
+				void set( int parentDepth ){ BSplineEvaluationData< FEMSig >::template SetChildCenterEvaluator< D >( *this , parentDepth ); }
+			};
+		};
+		template< unsigned int D > static void SetCenterEvaluator( typename CenterEvaluator< D >::Evaluator& evaluator , int depth );
+		template< unsigned int D > static void SetChildCenterEvaluator( typename CenterEvaluator< D >::ChildEvaluator& evaluator , int parentDepth );
+
+		template< unsigned int D >
+		struct CornerEvaluator
+		{
+			struct Evaluator : public EvaluationData::CornerEvaluator
+			{
+			protected:
+				friend BSplineEvaluationData;
+				int _depth;
+				double _ccValues[D+1][IndexSize][BSplineSupportSizes< Degree >::BCornerSize];
+			public:
+				Evaluator( void ){ _depth = 0 ; memset( _ccValues , 0 , sizeof( _ccValues ) ); }
+				double value( int fIdx , int cIdx , int d ) const;
+				int depth( void ) const { return _depth; }
+				void set( int depth ){ BSplineEvaluationData< FEMSig >::template SetCornerEvaluator< D >( *this , depth ); }
+			};
+			struct ChildEvaluator : public EvaluationData::CornerEvaluator
+			{
+			protected:
+				friend BSplineEvaluationData;
+				int _parentDepth;
+				double _pcValues[D+1][IndexSize][BSplineSupportSizes< Degree >::ChildBCornerSize];
+			public:
+				ChildEvaluator( void ){ _parentDepth = 0 ; memset( _pcValues , 0 , sizeof( _pcValues ) ); }
+				double value( int fIdx , int cIdx , int d ) const;
+				int parentDepth( void ) const { return _parentDepth; }
+				int childDepth( void ) const { return _parentDepth+1; }
+				void set( int parentDepth ){ BSplineEvaluationData< FEMSig >::template SetChildCornerEvaluator< D >( *this , parentDepth ); }
+			};
+		};
+		template< unsigned int D > static void SetCornerEvaluator( typename CornerEvaluator< D >::Evaluator& evaluator , int depth );
+		template< unsigned int D > static void SetChildCornerEvaluator( typename CornerEvaluator< D >::ChildEvaluator& evaluator , int parentDepth );
+
+		template< unsigned int D >
+		struct Evaluator
+		{
+			typename CenterEvaluator< D >::Evaluator centerEvaluator;
+			typename CornerEvaluator< D >::Evaluator cornerEvaluator;
+			double centerValue( int fIdx , int cIdx , int d ) const { return centerEvaluator.value( fIdx , cIdx , d ); }
+			double cornerValue( int fIdx , int cIdx , int d ) const { return cornerEvaluator.value( fIdx , cIdx , d ); }
+		};
+		template< unsigned int D > static void SetEvaluator( Evaluator< D >& evaluator , int depth ){ SetCenterEvaluator< D >( evaluator.centerEvaluator , depth ) , SetCornerEvaluator< D >( evaluator.cornerEvaluator , depth ); }
+		template< unsigned int D >
+		struct ChildEvaluator
+		{
+			typename CenterEvaluator< D >::ChildEvaluator centerEvaluator;
+			typename CornerEvaluator< D >::ChildEvaluator cornerEvaluator;
+			double centerValue( int fIdx , int cIdx , int d ) const { return centerEvaluator.value( fIdx , cIdx , d ); }
+			double cornerValue( int fIdx , int cIdx , int d ) const { return cornerEvaluator.value( fIdx , cIdx , d ); }
+		};
+		template< unsigned int D > static void SetChildEvaluator( ChildEvaluator< D >& evaluator , int depth ){ SetChildCenterEvaluator< D >( evaluator.centerEvaluator , depth ) , SetChildCornerEvaluator< D >( evaluator.cornerEvaluator , depth ); }
+
+		struct UpSampleEvaluator : public EvaluationData::UpSampleEvaluator
+		{
+		protected:
+			friend BSplineEvaluationData;
+			int _lowDepth;
+			double _pcValues[IndexSize][BSplineSupportSizes< Degree >::UpSampleSize];
+		public:
+			UpSampleEvaluator( void ){ _lowDepth = 0 ; memset( _pcValues , 0 , sizeof( _pcValues ) ); }
+			double value( int pIdx , int cIdx ) const;
+			int lowDepth( void ) const { return _lowDepth; }
+			void set( int lowDepth ){ BSplineEvaluationData::SetUpSampleEvaluator( *this , lowDepth ); }
+		};
+		static void SetUpSampleEvaluator( UpSampleEvaluator& evaluator , int lowDepth );
+	};
+
+	template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+	class BSplineIntegrationData
+	{
+	public:
+		static const unsigned int Degree1 = FEMSignature< FEMSig1 >::Degree;
+		static const unsigned int Degree2 = FEMSignature< FEMSig2 >::Degree;
+		static const int OffsetStart = - BSplineOverlapSizes< Degree1 , Degree2 >::OverlapSupportStart;
+		static const int OffsetStop  =   BSplineOverlapSizes< Degree1 , Degree2 >::OverlapSupportEnd + ( Degree1&1 );
+		static const int IndexSize = OffsetStart + OffsetStop + 1 + 2 * BSplineEvaluationData< FEMSig1 >::Pad;
+		static int OffsetToIndex( int depth , int offset )
+		{
+			int dim = BSplineSupportSizes< Degree1 >::Nodes( depth );
+			if     ( offset<OffsetStart )     return BSplineEvaluationData< FEMSig1 >::Pad + offset;
+			else if( offset>=dim-OffsetStop ) return BSplineEvaluationData< FEMSig1 >::Pad + OffsetStart + 1 + offset - ( dim-OffsetStop );
+			else                              return BSplineEvaluationData< FEMSig1 >::Pad + OffsetStart;
+		}
+		static inline int IndexToOffset( int depth , int idx ){ return ( idx-BSplineEvaluationData< FEMSig1 >::Pad<=OffsetStart ? idx-BSplineEvaluationData< FEMSig1 >::Pad : ( BSplineSupportSizes< Degree1 >::Nodes(depth) + BSplineEvaluationData< FEMSig1 >::Pad - IndexSize + idx ) ); }
+
+		template< unsigned int D1 , unsigned int D2 > static double Dot( int depth1 , int off1 , int depth2 , int off2 );
+		// An index is interiorly overlapped if the support of its overlapping neighbors is in the range [0,1<<depth)
+		inline static void InteriorOverlappedSpan( int depth , int& begin , int& end ){ begin = -BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart-BSplineSupportSizes< Degree2 >::SupportStart , end = (1<<depth)-BSplineOverlapSizes< Degree1 , Degree2 >::OverlapEnd-BSplineSupportSizes< Degree2 >::SupportEnd; }
+
+		struct FunctionIntegrator
+		{
+			template< unsigned int D1=Degree1 , unsigned int D2=Degree2 >
+			struct Integrator
+			{
+			protected:
+				friend BSplineIntegrationData;
+				int _depth;
+				double _ccIntegrals[D1+1][D2+1][IndexSize][BSplineOverlapSizes< Degree1 , Degree2 >::OverlapSize];
+			public:
+				Integrator( void )
+				{
+					_depth = 0;
+					memset(_ccIntegrals, 0, sizeof(_ccIntegrals));
+				}
+				double dot( int fIdx1 , int fidx2 , int d1 , int d2 ) const;
+				int depth( void ) const { return _depth; }
+				void set( int depth ){ BSplineIntegrationData::SetIntegrator( *this , depth ); }
+			};
+			template< unsigned int D1=Degree1 , unsigned int D2=Degree2 >
+			struct ChildIntegrator
+			{
+			protected:
+				friend BSplineIntegrationData;
+				int _parentDepth;
+				double _pcIntegrals[D1+1][D2+1][IndexSize][BSplineOverlapSizes< Degree1 , Degree2 >::ChildOverlapSize];
+			public:
+				ChildIntegrator( void )
+				{
+					_parentDepth = 0;
+					memset( _pcIntegrals , 0 , sizeof( _pcIntegrals ) ); 
+				}
+				double dot( int fIdx1 , int fidx2 , int d1 , int d2 ) const;
+				int parentDepth( void ) const { return _parentDepth; }
+				int childDepth( void ) const { return _parentDepth+1; }
+				void set( int depth ){ BSplineIntegrationData::SetChildIntegrator( *this , depth ); }
+			};
+		};
+		// D1 and D2 indicate the number of derivatives that should be taken
+		template< unsigned int D1 , unsigned int D2 >
+		static void SetIntegrator( typename FunctionIntegrator::template Integrator< D1 , D2 >& integrator , int depth );
+		template< unsigned int D1 , unsigned int D2 >
+		static void SetChildIntegrator( typename FunctionIntegrator::template ChildIntegrator< D1 , D2 >& integrator , int parentDepth );
+
+	protected:
+		// _D1 and _D2 indicate the total number of derivatives the integrator will be storing
+		template< unsigned int D1 , unsigned int D2 , unsigned int _D1 , unsigned int _D2 >
+		struct _IntegratorSetter
+		{
+			static void Set( typename FunctionIntegrator::template      Integrator< _D1 , _D2 >& integrator , int depth );
+			static void Set( typename FunctionIntegrator::template ChildIntegrator< _D1 , _D2 >& integrator , int depth );
+		};
+
+		template< unsigned int D1 , unsigned int D2 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+		struct IntegratorSetter
+		{
+			static void Set2D( Integrator& integrator , int depth );
+			static void Set1D( Integrator& integrator , int depth );
+		};
+		template< unsigned int D1 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+		struct IntegratorSetter< D1 , 0 , _D1 , _D2 , Integrator >
+		{
+			static void Set2D( Integrator& integrator , int  depth );
+			static void Set1D( Integrator& integrator , int  depth );
+		};
+		template< unsigned int D2 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+		struct IntegratorSetter< 0 , D2 , _D1 , _D2 , Integrator >
+		{
+			static void Set2D( Integrator& integrator , int  depth );
+			static void Set1D( Integrator& integrator , int  depth );
+		};
+		template< unsigned int _D1 , unsigned int _D2 , class Integrator >
+		struct IntegratorSetter< 0 , 0 , _D1 , _D2 , Integrator >
+		{
+			static void Set2D( Integrator& integrator , int  depth );
+			static void Set1D( Integrator& integrator , int  depth );
+		};
+	};
+#undef PR_BSPLINE_SET_BOUNDS
+#undef PR__FLOOR_OF_HALF
+#undef  PR__CEIL_OF_HALF
+#undef PR_FLOOR_OF_HALF
+#undef  PR_CEIL_OF_HALF
+#undef PR_SMALLEST_INTEGER_LARGER_THAN_HALF
+#undef PR_LARGEST_INTEGER_SMALLER_THAN_HALF
+#undef PR_SMALLEST_INTEGER_LARGER_THAN_OR_EQUAL_TO_HALF
+#undef PR_LARGEST_INTEGER_SMALLER_THAN_OR_EQUAL_TO_HALF
+
+
+	template< unsigned int FEMSig , unsigned int D=0 >
+	struct BSplineData
+	{
+		static const unsigned int Degree = FEMSignature< FEMSig >::Degree;
+		static const int _Degree = Degree;
+		// Note that this struct stores the components in left-to-right order
+		struct BSplineComponents
+		{
+			BSplineComponents( void ){ ; }
+			BSplineComponents( int depth , int offset );
+			const Polynomial< Degree >* operator[] ( int idx ) const { return _polys[idx]; }
+		protected:
+			Polynomial< Degree > _polys[Degree+1][D+1];
+		};
+		struct SparseBSplineEvaluator
+		{
+			void init( unsigned int depth )
+			{
+				_depth = depth , _width = 1./(1<<depth);
+				// _preStart + BSplineSupportSizes< _Degree >::SupportEnd >=0
+				_preStart = -BSplineSupportSizes< _Degree >::SupportEnd;
+				// _postStart + BSplineSupportSizes< _Degree >::SupportEnd <= (1<<depth)-1
+				_postStart = (1<<depth) - 1 - BSplineSupportSizes< _Degree >::SupportEnd;
+				_preEnd = _preStart + _Degree + 1;
+				_postEnd = _postStart + _Degree + 1;
+				_centerIndex = ( ( _preStart + _Degree + 1 ) + ( _postStart - 1 ) ) / 2;
+				_centerComponents = BSplineComponents( depth , _centerIndex );
+				for( int i=0 ; i<=Degree ; i++ ) _preComponents[i] = BSplineComponents( depth , _preStart+i ) , _postComponents[i] = BSplineComponents( depth , _postStart+i );
+			}
+			double value( double p ,            int fIdx , int d ) const { return value( p , (int)( p * (1<<_depth ) ) , fIdx , d ); }
+			double value( double p , int pIdx , int fIdx , int d ) const
+			{
+				if     ( fIdx<_preStart  ) return 0;
+				else if( fIdx<_preEnd    ) return _preComponents [fIdx-_preStart ][pIdx-fIdx+_LeftSupportRadius][d]( p );
+				else if( fIdx<_postStart ) return _centerComponents               [pIdx-fIdx+_LeftSupportRadius][d]( p+_width*(_centerIndex-fIdx) );
+				else if( fIdx<_postEnd   ) return _postComponents[fIdx-_postStart][pIdx-fIdx+_LeftSupportRadius][d]( p );
+				else                       return 0;
+			}
+			const Polynomial< _Degree >* polynomialsAndOffset( double& p ,            int fIdx ) const { return polynomialsAndOffset( p , (int)( p * (1<<_depth ) ) , fIdx ); }
+			const Polynomial< _Degree >* polynomialsAndOffset( double& p , int pIdx , int fIdx ) const
+			{
+				if     ( fIdx<_preEnd    ){                                   return _preComponents [fIdx-_preStart ][pIdx-fIdx+_LeftSupportRadius]; }
+				else if( fIdx<_postStart ){ p += _width*(_centerIndex-fIdx) ; return _centerComponents               [pIdx-fIdx+_LeftSupportRadius]; }
+				else                      {                                   return _postComponents[fIdx-_postStart][pIdx-fIdx+_LeftSupportRadius]; }
+			}
+		protected:
+			static const int _LeftSupportRadius = -BSplineSupportSizes< _Degree >::SupportStart;
+			BSplineComponents _preComponents[_Degree+1] , _postComponents[_Degree+1] ,_centerComponents;
+			int _preStart , _preEnd , _postStart , _postEnd , _centerIndex;
+			unsigned int _depth;
+			double _width;
+		};
+		const SparseBSplineEvaluator& operator[]( int depth ) const { return _evaluators[depth]; }
+
+		inline static int RemapOffset( int depth , int idx , bool& reflect );
+
+		BSplineData( void );
+		void reset( int maxDepth );
+		BSplineData( int maxDepth );
+		~BSplineData( void );
+
+	protected:
+		unsigned int _maxDepth;
+		Pointer( SparseBSplineEvaluator ) _evaluators;
+	};
+
+	template< unsigned int Degree1 , unsigned int Degree2 > void SetBSplineElementIntegrals( double integrals[Degree1+1][Degree2+1] );
+
+#include "BSplineData.inl"
+}
+
+#endif // BSPLINE_DATA_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/BSplineData.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/BSplineData.inl
@@ -1,0 +1,638 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+///////////////////////////
+// BSplineEvaluationData //
+///////////////////////////
+template< unsigned int FEMSig >
+double BSplineEvaluationData< FEMSig >::Value( int depth , int off , double s , int d )
+{
+	if( s<0 || s>1 ) return 0.;
+
+	int res = 1<<depth;
+	if( OutOfBounds( depth , off ) ) return 0;
+
+	typename BSplineData< FEMSig , Degree >::BSplineComponents components( depth , off );
+
+	// [NOTE] This is an ugly way to ensure that when s=1 we evaluate using a B-Spline component within the valid range.
+	int ii = std::max< int >( 0 , std::min< int >( res-1 , (int)floor( s * res ) ) ) - off;
+
+	if( ii<BSplineSupportSizes< Degree >::SupportStart || ii>BSplineSupportSizes< Degree >::SupportEnd ) return 0;
+	return d<=Degree ? components[ii-BSplineSupportSizes< Degree >::SupportStart][d](s) : 0;
+}
+template< unsigned int FEMSig >
+double BSplineEvaluationData< FEMSig >::Integral( int depth , int off , double b , double e , int d )
+{
+	double integral = 0;
+	// Check for valid integration bounds
+	if( OutOfBounds( depth , off ) ) return 0;
+	if( b>=e || b>=1 || e<=0 ) return 0;
+	if( b<0 ) b=0;
+	if( e>1 ) e=1;
+
+	int res = 1<<depth;
+	double _b = ( (double)( off     + BSplineSupportSizes< Degree >::SupportStart ) )/res;
+	double _e = ( (double)( off + 1 + BSplineSupportSizes< Degree >::SupportEnd   ) )/res;
+	if( b>=_e || e<=_b ) return 0;
+	typename BSplineData< FEMSig , Degree >::BSplineComponents components( depth , off );
+	for( int i=BSplineSupportSizes< Degree >::SupportStart ; i<=BSplineSupportSizes< Degree >::SupportEnd ; i++ )
+	{
+		// The index of the current cell
+		int c = off + i;
+		// The bounds of the current cell
+		_b = std::max< double >( b , ( (double)c ) / res ) , _e = std::min< double >( e , ( (double)(c+1) )/res );
+		if( _b<_e ) integral += d<=Degree ? components[i-BSplineSupportSizes< Degree >::SupportStart][d].integral( _b , _e ) : 0;
+	}
+	return integral;
+}
+template< unsigned int FEMSig >
+template< unsigned int D >
+void BSplineEvaluationData< FEMSig >::SetCenterEvaluator( typename CenterEvaluator< D >::Evaluator& evaluator , int depth )
+{
+	evaluator._depth = depth;
+	int res = 1<<depth;
+	for( int i=0 ; i<IndexSize ; i++ ) for( int j=BSplineSupportSizes< Degree >::SupportStart ; j<=BSplineSupportSizes< Degree >::SupportEnd ; j++ )
+	{
+		int ii = IndexToOffset( depth , i );
+		double s = 0.5 + ii + j;
+		for( int d1=0 ; d1<=D ; d1++ ) evaluator._ccValues[d1][i][j-BSplineSupportSizes< Degree >::SupportStart] = Value( depth , ii , s/res , d1 );
+	}
+}
+template< unsigned int FEMSig >
+template< unsigned int D >
+void BSplineEvaluationData< FEMSig >::SetChildCenterEvaluator( typename CenterEvaluator< D >::ChildEvaluator& evaluator , int parentDepth )
+{
+	evaluator._parentDepth = parentDepth;
+	int res = 1<<(parentDepth+1);
+	for( int i=0 ; i<IndexSize ; i++ ) for( int j=BSplineSupportSizes< Degree >::ChildSupportStart ; j<=BSplineSupportSizes< Degree >::ChildSupportEnd ; j++ )
+	{
+		int ii = IndexToOffset( parentDepth , i );
+		double s = 0.5 + 2*ii + j;
+		for( int d1=0 ; d1<=D ; d1++ ) evaluator._pcValues[d1][i][j-BSplineSupportSizes< Degree >::ChildSupportStart] = Value( parentDepth , ii , s/res , d1 );
+	}
+}
+template< unsigned int FEMSig >
+template< unsigned int D >
+double BSplineEvaluationData< FEMSig >::CenterEvaluator< D >::Evaluator::value( int fIdx , int cIdx , int d ) const
+{
+	int dd = cIdx-fIdx , res = 1<<(_depth);
+	if( cIdx<0 || cIdx>=res || OutOfBounds( _depth , fIdx ) || dd<BSplineSupportSizes< Degree >::SupportStart || dd>BSplineSupportSizes< Degree >::SupportEnd ) return 0;
+	return _ccValues[d][ OffsetToIndex( _depth , fIdx ) ][dd-BSplineSupportSizes< Degree >::SupportStart];
+}
+template< unsigned int FEMSig >
+template< unsigned int D >
+double BSplineEvaluationData< FEMSig >::CenterEvaluator< D >::ChildEvaluator::value( int fIdx , int cIdx , int d ) const
+{
+	int dd = cIdx-2*fIdx , res = 1<<(_parentDepth+1);
+	if( cIdx<0 || cIdx>=res || OutOfBounds( _parentDepth , fIdx ) || dd<BSplineSupportSizes< Degree >::ChildSupportStart || dd>BSplineSupportSizes< Degree >::ChildSupportEnd ) return 0;
+	return _pcValues[d][ OffsetToIndex( _parentDepth , fIdx ) ][dd-BSplineSupportSizes< Degree >::ChildSupportStart];
+}
+template< unsigned int FEMSig >
+template< unsigned int D >
+void BSplineEvaluationData< FEMSig >::SetCornerEvaluator( typename CornerEvaluator< D >::Evaluator& evaluator , int depth )
+{
+	evaluator._depth = depth;
+	int res = 1<<depth;
+	for( int i=0 ; i<IndexSize ; i++ ) for( int j=BSplineSupportSizes< Degree >::BCornerStart ; j<=BSplineSupportSizes< Degree >::BCornerEnd ; j++ )
+	{
+		int ii = IndexToOffset( depth , i );
+		double s = ii + j;
+		int jj = j-BSplineSupportSizes< Degree >::BCornerStart;
+		for( int d1=0 ; d1<=D ; d1++ )
+		{
+			if( d1==Degree )
+			{
+				if     ( j==BSplineSupportSizes< Degree >::BCornerStart ) evaluator._ccValues[d1][i][jj] = (                                            Value( depth , ii , ( s+0.5 )/res , d1 ) ) / 2;
+				else if( j==BSplineSupportSizes< Degree >::BCornerEnd   ) evaluator._ccValues[d1][i][jj] = ( Value( depth , ii , ( s-0.5 )/res , d1 )                                            ) / 2;
+				else                                                      evaluator._ccValues[d1][i][jj] = ( Value( depth , ii , ( s-0.5 )/res , d1 ) + Value( depth , ii , ( s+0.5 )/res , d1 ) ) / 2;
+			}
+			else evaluator._ccValues[d1][i][jj] = Value( depth , ii , s /res , d1 );
+		}
+	}
+}
+template< unsigned int FEMSig >
+template< unsigned int D  >
+void BSplineEvaluationData< FEMSig >::SetChildCornerEvaluator( typename CornerEvaluator< D >::ChildEvaluator& evaluator , int parentDepth )
+{
+	evaluator._parentDepth = parentDepth;
+	int res = 1<<(parentDepth+1);
+	for( int i=0 ; i<IndexSize ; i++ ) for( int j=BSplineSupportSizes< Degree >::ChildBCornerStart ; j<=BSplineSupportSizes< Degree >::ChildBCornerEnd ; j++ )
+	{
+		int ii = IndexToOffset( parentDepth , i );
+		double s = 2*ii + j;
+		int jj = j-BSplineSupportSizes< Degree >::ChildBCornerStart;
+		for( int d1=0 ; d1<=D ; d1++ )
+		{
+			if( d1==Degree )
+			{
+				if     ( j==BSplineSupportSizes< Degree >::ChildBCornerStart ) evaluator._pcValues[d1][i][jj] = (                                                  Value( parentDepth , ii , ( s+0.5 )/res , d1 ) ) / 2;
+				else if( j==BSplineSupportSizes< Degree >::ChildBCornerEnd   ) evaluator._pcValues[d1][i][jj] = ( Value( parentDepth , ii , ( s-0.5 )/res , d1 )                                                  ) / 2;
+				else                                                           evaluator._pcValues[d1][i][jj] = ( Value( parentDepth , ii , ( s-0.5 )/res , d1 ) + Value( parentDepth , ii , ( s+0.5 )/res , d1 ) ) / 2;
+			}
+			else evaluator._pcValues[d1][i][jj] = Value( parentDepth , ii , s /res , d1 );
+		}
+	}
+}
+template< unsigned int FEMSig >
+template< unsigned int D >
+double BSplineEvaluationData< FEMSig >::CornerEvaluator< D >::Evaluator::value( int fIdx , int cIdx , int d ) const
+{
+	int dd = cIdx-fIdx , res = ( 1<<_depth ) + 1;
+	if( cIdx<0 || cIdx>=res || OutOfBounds( _depth , fIdx ) || dd<BSplineSupportSizes< Degree >::BCornerStart || dd>BSplineSupportSizes< Degree >::BCornerEnd ) return 0;
+	return _ccValues[d][ OffsetToIndex( _depth , fIdx ) ][dd-BSplineSupportSizes< Degree >::BCornerStart];
+}
+template< unsigned int FEMSig >
+template< unsigned int D >
+double BSplineEvaluationData< FEMSig >::CornerEvaluator< D >::ChildEvaluator::value( int fIdx , int cIdx , int d ) const
+{
+	int dd = cIdx-2*fIdx , res = ( 1<<(_parentDepth+1) ) + 1;
+	if( cIdx<0 || cIdx>=res || OutOfBounds( _parentDepth , fIdx ) || dd<BSplineSupportSizes< Degree >::ChildBCornerStart || dd>BSplineSupportSizes< Degree >::ChildBCornerEnd ) return 0;
+	return _pcValues[d][ OffsetToIndex( _parentDepth , fIdx ) ][dd-BSplineSupportSizes< Degree >::ChildBCornerStart];
+}
+template< unsigned int FEMSig >
+void BSplineEvaluationData< FEMSig >::SetUpSampleEvaluator( UpSampleEvaluator& evaluator , int lowDepth )
+{
+	evaluator._lowDepth = lowDepth;
+	for( int i=0 ; i<IndexSize ; i++ )
+	{
+		int ii = IndexToOffset( lowDepth , i );
+		BSplineUpSamplingCoefficients b( lowDepth , ii );
+		for( int j=0 ; j<BSplineSupportSizes< Degree >::UpSampleSize ; j++ ) evaluator._pcValues[i][j] = b[j];
+	}
+}
+template< unsigned int FEMSig >
+double BSplineEvaluationData< FEMSig >::UpSampleEvaluator::value( int pIdx , int cIdx ) const
+{
+	int dd = cIdx-2*pIdx;
+	if( OutOfBounds( _lowDepth+1 , cIdx ) || OutOfBounds( _lowDepth , pIdx ) || dd<BSplineSupportSizes< Degree >::UpSampleStart || dd>BSplineSupportSizes< Degree >::UpSampleEnd ) return 0;
+	return _pcValues[ OffsetToIndex( _lowDepth , pIdx ) ][dd-BSplineSupportSizes< Degree >::UpSampleStart];
+}
+
+//////////////////////////////////////////////////////////
+// BSplineEvaluationData::BSplineUpSamplingCoefficients //
+//////////////////////////////////////////////////////////
+template< unsigned int FEMSig >
+BSplineEvaluationData< FEMSig >::BSplineUpSamplingCoefficients::BSplineUpSamplingCoefficients( int depth , int offset )
+{
+	static const BoundaryType BType = FEMSignature< FEMSig >::BType;
+	// [ 1/8 1/2 3/4 1/2 1/8]
+	// [ 1 , 1 ] ->  [ 3/4 , 1/2 , 1/8 ] + [ 1/8 , 1/2 , 3/4 ] = [ 7/8 , 1 , 7/8 ]
+	int dim = BSplineSupportSizes< Degree >::Nodes(depth) , _dim = BSplineSupportSizes< Degree >::Nodes(depth+1);
+	bool reflect;
+	offset = BSplineData< FEMSig >::RemapOffset( depth , offset , reflect );
+	int multiplier = ( BType==BOUNDARY_DIRICHLET && reflect ) ? -1 : 1;
+	bool useReflected = ( BType!=BOUNDARY_FREE ) && ( BSplineSupportSizes< Degree >::Inset || ( offset % ( dim-1 ) ) );
+	int b[ BSplineSupportSizes< Degree >::UpSampleSize ];
+	Polynomial< Degree+1 >::BinomialCoefficients( b );
+
+	// Clear the values
+	memset( _coefficients , 0 , sizeof(int) * BSplineSupportSizes< Degree >::UpSampleSize );
+
+	// Get the array of coefficients, relative to the origin
+#ifdef SANITIZED_PR
+	int baseOffset = - ( 2*offset + BSplineSupportSizes< Degree >::UpSampleStart );
+#else // !SANITIZED_PR
+	Pointer( int ) coefficients = GetPointer( _coefficients , BSplineSupportSizes< Degree >::UpSampleSize ) - ( 2*offset + BSplineSupportSizes< Degree >::UpSampleStart );
+#endif // SANITIZED_PR
+	for( int i=BSplineSupportSizes< Degree >::UpSampleStart ; i<=BSplineSupportSizes< Degree >::UpSampleEnd ; i++ )
+	{
+		int _offset = 2*offset+i;
+		_offset = BSplineData< FEMSig >::RemapOffset( depth+1 , _offset , reflect );
+		if( useReflected || !reflect )
+		{
+			int _multiplier = multiplier * ( ( BType==BOUNDARY_DIRICHLET && reflect ) ? -1 : 1 );
+#ifdef SANITIZED_PR
+			_coefficients[ _offset + baseOffset ] += b[ i-BSplineSupportSizes< Degree >::UpSampleStart ] * _multiplier;
+#else // !SANITIZED_PR
+			coefficients[ _offset ] += b[ i-BSplineSupportSizes< Degree >::UpSampleStart ] * _multiplier;
+#endif // SANITIZED_PR
+		}
+		// If we are not inset and we are at the boundary, use the reflection as well
+		if( BType!=BOUNDARY_FREE && !BSplineSupportSizes< Degree >::Inset && ( offset % (dim-1) ) && !( _offset % (_dim-1) ) )
+		{
+			_offset = BSplineData< FEMSig >::RemapOffset( depth+1 , _offset , reflect );
+			int _multiplier = multiplier * ( ( BType==BOUNDARY_DIRICHLET && reflect ) ? -1 : 1 );
+			if( BType==BOUNDARY_DIRICHLET ) _multiplier *= -1;
+#ifdef SANITIZED_PR
+			_coefficients[ _offset + baseOffset ] += b[ i-BSplineSupportSizes< Degree >::UpSampleStart ] * _multiplier;
+#else // !SANITIZED_PR
+			coefficients[ _offset ] += b[ i-BSplineSupportSizes< Degree >::UpSampleStart ] * _multiplier;
+#endif // SANITIZED_PR
+		}
+	}
+}
+
+////////////////////////////
+// BSplineIntegrationData //
+////////////////////////////
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 >
+double BSplineIntegrationData< FEMSig1 , FEMSig2 >::Dot( int depth1 ,  int off1 , int depth2 , int off2 )
+{
+	if( D1>Degree1 ) MK_THROW( "Taking more derivatives than the degree: " , D1 , " > " , Degree1 );
+	if( D2>Degree2 ) MK_THROW( "Taking more derivatives than the degree: " , D2 , " > " , Degree2 );
+	const int _Degree1 = ( Degree1>=D1 ) ? Degree1 - D1 : 0 , _Degree2 = ( Degree2>=D2 ) ? Degree2 - D2 : 0;
+	int sums[ Degree1+1 ][ Degree2+1 ];
+
+	int depth = std::max< int >( depth1 , depth2 );
+
+	BSplineElements< Degree1 > b1;
+	BSplineElements< Degree2 > b2;
+	if( BSplineSupportSizes< Degree1 >::IsInteriorlySupported( depth1 , off1 ) && BSplineSupportSizes< Degree2 >::IsInteriorlySupported( depth2 , off2 ) )
+	{
+		if( depth1<depth2 )
+		{
+			int begin1 , end1 , res = 1 - BSplineSupportSizes< Degree1 >::SupportStart + BSplineSupportSizes< Degree1 >::SupportEnd;
+			BSplineSupportSizes< Degree1 >::InteriorSupportedSpan( depth1 , begin1 , end1 );
+			b1 = BSplineElements< Degree1 >( res , begin1 , BOUNDARY_FREE );
+			for( int d=depth1 ; d<depth2 ; d++ )
+			{
+				BSplineElements< Degree1 > b=b1;
+				b.upSample( b1 );
+				res <<= 1;
+			}
+			b2 = BSplineElements< Degree2 >( res , off2 - ( (off1-begin1)<<(depth2-depth1) ) , BOUNDARY_FREE );
+		}
+		else
+		{
+			int begin2 , end2 , res = 1 - BSplineSupportSizes< Degree2 >::SupportStart + BSplineSupportSizes< Degree2 >::SupportEnd;
+			BSplineSupportSizes< Degree2 >::InteriorSupportedSpan( depth2 , begin2 , end2 );
+			b2 = BSplineElements< Degree2 >( res , begin2 , BOUNDARY_FREE );
+			for( int d=depth2 ; d<depth1 ; d++ )
+			{
+				BSplineElements< Degree2 > b=b2;
+				b.upSample( b2 );
+				res <<= 1;
+			}
+			b1 = BSplineElements< Degree1 >( res , off1 - ( (off2-begin2)<<(depth1-depth2) ) , BOUNDARY_FREE );
+		}
+	}
+	else
+	{
+		b1 = BSplineElements< Degree1 >( 1<<depth1 , off1 , FEMSignature< FEMSig1 >::BType );
+		b2 = BSplineElements< Degree2 >( 1<<depth2 , off2 , FEMSignature< FEMSig2 >::BType );
+		{
+			BSplineElements< Degree1 > b;
+			while( depth1<depth ) b=b1 , b.upSample( b1 ) , depth1++;
+		}
+		{
+			BSplineElements< Degree2 > b;
+			while( depth2<depth ) b=b2 , b.upSample( b2 ) , depth2++;
+		}
+	}
+
+	BSplineElements< Degree1-D1 > db1;
+	BSplineElements< Degree2-D2 > db2;
+	b1.template differentiate< D1 >( db1 ) , b2.template differentiate< D2 >( db2 );
+
+	int start1=-1 , end1=-1 , start2=-1 , end2=-1;
+	for( int i=0 ; i<int( b1.size() ) ; i++ )
+	{
+		for( int j=0 ; j<=Degree1 ; j++ )
+		{
+			if( b1[i][j] && start1==-1 ) start1 = i;
+			if( b1[i][j] ) end1 = i+1;
+		}
+		for( int j=0 ; j<=Degree2 ; j++ )
+		{
+			if( b2[i][j] && start2==-1 ) start2 = i;
+			if( b2[i][j] ) end2 = i+1;
+		}
+	}
+	if( start1==end1 || start2==end2 || start1>=end2 || start2>=end1 ) return 0.;
+	int start = std::max< int >( start1 , start2 ) , end = std::min< int >( end1 , end2 );
+	memset( sums , 0 , sizeof( sums ) );
+
+	// Iterate over the support
+	for( int i=start ; i<end ; i++ )
+		// Iterate over all pairs of elements within a node
+		for( int j=0 ; j<=_Degree1 ; j++ ) for( int k=0 ; k<=_Degree2 ; k++ )
+			// Accumulate the product of the coefficients
+			sums[j][k] += db1[i][j] * db2[i][k];
+
+	double _dot = 0;
+	{
+		double integrals[ _Degree1+1 ][ _Degree2+1 ];
+		SetBSplineElementIntegrals< _Degree1 , _Degree2 >( integrals );
+		for( int j=0 ; j<=_Degree1 ; j++ ) for( int k=0 ; k<=_Degree2 ; k++ ) _dot += integrals[j][k] * sums[j][k];
+	}
+	_dot /= b1.denominator;
+	_dot /= b2.denominator;
+	return ( !D1 && !D2 ) ? _dot / (1<<depth) : _dot * ( 1<<( depth*(D1+D2-1) ) );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::IntegratorSetter< D1 , D2 , _D1 , _D2 , Integrator >::Set2D( Integrator& integrator , int depth )
+{
+	IntegratorSetter< D1-1 , D2 , _D1 , _D2 , Integrator >::Set2D( integrator , depth );
+	IntegratorSetter< D1   , D2 , _D1 , _D2 , Integrator >::Set1D( integrator , depth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::IntegratorSetter< D1 , D2 , _D1 , _D2 , Integrator >::Set1D( Integrator& integrator , int depth )
+{
+	IntegratorSetter< D1 , D2-1 , _D1 , _D2 , Integrator >::Set1D( integrator , depth );
+	_IntegratorSetter< D1 , D2 , _D1 , _D2 >::Set( integrator , depth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D2 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::IntegratorSetter< 0 , D2 , _D1 , _D2 , Integrator >::Set2D( Integrator& integrator , int depth )
+{
+	IntegratorSetter< 0 , D2 , _D1 , _D2 , Integrator >::Set1D( integrator , depth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D2 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::IntegratorSetter< 0 , D2 , _D1 , _D2 , Integrator >::Set1D( Integrator& integrator , int depth )
+{
+	IntegratorSetter< 0 , D2-1 , _D1 , _D2 , Integrator >::Set1D( integrator , depth );
+	_IntegratorSetter< 0 , D2 , _D1 , _D2 >::Set( integrator , depth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::IntegratorSetter< D1 , 0 , _D1 , _D2 , Integrator >::Set2D( Integrator& integrator , int depth )
+{
+	IntegratorSetter< D1-1 , 0 , _D1 , _D2 , Integrator >::Set2D( integrator , depth );
+	IntegratorSetter< D1   , 0 , _D1 , _D2 , Integrator >::Set1D( integrator , depth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int _D1 , unsigned int _D2 , class Integrator >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::IntegratorSetter< D1 , 0 , _D1 , _D2 , Integrator >::Set1D( Integrator& integrator , int depth )
+{
+	_IntegratorSetter< D1 , 0 , _D1 , _D2 >::Set( integrator , depth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int _D1 , unsigned int _D2 , class Integrator >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::IntegratorSetter< 0 , 0 , _D1 , _D2 , Integrator >::Set2D( Integrator& integrator , int depth )
+{
+	IntegratorSetter< 0 , 0 , _D1 , _D2 , Integrator >::Set1D( integrator , depth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int _D1 , unsigned int _D2 , class Integrator >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::IntegratorSetter< 0 , 0 , _D1 , _D2 , Integrator >::Set1D( Integrator& integrator , int depth )
+{
+	_IntegratorSetter< 0 , 0 , _D1 , _D2 >::Set( integrator , depth );
+}
+
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 , unsigned int _D1 , unsigned int _D2 >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::_IntegratorSetter< D1 , D2 , _D1 , _D2 >::Set( typename FunctionIntegrator::template Integrator< _D1 , _D2 >& integrator , int depth )
+{
+	for( int i=0 ; i<IndexSize ; i++ ) for( int j=BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart ; j<=BSplineOverlapSizes< Degree1 , Degree2 >::OverlapEnd ; j++ )
+	{
+		int ii = IndexToOffset( depth , i );
+		integrator._ccIntegrals[D1][D2][i][j-BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart] = Dot< D1 , D2 >( depth , ii , depth , ii+j );
+	}
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 , unsigned int _D1 , unsigned int _D2 >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::_IntegratorSetter< D1 , D2 , _D1 , _D2 >::Set( typename FunctionIntegrator::template ChildIntegrator< _D1 , _D2 >& integrator , int pDepth )
+{
+	for( int i=0 ; i<IndexSize ; i++ ) for( int j=BSplineOverlapSizes< Degree1 , Degree2 >::ChildOverlapStart ; j<=BSplineOverlapSizes< Degree1 , Degree2 >::ChildOverlapEnd ; j++ )
+	{
+		int ii = IndexToOffset( pDepth , i );
+		integrator._pcIntegrals[D1][D2][i][j-BSplineOverlapSizes< Degree1 , Degree2 >::ChildOverlapStart] = Dot< D1 , D2 >( pDepth , ii , pDepth+1 , 2*ii+j );
+	}
+}
+
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::SetIntegrator( typename FunctionIntegrator::template Integrator< D1 , D2 >& integrator , int depth )
+{
+	integrator._depth = depth;
+	IntegratorSetter< D1 , D2 , D1 , D2 , typename FunctionIntegrator::template Integrator< D1 , D2 > >::Set2D( integrator , depth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 >
+void BSplineIntegrationData< FEMSig1 , FEMSig2 >::SetChildIntegrator( typename FunctionIntegrator::template ChildIntegrator< D1 , D2 >& integrator , int parentDepth )
+{
+	integrator._parentDepth = parentDepth;
+	IntegratorSetter< D1 , D2 , D1 , D2 , typename FunctionIntegrator::template ChildIntegrator< D1 , D2 > >::Set2D( integrator , parentDepth );
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 >
+double BSplineIntegrationData< FEMSig1 , FEMSig2 >::FunctionIntegrator::Integrator< D1 , D2 >::dot( int off1 , int off2 , int d1 , int d2 ) const
+{
+	int d = off2-off1;
+	if( BSplineEvaluationData< FEMSig1 >::OutOfBounds( _depth , off1 ) || BSplineEvaluationData< FEMSig2 >::OutOfBounds( _depth , off2 ) || d<BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart || d>BSplineOverlapSizes< Degree1 , Degree2 >::OverlapEnd ) return 0;
+	return _ccIntegrals[d1][d2][ OffsetToIndex( _depth , off1 ) ][d-BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart];
+}
+template< unsigned int FEMSig1 , unsigned int FEMSig2 >
+template< unsigned int D1 , unsigned int D2 >
+double BSplineIntegrationData< FEMSig1 , FEMSig2 >::FunctionIntegrator::ChildIntegrator< D1 , D2 >::dot( int off1 , int off2 , int d1 , int d2 ) const
+{
+	int d = off2-2*off1;
+	if( BSplineEvaluationData< FEMSig1 >::OutOfBounds( _parentDepth , off1 ) || BSplineEvaluationData< FEMSig2 >::OutOfBounds( _parentDepth+1 , off2 ) || d<BSplineOverlapSizes< Degree1 , Degree2 >::ChildOverlapStart || d>BSplineOverlapSizes< Degree1 , Degree2 >::ChildOverlapEnd ) return 0;
+	return _pcIntegrals[d1][d2][ OffsetToIndex( _parentDepth , off1 ) ][d-BSplineOverlapSizes< Degree1 , Degree2 >::ChildOverlapStart];
+}
+
+/////////////////
+// BSplineData //
+/////////////////
+#define PR_MODULO( A , B ) ( (A)<0 ? ( (B)-((-(A))%(B)) ) % (B) : (A) % (B) )
+
+template< unsigned int FEMSig , unsigned int D >
+BSplineData< FEMSig , D >::BSplineComponents::BSplineComponents( int depth , int offset )
+{
+	static const int _Degree = Degree;
+	int res = 1<<depth;
+	BSplineElements< Degree > elements( res , offset , FEMSignature< FEMSig >::BType );
+
+	// The first index is the position, the second is the element type
+	Polynomial< Degree > components[Degree+1][Degree+1];
+	// Generate the elements that can appear in the base function corresponding to the base function at (depth,offset) = (0,0)
+	for( int d=0 ; d<=Degree ; d++ ) for( int dd=0 ; dd<=Degree ; dd++ ) components[d][dd] = Polynomial< Degree >::BSplineComponent( _Degree-dd ).shift( -( (_Degree+1)/2 ) + d );
+
+	// Now adjust to the desired depth and offset
+	double width = 1. / res;
+	for( int d=0 ; d<=Degree ; d++ ) for( int dd=0 ; dd<=Degree ; dd++ ) components[d][dd] = components[d][dd].scale( width ).shift( width*offset );
+
+	// Now write in the polynomials
+	for( int d=0 ; d<=Degree ; d++ )
+	{
+		int idx = offset + BSplineSupportSizes< Degree >::SupportStart + d;
+		_polys[d][0] = Polynomial< Degree >();
+
+		if( idx>=0 && idx<res ) for( int dd=0 ; dd<=Degree ; dd++ ) _polys[d][0] += components[d][dd] * ( ( double )( elements[idx][dd] ) ) / elements.denominator;
+	}
+	for( int d=1 ; d<=D ; d++ ) for( int dd=0 ; dd<=Degree ; dd++ ) _polys[dd][d] = _polys[dd][d-1].derivative();
+}
+
+template< unsigned int FEMSig , unsigned int D >
+int BSplineData< FEMSig , D >::RemapOffset( int depth , int offset , bool& reflect )
+{
+	const int I = ( Degree&1 ) ? 0 : 1;
+	if( FEMSignature< FEMSig >::BType==BOUNDARY_FREE ){ reflect = false ; return offset; }
+	int dim = BSplineEvaluationData< FEMDegreeAndBType< Degree , BOUNDARY_NEUMANN >::Signature >::End( depth ) - BSplineEvaluationData< FEMDegreeAndBType< Degree , BOUNDARY_NEUMANN >::Signature >::Begin( depth );
+	offset = PR_MODULO( offset , 2*(dim-1+I) );
+	reflect = offset>=dim;
+	if( reflect ) return 2*(dim-1+I) - (offset+I);
+	else          return offset;
+}
+#undef PR_MODULO
+
+template< unsigned int FEMSig , unsigned int D >
+BSplineData< FEMSig , D >::BSplineData( void )
+{
+	_maxDepth = 0;
+	_evaluators = NullPointer( SparseBSplineEvaluator );
+}
+template< unsigned int FEMSig , unsigned int D >
+void BSplineData< FEMSig , D >::reset( int maxDepth )
+{
+	if( _evaluators ) DeletePointer( _evaluators );
+
+	_maxDepth = maxDepth;
+	_evaluators = NewPointer< SparseBSplineEvaluator >( _maxDepth+1 );
+	for( unsigned int d=0 ; d<=_maxDepth ; d++ ) _evaluators[d].init( d );
+}
+template< unsigned int FEMSig , unsigned int D >
+BSplineData< FEMSig , D >::BSplineData( int maxDepth )
+{
+	_evaluators = NullPointer( SparseBSplineEvaluator );
+	reset( maxDepth );
+}
+template< unsigned int FEMSig , unsigned int D >
+BSplineData< FEMSig , D >::~BSplineData( void )
+{
+	DeletePointer( _evaluators );
+}
+
+/////////////////////
+// BSplineElements //
+/////////////////////
+template< unsigned int Degree >
+BSplineElements< Degree >::BSplineElements( int res , int offset , BoundaryType bType )
+{
+	denominator = 1;
+	std::vector< BSplineElementCoefficients< Degree > >::resize( res , BSplineElementCoefficients< Degree >() );
+
+	// If we have primal dirichlet constraints, the boundary functions are necessarily zero
+	if( _Primal && bType==BOUNDARY_DIRICHLET && !(offset%res) ) return;
+
+	// Construct the B-Spline
+	for( int i=0 ; i<=Degree ; i++ )
+	{
+		int idx = -_Off + offset + i;
+		if( idx>=0 && idx<res ) (*this)[idx][i] = 1;
+	}
+	if( bType!=BOUNDARY_FREE )
+	{
+		// Fold in the periodic instances (which cancels the negation)
+		_addPeriodic< true >( _RotateLeft ( offset , res ) , false ) , _addPeriodic< false >( _RotateRight( offset , res ) , false );
+
+		// Recursively fold in the boundaries
+		if( _Primal && !(offset%res) ) return;
+
+		// Fold in the reflected instance (which may require negation)
+		_addPeriodic< true >( _ReflectLeft( offset , res ) , bType==BOUNDARY_DIRICHLET ) , _addPeriodic< false >( _ReflectRight( offset , res ) , bType==BOUNDARY_DIRICHLET );
+	}
+}
+template< unsigned int Degree > int BSplineElements< Degree >::_ReflectLeft ( int offset , int res ){ return (Degree&1) ?      -offset :      -1-offset; }
+template< unsigned int Degree > int BSplineElements< Degree >::_ReflectRight( int offset , int res ){ return (Degree&1) ? 2*res-offset : 2*res-1-offset; }
+template< unsigned int Degree > int BSplineElements< Degree >::_RotateLeft  ( int offset , int res ){ return offset-2*res; }
+template< unsigned int Degree > int BSplineElements< Degree >::_RotateRight ( int offset , int res ){ return offset+2*res; }
+
+template< unsigned int Degree >
+template< bool Left >
+void BSplineElements< Degree >::_addPeriodic( int offset , bool negate )
+{
+	int res = int( std::vector< BSplineElementCoefficients< Degree > >::size() );
+	bool set = false;
+	// Add in the corresponding B-spline elements (possibly negated)
+	for( int i=0 ; i<=Degree ; i++ )
+	{
+		int idx = -_Off + offset + i;
+		if( idx>=0 && idx<res ) (*this)[idx][i] += negate ? -1 : 1 , set = true;
+	}
+	// If there is a change for additional overlap, give it a go
+	if( set ) _addPeriodic< Left >( Left ? _RotateLeft( offset , res ) : _RotateRight( offset , res ) , negate );
+}
+template< unsigned int Degree >
+void BSplineElements< Degree >::upSample( BSplineElements< Degree >& high ) const
+{
+	int bCoefficients[ BSplineSupportSizes< Degree >::UpSampleSize ];
+	Polynomial< Degree+1 >::BinomialCoefficients( bCoefficients );
+
+	high.resize( std::vector< BSplineElementCoefficients< Degree > >::size()*2 );
+	high.assign( high.size() , BSplineElementCoefficients< Degree >() );
+	// [NOTE] We have flipped the order of the B-spline elements
+	for( int i=0 ; i<int(std::vector< BSplineElementCoefficients< Degree > >::size()) ; i++ ) for( int j=0 ; j<=Degree ; j++ )
+	{
+		// At index I , B-spline element J corresponds to a B-spline centered at:
+		//		I - SupportStart - J
+		int idx = i - BSplineSupportSizes< Degree >::SupportStart - j;
+		for( int k=BSplineSupportSizes< Degree >::UpSampleStart ; k<=BSplineSupportSizes< Degree >::UpSampleEnd ; k++ )
+		{
+			// Index idx at the coarser resolution gets up-sampled into indices:
+			//		2*idx + [UpSampleStart,UpSampleEnd]
+			// at the finer resolution
+			int _idx = 2*idx + k;
+			// Compute the index of the B-spline element relative to 2*i and 2*i+1
+			int _j1 = -_idx + 2*i - BSplineSupportSizes< Degree >::SupportStart , _j2 = -_idx + 2*i + 1 - BSplineSupportSizes< Degree >::SupportStart;
+			if( _j1>=0 && _j1<=Degree ) high[2*i+0][_j1] += (*this)[i][j] * bCoefficients[k-BSplineSupportSizes< Degree >::UpSampleStart];
+			if( _j2>=0 && _j2<=Degree ) high[2*i+1][_j2] += (*this)[i][j] * bCoefficients[k-BSplineSupportSizes< Degree >::UpSampleStart];
+		}
+	}
+	high.denominator = denominator<<Degree;
+}
+
+template< unsigned int Degree >
+template< unsigned int D >
+void BSplineElements< Degree >::differentiate( BSplineElements< Degree-D >& d ) const{ Differentiator< Degree , Degree-D >::Differentiate( *this , d ); }
+template< unsigned int Degree , unsigned int DDegree >
+void Differentiator< Degree , DDegree >::Differentiate( const BSplineElements< Degree >& bse , BSplineElements< DDegree >& dbse )
+{
+	BSplineElements< Degree-1 > _dbse;
+	_dbse.resize( bse.size() );
+	_dbse.assign( _dbse.size() , BSplineElementCoefficients< Degree-1 >() );
+	for( int i=0 ; i<(int)bse.size() ; i++ ) for( int j=0 ; j<=Degree ; j++ )
+	{
+		if( j-1>=0 )   _dbse[i][j-1] -= bse[i][j];
+		if( j<Degree ) _dbse[i][j  ] += bse[i][j];
+	}
+	_dbse.denominator = bse.denominator;
+	return Differentiator< Degree-1 , DDegree >::Differentiate( _dbse , dbse );
+}
+template< unsigned int Degree >
+void Differentiator< Degree , Degree >::Differentiate( const BSplineElements< Degree >& bse , BSplineElements< Degree >& dbse ){ dbse = bse; }
+
+// If we were really good, we would implement this integral table to store
+// rational values to improve precision...
+template< unsigned int Degree1 , unsigned int Degree2 >
+void SetBSplineElementIntegrals( double integrals[Degree1+1][Degree2+1] )
+{
+	for( int i=0 ; i<=Degree1 ; i++ )
+	{
+		Polynomial< Degree1 > p1 = Polynomial< Degree1 >::BSplineComponent( Degree1-i );
+		for( int j=0 ; j<=Degree2 ; j++ )
+		{
+			Polynomial< Degree2 > p2 = Polynomial< Degree2 >::BSplineComponent( Degree2-j );
+			integrals[i][j] = ( p1 * p2 ).integral( 0 , 1 );
+		}
+	}
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/BinaryNode.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/BinaryNode.h
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef BINARY_NODE_INCLUDED
+#define BINARY_NODE_INCLUDED
+
+namespace PoissonRecon
+{
+	class BinaryNode
+	{
+	public:
+		static inline size_t CenterCount( unsigned int depth ) { return  (size_t)1<<depth; }
+		static inline size_t CornerCount( unsigned int depth ) { return ((size_t)1<<depth)+1; }
+		static inline size_t CumulativeCenterCount( unsigned int maxDepth ) { return ((size_t)1<<(maxDepth+1))-1; }
+		static inline size_t CumulativeCornerCount( unsigned int maxDepth ) { return ((size_t)1<<(maxDepth+1))+maxDepth; }
+		static inline size_t CenterIndex( unsigned int depth , size_t offSet ) { return ((size_t)1<<depth)+offSet-1; }
+		static inline size_t CornerIndex( unsigned int depth , size_t offSet ) { return ((size_t)1<<depth)+offSet-1+depth; }
+
+		static inline size_t CornerIndex( unsigned int maxDepth , unsigned int depth , size_t offSet , int forwardCorner ){ return (offSet+forwardCorner)<<(maxDepth-depth); }
+		template< class Real > static inline Real Width( unsigned int depth ){ return Real(1.0/((size_t)1<<depth)); }
+		template< class Real > static inline void CenterAndWidth( unsigned int depth , size_t offset , Real& center , Real& width ){ width = Real (1.0/((size_t)1<<depth) ) , center = Real((0.5+offset)*width); }
+		template< class Real > static inline void CornerAndWidth( unsigned int depth , size_t offset , Real& corner , Real& width ){ width = Real(1.0/((size_t)1<<depth) ) , corner = Real(offset*width); }
+		template< class Real > static inline void CenterAndWidth( size_t idx , Real& center , Real& width )
+		{
+			unsigned int depth;
+			size_t offset;
+			CenterDepthAndOffset( idx , depth , offset );
+			CenterAndWidth( depth , offset , center , width );
+		}
+		template< class Real > static inline void CornerAndWidth( size_t idx , Real& corner , Real& width )
+		{
+			unsigned int depth;
+			size_t offset;
+			CornerDepthAndOffset( idx , depth , offset );
+			CornerAndWidth( depth , offset , corner , width );
+		}
+		static inline void CenterDepthAndOffset( size_t idx , unsigned int &depth , size_t &offset )
+		{
+			offset = idx , depth = 0;
+			while( offset>=((size_t)1<<depth) ) offset -= ((size_t)1<<depth) , depth++;
+		}
+		static inline void CornerDepthAndOffset( size_t idx , unsigned int &depth , size_t &offset )
+		{
+			offset = idx , depth = 0;
+			while( offset>=( ((size_t)1<<depth)+1 ) ) offset -= ( ((size_t)1<<depth)+1 ) , depth++;
+		}
+	};
+}
+#endif // BINARY_NODE_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/BlockedVector.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/BlockedVector.h
@@ -1,0 +1,269 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+
+#ifndef BLOCKED_VECTOR_INCLUDED
+#define BLOCKED_VECTOR_INCLUDED
+
+#include "MyMiscellany.h"
+
+namespace PoissonRecon
+{
+	// This represents a vector that can only grow in size.
+	// It has the property that once a reference to an element is returned, that reference remains valid until the vector is destroyed.
+	template< typename T , unsigned int LogBlockSize=10 , unsigned int InitialBlocks=10 , unsigned int AllocationMultiplier=2 >
+	struct BlockedVector
+	{
+		BlockedVector( size_t sz=0 , T defaultValue=T() ) : _defaultValue( defaultValue )
+		{
+			_reservedBlocks = InitialBlocks;
+			_blocks = NewPointer< Pointer( T ) >( _reservedBlocks );
+			for( size_t i=0 ; i<_reservedBlocks ; i++ ) _blocks[i] = NullPointer( T );
+			_allocatedBlocks = _size = 0;
+			if( sz ) resize( sz );
+		}
+
+		~BlockedVector( void )
+		{
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ ) DeletePointer( _blocks[i] );
+			DeletePointer( _blocks );
+		}
+
+		BlockedVector( const BlockedVector& v )
+		{
+#ifdef SANITIZED_PR
+			_reservedBlocks = v._reservedBlocks , _allocatedBlocks = v._allocatedBlocks , _size = v._size.load() , _defaultValue = v._defaultValue;
+#else // !SANITIZED_PR
+			_reservedBlocks = v._reservedBlocks , _allocatedBlocks = v._allocatedBlocks , _size = v._size , _defaultValue = v._defaultValue;
+#endif // SANITIZED_PR
+			_blocks = NewPointer< Pointer( T ) >( _reservedBlocks );
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ )
+			{
+				_blocks[i] = NewPointer< T >( _BlockSize );
+				memcpy( _blocks[i] , v._blocks[i] , sizeof(T)*_BlockSize );
+			}
+			for( size_t i=_allocatedBlocks ; i<_reservedBlocks ; i++ ) _blocks[i] = NullPointer( Pointer ( T ) );
+		}
+
+		BlockedVector& operator = ( const BlockedVector&  v )
+		{
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ ) DeletePointer( _blocks[i] );
+			DeletePointer( _blocks );
+#ifdef SANITIZED_PR
+			_reservedBlocks = v._reservedBlocks , _blocks = v._blocks.load() , _allocatedBlocks = v._allocatedBlocks , _size = v._size.load() , _defaultValue = v._defaultValue;
+#else // !SANITIZED_PR
+			_reservedBlocks = v._reservedBlocks , _blocks = v._blocks , _allocatedBlocks = v._allocatedBlocks , _size = v._size , _defaultValue = v._defaultValue;
+#endif // SANITIZED_PR
+			_blocks = NewPointer< Pointer( T ) >( _reservedBlocks );
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ )
+			{
+				_blocks[i] = NewPointer< T >( _BlockSize );
+				memcpy( _blocks[i] , v._blocks[i] , sizeof(T)*_BlockSize );
+			}
+			for( size_t i=_allocatedBlocks ; i<_reservedBlocks ; i++ ) _blocks[i] = NullPointer( T );
+			return *this;
+		}
+
+		BlockedVector( BlockedVector&& v )
+		{
+#ifdef SANITIZED_PR
+			_reservedBlocks = v._reservedBlocks , _allocatedBlocks = v._allocatedBlocks , _size = v._size.load() , _defaultValue = v._defaultValue , _blocks = v._blocks.load();
+#else // !SANITIZED_PR
+			_reservedBlocks = v._reservedBlocks , _allocatedBlocks = v._allocatedBlocks , _size = v._size , _defaultValue = v._defaultValue , _blocks = v._blocks;
+#endif // SANITIZED_PR
+			v._reservedBlocks = v._allocatedBlocks = v._size = 0 , v._blocks = NullPointer( Pointer( T ) );
+		}
+
+		BlockedVector& operator = ( BlockedVector&& v )
+		{
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ ) DeletePointer( _blocks[i] );
+			DeletePointer( _blocks );
+#ifdef SANITIZED_PR
+			_reservedBlocks = v._reservedBlocks , _allocatedBlocks = v._allocatedBlocks , _size = v._size.load() , _defaultValue = v._defaultValue , _blocks = v._blocks.load();
+#else // !SANITIZED_PR
+			_reservedBlocks = v._reservedBlocks , _allocatedBlocks = v._allocatedBlocks , _size = v._size , _defaultValue = v._defaultValue , _blocks = v._blocks;
+#endif // SANITIZED_PR
+			v._reservedBlocks = v._allocatedBlocks = v._size = 0 , v._blocks = NullPointer( Pointer( T ) );
+			return *this;
+		}
+
+		size_t size( void ) const { return _size; }
+
+		const T& operator[]( size_t idx ) const { return _blocks[idx>>LogBlockSize][idx&_Mask]; }
+		T& operator[]( size_t idx ){ return _blocks[idx>>LogBlockSize][idx&_Mask]; }
+
+		void resize( size_t size ){ resize( size , _defaultValue ); }
+		void resize( size_t size , const T& defaultValue )
+		{
+			reserve( size , defaultValue );
+			_size = size;
+		}
+
+		void clear( void ){ _size = 0; }
+
+		size_t reserved( void ) const { return _allocatedBlocks * _BlockSize; }
+
+		void reserve( size_t size ){ reserve( size , _defaultValue ); }
+		void reserve( size_t size , const T& defaultValue )
+		{
+			if( size<=_allocatedBlocks * _BlockSize ) return;
+			size_t index = size-1;
+			size_t block = index >> LogBlockSize;
+			size_t blockIndex = index & _Mask;
+
+			// If there are insufficiently many blocks
+			if( block>=_reservedBlocks )
+			{
+				size_t newReservedSize = std::max< size_t >( _reservedBlocks * AllocationMultiplier , block+1 );
+				Pointer( Pointer( T ) ) __blocks = NewPointer< Pointer( T ) >( newReservedSize );
+				memcpy( __blocks , _blocks , sizeof( Pointer( T ) ) * _reservedBlocks );
+				for( size_t i=_reservedBlocks ; i<newReservedSize ; i++ ) __blocks[i] = NullPointer( T );
+				Pointer( Pointer( T ) ) _oldBlocks = _blocks;
+				_blocks = __blocks;
+				_reservedBlocks = newReservedSize;
+				DeletePointer( _oldBlocks );
+			}
+
+			// If the block hasn't been allocated
+			if( block>=_allocatedBlocks )
+			{
+				for( size_t b=_allocatedBlocks ; b<=block ; b++ )
+				{
+					_blocks[b] = NewPointer< T >( _BlockSize );
+					for( size_t i=0 ; i<_BlockSize ; i++ ) _blocks[b][i] = defaultValue;
+				}
+				_allocatedBlocks = block+1;
+			}
+		}
+		void push_back( const T &value )
+		{
+			resize( _size+1 );
+			operator[]( _size-1 ) = value;
+		}
+		T &back( void ){ return operator[]( _size-1 ); }
+		const T &back( void ) const { return operator[]( _size-1 ); }
+		void pop_back( void ){ _size--; }
+
+		void write( BinaryStream &stream ) const
+		{
+			stream.write( _size );
+			stream.write( _defaultValue );
+			stream.write( _reservedBlocks );
+			stream.write( _allocatedBlocks );
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ ) stream.write( _blocks[i] , _BlockSize );
+		}
+
+		void read( BinaryStream &stream )
+		{
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ ) DeletePointer( _blocks[i] );
+			DeletePointer( _blocks );
+			if( !stream.read( _size ) ) MK_THROW( "Failed to read _size" );
+			if( !stream.read( _defaultValue ) ) MK_THROW( "Failed to read _defaultValue" );
+			if( !stream.read( _reservedBlocks ) ) MK_THROW( "Failed to read _reservedBlocks" );
+			if( !stream.read( _allocatedBlocks ) ) MK_THROW( "Failed to read _allocatedBlocks" );
+
+			_blocks = NewPointer< Pointer( T ) >( _reservedBlocks );
+			if( !_blocks ) MK_THROW( "Failed to allocate _blocks: " , _reservedBlocks );
+
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ )
+			{
+				_blocks[i] = NewPointer< T >( _BlockSize );
+				if( !_blocks[i] ) MK_THROW( "Failed to allocate _blocks[" , i , "]" );
+				if( !stream.read( _blocks[i] , _BlockSize ) ) MK_THROW( "Failed to read _blocks[" , i , "]" );
+			}
+			for( size_t i=_allocatedBlocks ; i<_reservedBlocks ; i++ ) _blocks[i] = NullPointer( T );
+		}
+
+		void read( BinaryStream &stream , const Serializer< T > &serializer )
+		{
+			const size_t serializedSize = serializer.size();
+
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ ) DeletePointer( _blocks[i] );
+			DeletePointer( _blocks );
+			_size = _allocatedBlocks = _reservedBlocks = 0;
+
+			if( !stream.read( _size ) ) MK_THROW( "Failed to read _size" );
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Should deserialize default value" )
+#endif // SHOW_WARNINGS
+			if( !stream.read( _defaultValue ) ) MK_THROW( "Failed to read _defaultValue" );
+			if( !stream.read( _reservedBlocks ) ) MK_THROW( "Failed to read _reservedBlocks" );
+			if( !stream.read( _allocatedBlocks ) ) MK_THROW( "Failed to read _allocatedBlocks" );
+			_blocks = NewPointer< Pointer( T ) >( _reservedBlocks );
+			if( !_blocks ) MK_THROW( "Failed to allocate _blocks: " , _reservedBlocks );
+			for( size_t i=0 ; i<_allocatedBlocks ; i++ )
+			{
+				_blocks[i] = NewPointer< T >( _BlockSize );
+				if( !_blocks[i] ) MK_THROW( "Failed to allocate _blocks[" , i , "]" );
+			}
+			if( _size )
+			{
+				Pointer( char ) buffer = NewPointer< char >( _size * serializedSize );
+				if( !stream.read( buffer , serializedSize*_size ) ) MK_THROW( "Failed tor read in data" );
+				for( unsigned int i=0 ; i<_size ; i++ ) serializer.deserialize( buffer+i*serializedSize , operator[]( i ) );
+				DeletePointer( buffer );
+			}
+		}
+
+		void write( BinaryStream &stream , const Serializer< T > &serializer ) const
+		{
+			const size_t serializedSize = serializer.size();
+
+			stream.write( _size );
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Should serialize default value" )
+#endif // SHOW_WARNINGS
+			stream.write( _defaultValue );
+			stream.write( _reservedBlocks );
+			stream.write( _allocatedBlocks );
+			if( _size )
+			{
+				Pointer( char ) buffer = NewPointer< char >( _size * serializedSize );
+				for( unsigned int i=0 ; i<_size ; i++ ) serializer.serialize( operator[]( i ) , buffer+i*serializedSize );
+				stream.write( buffer , serializedSize*_size );
+				DeletePointer( buffer );
+			}
+		}
+
+
+	protected:
+		static const size_t _BlockSize = 1<<LogBlockSize;
+		static const size_t _Mask = (1<<LogBlockSize)-1;
+
+		T _defaultValue;
+		size_t _allocatedBlocks , _reservedBlocks;
+#ifdef SANITIZED_PR
+		std::atomic< size_t > _size;
+		std::atomic< Pointer( Pointer( T ) ) > _blocks;
+#else // !SANITIZED_PR
+		size_t _size;
+		Pointer( Pointer( T ) ) _blocks;
+#endif // SANITIZED_PR
+	};
+}
+#endif // BLOCKED_VECTOR_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/CmdLineParser.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/CmdLineParser.h
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef CMD_LINE_PARSER_INCLUDED
+#define CMD_LINE_PARSER_INCLUDED
+
+#include <stdarg.h>
+#include <cstring>
+#include <cstdlib>
+#include <string>
+#include <cassert>
+#include <string.h>
+#include <vector>
+#include "Geometry.h"
+
+namespace PoissonRecon
+{
+#ifdef WIN32
+	int strcasecmp( const char* c1 , const char* c2 );
+#endif // WIN32
+
+	class CmdLineReadable
+	{
+	public:
+		bool set;
+		char *name;
+		CmdLineReadable( const char *name );
+		virtual ~CmdLineReadable( void );
+		virtual int read( char** argv , int argc );
+		virtual void writeValue( char* str ) const;
+	};
+
+	template< typename Type > struct CmdLineType;
+
+	template< typename Type >
+	struct CmdLineType
+	{
+		static void WriteValue( Type t , char* str );
+		static void CleanUp( Type* t ){}
+		static Type Initialize( void ){ return Type(); }
+		static Type Copy( Type t ){ return t; }
+		static Type StringToType( const char *str );
+	};
+
+	template< typename Real , unsigned int Dim >
+	struct CmdLineType< Point< Real , Dim > >
+	{
+		using Type = Point< Real , Dim >;
+		static void WriteValue( Type t , char* str );
+		static void CleanUp( Type* t ){}
+		static Type Initialize( void ){ return Type(); }
+		static Type Copy( Type t ){ return t; }
+		static Type StringToType( const char *str );
+	};
+	template< class Type >
+	class CmdLineParameter : public CmdLineReadable
+	{
+	public:
+		Type value;
+		CmdLineParameter( const char *name );
+		CmdLineParameter( const char *name , Type v );
+		~CmdLineParameter( void );
+		int read( char** argv , int argc );
+		void writeValue( char* str ) const;
+		bool expectsArg( void ) const { return true; }
+	};
+
+	template< class Type , int Dim >
+	class CmdLineParameterArray : public CmdLineReadable
+	{
+	public:
+		Type values[Dim];
+		CmdLineParameterArray( const char *name, const Type* v=NULL );
+		~CmdLineParameterArray( void );
+		int read( char** argv , int argc );
+		void writeValue( char* str ) const;
+		bool expectsArg( void ) const { return true; }
+	};
+
+	template< class Type >
+	class CmdLineParameters : public CmdLineReadable
+	{
+	public:
+		int count;
+		Type *values;
+		CmdLineParameters( const char* name );
+		~CmdLineParameters( void );
+		int read( char** argv , int argc );
+		void writeValue( char* str ) const;
+		bool expectsArg( void ) const { return true; }
+	};
+
+	void CmdLineParse( int argc , char **argv, CmdLineReadable** params );
+	char* FileExtension( char* fileName );
+	char* LocalFileName( char* fileName );
+	char* DirectoryName( char* fileName );
+	char* GetFileExtension( const char* fileName );
+	char* GetLocalFileName( const char* fileName );
+	char** ReadWords( const char* fileName , int& cnt );
+
+#include "CmdLineParser.inl"
+}
+#endif // CMD_LINE_PARSER_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/CmdLineParser.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/CmdLineParser.inl
@@ -1,0 +1,355 @@
+/* -*- C++ -*-
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#if defined( WIN32 ) || defined( _WIN64 )
+inline int strcasecmp( const char* c1 , const char* c2 ){ return _stricmp( c1 , c2 ); }
+#endif // WIN32 || _WIN64
+
+template< > inline void         CmdLineType< char*       >::CleanUp( char** t ){ if( *t ) free( *t ) ; *t = NULL; }
+
+template< > inline int          CmdLineType< int          >::Initialize( void ){ return 0; }
+template< > inline unsigned int CmdLineType< unsigned int >::Initialize( void ){ return 0u; }
+template< > inline float        CmdLineType< float        >::Initialize( void ){ return 0.f; }
+template< > inline double       CmdLineType< double       >::Initialize( void ){ return 0.; }
+template< > inline char *       CmdLineType< char *       >::Initialize( void ){ return NULL; }
+
+template< > inline void   CmdLineType< int          >::WriteValue( int          t , char* str ){ sprintf( str , "%d" , t ); }
+template< > inline void   CmdLineType< unsigned int >::WriteValue( unsigned int t , char* str ){ sprintf( str , "%u" , t ); }
+template< > inline void   CmdLineType< float        >::WriteValue( float        t , char* str ){ sprintf( str , "%f" , t ); }
+template< > inline void   CmdLineType< double       >::WriteValue( double       t , char* str ){ sprintf( str , "%f" , t ); }
+template< > inline void   CmdLineType< char *       >::WriteValue( char        *t , char* str ){ if( t ) sprintf( str , "%s" , t ) ; else str[0]=0; }
+template< > inline void   CmdLineType< std::string  >::WriteValue( std::string  t , char* str ){ sprintf( str , "%s" , t.c_str() ); }
+template< typename Real , unsigned int Dim >
+void CmdLineType< Point< Real , Dim > >::WriteValue( Point< Real , Dim > t , char *str )
+{
+	size_t start = 0;
+	sprintf( str , "{" );
+	start = strlen( str );
+	for( unsigned int d=0 ; d<Dim ; d++ )
+	{
+		if( d ) sprintf( str+start , ",%f" , t[d] );
+		else    sprintf( str+start ,  "%f" , t[d] );
+		start = strlen( str );
+	}
+	sprintf( str+start , "}" );
+}
+
+#if defined( WIN32 ) || defined( _WIN64 )
+template< > inline char*  CmdLineType< char*       >::Copy( char* t ){ return _strdup( t ); }
+#else // !WIN32 && !_WIN64
+template< > inline char*  CmdLineType< char*       >::Copy( char* t ){ return strdup( t ); }
+#endif // WIN32 || _WIN64
+
+template< > inline int          CmdLineType< int          >::StringToType( const char* str ){ return atoi( str ); }
+template< > inline unsigned int CmdLineType< unsigned int >::StringToType( const char* str ){ return (unsigned int)atoll( str ); }
+template< > inline float        CmdLineType< float        >::StringToType( const char* str ){ return float( atof( str ) ); }
+template< > inline double       CmdLineType< double       >::StringToType( const char* str ){ return double( atof( str ) ); }
+#if defined( WIN32 ) || defined( _WIN64 )
+template< > inline char *       CmdLineType< char*        >::StringToType( const char* str ){ return _strdup( str ); }
+#else // !WIN32 && !_WIN64
+template< > inline char *       CmdLineType< char*        >::StringToType( const char* str ){ return  strdup( str ); }
+#endif // WIN32 || _WIN64
+template< > inline std::string  CmdLineType< std::string  >::StringToType( const char* str ){ return std::string( str ); }
+
+template< typename Real , unsigned int Dim >
+Point< Real , Dim > CmdLineType< Point< Real , Dim > >::StringToType( const char *str )
+{
+	Point< Real , Dim > t;
+
+	char *_str = new char[ strlen(str)+1 ];
+	assert( _str );
+	strcpy( _str , str );
+	char *temp = strtok( _str , "," );
+
+	unsigned int d = 0;
+	while( temp!=NULL )
+	{
+		if( d==0 )
+		{
+			if( temp[0]!='{' ) MK_THROW( "Expected opening brace: " , std::string( str ) );
+			t[d++] = CmdLineType< Real >::StringToType( temp+1 );
+		}
+		else if( d==Dim-1 )
+		{
+			if( temp[ strlen(temp)-1 ]!='}' )  MK_THROW( "Expected closing brace: " , std::string( str ) );
+			temp[ strlen(temp)-1 ] = 0;
+			t[d++] = CmdLineType< Real >::StringToType( temp );
+			break;
+		}
+		else t[d++] = CmdLineType< Real >::StringToType( temp );
+		temp = strtok( NULL ,"," );
+	}
+	if( d<Dim ) MK_THROW( "Could not parse all coordinates: " , std::string( str ) , " (" , Dim , ")" );
+	delete[] _str;
+	return t;
+}
+
+
+/////////////////////
+// CmdLineReadable //
+/////////////////////
+#if defined( WIN32 ) || defined( _WIN64 )
+inline CmdLineReadable::CmdLineReadable( const char *name ) : set(false) { this->name = _strdup( name ); }
+#else // !WIN32 && !_WIN64
+inline CmdLineReadable::CmdLineReadable( const char *name ) : set(false) { this->name =  strdup( name ); }
+#endif // WIN32 || _WIN64
+
+inline CmdLineReadable::~CmdLineReadable( void ){ if( name ) free( name ) ; name = NULL; }
+inline int CmdLineReadable::read( char** , int ){ set = true ; return 0; }
+inline void CmdLineReadable::writeValue( char* str ) const { str[0] = 0; }
+
+//////////////////////
+// CmdLineParameter //
+//////////////////////
+template< class Type > CmdLineParameter< Type >::~CmdLineParameter( void ) { CmdLineType< Type >::CleanUp( &value ); }
+template< class Type > CmdLineParameter< Type >::CmdLineParameter( const char *name ) : CmdLineReadable( name ){ value = CmdLineType< Type >::Initialize(); }
+template< class Type > CmdLineParameter< Type >::CmdLineParameter( const char *name , Type v ) : CmdLineReadable( name ){ value = CmdLineType< Type >::Copy( v ); }
+template< class Type >
+int CmdLineParameter< Type >::read( char** argv , int argc )
+{
+	if( argc>0 )
+	{
+		CmdLineType< Type >::CleanUp( &value );
+		value = CmdLineType< Type >::StringToType( argv[0] );
+		set = true;
+		return 1;
+	}
+	else return 0;
+}
+template< class Type >
+void CmdLineParameter< Type >::writeValue( char* str ) const { CmdLineType< Type >::WriteValue( value , str ); }
+
+
+///////////////////////////
+// CmdLineParameterArray //
+///////////////////////////
+template< class Type , int Dim >
+CmdLineParameterArray< Type , Dim >::CmdLineParameterArray( const char *name , const Type* v ) : CmdLineReadable( name )
+{
+	if( v ) for( int i=0 ; i<Dim ; i++ ) values[i] = CmdLineType< Type >::Copy( v[i] );
+	else    for( int i=0 ; i<Dim ; i++ ) values[i] = CmdLineType< Type >::Initialize();
+}
+
+template< class Type , int Dim >
+CmdLineParameterArray< Type , Dim >::~CmdLineParameterArray( void ){ for( int i=0 ; i<Dim ; i++ ) CmdLineType< Type >::CleanUp( values+i ); }
+
+template< class Type , int Dim >
+int CmdLineParameterArray< Type , Dim >::read( char** argv , int argc )
+{
+	if( argc>=Dim )
+	{
+		for( int i=0 ; i<Dim ; i++ ) CmdLineType< Type >::CleanUp( values+i ) , values[i] = CmdLineType< Type >::StringToType( argv[i] );
+		set = true;
+		return Dim;
+	}
+	else return 0;
+}
+template< class Type , int Dim >
+void CmdLineParameterArray< Type , Dim >::writeValue( char* str ) const
+{
+	char* temp=str;
+	for( int i=0 ; i<Dim ; i++ )
+	{
+		CmdLineType< Type >::WriteValue( values[i] , temp );
+		temp = str+strlen( str );
+	}
+}
+///////////////////////
+// CmdLineParameters //
+///////////////////////
+template< class Type >
+CmdLineParameters< Type >::CmdLineParameters( const char* name ) : CmdLineReadable( name ) , values(NULL) , count(0) { }
+
+template< class Type >
+CmdLineParameters< Type >::~CmdLineParameters( void )
+{
+	if( values ) delete[] values;
+	values = NULL;
+	count = 0;
+}
+
+template< class Type >
+int CmdLineParameters< Type >::read( char** argv , int argc )
+{
+	if( values ) delete[] values;
+	values = NULL;
+
+	if( argc>0 )
+	{
+		count = atoi(argv[0]);
+		if( count <= 0 || argc <= count ) return 1;
+		values = new Type[count];
+		if( !values ) return 0;
+		for( int i=0 ; i<count ; i++ ) values[i] = CmdLineType< Type >::StringToType( argv[i+1] );
+		set = true;
+		return count+1;
+	}
+	else return 0;
+}
+
+template< class Type >
+void CmdLineParameters< Type >::writeValue( char* str ) const
+{
+	char* temp=str;
+	CmdLineType< int >::WriteValue( count , temp );
+	temp = str + strlen( str );
+	for( int i=0 ; i<count ; i++ )
+	{
+		temp[0] = ' ' , temp++;
+		CmdLineType< Type >::WriteValue( values[i] , temp );
+		temp = str+strlen( str );
+	}
+}
+
+inline char* FileExtension( char* fileName )
+{
+	char* temp = fileName;
+	for( int i=0 ; i<strlen(fileName) ; i++ ) if( fileName[i]=='.' ) temp = &fileName[i+1];
+	return temp;
+}
+
+inline char* GetFileExtension( const char* fileName )
+{
+	char* fileNameCopy;
+	char* ext=NULL;
+	char* temp;
+
+	fileNameCopy=new char[strlen(fileName)+1];
+	assert(fileNameCopy);
+	strcpy(fileNameCopy,fileName);
+	temp=strtok(fileNameCopy,".");
+	while(temp!=NULL)
+	{
+		if(ext!=NULL){delete[] ext;}
+		ext=new char[strlen(temp)+1];
+		assert(ext);
+		strcpy(ext,temp);
+		temp=strtok(NULL,".");
+	}
+	delete[] fileNameCopy;
+	return ext;
+}
+inline char* GetLocalFileName( const char* fileName )
+{
+	char* fileNameCopy;
+	char* name=NULL;
+	char* temp;
+
+	fileNameCopy=new char[strlen(fileName)+1];
+	assert(fileNameCopy);
+	strcpy(fileNameCopy,fileName);
+	temp=strtok(fileNameCopy,"\\");
+	while(temp!=NULL){
+		if(name!=NULL){delete[] name;}
+		name=new char[strlen(temp)+1];
+		assert(name);
+		strcpy(name,temp);
+		temp=strtok(NULL,"\\");
+	}
+	delete[] fileNameCopy;
+	return name;
+}
+inline char* LocalFileName( char* fileName )
+{
+	char* temp = fileName;
+	for( int i=0 ; i<(int)strlen(fileName) ; i++ ) if( fileName[i] =='\\' ) temp = &fileName[i+1];
+	return temp;
+}
+inline char* DirectoryName( char* fileName )
+{
+	for( int i=int( strlen(fileName) )-1 ; i>=0 ; i-- )
+		if( fileName[i] =='\\' )
+		{
+			fileName[i] = 0;
+			return fileName;
+		}
+	fileName[0] = 0;
+	return fileName;
+}
+
+inline void CmdLineParse( int argc , char **argv , CmdLineReadable** params )
+{
+	while( argc>0 )
+	{
+		if( argv[0][0]=='-' && argv[0][1]=='-' )
+		{
+			CmdLineReadable* readable=NULL;
+			for( int i=0 ; params[i]!=NULL && readable==NULL ; i++ ) if( !strcasecmp( params[i]->name , argv[0]+2 ) ) readable = params[i];
+			if( readable )
+			{
+				int j = readable->read( argv+1 , argc-1 );
+				argv += j , argc -= j;
+			}
+			else
+			{
+				MK_WARN( "Invalid option: " , argv[0] );
+				for( int i=0 ; params[i]!=NULL ; i++ ) fprintf( stderr , "\t--%s\n" , params[i]->name );
+			}
+		}
+		else MK_WARN( "Parameter name should be of the form --<name>: " , argv[0] );
+		++argv , --argc;
+	}
+}
+
+inline char** ReadWords(const char* fileName,int& cnt)
+{
+	char** names;
+	char temp[500];
+	FILE* fp;
+
+	fp=fopen(fileName,"r");
+	if(!fp){return NULL;}
+	cnt=0;
+	while(fscanf(fp," %s ",temp)==1){cnt++;}
+	fclose(fp);
+
+	names=new char*[cnt];
+	if(!names){return NULL;}
+
+	fp=fopen(fileName,"r");
+	if(!fp){
+		delete[] names;
+		cnt=0;
+		return NULL;
+	}
+	cnt=0;
+	while(fscanf(fp," %s ",temp)==1){
+		names[cnt]=new char[strlen(temp)+1];
+		if(!names){
+			for(int j=0;j<cnt;j++){delete[] names[j];}
+			delete[] names;
+			cnt=0;
+			fclose(fp);
+			return NULL;
+		}
+		strcpy(names[cnt],temp);
+		cnt++;
+	}
+	fclose(fp);
+	return names;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/DataStream.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/DataStream.h
@@ -1,0 +1,311 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef DATA_STREAM_INCLUDED
+#define DATA_STREAM_INCLUDED
+
+#include <mutex>
+#include <vector>
+#include <atomic>
+#include "Geometry.h"
+
+namespace PoissonRecon
+{
+	// The input/output stream types
+	template< typename ... Data > struct  InputDataStream;
+	template< typename ... Data > struct OutputDataStream;
+
+	// Input/output streams, internally represented by an std::vector< Input/OutputDataStream< Data ... > >
+	template< typename ... Data > struct  MultiInputDataStream;
+	template< typename ... Data > struct MultiOutputDataStream;
+
+	// Class for de-interleaving output
+	template< typename ... Data > using                    OutputIndexedDataStream =      OutputDataStream< size_t , Data ... >;
+	template< typename ... Data > using               MultiOutputIndexedDataStream = MultiOutputDataStream< size_t , Data ... >;
+	template< typename ... Data > struct DeInterleavedMultiOutputIndexedDataStream;
+
+	// Classes for re-interleaving input
+	template< typename ... Data > using                  InputIndexedDataStream =      InputDataStream< size_t , Data ... >;
+	template< typename ... Data > using             MultiInputIndexedDataStream = MultiInputDataStream< size_t , Data ... >;
+	template< typename ... Data > struct InterleavedMultiInputIndexedDataStream;
+
+	// Classes for converting one stream type to another
+	template< typename IDataTuple , typename XDataTuple > struct  InputDataStreamConverter;
+	template< typename IDataTuple , typename XDataTuple > struct OutputDataStreamConverter;
+
+	template< typename ... Data >
+	struct TupleConverter
+	{
+		static void FromTuple( const std::tuple< Data ... > &dTuple , Data& ... d );
+		static void ToTuple( std::tuple< Data ... > &dTuple , const Data& ... d );
+	protected:
+		template< unsigned int I , typename _Data , typename ... _Datas >
+		static void _FromTuple( const std::tuple< Data ... > &dTuple , _Data &d , _Datas& ... ds );
+		template< unsigned int I , typename _Data , typename ... _Datas >
+		static void _ToTuple( std::tuple< Data ... > &dTuple , const _Data &d , const _Datas& ... ds );
+	};
+
+	template< typename Real , typename ... Data >
+	struct DirectSumConverter
+	{
+		static void FromDirectSum( const DirectSum< Real ,  Data ... > &dSum , Data& ... d );
+		static void ToDirectSum( DirectSum< Real , Data ... > &dSum , const Data& ... d );
+	protected:
+		template< unsigned int I , typename _Data , typename ... _Datas >
+		static void _FromDirectSum( const DirectSum<Real , Data ... > &dSum , _Data &d , _Datas& ... ds );
+		template< unsigned int I , typename _Data , typename ... _Datas >
+		static void _ToDirectSum( DirectSum< Real , Data ... > &dSum , const _Data &d , const _Datas& ... ds );
+	};
+
+	////////////////////////
+	// Input data streams //
+	////////////////////////
+
+	// An input stream containing "Data" types
+	// Supporting:
+	// -- Resetting the stream to the start
+	// -- Trying to read the next element from the stream
+	template< typename ... Data >
+	struct InputDataStream
+	{
+		friend struct MultiInputDataStream< Data...  >;
+
+		virtual ~InputDataStream( void ){}
+
+		// Reset to the start of the stream
+		virtual void reset( void ) = 0;
+
+		// Read the next datum from the stream
+		virtual bool read(                       Data& ... d ) = 0;
+		virtual bool read( unsigned int thread , Data& ... d );
+
+		bool read(                       std::tuple< Data ... > &data );
+		bool read( unsigned int thread , std::tuple< Data ... > &data );
+
+		template< typename Real >
+		bool read(                       DirectSum< Real , Data ... > &data );
+		template< typename Real >
+		bool read( unsigned int thread , DirectSum< Real , Data ... > &data );
+
+	protected:
+		std::mutex _insertionMutex;
+
+		template< typename ... _Data >
+		bool _read( std::tuple< Data ... > &data , _Data& ... _data );
+		template< typename ... _Data >
+		bool _read( unsigned int thread , std::tuple< Data ... > &data , _Data& ... _data );
+		template< typename Real , typename ... _Data >
+		bool _read( DirectSum< Real , Data ... > &data , _Data& ... _data );
+		template< typename Real , typename ... _Data >
+		bool _read( unsigned int thread , DirectSum< Real , Data ... > &data , _Data& ... _data );
+	};
+
+
+	/////////////////////////
+	// Output data streams //
+	/////////////////////////
+	// 
+	// An output stream containing "Data" types
+	// Supporting:
+	// -- Writing the next element to the stream
+	// -- Pushing the next element to the stream (and getting the count of elements pushed so far)
+	template< typename ... Data >
+	struct OutputDataStream
+	{
+		friend struct MultiOutputDataStream< Data ... >;
+
+		OutputDataStream( void ){}
+		virtual ~OutputDataStream( void ){}
+
+		virtual size_t size( void ) const = 0;
+
+		virtual size_t write(                       const Data& ... d ) = 0;
+		virtual size_t write( unsigned int thread , const Data& ... d );
+
+		size_t write(                       const std::tuple< Data ... > &data );
+		size_t write( unsigned int thread , const std::tuple< Data ... > &data );
+
+		template< typename Real > size_t write(                       const DirectSum< Real , Data ... > &data );
+		template< typename Real > size_t write( unsigned int thread , const DirectSum< Real , Data ... > &data );
+
+	protected:
+		std::mutex _insertionMutex;
+
+		template< typename ... _Data > size_t _write(                       const std::tuple< Data ... > &data , const _Data& ... _data );
+		template< typename ... _Data > size_t _write( unsigned int thread , const std::tuple< Data ... > &data , const _Data& ... _data );
+
+		template< typename Real , typename ... _Data > size_t _write(                       const DirectSum< Real , Data ... > &data , const _Data& ... _data );
+		template< typename Real , typename ... _Data > size_t _write( unsigned int thread , const DirectSum< Real , Data ... > &data , const _Data& ... _data );
+	};
+
+	////////////////////////////////
+	// Multiple input data stream //
+	////////////////////////////////
+	template< typename ...Data >
+	struct MultiInputDataStream : public InputDataStream< Data ... >
+	{
+		using InputDataStream< Data ... >::read;
+
+		MultiInputDataStream( InputDataStream< Data ... > **streams , size_t N );
+		MultiInputDataStream( const std::vector< InputDataStream< Data ... > * > &streams );
+
+		void reset( void );
+
+		unsigned int numStreams( void ) const;
+
+		bool read( unsigned int t , Data& ... d );
+		bool read(                  Data& ... d );
+
+	protected:
+		std::vector< InputDataStream< Data ... > * > _streams;
+		unsigned int _current;
+	};
+
+
+	/////////////////////////////////
+	// Multiple output data stream //
+	/////////////////////////////////
+	template< typename ... Data >
+	struct MultiOutputDataStream : public OutputDataStream< Data ... >
+	{
+		using OutputDataStream< Data ... >::write;
+
+		MultiOutputDataStream( OutputDataStream< Data ... > **streams , size_t N );
+		MultiOutputDataStream( const std::vector< OutputDataStream< Data ... > * > &streams );
+
+		unsigned int numStreams( void ) const;
+
+		size_t size( void ) const { return _size; }
+
+		size_t write(                  const Data& ... d );
+		size_t write( unsigned int t , const Data& ... d );
+
+	protected:
+		std::vector< OutputDataStream< Data ... > * > _streams;
+		std::atomic< size_t > _size;
+	};
+
+	/////////////////////////////////
+	// Input data stream converter //
+	/////////////////////////////////
+	template< typename ... IData , typename ... XData >
+	struct InputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > > : public InputDataStream< XData ... >
+	{
+		using InputDataStream< XData ... >::read;
+
+		InputDataStreamConverter( InputDataStream< IData ... > &stream , std::function< std::tuple< XData ... > ( const std::tuple< IData ... >& ) > converter , IData ... zero );
+		void reset( void );
+		bool read(                       XData& ... xData );
+		bool read( unsigned int thread , XData& ... xData );
+
+	protected:
+		InputDataStream< IData ... > &_stream;
+		std::function< std::tuple< XData ... > ( const std::tuple< IData ... >& ) > _converter;
+		std::tuple< IData ... > _iZero;
+	};
+
+	//////////////////////////////////
+	// Output data stream converter //
+	//////////////////////////////////
+	template< typename ... IData , typename ... XData >
+	struct OutputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > > : public OutputDataStream< XData ... >
+	{
+		using OutputDataStream< XData ... >::write;
+
+		OutputDataStreamConverter( OutputDataStream< IData ... > &stream , std::function< std::tuple< IData ... > ( const std::tuple< XData ... >& ) > converter );
+
+		size_t size( void ) const { return _stream.size(); }
+
+		size_t write(                       const XData& ... xData );
+		size_t write( unsigned int thread , const XData& ... xData );
+	protected:
+		OutputDataStream< IData ... > &_stream;
+		std::function< std::tuple< IData ... > ( const std::tuple< XData ... >& ) > _converter;
+	};
+
+
+	////////////////////////////////////////////////
+	// De-interleaved multiple output data stream //
+	////////////////////////////////////////////////
+	template< typename ... Data >
+	struct DeInterleavedMultiOutputIndexedDataStream : public OutputDataStream< Data ... >
+	{
+		using OutputDataStream< Data ... >::write;
+
+		DeInterleavedMultiOutputIndexedDataStream( OutputIndexedDataStream< Data ... > **streams , size_t N );
+		DeInterleavedMultiOutputIndexedDataStream( const std::vector< OutputIndexedDataStream<  Data ... > * > &streams );
+
+		unsigned int numStreams( void ) const;
+
+		size_t size( void ) const { return _size; }
+
+		size_t write(                       const Data& ... d );
+		size_t write( unsigned int thread , const Data& ... d );
+
+	protected:
+		MultiOutputIndexedDataStream< Data ... > _multiStream;
+		std::atomic< size_t > _size;
+	};
+
+
+	////////////////////////////////////////////
+	// Interleaved multiple input data stream //
+	////////////////////////////////////////////
+
+	template< typename ... Data >
+	struct InterleavedMultiInputIndexedDataStream : public InputDataStream< Data ... >
+	{
+		using InputDataStream< Data... >::read;
+
+		InterleavedMultiInputIndexedDataStream( InputIndexedDataStream< Data ... > **streams , size_t N );
+		InterleavedMultiInputIndexedDataStream( const std::vector< InputIndexedDataStream<  Data ... > * > &streams );
+		void reset( void );
+		bool read( Data& ... d );
+
+	protected:
+
+		struct _NextValue
+		{
+			std::tuple< size_t , Data ... > data;
+			unsigned int streamIndex;
+			bool validData;
+
+			// Returns true if v1>v2 so that it's a min-heap
+			static bool Compare( const _NextValue &v1 , const _NextValue &v2 );
+		};
+
+		MultiInputIndexedDataStream< Data... > _multiStream;
+		std::vector< _NextValue > _nextValues;
+		bool _firstTime;
+
+		void _init( const std::tuple< Data ... > &data );
+	};
+#include "DataStream.inl"
+}
+
+#endif // DATA_STREAM_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/DataStream.imp.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/DataStream.imp.h
@@ -1,0 +1,393 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef DATA_STREAM_IMPLEMENTATION_INCLUDED
+#define DATA_STREAM_IMPLEMENTATION_INCLUDED
+
+#include <vector>
+#include "DataStream.h"
+#include "VertexFactory.h"
+#include "Ply.h"
+
+namespace PoissonRecon
+{
+	////////////////////////////////
+	// Vector-backed data streams //
+	////////////////////////////////
+	template< typename Data >
+	struct VectorBackedInputDataStream : public InputDataStream< Data >
+	{
+		VectorBackedInputDataStream( const std::vector< Data > &data ) : _data(data) , _current(0) {}
+		void reset( void ) { _current = 0; }
+
+		bool read( Data &d ){ if( _current<_data.size() ){ d = _data[_current++] ; return true; } else return false; }
+
+	protected:
+		const std::vector< Data > &_data;
+		size_t _current;
+	};
+
+	template< typename Data >
+	struct VectorBackedInputIndexedDataStream : public InputIndexedDataStream< Data >
+	{
+		VectorBackedInputIndexedDataStream( const std::vector< std::pair< size_t , Data > > &data ) : _data(data) , _current(0) {}
+		void reset( void ) { _current = 0; }
+
+		bool read( size_t &idx , Data &d )
+		{
+			if( _current<_data.size() )
+			{
+				idx = _data[_current].first;
+				d = _data[_current].second;
+				_current++;
+				return true;
+			}
+			else return false;
+		}
+
+	protected:
+		const std::vector< std::pair< size_t , Data > > &_data;
+		size_t _current;
+	};
+
+	template< typename Data >
+	struct VectorBackedOutputDataStream : public OutputDataStream< Data >
+	{
+		VectorBackedOutputDataStream( std::vector< Data > &data ) : _data(data) {}
+		size_t write( const Data &d ){ size_t idx = _data.size() ; _data.push_back(d) ; return idx; }
+		size_t size( void ) const { return _data.size(); }
+	protected:
+		std::vector< Data > &_data;
+	};
+
+	template< typename Data >
+	struct VectorBackedOutputIndexedDataStream : public OutputIndexedDataStream< Data >
+	{
+		VectorBackedOutputIndexedDataStream( std::vector< std::pair< size_t , Data > > &data ) : _data(data) {}
+		size_t write( const size_t &idx , const Data &d )
+		{
+			size_t sz = _data.size();
+			_data.push_back( std::make_pair( idx , d ) );
+			return idx;
+		}
+		size_t size( void ) const { return _data.size(); }
+	protected:
+		std::vector< std::pair< size_t , Data > > &_data;
+	};
+
+
+	////////////////////////////////////////////////////////////////////
+	// File-backed data stream (assumes Data is statically allocated) //
+	////////////////////////////////////////////////////////////////////
+	template< typename Data >
+	struct FileBackedInputDataStream : public InputDataStream< Data >
+	{
+		// It is assumed that the file pointer was open for binary reading
+		FileBackedInputDataStream( FILE *fp ) : _fp(fp) {}
+		void reset( void ){ fseek( _fp , 0 , SEEK_SET ); }
+		bool read( Data &d ){ return fread( &d , sizeof(Data) , 1 , _fp )==1; }
+
+	protected:
+		FILE *_fp;
+	};
+
+	template< typename Data >
+	struct FileBackedOutputDataStream : public OutputDataStream< Data >
+	{
+		// It is assumed that the file pointer was open for binary writing
+		FileBackedOutputDataStream( FILE *fp ) : _fp(fp) {}
+		size_t write( const Data &d ){ fwrite( &d , sizeof(Data) , 1 , _fp ) ; return _sz++; }
+		size_t size( void ) const { return _sz; }
+
+	protected:
+		size_t _sz = 0;
+		FILE *_fp;
+	};
+
+	/////////////////////////////////////////////////////////////////////////////////////////////
+	// File-backed data stream  specialized for vectors (assumes Data is statically allocated) //
+	/////////////////////////////////////////////////////////////////////////////////////////////
+	template< typename Data >
+	struct FileBackedInputDataStream< std::vector< Data > > : public InputDataStream< std::vector< Data > >
+	{
+		// It is assumed that the file pointer was open for binary reading
+		FileBackedInputDataStream( FILE *fp ) : _fp(fp) {}
+		void reset( void ){ fseek( _fp , 0 , SEEK_SET ); }
+		bool read( std::vector< Data > &d )
+		{
+			unsigned int pSize;
+			if( fread( &pSize , sizeof(unsigned int) , 1 , _fp )==1 )
+			{
+				d.resize( pSize );
+				if( fread( &d[0] , sizeof(Data) , pSize , _fp )==pSize ) return true;
+				MK_THROW( "Failed to read polygon from file" );
+				return true;
+			}
+			else return false;
+		}
+
+	protected:
+		FILE *_fp;
+	};
+
+	template< typename Data >
+	struct FileBackedOutputDataStream< std::vector< Data > > : public OutputDataStream< std::vector< Data > >
+	{
+		// It is assumed that the file pointer was open for binary writing
+		FileBackedOutputDataStream( FILE *fp ) : _fp(fp) {}
+		size_t write( const std::vector< Data > &d )
+		{
+			unsigned int pSize = (unsigned int)d.size();
+			fwrite( &pSize , sizeof(unsigned int) , 1 , _fp );
+			fwrite( &d[0] , sizeof(Data) , pSize , _fp );
+			return _sz++;
+		}
+		size_t size( void ) const { return _sz; }
+
+	protected:
+		size_t _sz = 0;
+		FILE *_fp;
+	};
+
+	////////////////////////////////////////////////////////
+	// File-backed stream with data desribed by a factory //
+	////////////////////////////////////////////////////////
+	template< typename Factory >
+	struct FileBackedInputFactoryTypeStream : public InputDataStream< typename Factory::VertexType >
+	{
+		using Data = typename Factory::VertexType;
+		// It is assumed that the file pointer was open for binary reading
+		FileBackedInputFactoryTypeStream( FILE *fp , const Factory &factory ) : _fp(fp) , _factory(factory) , _buffer( NewPointer< char >( _factory.bufferSize() ) ) , _bufferSize( _factory.bufferSize() ) {}
+		~FileBackedInputFactoryTypeStream( void ){ DeletePointer( _buffer ); }
+		void reset( void ){ fseek( _fp , 0 , SEEK_SET ); }
+		bool read( Data &d )
+		{
+			if( fread( _buffer , sizeof(unsigned char) , _bufferSize , _fp )==_bufferSize )
+			{
+				_factory.fromBuffer( _buffer , d );
+				return true;
+			}
+			else return false;
+			return _sz++;
+		}
+
+	protected:
+		size_t _sz = 0;
+		FILE *_fp;
+		const Factory _factory;
+		Pointer( char ) _buffer;
+		const size_t _bufferSize;
+	};
+
+	template< typename Factory >
+	struct FileBackedInputIndexedFactoryTypeStream : public InputIndexedDataStream< typename Factory::VertexType >
+	{
+		using Data = typename Factory::VertexType;
+		// It is assumed that the file pointer was open for binary reading
+		FileBackedInputIndexedFactoryTypeStream( FILE *fp , const Factory &factory ) : _fp(fp) , _factory(factory) , _buffer( NewPointer< char >( _factory.bufferSize() ) ) , _bufferSize( _factory.bufferSize() ) {}
+		~FileBackedInputIndexedFactoryTypeStream( void ){ DeletePointer( _buffer ); }
+		void reset( void ){ fseek( _fp , 0 , SEEK_SET ); }
+		bool read( size_t &idx , Data &d )
+		{
+			if( fread( &idx , sizeof(size_t) , 1 , _fp )!=1 ) return false;
+			if( fread( _buffer , sizeof(unsigned char) , _bufferSize , _fp )==_bufferSize )
+			{
+				_factory.fromBuffer( _buffer , d );
+				return true;
+			}
+			else return false;
+			return _sz++;
+		}
+
+	protected:
+		size_t _sz = 0;
+		FILE *_fp;
+		const Factory _factory;
+		Pointer( char ) _buffer;
+		const size_t _bufferSize;
+	};
+
+	template< typename Factory >
+	struct FileBackedOutputFactoryTypeStream : public OutputDataStream< typename Factory::VertexType >
+	{
+		using Data = typename Factory::VertexType;
+		// It is assumed that the file pointer was open for binary reading
+		FileBackedOutputFactoryTypeStream( FILE *fp , const Factory &factory ) : _fp(fp) , _factory(factory) , _buffer( NewPointer< char >( _factory.bufferSize() ) ) , _bufferSize( _factory.bufferSize() ) {}
+		~FileBackedOutputFactoryTypeStream( void ){ DeletePointer( _buffer ); }
+		size_t write( const Data &d )
+		{
+			_factory.toBuffer( d , _buffer );
+			fwrite( _buffer , sizeof(unsigned char) , _bufferSize , _fp );
+			return _sz++;
+		}
+		size_t size( void ) const { return _sz; }
+	protected:
+		size_t _sz = 0;
+		FILE *_fp;
+		const Factory _factory;
+		Pointer( char ) _buffer;
+		const size_t _bufferSize;
+	};
+
+	template< typename Factory >
+	struct FileBackedOutputIndexedFactoryTypeStream : public OutputIndexedDataStream< typename Factory::VertexType >
+	{
+		using Data = typename Factory::VertexType;
+		// It is assumed that the file pointer was open for binary reading
+		FileBackedOutputIndexedFactoryTypeStream( FILE *fp , const Factory &factory ) : _fp(fp) , _factory(factory) , _buffer( NewPointer< char >( _factory.bufferSize() ) ) , _bufferSize( _factory.bufferSize() ) {}
+		~FileBackedOutputIndexedFactoryTypeStream( void ){ DeletePointer( _buffer ); }
+		size_t write( const size_t &idx , const Data &d )
+		{
+			fwrite( &idx , sizeof(size_t) , 1 , _fp );
+			_factory.toBuffer( d , _buffer );
+			fwrite( _buffer , sizeof(unsigned char) , _bufferSize , _fp );
+			return _sz++;
+		}
+		size_t size( void ) const { return _sz; }
+	protected:
+		size_t _sz = 0;
+		FILE *_fp;
+		const Factory _factory;
+		Pointer( char ) _buffer;
+		const size_t _bufferSize;
+	};
+
+	///////////////////////////////////////////////////////////////////////////////////
+	// File-backed data streams, with functionality for reading/writing from/to disk //
+	///////////////////////////////////////////////////////////////////////////////////
+
+	template< typename Factory >
+	struct ASCIIInputDataStream : public InputDataStream< typename Factory::VertexType >
+	{
+		typedef typename Factory::VertexType Data;
+
+		ASCIIInputDataStream( const char* fileName , const Factory &factory );
+		~ASCIIInputDataStream( void );
+		void reset( void );
+		bool read( Data &d );
+
+	protected:
+		const Factory _factory;
+		FILE *_fp;
+	};
+
+	template< typename Factory >
+	struct ASCIIOutputDataStream : public OutputDataStream< typename Factory::VertexType >
+	{
+		typedef typename Factory::VertexType Data;
+
+		ASCIIOutputDataStream( const char* fileName , const Factory &factory );
+		~ASCIIOutputDataStream( void );
+		size_t write( const Data &d );
+		size_t size( void ) const { return _sz; }
+
+	protected:
+		size_t _sz = 0;
+		const Factory _factory;
+		FILE *_fp;
+	};
+
+	template< typename Factory >
+	struct BinaryInputDataStream : public InputDataStream< typename Factory::VertexType >
+	{
+		typedef typename Factory::VertexType Data;
+
+		BinaryInputDataStream( const char* filename , const Factory &factory );
+		~BinaryInputDataStream( void ){ fclose( _fp ) , _fp=NULL; }
+		void reset( void );
+		bool read( Data &d );
+
+	protected:
+		const Factory _factory;
+		FILE* _fp;
+	};
+
+	template< typename Factory >
+	struct BinaryOutputDataStream : public OutputDataStream< typename Factory::VertexType >
+	{
+		typedef typename Factory::VertexType Data;
+
+		BinaryOutputDataStream( const char* filename , const Factory &factory );
+		~BinaryOutputDataStream( void ){ fclose( _fp ) , _fp=NULL; }
+		void reset( void ){ fseek( _fp , 0 , SEEK_SET ); }
+		size_t write( const Data &d );
+		size_t size( void ) const { return _sz; }
+
+	protected:
+		size_t _sz = 0;
+		const Factory _factory;
+		FILE* _fp;
+	};
+
+	////////////////////////////////////////////
+	// File-backed PLY-described data streams //
+	////////////////////////////////////////////
+
+	template< typename Factory >
+	struct PLYInputDataStream : public InputDataStream< typename Factory::VertexType >
+	{
+		typedef typename Factory::VertexType Data;
+
+		PLYInputDataStream( const char* fileName , const Factory &factory );
+		PLYInputDataStream( const char* fileName , const Factory &factory , size_t &count );
+		~PLYInputDataStream( void );
+		void reset( void );
+		bool read( Data &d );
+
+	protected:
+		const Factory _factory;
+		char* _fileName;
+		PlyFile *_ply;
+		std::vector< std::string > _elist;
+		Pointer( char ) _buffer;
+
+		size_t _pCount , _pIdx;
+		void _free( void );
+	};
+
+	template< typename Factory >
+	struct PLYOutputDataStream : public OutputDataStream< typename Factory::VertexType >
+	{
+		typedef typename Factory::VertexType Data;
+
+		PLYOutputDataStream( const char* fileName , const Factory &factory , size_t count , int fileType=PLY_BINARY_NATIVE );
+		~PLYOutputDataStream( void );
+		size_t write( const Data &d );
+		size_t size( void ) const { return _pIdx; }
+
+	protected:
+		const Factory _factory;
+		PlyFile *_ply;
+		size_t _pCount , _pIdx;
+		Pointer( char ) _buffer;
+	};
+
+#include "DataStream.imp.inl"
+}
+
+#endif // DATA_STREAM_IMPLEMENTATION_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/DataStream.imp.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/DataStream.imp.inl
@@ -1,0 +1,242 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+//////////////////////////
+// ASCIIInputDataStream //
+//////////////////////////
+template< typename Factory >
+ASCIIInputDataStream< Factory >::ASCIIInputDataStream( const char* fileName , const Factory &factory ) : _factory( factory )
+{
+	_fp = fopen( fileName , "r" );
+	if( !_fp ) MK_THROW( "Failed to open file for reading: %s" , fileName );
+}
+
+template< typename Factory >
+ASCIIInputDataStream< Factory >::~ASCIIInputDataStream( void )
+{
+	fclose( _fp );
+	_fp = NULL;
+}
+
+template< typename Factory >
+void ASCIIInputDataStream< Factory >::reset( void ) { fseek( _fp , 0 , SEEK_SET ); }
+
+template< typename Factory >
+bool ASCIIInputDataStream< Factory >::read( Data &d ){ return _factory.readASCII( _fp , d ); }
+
+///////////////////////////
+// ASCIIOutputDataStream //
+///////////////////////////
+template< typename Factory >
+ASCIIOutputDataStream< Factory >::ASCIIOutputDataStream( const char* fileName , const Factory &factory ) : _factory( factory )
+{
+	_fp = fopen( fileName , "w" );
+	if( !_fp ) MK_THROW( "Failed to open file for writing: %s" , fileName );
+}
+
+template< typename Factory >
+ASCIIOutputDataStream< Factory >::~ASCIIOutputDataStream( void )
+{
+	fclose( _fp );
+	_fp = NULL;
+}
+
+template< typename Factory >
+size_t ASCIIOutputDataStream< Factory >::write( const Data &d ){ _factory.writeASCII( _fp , d ) ; return _sz++; }
+
+///////////////////////////
+// BinaryInputDataStream //
+///////////////////////////
+template< typename Factory >
+BinaryInputDataStream< Factory >::BinaryInputDataStream( const char* fileName , const Factory &factory ) : _factory(factory)
+{
+	_fp = fopen( fileName , "rb" );
+	if( !_fp ) MK_THROW( "Failed to open file for reading: %s" , fileName );
+}
+
+template< typename Factory >
+void BinaryInputDataStream< Factory >::reset( void ) { fseek( _fp , 0 , SEEK_SET ); }
+
+template< typename Factory >
+bool BinaryInputDataStream< Factory >::read( Data &d ){ return _factory.readBinary( _fp , d ); }
+
+////////////////////////////
+// BinaryOutputDataStream //
+////////////////////////////
+template< typename Factory >
+BinaryOutputDataStream< Factory >::BinaryOutputDataStream( const char* fileName , const Factory &factory ) : _factory(factory)
+{
+	_fp = fopen( fileName , "wb" );
+	if( !_fp ) MK_THROW( "Failed to open file for writing: %s" , fileName );
+}
+
+template< typename Factory >
+size_t BinaryOutputDataStream< Factory >::write( const Data &d ){ _factory.writeBinary( _fp , d ); return _sz++; }
+
+////////////////////////
+// PLYInputDataStream //
+////////////////////////
+template< typename Factory >
+PLYInputDataStream< Factory >::PLYInputDataStream( const char* fileName , const Factory &factory , size_t &count ) : _factory(factory)
+{
+	_fileName = new char[ strlen( fileName )+1 ];
+	strcpy( _fileName , fileName );
+	_ply = NULL;
+	if( factory.bufferSize() ) _buffer = NewPointer< char >( factory.bufferSize() );
+	else _buffer = NullPointer( char );
+	reset();
+	count = _pCount;
+}
+
+template< typename Factory >
+PLYInputDataStream< Factory >::PLYInputDataStream( const char* fileName , const Factory &factory ) : _factory(factory)
+{
+	_fileName = new char[ strlen( fileName )+1 ];
+	strcpy( _fileName , fileName );
+	_ply = NULL;
+	if( factory.bufferSize() ) _buffer = NewPointer< char >( factory.bufferSize() );
+	else _buffer = NullPointer( char );
+	reset();
+}
+
+template< typename Factory >
+void PLYInputDataStream< Factory >::reset( void )
+{
+	int fileType;
+	float version;
+	if( _ply ) _free();
+	_ply = PlyFile::Read( _fileName, _elist, fileType, version );
+	if( !_ply ) MK_THROW( "Failed to open ply file for reading: " , _fileName );
+
+	bool foundData = false;
+	for( int i=0 ; i<_elist.size() ; i++ )
+	{
+		std::string &elem_name = _elist[i];
+
+		if( elem_name=="vertex" )
+		{
+			size_t num_elems;
+			std::vector< PlyProperty > plist = _ply->get_element_description( elem_name , num_elems );
+			if( !plist.size() ) MK_THROW( "Failed to get description for \"" , elem_name , "\"" );
+
+			foundData = true;
+			_pCount = num_elems , _pIdx = 0;
+
+			bool* properties = new bool[ _factory.plyReadNum() ];
+			for( unsigned int i=0 ; i<_factory.plyReadNum() ; i++ )
+			{
+				PlyProperty prop;
+				if constexpr( Factory::IsStaticallyAllocated() ) prop = _factory.plyStaticReadProperty(i);
+				else                                             prop = _factory.plyReadProperty(i);
+				if( !_ply->get_property( elem_name , &prop ) ) properties[i] = false;
+				else                                           properties[i] = true;
+			}
+			bool valid = _factory.plyValidReadProperties( properties );
+			delete[] properties;
+			if( !valid ) MK_THROW( "Failed to validate properties in file" );
+		}
+	}
+	if( !foundData ) MK_THROW( "Could not find data in ply file" );
+}
+
+template< typename Factory >
+void PLYInputDataStream< Factory >::_free( void ){ delete _ply; }
+
+template< typename Factory >
+PLYInputDataStream< Factory >::~PLYInputDataStream( void )
+{
+	_free();
+	if( _fileName ) delete[] _fileName , _fileName = NULL;
+	DeletePointer( _buffer );
+}
+
+template< typename Factory >
+bool PLYInputDataStream< Factory >::read( Data &d )
+{
+	if( _pIdx<_pCount )
+	{
+		if constexpr( Factory::IsStaticallyAllocated() ) _ply->get_element( (void *)&d );
+		else
+		{
+			_ply->get_element( PointerAddress( _buffer ) );
+			_factory.fromBuffer( _buffer , d );
+		}
+		_pIdx++;
+		return true;
+	}
+	else return false;
+}
+
+/////////////////////////
+// PLYOutputDataStream //
+/////////////////////////
+template< typename Factory >
+PLYOutputDataStream< Factory >::PLYOutputDataStream( const char* fileName , const Factory &factory , size_t count , int fileType ) : _factory(factory)
+{
+	float version;
+	std::vector< std::string > elem_names = { std::string( "vertex" ) };
+	_ply = PlyFile::Write( fileName , elem_names , fileType , version );
+	if( !_ply ) MK_THROW( "Failed to open ply file for writing: " , fileName );
+
+	_pIdx = 0;
+	_pCount = count;
+	_ply->element_count( "vertex" , _pCount );
+	for( unsigned int i=0 ; i<_factory.plyWriteNum() ; i++ )
+	{
+		PlyProperty prop;
+		if constexpr( Factory::IsStaticallyAllocated() ) prop = _factory.plyStaticWriteProperty(i);
+		else                                             prop = _factory.plyWriteProperty(i);
+		_ply->describe_property( "vertex" , &prop );
+	}
+	_ply->header_complete();
+	_ply->put_element_setup( "vertex" );
+	if( _factory.bufferSize() ) _buffer = NewPointer< char >( _factory.bufferSize() );
+	else                        _buffer = NullPointer( char );
+}
+
+template< typename Factory >
+PLYOutputDataStream< Factory >::~PLYOutputDataStream( void )
+{
+	if( _pIdx!=_pCount ) MK_THROW( "Streamed points not equal to total count: " , _pIdx , " != " , _pCount );
+	delete _ply;
+	DeletePointer( _buffer );
+}
+
+template< typename Factory >
+size_t PLYOutputDataStream< Factory >::write( const Data &d )
+{
+	if( _pIdx==_pCount ) MK_THROW( "Trying to add more points than total: " , _pIdx , " < " , _pCount );
+	if constexpr( Factory::IsStaticallyAllocated() ) _ply->put_element( (void *)&d );
+	else
+	{
+		_factory.toBuffer( d , _buffer );
+		_ply->put_element( PointerAddress( _buffer ) );
+	}
+	return _pIdx++;
+}
+

--- a/LiverResections/Algorithm/PoissonRecon/Src/DataStream.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/DataStream.inl
@@ -1,0 +1,378 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+/////////////////////////////
+// Variadic <-> std::tuple //
+/////////////////////////////
+template< typename ... Data >
+void TupleConverter< Data ... >::FromTuple( const std::tuple< Data ... > &dTuple , Data& ... d ){ return _FromTuple< 0 >( dTuple , d... ); }
+template< typename ... Data >
+void TupleConverter< Data ... >::ToTuple( std::tuple< Data ... > &dTuple , const Data& ... d ){ return _ToTuple< 0 >( dTuple , d... ); }
+
+template< typename ... Data >
+template< unsigned int I , typename _Data , typename ... _Datas >
+void TupleConverter< Data ... >::_FromTuple( const std::tuple< Data ... > &dTuple , _Data &d , _Datas& ... ds )
+{
+	d = std::get< I >( dTuple );
+	if constexpr( sizeof...(_Datas) ) _FromTuple< I+1 >( dTuple , ds... );
+}
+
+template< typename ... Data >
+template< unsigned int I , typename _Data , typename ... _Datas >
+void TupleConverter< Data ... >::_ToTuple( std::tuple< Data ... > &dTuple , const _Data &d , const _Datas& ... ds )
+{
+	std::get< I >( dTuple ) = d;
+	if constexpr( sizeof...(_Datas) ) _ToTuple< I+1 >( dTuple , ds... );
+}
+
+////////////////////////////
+// Variadic <-> DirectSum //
+////////////////////////////
+template< typename Real , typename ... Data >
+void DirectSumConverter< Real , Data ... >::FromDirectSum( const DirectSum< Real , Data ... > &dSum , Data& ... d ){ return _FromDirectSum< 0 >( dSum , d... ); }
+
+template< typename Real , typename ... Data >
+void DirectSumConverter< Real , Data ... >::ToDirectSum( DirectSum< Real , Data ... > &dSum , const Data& ... d ){ return _ToDirectSum< 0 >( dSum , d... ); }
+
+template< typename Real , typename ... Data >
+template< unsigned int I , typename _Data , typename ... _Datas >
+void DirectSumConverter< Real , Data ... >::_FromDirectSum( const DirectSum< Real , Data ... > &dSum , _Data &d , _Datas& ... ds )
+{
+	d = dSum.template get<I>();
+	if constexpr( sizeof...(_Datas) ) _FromDirectSum< I+1 >( dSum , ds... );
+}
+
+template< typename Real , typename ... Data >
+template< unsigned int I , typename _Data , typename ... _Datas >
+void DirectSumConverter< Real , Data ... >::_ToDirectSum( DirectSum< Real , Data ... > &dSum , const _Data &d , const _Datas& ... ds )
+{
+	dSum.template get<I>() + d;
+	if constexpr( sizeof...(_Datas) ) _ToDirectSum< I+1 >( dSum , ds... );
+}
+
+////////////////////////
+// Input data streams //
+////////////////////////
+template< typename ... Data >
+bool InputDataStream< Data ... >::read( unsigned int thread , Data& ... d )
+{
+#ifdef SHOW_WARNINGS
+	MK_WARN_ONCE( "Serializing read: " , typeid(*this).name() );
+#endif // SHOW_WARNINGS
+	std::lock_guard< std::mutex > lock( _insertionMutex );
+	return read(d...);
+}
+
+template< typename ... Data >
+bool InputDataStream< Data ... >::read(                       std::tuple< Data ... > &data ){ return _read(          data ); }
+
+template< typename ... Data >
+bool InputDataStream< Data ... >::read( unsigned int thread , std::tuple< Data ... > &data ){ return _read( thread , data ); }
+
+template< typename ... Data >
+template< typename Real >
+bool InputDataStream< Data ... >::read(                       DirectSum< Real , Data ... > &data ){ return _read(          data ); }
+
+template< typename ... Data >
+template< typename Real >
+bool InputDataStream< Data ... >::read( unsigned int thread , DirectSum< Real , Data ... > &data ){ return _read( thread , data ); }
+
+template< typename ... Data >
+template< typename ... _Data >
+bool InputDataStream< Data ... >::_read( std::tuple< Data ... > &data , _Data& ... _data )
+{
+	if constexpr( sizeof...(_Data)==sizeof...(Data) ) return read( _data... );
+	else return _read( data , _data... , std::get< sizeof...(_Data) >( data ) );
+}
+
+template< typename ... Data >
+template< typename ... _Data >
+bool InputDataStream< Data ... >::_read( unsigned int thread , std::tuple< Data ... > &data , _Data& ... _data )
+{
+	if constexpr( sizeof...(_Data)==sizeof...(Data) ) return read( thread , _data... );
+	else return _read( thread , data , _data... , std::get< sizeof...(_Data) >( data ) );
+}
+
+template< typename ... Data >
+template< typename Real , typename ... _Data >
+bool InputDataStream< Data ... >::_read( DirectSum< Real , Data ... > &data , _Data& ... _data )
+{
+	if constexpr( sizeof...(_Data)==sizeof...(Data) ) return read( _data... );
+	else return _read( data , _data... , data.template get< sizeof...(_Data) >() );
+}
+
+template< typename ... Data >
+template< typename Real , typename ... _Data >
+bool InputDataStream< Data ... >::_read( unsigned int thread , DirectSum< Real , Data ... > &data , _Data& ... _data )
+{
+	if constexpr( sizeof...(_Data)==sizeof...(Data) ) return read( thread , _data... );
+	else return _read( thread , data , _data... , data.template get< sizeof...(_Data) >() );
+}
+
+
+/////////////////////////
+// Output data streams //
+/////////////////////////
+template< typename ... Data >
+size_t OutputDataStream< Data ... >::write( unsigned int thread , const Data& ... d )
+{
+#ifdef SHOW_WARNINGS
+	MK_WARN_ONCE( "Serializing write: " , typeid(*this).name() );
+#endif // SHOW_WARNINGS
+	std::lock_guard< std::mutex > lock( _insertionMutex );
+	return write(d...);
+}
+
+template< typename ... Data >
+size_t OutputDataStream< Data ... >::write(                       const std::tuple< Data ... > &data ){ return _write(          data ); }
+
+template< typename ... Data >
+size_t OutputDataStream< Data ... >::write( unsigned int thread , const std::tuple< Data ... > &data ){ return _write( thread , data ); }
+
+template< typename ... Data >
+template< typename Real >
+size_t OutputDataStream< Data ... >::write(                       const DirectSum< Real , Data ... > &data ){ return _write(          data ); }
+
+template< typename ... Data >
+template< typename Real >
+size_t OutputDataStream< Data ... >::write( unsigned int thread , const DirectSum< Real , Data ... > &data ){ return _write( thread , data ); }
+
+template< typename ... Data >
+template< typename ... _Data >
+size_t OutputDataStream< Data ... >::_write( const std::tuple< Data ... > &data , const _Data& ... _data )
+{
+	if constexpr( sizeof...(_Data)==sizeof...(Data) ) return write( _data... );
+	else return _write( data , _data... , std::get< sizeof...(_Data) >( data ) );
+}
+
+template< typename ... Data >
+template< typename ... _Data >
+size_t OutputDataStream< Data ... >::_write( unsigned int thread , const std::tuple< Data ... > &data , const _Data& ... _data )
+{
+	if constexpr( sizeof...(_Data)==sizeof...(Data) ) return write( thread , _data... );
+	else return _write( thread , data , _data... , std::get< sizeof...(_Data) >( data ) );
+}
+
+template< typename ... Data >
+template< typename Real , typename ... _Data >
+size_t OutputDataStream< Data ... >::_write( const DirectSum< Real , Data ... > &data , const _Data& ... _data )
+{
+	if constexpr( sizeof...(_Data)==sizeof...(Data) ) return write( _data... );
+	else return _write( data , _data... , data.template get< sizeof...(_Data) >() );
+}
+
+template< typename ... Data >
+template< typename Real , typename ... _Data >
+size_t OutputDataStream< Data ... >::_write( unsigned int thread , const DirectSum< Real , Data ... > &data , const _Data& ... _data )
+{
+	if constexpr( sizeof...(_Data)==sizeof...(Data) ) return write( thread , _data... );
+	else return _write( thread , data , _data... , data.template get< sizeof...(_Data) >() );
+}
+
+////////////////////////////////
+// Multiple input data stream //
+////////////////////////////////
+template< typename ...Data >
+MultiInputDataStream< Data ... >::MultiInputDataStream( InputDataStream< Data ... > **streams , size_t N ) : _current(0) , _streams( streams , streams+N ) {}
+
+template< typename ...Data >
+MultiInputDataStream< Data ... >::MultiInputDataStream( const std::vector< InputDataStream< Data ... > * > &streams ) : _current(0) , _streams( streams ) {}
+
+template< typename ...Data >
+void MultiInputDataStream< Data ... >::reset( void ){ for( unsigned int i=0 ; i<_streams.size() ; i++ ) _streams[i]->reset(); }
+
+template< typename ...Data >
+unsigned int MultiInputDataStream< Data ... >::numStreams( void ) const { return (unsigned int)_streams.size(); }
+
+template< typename ...Data >
+bool MultiInputDataStream< Data ... >::read( unsigned int t , Data& ... d ){ return _streams[t]->read(d...); }
+
+template< typename ...Data >
+bool MultiInputDataStream< Data ... >::read(                  Data& ... d )
+{
+	while( _current<_streams.size() )
+	{
+		if( _streams[_current]->read( d... ) ) return true;
+		else _current++;
+	}
+	return false;
+}
+
+/////////////////////////////////
+// Multiple output data stream //
+/////////////////////////////////
+
+template< typename ... Data >
+MultiOutputDataStream< Data ... >::MultiOutputDataStream( OutputDataStream< Data ... > **streams , size_t N ) : _size(0) , _streams( streams , streams+N ) {}
+
+template< typename ... Data >
+MultiOutputDataStream< Data ... >::MultiOutputDataStream( const std::vector< OutputDataStream< Data ... > * > &streams ) : _size(0) , _streams( streams ) {}
+
+template< typename ... Data >
+unsigned int MultiOutputDataStream< Data ... >::numStreams( void ) const { return (unsigned int)_streams.size(); }
+
+template< typename ... Data >
+size_t MultiOutputDataStream< Data ... >::write(                  const Data& ... d ){ size_t idx = _size++ ; _streams[0]->write(d...) ; return idx; }
+
+template< typename ... Data >
+size_t MultiOutputDataStream< Data ... >::write( unsigned int t , const Data& ... d ){ size_t idx = _size++ ; _streams[t]->write(d...) ; return idx; }
+
+////////////////////////////////////////////////
+// De-interleaved multiple output data stream //
+////////////////////////////////////////////////
+
+template< typename ... Data >
+DeInterleavedMultiOutputIndexedDataStream< Data ... >::DeInterleavedMultiOutputIndexedDataStream( OutputIndexedDataStream< Data ... > **streams , size_t N ) : _size(0) , _multiStream( streams , streams+N ) {}
+
+template< typename ... Data >
+DeInterleavedMultiOutputIndexedDataStream< Data ... >::DeInterleavedMultiOutputIndexedDataStream( const std::vector< OutputIndexedDataStream<  Data ... > * > &streams ) : _size(0) , _multiStream( streams ) {}
+
+template< typename ... Data >
+unsigned int DeInterleavedMultiOutputIndexedDataStream< Data ... >::numStreams( void ) const { return _multiStream.numStreams(); }
+
+template< typename ... Data >
+size_t DeInterleavedMultiOutputIndexedDataStream< Data ... >::write(                       const Data& ... d ){ size_t idx = _size++ ; _multiStream.write(          idx , d... ) ; return idx; }
+
+template< typename ... Data >
+size_t DeInterleavedMultiOutputIndexedDataStream< Data ... >::write( unsigned int thread , const Data& ... d ){ size_t idx = _size++ ; _multiStream.write( thread , idx , d... ) ; return idx; }
+
+/////////////////////////////////
+// Input data stream converter //
+/////////////////////////////////
+template< typename ... IData , typename ... XData >
+InputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > >::InputDataStreamConverter( InputDataStream< IData ... > &stream , std::function< std::tuple< XData ... > ( const std::tuple< IData ... >& ) > converter , IData ... zero )
+	: _stream(stream) , _converter(converter) , _iZero( std::make_tuple( zero... ) ) {}
+
+template< typename ... IData , typename ... XData >
+void InputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > >::reset( void ){ _stream.reset(); }
+
+template< typename ... IData , typename ... XData >
+bool InputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > >::read( XData& ... xData )
+{
+	std::tuple< IData ... > _iData = _iZero;
+	if( !_stream.read( _iData ) ) return false;
+	std::tuple< XData ... > _xData = _converter( _iData );
+	TupleConverter< XData ... >::FromTuple( _xData , xData ... );
+	return true;
+}
+
+template< typename ... IData , typename ... XData >
+bool InputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > >::read( unsigned int thread , XData& ... xData )
+{
+	std::tuple< IData ... > _iData = _iZero;
+	if( !_stream.read( thread , _iData ) ) return false;
+	std::tuple< XData ... > _xData = _converter( _iData );
+	TupleConverter< XData ... >::FromTuple( _xData , xData ... );
+	return true;
+}
+
+//////////////////////////////////
+// Output data stream converter //
+//////////////////////////////////
+template< typename ... IData , typename ... XData >
+OutputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > >::OutputDataStreamConverter( OutputDataStream< IData ... > &stream , std::function< std::tuple< IData ... > ( const std::tuple< XData ... >& ) > converter )
+	: _stream(stream) , _converter(converter) {}
+
+template< typename ... IData , typename ... XData >
+size_t OutputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > >::write( const XData& ... xData )
+{
+	std::tuple< XData ... > _xData;
+	TupleConverter< XData ... >::ToTuple( _xData , xData ... );
+	std::tuple< IData ... > _iData = _converter( _xData );
+	return _stream.write( _iData );
+}
+
+template< typename ... IData , typename ... XData >
+size_t OutputDataStreamConverter< std::tuple< IData ... > , std::tuple< XData ... > >::write( unsigned int thread , const XData& ... xData )
+{
+	std::tuple< XData ... > _xData;
+	TupleConverter< XData ... >::ToTuple( _xData , xData ... );
+	std::tuple< IData ... > _iData = _converter( _xData );
+	return _stream.write( thread , _iData );
+}
+
+
+////////////////////////////////////////////
+// Interleaved multiple input data stream //
+////////////////////////////////////////////
+
+template< typename ... Data >
+InterleavedMultiInputIndexedDataStream< Data ... >::InterleavedMultiInputIndexedDataStream( InputIndexedDataStream< Data ... > **streams , size_t N )
+	: _multiStream( streams , N )
+	, _firstTime(true)
+{
+	_nextValues.resize( _multiStream.numStreams() );
+}
+
+template< typename ... Data >
+InterleavedMultiInputIndexedDataStream< Data ... >::InterleavedMultiInputIndexedDataStream( const std::vector< InputIndexedDataStream< Data ... > * > &streams )
+	: _multiStream( streams )
+	, _firstTime(true)
+{
+	_nextValues.resize( _multiStream.numStreams() );
+}
+
+template< typename ... Data >
+void InterleavedMultiInputIndexedDataStream< Data ... >::reset( void ){ _multiStream.reset() , _firstTime = true; }
+
+template< typename ... Data >
+bool InterleavedMultiInputIndexedDataStream< Data ... >::_NextValue::Compare( const _NextValue &v1 , const _NextValue &v2 )
+{
+	if( !v2.validData ) return false;
+	else if( !v1.validData && v2.validData ) return true;
+	else return std::get<0>( v1.data ) > std::get<0>( v2.data );
+}
+
+template< typename ... Data >
+void InterleavedMultiInputIndexedDataStream< Data ... >::_init( const std::tuple< Data ... > &data )
+{
+	std::tuple< size_t , Data ... > _data = std::tuple_cat( std::make_tuple( (size_t)0 ) , data );
+	for( unsigned int i=0 ; i<_nextValues.size() ; i++ ) _nextValues[i].data = _data;
+	for( unsigned int i=0 ; i<_nextValues.size() ; i++ )
+	{
+		_nextValues[i].validData = _multiStream.read( i , _nextValues[i].data );
+		_nextValues[i].streamIndex = i;
+	}
+	std::make_heap( _nextValues.begin() , _nextValues.end() , _NextValue::Compare );
+}
+
+template< typename ... Data >
+bool InterleavedMultiInputIndexedDataStream< Data ... >::read( Data& ... d )
+{
+	if( _firstTime ) _init(d...) , _firstTime = false;
+	std::pop_heap( _nextValues.begin() , _nextValues.end() , _NextValue::Compare );
+	_NextValue &next = _nextValues.back();
+	if( !next.validData ) return false;
+	size_t sz;
+	TupleConverter< size_t , Data ... >::FromTuple( next.data , sz , d... );
+
+	next.validData = _multiStream.read( next.streamIndex , next.data );
+
+	std::push_heap( _nextValues.begin() , _nextValues.end() , _NextValue::Compare );
+	return true;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/Extrapolator.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Extrapolator.h
@@ -1,0 +1,245 @@
+/*
+Copyright (c) 2024, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef EXTRAPOLATOR_INCLUDED
+#define EXTRAPOLATOR_INCLUDED
+
+#include "PreProcessor.h"
+#include "MyMiscellany.h"
+#include "FEMTree.h"
+#include "PointExtent.h"
+#include "Reconstructors.streams.h"
+
+namespace PoissonRecon
+{
+	namespace Extrapolator
+	{
+		static unsigned int ProfilerMS = 20;		// The number of ms at which to poll the performance (set to zero for no polling)
+
+		template< typename Real , unsigned int Dim , typename AuxData >
+		using InputStream = Reconstructor::InputSampleStream< Real , Dim , AuxData >;
+
+		// Specialized solution information without auxiliary data
+		template< typename Real , unsigned int Dim , typename AuxData , unsigned int DataDegree=1 >
+		struct Implicit
+		{
+			struct Parameters
+			{
+				bool verbose = false;
+				Real scale = (Real)1.1;
+				Real width = (Real)0.;
+				Real samplesPerNode = (Real)1.5;
+				Real perLevelScaleFactor = (Real)32;
+				unsigned int baseDepth = -1;
+				unsigned int depth = 8;
+				unsigned int fullDepth = 5;
+				unsigned int alignDir = 0;
+			};
+
+			// The constructor
+			Implicit( InputStream< Real , Dim , AuxData > &pointStream , Parameters params , AuxData zero );
+
+			// The desctructor
+			~Implicit( void ){ delete auxData ; auxData = nullptr ; delete _auxEvaluator ; _auxEvaluator = nullptr; }
+
+			// The transformation taking points in the unit cube back to world coordinates
+			XForm< Real , Dim+1 > unitCubeToModel;
+
+			// The octree adapted to the points
+			FEMTree< Dim , Real > tree;
+
+			// The signature of the finite-element used for data extrapolation
+			static const unsigned int DataSig = FEMDegreeAndBType< DataDegree , BOUNDARY_FREE >::Signature;
+
+			// The auxiliary information stored with the oriented vertices
+			SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > > *auxData;
+
+			// An instance of "zero" AuxData
+			AuxData zeroAuxData;
+
+			struct OutOfUnitCubeException : public std::exception
+			{
+				OutOfUnitCubeException( Point< Real , Dim > world , Point< Real , Dim > cube )
+				{
+					std::stringstream sStream;
+					sStream << "Out-of-unit-cube input: " << world << " -> " << cube;
+					_message = sStream.str();						
+				}
+				const char * what( void ) const noexcept { return _message.c_str(); }
+			protected:
+				std::string _message;
+			};
+
+			XForm< Real , Dim+1 > worldToUnitCubeTransform( void ) const { return _worldToUnitCube; }
+
+			AuxData operator()( unsigned int t , Point< Real , Dim > p ){ return _value(t,p); }
+			AuxData operator()(                  Point< Real , Dim > p ){ return _value(0,p); }
+
+			void evaluate( unsigned int t , Point< Real , Dim > p , AuxData &data ){ return _evaluate( t , p , data ); }
+			void evaluate(                  Point< Real , Dim > p , AuxData &data ){ return _evaluate( 0 , p , data ); }
+
+		protected:
+			typename FEMTree< Dim , Real >::template MultiThreadedSparseEvaluator< IsotropicUIntPack< Dim , DataSig > , ProjectiveData< AuxData , Real > > *_auxEvaluator = nullptr;
+			XForm< Real , Dim+1 > _worldToUnitCube;
+
+			AuxData _value( unsigned int t , Point< Real , Dim > p )
+			{
+				Point< Real , Dim > q = _worldToUnitCube * p;
+				for( unsigned int d=0 ; d<Dim ; d++ ) if( q[d]<0 || q[d]>1 ) throw OutOfUnitCubeException(p,q);
+				ProjectiveData< AuxData , Real > pData( zeroAuxData );
+				_auxEvaluator->addValue( q , pData , t );
+				return pData.value();
+			}
+
+			void _evaluate( unsigned int t , Point< Real , Dim > p , AuxData &data )
+			{
+				Point< Real , Dim > q = _worldToUnitCube * p;
+				for( unsigned int d=0 ; d<Dim ; d++ ) if( q[d]<0 || q[d]>1 ) throw OutOfUnitCubeException(p,q);
+
+				Real weight = (Real)0.;
+				data *= 0;
+
+				auto Accumulation = [&weight,&data]( const ProjectiveData< AuxData , Real > &pData , Real scale )
+					{
+						weight += pData.weight * scale;
+						data += pData.data * scale;
+					};
+				_auxEvaluator->accumulate( q , Accumulation , t );
+				if( weight ) data /= weight;
+			}
+		};
+
+		template< typename Real , unsigned int Dim , typename AuxData , unsigned int DataDegree >
+		Implicit< Real , Dim , AuxData , DataDegree >::Implicit( InputStream< Real , Dim , AuxData > &pointStream , Parameters params , AuxData zeroAuxData )
+			: tree(MEMORY_ALLOCATOR_BLOCK_SIZE) , unitCubeToModel( XForm< Real , Dim+1 >::Identity() ) , zeroAuxData(zeroAuxData)
+		{
+			// The finite-element tracking tree node
+			using FEMTreeNode = RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >;
+
+			// The type describing the sampling density
+			using DensityEstimator = typename FEMTree< Dim , Real >::template DensityEstimator< 0 >;
+
+			// The signature for the finite-elements representing the auxiliary data (if it's there)
+			static const unsigned int DataSig = FEMDegreeAndBType< DataDegree , BOUNDARY_FREE >::Signature;
+
+			XForm< Real , Dim+1 > modelToUnitCube = XForm< Real , Dim+1 >::Identity();
+
+			Profiler profiler( ProfilerMS );
+
+			size_t pointCount;
+
+			ProjectiveData< Point< Real , 2 > , Real > pointDepthAndWeight;
+			std::vector< typename FEMTree< Dim , Real >::PointSample > *samples = new std::vector< typename FEMTree< Dim , Real >::PointSample >();
+			std::vector< AuxData > *sampleAuxData = nullptr;
+
+			// Read in the samples (and auxiliary data)
+			{
+				profiler.reset();
+
+				pointStream.reset();
+				sampleAuxData = new std::vector< AuxData >();
+
+				modelToUnitCube = params.scale>0 ? PointExtent::GetXForm< Real , Dim , true , AuxData >( pointStream , zeroAuxData , params.scale , params.alignDir ) * modelToUnitCube : modelToUnitCube;
+				pointStream.reset();
+
+				if( params.width>0 )
+				{
+					// Assuming the transformation is rigid so that the (max) scale can be pulled from the Frobenius norm
+					Real maxScale = 0;
+					for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ ) maxScale += modelToUnitCube(i,j) * modelToUnitCube(i,j);
+					maxScale = (Real)( 1. / sqrt( maxScale / Dim ) );
+					params.depth = (unsigned int)ceil( std::max< double >( 0. , log( maxScale/params.width )/log(2.) ) );
+				}
+
+				{
+					Reconstructor::TransformedInputSampleStream< Real , Dim , AuxData > _pointStream( modelToUnitCube , pointStream );
+					auto ProcessData = []( const Point< Real , Dim > &p , AuxData &d ){ return (Real)1.; };
+					pointCount = FEMTreeInitializer< Dim , Real >::template Initialize< AuxData >( tree.spaceRoot() , _pointStream , zeroAuxData , params.depth , *samples , *sampleAuxData , tree.nodeAllocators.size() ? tree.nodeAllocators[0] : nullptr , tree.initializer() , ProcessData );
+				}
+
+				if( params.fullDepth>params.depth )
+				{
+					if( params.fullDepth!=-1 ) MK_WARN( "Full depth cannot exceed depth: " , params.fullDepth , " <= " , params.depth );
+					params.fullDepth = params.depth;
+				}
+				if( params.baseDepth>params.fullDepth )
+				{
+					if( params.baseDepth!=-1 ) MK_WARN( "Base depth must be smaller than full depth: " , params.baseDepth , " <= " , params.fullDepth );
+					params.baseDepth = params.fullDepth;
+				}
+
+
+				unitCubeToModel = modelToUnitCube.inverse();
+
+				if( params.verbose )
+				{
+					std::cout << "Input Points / Samples: " << pointCount << " / " << samples->size() << std::endl;
+					std::cout << "# Read input into tree: " << profiler << std::endl;
+				}
+			}
+			tree.resetNodeIndices( 0 , std::make_tuple() );
+			{
+				profiler.reset();
+				auto SampleFunctor = [&]( size_t i ) -> const typename FEMTree< Dim , Real >::PointSample & { return (*samples)[i]; };
+				auto SampleDataFunctor = [&]( size_t i ) -> const AuxData & { return (*sampleAuxData)[i]; };
+				auxData = new SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > >( tree.template setExtrapolatedDataField< DataSig , false , 0 , AuxData >( zeroAuxData , samples->size() , SampleFunctor , SampleDataFunctor , (DensityEstimator*)nullptr ) );
+				delete sampleAuxData;
+				if( params.verbose ) std::cout << "#         Got aux data: " << profiler << std::endl;
+			}
+
+			{
+				profiler.reset();
+				auto hasDataFunctor = [&]( const FEMTreeNode *node )
+					{
+						ProjectiveData< AuxData , Real > *data = auxData->operator()( node );
+						return data && data->weight;
+					};
+				auto addNodeFunctor = [&]( int d , const int off[Dim] ){ return d<=(int)params.fullDepth; };
+				tree.template finalizeForMultigrid< 0 , 0 >( 0 , addNodeFunctor , hasDataFunctor , std::make_tuple() , std::make_tuple( auxData ) );
+			}
+
+			if( params.verbose ) std::cout << "#       Finalized tree: " << profiler << std::endl;
+			if( params.verbose ) std::cout << "All Nodes / Active Nodes / Ghost Nodes: " << tree.allNodes() << " / " << tree.activeNodes() << " / " << tree.ghostNodes() << std::endl;
+			if( params.verbose ) std::cout << "Memory Usage: " << float( MemoryInfo::Usage())/(1<<20) << " MB" << std::endl;
+			delete samples;
+
+			auto nodeFunctor = [&]( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *n )
+				{
+					ProjectiveData< AuxData , Real >* clr = (*auxData)( n );
+					if( clr ) (*clr) *= (Real)pow( params.perLevelScaleFactor , tree.depth( n ) );
+				};
+			tree.tree().processNodes( nodeFunctor );
+
+			_worldToUnitCube = unitCubeToModel.inverse();
+			_auxEvaluator = new typename FEMTree< Dim , Real >::template MultiThreadedSparseEvaluator< IsotropicUIntPack< Dim , DataSig > , ProjectiveData< AuxData , Real > >( &tree , *auxData , ThreadPool::NumThreads() );
+
+		}
+	}
+}
+
+#endif // EXTRAPOLATOR_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.Evaluation.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.Evaluation.inl
@@ -1,0 +1,1197 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , unsigned int PointD >
+template< unsigned int _PointD >
+CumulativeDerivativeValues< double , Dim , _PointD > FEMTree< Dim , Real >::_Evaluator< UIntPack< FEMSigs ... > , PointD >::_values( unsigned int d , const int fIdx[Dim] , const int cIdx[Dim] , const _CenterOffset off[Dim] , bool parentChild ) const
+{
+	double dValues[Dim][_PointD+1];
+	_setDValues< _PointD >( d , fIdx , cIdx , off , parentChild , dValues );
+	return Evaluate< Dim , double , _PointD >( dValues );
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , unsigned int PointD >
+template< unsigned int _PointD >
+CumulativeDerivativeValues< double , Dim , _PointD > FEMTree< Dim , Real >::_Evaluator< UIntPack< FEMSigs ... > , PointD >::_centerValues( unsigned int d , const int fIdx[Dim] , const int cIdx[Dim] , bool parentChild ) const
+{
+	_CenterOffset off[Dim];
+	for( int d=0 ; d<Dim ; d++ ) off[d] = CENTER;
+	return _values< _PointD >( d , fIdx , cIdx , off , parentChild );
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , unsigned int PointD >
+template< unsigned int _PointD >
+CumulativeDerivativeValues< double , Dim , _PointD > FEMTree< Dim , Real >::_Evaluator< UIntPack< FEMSigs ... > , PointD >::_cornerValues( unsigned int d , const int fIdx[Dim] , const int cIdx[Dim] , int corner , bool parentChild ) const
+{
+	_CenterOffset off[Dim];
+	for( int d=0 ; d<Dim ; d++ ) off[d] = ( (corner>>d) & 1 ) ? FRONT : BACK;
+	return _values< _PointD >( d , fIdx , cIdx , off , parentChild );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , unsigned int PointD >
+void FEMTree< Dim , Real >::_Evaluator< UIntPack< FEMSigs ... > , PointD >::set( LocalDepth maxDepth )
+{
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > CenterSizes;
+	static const unsigned int LeftCenterRadii[] = { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportEnd ... };
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > CornerSizes;
+	static const unsigned int LeftCornerRadii[] = { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportEnd ... };
+	typedef UIntPack< ( BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::BCornerSize + 1 ) ... > BCornerSizes;
+	static const unsigned int LeftBCornerRadii[] = { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::BCornerEnd ... };
+
+	if( stencilData ) DeletePointer( stencilData );
+	stencilData = NewPointer< StencilData >( maxDepth+1 );
+	if( evaluators ) DeletePointer( evaluators );
+	evaluators = NewPointer< Evaluators >( maxDepth+1 );
+	if( childEvaluators ) DeletePointer( childEvaluators );
+	childEvaluators = NewPointer< ChildEvaluators >( maxDepth+1 );
+	_setEvaluators( maxDepth );
+	for( int depth=0 ; depth<=maxDepth ; depth++ )
+	{
+		int center = ( 1<<depth )>>1;
+		int cIdx[Dim] , fIdx[Dim];
+		for( int d=0 ; d<Dim ; d++ ) cIdx[d] = center;
+
+		// First set the stencils for the current depth
+		{
+			// The center stencil
+			WindowLoop< Dim >::Run
+			(
+				ZeroUIntPack< Dim >() , CenterSizes() ,
+				[&]( int d , int i ){ fIdx[d] = center + i - LeftCenterRadii[d]; } ,
+				[&]( CumulativeDerivativeValues< double , Dim , PointD >& p ){ p = _centerValues( depth , fIdx , cIdx , false ); } ,
+				stencilData[depth].ccCenterStencil()
+			);
+			// The corner stencil
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , CornerSizes() ,
+					[&]( int d , int i ){ fIdx[d] = center + i - LeftCornerRadii[d]; } ,
+					[&]( CumulativeDerivativeValues< double , Dim , PointD >& p ){ p = _cornerValues( depth , fIdx , cIdx , c , false ); } ,
+					stencilData[depth].ccCornerStencil[c]()
+				);
+			// The boundary corner stencil
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , BCornerSizes() ,
+					[&]( int d , int i ){ fIdx[d] = center + i - LeftBCornerRadii[d]; } ,
+					[&]( CumulativeDerivativeValues< double , Dim , PointD >& p ){ p = _cornerValues( depth , fIdx , cIdx , c , false ); } ,
+					stencilData[depth].ccBCornerStencil[c]()
+				);
+		}
+
+		// Now set the stencils for the parents
+		for( int c=0 ; c<(1<<Dim) ; c++ )
+		{
+			int cIdx[Dim] , fIdx[Dim];
+			for( int d=0 ; d<Dim ; d++ ) cIdx[d] = center + ( (c>>d) & 1 );
+
+			// The center stencil
+			WindowLoop< Dim >::Run
+			(
+				ZeroUIntPack< Dim >() , CenterSizes() ,
+				[&]( int d , int i ){ fIdx[d] = center/2 + i - LeftCenterRadii[d]; } ,
+				[&]( CumulativeDerivativeValues< double , Dim , PointD >& p ){ p = _centerValues( depth , fIdx , cIdx , true ); } ,
+				stencilData[depth].pcCenterStencils[c]()
+			);
+			// The corner stencil
+			for( int cc=0 ; cc<(1<<Dim) ; cc++ )
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , CornerSizes() ,
+					[&]( int d , int i ){ fIdx[d] = center/2 + i - LeftCornerRadii[d]; } ,
+					[&]( CumulativeDerivativeValues< double , Dim , PointD >& p ){ p = _cornerValues( depth , fIdx , cIdx , cc , true ); } ,
+					stencilData[depth].pcCornerStencils[c][cc]()
+				);
+			// The boundary corner stencil
+			for( int cc=0 ; cc<(1<<Dim) ; cc++ )
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , BCornerSizes() ,
+					[&]( int d , int i ){ fIdx[d] = center/2 + i - LeftBCornerRadii[d]; } ,
+					[&]( CumulativeDerivativeValues< double , Dim , PointD >& p ){ p = _cornerValues( depth , fIdx , cIdx , cc , true ); } ,
+					stencilData[depth].pcBCornerStencils[c][cc]()
+				);
+		}
+	}
+	if( _pointEvaluator ) delete _pointEvaluator;
+	_pointEvaluator = new PointEvaluator< UIntPack< FEMSigs ... > , IsotropicUIntPack< Dim , PointD > >( maxDepth );
+}
+
+template< unsigned int Dim , class Real >
+template< class V , unsigned int _PointD , unsigned int ... FEMSigs , unsigned int PointD >
+CumulativeDerivativeValues< V , Dim , _PointD > FEMTree< Dim , Real >::_getValues( const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , Point< Real , Dim > p , ConstPointer( V ) solution , ConstPointer( V ) coarseSolution , const _Evaluator< UIntPack< FEMSigs ... > , PointD >& evaluator , int maxDepth ) const
+{
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > SupportSizes;
+
+	if( IsActiveNode< Dim >( node->children ) && _localDepth( node->children )<=maxDepth ) MK_WARN( "getValue assumes leaf node" );
+	CumulativeDerivativeValues< V , Dim , _PointD > values;
+
+	PointEvaluatorState< UIntPack< FEMSigs ... > , IsotropicUIntPack< Dim , _PointD > > state;
+
+#ifdef SHOW_WARNINGS
+#pragma message ( "[WARNING] Nudging evaluation point into the interior" )
+#endif // SHOW_WARNINGS
+	for( int dd=0 ; dd<Dim ; dd++ )
+	{
+		if     ( p[dd]==0 ) p[dd] = (Real)(0.+1e-6);
+		else if( p[dd]==1 ) p[dd] = (Real)(1.-1e-6);
+	}
+	auto AddToValues = [&]( const typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors , ConstPointer( V ) coefficients )
+	{
+		ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+		for( unsigned int i=0 ; i<WindowSize< SupportSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) )
+		{
+			LocalDepth d ; LocalOffset off ; _localDepthAndOffset( nodes[i] , d , off );
+			CumulativeDerivativeValues< Real , Dim , _PointD > _values = state.template dValues< Real , CumulativeDerivatives< Dim , _PointD > >( off );
+			for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[i]->nodeData.nodeIndex ] * _values[d];
+		}
+	};
+
+	LocalDepth depth = _localDepth( node );
+	while( GetGhostFlag< Dim >( node ) ) node = node->parent , depth--;
+
+	{
+		evaluator._pointEvaluator->initEvaluationState( p , depth , state );
+		AddToValues( neighborKey.neighbors[ node->depth() ] , solution );
+		if( depth>0 )
+		{
+			evaluator._pointEvaluator->initEvaluationState( p , depth-1 , state );
+			AddToValues( neighborKey.neighbors[ node->parent->depth() ] , coarseSolution );
+		}
+	}
+	// If there could be finer neighbors whose support overlaps the point
+	if( depth<_maxDepth )
+	{
+		typename FEMTreeNode::template ConstNeighbors< SupportSizes > cNeighbors;
+		int cIdx = 0;
+		Point< Real , Dim > c ; Real w;
+		_centerAndWidth( node , c , w );
+		for( int d=0 ; d<Dim ; d++ ) if( p[d]>c[d] ) cIdx |= (1<<d);
+		if( neighborKey.getChildNeighbors( cIdx , node->depth() , cNeighbors ) )
+		{
+			evaluator._pointEvaluator->initEvaluationState( p , depth+1 , state );
+			AddToValues( cNeighbors , solution );
+		}
+	}
+	return values;
+}
+template< unsigned int Dim , class Real >
+template< class V , unsigned int _PointD , unsigned int ... FEMSigs , unsigned int PointD >
+CumulativeDerivativeValues< V , Dim , _PointD > FEMTree< Dim , Real >::_getCenterValues( const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , ConstPointer( V ) solution , ConstPointer( V ) coarseSolution , const _Evaluator< UIntPack< FEMSigs ... > , PointD >& evaluator , int maxDepth , bool isInterior ) const
+{
+	if( IsActiveNode< Dim >( node->children ) && _localDepth( node->children )<=maxDepth ) MK_THROW( "getCenterValues assumes leaf node" );
+	typedef _Evaluator< UIntPack< FEMSigs ... > , PointD > _Evaluator;
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > SupportSizes;
+	static const unsigned int supportSizes[] = { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... };
+
+	if( IsActiveNode< Dim >( node->children ) && _localDepth( node->children )<=maxDepth ) MK_THROW( "getCenterValue assumes leaf node" );
+	CumulativeDerivativeValues< V , Dim , _PointD > values;
+
+	LocalDepth d ; LocalOffset cIdx;
+	_localDepthAndOffset( node , d , cIdx );
+
+	static const int corner = (1<<Dim)-1;
+
+	static const CornerLoopData< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > loopData;
+	auto AddToValuesInterior = [&]
+	( 
+		unsigned int size , const unsigned int* indices ,
+		const typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors ,
+		const typename _Evaluator::CornerStencil& cornerStencil ,
+		ConstPointer( V ) coefficients
+	)
+	{
+		ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+		ConstPointer( CumulativeDerivativeValues< double , Dim , PointD > ) _values = cornerStencil().data;
+		for( unsigned int i=0 ; i<size ; i++ ) 
+		{
+			int idx = indices[i];
+			if( IsActiveNode< Dim >( nodes[ idx ] ) ) for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[ idx ]->nodeData.nodeIndex ] * (Real)_values[ idx ][d];
+		}
+	};
+	auto AddToValuesExterior = [&]
+	( 
+		unsigned int size , const unsigned int* indices ,
+		LocalDepth d , LocalOffset cIdx ,
+		const typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors ,
+		ConstPointer( V ) coefficients , bool parent
+	)
+	{
+		ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+		for( unsigned int i=0 ; i<size ; i++ ) 
+		{
+			int idx = indices[i];
+			if( IsActiveNode< Dim >( nodes[ idx ] ) )
+			{
+				LocalDepth _d ; LocalOffset fIdx;
+				this->_localDepthAndOffset( nodes[idx] , _d , fIdx );
+				CumulativeDerivativeValues< double , Dim , _PointD > _values = evaluator.template _cornerValues< _PointD >( d , fIdx , cIdx , corner , parent );
+				for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[ idx ]->nodeData.nodeIndex ] * (Real)_values[d];
+			}
+		}
+	};
+
+	if( isInterior )
+	{
+		auto AddToValues = [&]
+		(
+			const typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors ,
+			const typename _Evaluator::CenterStencil& centerStencil ,
+			ConstPointer( V ) coefficients
+		)
+		{
+			ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+			ConstPointer( CumulativeDerivativeValues< double , Dim , PointD > ) _values = centerStencil.data;
+			for( int i=0 ; i<WindowSize< SupportSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) )
+				for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[i]->nodeData.nodeIndex ] * (Real)_values[i][d];
+		};
+		AddToValues( neighborKey.neighbors[ node->depth() ] , evaluator.stencilData[d].ccCenterStencil , solution );
+		if( d>0 )
+		{
+			int _corner = int( node - node->parent->children );
+			AddToValues( neighborKey.neighbors[ node->parent->depth() ] , evaluator.stencilData[d].pcCenterStencils[_corner] , coarseSolution );
+		}
+	}
+	else
+	{
+		auto AddToValues = [&]( const typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors , ConstPointer( V ) coefficients , bool parentChild )
+		{
+			ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+			for( int i=0 ; i<WindowSize< SupportSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) ) 
+			{
+				LocalDepth _d ; LocalOffset fIdx;
+				_localDepthAndOffset( nodes[i] , _d , fIdx );
+				const CumulativeDerivativeValues< double , Dim , _PointD >& _values = evaluator.template _centerValues< _PointD >( d , fIdx , cIdx , parentChild );
+				for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[i]->nodeData.nodeIndex ] * (Real)_values[d];
+			}
+		};
+
+		AddToValues( neighborKey.neighbors[ node->depth() ] , solution , false );
+		if( d>0 ) AddToValues( neighborKey.neighbors[ node->parent->depth() ] , coarseSolution , true );
+	}
+	// If there could be finer neighbors whose support overlaps the point
+	if( d<_maxDepth )
+	{
+		typename FEMTreeNode::template ConstNeighbors< SupportSizes > cNeighbors;
+		if( neighborKey.getChildNeighbors( 0 , node->depth() , cNeighbors ) )
+		{
+			if( isInterior ) AddToValuesInterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , cNeighbors , evaluator.stencilData[d+1].ccCornerStencil[corner] , solution );
+			else
+			{
+				LocalDepth _d=d+1 ; LocalOffset _cIdx;
+				for( int d=0 ; d<Dim ; d++ ) _cIdx[d] = cIdx[d]<<1;
+				AddToValuesExterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , _d , _cIdx , cNeighbors , solution , false );
+			}
+		}
+	}
+	return values;
+}
+
+template< unsigned int Dim , class Real >
+template< class V , unsigned int _PointD , unsigned int ... FEMSigs , unsigned int PointD >
+CumulativeDerivativeValues< V , Dim , _PointD > FEMTree< Dim , Real >::_getCornerValues( const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , int corner , ConstPointer( V ) solution , ConstPointer( V ) coarseSolution , const _Evaluator< UIntPack< FEMSigs ... > , PointD >& evaluator , int maxDepth , bool isInterior ) const
+{
+	if( IsActiveNode< Dim >( node->children ) && _localDepth( node->children )<=maxDepth ) MK_WARN( "getValue assumes leaf node" );
+	typedef _Evaluator< UIntPack< FEMSigs ... > , PointD > _Evaluator;
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > SupportSizes;
+	static const unsigned int supportSizes[] = { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... };
+
+	CumulativeDerivativeValues< V , Dim , _PointD > values;
+	LocalDepth d ; LocalOffset cIdx;
+	_localDepthAndOffset( node , d , cIdx );
+
+	static const CornerLoopData< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > loopData;
+	{
+		auto AddToValuesInterior = [&]
+		( 
+			unsigned int size , const unsigned int* indices ,
+			const typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors ,
+			const typename _Evaluator::CornerStencil& cornerStencil ,
+			ConstPointer( V ) coefficients
+		)
+		{
+			ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+			ConstPointer( CumulativeDerivativeValues< double , Dim , PointD > ) _values = cornerStencil().data;
+			for( unsigned int i=0 ; i<size ; i++ ) 
+			{
+				int idx = indices[i];
+				if( IsActiveNode< Dim >( nodes[ idx ] ) ) for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[ idx ]->nodeData.nodeIndex ] * (Real)_values[ idx ][d];
+			}
+		};
+		auto AddToValuesExterior = [&]
+		( 
+			unsigned int size , const unsigned int* indices ,
+			LocalDepth d , LocalOffset cIdx ,
+			const typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors ,
+			ConstPointer( V ) coefficients , bool parent
+		)
+		{
+			ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+			for( unsigned int i=0 ; i<size ; i++ ) 
+			{
+				int idx = indices[i];
+				if( IsActiveNode< Dim >( nodes[ idx ] ) )
+				{
+					LocalDepth _d ; LocalOffset fIdx;
+					this->_localDepthAndOffset( nodes[idx] , _d , fIdx );
+					CumulativeDerivativeValues< double , Dim , _PointD > _values = evaluator.template _cornerValues< _PointD >( d , fIdx , cIdx , corner , parent );
+					for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[ idx ]->nodeData.nodeIndex ] * (Real)_values[d];
+				}
+			}
+		};
+		if( isInterior ) AddToValuesInterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , neighborKey.neighbors[ node->depth() ] , evaluator.stencilData[d].ccCornerStencil[corner] , solution );
+		else             AddToValuesExterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , d , cIdx , neighborKey.neighbors[ node->depth() ] , solution , false );
+		if( d>0 )
+		{
+			int _corner = int( node - node->parent->children );
+			if( isInterior ) AddToValuesInterior( loopData.pcSize[corner][_corner] , loopData.pcIndices[corner][_corner] , neighborKey.neighbors[ node->parent->depth() ] , evaluator.stencilData[d].pcCornerStencils[_corner][corner] , coarseSolution );
+			else             AddToValuesExterior( loopData.pcSize[corner][_corner] , loopData.pcIndices[corner][_corner] , d , cIdx , neighborKey.neighbors[ node->parent->depth() ] , coarseSolution , true );
+		}
+		// If there could be finer neighbors whose support overlaps the point
+		if( d<_maxDepth )
+		{
+			typename FEMTreeNode::template ConstNeighbors< SupportSizes > cNeighbors;
+			if( neighborKey.getChildNeighbors( corner , node->depth() , cNeighbors ) )
+			{
+				if( isInterior ) AddToValuesInterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , cNeighbors , evaluator.stencilData[d+1].ccCornerStencil[corner] , solution );
+				else
+				{
+					LocalDepth _d=d+1 ; LocalOffset _cIdx;
+					for( int d=0 ; d<Dim ; d++ ) _cIdx[d] = (cIdx[d]<<1) | ( (corner&(1<<d)) ? 1 : 0 );
+					AddToValuesExterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , _d , _cIdx , cNeighbors , solution , false );
+				}
+			}
+		}
+		return values;
+	}
+}
+template< unsigned int Dim , class Real >
+template< class V , unsigned int _PointD , unsigned int ... FEMSigs , unsigned int PointD >
+CumulativeDerivativeValues< V , Dim , _PointD > FEMTree< Dim , Real >::_getCornerValues( const ConstCornerSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , int corner , ConstPointer( V ) solution , ConstPointer( V ) coarseSolution , const _Evaluator< UIntPack< FEMSigs ... > , PointD >& evaluator , int maxDepth , bool isInterior ) const
+{
+	typedef _Evaluator< UIntPack< FEMSigs ... > , PointD > _Evaluator;
+
+	typedef UIntPack< ( BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::BCornerSize + 1 ) ... > BCornerSizes;
+	static const unsigned int bCornerSizes[] = { ( BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::BCornerSize + 1 ) ... };
+	CumulativeDerivativeValues< V , Dim , _PointD > values;
+	LocalDepth d ; LocalOffset cIdx;
+	_localDepthAndOffset( node , d , cIdx );
+
+	static const CornerLoopData< ( BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::BCornerSize + 1 ) ... > loopData;
+
+	{
+		auto AddToValuesInterior = [&]
+		( 
+			unsigned int size , const unsigned int* indices ,
+			const typename FEMTreeNode::template ConstNeighbors< BCornerSizes >& neighbors ,
+			const typename _Evaluator::BCornerStencil& cornerStencil ,
+			ConstPointer( V ) coefficients
+		)
+		{
+			ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+			ConstPointer( CumulativeDerivativeValues< double , Dim , PointD > ) _values = cornerStencil().data;
+			for( unsigned int i=0 ; i<size ; i++ ) 
+			{
+				int idx = indices[i];
+				if( IsActiveNode< Dim >( nodes[ idx ] ) ) for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[ idx ]->nodeData.nodeIndex ] * (Real)_values[ idx ][d];
+			}
+		};
+		auto AddToValuesExterior = [&]
+		( 
+			unsigned int size , const unsigned int* indices ,
+			LocalDepth d , LocalOffset cIdx ,
+			const typename FEMTreeNode::template ConstNeighbors< BCornerSizes >& neighbors ,
+			ConstPointer( V ) coefficients , bool parent
+		)
+		{
+			ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+			for( unsigned int i=0 ; i<size ; i++ ) 
+			{
+				int idx = indices[i];
+				if( IsActiveNode< Dim >( nodes[ idx ] ) )
+				{
+					LocalDepth _d ; LocalOffset fIdx;
+					_localDepthAndOffset( nodes[idx] , _d , fIdx );
+					CumulativeDerivativeValues< double , Dim , _PointD > _values = evaluator.template _cornerValues< _PointD >( d , fIdx , cIdx , corner , parent );
+					for( int d=0 ; d<CumulativeDerivatives< Dim , _PointD >::Size ; d++ ) values[d] += coefficients[ nodes[idx]->nodeData.nodeIndex ] * (Real)_values[d];
+				}
+			}
+		};
+		if( isInterior ) AddToValuesInterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , neighborKey.neighbors[ node->depth() ] , evaluator.stencilData[d].ccBCornerStencil[corner] , solution );
+		else             AddToValuesExterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , d , cIdx , neighborKey.neighbors[ node->depth() ] , solution , false );
+		if( d>0 )
+		{
+			int _corner = int( node - node->parent->children );
+			if( isInterior ) AddToValuesInterior( loopData.pcSize[corner][_corner] , loopData.pcIndices[corner][_corner] , neighborKey.neighbors[ node->parent->depth() ] , evaluator.stencilData[d].pcBCornerStencils[_corner][corner] , coarseSolution );
+			else             AddToValuesExterior( loopData.pcSize[corner][_corner] , loopData.pcIndices[corner][_corner] , d , cIdx , neighborKey.neighbors[ node->parent->depth() ] , coarseSolution , true );
+		}
+		// If there could be finer neighbors whose support overlaps the point
+		if( d<_maxDepth )
+		{
+			typename FEMTreeNode::template ConstNeighbors< BCornerSizes > cNeighbors;
+			if( neighborKey.getChildNeighbors( corner , node->depth() , cNeighbors ) )
+			{
+				if( isInterior ) AddToValuesInterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , cNeighbors , evaluator.stencilData[d+1].ccBCornerStencil[corner] , solution );
+				else
+				{
+					LocalDepth _d=d+1 ; LocalOffset _cIdx;
+					for( int d=0 ; d<Dim ; d++ ) _cIdx[d] = (cIdx[d]<<1) | ( (corner&(1<<d)) ? 1 : 0 );
+					AddToValuesExterior( loopData.ccSize[corner] , loopData.ccIndices[corner] , _d , _cIdx , cNeighbors , solution , false );
+				}
+			}
+		}
+	}
+	return values;
+}
+////////////////////////////
+// MultiThreadedEvaluator //
+////////////////////////////
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , unsigned int PointD , typename T >
+FEMTree< Dim , Real >::_MultiThreadedEvaluator< UIntPack< FEMSigs ... > , PointD , T >::_MultiThreadedEvaluator( const FEMTree< Dim , Real >* tree , const DenseNodeData< T , FEMSignatures >& coefficients , int threads ) : _coefficients( coefficients ) , _tree( tree )
+{
+	tree->_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	_threads = std::max< int >( 1 , threads );
+	_pointNeighborKeys.resize( _threads );
+	_cornerNeighborKeys.resize( _threads );
+	_coarseCoefficients = _tree->template coarseCoefficients< T >( _coefficients );
+	_evaluator.set( _tree->_maxDepth );
+	for( int t=0 ; t<_pointNeighborKeys.size() ; t++ ) _pointNeighborKeys[t].set( tree->_localToGlobal( _tree->_maxDepth ) );
+	for( int t=0 ; t<_cornerNeighborKeys.size() ; t++ ) _cornerNeighborKeys[t].set( tree->_localToGlobal( _tree->_maxDepth ) );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , unsigned int PointD , typename T >
+template< unsigned int _PointD >
+CumulativeDerivativeValues< T , Dim , _PointD > FEMTree< Dim , Real >::_MultiThreadedEvaluator< UIntPack< FEMSigs ... > , PointD , T >::values( Point< Real , Dim > p , int thread , const FEMTreeNode* node )
+{
+	if( _PointD>PointD ) MK_THROW( "Evaluating more derivatives than available: " , _PointD , " <= " , PointD );
+	if( !node ) node = _tree->leaf( p );
+	ConstPointSupportKey< FEMDegrees >& nKey = _pointNeighborKeys[thread];
+	nKey.getNeighbors( node );
+	return _tree->template _getValues< T , _PointD >( nKey , node , p , _coefficients() , _coarseCoefficients() , _evaluator , _tree->_maxDepth );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , unsigned int PointD , typename T >
+template< unsigned int _PointD >
+CumulativeDerivativeValues< T , Dim , _PointD > FEMTree< Dim , Real >::_MultiThreadedEvaluator< UIntPack< FEMSigs ... > , PointD , T >::centerValues( const FEMTreeNode* node , int thread )
+{
+	if( _PointD>PointD ) MK_THROW( "Evaluating more derivatives than available: " , _PointD, " <= " , PointD );
+	ConstPointSupportKey< FEMDegrees >& nKey = _pointNeighborKeys[thread];
+	nKey.getNeighbors( node );
+	LocalDepth d ; LocalOffset off;
+	_tree->_localDepthAndOffset( node->parent , d , off );
+	return _tree->template _getCenterValues< T , _PointD >( nKey , node , _coefficients() , _coarseCoefficients() , _evaluator , _tree->_maxDepth , BaseFEMIntegrator::IsInteriorlySupported( UIntPack< FEMSigs ... >() , d , off ) );
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , unsigned int PointD , typename T >
+template< unsigned int _PointD >
+CumulativeDerivativeValues< T , Dim , _PointD > FEMTree< Dim , Real >::_MultiThreadedEvaluator< UIntPack< FEMSigs ... > , PointD , T >::cornerValues( const FEMTreeNode* node , int corner , int thread )
+{
+	if( _PointD>PointD ) MK_THROW( "Evaluating more derivatives than available: " , _PointD , " <= " , PointD );
+	ConstCornerSupportKey< FEMDegrees >& nKey = _cornerNeighborKeys[thread];
+	nKey.getNeighbors( node );
+	LocalDepth d ; LocalOffset off;
+	_tree->_localDepthAndOffset( node->parent , d , off );
+	return _tree->template _getCornerValues< T , _PointD >( nKey , node , corner , _coefficients() , _coarseCoefficients() , _evaluator , _tree->_maxDepth , BaseFEMIntegrator::IsInteriorlySupported( UIntPack< FEMSigs ... >() , d , off ) );
+}
+
+//////////////////////////////////
+// MultiThreadedSparseEvaluator //
+//////////////////////////////////
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T >
+FEMTree< Dim , Real >::MultiThreadedSparseEvaluator< UIntPack< FEMSigs ... > , T >::MultiThreadedSparseEvaluator( const FEMTree< Dim , Real >* tree , const SparseNodeData< T , FEMSignatures >& coefficients , int threads ) : _coefficients( coefficients ) , _tree( tree )
+{
+	tree->_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	_threads = std::max< int >( 1 , threads );
+	_pointNeighborKeys.resize( _threads );
+	_pointEvaluator = new typename FEMIntegrator::template PointEvaluator< UIntPack< FEMSigs ... > , ZeroUIntPack< Dim > >( _tree->_maxDepth );
+	for( int t=0 ; t<_pointNeighborKeys.size() ; t++ ) _pointNeighborKeys[t].set( tree->_localToGlobal( _tree->_maxDepth ) );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T >
+void FEMTree< Dim , Real >::MultiThreadedSparseEvaluator< UIntPack< FEMSigs ... > , T >::addValue( Point< Real , Dim > p , T &t , int thread , const FEMTreeNode *node )
+{
+	if( !node ) node = _tree->leaf( p );
+	ConstPointSupportKey< FEMDegrees >& nKey = _pointNeighborKeys[thread];
+	nKey.getNeighbors( node );
+	_tree->template _addEvaluation< T , SparseNodeData< T , FEMSignatures > , 0 >( _coefficients , p , _tree->_globalToLocal( node->depth() ) , *_pointEvaluator , nKey , t );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T >
+template< typename AccumulationFunctor/*=std::function< void ( const T & , Real s ) > */ >
+void FEMTree< Dim , Real >::MultiThreadedSparseEvaluator< UIntPack< FEMSigs ... > , T >::accumulate( Point< Real , Dim > p , AccumulationFunctor &Accumulate , int thread , const FEMTreeNode *node )
+{
+	if( !node ) node = _tree->leaf( p );
+	ConstPointSupportKey< FEMDegrees >& nKey = _pointNeighborKeys[thread];
+	nKey.getNeighbors( node );
+	_tree->template _accumulate< T , SparseNodeData< T , FEMSignatures > , 0 , AccumulationFunctor >( _coefficients , p , _tree->_globalToLocal( node->depth() ) , *_pointEvaluator , nKey , Accumulate );
+}
+
+template< unsigned int Dim , class Real >
+template< class V , class Coefficients , unsigned int D , unsigned int ... DataSigs >
+void FEMTree< Dim , Real >::_addEvaluation( const Coefficients& coefficients , Point< Real , Dim > p , const PointEvaluator< UIntPack< DataSigs ... > , IsotropicUIntPack< Dim , D > >& pointEvaluator , const ConstPointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , V &value ) const
+{
+	auto AF = [&value]( const V &w , Real s ){ value += w * s; };
+	_accumulate< V , Coefficients , D , decltype(AF) , DataSigs ... >( coefficients , p , pointEvaluator , dataKey , AF );
+}
+
+template< unsigned int Dim , class Real >
+template< class V , class Coefficients , unsigned int D , unsigned int ... DataSigs >
+void FEMTree< Dim , Real >::_addEvaluation( const Coefficients& coefficients , Point< Real , Dim > p , LocalDepth pointDepth , const PointEvaluator< UIntPack< DataSigs ... > , IsotropicUIntPack< Dim , D > >& pointEvaluator , const ConstPointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , V &value ) const
+{
+	auto AF = [&value]( const V &w , Real s ){ value += w * s; };
+	_accumulate< V , Coefficients , D , decltype(AF) , DataSigs... >( coefficients , p , pointDepth , pointEvaluator , dataKey , AF );
+}
+
+template< unsigned int Dim , class Real >
+template< typename V , typename Coefficients , unsigned int D , typename AccumulationFunctor , unsigned int ... DataSigs >
+void FEMTree< Dim , Real >::_accumulate( const Coefficients& coefficients , Point< Real , Dim > p , const PointEvaluator< UIntPack< DataSigs ... > , IsotropicUIntPack< Dim , D > >& pointEvaluator , const ConstPointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , AccumulationFunctor &Accumulate ) const
+{
+	_accumulate< V , Coefficients , D , AccumulationFunctor , DataSigs ... >( coefficients , p , _globalToLocal( dataKey.depth() ) , pointEvaluator , dataKey , Accumulate );
+}
+
+template< unsigned int Dim , class Real >
+template< typename V , typename Coefficients , unsigned int D , typename AccumulationFunctor , unsigned int ... DataSigs >
+void FEMTree< Dim , Real >::_accumulate( const Coefficients& coefficients , Point< Real , Dim > p , LocalDepth pointDepth , const PointEvaluator< UIntPack< DataSigs ... > , IsotropicUIntPack< Dim , D > >& pointEvaluator , const ConstPointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , AccumulationFunctor &Accumulate ) const
+{
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > SupportSizes;
+	PointEvaluatorState< UIntPack< DataSigs ... > , ZeroUIntPack< Dim > > state;
+	unsigned int derivatives[Dim];
+	memset( derivatives , 0 , sizeof( derivatives ) );
+	typedef PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > > DataKey;
+
+	for( int d=_localToGlobal( 0 ) ; d<=_localToGlobal( pointDepth ) ; d++ )
+	{
+		{
+			const FEMTreeNode* node = dataKey.neighbors[d].neighbors.data[ WindowIndex< UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > , UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportEnd ... > >::Index ];
+			if( !node ) MK_THROW( "Point is not centered on a node: " , p , " " , WindowIndex< UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > , UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportEnd ... > >::Index , " @ " , d );
+			pointEvaluator.initEvaluationState( p , _localDepth( node ) , state );
+		}
+		double scratch[Dim+1];
+		scratch[0] = 1;
+		ConstPointer( FEMTreeNode * const ) nodes = dataKey.neighbors[d].neighbors().data;
+		for( int i=0 ; i<WindowSize< SupportSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) )
+		{
+			const V* v = coefficients( nodes[i] );
+			if( v )
+			{
+				LocalDepth d ; LocalOffset off ; _localDepthAndOffset( nodes[i] , d , off );
+				Accumulate( *v , (Real)state.value( off , derivatives ) );
+			}
+		}
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< bool XMajor , class V , unsigned int ... DataSigs >
+Pointer( V ) FEMTree< Dim , Real >::regularGridEvaluate( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , int& res , LocalDepth depth , bool primal ) const
+{
+	if( depth<=0 ) depth = _maxDepth;
+	Pointer( V ) _coefficients = regularGridUpSample< XMajor >( coefficients , depth );
+
+	const int begin[] = { _BSplineBegin< DataSigs >( depth ) ... };
+	const int end  [] = { _BSplineEnd< DataSigs >( depth ) ... };
+	const int dim  [] = { ( _BSplineEnd< DataSigs >( depth ) - _BSplineBegin< DataSigs >( depth ) ) ... };
+
+	res = 1<<depth;
+	if( primal ) res++;
+	size_t cellCount = 1;
+	for( int d=0 ; d<Dim ; d++ ) cellCount *= res;
+	Pointer( V ) values = NewPointer< V >( cellCount );
+	memset( values , 0 , sizeof(V) * cellCount );
+
+	if( primal )
+	{
+		// evaluate at the cell corners
+		typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize ... > CornerSizes;
+		typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerEnd ... > CornerEnds;
+
+		EvaluationData::CornerEvaluator* evaluators[] = { ( new typename BSplineEvaluationData< DataSigs >::template CornerEvaluator< 0 >::Evaluator() ) ... };
+		for( int d=0 ; d<Dim ; d++ ) evaluators[d]->set( depth );
+		// Compute the offest from coefficient index to voxel index and the value of the stencil (if the voxel is interior)
+		StaticWindow< long long , UIntPack< ( BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize ? BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize : 1 ) ... > > offsets;
+		StaticWindow< double    , UIntPack< ( BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize ? BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize : 1 ) ... > > cornerValues;
+		int dimMultiplier[Dim];
+		if( XMajor )
+		{
+			dimMultiplier[0] = 1;
+			for( int d=1 ; d<Dim ; d++ ) dimMultiplier[d] = dimMultiplier[d-1] * dim[d-1];
+		}
+		else
+		{
+			dimMultiplier[Dim-1] = 1;
+			for( int d=Dim-2 ; d>=0 ; d-- ) dimMultiplier[d] = dimMultiplier[d+1] * dim[d+1];
+		}
+
+		{
+			int center = ( 1<<depth )>>1;
+			long long offset[Dim+1] ; offset[0] = 0;
+			double upValue[Dim+1] ; upValue[0] = 1;
+			WindowLoop< Dim >::Run
+			(
+				ZeroUIntPack< Dim >() , CornerSizes() ,
+				[&]( int d , int i ){ offset[d+1] = offset[d] + ( i - (int)CornerEnds::Values[d] - begin[d] ) * dimMultiplier[d] ; upValue[d+1] = upValue[d] * evaluators[d]->value( center + i - (int)CornerEnds::Values[d] , center , false ); } ,
+				[&]( long long& offsetValue , double& cornerValue ){ offsetValue = offset[Dim] , cornerValue = upValue[Dim]; } ,
+				offsets() , cornerValues()
+			);
+		}
+		ThreadPool::ParallelFor( 0 , cellCount , [&]( unsigned int , size_t c )
+		{
+			V& value = values[c];
+			int idx[Dim];
+			{
+				size_t _c = c;
+				if( XMajor ) for( int d=0 ; d<Dim ; d++ ) idx[      d] = _c % res , _c /= res;
+				else         for( int d=0 ; d<Dim ; d++ ) idx[Dim-1-d] = _c % res , _c /= res;
+			}
+			long long ii = 0;
+			for( int d=0 ; d<Dim ; d++ ) ii += idx[d] * dimMultiplier[d];
+
+			bool isInterior = true;
+			for( int d=0 ; d<Dim ; d++ ) if( ( idx[d] - (int)CornerEnds::Values[d] )<begin[d] || ( idx[d] - (int)CornerEnds::Values[d] + (int)CornerSizes::Values[d] )>=end[d] ) isInterior = false;
+
+			if( isInterior )
+			{
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] This should be modified to support 0-degree elements" )
+#endif // SHOW_WARNINGS
+				ConstPointer( long long ) offsetValues = offsets().data;
+				ConstPointer( double ) _cornerValues = cornerValues().data;
+				for( int i=0 ; i<WindowSize< CornerSizes >::Size ; i++ ) value += _coefficients[ offsetValues[i]+ii ] * (Real)_cornerValues[i];
+			}
+			else
+			{
+				double upValues[Dim+1] ; upValues[0] = 1;	// Accumulates the product of the weights
+				bool isValid[Dim+1] ; isValid[0] = true;
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , CornerSizes() ,
+					[&]( int d , int i )
+					{
+						int ii = idx[d] + i - (int)CornerEnds::Values[d];
+						if( ii>=begin[d] && ii<end[d] )
+						{
+							upValues[d+1] = upValues[d] * evaluators[d]->value( ii , idx[d] , false );
+							isValid[d+1] = isValid[d];
+						}
+						else isValid[d+1] = false;
+					} ,
+					[&]( long long offsetValue ){ if( isValid[Dim] ) value += _coefficients[ offsetValue + ii ] * (Real)upValues[Dim]; } ,
+					offsets()
+				);
+			}
+		}
+		);
+		for( int d=0 ; d<Dim ; d++ ) delete evaluators[d];
+	}
+	else
+	{
+		// evaluate at the cell centers
+		typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > SupportSizes;
+		typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportEnd ... > SupportEnds;
+
+		EvaluationData::CenterEvaluator* evaluators[] = { ( new typename BSplineEvaluationData< DataSigs >::template CenterEvaluator< 0 >::Evaluator() ) ... };
+		for( int d=0 ; d<Dim ; d++ ) evaluators[d]->set( depth );
+		// Compute the offest from coefficient index to voxel index and the value of the stencil (if the voxel is interior)
+		StaticWindow< long long , UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > > offsets;
+		StaticWindow< double    , UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > > centerValues;
+
+		int dimMultiplier[Dim];
+		if( XMajor )
+		{
+			dimMultiplier[0] = 1;
+			for( int d=1 ; d<Dim ; d++ ) dimMultiplier[d] = dimMultiplier[d-1] * dim[d-1];
+		}
+		else
+		{
+			dimMultiplier[Dim-1] = 1;
+			for( int d=Dim-2 ; d>=0 ; d-- ) dimMultiplier[d] = dimMultiplier[d+1] * dim[d+1];
+		}
+
+		{
+			int center = ( 1<<depth )>>1;
+			long long offset[Dim+1] ; offset[0] = 0;
+			double upValue[Dim+1] ; upValue[0] = 1;
+			WindowLoop< Dim >::Run
+			(
+				ZeroUIntPack< Dim >() , SupportSizes() ,
+				[&]( int d , int i ){ offset[d+1] = offset[d] + ( i - (int)SupportEnds::Values[d] - begin[d] ) * dimMultiplier[d] ; upValue[d+1] = upValue[d] * evaluators[d]->value( center + i - (int)SupportEnds::Values[d] , center , false ); } ,
+				[&]( long long& offsetValue , double& centerValue ){ offsetValue = offset[Dim] , centerValue = upValue[Dim]; } ,
+				offsets() , centerValues()
+			);
+		}
+		ThreadPool::ParallelFor( 0 , cellCount , [&]( unsigned int , size_t c )
+		{
+			V& value = values[c];
+			int idx[Dim];
+			{
+				size_t _c = c;
+				if( XMajor ) for( int d=0 ; d<Dim ; d++ ) idx[      d] = _c % res , _c /= res;
+				else         for( int d=0 ; d<Dim ; d++ ) idx[Dim-1-d] = _c % res , _c /= res;
+			}
+			long long ii = 0;
+			for( int d=0 ; d<Dim ; d++ ) ii += idx[d] * dimMultiplier[d];
+
+			bool isInterior = true;
+			for( int d=0 ; d<Dim ; d++ ) if( ( idx[d] - (int)SupportEnds::Values[d] )<begin[d] || ( idx[d] - (int)SupportEnds::Values[d] + (int)SupportSizes::Values[d] )>=end[d] ) isInterior = false;
+
+			if( isInterior )
+			{
+				ConstPointer( long long ) offsetValues = offsets().data;
+				ConstPointer( double ) _centerValues = centerValues().data;
+				for( int i=0 ; i<WindowSize< SupportSizes >::Size ; i++ ) value += _coefficients[ offsetValues[i] + ii ] * (Real)_centerValues[i];
+			}
+			else
+			{
+				double upValues[Dim+1] ; upValues[0] = 1;	// Accumulates the product of the weights
+				bool isValid[Dim+1] ; isValid[0] = true;
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , SupportSizes() ,
+					[&]( int d , int i )
+					{
+						int ii = idx[d] + i - (int)SupportEnds::Values[d];
+						if( ii>=begin[d] && ii<end[d] )
+						{
+							upValues[d+1] = upValues[d] * evaluators[d]->value( ii , idx[d] , false );
+							isValid[d+1] = isValid[d];
+						}
+						else isValid[d+1] = false;
+					} ,
+					[&]( long long offsetValue ){ if( isValid[Dim] ) value += _coefficients[ offsetValue + ii ] * (Real)upValues[Dim]; } ,
+					offsets()
+				);
+			}
+		}
+		);
+		for( int d=0 ; d<Dim ; d++ ) delete evaluators[d];
+	}
+	DeletePointer( _coefficients );
+
+	return values;
+}
+
+template< unsigned int Dim , class Real >
+template< bool XMajor , class V , unsigned int ... DataSigs >
+Pointer( V ) FEMTree< Dim , Real >::regularGridEvaluate( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , const unsigned int begin[Dim] , const unsigned int end[Dim] , unsigned int res[Dim] , bool primal ) const
+{
+	LocalDepth depth = _maxDepth;
+	Pointer( V ) _coefficients = regularGridUpSample< XMajor >( coefficients , depth );
+
+	const int _begin[] = { _BSplineBegin< DataSigs >( depth ) ... };
+	const int _end  [] = { _BSplineEnd< DataSigs >( depth ) ... };
+	const int _dim  [] = { ( _BSplineEnd< DataSigs >( depth ) - _BSplineBegin< DataSigs >( depth ) ) ... };
+
+	size_t cellCount = 1;
+	for( unsigned int d=0 ; d<Dim ; d++ ) res[d] = primal ? ( end[d]-begin[d]+1 ) : ( end[d]-begin[d] );
+	for( unsigned int d=0 ; d<Dim ; d++ ) cellCount *= res[d];
+
+	Pointer( V ) values = NewPointer< V >( cellCount );
+	memset( values , 0 , sizeof(V) * cellCount );
+
+	if( primal )
+	{
+		// evaluate at the cell corners
+		typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize ... > CornerSizes;
+		typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerEnd ... > CornerEnds;
+
+		EvaluationData::CornerEvaluator* evaluators[] = { ( new typename BSplineEvaluationData< DataSigs >::template CornerEvaluator< 0 >::Evaluator() ) ... };
+		for( int d=0 ; d<Dim ; d++ ) evaluators[d]->set( depth );
+		// Compute the offest from coefficient index to voxel index and the value of the stencil (if the voxel is interior)
+		StaticWindow< long long , UIntPack< ( BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize ? BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize : 1 ) ... > > offsets;
+		StaticWindow< double    , UIntPack< ( BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize ? BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::CornerSize : 1 ) ... > > cornerValues;
+		int dimMultiplier[Dim];
+		if( XMajor )
+		{
+			dimMultiplier[0] = 1;
+			for( int d=1 ; d<Dim ; d++ ) dimMultiplier[d] = dimMultiplier[d-1] * _dim[d-1];
+		}
+		else
+		{
+			dimMultiplier[Dim-1] = 1;
+			for( int d=Dim-2 ; d>=0 ; d-- ) dimMultiplier[d] = dimMultiplier[d+1] * _dim[d+1];
+		}
+
+		{
+			int center = ( 1<<depth )>>1;
+			long long offset[Dim+1] ; offset[0] = 0;
+			double upValue[Dim+1] ; upValue[0] = 1;
+			WindowLoop< Dim >::Run
+			(
+				ZeroUIntPack< Dim >() , CornerSizes() ,
+				[&]( int d , int i ){ offset[d+1] = offset[d] + ( i - (int)CornerEnds::Values[d] - _begin[d] ) * dimMultiplier[d] ; upValue[d+1] = upValue[d] * evaluators[d]->value( center + i - (int)CornerEnds::Values[d] , center , false ); } ,
+				[&]( long long& offsetValue , double& cornerValue ){ offsetValue = offset[Dim] , cornerValue = upValue[Dim]; } ,
+				offsets() , cornerValues()
+			);
+		}
+		ThreadPool::ParallelFor( 0 , cellCount , [&]( unsigned int , size_t c )
+			{
+				V &value = values[c];
+				int idx[Dim];
+				{
+					size_t _c = c;
+					if( XMajor ) for( int d=0 ; d<Dim ; d++ ) idx[      d] = begin[d] + _c % res[d] , _c /= res[d];
+					else         for( int d=0 ; d<Dim ; d++ ) idx[Dim-1-d] = begin[d] + _c % res[d] , _c /= res[d];
+				}
+				long long ii = 0;
+				for( int d=0 ; d<Dim ; d++ ) ii += idx[d] * dimMultiplier[d];
+
+				bool isInterior = true;
+				for( int d=0 ; d<Dim ; d++ ) if( ( idx[d] - (int)CornerEnds::Values[d] )<_begin[d] || ( idx[d] - (int)CornerEnds::Values[d] + (int)CornerSizes::Values[d] )>=_end[d] ) isInterior = false;
+
+				if( isInterior )
+				{
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] This should be modified to support 0-degree elements" )
+#endif // SHOW_WARNINGS
+					ConstPointer( long long ) offsetValues = offsets().data;
+					ConstPointer( double ) _cornerValues = cornerValues().data;
+					for( int i=0 ; i<WindowSize< CornerSizes >::Size ; i++ ) value += _coefficients[ offsetValues[i]+ii ] * (Real)_cornerValues[i];
+				}
+				else
+				{
+					double upValues[Dim+1] ; upValues[0] = 1;	// Accumulates the product of the weights
+					bool isValid[Dim+1] ; isValid[0] = true;
+					WindowLoop< Dim >::Run
+					(
+						ZeroUIntPack< Dim >() , CornerSizes() ,
+						[&]( int d , int i )
+						{
+							int ii = idx[d] + i - (int)CornerEnds::Values[d];
+							if( ii>=_begin[d] && ii<_end[d] )
+							{
+								upValues[d+1] = upValues[d] * evaluators[d]->value( ii , idx[d] , false );
+								isValid[d+1] = isValid[d];
+							}
+							else isValid[d+1] = false;
+						} ,
+						[&]( long long offsetValue ){ if( isValid[Dim] ) value += _coefficients[ offsetValue + ii ] * (Real)upValues[Dim]; } ,
+							offsets()
+							);
+				}
+			}
+		);
+		for( int d=0 ; d<Dim ; d++ ) delete evaluators[d];
+	}
+	else
+	{
+		// evaluate at the cell centers
+		typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > SupportSizes;
+		typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportEnd ... > SupportEnds;
+
+		EvaluationData::CenterEvaluator* evaluators[] = { ( new typename BSplineEvaluationData< DataSigs >::template CenterEvaluator< 0 >::Evaluator() ) ... };
+		for( int d=0 ; d<Dim ; d++ ) evaluators[d]->set( depth );
+		// Compute the offest from coefficient index to voxel index and the value of the stencil (if the voxel is interior)
+		StaticWindow< long long , UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > > offsets;
+		StaticWindow< double    , UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > > centerValues;
+
+		int dimMultiplier[Dim];
+		if( XMajor )
+		{
+			dimMultiplier[0] = 1;
+			for( int d=1 ; d<Dim ; d++ ) dimMultiplier[d] = dimMultiplier[d-1] * _dim[d-1];
+		}
+		else
+		{
+			dimMultiplier[Dim-1] = 1;
+			for( int d=Dim-2 ; d>=0 ; d-- ) dimMultiplier[d] = dimMultiplier[d+1] * _dim[d+1];
+		}
+
+		{
+			int center = ( 1<<depth )>>1;
+			long long offset[Dim+1] ; offset[0] = 0;
+			double upValue[Dim+1] ; upValue[0] = 1;
+			WindowLoop< Dim >::Run
+			(
+				ZeroUIntPack< Dim >() , SupportSizes() ,
+				[&]( int d , int i ){ offset[d+1] = offset[d] + ( i - (int)SupportEnds::Values[d] - _begin[d] ) * dimMultiplier[d] ; upValue[d+1] = upValue[d] * evaluators[d]->value( center + i - (int)SupportEnds::Values[d] , center , false ); } ,
+				[&]( long long& offsetValue , double& centerValue ){ offsetValue = offset[Dim] , centerValue = upValue[Dim]; } ,
+				offsets() , centerValues()
+			);
+		}
+		ThreadPool::ParallelFor( 0 , cellCount , [&]( unsigned int , size_t c )
+			{
+				V &value = values[c];
+				int idx[Dim];
+				{
+					size_t _c = c;
+					if( XMajor ) for( int d=0 ; d<Dim ; d++ ) idx[      d] = begin[d] + _c % res[d] , _c /= res[d];
+					else         for( int d=0 ; d<Dim ; d++ ) idx[Dim-1-d] = begin[d] + _c % res[d] , _c /= res[d];
+				}
+				long long ii = 0;
+				for( int d=0 ; d<Dim ; d++ ) ii += idx[d] * dimMultiplier[d];
+
+				bool isInterior = true;
+				for( int d=0 ; d<Dim ; d++ ) if( ( idx[d] - (int)SupportEnds::Values[d] )<_begin[d] || ( idx[d] - (int)SupportEnds::Values[d] + (int)SupportSizes::Values[d] )>=_end[d] ) isInterior = false;
+
+				if( isInterior )
+				{
+					ConstPointer( long long ) offsetValues = offsets().data;
+					ConstPointer( double ) _centerValues = centerValues().data;
+					for( int i=0 ; i<WindowSize< SupportSizes >::Size ; i++ ) value += _coefficients[ offsetValues[i] + ii ] * (Real)_centerValues[i];
+				}
+				else
+				{
+					double upValues[Dim+1] ; upValues[0] = 1;	// Accumulates the product of the weights
+					bool isValid[Dim+1] ; isValid[0] = true;
+					WindowLoop< Dim >::Run
+					(
+						ZeroUIntPack< Dim >() , SupportSizes() ,
+						[&]( int d , int i )
+						{
+							int ii = idx[d] + i - (int)SupportEnds::Values[d];
+							if( ii>=_begin[d] && ii<_end[d] )
+							{
+								upValues[d+1] = upValues[d] * evaluators[d]->value( ii , idx[d] , false );
+								isValid[d+1] = isValid[d];
+							}
+							else isValid[d+1] = false;
+						} ,
+						[&]( long long offsetValue ){ if( isValid[Dim] ) value += _coefficients[ offsetValue + ii ] * (Real)upValues[Dim]; } ,
+							offsets()
+							);
+				}
+			}
+		);
+		for( int d=0 ; d<Dim ; d++ ) delete evaluators[d];
+	}
+	DeletePointer( _coefficients );
+
+	return values;
+}
+
+template< unsigned int Dim , class Real >
+template< bool XMajor , class V , unsigned int ... DataSigs >
+Pointer( V ) FEMTree< Dim , Real >::regularGridUpSample( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , LocalDepth depth ) const
+{
+	if( depth<=0 ) depth = _maxDepth;
+	int begin[Dim] , end[Dim];
+	FEMIntegrator::BSplineBegin( UIntPack< DataSigs ... >() , depth , begin );
+	FEMIntegrator::BSplineEnd  ( UIntPack< DataSigs ... >() , depth , end   );
+	return regularGridUpSample< XMajor >( coefficients , begin , end , depth );
+}
+template< unsigned int Dim , class Real >
+template< bool XMajor , class V , unsigned int ... DataSigs >
+Pointer( V ) FEMTree< Dim , Real >::regularGridUpSample( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , const int begin[Dim] , const int end[Dim] , LocalDepth depth ) const
+{
+	if( depth<=0 ) depth = _maxDepth;
+
+	static const int DownSampleStart[][sizeof...(DataSigs)] = { { BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::DownSampleStart[0] ... } , { BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::DownSampleStart[1] ... } };
+	static const int DownSampleEnd  [][sizeof...(DataSigs)] = { { BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::DownSampleEnd  [0] ... } , { BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::DownSampleEnd  [1] ... } };
+
+	struct GridDimensions
+	{
+		int begin[Dim] , end[Dim] , dim[Dim];
+		int dimMultiplier[Dim];
+		GridDimensions( void ){ }
+		GridDimensions( const int b[Dim] , const int e[Dim] )
+		{
+			memcpy( begin , b , sizeof(begin) );
+			memcpy( end , e , sizeof(end) );
+			for( int d=0 ; d<Dim ; d++ ) dim[d] = end[d] - begin[d];
+			if( XMajor )
+			{
+				dimMultiplier[0] = 1;
+				for( int d=1 ; d<Dim ; d++ ) dimMultiplier[d] = dimMultiplier[d-1] * dim[d-1];
+			}
+			else
+			{
+				dimMultiplier[Dim-1] = 1;
+				for( int d=Dim-2 ; d>=0 ; d-- ) dimMultiplier[d] = dimMultiplier[d+1] * dim[d+1];
+			}
+		}
+	};
+
+	auto SetCoarseGridDimensions = []( const GridDimensions& fine , GridDimensions& coarse , int lowDepth )
+	{
+		int begin[Dim] , end[Dim];
+		FEMIntegrator::BSplineBegin( UIntPack< DataSigs ... >() , lowDepth , begin );
+		FEMIntegrator::BSplineEnd  ( UIntPack< DataSigs ... >() , lowDepth , end   );
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			coarse.begin[d] = std::max< int >( begin[d] , (fine.begin[d]>>1) + DownSampleStart[fine.begin[d]&1][d]   );
+			coarse.end  [d] = std::min< int >( end  [d] , (fine.end  [d]>>1) + DownSampleEnd  [fine.end  [d]&1][d]+1 );
+			coarse.dim  [d] = coarse.end[d] - coarse.begin[d];
+		}
+		if( XMajor )
+		{
+			coarse.dimMultiplier[0] = 1;
+			for( int d=1 ; d<Dim ; d++ ) coarse.dimMultiplier[d] = coarse.dimMultiplier[d-1] * coarse.dim[d-1];
+		}
+		else
+		{
+			coarse.dimMultiplier[Dim-1] = 1;
+			for( int d=Dim-2 ; d>=0 ; d-- ) coarse.dimMultiplier[d] = coarse.dimMultiplier[d+1] * coarse.dim[d+1];
+		}
+	};
+	auto InBounds = []( const LocalOffset& off , const GridDimensions& gDim )
+	{
+		for( int d=0 ; d<Dim ; d++ ) if( off[d]<gDim.begin[d] || off[d]>=gDim.end[d] ) return false;
+		return true;
+	};
+
+	std::vector< GridDimensions > gridDimensions( depth+1 );
+	gridDimensions[depth] = GridDimensions( begin , end );
+	for( int d=depth ; d>0 ; d-- ) SetCoarseGridDimensions( gridDimensions[d] , gridDimensions[d-1] , d-1 );
+
+	// Initialize the coefficients at the coarsest level
+	Pointer( V ) upSampledCoefficients = NullPointer( V );
+	{
+		LocalDepth _depth = 0;
+		size_t count = 1;
+		for( int dd=0 ; dd<Dim ; dd++ ) count *= gridDimensions[_depth].dim[dd];
+		upSampledCoefficients = NewPointer< V >( count );
+		memset( upSampledCoefficients , 0 , sizeof( V ) * count );
+		ThreadPool::ParallelFor( _sNodesBegin(_depth) , _sNodesEnd(_depth) , [&]( unsigned int , size_t i )
+		{
+			if( !_outOfBounds( UIntPack< DataSigs ... >() , _sNodes.treeNodes[i] ) )
+			{
+				LocalDepth _d ; LocalOffset _off;
+				_localDepthAndOffset( _sNodes.treeNodes[i] , _d , _off );
+				if( InBounds( _off , gridDimensions[_depth] ) )
+				{
+					size_t idx = 0;
+					for( int d=0 ; d<Dim ; d++ ) idx += gridDimensions[_depth].dimMultiplier[d] * ( _off[d] - gridDimensions[_depth].begin[d] );
+					upSampledCoefficients[idx] = coefficients[i];
+				}
+			}
+		}
+		);
+	}
+	// Up-sample and add in the existing coefficients
+	for( LocalDepth _depth=1 ; _depth<=depth ; _depth++ )
+	{
+		size_t count = 1;
+		for( int d=0 ; d<Dim ; d++ ) count *= gridDimensions[_depth].dim[d];
+		Pointer( V ) _coefficients = NewPointer< V >( count );
+		memset( _coefficients , 0 , sizeof( V ) * count );
+		if( _depth<=_maxDepth )
+			ThreadPool::ParallelFor( _sNodesBegin(_depth) , _sNodesEnd(_depth) , [&]( unsigned int , size_t i )
+			{
+				if( !_outOfBounds( UIntPack< DataSigs ... >() , _sNodes.treeNodes[i] ) )
+				{
+					LocalDepth _d ; LocalOffset _off;
+					_localDepthAndOffset( _sNodes.treeNodes[i] , _d , _off );
+					if( InBounds( _off , gridDimensions[_depth] ) )
+					{
+						size_t idx = 0;
+						for( int d=0 ; d<Dim ; d++ ) idx += gridDimensions[_depth].dimMultiplier[d] * ( _off[d] - gridDimensions[_depth].begin[d] );
+						_coefficients[idx] = coefficients[i];
+					}
+				}
+			}
+		);
+		_RegularGridUpSample< XMajor >( UIntPack< DataSigs ... >() , gridDimensions[_depth-1].begin , gridDimensions[_depth-1].end , gridDimensions[_depth].begin , gridDimensions[_depth].end , _depth , ( ConstPointer(V) )upSampledCoefficients , _coefficients );
+		DeletePointer( upSampledCoefficients );
+		upSampledCoefficients = _coefficients;
+	}
+	return upSampledCoefficients;
+}
+template< unsigned int Dim , class Real >
+template< class V , unsigned int ... DataSigs >
+V FEMTree< Dim , Real >::average( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients ) const
+{
+	Real begin[Dim] , end[Dim];
+	for( int d=0 ; d<Dim ; d++ ) begin[d] = (Real)0. , end[d] = (Real)1.;
+	return average( coefficients , begin , end );
+}
+template< unsigned int Dim , class Real >
+template< class V , unsigned int ... DataSigs >
+V FEMTree< Dim , Real >::average( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , const Real begin[Dim] , const Real end[Dim] ) const
+{
+	_setFEM1ValidityFlags( UIntPack< DataSigs ... >() );
+	std::vector< V > avgs( ThreadPool::NumThreads() );
+	for( int i=0 ; i<avgs.size() ; i++ ) avgs[i] = {};
+	double _begin[Dim] , _end[Dim];
+	for( int d=0 ; d<Dim ; d++ ) _begin[d] = begin[d] , _end[d] = end[d];
+	for( int d=0 ; d<=_maxDepth ; d++ )
+	{
+		int center = ( 1<<d )>>1;
+		int off[Dim];
+		double __begin[Dim] , __end[Dim];
+		for( int dd=0 ; dd<Dim ; dd++ ) off[dd] = center , __begin[dd] = 0 , __end[dd] = 1;
+		double integral = FEMIntegrator::Integral( UIntPack< DataSigs ... >() , d , off , __begin , __end );
+		ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int thread , size_t i )
+		{
+			if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+			{
+				int d , off[Dim];
+				_localDepthAndOffset( _sNodes.treeNodes[i] , d , off );
+				if( BaseFEMIntegrator::IsInteriorlySupported( UIntPack< FEMSignature< DataSigs >::Degree ... >() , d , off , _begin , _end ) ) avgs[ thread ] += (V)( coefficients[i] * (Real)integral );
+			}
+		}
+		);
+	}
+	V avg = {};
+	for( int i=0 ; i<avgs.size() ; i++ ) avg += avgs[i];
+	Real scale = (Real)1.;
+	for( int d=0 ; d<Dim ; d++ ) scale *= end[d] - begin[d];
+	return avg / scale;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int PointD , unsigned int ... FEMSigs >
+SparseNodeData< CumulativeDerivativeValues< Real , Dim , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > FEMTree< Dim , Real >::leafValues( const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , int maxDepth ) const
+{
+	if( maxDepth<0 ) maxDepth = _maxDepth;
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	SparseNodeData< CumulativeDerivativeValues< Real , Dim , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > values;
+	DenseNodeData< Real , UIntPack< FEMSigs ... > > _coefficients = coarseCoefficients< Real >( coefficients );
+	_Evaluator< UIntPack< FEMSigs ... > , PointD > evaluator;
+	evaluator.set( maxDepth );
+	for( LocalDepth d=maxDepth ; d>=0 ; d-- )
+	{
+		std::vector< ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > > > neighborKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( d ) );
+		ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int thread , size_t i )
+		{
+			if( _isValidSpaceNode( _sNodes.treeNodes[i] ) )
+			{
+				ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey = neighborKeys[ thread ];
+				FEMTreeNode* node = _sNodes.treeNodes[i];
+				if( !IsActiveNode< Dim >( node->children ) || d==maxDepth )
+				{
+					neighborKey.getNeighbors( node );
+					bool isInterior = _isInteriorlySupported( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , node->parent );
+					values[ node ] = _getCenterValues< Real , PointD >( neighborKey , node , coefficients() , _coefficients() , evaluator , maxDepth , isInterior );
+				}
+			}
+		}
+		);
+	}
+	return values;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.Initialize.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.Initialize.inl
@@ -1,0 +1,1184 @@
+/*
+Copyright (c) 2016, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+////////////////////////
+// FEMTreeInitializer //
+////////////////////////
+template< unsigned int Dim , class Real >
+size_t FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode &root , int maxDepth , std::function< bool ( int , int[] ) > Refine , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( root );
+	return _Initialize( root , maxDepth , Refine , nodeAllocator , NodeInitializer );
+}
+
+template< unsigned int Dim , class Real >
+size_t FEMTreeInitializer< Dim , Real >::_Initialize( FEMTreeNode &node , int maxDepth , std::function< bool ( int , int[] ) > Refine , Allocator< FEMTreeNode > *nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	size_t count = 0;
+	int d , off[3];
+	node.depthAndOffset( d , off );
+	if( d<maxDepth && Refine( d , off ) )
+	{
+		if( !node.children ) node.template initChildren< false >( nodeAllocator , NodeInitializer ) , count += 1<<Dim;
+		for( int c=0 ; c<(1<<Dim) ; c++ ) count += _Initialize( node.children[c] , maxDepth , Refine , nodeAllocator , NodeInitializer );
+	}
+	return count;
+}
+
+template< unsigned int Dim , class Real >
+template< typename IsValidFunctor /*=std::function< bool ( const Point< Real , Dim > & , const AuxData &... ) >*/ , typename ProcessFunctor/*=std::function< bool ( FEMTreeNode & , const Point< Real , Dim > & , const AuxData &... ) >*/ , typename ... AuxData >
+size_t FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData ... > &pointStream , AuxData ... d , int maxDepth ,                                                                  Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , IsValidFunctor IsValid , ProcessFunctor Process )
+{
+	return Initialize< IsValidFunctor , ProcessFunctor , AuxData ... >( root , pointStream , d... , maxDepth , [&]( Point< Real , Dim > ){ return maxDepth; } , nodeAllocator , NodeInitializer , IsValid , Process );
+}
+
+template< unsigned int Dim , class Real >
+template< typename IsValidFunctor/*=std::function< bool ( const Point< Real , Dim > & , const AuxData &... ) >*/ , typename ProcessFunctor/*=std::function< bool ( FEMTreeNode & , const Point< Real , Dim > & , const AuxData &... ) >*/ , typename ... AuxData >
+size_t FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData ... > &pointStream , AuxData ... d , int maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , IsValidFunctor IsValid , ProcessFunctor Process )
+{
+	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( root );
+	auto Leaf = [&]( FEMTreeNode& root , Point< Real , Dim > p , unsigned int maxDepth )
+		{
+			for( int d=0 ; d<Dim ; d++ ) if( p[d]<0 || p[d]>1 ) return (FEMTreeNode*)NULL;
+			Point< Real , Dim > center;
+			Real width;
+			typename FEMTree< Dim , Real >::LocalDepth depth;
+			typename FEMTree< Dim , Real >::LocalOffset offset;
+			root.centerAndWidth( center , width );
+			root.depthAndOffset( depth , offset );
+
+			FEMTreeNode* node = &root;
+
+			while( depth<(int)maxDepth )
+			{
+				if( !node->children ) node->template initChildren< false >( nodeAllocator , NodeInitializer );
+				int cIndex = FEMTreeNode::ChildIndex( center , p );
+				node = node->children + cIndex;
+				width /= 2;
+
+				depth++;
+				for( int dd=0 ; dd<Dim ; dd++ )
+					if( (cIndex>>dd) & 1 ) center[dd] += width/2 , offset[dd] = (offset[dd]<<1) | 1;
+					else                   center[dd] -= width/2 , offset[dd] = (offset[dd]<<1) | 0;
+			}
+			return node;
+		};
+
+	// Add the point data
+	size_t outOfBoundPoints = 0 , badDataCount = 0 , pointCount = 0;
+	Point< Real , Dim > p;
+	while( pointStream.read( p , d... ) )
+	{
+		// Check if the data is good
+		if( !IsValid( p , d... ) ){ badDataCount++ ; continue; }
+
+		// Check that the position is in-range
+		FEMTreeNode *leaf = Leaf( root , p , pointDepthFunctor(p) );
+		if( !leaf ){ outOfBoundPoints++ ; continue; }
+
+		// Process the data
+		if( Process( *leaf , p , d ... ) ) pointCount++;
+	}
+	pointStream.reset();
+	return pointCount;
+}
+
+template< unsigned int Dim , class Real >
+template< typename AuxData >
+size_t FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData > &pointStream , AuxData zeroData , int maxDepth , std::vector< PointSample >& samplePoints , std::vector< AuxData > &sampleData , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< Real ( const Point< Real , Dim > & , AuxData & ) > ProcessData )
+{
+	struct StreamInitializationData sid;
+	return Initialize< AuxData >( sid , root , pointStream , zeroData , maxDepth , samplePoints , sampleData , nodeAllocator , NodeInitializer , ProcessData );
+}
+
+template< unsigned int Dim , class Real >
+template< typename AuxData >
+size_t FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData > &pointStream , AuxData zeroData , int maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , std::vector< PointSample >& samplePoints , std::vector< AuxData > &sampleData , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< Real ( const Point< Real , Dim > & , AuxData & ) > ProcessData )
+{
+	struct StreamInitializationData sid;
+	return Initialize< AuxData >( sid , root , pointStream , zeroData , maxDepth , pointDepthFunctor , samplePoints , sampleData , nodeAllocator , NodeInitializer , ProcessData );
+}
+
+template< unsigned int Dim , class Real >
+template< typename AuxData >
+size_t FEMTreeInitializer< Dim , Real >::Initialize( struct StreamInitializationData &sid , FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData > &pointStream , AuxData zeroData , int maxDepth , std::vector< PointSample >& samplePoints , std::vector< AuxData > &sampleData , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< Real ( const Point< Real , Dim > & , AuxData & ) > ProcessData )
+{
+	return Initialize< AuxData >( sid , root , pointStream , zeroData , maxDepth , [&]( Point< Real , Dim > ){ return maxDepth; } , samplePoints , sampleData , nodeAllocator , NodeInitializer , ProcessData );
+}
+
+template< unsigned int Dim , class Real >
+template< typename AuxData >
+size_t FEMTreeInitializer< Dim , Real >::Initialize( struct StreamInitializationData &sid , FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData > &pointStream , AuxData zeroData , int maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , std::vector< PointSample >& samplePoints , std::vector< AuxData > &sampleData , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< Real ( const Point< Real , Dim > & , AuxData & ) > ProcessData )
+{
+	Real weight;
+	std::vector< node_index_type > &nodeToIndexMap = sid._nodeToIndexMap;
+
+	auto IsValid = [&]( const Point< Real , Dim > &p , AuxData & d )
+		{
+			weight = ProcessData( p , d );
+			return weight>0;
+		};
+	auto Process = [&]( FEMTreeNode &node , const Point< Real , Dim > &p , AuxData &d )
+		{
+			node_index_type nodeIndex = node.nodeData.nodeIndex;
+			// If the node's index exceeds what's stored in the node-to-index map, grow the node-to-index map
+			if( nodeIndex>=(node_index_type)nodeToIndexMap.size() ) nodeToIndexMap.resize( nodeIndex+1 , -1 );
+
+			node_index_type idx = nodeToIndexMap[ nodeIndex ];
+			if( idx==-1 )
+			{
+				idx = (node_index_type)samplePoints.size();
+				nodeToIndexMap[ nodeIndex ] = idx;
+				samplePoints.resize( idx+1 ) , samplePoints[idx].node = &node;
+				sampleData.resize( idx+1 );
+				samplePoints[idx].sample = ProjectiveData< Point< Real , Dim > , Real >( p*weight , weight );
+				sampleData[idx] = d*weight;
+			}
+			else
+			{
+				samplePoints[idx].sample += ProjectiveData< Point< Real , Dim > , Real >( p*weight , weight );
+				sampleData[ idx ] += d*weight;
+			}
+			return true;
+		};
+	return Initialize< decltype(IsValid) , decltype(Process) , AuxData >( root , pointStream , zeroData , maxDepth , pointDepthFunctor , nodeAllocator , NodeInitializer , IsValid , Process );
+}
+
+template< unsigned int Dim , class Real >
+void FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode &root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , int maxDepth , std::vector< PointSample >& samples , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( root );
+
+	std::vector< node_index_type > nodeToIndexMap;
+	ThreadPool::ParallelFor( 0 , simplices.size() , [&]( unsigned int t , size_t  i )
+	{
+		Simplex< Real , Dim , Dim-1 > s;
+		for( int k=0 ; k<Dim ; k++ ) s[k] = vertices[ simplices[i][k] ];
+		_AddSimplex< true >( root , s , maxDepth , samples , &nodeToIndexMap , nodeAllocators.size() ? nodeAllocators[t] : NULL , NodeInitializer );
+	} );
+}
+
+template< unsigned int Dim , class Real >
+void FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode &root , const std::vector< ProjectiveData< Point< Real , Dim > , Real > > &points , int maxDepth , std::vector< PointSample >& samples , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( root );
+
+	std::vector< node_index_type > nodeToIndexMap;
+	ThreadPool::ParallelFor( 0 , points.size() , [&]( unsigned int t , size_t  i )
+	{
+		_AddSample< true >( root , points[i] , maxDepth , samples , &nodeToIndexMap , nodeAllocators.size() ? nodeAllocators[t] : NULL , NodeInitializer );
+	} );
+}
+
+template< unsigned int Dim , class Real >
+void FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode &root , const std::vector< ProjectiveData< Point< Real , Dim > , Real > > &points , int maxDepth , std::vector< PointSample >& samples )
+{
+	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( root );
+
+	std::vector< node_index_type > nodeToIndexMap;
+	ThreadPool::ParallelFor( 0 , points.size() , [&]( unsigned int t , size_t  i )
+	{
+		_AddSample( root , points[i] , maxDepth , samples , &nodeToIndexMap );
+	} );
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe >
+size_t FEMTreeInitializer< Dim , Real >::_AddSample( FEMTreeNode& root , ProjectiveData< Point< Real , Dim > , Real > s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	auto Leaf = [&]( Point< Real , Dim > p , int maxDepth )
+	{
+		for( int d=0 ; d<Dim ; d++ ) if( p[d]<0 || p[d]>1 ) return (FEMTreeNode*)NULL;
+		Point< Real , Dim > center;
+		for( int d=0 ; d<Dim ; d++ ) center[d] = (Real)0.5;
+		Real width = Real(1.0);
+		FEMTreeNode* node = &root;
+		int d=0;
+		while( d<maxDepth )
+		{
+			if( !node->children ) node->template initChildren< ThreadSafe >( nodeAllocator , NodeInitializer );
+			int cIndex = FEMTreeNode::ChildIndex( center , p );
+			node = node->children + cIndex;
+			d++;
+			width /= 2;
+			for( int d=0 ; d<Dim ; d++ )
+				if( (cIndex>>d) & 1 ) center[d] += width/2;
+				else                  center[d] -= width/2;
+		}
+		return node;
+	};
+	FEMTreeNode *node = Leaf( s.value() , maxDepth );
+	if( !node ) return 0;
+	else        return _AddSample( node , s , maxDepth , samples , nodeToIndexMap );
+}
+
+template< unsigned int Dim , class Real >
+size_t FEMTreeInitializer< Dim , Real >::_AddSample( FEMTreeNode& root , ProjectiveData< Point< Real , Dim > , Real > s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap )
+{
+	auto Leaf = [&]( Point< Real , Dim > p , int maxDepth )
+	{
+		for( int d=0 ; d<Dim ; d++ ) if( p[d]<0 || p[d]>1 ) return (FEMTreeNode*)NULL;
+		Point< Real , Dim > center;
+		for( int d=0 ; d<Dim ; d++ ) center[d] = (Real)0.5;
+		Real width = Real(1.0);
+		FEMTreeNode* node = &root;
+		int d=0;
+		while( d<maxDepth && node->children )
+		{
+			int cIndex = FEMTreeNode::ChildIndex( center , p );
+			node = node->children + cIndex;
+			d++;
+			width /= 2;
+			for( int d=0 ; d<Dim ; d++ )
+				if( (cIndex>>d) & 1 ) center[d] += width/2;
+				else                  center[d] -= width/2;
+		}
+		return node;
+	};
+	FEMTreeNode *node = Leaf( s.value() , maxDepth );
+	if( !node ) return 0;
+	else        return _AddSample( node , s , maxDepth , samples , nodeToIndexMap );
+}
+
+template< unsigned int Dim , class Real >
+size_t FEMTreeInitializer< Dim , Real >::_AddSample( FEMTreeNode* node , ProjectiveData< Point< Real , Dim > , Real > s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap )
+{
+	if( nodeToIndexMap )
+	{
+		node_index_type nodeIndex = node->nodeData.nodeIndex;
+		{
+			static std::mutex m;
+			std::lock_guard< std::mutex > lock(m);
+			if( nodeIndex>=(node_index_type)nodeToIndexMap->size() ) nodeToIndexMap->resize( nodeIndex+1 , -1 );
+			node_index_type idx = (*nodeToIndexMap)[ nodeIndex ];
+			if( idx==-1 )
+			{
+				idx = (node_index_type)samples.size();
+				(*nodeToIndexMap)[ nodeIndex ] = idx;
+				samples.resize( idx+1 );
+				samples[idx].node = node;
+			}
+			samples[idx].sample += s;
+		}
+	}
+	else
+	{
+		{
+			static std::mutex m;
+			std::lock_guard< std::mutex > lock(m);
+			node_index_type idx = (node_index_type)samples.size();
+			samples.resize( idx+1 );
+			samples[idx].node = node;
+			samples[idx].sample = s;
+		}
+	}
+	return 1;
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe >
+size_t FEMTreeInitializer< Dim , Real >::_AddSimplex( FEMTreeNode& root , Simplex< Real , Dim , Dim-1 >& s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	std::vector< Simplex< Real , Dim , Dim-1 > > subSimplices;
+	subSimplices.push_back( s );
+
+	// Clip the simplex to the unit cube
+	{
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			Point< Real , Dim > n;
+			n[d] = 1;
+			{
+				std::vector< Simplex< Real , Dim , Dim-1 > > back , front;
+				for( int i=0 ; i<subSimplices.size() ; i++ ) subSimplices[i].split( n , 0 , back , front );
+				subSimplices = front;
+			}
+			{
+				std::vector< Simplex< Real , Dim , Dim-1 > > back , front;
+				for( int i=0 ; i<subSimplices.size() ; i++ ) subSimplices[i].split( n , 1 , back , front );
+				subSimplices = back;
+			}
+		}
+	}
+
+	struct RegularGridIndex
+	{
+		int idx[Dim];
+		bool operator != ( const RegularGridIndex& i ) const
+		{
+			for( int d=0 ; d<Dim ; d++ ) if( idx[d]!=i.idx[d] ) return true;
+			return false;
+		}
+	};
+
+	auto Leaf = [&]( Point< Real , Dim > p , int maxDepth )
+	{
+		for( int d=0 ; d<Dim ; d++ ) if( p[d]<0 || p[d]>1 ) return (FEMTreeNode*)NULL;
+		Point< Real , Dim > center;
+		for( int d=0 ; d<Dim ; d++ ) center[d] = (Real)0.5;
+		Real width = Real(1.0);
+		FEMTreeNode* node = &root;
+		int d=0;
+		while( d<maxDepth )
+		{
+			if( !node->children ) node->template initChildren< ThreadSafe >( nodeAllocator , NodeInitializer );
+			int cIndex = FEMTreeNode::ChildIndex( center , p );
+			node = node->children + cIndex;
+			d++;
+			width /= 2;
+			for( int d=0 ; d<Dim ; d++ )
+				if( (cIndex>>d) & 1 ) center[d] += width/2;
+				else                  center[d] -= width/2;
+		}
+		return node;
+	};
+
+	size_t sCount = 0;
+	for( int i=0 ; i<subSimplices.size() ; i++ )
+	{
+		// Find the finest depth at which the simplex is entirely within a node
+		int tDepth;
+		RegularGridIndex idx0 , idx;
+		for( tDepth=0 ; tDepth<maxDepth ; tDepth++ )
+		{
+			// Get the grid index of the first vertex of the simplex
+			for( int d=0 ; d<Dim ; d++ ) idx0.idx[d] = idx.idx[d] = (int)( subSimplices[i][0][d] * (1<<(tDepth+1)) );
+			bool done = false;
+			for( int k=0 ; k<Dim && !done ; k++ )
+			{
+				for( int d=0 ; d<Dim ; d++ ) idx.idx[d] = (int)( subSimplices[i][k][d] * (1<<(tDepth+1)) );
+				if( idx!=idx0 ) done = true;
+			}
+			if( done ) break;
+		}
+
+		// Generate a point in the middle of the simplex
+		sCount += _AddSimplex< ThreadSafe >( Leaf( subSimplices[i].center() , tDepth ) , subSimplices[i] , maxDepth , samples , nodeToIndexMap , nodeAllocator , NodeInitializer );
+	}
+	return sCount;
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe >
+size_t FEMTreeInitializer< Dim , Real >::_AddSimplex( FEMTreeNode* node , Simplex< Real , Dim , Dim-1 >& s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	int d = node->depth();
+	if( d==maxDepth )
+	{
+		Real weight = s.measure();
+		Point< Real , Dim > position = s.center();
+		if( weight && weight==weight )
+		{
+			if( nodeToIndexMap )
+			{
+				node_index_type nodeIndex = node->nodeData.nodeIndex;
+				{
+					static std::mutex m;
+					std::lock_guard< std::mutex > lock(m);
+					if( nodeIndex>=(node_index_type)nodeToIndexMap->size() ) nodeToIndexMap->resize( nodeIndex+1 , -1 );
+					node_index_type idx = (*nodeToIndexMap)[ nodeIndex ];
+					if( idx==-1 )
+					{
+						idx = (node_index_type)samples.size();
+						(*nodeToIndexMap)[ nodeIndex ] = idx;
+						samples.resize( idx+1 );
+						samples[idx].node = node;
+					}
+					samples[idx].sample += ProjectiveData< Point< Real , Dim > , Real >( position*weight , weight );
+				}
+			}
+			else
+			{
+				{
+					static std::mutex m;
+					std::lock_guard< std::mutex > lock(m);
+					node_index_type idx = (node_index_type)samples.size();
+					samples.resize( idx+1 );
+					samples[idx].node = node;
+					samples[idx].sample = ProjectiveData< Point< Real , Dim > , Real >( position*weight , weight );
+				}
+			}
+		}
+		return 1;
+	}
+	else
+	{
+		size_t sCount = 0;
+		if( !node->children ) node->template initChildren< ThreadSafe >( nodeAllocator , NodeInitializer );
+
+		// Split up the simplex and pass the parts on to the children
+		Point< Real , Dim > center;
+		Real width;
+		node->centerAndWidth( center , width );
+
+		std::vector< std::vector< Simplex< Real , Dim , Dim-1 > > > childSimplices( 1 );
+		childSimplices[0].push_back( s );
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			Point< Real , Dim > n ; n[Dim-d-1] = 1;
+			std::vector< std::vector< Simplex< Real , Dim , Dim-1 > > > temp( (int)( 1<<(d+1) ) );
+			for( int c=0 ; c<(1<<d) ; c++ ) for( size_t i=0 ; i<childSimplices[c].size() ; i++ ) childSimplices[c][i].split( n , center[Dim-d-1] , temp[2*c] , temp[2*c+1] );
+			childSimplices = temp;
+		}
+		for( int c=0 ; c<(1<<Dim) ; c++ ) for( size_t i=0 ; i<childSimplices[c].size() ; i++ ) if( childSimplices[c][i].measure() ) sCount += _AddSimplex< ThreadSafe >( node->children+c , childSimplices[c][i] , maxDepth , samples , nodeToIndexMap , nodeAllocator , NodeInitializer );
+		return sCount;
+	}
+}
+
+template< unsigned int Dim , class Real >
+void FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode& root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , unsigned int regularGridDepth , unsigned int maxDepth , std::vector< NodeSimplices< Dim , Real > >& nodeSimplices , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	if( regularGridDepth>maxDepth ) MK_THROW( "Regular grid depth cannot excceed maximum depth: " , regularGridDepth , " <= " , maxDepth );
+
+	// Allocate the tree up to the prescribed depth
+	const Real RegularGridWidth = (Real)( 1./(1<<regularGridDepth) );
+
+	auto Leaf = [&]( FEMTreeNode *root , Point< Real , Dim > p , int depth )
+	{
+		for( int d=0 ; d<Dim ; d++ ) if( p[d]<0 || p[d]>1 ) return (FEMTreeNode*)NULL;
+		Point< Real , Dim > center;
+		Real width;
+		root->centerAndWidth( center , width );
+		FEMTreeNode *node = root;
+		int d=node->depth();
+		while( d<depth )
+		{
+			if( !node->children ) node->template initChildren< false >( nodeAllocators.size() ? nodeAllocators[0] : NULL , NodeInitializer );
+			int cIndex = FEMTreeNode::ChildIndex( center , p );
+			node = node->children + cIndex;
+			d++;
+			width /= 2;
+			for( int d=0 ; d<Dim ; d++ )
+				if( (cIndex>>d) & 1 ) center[d] += width/2;
+				else                  center[d] -= width/2;
+		}
+		return node;
+	};
+
+	IndexedSimplicialComplex< Real , Dim , Dim-1 , node_index_type > sComplex( vertices , simplices );
+	typename Rasterizer< Real , Dim >::template SimplexRasterizationGrid< node_index_type , Dim-1 > raster = Rasterizer< Real , Dim >::template Rasterize< node_index_type >( sComplex , regularGridDepth , typename Rasterizer< Real , Dim >::ThreadSafety( Rasterizer< Real , Dim >::ThreadSafety::MUTEXES , regularGridDepth ) );
+//	typename Rasterizer< Real , Dim >::template SimplexRasterizationGrid< node_index_type , Dim-1 > raster = Rasterizer< Real , Dim >::template Rasterize< node_index_type >( sComplex , regularGridDepth , typename Rasterizer< Real , Dim >::ThreadSafety( Rasterizer< Real , Dim >::ThreadSafety::SINGLE_THREADED ) );
+//	typename Rasterizer< Real , Dim >::template SimplexRasterizationGrid< node_index_type , Dim-1 > raster = Rasterizer< Real , Dim >::template Rasterize< node_index_type >( sComplex , regularGridDepth , typename Rasterizer< Real , Dim >::ThreadSafety( Rasterizer< Real , Dim >::ThreadSafety::MAP_REDUCE ) );
+
+	size_t geometricCellCount = 0;
+	for( size_t i=0 ; i<raster.resolution() ; i++ ) if( raster[i].size() ) geometricCellCount++;
+
+	if( maxDepth==regularGridDepth )
+	{
+		nodeSimplices.resize( geometricCellCount );
+
+		geometricCellCount = 0;
+		for( size_t i=0 ; i<raster.resolution() ; i++ ) if( raster[i].size() )
+		{
+			int idx[Dim];
+			raster.setIndex( i , idx );
+			Point< Real , Dim > p;
+			for( int d=0 ; d<Dim ; d++ ) p[d] = (Real)( idx[d] + 0.5 ) * RegularGridWidth;
+			NodeSimplices< Dim , Real > &nSimplices = nodeSimplices[ geometricCellCount++ ];
+			nSimplices.node = Leaf( &root , p , maxDepth );
+			nSimplices.data = raster[i];
+		}
+	}
+	else
+	{
+		// The indices of the grid cells containing geometry
+		std::vector< size_t > cellIndices( geometricCellCount );
+		// The list of nodes @{regularGridDepth} containing geometry
+		std::vector< FEMTreeNode * > roots( geometricCellCount );
+		std::vector< node_index_type > nodeToIndexMap;
+
+		// Get the list of the indices of the regular grid containing geometry
+		geometricCellCount = 0;
+		// [WARNING] In principal, this could be done in parallel but then Leaf would need to be thread-safe.
+		for( size_t i=0 ; i<raster.resolution() ; i++ ) if( raster[i].size() )
+		{
+			cellIndices[ geometricCellCount ] = i;
+			int idx[Dim];
+			raster.setIndex( i , idx );
+			Point< Real , Dim > p;
+			for( int d=0 ; d<Dim ; d++ ) p[d] = (Real)( idx[d] + 0.5 ) * RegularGridWidth;
+			roots[ geometricCellCount ] = Leaf( &root , p , regularGridDepth );
+			geometricCellCount++;
+		}
+
+		std::vector< Allocator< FEMTreeNode > * > _nodeAllocators( ThreadPool::NumThreads() );
+		for( int i=0 ; i<_nodeAllocators.size() ; i++ ) _nodeAllocators[i] = nodeAllocators.size() ? nodeAllocators[i] : NULL;
+		ThreadPool::ParallelFor( 0 , geometricCellCount , [&]( unsigned int t , size_t i )
+		{
+			auto &cellSimplices = raster[ cellIndices[i] ];
+			for( int j=0 ; j<cellSimplices.size() ; j++ ) _AddSimplex< false , true >( *roots[i] , cellSimplices[j].first , cellSimplices[j].second , maxDepth , nodeSimplices , nodeToIndexMap , _nodeAllocators[t] , NodeInitializer );
+		} );
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafeAllocation , bool ThreadSafeSimplices >
+size_t FEMTreeInitializer< Dim , Real >::_AddSimplex( FEMTreeNode& root , node_index_type id , Simplex< Real , Dim , Dim-1 >& s , int maxDepth , std::vector< NodeSimplices< Dim , Real > >& simplices , std::vector< node_index_type >& nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	struct RegularGridIndex
+	{
+		int idx[Dim];
+		bool operator != ( const RegularGridIndex& i ) const
+		{
+			for( int d=0 ; d<Dim ; d++ ) if( idx[d]!=i.idx[d] ) return true;
+			return false;
+		}
+	};
+
+	auto Leaf = [&]( Point< Real , Dim > p , int maxDepth )
+	{
+		for( int d=0 ; d<Dim ; d++ ) if( p[d]<0 || p[d]>1 ) return (FEMTreeNode*)NULL;
+		Point< Real , Dim > center;
+		Real width;
+		root.centerAndWidth( center , width );
+		int d = root.depth();
+		FEMTreeNode* node = &root;
+		while( d<maxDepth )
+		{
+			if( !node->children ) node->template initChildren< ThreadSafeAllocation >( nodeAllocator , NodeInitializer );
+			int cIndex = FEMTreeNode::ChildIndex( center , p );
+			node = node->children + cIndex;
+			d++;
+			width /= 2;
+			for( int d=0 ; d<Dim ; d++ )
+				if( (cIndex>>d) & 1 ) center[d] += width/2;
+				else                  center[d] -= width/2;
+		}
+		return node;
+	};
+
+	// Find the finest depth at which the simplex is entirely within a node
+	int tDepth;
+	RegularGridIndex idx0 , idx;
+	for( tDepth=0 ; tDepth<maxDepth ; tDepth++ )
+	{
+		// Get the grid index of the first vertex of the simplex
+		for( int d=0 ; d<Dim ; d++ ) idx0.idx[d] = (int)( s[0][d] * (1<<(tDepth+1)) );
+		bool done = false;
+		for( int k=1 ; k<=Dim && !done ; k++ )
+		{
+			for( int d=0 ; d<Dim ; d++ ) idx.idx[d] = (int)( s[k][d] * (1<<(tDepth+1)) );
+			if( idx!=idx0 ) done = true;
+		}
+		if( done ) break;
+	}
+	// Add the simplex to the node
+	return _AddSimplex< ThreadSafeAllocation , ThreadSafeSimplices >( Leaf( s.center() , tDepth ) , id , s , maxDepth , simplices , nodeToIndexMap , nodeAllocator , NodeInitializer );
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafeAllocation , bool ThreadSafeSimplices >
+size_t FEMTreeInitializer< Dim , Real >::_AddSimplex( FEMTreeNode* node , node_index_type id , Simplex< Real , Dim , Dim-1 >& s , int maxDepth , std::vector< NodeSimplices< Dim , Real > >& simplices , std::vector< node_index_type >& nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	int d = node->depth();
+	if( d==maxDepth )
+	{
+		// If the simplex has non-zero size, add it to the list
+		Real weight = s.measure();
+		if( weight && weight==weight )
+		{
+			node_index_type nodeIndex = node->nodeData.nodeIndex;
+			if( ThreadSafeSimplices )
+			{
+				static std::mutex m;
+				std::lock_guard< std::mutex > lock(m);
+				if( nodeIndex>=(node_index_type)nodeToIndexMap.size() ) nodeToIndexMap.resize( nodeIndex+1 , -1 );
+				node_index_type idx = nodeToIndexMap[ nodeIndex ];
+				if( idx==-1 )
+				{
+					idx = (node_index_type)simplices.size();
+					nodeToIndexMap[ nodeIndex ] = idx;
+					simplices.resize( idx+1 );
+					simplices[idx].node = node;
+				}
+				simplices[idx].data.push_back( std::pair< node_index_type , Simplex< Real , Dim , Dim-1 > >( id , s ) );
+			}
+			else
+			{
+				if( nodeIndex>=(node_index_type)nodeToIndexMap.size() ) nodeToIndexMap.resize( nodeIndex+1 , -1 );
+				node_index_type idx = nodeToIndexMap[ nodeIndex ];
+				if( idx==-1 )
+				{
+					idx = (node_index_type)simplices.size();
+					nodeToIndexMap[ nodeIndex ] = idx;
+					simplices.resize( idx+1 );
+					simplices[idx].node = node;
+				}
+				simplices[idx].data.push_back( std::pair< node_index_type , Simplex< Real , Dim , Dim-1 > >( id , s ) );
+			}
+		}
+		return 1;
+	}
+	else
+	{
+		size_t sCount = 0;
+		if( !node->children ) node->template initChildren< ThreadSafeAllocation >( nodeAllocator , NodeInitializer );
+
+		// Split up the simplex and pass the parts on to the children
+		Point< Real , Dim > center;
+		Real width;
+		node->centerAndWidth( center , width );
+
+		std::vector< std::vector< Simplex< Real , Dim , Dim-1 > > > childSimplices( 1 );
+		childSimplices[0].push_back( s );
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			Point< Real , Dim > n ; n[Dim-d-1] = 1;
+			std::vector< std::vector< Simplex< Real , Dim , Dim-1 > > > temp( (int)( 1<<(d+1) ) );
+			for( int c=0 ; c<(1<<d) ; c++ ) for( int i=0 ; i<childSimplices[c].size() ; i++ ) childSimplices[c][i].split( n , center[Dim-d-1] , temp[2*c] , temp[2*c+1] );
+			childSimplices = temp;
+		}
+		for( int c=0 ; c<(1<<Dim) ; c++ ) for( int i=0 ; i<childSimplices[c].size() ; i++ ) sCount += _AddSimplex< ThreadSafeAllocation , ThreadSafeSimplices >( node->children+c , id , childSimplices[c][i] , maxDepth , simplices , nodeToIndexMap , nodeAllocator , NodeInitializer );
+		return sCount;
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< class Data , class _Data , bool Dual >
+size_t FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode& root , ConstPointer( Data ) values , ConstPointer( int ) labels , int resolution[Dim] , std::vector< NodeSample< Dim , _Data > > derivatives[Dim] , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< _Data ( const Data& ) > DataConverter )
+{
+	auto Leaf = [&]( FEMTreeNode& root , const int idx[Dim] , int maxDepth )
+	{
+		for( int d=0 ; d<Dim ; d++ ) if( idx[d]<0 || idx[d]>=(1<<maxDepth) ) return (FEMTreeNode*)NULL;
+		FEMTreeNode* node = &root;
+		for( int d=0 ; d<maxDepth ; d++ )
+		{
+			if( !node->children ) node->template initChildren< false >( nodeAllocator , NodeInitializer );
+			int cIndex = 0;
+			for( int dd=0 ; dd<Dim ; dd++ ) if( idx[dd]&(1<<(maxDepth-d-1)) ) cIndex |= 1<<dd;
+			node = node->children + cIndex;
+		}
+		return node;
+	};
+	auto FactorIndex = []( size_t i , const int resolution[Dim] , int idx[Dim] )
+	{
+		size_t ii = i;
+		for( int d=0 ; d<Dim ; d++ ) idx[d] = ii % resolution[d] , ii /= resolution[d];
+	};
+	auto MakeIndex = [] ( const int idx[Dim] , const int resolution[Dim] )
+	{
+		size_t i = 0;
+		for( int d=0 ; d<Dim ; d++ ) i = i * resolution[Dim-1-d] + idx[Dim-1-d];
+		return i;
+	};
+
+
+	int maxResolution = resolution[0];
+	for( int d=1 ; d<Dim ; d++ ) maxResolution = std::max< int >( maxResolution , resolution[d] );
+	int maxDepth = 0;
+	while( ( (1<<maxDepth) + ( Dual ? 0 : 1 ) )<maxResolution ) maxDepth++;
+
+	size_t totalRes = 1;
+	for( int d=0 ; d<Dim ; d++ ) totalRes *= resolution[d];
+
+	// Iterate over each direction
+	for( int d=0 ; d<Dim ; d++ ) for( size_t i=0 ; i<totalRes ; i++ )
+	{
+		// Factor the index into directional components and get the index of the next cell
+		int idx[Dim] ; FactorIndex( i , resolution , idx ) ; idx[d]++;
+
+		if( idx[d]<resolution[d] )
+		{
+			// Get the index of the next cell
+			size_t ii = MakeIndex( idx , resolution );
+
+			// [NOTE] There are no derivatives across negative labels
+			if( labels[i]!=labels[ii] && labels[i]>=0 && labels[ii]>=0 )
+			{
+				if( !Dual ) idx[d]--;
+				NodeSample< Dim , _Data > nodeSample;
+				nodeSample.node = Leaf( root , idx , maxDepth );
+				nodeSample.data = DataConverter( values[ii] ) - DataConverter( values[i] );
+				if( nodeSample.node ) derivatives[d].push_back( nodeSample );
+			}
+		}
+	}
+	return maxDepth;
+}
+
+template< unsigned int Dim , class Real >
+template< bool Dual , class Data >
+unsigned int FEMTreeInitializer< Dim , Real >::Initialize( FEMTreeNode& root , DerivativeStream< Data >& dStream , Data zeroData , std::vector< NodeSample< Dim , Data > > derivatives[Dim] , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	// Note:
+	// --   Dual: The difference between [i] and [i+1] is stored at cell [i+1]
+	// -- Primal: The difference between [i] and [i+1] is stored at cell [i]
+
+	// Find the leaf containing the specified cell index
+	auto Leaf = [&]( FEMTreeNode& root , const unsigned int idx[Dim] , unsigned int maxDepth )
+	{
+		for( int d=0 ; d<Dim ; d++ ) if( idx[d]<0 || idx[d]>=(unsigned int)(1<<maxDepth) ) return (FEMTreeNode*)NULL;
+		FEMTreeNode* node = &root;
+		for( unsigned int d=0 ; d<maxDepth ; d++ )
+		{
+			if( !node->children ) node->template initChildren< false >( nodeAllocator , NodeInitializer );
+			int cIndex = 0;
+			for( int dd=0 ; dd<Dim ; dd++ ) if( idx[dd]&(1<<(maxDepth-d-1)) ) cIndex |= 1<<dd;
+			node = node->children + cIndex;
+		}
+		return node;
+	};
+
+	unsigned int resolution[Dim];
+	dStream.resolution( resolution );
+	unsigned int maxResolution = resolution[0];
+	for( int d=1 ; d<Dim ; d++ ) maxResolution = std::max< unsigned int >( maxResolution , resolution[d] );
+	unsigned int maxDepth = 0;
+
+	// If we are using a dual formulation, we need at least maxResolution cells.
+	// Otherwise, we need at least maxResolution-1 cells.
+	while( (unsigned int)( (1<<maxDepth) + ( Dual ? 0 : 1 ) )<maxResolution ) maxDepth++;
+
+	unsigned int idx[Dim] , dir;
+	Data dValue = zeroData;
+	while( dStream.nextDerivative( idx , dir , dValue ) )
+	{
+		if( Dual ) idx[dir]++;
+		NodeSample< Dim , Data > nodeSample;
+		nodeSample.node = Leaf( root , idx , maxDepth );
+		nodeSample.data = dValue;
+		if( nodeSample.node ) derivatives[dir].push_back( nodeSample );
+	}
+	return maxDepth;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int _Dim >
+typename std::enable_if< _Dim!=1 , DenseNodeData< typename FEMTreeInitializer< Dim , Real >::GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > >::type FEMTreeInitializer< Dim , Real >::GetGeometryNodeDesignators( FEMTreeNode *root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , unsigned int regularGridDepth , unsigned int maxDepth , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	static_assert( Dim==_Dim , "[ERROR] Dimensions don't match" );
+	std::vector< Point< Real , Dim > > normals( simplices.size() );
+	ThreadPool::ParallelFor
+	(
+		0 , simplices.size() ,
+		[&]( unsigned int , size_t i )
+	{
+		Simplex< Real , Dim , Dim-1 > s;
+		for( int j=0 ; j<Dim ; j++ ) s[j] = vertices[ simplices[i][j] ];
+		normals[i] = s.normal();
+	}
+	);
+	return _GetGeometryNodeDesignators( root , vertices , simplices , normals , regularGridDepth , maxDepth , nodeAllocators , NodeInitializer );
+}
+template< unsigned int Dim , class Real >
+template< unsigned int _Dim >
+typename std::enable_if< _Dim==1 , DenseNodeData< typename FEMTreeInitializer< Dim , Real >::GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > >::type FEMTreeInitializer< Dim , Real >::GetGeometryNodeDesignators( FEMTreeNode *root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , unsigned int regularGridDepth , unsigned int maxDepth , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	static_assert( Dim==_Dim , "[ERROR] Dimensions don't match" );
+	if( simplices.size()%2 ) MK_THROW( "Expected even number of hull points: " , simplices.size() );
+	struct HullPoint
+	{
+		Real x;
+		size_t idx;
+	};
+	std::vector< HullPoint > hullPoints( simplices.size() );
+	for( size_t i=0 ; i<simplices.size() ; i++ ) hullPoints[i].x = vertices[ simplices[i][0] ][0] , hullPoints[i].idx = i;
+	std::sort( hullPoints.begin() , hullPoints.end() , []( const HullPoint &hp1 , const HullPoint &hp2 ){ return hp1.x<hp2.x; } );
+	std::vector< Point< Real , Dim > > normals( simplices.size() );
+	for( int i=0 ; i<hullPoints.size() ; i++ ) normals[ hullPoints[i].idx ][0] = (i%2) ? (Real)1. : (Real)-1.;
+	return _GetGeometryNodeDesignators( root , vertices , simplices , normals , regularGridDepth , maxDepth , nodeAllocators , NodeInitializer );
+}
+
+template< unsigned int Dim , class Real >
+DenseNodeData< typename FEMTreeInitializer< Dim , Real >::GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > FEMTreeInitializer< Dim , Real >::_GetGeometryNodeDesignators( FEMTreeNode *root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , const std::vector< Point< Real , Dim > > &normals , unsigned int regularGridDepth , unsigned int maxDepth , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer )
+{
+	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( root );
+
+	typedef typename FEMTreeNode::template ConstNeighborKey< IsotropicUIntPack< Dim , 1 > , IsotropicUIntPack< Dim , 1 > > NeighborKey;
+	typedef typename FEMTreeNode::template ConstNeighbors< IsotropicUIntPack< Dim , 3 > > Neighbors;
+	DenseNodeData< typename FEMTreeInitializer< Dim , Real >::GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > geometryNodeDesignators;
+
+	// Rasterize the geometry into the tree
+	std::vector< NodeSimplices< Dim , Real > > nodeSimplices;
+	FEMTreeInitializer< Dim , Real >::Initialize( *root , vertices , simplices , regularGridDepth , maxDepth , nodeSimplices , nodeAllocators , NodeInitializer );
+
+	// Mark all the nodes containing geometry
+	node_index_type nodeCount = 0;
+	root->processNodes( [&]( FEMTreeNode *node ){ nodeCount = std::max< node_index_type >( nodeCount , node->nodeData.nodeIndex ); } );
+	nodeCount++;
+
+	geometryNodeDesignators.resize( nodeCount );
+
+	ThreadPool::ParallelFor( 0 , nodeSimplices.size() , [&]( unsigned int , size_t i ){ for( FEMTreeNode *node=nodeSimplices[i].node ; node ; node=node->parent ) geometryNodeDesignators[node] = GeometryNodeType::BOUNDARY; } );
+
+	// Propagate out from the boundary nodes
+	std::vector< const FEMTreeNode * > interiorNodes , exteriorNodes;
+	std::vector< std::vector< const FEMTreeNode * > > _interiorNodes( ThreadPool::NumThreads() ) ,  _exteriorNodes( ThreadPool::NumThreads() );
+
+	std::vector< NeighborKey > neighborKeys( ThreadPool::NumThreads() );
+	for( int i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( maxDepth );
+
+	// In the first pass, flood-fill from the geometry-containing nodes
+	ThreadPool::ParallelFor( 0 , nodeSimplices.size() , [&]( unsigned int thread , size_t i )
+	{
+		std::vector< const FEMTreeNode * > &interiorNodes = _interiorNodes[thread];
+		std::vector< const FEMTreeNode * > &exteriorNodes = _exteriorNodes[thread];
+		NeighborKey &neighborKey = neighborKeys[thread];
+		Point< Real , Dim > center ; Real width;
+		nodeSimplices[i].node->centerAndWidth( center , width );
+		Neighbors &neighbors = neighborKey.getNeighbors( nodeSimplices[i].node );
+
+		// Iterate over the faces
+		for( unsigned int d=0 ; d<Dim ; d++ ) for( int dir=0 ; dir<=2 ; dir+=2 )
+		{
+			unsigned int idx[Dim];
+			for( unsigned int d=0 ; d<Dim ; d++ ) idx[d] = 1;
+			idx[d] = dir;
+
+			// Terminate early if the neighbor node exists but contains geometry
+			const FEMTreeNode *node = neighbors.neighbors( idx );
+			if( node && geometryNodeDesignators[node]==GeometryNodeType::BOUNDARY ) continue;
+
+			// Compute the center of the face
+			Point< Real , Dim > p = center;
+			p[d] += (Real)(dir-1) * width / 2;
+
+			// If the center of the face is outside and the face-adjacent node does not contain geometry, add the face-adjacent neighbor to the list of exterior nodes
+			std::vector< Simplex< Real , Dim , Dim-1 > > _simplices( nodeSimplices[i].data.size() );
+			std::vector< Point< Real , Dim > > _normals( nodeSimplices[i].data.size() ); 
+			for( int j=0 ; j<nodeSimplices[i].data.size() ; j++ )
+			{
+				_simplices[j] = nodeSimplices[i].data[j].second;
+				_normals[j] = normals[ nodeSimplices[i].data[j].first ];
+			}
+
+			bool interior = Simplex< Real , Dim , Dim-1 >::IsInterior( p , _simplices , _normals );
+			{
+				const FEMTreeNode *node = neighbors.neighbors( idx );
+
+				// If the face-adjacent node exists and does not contain geometry, add it to the list of exterior nodes
+				if( node )
+				{
+					if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN )
+						if( interior ) interiorNodes.push_back( node );
+						else           exteriorNodes.push_back( node );
+				}
+				// Otherwise, try the parents' face-adjacent neighbors
+				else
+				{
+					for( int depth=maxDepth-1 ; depth>=0 ; depth-- )
+					{
+						node = neighborKey.neighbors[depth].neighbors( idx );
+						if( node )
+						{
+							if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN )
+								if( interior ) interiorNodes.push_back( node );
+								else           exteriorNodes.push_back( node );
+							break;
+						}
+					}
+				}
+			}
+		}
+	} );
+
+	// Merge the exterior nodes computed by the different threads and mark them exterior
+	{
+		size_t interiorCount = 0 , exteriorCount = 0;;
+		for( int i=0 ; i<_interiorNodes.size() ; i++ ) interiorCount += _interiorNodes[i].size();
+		for( int i=0 ; i<_exteriorNodes.size() ; i++ ) exteriorCount += _exteriorNodes[i].size();
+		interiorNodes.reserve( interiorCount ) , exteriorNodes.reserve( exteriorCount );
+		for( int i=0 ; i<_interiorNodes.size() ; i++ ) for( int j=0 ; j<_interiorNodes[i].size() ; j++ )
+		{
+			if( geometryNodeDesignators[ _interiorNodes[i][j] ]==GeometryNodeType::BOUNDARY ) MK_THROW( "Interior node has geometry" );
+			else if( geometryNodeDesignators[ _interiorNodes[i][j] ]==GeometryNodeType::UNKNOWN )
+			{
+				geometryNodeDesignators[ _interiorNodes[i][j] ] = GeometryNodeType::INTERIOR;
+				interiorNodes.push_back( _interiorNodes[i][j] );
+			}
+		}
+		for( int i=0 ; i<_exteriorNodes.size() ; i++ ) for( int j=0 ; j<_exteriorNodes[i].size() ; j++ )
+		{
+			if( geometryNodeDesignators[ _exteriorNodes[i][j] ]==GeometryNodeType::BOUNDARY ) MK_THROW( "Exterior node has geometry" );
+			else if( geometryNodeDesignators[ _exteriorNodes[i][j] ]==GeometryNodeType::UNKNOWN )
+			{
+				geometryNodeDesignators[ _exteriorNodes[i][j] ] = GeometryNodeType::EXTERIOR;
+				exteriorNodes.push_back( _exteriorNodes[i][j] );
+			}
+		}
+	}
+
+	// In subsequent passes, propagate from nodes marked as interior/exterior
+	while( interiorNodes.size() || exteriorNodes.size() )
+	{
+		for( int i=0 ; i<_interiorNodes.size() ; i++ ) _interiorNodes[i].resize( 0 );
+		for( int i=0 ; i<_exteriorNodes.size() ; i++ ) _exteriorNodes[i].resize( 0 );
+
+		ThreadPool::ParallelFor( 0 , interiorNodes.size() , [&]( unsigned int thread , size_t i )
+		{
+			std::vector< const FEMTreeNode * > &__interiorNodes = _interiorNodes[thread];
+			NeighborKey &neighborKey = neighborKeys[thread];
+			Neighbors &neighbors = neighborKey.getNeighbors( interiorNodes[i] );
+
+			// Iterate over the faces
+			for( unsigned int d=0 ; d<Dim ; d++ ) for( int dir=0 ; dir<=2 ; dir+=2 )
+			{
+				unsigned int idx[Dim];
+				for( unsigned int _d=0 ; _d<Dim ; _d++ ) idx[_d] = 1;
+				idx[d] = dir;
+
+				for( int depth=interiorNodes[i]->depth() ; depth>=0 ; depth-- )
+				{
+					const FEMTreeNode *node = neighborKey.neighbors[depth].neighbors( idx );
+					if( node )
+					{
+						if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN ) __interiorNodes.push_back( node );
+						break;
+					}
+				}
+			}
+		} );
+
+		ThreadPool::ParallelFor( 0 , exteriorNodes.size() , [&]( unsigned int thread , size_t i )
+		{
+			std::vector< const FEMTreeNode * > &__exteriorNodes = _exteriorNodes[thread];
+			NeighborKey &neighborKey = neighborKeys[thread];
+			Neighbors &neighbors = neighborKey.getNeighbors( exteriorNodes[i] );
+
+			// Iterate over the faces
+			for( unsigned int d=0 ; d<Dim ; d++ ) for( int dir=0 ; dir<=2 ; dir+=2 )
+			{
+				unsigned int idx[Dim];
+				for( unsigned int _d=0 ; _d<Dim ; _d++ ) idx[_d] = 1;
+				idx[d] = dir;
+
+				for( int depth=exteriorNodes[i]->depth() ; depth>=0 ; depth-- )
+				{
+					const FEMTreeNode *node = neighborKey.neighbors[depth].neighbors( idx );
+					if( node )
+					{
+						if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN ) __exteriorNodes.push_back( node );
+						break;
+					}
+				}
+			}
+		} );
+
+		// Merge the interior/exterior nodes computed by the different threads
+		{
+			size_t interiorCount = 0 , exteriorCount = 0;
+			for( int i=0 ; i<_interiorNodes.size() ; i++ ) interiorCount += _interiorNodes[i].size();
+			for( int i=0 ; i<_exteriorNodes.size() ; i++ ) exteriorCount += _exteriorNodes[i].size();
+			if( !interiorCount && !exteriorCount ) break;
+			interiorNodes.resize( 0 ) , exteriorNodes.resize( 0 );
+			interiorNodes.reserve( interiorCount ) , exteriorNodes.reserve( exteriorCount );
+
+			for( int i=0 ; i<_interiorNodes.size() ; i++ ) for( int j=0 ; j<_interiorNodes[i].size() ; j++ )
+			{
+				if( geometryNodeDesignators[ _interiorNodes[i][j] ]==GeometryNodeType::BOUNDARY ) MK_THROW( "Interior node has geometry" );
+				else if( geometryNodeDesignators[ _interiorNodes[i][j] ]==GeometryNodeType::UNKNOWN )
+				{
+					geometryNodeDesignators[ _interiorNodes[i][j] ] = GeometryNodeType::INTERIOR;
+					interiorNodes.push_back( _interiorNodes[i][j] );
+				}
+			}
+			for( int i=0 ; i<_exteriorNodes.size() ; i++ ) for( int j=0 ; j<_exteriorNodes[i].size() ; j++ )
+			{
+				if( geometryNodeDesignators[ _exteriorNodes[i][j] ]==GeometryNodeType::BOUNDARY ) MK_THROW( "Exterior node has geometry" );
+				else if( geometryNodeDesignators[ _exteriorNodes[i][j] ]==GeometryNodeType::UNKNOWN )
+				{
+					geometryNodeDesignators[ _exteriorNodes[i][j] ] = GeometryNodeType::EXTERIOR;
+					exteriorNodes.push_back( _exteriorNodes[i][j] );
+				}
+			}
+		}
+	}
+
+	size_t correctionCount=0;
+	std::function< void ( FEMTreeNode * ) > CorrectDesignatorsFromChildren = [&]( const FEMTreeNode *node )
+	{
+		if( node->children )
+		{
+			int interiorCount=0 , exteriorCount=0 , boundaryCount=0;
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+			{
+				CorrectDesignatorsFromChildren( node->children+c );
+				if     ( geometryNodeDesignators[node->children+c]==GeometryNodeType::INTERIOR ) interiorCount++;
+				else if( geometryNodeDesignators[node->children+c]==GeometryNodeType::EXTERIOR ) exteriorCount++;
+				else if( geometryNodeDesignators[node->children+c]==GeometryNodeType::BOUNDARY ) boundaryCount++;
+			}
+			if( boundaryCount || ( exteriorCount && interiorCount ) )
+			{
+				if( geometryNodeDesignators[node]!=GeometryNodeType::UNKNOWN && geometryNodeDesignators[node]!=GeometryNodeType::BOUNDARY ) correctionCount++;
+				geometryNodeDesignators[node] = GeometryNodeType::BOUNDARY;
+			}
+			else if( interiorCount==(1<<Dim) )
+			{
+				if( geometryNodeDesignators[node]!=GeometryNodeType::UNKNOWN && geometryNodeDesignators[node]!=GeometryNodeType::INTERIOR ) correctionCount++;
+				geometryNodeDesignators[node] = GeometryNodeType::INTERIOR;
+			}
+			else if( exteriorCount==(1<<Dim) )
+			{
+				if( geometryNodeDesignators[node]!=GeometryNodeType::UNKNOWN && geometryNodeDesignators[node]!=GeometryNodeType::EXTERIOR ) correctionCount++;
+				geometryNodeDesignators[node] = GeometryNodeType::EXTERIOR;
+			}
+			else if( interiorCount )
+			{
+				if( geometryNodeDesignators[node]!=GeometryNodeType::UNKNOWN && geometryNodeDesignators[node]!=GeometryNodeType::INTERIOR && geometryNodeDesignators[node]!=GeometryNodeType::BOUNDARY ) correctionCount++;
+				geometryNodeDesignators[node] = GeometryNodeType::BOUNDARY;
+			}
+			else if( exteriorCount )
+			{
+				if( geometryNodeDesignators[node]!=GeometryNodeType::UNKNOWN && geometryNodeDesignators[node]!=GeometryNodeType::EXTERIOR && geometryNodeDesignators[node]!=GeometryNodeType::BOUNDARY ) correctionCount++;
+				geometryNodeDesignators[node] = GeometryNodeType::BOUNDARY;
+			}
+		}
+	};
+	CorrectDesignatorsFromChildren( root );
+	if( correctionCount ) MK_WARN( "Adjusted designator inconsistencies: " , correctionCount );
+
+	std::function< void ( FEMTreeNode * ) > SetUnknownDesignatorsFromParents = [&]( FEMTreeNode *node )
+	{
+		if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN && node->parent ) geometryNodeDesignators[node] = geometryNodeDesignators[node->parent];
+		if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) SetUnknownDesignatorsFromParents( node->children + c );
+	};
+	std::function< void ( FEMTreeNode * ) > SetUnknownDesignatorsFromChildren = [&]( FEMTreeNode *node )
+	{
+		if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) SetUnknownDesignatorsFromChildren( node->children + c );
+		if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN )
+			if( node->children )
+			{
+				int interiorCount = 0 , exteriorCount = 0 , boundaryCount = 0;
+				for( int c=0 ; c<(1<<Dim) ; c++ )
+				{
+					if     ( geometryNodeDesignators[node->children+c]==GeometryNodeType::INTERIOR ) interiorCount++;
+					else if( geometryNodeDesignators[node->children+c]==GeometryNodeType::EXTERIOR ) exteriorCount++;
+					else if( geometryNodeDesignators[node->children+c]==GeometryNodeType::BOUNDARY ) boundaryCount++;
+				}
+				if( interiorCount+exteriorCount+boundaryCount!=(1<<Dim) ) MK_THROW( "Children are unknown" );
+				else if( boundaryCount==0 && interiorCount!=0 && exteriorCount!=0 ) MK_THROW( "Expected boundary between interior/exterior" );
+				else if( boundaryCount!=0 ) geometryNodeDesignators[node] = GeometryNodeType::BOUNDARY;
+				else if( interiorCount!=0 ) geometryNodeDesignators[node] = GeometryNodeType::INTERIOR;
+				else if( exteriorCount!=0 ) geometryNodeDesignators[node] = GeometryNodeType::INTERIOR;
+			}
+			else if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN ) MK_THROW( "Leaf node is unknown" );
+	};
+	SetUnknownDesignatorsFromParents( root );
+	SetUnknownDesignatorsFromChildren( root );
+
+	return geometryNodeDesignators;
+}
+
+template< unsigned int Dim , class Real >
+void FEMTreeInitializer< Dim , Real >::TestGeometryNodeDesignators( const FEMTreeNode *root , const DenseNodeData< typename FEMTreeInitializer< Dim , Real >::GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > &geometryNodeDesignators )
+{
+	std::function< void ( const FEMTreeNode * ) > Test = [&]( const FEMTreeNode *node )
+	{
+		if( node->children )
+		{
+			if( node->nodeData.nodeIndex>=0 && node->nodeData.nodeIndex<(node_index_type)geometryNodeDesignators.size() && geometryNodeDesignators[node->nodeData.nodeIndex]!=GeometryNodeType::UNKNOWN )
+			{
+				GeometryNodeType type = geometryNodeDesignators[node->nodeData.nodeIndex];
+				int interiorCount=0 , exteriorCount=0 , boundaryCount=0 , unknownCount=0;
+				for( int c=0 ; c<(1<<Dim) ; c++ )
+				{
+					if( node->children[c].nodeData.nodeIndex>=0 && node->children[c].nodeData.nodeIndex<(node_index_type)geometryNodeDesignators.size() )
+					{
+						if( geometryNodeDesignators[ node->children[c].nodeData.nodeIndex ]==GeometryNodeType::UNKNOWN  )  unknownCount++;
+						if( geometryNodeDesignators[ node->children[c].nodeData.nodeIndex ]==GeometryNodeType::INTERIOR ) interiorCount++;
+						if( geometryNodeDesignators[ node->children[c].nodeData.nodeIndex ]==GeometryNodeType::EXTERIOR ) exteriorCount++;
+						if( geometryNodeDesignators[ node->children[c].nodeData.nodeIndex ]==GeometryNodeType::BOUNDARY ) boundaryCount++;
+					}
+				}
+				if( boundaryCount || ( interiorCount && exteriorCount ) )
+				{
+					if( type!=GeometryNodeType::UNKNOWN && type!=GeometryNodeType::BOUNDARY ) MK_THROW( "Expected unknown or boundary, got: " , type , " | " , node->depthAndOffset() );
+				}
+				else if( interiorCount==(1<<Dim) )
+				{
+					if( type!=GeometryNodeType::UNKNOWN && type!=GeometryNodeType::INTERIOR ) MK_THROW( "Expected unknown or interior, got: " , type , " | " , node->depthAndOffset() );
+				}
+				else if( exteriorCount==(1<<Dim) )
+				{
+					if( type!=GeometryNodeType::UNKNOWN && type!=GeometryNodeType::EXTERIOR ) MK_THROW( "Expected unknown or exterior, got: " , type , " | " , node->depthAndOffset() );
+				}
+				else if( interiorCount )
+				{
+					if( type!=GeometryNodeType::UNKNOWN && type!=GeometryNodeType::INTERIOR && type!=GeometryNodeType::BOUNDARY ) MK_THROW( "Expected unknown, interior , or boundary, got: " , type , " | " , node->depthAndOffset() );
+				}
+				else if( exteriorCount==(1<<Dim) )
+				{
+					if( type!=GeometryNodeType::UNKNOWN && type!=GeometryNodeType::EXTERIOR && type!=GeometryNodeType::BOUNDARY ) MK_THROW( "Expected unknown, exterior, or boundary, got: " , type , " | " , node->depthAndOffset() );
+				}
+			}
+
+			for( int c=0 ; c<(1<<Dim) ; c++ ) Test( node->children+c );
+		}
+	};
+
+	Test( root );
+}
+
+template< unsigned int Dim , class Real >
+void FEMTreeInitializer< Dim , Real >::PushGeometryNodeDesignatorsToFiner( const FEMTreeNode *root , DenseNodeData< typename FEMTreeInitializer< Dim , Real >::GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > &geometryNodeDesignators , unsigned int maxDepth )
+{
+	std::function< void ( const FEMTreeNode * ) > Push = [&]( const FEMTreeNode *node )
+	{
+		if( node->nodeData.nodeIndex>=0 && node->nodeData.nodeIndex<(node_index_type)geometryNodeDesignators.size() )
+		{
+			if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN )
+				if( node!=root ) geometryNodeDesignators[node] = geometryNodeDesignators[node->parent];
+				else MK_THROW( "Root node should not be unknown" );
+			else if( node!=root && geometryNodeDesignators[node]!=geometryNodeDesignators[node->parent] && geometryNodeDesignators[node->parent]!=GeometryNodeType::BOUNDARY )
+			{
+				int d , off[Dim];
+				node->depthAndOffset( d , off );
+				MK_THROW( "Child designator does not match parent: " , geometryNodeDesignators[node] , " != " , geometryNodeDesignators[node->parent] , " | " , d , " @ ( " , off[0] , " , " , off[1] , " , " , off[2] , " ) " );
+			}
+			if( node->depth()<(long long)maxDepth && node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) Push( node->children+c );
+		}
+	};
+
+	Push( root );
+}
+
+template< unsigned int Dim , class Real >
+void FEMTreeInitializer< Dim , Real >::PullGeometryNodeDesignatorsFromFiner( const FEMTreeNode *root , DenseNodeData< typename FEMTreeInitializer< Dim , Real >::GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > &geometryNodeDesignators , unsigned int maxDepth )
+{
+	std::function< void ( const FEMTreeNode * ) > Pull = [&]( const FEMTreeNode *node )
+	{
+		if( node->nodeData.nodeIndex>=0 && node->nodeData.nodeIndex<(node_index_type)geometryNodeDesignators.size() )
+		{
+			if( node->depth()<(long long)maxDepth && node->children && node->children->nodeData.nodeIndex>=0 && node->children->nodeData.nodeIndex<(node_index_type)geometryNodeDesignators.size() )
+			{
+				size_t interiorCount = 0 , exteriorCount = 0;
+				for( int c=0 ; c<(1<<Dim) ; c++ )
+				{
+					Pull( node->children+c );
+					if     ( geometryNodeDesignators[ node->children+c ]==GeometryNodeType::EXTERIOR ) exteriorCount++;
+					else if( geometryNodeDesignators[ node->children+c ]==GeometryNodeType::INTERIOR ) interiorCount++;
+				}
+				if     ( interiorCount==(1<<Dim) ) geometryNodeDesignators[node] = GeometryNodeType::INTERIOR;
+				else if( exteriorCount==(1<<Dim) ) geometryNodeDesignators[node] = GeometryNodeType::EXTERIOR;
+				else                               geometryNodeDesignators[node] = GeometryNodeType::BOUNDARY;
+			}
+			else if( geometryNodeDesignators[node]==GeometryNodeType::UNKNOWN ) MK_THROW( "Should not have unknown nodes" );
+		}
+	};
+	Pull( root );
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.LevelSet.2D.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.LevelSet.2D.inl
@@ -1,0 +1,1209 @@
+/*
+Copyright (c) 2022, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+// Specialized level-set curve extraction
+template< bool HasData , typename Real , typename Data >
+struct _LevelSetExtractor< HasData , Real , 2 , Data >
+{
+	static const unsigned int Dim = 2;
+	// Store the position, the (interpolated) gradient, the weight, and possibly data
+	typedef std::conditional_t
+		<
+			HasData ,
+			DirectSum< Real , Point< Real , Dim > , Point< Real , Dim > , Real , Data > ,
+			DirectSum< Real , Point< Real , Dim > , Point< Real , Dim > , Real >
+		> Vertex;
+
+	using OutputVertexStream = std::conditional_t
+		<
+			HasData ,
+			OutputDataStream< Point< Real , Dim > , Point< Real , Dim > , Real , Data > ,
+			OutputDataStream< Point< Real , Dim > , Point< Real , Dim > , Real >
+		>;
+
+protected:
+	static std::atomic< size_t > _BadRootCount;
+public:
+
+	using LocalDepth = typename FEMTree< Dim , Real >::LocalDepth;
+	using LocalOffset = typename FEMTree< Dim , Real >::LocalOffset;
+	using ConstOneRingNeighborKey = typename FEMTree< Dim , Real >::ConstOneRingNeighborKey;
+	using ConstOneRingNeighbors = typename FEMTree< Dim , Real >::ConstOneRingNeighbors;
+	using TreeNode = RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >;
+	template< unsigned int WeightDegree > using DensityEstimator = typename FEMTree< Dim , Real >::template DensityEstimator< WeightDegree >;
+	template< typename FEMSigPack , unsigned int PointD > using _Evaluator = typename FEMTree< Dim , Real >::template _Evaluator< FEMSigPack , PointD >;
+
+	using Key = LevelSetExtraction::Key< Dim >;
+	using IsoEdge = LevelSetExtraction::IsoEdge< Dim >;
+	template< unsigned int D , unsigned int ... Ks >
+	using HyperCubeTables = typename LevelSetExtraction::template HyperCubeTables< D , Ks ... >;
+
+	////////////////
+	// FaceEdges //
+	////////////////
+	struct FaceEdges
+	{
+		IsoEdge edges[2];
+		int count;
+		FaceEdges( void ) : count(-1){}
+	};
+
+	/////////////////
+	// SliceValues //
+	/////////////////
+	struct SliceValues
+	{
+		struct Scratch
+		{
+			using FKeyValues = std::vector< std::vector< std::pair< Key , std::vector< IsoEdge > > > >;
+			using EKeyValues = std::vector< std::vector< std::pair< Key , node_index_type > > >;
+			using VKeyValues = std::vector< std::vector< std::pair< Key , Key > > >;
+
+			FKeyValues fKeyValues;
+			EKeyValues eKeyValues;
+			VKeyValues vKeyValues;
+
+#ifdef SANITIZED_PR
+			Pointer( std::atomic< char > ) cSet;
+			Pointer( std::atomic< char > ) eSet;
+#else // !SANITIZED_PR
+			Pointer( char ) cSet;
+			Pointer( char ) eSet;
+#endif // SANITIZED_PR
+
+			Scratch( void )
+			{
+				vKeyValues.resize( ThreadPool::NumThreads() );
+				eKeyValues.resize( ThreadPool::NumThreads() );
+				fKeyValues.resize( ThreadPool::NumThreads() );
+#ifdef SANITIZED_PR
+				cSet = NullPointer( std::atomic< char > );
+				eSet = NullPointer( std::atomic< char > );
+#else // !SANITIZED_PR
+				cSet = NullPointer( char );
+				eSet = NullPointer( char );
+#endif // SANITIZED_PR
+			}
+
+			~Scratch( void )
+			{
+#ifdef SANITIZED_PR
+				DeletePointer( cSet );
+				DeletePointer( eSet );
+#else // !SANITIZED_PR
+				FreePointer( cSet );
+				FreePointer( eSet );
+#endif // SANITIZED_PR
+			}
+
+			void reset( const LevelSetExtraction::FullCellIndexData< Dim > &cellIndices )
+			{
+				for( size_t i=0 ; i<vKeyValues.size() ; i++ ) vKeyValues[i].clear();
+				for( size_t i=0 ; i<eKeyValues.size() ; i++ ) eKeyValues[i].clear();
+				for( size_t i=0 ; i<fKeyValues.size() ; i++ ) fKeyValues[i].clear();
+#ifdef SANITIZED_PR
+				DeletePointer( cSet );
+				DeletePointer( eSet );
+				if( cellIndices.counts[0] )
+				{
+					cSet = NewPointer< std::atomic< char > >( cellIndices.counts[0] );
+					for( unsigned int i=0 ; i<cellIndices.counts[0] ; i++ ) cSet[i] = 0;
+				}
+				if( cellIndices.counts[1] )
+				{
+					eSet = NewPointer< std::atomic< char > >( cellIndices.counts[1] );
+					for( unsigned int i=0 ; i<cellIndices.counts[1] ; i++ ) eSet[i] = 0;
+				}
+#else // !SANITIZED_PR
+				FreePointer( cSet );
+				FreePointer( eSet );
+				if( cellIndices.counts[0] )
+				{
+					cSet = AllocPointer< char >( cellIndices.counts[0] );
+					memset( cSet , 0 , sizeof( char ) * cellIndices.counts[0] );
+				}
+				if( cellIndices.counts[1] )
+				{
+					eSet = AllocPointer< char >( cellIndices.counts[1] );
+					memset( eSet , 0 , sizeof( char ) * cellIndices.counts[1] );
+				}
+#endif // SANITIZED_PR
+			}
+		};
+
+		// A data-structure for taking the a node index and the local index of a cell within the node and returning the global index for that cell
+		LevelSetExtraction::FullCellIndexData< Dim > cellIndices;
+
+		// A table taking a node index and returning the associated marching squares index
+		Pointer( char ) mcIndices;
+
+		// Tables taking a corner index and returning the value (and possibly the gradient) at the corresponding location
+		Pointer( Real ) cornerValues ; Pointer( Point< Real , Dim > ) cornerGradients;
+
+		// A table taking an edge index and returning the associated key
+		Pointer( Key ) edgeKeys;
+
+		// A table taking a face index and returning the associated key
+		Pointer( FaceEdges ) faceEdges;
+
+		// A map taking a key for a face and returning the iso-edges within that face
+		LevelSetExtraction::KeyMap< Dim , std::vector< IsoEdge > > faceEdgeMap;
+		// A map taking a key for an edge and returning the index of the iso-vertex along that edge
+		LevelSetExtraction::KeyMap< Dim , node_index_type > edgeVertexMap;
+		// A map linking an iso-vertex to its pair
+		LevelSetExtraction::KeyMap< Dim , Key > vertexPairMap;
+
+		SliceValues( void )
+		{
+			cornerValues = NullPointer( Real ) ; cornerGradients = NullPointer( Point< Real , Dim > );
+			edgeKeys = NullPointer( Key );
+			faceEdges = NullPointer( FaceEdges );
+			mcIndices = NullPointer( char );
+		}
+
+		~SliceValues( void ){ clear(); }
+
+		void clear( void )
+		{
+			cellIndices.clear();
+			FreePointer( cornerValues ) ; FreePointer( cornerGradients );
+			DeletePointer( edgeKeys );
+			DeletePointer( faceEdges );
+			FreePointer( mcIndices );
+		}
+
+		void read( BinaryStream &stream )
+		{
+			clear();
+
+			cellIndices.read( stream );
+
+			if( cellIndices.size() )
+			{
+				mcIndices = AllocPointer< char >( cellIndices.size() );
+				if( !stream.read( mcIndices , cellIndices.size() ) ) MK_THROW( "Failed to read mc indices" );
+			}
+			if( cellIndices.counts[0] )
+			{
+				cornerValues = AllocPointer< Real >( cellIndices.counts[0] );
+				if( !stream.read( cornerValues , cellIndices.counts[0] ) ) MK_THROW( "Failed to read corner values" );
+				char hasCornerGradients;
+				if( !stream.read( hasCornerGradients ) ) MK_THROW( "Could not read corner gradient state" );
+				if( hasCornerGradients )
+				{
+					cornerGradients = AllocPointer< Point< Real , Dim > >( cellIndices.counts[0] );
+					if( !stream.read( cornerGradients , cellIndices.counts[0] ) ) MK_THROW( "Could not read corner gradients" );
+				}
+			}
+
+			if( cellIndices.counts[1] )
+			{
+				edgeKeys = NewPointer< Key >( cellIndices.counts[1] );
+				if( !stream.read( edgeKeys , cellIndices.counts[1]) ) MK_THROW( "Could not read edge keys" );
+			}
+
+			if( cellIndices.counts[2] )
+			{
+				faceEdges = NewPointer< FaceEdges >( cellIndices.counts[2] );
+				if( !stream.read( faceEdges , cellIndices.counts[2] ) ) MK_THROW( "Could not read face edges" );
+			}
+
+			auto ReadIsoEdgeVector = [&]( BinaryStream &stream , std::vector< IsoEdge > &edges )
+			{
+				size_t sz;
+				if( !stream.read( sz ) ) MK_THROW( "Could not read iso-edge vector size" );
+				edges.resize( sz );
+				if( sz && !stream.read( GetPointer( edges ) , sz ) ) MK_THROW( "Could not read iso-edges" );
+			};
+			{
+				size_t sz;
+				if( !stream.read( sz ) ) MK_THROW( "Could not read face-edge-map size" );
+				for( unsigned int i=0 ; i<sz ; i++ )
+				{
+					Key key;
+					if( !stream.read( key ) ) MK_THROW( "Could not read face-edge-map key" );
+					ReadIsoEdgeVector( stream , faceEdgeMap[key] );
+				}
+			}
+			{
+				size_t sz;
+				if( !stream.read( sz ) ) MK_THROW( "Could not read edge-vertex-map size" );
+				for( unsigned int i=0 ; i<sz ; i++ )
+				{
+					Key key;
+					if( !stream.read( key ) ) MK_THROW( "Could not read edge-vertex-map key" );
+					if( !stream.read( edgeVertexMap[key] ) ) MK_THROW( "Could not read edge-vertex-map value" );
+				}
+			}
+			{
+				size_t sz;
+				if( !stream.read( sz ) ) MK_THROW( "Could not read vertex-pair-map size" );
+				for( unsigned int i=0 ; i<sz ; i++ )
+				{
+					Key key;
+					if( !stream.read( key ) ) MK_THROW( "Could not read vertex-pair-map key" );
+					if( !stream.read( vertexPairMap[key] ) ) MK_THROW( "Could not read vertex-pair-map value" );
+				}
+			}
+		}
+
+		void write( BinaryStream &stream , bool serialize ) const
+		{
+			cellIndices.write( stream );
+
+			if( cellIndices.size() ) stream.write( mcIndices , cellIndices.size() );
+			if( cellIndices.counts[0] )
+			{
+				stream.write( cornerValues , cellIndices.counts[0] );
+				char hasCornerGradients = cornerGradients==NullPointer( char ) ? 0 : 1;
+				stream.write( hasCornerGradients );
+				if( hasCornerGradients ) stream.write( cornerGradients , cellIndices.counts[0] );
+			}
+			if( cellIndices.counts[1] ) stream.write(  edgeKeys , cellIndices.counts[1] );
+			if( cellIndices.counts[2] ) stream.write( faceEdges , cellIndices.counts[2] );
+
+			auto WriteIsoEdgeVector = [&]( BinaryStream &stream , const std::vector< IsoEdge > &edges )
+			{
+				size_t sz = edges.size();
+				stream.write( sz );
+				if( sz ) stream.write( GetPointer( edges ) , sz );
+			};
+
+			auto SerializeFaceEdgeMap = [&]( size_t &sz )
+			{
+				using map = LevelSetExtraction::KeyMap< Dim , std::vector< IsoEdge > >;
+
+				sz = 0;
+				for( typename map::const_iterator iter=faceEdgeMap.begin() ; iter!=faceEdgeMap.end() ; iter++ )
+					sz += sizeof( typename LevelSetExtraction::Key< Dim > ) + sizeof( size_t ) + sizeof( IsoEdge ) * iter->second.size();
+
+				Pointer( char ) buffer = NewPointer< char >( sz );
+				Pointer( char ) _buffer = buffer;
+				for( typename map::const_iterator iter=faceEdgeMap.begin() ; iter!=faceEdgeMap.end() ; iter++ )
+				{
+					memcpy( _buffer , &iter->first , sizeof( typename LevelSetExtraction::Key< Dim > ) ) ; _buffer += sizeof( typename LevelSetExtraction::Key< Dim > );
+					size_t num = iter->second.size();
+					memcpy( _buffer , &num , sizeof( size_t ) ) ; _buffer += sizeof( size_t );
+					if( num ) memcpy( _buffer , &iter->second[0] , sizeof(IsoEdge) * iter->second.size() ) ; _buffer += sizeof(IsoEdge) * iter->second.size();
+				}
+				return buffer;
+			};
+
+			{
+				using map = LevelSetExtraction::KeyMap< Dim , std::vector< IsoEdge > >;
+				if( serialize )
+				{
+					size_t sz = faceEdgeMap.size();
+					stream.write( sz );
+					if( sz )
+					{
+						Pointer( char ) buffer = SerializeFaceEdgeMap( sz );
+						stream.write( buffer , sz );
+						DeletePointer( buffer );
+					}
+				}
+				else
+				{
+					size_t sz = faceEdgeMap.size();
+					stream.write( sz );
+					for( typename map::const_iterator iter=faceEdgeMap.begin() ; iter!=faceEdgeMap.end() ; iter++ )
+					{
+						stream.write( iter->first );
+						WriteIsoEdgeVector( stream , iter->second );
+					}
+				}
+			}
+
+			{
+				using map = LevelSetExtraction::KeyMap< Dim , node_index_type >;
+				if( serialize )
+				{
+					size_t sz = edgeVertexMap.size();
+					stream.write( sz );
+					if( sz )
+					{
+						size_t elementSize = sizeof( typename LevelSetExtraction::Key< Dim > ) + sizeof( node_index_type );
+						Pointer( char ) buffer = NewPointer< char >( edgeVertexMap.size() * elementSize );
+						{
+							Pointer( char ) _buffer = buffer;
+							for( typename map::const_iterator iter=edgeVertexMap.begin() ; iter!=edgeVertexMap.end() ; iter++ )
+							{
+								memcpy( _buffer , &iter->first , sizeof( typename LevelSetExtraction::Key< Dim >  ) ) ; _buffer += sizeof( typename LevelSetExtraction::Key< Dim > );
+								memcpy( _buffer , &iter->second , sizeof( node_index_type ) ) ; _buffer += sizeof( node_index_type );
+							}
+						}
+						stream.write( buffer , edgeVertexMap.size() * elementSize );
+						DeletePointer( buffer );
+					}
+				}
+				else
+				{
+					size_t sz = edgeVertexMap.size();
+					stream.write( sz );
+					for( typename map::const_iterator iter=edgeVertexMap.begin() ; iter!=edgeVertexMap.end() ; iter++ )
+					{
+						stream.write( iter->first );
+						stream.write( iter->second );
+					}
+				}
+			}
+
+			{
+				using map = LevelSetExtraction::KeyMap< Dim , Key >;
+				if( serialize )
+				{
+					std::vector< std::pair< typename LevelSetExtraction::Key< Dim > , Key > > pairs;
+					pairs.reserve( vertexPairMap.size() );
+					for( typename map::const_iterator iter=vertexPairMap.begin() ; iter!=vertexPairMap.end() ; iter++ )
+						pairs.push_back( std::pair< typename LevelSetExtraction::Key< Dim > , Key >( iter->first , iter->second ) );
+					stream.write( pairs );
+				}
+				else
+				{
+					size_t sz = vertexPairMap.size();
+					stream.write( sz );
+					for( typename map::const_iterator iter=vertexPairMap.begin() ; iter!=vertexPairMap.end() ; iter++ )
+					{
+						stream.write( iter->first );
+						stream.write( iter->second );
+					}
+				}
+			}
+		}
+
+		void setFromScratch( typename Scratch::EKeyValues &scratch )
+		{
+			for( node_index_type i=0 ; i<(node_index_type)scratch.size() ; i++ )
+			{
+				for( int j=0 ; j<scratch[i].size() ; j++ ) edgeVertexMap[ scratch[i][j].first ] = scratch[i][j].second;
+				scratch[i].clear();
+			}
+		}
+
+		void setFromScratch( typename Scratch::VKeyValues &scratch )
+		{
+			for( node_index_type i=0 ; i<(node_index_type)scratch.size() ; i++ )
+			{
+				for( int j=0 ; j<scratch[i].size() ; j++ )
+				{
+					// Note that both vertices are added as keys
+					vertexPairMap[ scratch[i][j].first ] = scratch[i][j].second;
+					vertexPairMap[ scratch[i][j].second ] = scratch[i][j].first;
+				}
+				scratch[i].clear();
+			}
+		}
+
+		void setFromScratch( typename Scratch::FKeyValues &scratch )
+		{
+			for( node_index_type i=0 ; i<(node_index_type)scratch.size() ; i++ )
+			{
+				for( int j=0 ; j<scratch[i].size() ; j++ )
+				{
+					std::vector< IsoEdge > &faceEdges = faceEdgeMap[ scratch[i][j].first ];
+					faceEdges.insert( faceEdges.end() , scratch[i][j].second.begin() , scratch[i][j].second.end() );
+				}
+				scratch[i].clear();
+			}
+		}
+
+		void reset( bool computeGradients )
+		{
+			faceEdgeMap.clear() , edgeVertexMap.clear() , vertexPairMap.clear();
+
+			FreePointer( mcIndices );
+			if( cellIndices.size()>0 ) mcIndices = AllocPointer< char >( cellIndices.size() );
+
+			FreePointer( cornerValues ) ; FreePointer( cornerGradients );
+			if( cellIndices.counts[0]>0 )
+			{
+				cornerValues = AllocPointer< Real >( cellIndices.counts[0] );
+				if( computeGradients ) cornerGradients = AllocPointer< Point< Real , Dim > >( cellIndices.counts[0] );
+			}
+
+			DeletePointer( edgeKeys );
+			edgeKeys = NewPointer< Key >( cellIndices.counts[1] );
+
+			DeletePointer( faceEdges );
+			faceEdges = NewPointer< FaceEdges >( cellIndices.counts[2] );
+
+		}
+
+		bool setVertexPair( Key current , Key &pair ) const
+		{
+			typename LevelSetExtraction::KeyMap< Dim , Key >::const_iterator iter;
+
+			if( (iter=vertexPairMap.find(current))!=vertexPairMap.end() )
+			{
+				pair = iter->second;
+				return true;
+			}
+			else return false;
+		}
+	};
+
+	struct TreeSliceValuesAndVertexPositions
+	{
+		const FEMTree< Dim , Real > sliceTree;
+		std::vector< SliceValues > sliceValues;
+		// [WARNING] Should really be using Vertex instead of Point< Real , Dim >
+		std::vector< Point< Real , Dim > > vertexPositions;
+
+		TreeSliceValuesAndVertexPositions( void ) : sliceTree(NULL){}
+		TreeSliceValuesAndVertexPositions( BinaryStream &stream  , XForm< Real , Dim+1 > &xForm , size_t blockSize ) : sliceTree( stream , blockSize )
+		{
+			stream.read( xForm );
+
+			size_t sz;
+			if( !stream.read( sz ) ) MK_THROW( "Could not read slice count" );
+			sliceValues.resize( sz );
+			for( unsigned int i=0 ; i<sliceValues.size() ; i++ ) sliceValues[i].read( stream );
+			if( !stream.read( sz ) ) MK_THROW( "Could not read iso-vertex count" );
+			if( sz )
+			{
+				vertexPositions.resize( sz );
+				if( sz && !stream.read( GetPointer( vertexPositions ) , sz ) ) MK_THROW( "Could not read iso-vertex positions" );
+			}
+		}
+
+		std::vector< Key > vertexKeys( void ) const
+		{
+			std::vector< Key > keys( vertexPositions.size() );
+			for( unsigned int i=0 ; i<sliceValues.size() ; i++ )
+				for( typename LevelSetExtraction::KeyMap< Dim , node_index_type >::const_iterator iter=sliceValues[i].edgeVertexMap.cbegin() ; iter!=sliceValues[i].edgeVertexMap.cend() ; iter++ )
+				{
+					if( iter->second>=(node_index_type)vertexPositions.size() ) MK_THROW( "Unexpected vertex index: " , iter->second , " <= " , vertexPositions.size() );
+					keys[iter->second] = iter->first;
+				}
+			return keys;
+		};
+
+		static void Write( BinaryStream &stream , const FEMTree< Dim , Real > *sliceTree , XForm< Real , Dim+1 > xForm , const std::vector< SliceValues > &sliceValues , const std::vector< Point< Real , Dim > > &vertices , bool serialize )
+		{
+			sliceTree->write( stream , serialize );
+			stream.write( xForm );
+
+			size_t sz = sliceValues.size();
+			stream.write( sz );
+			for( unsigned int i=0 ; i<sliceValues.size() ; i++ ) sliceValues[i].write( stream , serialize );
+
+			stream.write( vertices );
+		}
+
+		void write( BinaryStream &stream , XForm< Real , Dim+1 > xForm , bool serialize ) const
+		{
+			Write( stream , &sliceTree , xForm , sliceValues , vertexPositions , serialize );
+		}
+	};
+
+
+	template< unsigned int ... FEMSigs >
+	static void SetSCornerValues( const FEMTree< Dim , Real >& tree , ConstPointer( Real ) coefficients , ConstPointer( Real ) coarseCoefficients , Real isoValue , LocalDepth depth , LocalDepth fullDepth , std::vector< SliceValues >& sliceValues , std::vector< typename SliceValues::Scratch > &scratchValues , const _Evaluator< UIntPack< FEMSigs ... > , 1 >& evaluator )
+	{
+		static const unsigned int FEMDegrees[] = { FEMSignature< FEMSigs >::Degree ... };
+		SliceValues& sValues = sliceValues[depth];
+#ifdef SANITIZED_PR
+		Pointer( std::atomic< char > ) cornerSet = scratchValues[depth].cSet;
+#else // !SANITIZED_PR
+		Pointer( char ) cornerSet = scratchValues[depth].cSet;
+#endif // SANITIZED_PR
+		bool useBoundaryEvaluation = false;
+		for( int d=0 ; d<Dim ; d++ ) if( FEMDegrees[d]==0 || ( FEMDegrees[d]==1 && sValues.cornerGradients ) ) useBoundaryEvaluation = true;
+		std::vector< ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > > > neighborKeys( ThreadPool::NumThreads() );
+		std::vector< ConstCornerSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > > > bNeighborKeys( ThreadPool::NumThreads() );
+		if( useBoundaryEvaluation ) for( size_t i=0 ; i<neighborKeys.size() ; i++ ) bNeighborKeys[i].set( tree._localToGlobal( depth ) );
+		else                        for( size_t i=0 ; i<neighborKeys.size() ; i++ )  neighborKeys[i].set( tree._localToGlobal( depth ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth) , tree._sNodesEnd(depth) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				Real squareValues[ HyperCube::Cube< Dim >::template ElementNum< 0 >() ];
+				ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey = neighborKeys[ thread ];
+				ConstCornerSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bNeighborKey = bNeighborKeys[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+				// Iterate over all leaf nodes
+				if( !IsActiveNode< Dim >( leaf->children ) )
+				{
+					const typename LevelSetExtraction::FullCellIndexData< Dim >::template CellIndices<0> &cIndices = sValues.cellIndices.template indices<0>( leaf );
+
+					bool isInterior = tree._isInteriorlySupported( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , leaf->parent );
+					if( useBoundaryEvaluation ) bNeighborKey.getNeighbors( leaf );
+					else                         neighborKey.getNeighbors( leaf );
+
+					// Iterate over the corners of the cell
+					for( typename HyperCube::Cube< Dim >::template Element< 0 > c ; c<HyperCube::Cube< Dim >::template ElementNum< 0 >() ; c++ )
+					{
+						// Grab the global corner index, and if its value hasn't been set yet get the values (and gradients) and store them
+						node_index_type vIndex = cIndices[c.index];
+						if( !cornerSet[vIndex] )
+						{
+							if( sValues.cornerGradients )
+							{
+								CumulativeDerivativeValues< Real , Dim , 1 > p;
+								if( useBoundaryEvaluation ) p = tree.template _getCornerValues< Real , 1 >( bNeighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior );
+								else                        p = tree.template _getCornerValues< Real , 1 >(  neighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior );
+								sValues.cornerValues[vIndex] = p[0] , sValues.cornerGradients[vIndex] = Point< Real , Dim >( p[1] , p[2] );
+							}
+							else
+							{
+								if( useBoundaryEvaluation ) sValues.cornerValues[vIndex] = tree.template _getCornerValues< Real , 0 >( bNeighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior )[0];
+								else                        sValues.cornerValues[vIndex] = tree.template _getCornerValues< Real , 0 >(  neighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior )[0];
+							}
+							cornerSet[vIndex] = 1;
+						}
+						squareValues[c.index] = sValues.cornerValues[ vIndex ];
+
+						// Copy from the finer depth to the coarser depth
+						TreeNode* node = leaf;
+						LocalDepth _depth = depth;
+						// Iterate to the parents as long as they contain the corner
+						while( _depth>fullDepth && tree._isValidSpaceNode( node->parent ) && (node-node->parent->children)==c.index )
+						{
+							node = node->parent , _depth--;
+							SliceValues& _sValues = sliceValues[_depth];
+#ifdef SANITIZED_PR
+							Pointer( std::atomic< char > ) _cornerSet = scratchValues[_depth].cSet;
+#else // !SANITIZED_PR
+							Pointer( char ) _cornerSet = scratchValues[_depth].cSet;
+#endif // SANITIZED_PR
+							const typename LevelSetExtraction::FullCellIndexData< Dim >::template CellIndices<0> &_cIndices = _sValues.cellIndices.template indices<0>( node );
+							node_index_type _vIndex = _cIndices[c.index];
+							_sValues.cornerValues[_vIndex] = sValues.cornerValues[vIndex];
+							if( _sValues.cornerGradients ) _sValues.cornerGradients[_vIndex] = sValues.cornerGradients[vIndex];
+							_cornerSet[_vIndex] = 1;
+						}
+					}
+
+					// Set the marching squares index for the face
+					sValues.mcIndices[ i - sValues.cellIndices.nodeOffset ] = HyperCube::Cube< Dim >::MCIndex( squareValues , isoValue );
+				}
+			}
+		}
+		);
+	}
+
+
+	template< unsigned int WeightDegree , unsigned int DataSig , typename VertexStream >
+	static void SetIsoVertices
+	(
+		const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator ,
+		const FEMTree< Dim , Real >& tree ,
+		bool nonLinearFit ,
+		bool outputGradients ,
+		typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > > *pointEvaluator ,
+		const DensityEstimator< WeightDegree > *densityWeights ,
+		const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data ,
+		Real isoValue ,
+		LocalDepth depth ,
+		LocalDepth fullDepth ,
+		VertexStream &vertexStream ,
+		std::vector< SliceValues > &sliceValues ,
+		std::vector< typename SliceValues::Scratch > &scratchValues ,
+		const Data &zeroData
+	)
+	{
+		auto _EdgeIndex = [&]( const TreeNode *node , typename HyperCube::Cube< Dim >::template Element< 1 > e )
+		{
+			int depth , offset[Dim];
+			tree.depthAndOffset( node , depth , offset );
+			return keyGenerator( depth , offset , e );
+		};
+		static const unsigned int DataDegree = FEMSignature< DataSig >::Degree;
+
+		SliceValues &sValues = sliceValues[depth];
+		typename SliceValues::Scratch &scValues = scratchValues[depth];
+		// [WARNING] In the case Degree=2, these two keys are the same, so we don't have to maintain them separately.
+		std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+		std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > > > weightKeys( ThreadPool::NumThreads() );
+		std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , DataDegree > > > dataKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( tree._localToGlobal( depth ) ) , weightKeys[i].set( tree._localToGlobal( depth ) ) , dataKeys[i].set( tree._localToGlobal( depth ) );
+
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth) , tree._sNodesEnd(depth) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+				ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey = weightKeys[ thread ];
+				ConstPointSupportKey< IsotropicUIntPack< Dim , DataDegree > >& dataKey = dataKeys[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+
+				// Iterate over all leaf nodes in the tree
+				if( !IsActiveNode< Dim >( leaf->children ) )
+				{
+					node_index_type idx = (node_index_type)i - sValues.cellIndices.nodeOffset;
+					const typename LevelSetExtraction::FullCellIndexData< Dim >::template CellIndices<1> eIndices = sValues.cellIndices.template indices<1>( leaf );
+
+					// Check if the face has zero-crossings
+					if( HyperCube::Cube< Dim >::HasMCRoots( sValues.mcIndices[idx] ) )
+					{
+						neighborKey.getNeighbors( leaf );
+						if( densityWeights ) weightKey.getNeighbors( leaf );
+						if constexpr( HasData ) if( data ) dataKey.getNeighbors( leaf );
+
+						// Check if the individual edges have zero-crossings
+						for( typename HyperCube::Cube< Dim >::template Element< 1 > e ; e<HyperCube::Cube< Dim >::template ElementNum< 1 >() ; e++ )
+							if( HyperCube::Cube< 1 >::HasMCRoots( HyperCube::Cube< Dim >::ElementMCIndex( e , sValues.mcIndices[idx] ) ) )
+							{
+								node_index_type vIndex = eIndices[e.index];
+#ifdef SANITIZED_PR
+								std::atomic< char > &edgeSet = scValues.eSet[vIndex];
+#else // !SANITIZED_PR
+								volatile char &edgeSet = scValues.eSet[vIndex];
+#endif // SANITIZED_PR
+								// If the edge hasn't been set already (e.g. either by another thread or from a finer resolution)
+								if( !edgeSet )
+								{
+									Vertex vertex;
+									Key key = _EdgeIndex( leaf , e );
+									GetIsoVertex< WeightDegree , DataSig >( tree , nonLinearFit , outputGradients , pointEvaluator , densityWeights , data , isoValue , weightKey , dataKey , leaf , e , sValues , vertex , zeroData );
+									bool stillOwner = false;
+									std::pair< node_index_type , Vertex > hashed_vertex;
+
+									{
+										char desired = 1 , expected = 0;
+#ifdef SANITIZED_PR
+										if( edgeSet.compare_exchange_weak( expected , desired ) )
+#else // !SANITIZED_PR
+										if( SetAtomic( edgeSet , desired , expected ) )
+#endif // SANITIZED_PR
+										{
+											hashed_vertex = std::pair< node_index_type , Vertex >( (node_index_type)vertexStream.write( thread , vertex ) , vertex );
+											stillOwner = true;
+										}
+									}
+
+									if( stillOwner )	// If this edge is the one generating the iso-vertex
+									{
+										sValues.edgeKeys[ vIndex ] = key;
+										scValues.eKeyValues[ thread ].push_back( std::pair< Key , node_index_type >( key , hashed_vertex.first ) );
+
+										// We only need to pass the iso-vertex down if the edge it lies on is adjacent to a coarser leaf
+										const typename HyperCube::Cube< Dim >::template Element< Dim > *f = HyperCubeTables< Dim , 1 , Dim >::OverlapElements[e.index];
+										// Note that this is a trivial loop of size 1
+										for( int k=0 ; k<HyperCubeTables< Dim , 1 , Dim >::OverlapElementNum ; k++ )
+										{
+											TreeNode *node = leaf;
+											LocalDepth _depth = depth;
+											while( _depth>fullDepth && tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , Dim , 0 >::Overlap[f[k].index][(unsigned int)(node-node->parent->children) ] ) 
+											{
+												node = node->parent , _depth--;
+												typename SliceValues::Scratch &_scValues = scratchValues[_depth];
+												_scValues.eKeyValues[ thread ].push_back( std::pair< Key , node_index_type >( key , hashed_vertex.first ) );
+											}
+										}
+									}
+								}
+							}
+					}
+				}
+			}
+		}
+		);
+	}
+
+	static void CopyFinerSliceIsoEdgeKeys( const FEMTree< Dim , Real >& tree , LocalDepth depth , LocalDepth fullDepth , std::vector< SliceValues >& sliceValues , std::vector< typename SliceValues::Scratch > &scratchValues )
+	{
+		SliceValues& pSliceValues = sliceValues[depth  ];
+		SliceValues& cSliceValues = sliceValues[depth+1];
+		typename SliceValues::Scratch &pScratchSliceValues = scratchValues[depth  ];
+		typename SliceValues::Scratch &cScratchSliceValues = scratchValues[depth+1];
+		LevelSetExtraction::FullCellIndexData< Dim > &pCellIndices = pSliceValues.cellIndices;
+		LevelSetExtraction::FullCellIndexData< Dim > &cCellIndices = cSliceValues.cellIndices;
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth) , tree._sNodesEnd(depth) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) ) if( IsActiveNode< Dim >( tree._sNodes.treeNodes[i]->children ) )
+			{
+				// Get the mapping from local edge indices to global edge indices
+				typename LevelSetExtraction::FullCellIndexData< Dim >::template CellIndices<1> &pIndices = pCellIndices.template indices<1>( (node_index_type)i );
+				// Copy the edges that overlap the coarser edges
+				for( typename HyperCube::Cube< Dim >::template Element< 1 > e ; e<HyperCube::Cube< Dim >::template ElementNum< 1 >() ; e++ )
+				{
+					// The global (coarse) edge index
+					node_index_type pIndex = pIndices[e.index];
+					if( !pScratchSliceValues.eSet[ pIndex ] )
+					{
+						// The corner indices incident on the edeg
+						const typename HyperCube::Cube< Dim >::template Element< 0 > *c = HyperCubeTables< Dim , 1 , 0 >::OverlapElements[e.index];
+						// [SANITY CHECK]
+						//						if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c[0].index )!=tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c[1].index ) ) MK_THROW( "Finer edges should both be valid or invalid" );
+						// Can only copy edge information from the finer nodes incident on the edge if they are valid (note since we refine in broods, we can't have one child in and the other out)
+						if( !tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c[0].index ) || !tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c[1].index ) ) continue;
+
+
+						// The global (fine) edge indices
+						node_index_type cIndex1 = cCellIndices.template indices<1>( tree._sNodes.treeNodes[i]->children + c[0].index )[e.index];
+						node_index_type cIndex2 = cCellIndices.template indices<1>( tree._sNodes.treeNodes[i]->children + c[1].index )[e.index];
+
+						// If only one of the finer edges has a zero-crossing, then the coarse edge will as well
+						if( cScratchSliceValues.eSet[cIndex1] != cScratchSliceValues.eSet[cIndex2] )
+						{
+							Key key;
+							if( cScratchSliceValues.eSet[cIndex1] ) key = cSliceValues.edgeKeys[cIndex1];
+							else                                    key = cSliceValues.edgeKeys[cIndex2];
+							pSliceValues.edgeKeys[pIndex] = key;
+							pScratchSliceValues.eSet[pIndex] = 1;
+						}
+						// If both of the finer edges have a zero-crossing, those will form a pair (but the coarser edge will not have a zero crossing)
+						else if( cScratchSliceValues.eSet[cIndex1] && cScratchSliceValues.eSet[cIndex2] )
+						{
+							Key key1 = cSliceValues.edgeKeys[cIndex1] , key2 = cSliceValues.edgeKeys[cIndex2];
+							pScratchSliceValues.vKeyValues[ thread ].push_back( std::pair< Key , Key >( key1 , key2 ) );
+
+							const TreeNode* node = tree._sNodes.treeNodes[i];
+							LocalDepth _depth = depth;
+							while( _depth>fullDepth && tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , 1 , 0 >::Overlap[e.index][(unsigned int)(node-node->parent->children) ] )
+							{
+								node = node->parent , _depth--;
+								typename SliceValues::Scratch &_pScratchSliceValues = scratchValues[_depth];
+								_pScratchSliceValues.vKeyValues[ thread ].push_back( std::pair< Key , Key >( key1 , key2 ) );
+							}
+						}
+					}
+				}
+			}
+		}
+		);
+	}
+
+
+	static void SetIsoEdges( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , const FEMTree< Dim , Real >& tree , LocalDepth depth , LocalDepth fullDepth ,  std::vector< SliceValues >& sliceValues , std::vector< typename SliceValues::Scratch > &scratchValues )
+	{
+		auto _FaceIndex = [&]( const TreeNode *node , typename HyperCube::Cube< Dim >::template Element< 2 > f )
+		{
+			int depth , offset[Dim];
+			tree.depthAndOffset( node , depth , offset );
+			return keyGenerator( depth , offset , f );
+		};
+
+		SliceValues& sValues = sliceValues[depth];
+#ifdef SANITIZED_PR
+		Pointer( std::atomic< char > ) edgeSet = scratchValues[depth].eSet;
+#else // !SANITIZED_PR
+		Pointer( char ) edgeSet = scratchValues[depth].eSet;
+#endif // SANITIZED_PR
+		std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( tree._localToGlobal( depth ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth) , tree._sNodesEnd(depth) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				int isoEdges[ 2 * HyperCube::MarchingSquares::MAX_EDGES ];
+				ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+				// Process the face if it is on a leaf node
+				if( !IsActiveNode< Dim >( leaf->children ) )
+				{
+					const typename LevelSetExtraction::FullCellIndexData< Dim >::template CellIndices<1> &eIndices = sValues.cellIndices.template indices<1>( leaf );
+					const typename LevelSetExtraction::FullCellIndexData< Dim >::template CellIndices<2> &fIndices = sValues.cellIndices.template indices<2>( leaf );
+					unsigned char mcIndex = sValues.mcIndices[ (node_index_type)i - sValues.cellIndices.nodeOffset ];
+
+					// [NOTE] We do not add the vector of iso-edges at the depth where they are generate (as there can be at most two).
+					//        We only add them to the coarser resolutions.
+					// Calculate the iso-edges for the face
+					FaceEdges fe;
+					fe.count = HyperCube::MarchingSquares::AddEdgeIndices( mcIndex , isoEdges );
+					for( int j=0 ; j<fe.count ; j++ ) for( int k=0 ; k<2 ; k++ )
+					{
+						if( !edgeSet[ eIndices[ isoEdges[2*j+k] ] ] ) MK_THROW( "Edge not set: " , 1<<depth );
+						fe.edges[j][k] = sValues.edgeKeys[ eIndices[ isoEdges[2*j+k] ] ];
+					}
+					sValues.faceEdges[ fIndices[0] ] = fe;
+					// Pass the information to the parents
+					// [NOTE] For the 3D case we ony pass up to the parents if the face-adjacent neighbor does not exists.
+					//        That could be bad if we want to use the information to extract from a sub-tree
+					TreeNode *node = leaf;
+					LocalDepth _depth = depth;
+					typename HyperCube::Cube< Dim >::template Element< Dim > f( 0u );
+
+					// Add the edges to the vector of iso-edges associated with a face
+					std::vector< IsoEdge > edges( fe.count );
+					for( int j=0 ; j<fe.count ; j++ ) edges[j] = fe.edges[j];
+					// Add the edges to all ancestors
+					while( _depth>fullDepth && tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , 2 , 0 >::Overlap[f.index][(unsigned int)(node-node->parent->children) ] )
+					{
+						node = node->parent , _depth--;
+						Key key = _FaceIndex( node , f );
+						typename SliceValues::Scratch &_scValues = scratchValues[_depth];
+						_scValues.fKeyValues[ thread ].push_back( std::pair< Key , std::vector< IsoEdge > >( key , edges ) );
+					}
+				}
+			}
+		}
+		);
+	}
+
+	static void SetLevelSet( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , const FEMTree< Dim , Real >& tree , LocalDepth depth , const SliceValues &sValues , OutputDataStream< std::pair< node_index_type , node_index_type > >& edgeStream , bool flipOrientation )
+	{
+		auto _FaceIndex = [&]( const TreeNode *node , typename HyperCube::Cube< Dim >::template Element< 2 > f )
+		{
+			int depth , offset[Dim];
+			tree.depthAndOffset( node , depth , offset );
+			return keyGenerator( depth , offset , f );
+		};
+
+		auto AddEdge = [&]( unsigned int thread , IsoEdge e )
+		{
+			typename LevelSetExtraction::KeyMap< Dim , node_index_type >::const_iterator iter;
+			node_index_type idx1 , idx2;
+			if( ( iter=sValues.edgeVertexMap.find( e[0] ) )!=sValues.edgeVertexMap.end() ) idx1 = iter->second;
+			else MK_THROW( "Couldn't find vertex in edge map" );
+			if( ( iter=sValues.edgeVertexMap.find( e[1] ) )!=sValues.edgeVertexMap.end() ) idx2 = iter->second;
+			else MK_THROW( "Couldn't find vertex in edge map" );
+			if( flipOrientation ) edgeStream.write( thread , std::make_pair( idx2 , idx1 ) );
+			else                  edgeStream.write( thread , std::make_pair( idx1 , idx2 ) );
+		};
+
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth) , tree._sNodesEnd(depth) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				TreeNode *leaf = tree._sNodes.treeNodes[i];
+				int res = 1<<depth;
+				LocalDepth d ; LocalOffset off;
+				tree._localDepthAndOffset( leaf , d , off );
+				bool inBounds = off[0]>=0 && off[0]<res && off[1]>=0 && off[1]<res;
+
+				if( inBounds && !IsActiveNode< Dim >( leaf->children ) )
+				{
+					// Gather the edges from the faces
+					for( typename HyperCube::Cube< Dim >::template Element< 2 > f ; f<HyperCube::Cube< Dim >::template ElementNum< 2 >() ; f++ )
+					{
+						node_index_type fIdx = sValues.cellIndices.template indices<2>((node_index_type)i)[0];
+						{
+							const FaceEdges& fe = sValues.faceEdges[ fIdx ];
+							for( int j=0 ; j<fe.count ; j++ ) AddEdge( thread , IsoEdge( fe.edges[j][0] , fe.edges[j][1] ) );
+						}
+					}
+				}
+			}
+		}
+		);
+	}
+
+
+	template< unsigned int WeightDegree , unsigned int DataSig >
+	static bool GetIsoVertex( const FEMTree< Dim , Real >& tree , bool nonLinearFit , bool outputGradients , typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > >* pointEvaluator , const DensityEstimator< WeightDegree >* densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data , Real isoValue , ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , ConstPointSupportKey< IsotropicUIntPack< Dim , FEMSignature< DataSig >::Degree > >& dataKey , const TreeNode* node , typename HyperCube::template Cube< Dim >::template Element< 1 > e , const SliceValues& sValues , Vertex& vertex , const Data &zeroData )
+	{
+		static const unsigned int DataDegree = FEMSignature< DataSig >::Degree;
+		Point< Real , Dim > position , gradient;
+		int c0 , c1;
+		const typename HyperCube::Cube< Dim >::template Element< 0 > *c = HyperCubeTables< Dim , 1 , 0 >::OverlapElements[e.index];
+		c0 = c[0].index , c1 = c[1].index;
+
+		const typename LevelSetExtraction::FullCellIndexData< Dim >::template CellIndices<0> &idx = sValues.cellIndices.template indices<0>( node );
+		Real x0 = sValues.cornerValues[idx[c0]] , x1 = sValues.cornerValues[idx[c1]];
+		Point< Real , Dim > dx0 , dx1;
+		if( outputGradients ) dx0 = sValues.cornerGradients[idx[c0]] , dx1 = sValues.cornerGradients[idx[c1]];
+		Point< Real , Dim > s;
+		Real start , width;
+		tree._startAndWidth( node , s , width );
+		int o;
+		{
+			const HyperCube::Direction* dirs = HyperCubeTables< Dim , 1 >::Directions[ e.index ];
+			for( int d=0 ; d<Dim ; d++ ) if( dirs[d]==HyperCube::CROSS )
+			{
+				o = d;
+				start = s[d];
+				for( int dd=1 ; dd<Dim ; dd++ ) position[(d+dd)%Dim] = s[(d+dd)%Dim] + width * ( dirs[(d+dd)%Dim]==HyperCube::BACK ? 0 : 1 );
+			}
+		}
+
+		double averageRoot;
+		bool rootFound = false;
+		if( nonLinearFit )
+		{
+			double dx0 = sValues.cornerGradients[idx[c0]][o] * width , dx1 = sValues.cornerGradients[idx[c1]][o] * width;
+
+			// The scaling will turn the Hermite Spline into a quadratic
+			double scl = (x1-x0) / ( (dx1+dx0 ) / 2 );
+			dx0 *= scl , dx1 *= scl;
+
+			// Hermite Spline
+			Polynomial< 2 > P;
+			P.coefficients[0] = x0;
+			P.coefficients[1] = dx0;
+			P.coefficients[2] = 3*(x1-x0)-dx1-2*dx0;
+
+			double roots[2];
+			int rCount = 0 , rootCount = P.getSolutions( isoValue , roots , 0 );
+			averageRoot = 0;
+			for( int i=0 ; i<rootCount ; i++ ) if( roots[i]>=0 && roots[i]<=1 ) averageRoot += roots[i] , rCount++;
+			if( rCount ) rootFound = true;
+			averageRoot /= rCount;
+		}
+		if( !rootFound )
+		{
+			// We have a linear function L, with L(0) = x0 and L(1) = x1
+			// => L(t) = x0 + t * (x1-x0)
+			// => L(t) = isoValue <=> t = ( isoValue - x0 ) / ( x1 - x0 )
+			if( x0==x1 ) MK_THROW( "Not a zero-crossing root: " , x0 , " " , x1 );
+			averageRoot = ( isoValue - x0 ) / ( x1 - x0 );
+		}
+		if( averageRoot<=0 || averageRoot>=1 )
+		{
+			_BadRootCount++;
+			if( averageRoot<0 ) averageRoot = 0;
+			if( averageRoot>1 ) averageRoot = 1;
+		}
+		position[o] = Real( start + width*averageRoot );
+		gradient = dx0 * (Real)( 1.-averageRoot ) + dx1 * (Real)averageRoot;
+		Real depth = (Real)1.;
+		Data dataValue;
+		if( densityWeights )
+		{
+			Real weight;
+			tree._getSampleDepthAndWeight( *densityWeights , node , position , weightKey , depth , weight );
+		}
+		if constexpr( HasData ) if( data )
+		{
+			if( DataDegree==0 ) 
+			{
+				Point< Real , 2 > center( s[0] + width/2 , s[1] + width/2 );
+				ProjectiveData< Data , Real > pValue( zeroData );
+				tree.template _addEvaluation< ProjectiveData< Data , Real > , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > , 0 >( *data , center , *pointEvaluator , dataKey , pValue );
+				dataValue = pValue.weight ? pValue.value() : zeroData;
+			}
+			else
+			{
+				ProjectiveData< Data , Real > pValue( zeroData );
+				tree.template _addEvaluation< ProjectiveData< Data , Real > , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > , 0 >( *data , position , *pointEvaluator , dataKey , pValue );
+				dataValue = pValue.weight ? pValue.value() : zeroData;
+			}
+		}
+		vertex.template get<0>() = position;
+		vertex.template get<1>() = gradient;
+		vertex.template get<2>() = depth;
+		if constexpr( HasData ) vertex.template get<3>() = dataValue;
+		return true;
+	}
+
+	struct Stats
+	{
+		double cornersTime , verticesTime , edgesTime , curveTime;
+		double copyFinerTime , setTableTime;
+		Stats( void ) : cornersTime(0) , verticesTime(0) , edgesTime(0) , curveTime(0), copyFinerTime(0) , setTableTime(0) {;}
+		std::string toString( void ) const
+		{
+			std::stringstream stream;
+			stream << "Corners / Vertices / Edges / Curve / Set Table / Copy Finer: ";
+			stream << std::fixed << std::setprecision(1) << cornersTime << " / " << verticesTime << " / " << edgesTime << " / " << curveTime << " / " << setTableTime << " / " << copyFinerTime;
+			stream << " (s)";
+			return stream.str();
+		}
+	};
+
+protected:
+	enum _SetFlag
+	{
+		CORNER_VALUES = 1,
+		ISO_VERTICES = 2,
+		ISO_EDGES = 4
+	};
+
+public:
+	static int SetCornerValuesFlag( void ){ return _SetFlag::CORNER_VALUES; }
+	static int SetIsoVerticesFlag ( void ){ return _SetFlag::CORNER_VALUES | _SetFlag::ISO_VERTICES; }
+	static int SetIsoEdgesFlag    ( void ){ return _SetFlag::CORNER_VALUES | _SetFlag::ISO_VERTICES | _SetFlag::ISO_EDGES; }
+
+	template< unsigned int WeightDegree , unsigned int DataSig , typename VertexStream , unsigned int ... FEMSigs >
+	static Stats SetSliceValues( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , UIntPack< DataSig > , const FEMTree< Dim , Real > &tree , int maxKeyDepth , const DensityEstimator< WeightDegree > *densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data , const DenseNodeData< Real , UIntPack< FEMSigs ... > > &coefficients , Real isoValue , VertexStream &vertexStream , const Data &zeroData , bool nonLinearFit , bool outputGradients , std::vector< SliceValues > &sliceValues , int setFlag )
+	{
+		if( maxKeyDepth<tree._maxDepth ) MK_THROW( "Max key depth has to be at least tree depth: " , tree._maxDepth , " <= " , maxKeyDepth );
+		LevelSetExtraction::KeyGenerator< Dim > keyGenerator( maxKeyDepth );
+		unsigned int slabStart = 0 , slabEnd = 1<<tree._maxDepth;
+		LocalDepth fullDepth = tree.getFullDepth( UIntPack< FEMSignature< FEMSigs >::Degree ... >() );
+
+		_BadRootCount = 0u;
+		Stats stats;
+
+		static_assert( sizeof...(FEMSigs)==Dim , "[ERROR] Number of signatures should match dimension" );
+		tree._setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+		static const int FEMDegrees[] = { FEMSignature< FEMSigs >::Degree ... };
+		for( int d=0 ; d<Dim ; d++ ) if( FEMDegrees[d]==0 && nonLinearFit ) MK_THROW( "Constant B-Splines do not support gradient estimation" );
+
+		LevelSetExtraction::SetHyperCubeTables< Dim >();
+
+		typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > >* pointEvaluator = NULL;
+		if constexpr( HasData ) if( data ) pointEvaluator = new typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > >( tree._maxDepth );
+		DenseNodeData< Real , UIntPack< FEMSigs ... > > coarseCoefficients( tree._sNodesEnd( tree._maxDepth-1 ) );
+		memset( coarseCoefficients() , 0 , sizeof(Real)*tree._sNodesEnd( tree._maxDepth-1 ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(0) , tree._sNodesEnd( tree._maxDepth-1 ) , [&]( unsigned int, size_t i ){ coarseCoefficients[i] = coefficients[i]; } );
+		typename FEMIntegrator::template RestrictionProlongation< UIntPack< FEMSigs ... > > rp;
+		for( LocalDepth d=1 ; d<tree._maxDepth ; d++ ) tree._upSample( UIntPack< FEMSigs ... >() , rp , d , ( ConstPointer(Real) )coarseCoefficients()+tree._sNodesBegin(d-1) , coarseCoefficients()+tree._sNodesBegin(d) );
+
+		std::vector< _Evaluator< UIntPack< FEMSigs ... > , 1 > > evaluators( tree._maxDepth+1 );
+		for( LocalDepth d=0 ; d<=tree._maxDepth ; d++ ) evaluators[d].set( tree._maxDepth );
+
+		sliceValues.resize( tree._maxDepth+1 );
+		std::vector< typename SliceValues::Scratch > scratchValues( tree._maxDepth+1 );
+
+		// Initialize the slice
+		for( LocalDepth d=tree._maxDepth ; d>=fullDepth ; d-- )
+		{
+			double t = Time();
+			sliceValues[d].cellIndices.set( tree._sNodes , tree._localToGlobal( d ) );
+			stats.setTableTime += Time()-t;
+			sliceValues[d].reset( nonLinearFit || outputGradients );
+			scratchValues[d].reset( sliceValues[d].cellIndices );
+		}
+
+		for( LocalDepth d=tree._maxDepth; d>=fullDepth ; d-- )
+		{
+			// Copy edges from finer
+			if( setFlag & _SetFlag::ISO_EDGES )
+			{
+				double t = Time();
+				if( d<tree._maxDepth ) CopyFinerSliceIsoEdgeKeys( tree , d , fullDepth , sliceValues , scratchValues );
+				stats.copyFinerTime += Time()-t;
+			}
+
+			if( setFlag & _SetFlag::CORNER_VALUES )
+			{
+				double t = Time();
+				SetSCornerValues< FEMSigs ... >( tree , coefficients() , coarseCoefficients() , isoValue , d , fullDepth , sliceValues , scratchValues , evaluators[d] );
+				stats.cornersTime += Time()-t;
+			}
+
+			if( setFlag & _SetFlag::ISO_VERTICES )
+			{
+				double t = Time();
+				SetIsoVertices< WeightDegree , DataSig >( keyGenerator , tree , nonLinearFit , outputGradients , pointEvaluator , densityWeights , data , isoValue , d , fullDepth , vertexStream , sliceValues , scratchValues , zeroData );
+				stats.verticesTime += Time()-t;
+			}
+
+			if( setFlag & _SetFlag::ISO_EDGES )
+			{
+				double t = Time();
+				SetIsoEdges( keyGenerator , tree , d , fullDepth , sliceValues , scratchValues );
+				stats.edgesTime += Time()-t , t = Time();
+			}
+		}
+
+		for( LocalDepth d=tree._maxDepth ; d>=fullDepth ; d-- )
+		{
+			ThreadPool::ParallelSections
+			(
+				[ &sliceValues , &scratchValues , d ]( void ){ sliceValues[d].setFromScratch( scratchValues[d].vKeyValues ); } ,
+				[ &sliceValues , &scratchValues , d ]( void ){ sliceValues[d].setFromScratch( scratchValues[d].eKeyValues ); } ,
+				[ &sliceValues , &scratchValues , d ]( void ){ sliceValues[d].setFromScratch( scratchValues[d].fKeyValues ); }
+			);
+			if( ( setFlag & _SetFlag::ISO_VERTICES) && d<tree._maxDepth ) for( auto iter=sliceValues[d+1].vertexPairMap.begin() ; iter!=sliceValues[d+1].vertexPairMap.end() ; iter++ ) sliceValues[d].vertexPairMap[ iter->first ] = iter->second;
+		}
+
+		size_t badRootCount = _BadRootCount;
+		if( badRootCount!=0 ) MK_WARN( "bad average roots: " , badRootCount );
+		return stats;
+	}
+
+	static void SetLevelSets( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , const FEMTree< Dim , Real >& tree , LocalDepth fullDepth , const std::vector< SliceValues > &sliceValues , OutputDataStream< std::pair< node_index_type , node_index_type > >& edgeStream , bool flipOrientation )
+	{
+		for( LocalDepth d=tree._maxDepth ; d>=fullDepth ; d-- ) SetLevelSet( keyGenerator , tree , d , sliceValues[d] , edgeStream , flipOrientation );
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig , typename VertexStream , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , UIntPack< DataSig > , const FEMTree< Dim , Real >& tree , const DensityEstimator< WeightDegree >* densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data , const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , Real isoValue , VertexStream &vertexStream , OutputDataStream< std::pair< node_index_type , node_index_type > > &edgeStream , const Data &zeroData , bool nonLinearFit , bool outputGradients , bool flipOrientation )
+	{
+		std::vector< SliceValues > sliceValues;
+
+		Stats stats = SetSliceValues( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , tree.maxDepth() , densityWeights , data , coefficients , isoValue , vertexStream , zeroData , nonLinearFit , outputGradients , sliceValues , SetIsoEdgesFlag() );
+		LevelSetExtraction::KeyGenerator< Dim > keyGenerator( tree.maxDepth() );
+		{
+			double t = Time();
+			SetLevelSets( keyGenerator , tree , tree.getFullDepth( UIntPack< FEMSignature< FEMSigs >::Degree ... >() ) , sliceValues , edgeStream , flipOrientation );
+			stats.curveTime += Time()-t;
+		}
+		return stats;
+	}
+};
+
+template< bool HasData , typename Real , typename Data > std::atomic< size_t > _LevelSetExtractor< HasData , Real , 2 , Data >::_BadRootCount;
+
+template< typename Real >
+struct LevelSetExtractor< Real , 2 >
+{
+	static const unsigned int Dim = 2;
+	static const bool HasData = false;
+	typedef unsigned char Data;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::Stats Stats;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::Vertex Vertex;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::SliceValues SliceValues;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::TreeSliceValuesAndVertexPositions TreeSliceValuesAndVertexPositions;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::TreeNode TreeNode;
+	using OutputVertexStream = typename _LevelSetExtractor< HasData , Real , Dim , Data >::OutputVertexStream;
+	template< unsigned int WeightDegree > using DensityEstimator = typename _LevelSetExtractor< HasData , Real , Dim , Data >::template DensityEstimator< WeightDegree >;
+	static int SetCornerValuesFlag( void ){ return _LevelSetExtractor< HasData , Real , Dim , Data >::SetCornerValuesFlag(); }
+	static int SetIsoVerticesFlag ( void ){ return _LevelSetExtractor< HasData , Real , Dim , Data >::SetIsoVerticesFlag (); }
+	static int SetIsoEdgesFlag    ( void ){ return _LevelSetExtractor< HasData , Real , Dim , Data >::SetIsoEdgesFlag    (); }
+
+	template< unsigned int WeightDegree , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , const FEMTree< Dim , Real >& tree , const DensityEstimator< WeightDegree >* densityWeights , const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , Real isoValue , OutputVertexStream &vertexStream , OutputDataStream< std::pair< node_index_type , node_index_type > > &edgeStream , bool nonLinearFit , bool outputGradients , bool flipOrientation )
+	{
+		Data zeroData = 0;
+		static const unsigned int DataSig = FEMDegreeAndBType< 0 , BOUNDARY_FREE >::Signature;
+		const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data = NULL;
+		return _LevelSetExtractor< HasData , Real , Dim , Data >::template Extract< WeightDegree , DataSig , OutputVertexStream , FEMSigs ... >( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , densityWeights , data , coefficients , isoValue , vertexStream , edgeStream , zeroData , nonLinearFit , outputGradients , flipOrientation );
+	}
+
+	template< unsigned int WeightDegree , unsigned int ... FEMSigs >
+	static Stats SetSliceValues( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , const FEMTree< Dim , Real > &tree , int maxKeyDepth , const DensityEstimator< WeightDegree > *densityWeights , const DenseNodeData< Real , UIntPack< FEMSigs ... > > &coefficients , Real isoValue , OutputVertexStream &vertexStream , bool nonLinearFit , bool outputGradients , std::vector< SliceValues > &sliceValues , int setFlag )
+	{
+		Data zeroData = 0;
+		static const unsigned int DataSig = FEMDegreeAndBType< 0 , BOUNDARY_FREE >::Signature;
+		const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data = NULL;
+		return _LevelSetExtractor< HasData , Real , Dim , Data >::template SetSliceValues< WeightDegree , DataSig , OutputVertexStream , FEMSigs ... >( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , maxKeyDepth , densityWeights , data , coefficients , isoValue , vertexStream , zeroData , nonLinearFit , outputGradients , sliceValues , setFlag );
+	}
+};
+
+template< typename Real , typename Data >
+struct LevelSetExtractor< Real , 2 , Data >
+{
+	static const unsigned int Dim = 2;
+	static const bool HasData = true;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::Stats Stats;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::Vertex Vertex;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::SliceValues SliceValues;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::TreeSliceValuesAndVertexPositions TreeSliceValuesAndVertexPositions;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::TreeNode TreeNode;
+	using OutputVertexStream = typename _LevelSetExtractor< HasData , Real , Dim , Data >::OutputVertexStream;
+	template< unsigned int WeightDegree > using DensityEstimator = typename _LevelSetExtractor< HasData , Real , Dim , Data >::template DensityEstimator< WeightDegree >;
+	static int SetCornerValuesFlag( void ){ return _LevelSetExtractor< HasData , Real , Dim , Data >::SetCornerValuesFlag(); }
+	static int SetIsoVerticesFlag ( void ){ return _LevelSetExtractor< HasData , Real , Dim , Data >::SetIsoVerticesFlag (); }
+	static int SetIsoEdgesFlag    ( void ){ return _LevelSetExtractor< HasData , Real , Dim , Data >::SetIsoEdgesFlag    (); }
+
+	template< unsigned int WeightDegree , unsigned int DataSig , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , UIntPack< DataSig > , const FEMTree< Dim , Real >& tree , const DensityEstimator< WeightDegree > *densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data , const DenseNodeData< Real , UIntPack< FEMSigs ... > > &coefficients , Real isoValue , OutputVertexStream &vertexStream , OutputDataStream< std::pair< node_index_type , node_index_type > > &edgeStream , const Data &zeroData , bool nonLinearFit , bool outputGradients , bool flipOrientation )
+	{
+		return _LevelSetExtractor< HasData , Real , Dim , Data >::template Extract< WeightDegree , DataSig , OutputVertexStream , FEMSigs ... >( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , densityWeights , data , coefficients , isoValue , vertexStream , edgeStream , zeroData , nonLinearFit , outputGradients , flipOrientation );
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig , unsigned int ... FEMSigs >
+	static Stats SetSliceValues( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , UIntPack< DataSig > , const FEMTree< Dim , Real > &tree , int maxKeyDepth , const DensityEstimator< WeightDegree > *densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data , const DenseNodeData< Real , UIntPack< FEMSigs ... > > &coefficients , Real isoValue , OutputVertexStream &vertexStream , const Data &zeroData , bool nonLinearFit , bool outputGradients , std::vector< SliceValues > &sliceValues , int setFlag )
+	{
+		return _LevelSetExtractor< HasData , Real , Dim , Data >::template SetSliceValues< WeightDegree , DataSig , OutputVertexStream , FEMSigs ... >( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , maxKeyDepth , densityWeights , data , coefficients , isoValue , vertexStream , zeroData , nonLinearFit , outputGradients , sliceValues , setFlag );
+	}
+};

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.LevelSet.3D.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.LevelSet.3D.inl
@@ -1,0 +1,2469 @@
+/*
+Copyright (c) 2022, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+// Specialized level-set surface extraction
+template< bool HasData , typename Real , typename Data >
+struct _LevelSetExtractor< HasData , Real , 3 , Data >
+{
+	static const unsigned int Dim = 3;
+	// Store the position, the (interpolated) gradient, the weight, and possibly data
+	typedef std::conditional_t
+		<
+			HasData ,
+			DirectSum< Real , Point< Real , Dim > , Point< Real , Dim > , Real , Data > ,
+			DirectSum< Real , Point< Real , Dim > , Point< Real , Dim > , Real >
+		> Vertex;
+
+	using OutputVertexStream = std::conditional_t
+		<
+			HasData ,
+			OutputDataStream< Point< Real , Dim > , Point< Real , Dim > , Real , Data > ,
+			OutputDataStream< Point< Real , Dim > , Point< Real , Dim > , Real >
+		>;
+
+protected:
+	static std::atomic< size_t > _BadRootCount;
+
+public:
+	typedef typename FEMTree< Dim , Real >::LocalDepth LocalDepth;
+	typedef typename FEMTree< Dim , Real >::LocalOffset LocalOffset;
+	typedef typename FEMTree< Dim , Real >::ConstOneRingNeighborKey ConstOneRingNeighborKey;
+	typedef typename FEMTree< Dim , Real >::ConstOneRingNeighbors ConstOneRingNeighbors;
+	typedef RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > TreeNode;
+	template< unsigned int WeightDegree > using DensityEstimator = typename FEMTree< Dim , Real >::template DensityEstimator< WeightDegree >;
+	template< typename FEMSigPack , unsigned int PointD > using _Evaluator = typename FEMTree< Dim , Real >::template _Evaluator< FEMSigPack , PointD >;
+
+	using Key = LevelSetExtraction::Key< Dim >;
+	using IsoEdge = LevelSetExtraction::IsoEdge< Dim >;
+	template< unsigned int D , unsigned int ... Ks >
+	using HyperCubeTables = LevelSetExtraction::HyperCubeTables< D , Ks ... >;
+
+	////////////////
+	// FaceEdges //
+	////////////////
+	struct FaceEdges
+	{
+		IsoEdge edges[2];
+		int count;
+		FaceEdges( void ) : count(-1){}
+
+		friend FaceEdges SetAtomic( volatile FaceEdges & value , FaceEdges newValue )
+		{
+			FaceEdges oldEdge;
+			oldEdge.edges[0] = SetAtomic( value.edges[0] , newValue.edges[0] );
+			oldEdge.edges[1] = SetAtomic( value.edges[1] , newValue.edges[1] );
+			oldEdge.count = SetAtomic( value.count , newValue.count );
+			return oldEdge;
+		}
+	};
+
+	///////////////
+	// SliceData //
+	///////////////
+	class SliceData
+	{
+	public:
+		template< unsigned int Indices >
+		struct  _Indices
+		{
+			node_index_type idx[Indices];
+			_Indices( void ){ for( unsigned int i=0 ; i<Indices ; i++ ) idx[i] = -1; }
+			node_index_type& operator[] ( int i ) { return idx[i]; }
+			const node_index_type& operator[] ( int i ) const { return idx[i]; }
+		};
+		// The four corner indices associated with a square face
+		using SquareCornerIndices = _Indices< HyperCube::Cube< Dim-1 >::template ElementNum< 0 >() >;
+		// The four edge indices associated with a square face
+		using SquareEdgeIndices   = _Indices< HyperCube::Cube< Dim-1 >::template ElementNum< 1 >() >;
+		// The one face index associated with a square face
+		using SquareFaceIndices   = _Indices< HyperCube::Cube< Dim-1 >::template ElementNum< 2 >() >;
+	};
+
+	/////////////////
+	// SliceValues //
+	/////////////////
+	struct SliceValues
+	{
+		struct Scratch
+		{
+			using FKeyValues = std::vector< std::vector< std::pair< Key , std::vector< IsoEdge > > > >;
+			using EKeyValues = std::vector< std::vector< std::pair< Key , std::pair< node_index_type , Vertex > > > >;
+			using VKeyValues = std::vector< std::vector< std::pair< Key , Key > > >;
+
+			FKeyValues fKeyValues;
+			EKeyValues eKeyValues;
+			VKeyValues vKeyValues;
+
+#ifdef SANITIZED_PR
+			Pointer( std::atomic< char > ) cSet;
+			Pointer( std::atomic< char > ) eSet;
+			Pointer( std::atomic< char > ) fSet;
+#else // !SANITIZED_PR
+			Pointer( char ) cSet;
+			Pointer( char ) eSet;
+			Pointer( char ) fSet;
+#endif // SANITIZED_PR
+
+			Scratch( void )
+			{
+				vKeyValues.resize( ThreadPool::NumThreads() );
+				eKeyValues.resize( ThreadPool::NumThreads() );
+				fKeyValues.resize( ThreadPool::NumThreads() );
+#ifdef SANITIZED_PR
+				cSet = NullPointer( std::atomic< char > );
+				eSet = NullPointer( std::atomic< char > );
+				fSet = NullPointer( std::atomic< char > );
+#else // !SANITIZED_PR
+				cSet = NullPointer( char );
+				eSet = NullPointer( char );
+				fSet = NullPointer( char );
+#endif // SANITIZED_PR
+			}
+
+			~Scratch( void )
+			{
+#ifdef SANITIZED_PR
+				DeletePointer( cSet );
+				DeletePointer( eSet );
+				DeletePointer( fSet );
+#else // !SANITIZED_PR
+				FreePointer( cSet );
+				FreePointer( eSet );
+				FreePointer( fSet );
+#endif // SANITIZED_PR
+			}
+
+			void reset( const LevelSetExtraction::SliceCellIndexData< Dim > &cellIndices )
+			{
+				for( size_t i=0 ; i<vKeyValues.size() ; i++ ) vKeyValues[i].clear();
+				for( size_t i=0 ; i<eKeyValues.size() ; i++ ) eKeyValues[i].clear();
+				for( size_t i=0 ; i<fKeyValues.size() ; i++ ) fKeyValues[i].clear();
+#ifdef SANITIZED_PR
+				DeletePointer( cSet );
+				DeletePointer( eSet );
+				DeletePointer( fSet );
+				if( cellIndices.counts[0] )
+				{
+					cSet = NewPointer< std::atomic< char > >( cellIndices.counts[0] );
+					for( unsigned int i=0 ; i<cellIndices.counts[0] ; i++ ) cSet[i] = 0;
+				}
+				if( cellIndices.counts[1] )
+				{
+					eSet = NewPointer< std::atomic< char > >( cellIndices.counts[1] );
+					for( unsigned int i=0 ; i<cellIndices.counts[1] ; i++ ) eSet[i] = 0;
+				}
+				if( cellIndices.counts[2] )
+				{
+					fSet = NewPointer< std::atomic< char > >( cellIndices.counts[2] );
+					for( unsigned int i=0 ; i<cellIndices.counts[2] ; i++ ) fSet[i] = 0;
+				}
+#else // !SANITIZED_PR
+				FreePointer( cSet );
+				FreePointer( eSet );
+				FreePointer( fSet );
+				if( cellIndices.counts[0] )
+				{
+					cSet = AllocPointer< char >( cellIndices.counts[0] );
+					memset( cSet , 0 , sizeof( char ) * cellIndices.counts[0] );
+				}
+				if( cellIndices.counts[1] )
+				{
+					eSet = AllocPointer< char >( cellIndices.counts[1] );
+					memset( eSet , 0 , sizeof( char ) * cellIndices.counts[1] );
+				}
+				if( cellIndices.counts[2] )
+				{
+					fSet = AllocPointer< char >( cellIndices.counts[2] );
+					memset( fSet , 0 , sizeof( char ) * cellIndices.counts[2] );
+				}
+#endif // SANITIZED_PR
+			}
+		};
+
+		LevelSetExtraction::SliceCellIndexData< Dim > cellIndices;
+		Pointer( Real ) cornerValues ; Pointer( Point< Real , Dim > ) cornerGradients;
+		Pointer( Key ) edgeKeys;
+		Pointer( FaceEdges ) faceEdges;
+		Pointer( char ) mcIndices;
+		LevelSetExtraction::KeyMap< Dim , std::vector< IsoEdge > > faceEdgeMap;
+		LevelSetExtraction::KeyMap< Dim , std::pair< node_index_type , Vertex > > edgeVertexMap;
+		LevelSetExtraction::KeyMap< Dim , Key > vertexPairMap;
+
+		SliceValues( void )
+		{
+			_slice = -1;
+			_oldCCount = _oldECount = _oldFCount = 0;
+			_oldNCount = 0;
+			cornerValues = NullPointer( Real ) ; cornerGradients = NullPointer( Point< Real , Dim > );
+			edgeKeys = NullPointer( Key );
+			faceEdges = NullPointer( FaceEdges );
+			mcIndices = NullPointer( char );
+		}
+		~SliceValues( void )
+		{
+			_oldCCount = _oldECount = _oldFCount = 0;
+			_oldNCount = 0;
+			FreePointer( cornerValues ) ; FreePointer( cornerGradients );
+			DeletePointer( edgeKeys );
+			DeletePointer( faceEdges );
+			FreePointer( mcIndices );
+		}
+
+		void setFromScratch( typename Scratch::VKeyValues &scratch )
+		{
+			for( unsigned int t=0 ; t<scratch.size() ; t++ )
+			{
+				for( int i=0 ; i<scratch[t].size() ; i++ )
+				{
+					vertexPairMap[ scratch[t][i].first ] = scratch[t][i].second;
+					vertexPairMap[ scratch[t][i].second ] = scratch[t][i].first;
+				}
+				scratch[t].clear();
+			}
+		}
+
+		void setFromScratch( typename Scratch::EKeyValues &scratch )
+		{
+			for( unsigned int t=0 ; t<scratch.size() ; t++ )
+			{
+				for( int i=0 ; i<scratch[t].size() ; i++ ) edgeVertexMap[ scratch[t][i].first ] = scratch[t][i].second;
+				scratch[t].clear();
+			}
+		}
+
+		void setFromScratch( typename Scratch::FKeyValues &scratch )
+		{
+			for( unsigned int t=0 ; t<scratch.size() ; t++ )
+			{
+				for( int i=0 ; i<scratch[t].size() ; i++ )
+				{
+					std::vector< IsoEdge > &faceEdges = faceEdgeMap[ scratch[t][i].first ];
+					faceEdges.insert( faceEdges.end() , scratch[t][i].second.begin() , scratch[t][i].second.end() );
+				}
+				scratch[t].clear();
+			}
+		}
+
+		unsigned int slice( void ) const { return _slice; }
+		void reset( unsigned int slice , bool computeGradients )
+		{
+			_slice = slice;
+			faceEdgeMap.clear() , edgeVertexMap.clear() , vertexPairMap.clear();
+
+			if( _oldNCount<(node_index_type)cellIndices.size() )
+			{
+				_oldNCount = (node_index_type)cellIndices.size();
+				FreePointer( mcIndices );
+				if( _oldNCount>0 ) mcIndices = AllocPointer< char >( _oldNCount );
+			}
+			if( _oldCCount<(node_index_type)cellIndices.counts[0] )
+			{
+				_oldCCount = (node_index_type)cellIndices.counts[0];
+				FreePointer( cornerValues ) ; FreePointer( cornerGradients );
+				if( cellIndices.counts[0]>0 )
+				{
+					cornerValues = AllocPointer< Real >( _oldCCount );
+					if( computeGradients ) cornerGradients = AllocPointer< Point< Real , Dim > >( _oldCCount );
+				}
+			}
+			if( _oldECount<(node_index_type)cellIndices.counts[1] )
+			{
+				_oldECount = (node_index_type)cellIndices.counts[1];
+				DeletePointer( edgeKeys );
+				edgeKeys = NewPointer< Key >( _oldECount );
+			}
+			if( _oldFCount<(node_index_type)cellIndices.counts[2] )
+			{
+				_oldFCount = (node_index_type)cellIndices.counts[2];
+				DeletePointer( faceEdges );
+				faceEdges = NewPointer< FaceEdges >( _oldFCount );
+			}
+		}
+
+		template< typename FaceIndexFunctor /* = std::function< LevelSetExtraction::Key< Dim > ( const TreeNode * , typename HyperCube::Cube< Dim >::template Element< 2 > ) */ >
+		void addIsoEdges( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , FaceIndexFunctor &faceIndexFunctor , const FEMTree< Dim , Real > &tree , const Scratch &scratch , const TreeNode *leaf , unsigned int sliceIndex , std::vector< IsoEdge > &edges , bool isOriented ) const
+		{
+			auto _FaceIndex = [&]( const TreeNode *node )
+			{
+				int depth , offset[Dim];
+				tree.depthAndOffset( node , depth , offset );
+				typename HyperCube::Cube< Dim >::template Element< 2 > f;
+				if     ( offset[Dim-1]+0==sliceIndex ) f = typename HyperCube::Cube< Dim >::template Element< 2 >( HyperCube::BACK  , 0 );
+				else if( offset[Dim-1]+1==sliceIndex ) f = typename HyperCube::Cube< Dim >::template Element< 2 >( HyperCube::FRONT , 0 );
+				else MK_THROW( "Node/slice-index mismatch: " , offset[Dim-1] , " <-> " , sliceIndex );
+				return faceIndexFunctor( node , f );
+			};
+
+			int flip = isOriented ? 0 : 1;
+
+			node_index_type fIdx = cellIndices.template indices<2>(leaf->nodeData.nodeIndex)[0];
+			if( scratch.fSet[fIdx] )
+			{
+				const FaceEdges &fe = faceEdges[ fIdx ];
+				for( int i=0 ; i<fe.count ; i++ ) edges.push_back( IsoEdge( fe.edges[i][flip] , fe.edges[i][1-flip] ) );
+			}
+			else
+			{
+				Key key = _FaceIndex( leaf );
+				typename LevelSetExtraction::KeyMap< Dim , std::vector< IsoEdge > >::const_iterator iter = faceEdgeMap.find( key );
+				if( iter!=faceEdgeMap.end() )
+				{
+					const std::vector< IsoEdge >& _edges = iter->second;
+					for( size_t i=0 ; i<_edges.size() ; i++ ) edges.push_back( IsoEdge( _edges[i][flip] , _edges[i][1-flip] ) );
+				}
+				else
+				{
+					LocalDepth d ; LocalOffset off;
+					tree.depthAndOffset( leaf , d , off );
+					// [WARNING] Is this right? If the face isn't set, wouldn't it inherit?
+					MK_WARN( "Invalid face: [" , off[0] , " " , off[1] , " " , off[2] , " @ " , d , " | " , sliceIndex , " : " , leaf->nodeData.nodeIndex , " ( " , keyGenerator.to_string(key) , " | " , key.to_string() , " )"  );
+				}
+			}
+		}
+
+		bool setVertexPair( Key current , Key &pair ) const
+		{
+			typename LevelSetExtraction::KeyMap< Dim , Key >::const_iterator iter;
+
+			if( (iter=vertexPairMap.find(current))!=vertexPairMap.end() )
+			{
+				pair = iter->second;
+				return true;
+			}
+			else return false;
+		}
+
+		bool setEdgeVertex( Key key , std::pair< node_index_type , Vertex > &edgeVertex ) const
+		{
+			typename LevelSetExtraction::KeyMap< Dim , std::pair< node_index_type , Vertex > >::const_iterator iter;
+			if( ( iter=edgeVertexMap.find( key ) )!=edgeVertexMap.end() )
+			{
+				edgeVertex = iter->second;
+				return true;
+			}
+			else return false;
+		}
+	protected:
+		node_index_type _oldCCount , _oldECount , _oldFCount;
+		node_index_type _oldNCount;
+		unsigned int _slice;
+	};
+
+	//////////////////
+	// XSliceValues //
+	//////////////////
+	struct XSliceValues
+	{
+		struct Scratch
+		{
+			using FKeyValues = std::vector< std::vector< std::pair< Key , std::vector< IsoEdge > > > >;
+			using EKeyValues = std::vector< std::vector< std::pair< Key , std::pair< node_index_type , Vertex > > > >;
+			using VKeyValues = std::vector< std::vector< std::pair< Key , Key > > >;
+
+			FKeyValues fKeyValues;
+			EKeyValues eKeyValues;
+			VKeyValues vKeyValues;
+
+#ifdef SANITIZED_PR
+			Pointer( std::atomic< char > ) eSet;
+			Pointer( std::atomic< char > ) fSet;
+#else // !SANITIZED_PR
+			Pointer( char ) eSet;
+			Pointer( char ) fSet;
+#endif // SANITIZED_PR
+
+			Scratch( void )
+			{
+				vKeyValues.resize( ThreadPool::NumThreads() );
+				eKeyValues.resize( ThreadPool::NumThreads() );
+				fKeyValues.resize( ThreadPool::NumThreads() );
+#ifdef SANITIZED_PR
+				eSet = NullPointer( std::atomic< char > );
+				fSet = NullPointer( std::atomic< char > );
+#else // !SANITIZED_PR
+				eSet = NullPointer( char );
+				fSet = NullPointer( char );
+#endif // SANITIZED_PR
+			}
+
+			~Scratch( void )
+			{
+#ifdef SANITIZED_PR
+				DeletePointer( eSet );
+				DeletePointer( fSet );
+#else // !SANITIZED_PR
+				FreePointer( eSet );
+				FreePointer( fSet );
+#endif // SANITIZED_PR
+			}
+
+			void reset( const LevelSetExtraction::SlabCellIndexData< Dim > &cellIndices )
+			{
+				for( size_t i=0 ; i<vKeyValues.size() ; i++ ) vKeyValues[i].clear();
+				for( size_t i=0 ; i<eKeyValues.size() ; i++ ) eKeyValues[i].clear();
+				for( size_t i=0 ; i<fKeyValues.size() ; i++ ) fKeyValues[i].clear();
+#ifdef SANITIZED_PR
+				DeletePointer( eSet );
+				DeletePointer( fSet );
+				if( cellIndices.counts[0] )
+				{
+					eSet = NewPointer< std::atomic< char > >( cellIndices.counts[0] );
+					for( unsigned int i=0 ; i<cellIndices.counts[0] ; i++ ) eSet[i] = 0;
+				}
+				if( cellIndices.counts[1] )
+				{
+					fSet = NewPointer< std::atomic< char > >( cellIndices.counts[1] );
+					for( unsigned int i=0 ; i<cellIndices.counts[1] ; i++ ) fSet[i] = 0;
+				}
+#else // !SANITIZED_PR
+				FreePointer( eSet );
+				FreePointer( fSet );
+				if( cellIndices.counts[0] )
+				{
+					eSet = AllocPointer< char >( cellIndices.counts[0] );
+					memset( eSet , 0 , sizeof( char ) * cellIndices.counts[0] );
+				}
+				if( cellIndices.counts[1] )
+				{
+					fSet = AllocPointer< char >( cellIndices.counts[1] );
+					memset( fSet , 0 , sizeof( char ) * cellIndices.counts[1] );
+				}
+#endif // SANITIZED_PR
+			}
+		};
+
+		LevelSetExtraction::SlabCellIndexData< Dim > cellIndices;
+		Pointer( Key ) edgeKeys;
+		Pointer( FaceEdges ) faceEdges;
+		LevelSetExtraction::KeyMap< Dim , std::vector< IsoEdge > > faceEdgeMap;
+		LevelSetExtraction::KeyMap< Dim , std::pair< node_index_type , Vertex > > edgeVertexMap;
+		LevelSetExtraction::KeyMap< Dim , Key > vertexPairMap;
+
+		XSliceValues( void )
+		{
+			_slab = -1;
+			_oldECount = _oldFCount = 0;
+			edgeKeys = NullPointer( Key );
+			faceEdges = NullPointer( FaceEdges );
+		}
+
+		~XSliceValues( void )
+		{
+			_oldECount = _oldFCount = 0;
+			DeletePointer( edgeKeys );
+			DeletePointer( faceEdges );
+		}
+
+		void setFromScratch( typename Scratch::VKeyValues &scratch )
+		{
+			for( unsigned int t=0 ; t<scratch.size() ; t++ )
+			{
+				for( int i=0 ; i<scratch[t].size() ; i++ )
+				{
+					vertexPairMap[ scratch[t][i].first ] = scratch[t][i].second;
+					vertexPairMap[ scratch[t][i].second ] = scratch[t][i].first;
+				}
+				scratch[t].clear();
+			}
+		}
+
+		void setFromScratch( typename Scratch::EKeyValues &scratch )
+		{
+			for( unsigned int t=0 ; t<scratch.size() ; t++ )
+			{
+				for( int i=0 ; i<scratch[t].size() ; i++ ) edgeVertexMap[ scratch[t][i].first ] = scratch[t][i].second;
+				scratch[t].clear();
+			}
+		}
+
+		void setFromScratch( typename Scratch::FKeyValues &scratch )
+		{
+			for( unsigned int t=0 ; t<scratch.size() ; t++ )
+			{
+				for( int i=0 ; i<scratch[t].size() ; i++ )
+				{
+					auto iter = faceEdgeMap.find( scratch[t][i].first );
+					if( iter==faceEdgeMap.end() ) faceEdgeMap[ scratch[t][i].first ] = scratch[t][i].second;
+					else for( int j=0 ; j<scratch[t][i].second.size() ; j++ ) iter->second.push_back( scratch[t][i].second[j] );
+				}
+				scratch[t].clear();
+			}
+		}
+
+		unsigned int slab( void ) const { return _slab; }
+		void reset( unsigned int slab )
+		{
+			_slab = slab;
+			faceEdgeMap.clear() , edgeVertexMap.clear() , vertexPairMap.clear();
+
+			if( _oldECount<(node_index_type)cellIndices.counts[0] )
+			{
+				_oldECount = (node_index_type)cellIndices.counts[0];
+				DeletePointer( edgeKeys );
+				edgeKeys = NewPointer< Key >( _oldECount );
+			}
+			if( _oldFCount<(node_index_type)cellIndices.counts[1] )
+			{
+				_oldFCount = (node_index_type)cellIndices.counts[1];
+				DeletePointer( faceEdges );
+				faceEdges = NewPointer< FaceEdges >( _oldFCount );
+			}
+		}
+
+	protected:
+		node_index_type _oldECount , _oldFCount;
+		unsigned int _slab;
+	};
+
+	////////////////
+	// SlabValues //
+	////////////////
+	struct SlabValues
+	{
+	protected:
+		XSliceValues _xSliceValues[2];
+		SliceValues _sliceValues[2];
+		typename  SliceValues::Scratch  _sliceScratch[2];
+		typename XSliceValues::Scratch _xSliceScratch[2];
+	public:
+		      SliceValues& sliceValues( int idx ){ return _sliceValues[idx&1]; }
+		const SliceValues& sliceValues( int idx ) const { return _sliceValues[idx&1]; }
+		      XSliceValues& xSliceValues( int idx ){ return _xSliceValues[idx&1]; }
+		const XSliceValues& xSliceValues( int idx ) const { return _xSliceValues[idx&1]; }
+		      typename  SliceValues::Scratch &sliceScratch ( int idx )       { return  _sliceScratch[idx&1]; }
+		const typename  SliceValues::Scratch &sliceScratch ( int idx ) const { return  _sliceScratch[idx&1]; }
+		      typename XSliceValues::Scratch &xSliceScratch( int idx )       { return _xSliceScratch[idx&1]; }
+		const typename XSliceValues::Scratch &xSliceScratch( int idx ) const { return _xSliceScratch[idx&1]; }
+
+		bool validSlice( int slice ) const { return _sliceValues[slice&1].slice()==slice; }
+		bool validXSlice( int slab ) const { return _xSliceValues[slab&1].slab()==slab; }
+	};
+
+	static std::vector< std::pair< node_index_type , node_index_type > > SetIncidence( const FEMTree< Dim , Real > &tree , const FEMTree< Dim-1 , Real > &sliceTree , LocalDepth fullDepth , unsigned int sliceAtMaxDepth , unsigned int maxDepth )
+	{
+		using SliceTreeNode    = typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeNode;
+		using SliceLocalDepth  = typename FEMTree< Dim-1 , Real >::LocalDepth;
+		using SliceLocalOffset = typename FEMTree< Dim-1 , Real >::LocalOffset;
+
+		std::vector< std::pair< node_index_type , node_index_type > > incidence( sliceTree.nodesSize() , std::pair< node_index_type , node_index_type >( -1 , -1 ) );
+
+		// Recursively set the incidence
+		std::function< void ( const TreeNode * , const SliceTreeNode * ) > SetIncidenceFunctor = [&]( const TreeNode *node , const SliceTreeNode *sliceNode )
+		{
+			LocalDepth depth ; LocalOffset offset;
+			SliceLocalDepth sliceDepth ; SliceLocalOffset sliceOffset;
+			tree.depthAndOffset( node , depth , offset );
+			sliceTree.depthAndOffset( sliceNode , sliceDepth , sliceOffset );
+			if( depth!=sliceDepth ) MK_THROW( "Depths do not match: " , depth , " != " , sliceDepth );
+			for( unsigned int i=0 ; i<Dim-1 ; i++ ) if( offset[i]!=sliceOffset[i] ) MK_THROW( "Offsets do not match[ " , i , "]: " , offset[i] , " != " , sliceOffset[i] );
+
+			unsigned int beginAtMaxDepth = ( offset[Dim-1] + 0 )<<( maxDepth - depth );
+			unsigned int   endAtMaxDepth = ( offset[Dim-1] + 1 )<<( maxDepth - depth );
+			unsigned int   midAtMaxDepth = ( beginAtMaxDepth + endAtMaxDepth ) / 2;
+
+			if( node->nodeData.nodeIndex==-1 ) return;
+			else if( sliceNode->nodeData.nodeIndex==-1 ) MK_THROW( "Expected valid slice node" );
+
+			if( sliceAtMaxDepth<beginAtMaxDepth || sliceAtMaxDepth>endAtMaxDepth ) MK_THROW( "Bad slice: " , sliceAtMaxDepth , " in [ " , beginAtMaxDepth , " , " , endAtMaxDepth , " ]" );
+			if( depth>=fullDepth )
+			{
+				// Set the incidence
+				if     ( sliceAtMaxDepth==beginAtMaxDepth ) incidence[ sliceNode->nodeData.nodeIndex ].second = node->nodeData.nodeIndex;
+				else if( sliceAtMaxDepth==endAtMaxDepth   ) incidence[ sliceNode->nodeData.nodeIndex ].first  = node->nodeData.nodeIndex;
+				else
+				{
+					incidence[ sliceNode->nodeData.nodeIndex ].second = node->nodeData.nodeIndex;
+					incidence[ sliceNode->nodeData.nodeIndex ].first  = node->nodeData.nodeIndex;
+				}
+			}
+
+			if( !GetGhostFlag( node->children ) )
+			{
+				if( !sliceNode->children )
+				{
+					int d , off[Dim] , _d , _off[Dim-1];
+					Point< int , Dim > p;
+					Point< int , Dim-1 > _p;
+					for( unsigned int d=0 ; d<Dim ; d++ ) p[d] = off[d];
+					for( unsigned int d=0 ; d<Dim-1 ; d++ ) _p[d] = _off[d];
+					tree.depthAndOffset( node , d , off );
+					sliceTree.depthAndOffset( sliceNode , _d , _off );
+					MK_THROW( "Expected slice children: " , p , " @ " , d , " <-> " , _p , " @ " , _d , " : ",  node->nodeData.nodeIndex , " <-> " , sliceNode->nodeData.nodeIndex );
+				}
+				if( sliceAtMaxDepth<=midAtMaxDepth ) for( int c=0 ; c<(1<<(Dim-1)) ; c++ ) SetIncidenceFunctor( node->children+(c             ) , sliceNode->children + c );
+				if( sliceAtMaxDepth>=midAtMaxDepth ) for( int c=0 ; c<(1<<(Dim-1)) ; c++ ) SetIncidenceFunctor( node->children+(c|(1<<(Dim-1))) , sliceNode->children + c );
+			}
+		};
+		SetIncidenceFunctor( &tree.spaceRoot() , &sliceTree.spaceRoot() );
+		return incidence;
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig , typename VertexStream , typename SliceFunctor /* = std::function< SliceValues & ( unsigned int ) > */ , typename ScratchFunctor /* = std::function< typename SliceValues::Scratch & ( unsigned int ) */ >
+	static void CopyIsoStructure
+	(
+		const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator ,
+		const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions &boundaryInfo ,
+		const FEMTree< Dim , Real > &tree ,
+		LocalDepth fullDepth ,
+		unsigned int sliceAtMaxDepth ,
+		unsigned int maxDepth ,
+		SliceFunctor sliceFunctor ,
+		ScratchFunctor scratchFunctor ,
+		const std::vector< std::pair< node_index_type , node_index_type > > &incidence ,
+		VertexStream &vertexStream ,
+		bool gradientNormals ,
+		typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > > *pointEvaluator ,
+		const DensityEstimator< WeightDegree >* densityWeights ,
+		const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data ,
+		const Data &zeroData
+	)
+	{
+		using SliceTreeNode    = typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeNode;
+		using SliceSliceValues = typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::SliceValues;
+		using SliceKey         = LevelSetExtraction::Key< Dim-1 >;
+		using SliceIsoEdge     = LevelSetExtraction::IsoEdge< Dim-1 >;
+
+		auto PromoteIsoVertex = [&]( SliceKey key )
+		{
+			return keyGenerator( maxDepth , sliceAtMaxDepth , key );
+		};
+
+		auto PromoteIsoEdge = [&]( SliceIsoEdge edge )
+		{
+			IsoEdge pEdge;
+			for( unsigned int i=0 ; i<2 ; i++ ) pEdge[i] = keyGenerator( maxDepth , sliceAtMaxDepth , edge[i] );
+			return pEdge;
+		};
+
+		std::vector< node_index_type > vertexIndices( boundaryInfo.vertexPositions.size() );
+		std::vector< Vertex > vertices( boundaryInfo.vertexPositions.size() );
+		// Add the iso-vertices
+		{
+			static const unsigned int DataDegree = FEMSignature< DataSig >::Degree;
+
+			// A functor returning the finest leaf node containing the iso-vertex
+			std::function< const TreeNode * ( const TreeNode * , Key ) > FinestLeaf = [&]( const TreeNode *node , Key key )
+			{
+				const TreeNode *candidate = node;
+				if( node->children )
+				{
+					LocalDepth depth ; LocalOffset offset;
+					int start[Dim] , mid[Dim] , end[Dim];
+					tree.depthAndOffset( node , depth , offset );
+					for( unsigned int d=0 ; d<Dim ; d++ )
+					{
+						start[d] = (offset[d]+0)<<(maxDepth+2-depth);
+						end  [d] = (offset[d]+1)<<(maxDepth+2-depth);
+						mid  [d] = (start[d]+end[d])>>1;
+					}
+					for( unsigned int c=0 ; c<(1<<Dim) ; c++ )
+					{
+						bool containsKey = true;
+						for( unsigned int d=0 ; d<Dim ; d++ )
+							if( c&(1<<d) ) containsKey &= ((int)key[d]>=mid  [d] && (int)key[d]<=end[d]);
+							else           containsKey &= ((int)key[d]>=start[d] && (int)key[d]<=mid[d]);
+						if( containsKey )
+						{
+							const TreeNode *_candidate = FinestLeaf( node->children+c , key );
+							if( tree.depth(_candidate)>tree.depth(candidate) ) candidate = _candidate;
+						}
+					}
+				}
+				return candidate;
+			};
+
+			std::vector< Key > keys;
+			{
+				std::vector< LevelSetExtraction::Key< Dim-1 > > _keys = boundaryInfo.vertexKeys();
+				keys.resize( _keys.size() );
+				for( unsigned int i=0 ; i<_keys.size() ; i++ ) keys[i] = PromoteIsoVertex( _keys[i] );
+			}
+
+			for( unsigned int i=0 ; i<boundaryInfo.vertexPositions.size(); i++ )
+			{
+				ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > > weightKey;
+				ConstPointSupportKey< IsotropicUIntPack< Dim , DataDegree > > dataKey;
+				Point< Real , Dim > p;
+				for( unsigned int d=0 ; d<Dim-1 ; d++ ) p[d] = boundaryInfo.vertexPositions[i][d];
+				p[Dim-1] = (Real)sliceAtMaxDepth/(Real)(1<<maxDepth);
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Not setting normal gradients" )
+#endif // SHOW_WARNINGS
+				Real depth = (Real)1.;
+				Data dataValue;
+				const TreeNode *node = NULL;
+				if( densityWeights || data ) node = FinestLeaf( &tree.spaceRoot() , keys[i] );
+				if( densityWeights )
+				{
+					weightKey.set( node->depth() );
+					weightKey.getNeighbors( node );
+					Real weight;
+					tree._getSampleDepthAndWeight( *densityWeights , node , p , weightKey , depth , weight );
+				}
+				if constexpr( HasData ) if( data )
+				{
+					dataKey.set( node->depth() );
+					dataKey.getNeighbors( node );
+					Point< Real , Dim > start;
+					Real width;
+					tree.startAndWidth( node , start , width );
+					if( DataDegree==0 ) 
+					{
+						Point< Real , Dim > center( start[0] + width/2 , start[1] + width/2 , start[2] + width/2 );
+						ProjectiveData< Data , Real > pValue( zeroData );
+						tree.template _addEvaluation< ProjectiveData< Data , Real > , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > , 0 >( *data , center , *pointEvaluator , dataKey , pValue );
+						dataValue = pValue.weight ? pValue.value() : zeroData;
+					}
+					else
+					{
+						ProjectiveData< Data , Real > pValue( zeroData );
+						tree.template _addEvaluation< ProjectiveData< Data , Real > , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > , 0 >( *data , p , *pointEvaluator , dataKey , pValue );
+						dataValue = pValue.weight ? pValue.value() : zeroData;
+					}
+				}
+				vertices[i].template get<0>() = p;
+				vertices[i].template get<1>() = Point< Real , Dim >();
+				vertices[i].template get<2>() = depth;
+				if constexpr( HasData ) vertices[i].template get<3>() = dataValue;
+				vertexIndices[i] = (node_index_type)vertexStream.write( 0 , vertices[i] );
+			}
+		}
+
+		// Copy over the edge/face -> key tables
+		for( unsigned int depth=fullDepth ; depth<=std::min< unsigned int >( tree._maxDepth , boundaryInfo.sliceTree.depth() ) ; depth++ )
+		{
+			SliceValues &sValues = sliceFunctor( depth );
+			typename SliceValues::Scratch &sScratch = scratchFunctor( depth );
+			const SliceSliceValues &ssValues = boundaryInfo.sliceValues[depth];
+
+			auto CopyEdgeAndFaceInfo = [&]( node_index_type sliceIndex , node_index_type index )
+			{
+				if( index==-1 ) return;
+				const TreeNode *node = tree._sNodes.treeNodes[ index ];
+				const SliceTreeNode *sliceNode = boundaryInfo.sliceTree._sNodes.treeNodes[ sliceIndex ];
+
+				const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<1> &eIndices = sValues.cellIndices.template indices<1>( node );
+				const typename LevelSetExtraction::FullCellIndexData< Dim-1 >::template CellIndices<1> &sliceEIndices = ssValues.cellIndices.template indices< 1 >( sliceNode );
+				for( typename HyperCube::Cube< Dim-1 >::template Element< 1 > _e ; _e<HyperCube::Cube< Dim-1 >::template ElementNum< 1 >() ; _e++ )
+				{
+					node_index_type eIndex = eIndices[_e.index];
+					node_index_type sliceEIndex = sliceEIndices[_e.index];
+					if( ssValues.edgeKeys[sliceEIndex].idx[0]!=-1 )
+					{
+						sValues.edgeKeys[eIndex] = keyGenerator( maxDepth , sliceAtMaxDepth , ssValues.edgeKeys[sliceEIndex] );
+						sScratch.eSet[eIndex] = 1;
+					}
+					else sScratch.eSet[eIndex] = 0;
+				}
+
+				const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<2> &fIndices = sValues.cellIndices.template indices<2>( node );
+				const typename LevelSetExtraction::FullCellIndexData< Dim-1 >::template CellIndices< 2 > &sliceFIndices = ssValues.cellIndices.template indices<2>( sliceNode );
+				for( typename HyperCube::Cube< Dim-1 >::template Element< 2 > _f ; _f<HyperCube::Cube< Dim-1 >::template ElementNum< 2 >() ; _f++ )
+				{
+					node_index_type fIndex = fIndices[_f.index];
+					node_index_type sliceFIndex = sliceFIndices[_f.index];
+					sValues.faceEdges[fIndex].count = ssValues.faceEdges[sliceFIndex].count;
+					for( int c=0 ; c<ssValues.faceEdges[sliceFIndex].count ; c++ ) sValues.faceEdges[fIndex].edges[c] = PromoteIsoEdge( ssValues.faceEdges[sliceFIndex].edges[c] );
+					sScratch.fSet[fIndex] = sValues.faceEdges[fIndex].count!=-1;
+				}
+			};
+			for( node_index_type i=boundaryInfo.sliceTree.nodesBegin(depth) ; i<boundaryInfo.sliceTree.nodesEnd(depth) ; i++ ) CopyEdgeAndFaceInfo( i , incidence[i].first ) , CopyEdgeAndFaceInfo( i , incidence[i].second );
+		}
+
+		// Copy over the iso-information
+		for( unsigned int depth=fullDepth ; depth<=std::min< unsigned int >( tree._maxDepth , boundaryInfo.sliceTree.depth() ) ; depth++ )
+		{
+			SliceValues &sValues = sliceFunctor( depth );
+			const SliceSliceValues &ssValues = boundaryInfo.sliceValues[depth];
+
+			// Copy the face->edge map
+			for( auto iter=ssValues.faceEdgeMap.cbegin() ; iter!=ssValues.faceEdgeMap.cend() ; iter++ )
+			{
+				Key key = keyGenerator( maxDepth , sliceAtMaxDepth , iter->first );
+				std::vector< IsoEdge > edges( iter->second.size() );
+				for( unsigned int i=0 ; i<iter->second.size() ; i++ ) edges[i] = PromoteIsoEdge( iter->second[i] );
+				sValues.faceEdgeMap[key] = edges;
+			}
+
+			// Copy the edge-vertex map
+			for( auto iter=ssValues.edgeVertexMap.cbegin() ; iter!=ssValues.edgeVertexMap.cend() ; iter++ )
+			{
+				Key key = keyGenerator( maxDepth , sliceAtMaxDepth , iter->first );
+				node_index_type idx = iter->second;
+				sValues.edgeVertexMap[key] = std::pair< node_index_type , Vertex >( vertexIndices[idx] , vertices[idx] );
+			}
+
+			// Copy the vertex-vertex map
+			for( auto iter=ssValues.vertexPairMap.cbegin() ; iter!=ssValues.vertexPairMap.cend() ; iter++ )
+			{
+				Key key = keyGenerator( maxDepth , sliceAtMaxDepth , iter->first );
+				sValues.vertexPairMap[key] = keyGenerator( maxDepth , sliceAtMaxDepth , iter->second );
+			}
+		}
+	}
+
+	static void OverwriteCornerValues( const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions &boundaryInfo , const std::vector< Real > &dValues , const FEMTree< Dim , Real > &tree , LocalDepth depth , unsigned int sliceAtMaxDepth , unsigned int maxDepth , bool isBack , std::vector< SlabValues > &slabValues , const std::vector< std::pair< node_index_type , node_index_type > > &incidence )
+	{
+		using SliceTreeNode    = typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeNode;
+		using SliceSliceValues = typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::SliceValues;
+
+		unsigned int slice = sliceAtMaxDepth>>( maxDepth - depth );
+		if( !isBack && sliceAtMaxDepth!=( slice<<(maxDepth-depth ) ) ) slice++;
+		if( !slabValues[depth].validSlice( slice ) ) MK_THROW( "Invalid slice: " , slice , " @ " , depth , " : " , slabValues[depth].sliceValues(slice).slice() );
+		SliceValues &sValues = slabValues[depth].sliceValues( slice );
+		const SliceSliceValues &ssValues = boundaryInfo.sliceValues[depth];
+
+		if( sValues.cornerGradients && !ssValues.cornerGradients ) MK_THROW( "Epxected slice gradients" );
+
+		auto CopyCornerInfo = [&]( node_index_type sliceIndex , node_index_type index )
+		{
+
+			if( index==-1 ) return;
+			const TreeNode *node = tree._sNodes.treeNodes[ index ];
+			const SliceTreeNode *sliceNode = boundaryInfo.sliceTree._sNodes.treeNodes[ sliceIndex ];
+
+			const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices< 0 > &cIndices = sValues.cellIndices.template indices<0>( node );
+			const typename LevelSetExtraction::FullCellIndexData< Dim-1 >::template CellIndices< 0 > &sliceCIndices = ssValues.cellIndices.template indices< 0 >( sliceNode );
+			for( typename HyperCube::Cube< Dim-1 >::template Element< 0 > _c ; _c<HyperCube::Cube< Dim-1 >::template ElementNum< 0 >() ; _c++ )
+			{
+				node_index_type vIndex = cIndices[_c.index];
+				node_index_type sliceVIndex = sliceCIndices[_c.index];
+				sValues.cornerValues[vIndex] = ssValues.cornerValues[sliceVIndex];
+				if( sValues.cornerGradients )
+				{
+					for( unsigned int i=0 ; i<Dim-1 ; i++ ) sValues.cornerGradients[vIndex][i] = ssValues.cornerGradients[sliceVIndex][i];
+					sValues.cornerGradients[vIndex][Dim-1] = dValues[sliceVIndex];
+				}
+			}
+		};
+		for( node_index_type i=boundaryInfo.sliceTree.nodesBegin(depth) ; i<boundaryInfo.sliceTree.nodesEnd(depth) ; i++ ) CopyCornerInfo( i , incidence[i].first ) , CopyCornerInfo( i , incidence[i].second );
+	}
+
+	template< unsigned int ... FEMSigs >
+	static void SetSliceCornerValuesAndMCIndices( const FEMTree< Dim , Real >& tree , ConstPointer( Real ) coefficients , ConstPointer( Real ) coarseCoefficients , Real isoValue , LocalDepth depth , LocalDepth fullDepth , int slice ,         std::vector< SlabValues >& slabValues , const _Evaluator< UIntPack< FEMSigs ... > , 1 >& evaluator )
+	{
+		if( slice>0          ) SetSliceCornerValuesAndMCIndices< FEMSigs ... >( tree , coefficients , coarseCoefficients , isoValue , depth , fullDepth , slice , HyperCube::FRONT , slabValues , evaluator );
+		if( slice<(1<<depth) ) SetSliceCornerValuesAndMCIndices< FEMSigs ... >( tree , coefficients , coarseCoefficients , isoValue , depth , fullDepth , slice , HyperCube::BACK  , slabValues , evaluator );
+	}
+
+	template< unsigned int ... FEMSigs >
+	static void SetSliceCornerValuesAndMCIndices( const FEMTree< Dim , Real >& tree , ConstPointer( Real ) coefficients , ConstPointer( Real ) coarseCoefficients , Real isoValue , LocalDepth depth , LocalDepth fullDepth , int slice , HyperCube::Direction zDir , std::vector< SlabValues >& slabValues , const _Evaluator< UIntPack< FEMSigs ... > , 1 >& evaluator )
+	{
+		static const unsigned int FEMDegrees[] = { FEMSignature< FEMSigs >::Degree ... };
+		SliceValues& sValues = slabValues[depth].sliceValues( slice );
+		typename SliceValues::Scratch &sScratch = slabValues[depth].sliceScratch( slice );
+		bool useBoundaryEvaluation = false;
+		for( int d=0 ; d<Dim ; d++ ) if( FEMDegrees[d]==0 || ( FEMDegrees[d]==1 && sValues.cornerGradients ) ) useBoundaryEvaluation = true;
+		std::vector< ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > > > neighborKeys( ThreadPool::NumThreads() );
+		std::vector< ConstCornerSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > > > bNeighborKeys( ThreadPool::NumThreads() );
+		if( useBoundaryEvaluation ) for( size_t i=0 ; i<neighborKeys.size() ; i++ ) bNeighborKeys[i].set( tree._localToGlobal( depth ) );
+		else                        for( size_t i=0 ; i<neighborKeys.size() ; i++ )  neighborKeys[i].set( tree._localToGlobal( depth ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , tree._sNodesEnd(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				Real squareValues[ HyperCube::Cube< Dim-1 >::template ElementNum< 0 >() ];
+				ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey = neighborKeys[ thread ];
+				ConstCornerSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bNeighborKey = bNeighborKeys[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+				if( !IsActiveNode< Dim >( leaf->children ) )
+				{
+					const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<0> &cIndices = sValues.cellIndices.template indices<0>( leaf );
+
+					bool isInterior = tree._isInteriorlySupported( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , leaf->parent );
+					if( useBoundaryEvaluation ) bNeighborKey.getNeighbors( leaf );
+					else                         neighborKey.getNeighbors( leaf );
+
+					for( typename HyperCube::Cube< Dim-1 >::template Element< 0 > _c ; _c<HyperCube::Cube< Dim-1 >::template ElementNum< 0 >() ; _c++ )
+					{
+						typename HyperCube::Cube< Dim >::template Element< 0 > c( zDir , _c.index );
+#ifdef SANITIZED_PR
+						node_index_type vIndex = ReadAtomic( cIndices[_c.index] );
+#else // !SANITIZED_PR
+						node_index_type vIndex = cIndices[_c.index];
+#endif // SANITIZED_PR
+						if( !sScratch.cSet[vIndex] )
+						{
+							if( sValues.cornerGradients )
+							{
+								CumulativeDerivativeValues< Real , Dim , 1 > p;
+								if( useBoundaryEvaluation ) p = tree.template _getCornerValues< Real , 1 >( bNeighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior );
+								else                        p = tree.template _getCornerValues< Real , 1 >(  neighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior );
+#ifdef SANITIZED_PR
+								SetAtomic( sValues.cornerValues[vIndex] , p[0] );
+								SetAtomic( sValues.cornerGradients[vIndex] , Point< Real , Dim >( p[1] , p[2] , p[3] ) );
+#else // !SANITIZED_PR
+								sValues.cornerValues[vIndex] = p[0] , sValues.cornerGradients[vIndex] = Point< Real , Dim >( p[1] , p[2] , p[3] );
+#endif // SANITIZED_PR
+							}
+							else
+							{
+#ifdef SANITIZED_PR
+								if( useBoundaryEvaluation ) SetAtomic( sValues.cornerValues[vIndex] , tree.template _getCornerValues< Real , 0 >( bNeighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior )[0] );
+								else                        SetAtomic( sValues.cornerValues[vIndex] , tree.template _getCornerValues< Real , 0 >(  neighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior )[0] );
+#else // !SANITIZED_PR
+								if( useBoundaryEvaluation ) sValues.cornerValues[vIndex] = tree.template _getCornerValues< Real , 0 >( bNeighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior )[0];
+								else                        sValues.cornerValues[vIndex] = tree.template _getCornerValues< Real , 0 >(  neighborKey , leaf , c.index , coefficients , coarseCoefficients , evaluator , tree._maxDepth , isInterior )[0];
+#endif // SANITIZED_PR
+							}
+							sScratch.cSet[vIndex] = 1;
+						}
+#ifdef SANITIZED_PR
+						squareValues[_c.index] = ReadAtomic( sValues.cornerValues[ vIndex ] );
+#else // !SANITIZED_PR
+						squareValues[_c.index] = sValues.cornerValues[ vIndex ];
+#endif // SANITIZED_PR
+						TreeNode* node = leaf;
+						LocalDepth _depth = depth;
+						int _slice = slice;
+						while( _depth>fullDepth && tree._isValidSpaceNode( node->parent ) && (node-node->parent->children)==c.index )
+						{
+							node = node->parent , _depth-- , _slice >>= 1;
+							SliceValues &_sValues = slabValues[_depth].sliceValues( _slice );
+							typename SliceValues::Scratch &_sScratch = slabValues[_depth].sliceScratch( _slice );
+							const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<0> &_cIndices = _sValues.cellIndices.template indices<0>( node );
+							node_index_type _vIndex = _cIndices[_c.index];
+#ifdef SANITIZED_PR
+							SetAtomic( _sValues.cornerValues[_vIndex] , ReadAtomic( sValues.cornerValues[vIndex] ) );
+							if( _sValues.cornerGradients ) SetAtomic( _sValues.cornerGradients[_vIndex] , ReadAtomic( sValues.cornerGradients[vIndex] ) );
+#else // !SANITIZED_PR
+							_sValues.cornerValues[_vIndex] = sValues.cornerValues[vIndex];
+							if( _sValues.cornerGradients ) _sValues.cornerGradients[_vIndex] = sValues.cornerGradients[vIndex];
+#endif // SANITIZED_PR
+							_sScratch.cSet[_vIndex] = 1;
+						}
+					}
+					sValues.mcIndices[ i - sValues.cellIndices.nodeOffset ] = HyperCube::Cube< Dim-1 >::MCIndex( squareValues , isoValue );
+				}
+			}
+		}
+		);
+	}
+
+	static void SetMCIndices( const FEMTree< Dim , Real >& tree , Real isoValue , LocalDepth depth , LocalDepth fullDepth , int slice , std::vector< SlabValues >& slabValues )
+	{
+		if( slice>0          ) SetMCIndices( tree , isoValue , depth , fullDepth , slice , HyperCube::FRONT , slabValues );
+		if( slice<(1<<depth) ) SetMCIndices( tree , isoValue , depth , fullDepth , slice , HyperCube::BACK  , slabValues );
+	}
+
+	static void SetMCIndices( const FEMTree< Dim , Real >& tree , Real isoValue , LocalDepth depth , LocalDepth fullDepth , int slice , HyperCube::Direction zDir , std::vector< SlabValues >& slabValues )
+	{
+		SliceValues& sValues = slabValues[depth].sliceValues( slice );
+		bool useBoundaryEvaluation = false;
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , tree._sNodesEnd(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , [&]( unsigned int thread , size_t i )
+			{
+				Real squareValues[ HyperCube::Cube< Dim-1 >::template ElementNum< 0 >() ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+
+				if( tree._isValidSpaceNode( leaf ) && !IsActiveNode< Dim >( leaf->children ) )
+				{
+					const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<0> &cIndices = sValues.cellIndices.template indices<0>( leaf );
+
+					for( typename HyperCube::Cube< Dim-1 >::template Element< 0 > _c ; _c<HyperCube::Cube< Dim-1 >::template ElementNum< 0 >() ; _c++ )
+					{
+						typename HyperCube::Cube< Dim >::template Element< 0 > c( zDir , _c.index );
+						node_index_type vIndex = cIndices[_c.index];
+						squareValues[_c.index] = sValues.cornerValues[ vIndex ];
+						sValues.mcIndices[ i - sValues.cellIndices.nodeOffset ] = HyperCube::Cube< Dim-1 >::MCIndex( squareValues , isoValue );
+					}
+				}
+			}
+		);
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig , typename VertexStream >
+	static void SetSliceIsoVertices( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , const FEMTree< Dim , Real >& tree , bool nonLinearFit , bool gradientNormals , typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > >* pointEvaluator , const DensityEstimator< WeightDegree >* densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data , Real isoValue , LocalDepth depth , LocalDepth fullDepth , int slice , VertexStream &vertexStream , std::vector< SlabValues >& slabValues , const Data &zeroData )
+	{
+		if( slice>0          ) SetSliceIsoVertices< WeightDegree , DataSig >( keyGenerator , tree , nonLinearFit , gradientNormals , pointEvaluator , densityWeights , data , isoValue , depth , fullDepth , slice , HyperCube::FRONT , vertexStream , slabValues , zeroData );
+		if( slice<(1<<depth) ) SetSliceIsoVertices< WeightDegree , DataSig >( keyGenerator , tree , nonLinearFit , gradientNormals , pointEvaluator , densityWeights , data , isoValue , depth , fullDepth , slice , HyperCube::BACK  , vertexStream , slabValues , zeroData );
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig , typename VertexStream >
+	static void SetSliceIsoVertices( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , const FEMTree< Dim , Real >& tree , bool nonLinearFit , bool gradientNormals , typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > >* pointEvaluator , const DensityEstimator< WeightDegree >* densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data , Real isoValue , LocalDepth depth , LocalDepth fullDepth , int slice , HyperCube::Direction zDir , VertexStream &vertexStream , std::vector< SlabValues >& slabValues , const Data &zeroData )
+	{
+		auto _EdgeIndex = [&]( const TreeNode *node , typename HyperCube::Cube< Dim >::template Element< 1 > e )
+		{
+			int depth , offset[Dim];
+			tree.depthAndOffset( node , depth , offset );
+			return keyGenerator( depth , offset , e );
+		};
+
+		static const unsigned int DataDegree = FEMSignature< DataSig >::Degree;
+		SliceValues &sValues = slabValues[depth].sliceValues( slice );
+		typename SliceValues::Scratch &sScratch = slabValues[depth].sliceScratch( slice );
+		// [WARNING] In the case Degree=2, these two keys are the same, so we don't have to maintain them separately.
+		std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+		std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > > > weightKeys( ThreadPool::NumThreads() );
+		std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , DataDegree > > > dataKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( tree._localToGlobal( depth ) ) , weightKeys[i].set( tree._localToGlobal( depth ) ) , dataKeys[i].set( tree._localToGlobal( depth ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , tree._sNodesEnd(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				ConstOneRingNeighborKey& neighborKey =  neighborKeys[ thread ];
+				ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey = weightKeys[ thread ];
+				ConstPointSupportKey< IsotropicUIntPack< Dim , DataDegree > >& dataKey = dataKeys[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+				if( !IsActiveNode< Dim >( leaf->children ) )
+				{
+					node_index_type idx = (node_index_type)i - sValues.cellIndices.nodeOffset;
+					const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<1> &eIndices = sValues.cellIndices.template indices<1>( leaf );
+					if( HyperCube::Cube< Dim-1 >::HasMCRoots( sValues.mcIndices[idx] ) )
+					{
+						neighborKey.getNeighbors( leaf );
+						if( densityWeights ) weightKey.getNeighbors( leaf );
+						if constexpr( HasData ) if( data ) dataKey.getNeighbors( leaf );
+
+						for( typename HyperCube::Cube< Dim-1 >::template Element< 1 > _e ; _e<HyperCube::Cube< Dim-1 >::template ElementNum< 1 >() ; _e++ )
+							if( HyperCube::Cube< 1 >::HasMCRoots( HyperCube::Cube< Dim-1 >::ElementMCIndex( _e , sValues.mcIndices[idx] ) ) )
+							{
+								typename HyperCube::Cube< Dim >::template Element< 1 > e( zDir , _e.index );
+								node_index_type vIndex = eIndices[_e.index];
+#ifdef SANITIZED_PR
+								std::atomic< char > &edgeSet = sScratch.eSet[vIndex];
+#else // !SANITIZED_PR
+								volatile char &edgeSet = sScratch.eSet[vIndex];
+#endif // SANITIZED_PR
+								if( !edgeSet )
+								{
+									Vertex vertex;
+									Key key = _EdgeIndex( leaf , e );
+									GetIsoVertex< WeightDegree , DataSig >( tree , nonLinearFit , gradientNormals , pointEvaluator , densityWeights , data , isoValue , weightKey , dataKey , leaf , _e , zDir , sValues , vertex , zeroData );
+									bool stillOwner = false;
+									std::pair< node_index_type , Vertex > hashed_vertex;
+
+									{
+										char desired = 1 , expected = 0;
+#ifdef SANITIZED_PR
+										if( edgeSet.compare_exchange_weak( expected , desired ) )
+#else // !SANITIZED_PR
+										if( SetAtomic( edgeSet , desired , expected ) )
+#endif // SANITIZED_PR
+										{
+											hashed_vertex = std::pair< node_index_type , Vertex >( (node_index_type)vertexStream.write( thread , vertex ) , vertex );
+											stillOwner = true;
+										}
+									}
+
+									if( stillOwner )
+									{
+										sValues.edgeKeys[ vIndex ] = key;
+										sScratch.eKeyValues[ thread ].push_back( std::pair< Key , std::pair< node_index_type , Vertex > >( key , hashed_vertex ) );
+										// We only need to pass the iso-vertex down if the edge it lies on is adjacent to a coarser leaf
+										auto IsNeeded = [&]( unsigned int depth )
+										{
+											bool isNeeded = false;
+											typename HyperCube::Cube< Dim >::template IncidentCubeIndex< 1 > my_ic = HyperCubeTables< Dim , 1 >::IncidentCube[e.index];
+											for( typename HyperCube::Cube< Dim >::template IncidentCubeIndex< 1 > ic ; ic<HyperCube::Cube< Dim >::template IncidentCubeNum< 1 >() ; ic++ ) if( ic!=my_ic )
+											{
+												unsigned int xx = HyperCubeTables< Dim , 1 >::CellOffset[e.index][ic.index];
+												isNeeded |= !tree._isValidSpaceNode( neighborKey.neighbors[ tree._localToGlobal( depth ) ].neighbors.data[xx] );
+											}
+											return isNeeded;
+										};
+										if( IsNeeded( depth ) )
+										{
+											const typename HyperCube::Cube< Dim >::template Element< Dim-1 > *f = HyperCubeTables< Dim , 1 , Dim-1 >::OverlapElements[e.index];
+											for( int k=0 ; k<HyperCubeTables< Dim , 1 , Dim-1 >::OverlapElementNum ; k++ )
+											{
+												TreeNode* node = leaf;
+												LocalDepth _depth = depth;
+												int _slice = slice;
+												bool _cross = false;
+												while( tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , Dim-1 , 0 >::Overlap[f[k].index][(unsigned int)(node-node->parent->children) ] )
+												{
+													if( _slice&1 ) _cross = true;
+													node = node->parent , _depth-- , _slice >>= 1;
+													SliceValues &_sValues = slabValues[_depth].sliceValues( _slice );
+													typename SliceValues::Scratch &_sScratch = slabValues[_depth].sliceScratch( _slice );
+
+													if( _depth>=fullDepth && !_cross )
+													{
+														const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<1> &_eIndices = _sValues.cellIndices.template indices<1>( node );
+														node_index_type _vIndex = _eIndices[_e.index];
+														_sScratch.eSet[_vIndex] = 1;
+													}
+
+													if( _cross )
+													{
+														XSliceValues& _xValues = slabValues[_depth].xSliceValues( _slice );
+														typename XSliceValues::Scratch &_xScratch = slabValues[_depth].xSliceScratch( _slice );
+														_xScratch.eKeyValues[ thread ].push_back( std::pair< Key , std::pair< node_index_type , Vertex > >( key , hashed_vertex ) );
+													}
+													else
+													{
+														SliceValues& _sValues = slabValues[_depth].sliceValues( _slice );
+														typename SliceValues::Scratch &_sScratch = slabValues[_depth].sliceScratch( _slice );
+														_sScratch.eKeyValues[ thread ].push_back( std::pair< Key , std::pair< node_index_type , Vertex > >( key , hashed_vertex ) );
+													}
+													if( !IsNeeded( _depth ) ) break;
+												}
+											}
+										}
+									}
+								}
+							}
+					}
+				}
+			}
+		}
+		);
+	}
+
+	////////////////////
+	// Iso-Extraction //
+	////////////////////
+	template< unsigned int WeightDegree , unsigned int DataSig , typename VertexStream >
+	static void SetXSliceIsoVertices( const LevelSetExtraction::KeyGenerator< Dim >  &keyGenerator , const FEMTree< Dim , Real >& tree , bool nonLinearFit , bool gradientNormals , typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > >* pointEvaluator , const DensityEstimator< WeightDegree >* densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data , Real isoValue , LocalDepth depth , LocalDepth fullDepth , int slab , Real bCoordinate , Real fCoordinate , VertexStream &vertexStream , std::vector< SlabValues >& slabValues , const Data &zeroData )
+	{
+		auto _EdgeIndex = [&]( const TreeNode *node , typename HyperCube::Cube< Dim >::template Element< 1 > e )
+		{
+			int depth , offset[Dim];
+			tree.depthAndOffset( node , depth , offset );
+			return keyGenerator( depth , offset , e );
+		};
+
+		static const unsigned int DataDegree = FEMSignature< DataSig >::Degree;
+		SliceValues& bValues = slabValues[depth].sliceValues ( slab   );
+		SliceValues& fValues = slabValues[depth].sliceValues ( slab+1 );
+		XSliceValues& xValues = slabValues[depth].xSliceValues( slab   );
+		typename  SliceValues::Scratch &bScratch = slabValues[depth]. sliceScratch( slab   );
+		typename  SliceValues::Scratch &fScratch = slabValues[depth]. sliceScratch( slab+1 );
+		typename XSliceValues::Scratch &xScratch = slabValues[depth].xSliceScratch( slab   );
+
+		// [WARNING] In the case Degree=2, these two keys are the same, so we don't have to maintain them separately.
+		std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+		std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > > > weightKeys( ThreadPool::NumThreads() );
+		std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , DataDegree > > > dataKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( tree._localToGlobal( depth ) ) , weightKeys[i].set( tree._localToGlobal( depth ) ) , dataKeys[i].set( tree._localToGlobal( depth ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth,slab) , tree._sNodesEnd(depth,slab) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				ConstOneRingNeighborKey& neighborKey =  neighborKeys[ thread ];
+				ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey = weightKeys[ thread ];
+				ConstPointSupportKey< IsotropicUIntPack< Dim , DataDegree > >& dataKey = dataKeys[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+				if( !IsActiveNode< Dim >( leaf->children ) )
+				{
+					unsigned char mcIndex = ( bValues.mcIndices[ i - bValues.cellIndices.nodeOffset ] ) | ( fValues.mcIndices[ i - fValues.cellIndices.nodeOffset ] )<<4;
+					const typename LevelSetExtraction::SlabCellIndexData< Dim >::template CellIndices<0> &eIndices = xValues.cellIndices.template indices<0>( leaf );
+					if( HyperCube::Cube< Dim >::HasMCRoots( mcIndex ) )
+					{
+						neighborKey.getNeighbors( leaf );
+						if( densityWeights ) weightKey.getNeighbors( leaf );
+						if constexpr( HasData ) if( data ) dataKey.getNeighbors( leaf );
+						for( typename HyperCube::Cube< Dim-1 >::template Element< 0 > _c ; _c<HyperCube::Cube< Dim-1 >::template ElementNum< 0 >() ; _c++ )
+						{
+							typename HyperCube::Cube< Dim >::template Element< 1 > e( HyperCube::CROSS , _c.index );
+							unsigned int _mcIndex = HyperCube::Cube< Dim >::ElementMCIndex( e , mcIndex );
+							if( HyperCube::Cube< 1 >::HasMCRoots( _mcIndex ) )
+							{
+								node_index_type vIndex = eIndices[_c.index];
+#ifdef SANITIZED_PR
+								std::atomic< char > &edgeSet = xScratch.eSet[vIndex];
+#else // !SANITIZED_PR
+								volatile char &edgeSet = xScratch.eSet[vIndex];
+#endif // SANITIZED_PR
+								if( !edgeSet )
+								{
+									Vertex vertex;
+									Key key = _EdgeIndex( leaf , e.index );
+									GetIsoVertex< WeightDegree , DataSig >( tree , nonLinearFit , gradientNormals , pointEvaluator , densityWeights , data , isoValue , weightKey , dataKey , leaf , _c , bCoordinate , fCoordinate , bValues , fValues , vertex , zeroData );
+									bool stillOwner = false;
+									std::pair< node_index_type , Vertex > hashed_vertex;
+
+									{
+										char desired = 1 , expected = 0;
+#ifdef SANITIZED_PR
+										if( edgeSet.compare_exchange_weak( expected , desired ) )
+#else // !SANITIZED_PR
+										if( SetAtomic( edgeSet , desired , expected ) )
+#endif // SANITIZED_PR
+										{
+											hashed_vertex = std::pair< node_index_type , Vertex >( (node_index_type)vertexStream.write( thread , vertex ) , vertex );
+											stillOwner = true;
+										}
+									}
+
+									if( stillOwner )
+									{
+										xValues.edgeKeys[ vIndex ] = key;
+										xScratch.eKeyValues[ thread ].push_back( std::pair< Key , std::pair< node_index_type , Vertex > >( key , hashed_vertex ) );
+
+										// We only need to pass the iso-vertex down if the edge it lies on is adjacent to a coarser leaf
+										auto IsNeeded = [&]( unsigned int depth )
+										{
+											bool isNeeded = false;
+											typename HyperCube::Cube< Dim >::template IncidentCubeIndex< 1 > my_ic = HyperCubeTables< Dim , 1 >::IncidentCube[e.index];
+											for( typename HyperCube::Cube< Dim >::template IncidentCubeIndex< 1 > ic ; ic<HyperCube::Cube< Dim >::template IncidentCubeNum< 1 >() ; ic++ ) if( ic!=my_ic )
+											{
+												unsigned int xx = HyperCubeTables< Dim , 1 >::CellOffset[e.index][ic.index];
+												isNeeded |= !tree._isValidSpaceNode( neighborKey.neighbors[ tree._localToGlobal( depth ) ].neighbors.data[xx] );
+											}
+											return isNeeded;
+										};
+										if( IsNeeded( depth ) )
+										{
+											const typename HyperCube::Cube< Dim >::template Element< Dim-1 > *f = HyperCubeTables< Dim , 1 , Dim-1 >::OverlapElements[e.index];
+											for( int k=0 ; k<2 ; k++ )
+											{
+												TreeNode* node = leaf;
+												LocalDepth _depth = depth;
+												int _slab = slab;
+												// As long as we are still in the tree and the parent is also adjacent to the node
+												while( tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , Dim-1 , 0 >::Overlap[f[k].index][(unsigned int)(node-node->parent->children) ] )
+												{
+													node = node->parent , _depth-- , _slab >>= 1;
+													XSliceValues& _xValues = slabValues[_depth].xSliceValues( _slab );
+													typename XSliceValues::Scratch &_xScratch = slabValues[_depth].xSliceScratch( _slab );
+													_xScratch.eKeyValues[ thread ].push_back( std::pair< Key , std::pair< node_index_type , Vertex > >( key , hashed_vertex ) );
+
+													if( _depth>=fullDepth )
+													{
+														const typename LevelSetExtraction::SlabCellIndexData< Dim >::template CellIndices<0> &_eIndices = _xValues.cellIndices.template indices<0>( node );
+														node_index_type _vIndex = _eIndices[_c.index];
+														_xScratch.eSet[_vIndex] = 1;
+													}
+
+													if( !IsNeeded( _depth ) ) break;
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		);
+	}
+
+	static void CopyFinerSliceIsoEdgeKeys( const FEMTree< Dim , Real >& tree , LocalDepth depth , LocalDepth fullDepth , int slice , std::vector< SlabValues >& slabValues )
+	{
+		if( slice>0          ) CopyFinerSliceIsoEdgeKeys( tree , depth , fullDepth , slice , HyperCube::FRONT , slabValues );
+		if( slice<(1<<depth) ) CopyFinerSliceIsoEdgeKeys( tree , depth , fullDepth , slice , HyperCube::BACK  , slabValues );
+	}
+
+	static void CopyFinerSliceIsoEdgeKeys( const FEMTree< Dim , Real >& tree , LocalDepth depth , LocalDepth fullDepth , int slice , HyperCube::Direction zDir , std::vector< SlabValues >& slabValues )
+	{
+		SliceValues& pSliceValues = slabValues[depth  ].sliceValues(slice   );
+		SliceValues& cSliceValues = slabValues[depth+1].sliceValues(slice<<1);
+		typename SliceValues::Scratch &pSliceScratch = slabValues[depth  ].sliceScratch(slice   );
+		typename SliceValues::Scratch &cSliceScratch = slabValues[depth+1].sliceScratch(slice<<1);
+		LevelSetExtraction::SliceCellIndexData< Dim > &pCellIndices = pSliceValues.cellIndices;
+		LevelSetExtraction::SliceCellIndexData< Dim > &cCellIndices = cSliceValues.cellIndices;
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , tree._sNodesEnd(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) ) if( IsActiveNode< Dim >( tree._sNodes.treeNodes[i]->children ) )
+			{
+				typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<1> &pIndices = pCellIndices.template indices<1>( (node_index_type)i );
+				// Copy the edges that overlap the coarser edges
+				for( typename HyperCube::Cube< Dim-1 >::template Element< 1 > _e ; _e<HyperCube::Cube< Dim-1 >::template ElementNum< 1 >() ; _e++ )
+				{
+					node_index_type pIndex = pIndices[_e.index];
+					{
+						typename HyperCube::Cube< Dim >::template Element< 1 > e( zDir , _e.index );
+						const typename HyperCube::Cube< Dim >::template Element< 0 > *c = HyperCubeTables< Dim , 1 , 0 >::OverlapElements[e.index];
+						// [SANITY CHECK]
+						//						if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c[0].index )!=tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c[1].index ) ) MK_THROW( "Finer edges should both be valid or invalid" );
+						if( !tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c[0].index ) || !tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c[1].index ) ) continue;
+
+						node_index_type cIndex1 = cCellIndices.template indices<1>( tree._sNodes.treeNodes[i]->children + c[0].index )[_e.index];
+						node_index_type cIndex2 = cCellIndices.template indices<1>( tree._sNodes.treeNodes[i]->children + c[1].index )[_e.index];
+						if( cSliceScratch.eSet[cIndex1] != cSliceScratch.eSet[cIndex2] )
+						{
+							Key key;
+							if( cSliceScratch.eSet[cIndex1] ) key = cSliceValues.edgeKeys[cIndex1];
+							else                              key = cSliceValues.edgeKeys[cIndex2];
+#ifdef SANITIZED_PR
+							SetAtomic( pSliceValues.edgeKeys[pIndex] , key );
+#else // !SANITIZED_PR
+							pSliceValues.edgeKeys[pIndex] = key;
+#endif // SANITIZED_PR
+							pSliceScratch.eSet[pIndex] = 1;
+						}
+						else if( cSliceScratch.eSet[cIndex1] && cSliceScratch.eSet[cIndex2] )
+						{
+							Key key1 = cSliceValues.edgeKeys[cIndex1] , key2 = cSliceValues.edgeKeys[cIndex2];
+							pSliceScratch.vKeyValues[ thread ].push_back( std::pair< Key , Key >( key1 , key2 ) );
+
+							const TreeNode* node = tree._sNodes.treeNodes[i];
+							LocalDepth _depth = depth;
+							int _slice = slice;
+							while( _depth>fullDepth && tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , 1 , 0 >::Overlap[e.index][(unsigned int)(node-node->parent->children) ] )
+							{
+								node = node->parent , _depth-- , _slice >>= 1;
+								SliceValues& _pSliceValues = slabValues[_depth].sliceValues(_slice);
+								typename SliceValues::Scratch &_pSliceScratch = slabValues[_depth].sliceScratch(_slice);
+								_pSliceScratch.vKeyValues[ thread ].push_back( std::pair< Key , Key >( key1 , key2 ) );
+							}
+						}
+					}
+				}
+			}
+		}
+		);
+	}
+
+	static void CopyFinerXSliceIsoEdgeKeys( const FEMTree< Dim , Real >& tree , LocalDepth depth , LocalDepth fullDepth , int slab , std::vector< SlabValues>& slabValues )
+	{
+		XSliceValues& pSliceValues  = slabValues[depth  ].xSliceValues(slab);
+		XSliceValues& cSliceValues0 = slabValues[depth+1].xSliceValues( (slab<<1)|0 );
+		XSliceValues& cSliceValues1 = slabValues[depth+1].xSliceValues( (slab<<1)|1 );
+		typename XSliceValues::Scratch &pSliceScratch  = slabValues[depth  ].xSliceScratch(slab);
+		typename XSliceValues::Scratch &cSliceScratch0 = slabValues[depth+1].xSliceScratch( (slab<<1)|0 );
+		typename XSliceValues::Scratch &cSliceScratch1 = slabValues[depth+1].xSliceScratch( (slab<<1)|1 );
+		LevelSetExtraction::SlabCellIndexData< Dim > &pCellIndices  = pSliceValues. cellIndices;
+		LevelSetExtraction::SlabCellIndexData< Dim > &cCellIndices0 = cSliceValues0.cellIndices;
+		LevelSetExtraction::SlabCellIndexData< Dim > &cCellIndices1 = cSliceValues1.cellIndices;
+
+		bool has0 = cSliceValues0.slab()==((slab<<1)|0);
+		bool has1 = cSliceValues1.slab()==((slab<<1)|1);
+
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth,slab) , tree._sNodesEnd(depth,slab) , [&]( unsigned int thread , size_t i )
+		{
+			// If the node is not a leaf, inherit iso-edges from children
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) &&  IsActiveNode< Dim >( tree._sNodes.treeNodes[i]->children ) )
+			{
+				// Get the mapping from node + local face-corner -> global corner
+				typename LevelSetExtraction::SlabCellIndexData< Dim >::template CellIndices<0> &pIndices = pCellIndices.template indices<0>( (node_index_type)i );
+				for( typename HyperCube::Cube< Dim-1 >::template Element< 0 > _c ; _c<HyperCube::Cube< Dim-1 >::template ElementNum< 0 >() ; _c++ )
+				{
+					// Transform the face-corner index to a cross-edge index
+					typename HyperCube::Cube< Dim >::template Element< 1 > e( HyperCube::CROSS , _c.index );
+					node_index_type pIndex = pIndices[ _c.index ];
+
+					{
+						typename HyperCube::Cube< Dim >::template Element< 0 > c0( HyperCube::BACK , _c.index ) , c1( HyperCube::FRONT , _c.index );
+
+						// [SANITY CHECK]
+						//					if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c0 )!=tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c1 ) ) MK_THROW( "Finer edges should both be valid or invalid" );
+						if( !tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c0.index ) || !tree._isValidSpaceNode( tree._sNodes.treeNodes[i]->children + c1.index ) ) continue;
+
+						node_index_type cIndex0 , cIndex1;
+						if( has0 ) cIndex0 = cCellIndices0.template indices<0>( tree._sNodes.treeNodes[i]->children + c0.index )[_c.index];
+						if( has1 ) cIndex1 = cCellIndices1.template indices<0>( tree._sNodes.treeNodes[i]->children + c1.index )[_c.index];
+						char eSet0 = has0 && cSliceScratch0.eSet[cIndex0] , eSet1 = has1 && cSliceScratch1.eSet[cIndex1];
+
+						// If there's one zero-crossing along the edge
+						if( eSet0 != eSet1 )
+						{
+							Key key;
+							if( eSet0 ) key = cSliceValues0.edgeKeys[cIndex0]; //, vPair = cSliceValues0.edgeVertexMap.find( key )->second;
+							else        key = cSliceValues1.edgeKeys[cIndex1]; //, vPair = cSliceValues1.edgeVertexMap.find( key )->second;
+#ifdef SANITIZED_PR
+							SetAtomic( pSliceValues.edgeKeys[ pIndex ] , key );
+#else // !SANITIZED_PR
+							pSliceValues.edgeKeys[ pIndex ] = key;
+#endif // SANITIZED_PR
+							pSliceScratch.eSet[ pIndex ] = 1;
+						}
+						// If there's are two zero-crossings along the edge
+						else if( eSet0 && eSet1 )
+						{
+							Key key0 = cSliceValues0.edgeKeys[cIndex0] , key1 = cSliceValues1.edgeKeys[cIndex1];
+							pSliceScratch.vKeyValues[ thread ].push_back( std::pair< Key , Key >( key0 , key1 ) );
+							const TreeNode* node = tree._sNodes.treeNodes[i];
+							LocalDepth _depth = depth;
+							int _slab = slab;
+							while( _depth>fullDepth && tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , 1 , 0 >::Overlap[e.index][(unsigned int)(node-node->parent->children) ] )
+							{
+								node = node->parent , _depth-- , _slab>>= 1;
+								SliceValues& _pSliceValues = slabValues[_depth].sliceValues(_slab);
+								typename SliceValues::Scratch &_pSliceScratch = slabValues[_depth].sliceScratch(_slab);
+								_pSliceScratch.vKeyValues[ thread ].push_back( std::pair< Key , Key >( key0 , key1 ) );
+							}
+						}
+					}
+				}
+			}
+		}
+		);
+	}
+
+	static void SetSliceIsoEdges( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , const FEMTree< Dim , Real >& tree , LocalDepth depth , int slice , std::vector< SlabValues >& slabValues )
+	{
+		if( slice>0          ) SetSliceIsoEdges( keyGenerator , tree , depth , slice , HyperCube::FRONT , slabValues );
+		if( slice<(1<<depth) ) SetSliceIsoEdges( keyGenerator , tree , depth , slice , HyperCube::BACK  , slabValues );
+	}
+
+	static void SetSliceIsoEdges( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , const FEMTree< Dim , Real >& tree , LocalDepth depth , int slice , HyperCube::Direction zDir , std::vector< SlabValues >& slabValues )
+	{
+		auto _FaceIndex = [&]( const TreeNode *node , typename HyperCube::Cube< Dim >::template Element< 2 > f )
+		{
+			int depth , offset[Dim];
+			tree.depthAndOffset( node , depth , offset );
+			return keyGenerator( depth , offset , f );
+		};
+
+		SliceValues& sValues = slabValues[depth].sliceValues( slice );
+		typename SliceValues::Scratch &sScratch = slabValues[depth].sliceScratch( slice );
+		std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( tree._localToGlobal( depth ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth, slice-(zDir==HyperCube::BACK ? 0 : 1)) , tree._sNodesEnd(depth,slice-(zDir==HyperCube::BACK ? 0 : 1)) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				int isoEdges[ 2 * HyperCube::MarchingSquares::MAX_EDGES ];
+				ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+				if( !IsActiveNode< Dim >( leaf->children ) )
+				{
+					node_index_type idx = (node_index_type)i - sValues.cellIndices.nodeOffset;
+					const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<1> &eIndices = sValues.cellIndices.template indices<1>( leaf );
+					const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<2> &fIndices = sValues.cellIndices.template indices<2>( leaf );
+					unsigned char mcIndex = sValues.mcIndices[idx];
+					if( !sScratch.fSet[ fIndices[0] ] )
+					{
+						neighborKey.getNeighbors( leaf );
+						unsigned int xx = WindowIndex< IsotropicUIntPack< Dim , 3 > , IsotropicUIntPack< Dim , 1 > >::Index + (zDir==HyperCube::BACK ? -1 : 1);
+						if( !IsActiveNode< Dim >( neighborKey.neighbors[ tree._localToGlobal( depth ) ].neighbors.data[xx] ) || !IsActiveNode< Dim >( neighborKey.neighbors[ tree._localToGlobal( depth ) ].neighbors.data[xx]->children ) )
+						{
+							FaceEdges fe;
+							fe.count = HyperCube::MarchingSquares::AddEdgeIndices( mcIndex , isoEdges );
+							for( int j=0 ; j<fe.count ; j++ ) for( int k=0 ; k<2 ; k++ )
+							{
+								if( !sScratch.eSet[ eIndices[ isoEdges[2*j+k] ] ] ) MK_THROW( "Edge not set: " , slice-(zDir==HyperCube::BACK ? 0 : 1) , " / " , 1<<depth );
+								fe.edges[j][k] = sValues.edgeKeys[ eIndices[ isoEdges[2*j+k] ] ];
+							}
+							sScratch.fSet[ fIndices[0] ] = 1;
+							sValues.faceEdges[ fIndices[0] ] = fe;
+
+							TreeNode* node = leaf;
+							LocalDepth _depth = depth;
+							int _slice = slice;
+							typename HyperCube::Cube< Dim >::template Element< Dim-1 > f( zDir , 0 );
+							std::vector< IsoEdge > edges;
+							edges.resize( fe.count );
+							for( int j=0 ; j<fe.count ; j++ ) edges[j] = fe.edges[j];
+							while( tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , 2 , 0 >::Overlap[f.index][(unsigned int)(node-node->parent->children) ] )
+							{
+								node = node->parent , _depth-- , _slice >>= 1;
+								if( IsActiveNode< Dim >( neighborKey.neighbors[ tree._localToGlobal( _depth ) ].neighbors.data[xx] ) && IsActiveNode< Dim >( neighborKey.neighbors[ tree._localToGlobal( _depth ) ].neighbors.data[xx]->children ) ) break;
+								Key key = _FaceIndex( node , f );
+								SliceValues& _sValues = slabValues[_depth].sliceValues( _slice );
+								typename SliceValues::Scratch &_sScratch = slabValues[_depth].sliceScratch( _slice );
+								_sScratch.fKeyValues[ thread ].push_back( std::pair< Key , std::vector< IsoEdge > >( key , edges ) );
+							}
+						}
+					}
+				}
+			}
+		}
+		);
+	}
+
+	static void SetXSliceIsoEdges( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , const FEMTree< Dim , Real >& tree , LocalDepth depth , int slab , std::vector< SlabValues >& slabValues )
+	{
+		auto _FaceIndex = [&]( const TreeNode *node , typename HyperCube::Cube< Dim >::template Element< 2 > f )
+		{
+			int depth , offset[Dim];
+			tree.depthAndOffset( node , depth , offset );
+			return keyGenerator( depth , offset , f );
+		};
+
+		SliceValues& bValues = slabValues[depth].sliceValues ( slab   );
+		SliceValues& fValues = slabValues[depth].sliceValues ( slab+1 );
+		XSliceValues& xValues = slabValues[depth].xSliceValues( slab   );
+		typename  SliceValues::Scratch &bScratch = slabValues[depth]. sliceScratch( slab   );
+		typename  SliceValues::Scratch &fScratch = slabValues[depth]. sliceScratch( slab+1 );
+		typename XSliceValues::Scratch &xScratch = slabValues[depth].xSliceScratch( slab   );
+
+		std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( tree._localToGlobal( depth ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth,slab) , tree._sNodesEnd(depth,slab) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				int isoEdges[ 2 * HyperCube::MarchingSquares::MAX_EDGES ];
+				ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+				if( !IsActiveNode< Dim >( leaf->children ) )
+				{
+					const typename LevelSetExtraction::SlabCellIndexData< Dim >::template CellIndices<0> &cIndices = xValues.cellIndices.template indices<0>( leaf );
+					const typename LevelSetExtraction::SlabCellIndexData< Dim >::template CellIndices<1> &eIndices = xValues.cellIndices.template indices<1>( leaf );
+					unsigned char mcIndex = ( bValues.mcIndices[ i - bValues.cellIndices.nodeOffset ] ) | ( fValues.mcIndices[ i - fValues.cellIndices.nodeOffset ]<<4 );
+					{
+						neighborKey.getNeighbors( leaf );
+						// Iterate over the edges on the back
+						for( typename HyperCube::Cube< Dim-1 >::template Element< 1 > _e ; _e<HyperCube::Cube< Dim-1 >::template ElementNum< 1 >() ; _e++ )
+						{
+							typename HyperCube::Cube< Dim >::template Element< 2 > f( HyperCube::CROSS , _e.index );
+							unsigned char _mcIndex = HyperCube::Cube< Dim >::template ElementMCIndex< 2 >( f , mcIndex );
+
+							unsigned int xx = HyperCubeTables< Dim , 2 >::CellOffsetAntipodal[f.index];
+							if(	!xScratch.fSet[ eIndices[_e.index] ] && ( !IsActiveNode< Dim >( neighborKey.neighbors[ tree._localToGlobal( depth ) ].neighbors.data[xx] ) || !IsActiveNode< Dim >( neighborKey.neighbors[ tree._localToGlobal( depth ) ].neighbors.data[xx]->children ) ) )
+							{
+								FaceEdges fe;
+								fe.count = HyperCube::MarchingSquares::AddEdgeIndices( _mcIndex , isoEdges );
+								for( int j=0 ; j<fe.count ; j++ ) for( int k=0 ; k<2 ; k++ )
+								{
+									typename HyperCube::Cube< Dim >::template Element< 1 > e( f , typename HyperCube::Cube< Dim-1 >::template Element< 1 >( isoEdges[2*j+k] ) );
+									HyperCube::Direction dir ; unsigned int coIndex;
+									e.factor( dir , coIndex );
+									if( dir==HyperCube::CROSS ) // Cross-edge
+									{
+										node_index_type idx = cIndices[ coIndex ];
+										if( !xScratch.eSet[ idx ] ) MK_THROW( "Edge not set: " , slab , " / " , 1<<depth );
+										fe.edges[j][k] = xValues.edgeKeys[ idx ];
+									}
+									else
+									{
+										const SliceValues& sValues = dir==HyperCube::BACK ? bValues : fValues;
+										const typename SliceValues::Scratch &sScratch = dir==HyperCube::BACK ? bScratch : fScratch;
+										node_index_type idx = sValues.cellIndices.template indices<1>((node_index_type)i)[ coIndex ];
+										if( !sScratch.eSet[ idx ] ) MK_THROW( "Edge not set: " , slab , " / " , 1<<depth );
+										fe.edges[j][k] = sValues.edgeKeys[ idx ];
+									}
+								}
+								xScratch.fSet[ eIndices[_e.index] ] = 1;
+#ifdef SANITIZED_PR
+								SetAtomic( xValues.faceEdges[ eIndices[_e.index] ] , fe );
+#else // !SANITIZED_PR
+								xValues.faceEdges[ eIndices[_e.index] ] = fe;
+#endif // SANITIZED_PR
+
+								TreeNode* node = leaf;
+								LocalDepth _depth = depth;
+								int _slab = slab;
+								std::vector< IsoEdge > edges;
+								edges.resize( fe.count );
+								for( int j=0 ; j<fe.count ; j++ ) edges[j] = fe.edges[j];
+								while( tree._isValidSpaceNode( node->parent ) && HyperCubeTables< Dim , 2 , 0 >::Overlap[f.index][(unsigned int)(node-node->parent->children) ] )
+								{
+									node = node->parent , _depth-- , _slab >>= 1;
+									if( IsActiveNode< Dim >( neighborKey.neighbors[ tree._localToGlobal( _depth ) ].neighbors.data[xx] ) && IsActiveNode< Dim >( neighborKey.neighbors[ tree._localToGlobal( _depth ) ].neighbors.data[xx]->children ) ) break;
+									Key key = _FaceIndex( node , f );
+									XSliceValues& _xValues = slabValues[_depth].xSliceValues( _slab );
+									typename XSliceValues::Scratch &_xScratch = slabValues[_depth].xSliceScratch( _slab );
+									_xScratch.fKeyValues[ thread ].push_back( std::pair< Key , std::vector< IsoEdge > >( key , edges ) );
+								}
+							}
+						}
+					}
+				}
+			}
+		} );
+	}
+
+	template< typename VertexStream , typename FaceIndexFunctor /* = std::function< LevelSetExtraction::Key< Dim > ( const TreeNode * , typename HyperCube::Cube< Dim >::template Element< 2 > ) */ >
+	static void SetLevelSet( const LevelSetExtraction::KeyGenerator< Dim > &keyGenerator , FaceIndexFunctor faceIndexFunctor , const FEMTree< Dim , Real >& tree , LocalDepth depth , int offset , const SliceValues& bValues , const SliceValues& fValues , const XSliceValues& xValues , const typename SliceValues::Scratch &bScratch , const typename SliceValues::Scratch &fScratch , const typename XSliceValues::Scratch &xScratch , VertexStream &vertexStream , OutputDataStream< std::vector< node_index_type > > &polygonStream , bool polygonMesh , bool addBarycenter , bool flipOrientation )
+	{
+		std::vector< std::pair< node_index_type , Vertex > > polygon;
+		std::vector< std::vector< IsoEdge > > edgess( ThreadPool::NumThreads() );
+		ThreadPool::ParallelFor( tree._sNodesBegin(depth,offset) , tree._sNodesEnd(depth,offset) , [&]( unsigned int thread , size_t i )
+		{
+			if( tree._isValidSpaceNode( tree._sNodes.treeNodes[i] ) )
+			{
+				std::vector< IsoEdge >& edges = edgess[ thread ];
+				TreeNode* leaf = tree._sNodes.treeNodes[i];
+				int res = 1<<depth;
+				LocalDepth d ; LocalOffset off;
+				tree._localDepthAndOffset( leaf , d , off );
+				bool inBounds = off[0]>=0 && off[0]<res && off[1]>=0 && off[1]<res && off[2]>=0 && off[2]<res;
+				if( inBounds && !IsActiveNode< Dim >( leaf->children ) )
+				{
+					edges.clear();
+					{
+						// Gather the edges from the faces (with the correct orientation)
+						for( typename HyperCube::Cube< Dim >::template Element< Dim-1 > f ; f<HyperCube::Cube< Dim >::template ElementNum< Dim-1 >() ; f++ )
+						{
+							bool isOriented = HyperCube::Cube< Dim >::IsOriented( f );
+							int flip = isOriented ? 0 : 1;
+							HyperCube::Direction fDir = f.direction();
+
+							if     ( fDir==HyperCube::BACK  ) bValues.addIsoEdges( keyGenerator , faceIndexFunctor , tree , bScratch , leaf , offset+0 , edges , isOriented );
+							else if( fDir==HyperCube::FRONT ) fValues.addIsoEdges( keyGenerator , faceIndexFunctor , tree , fScratch , leaf , offset+1 , edges , isOriented );
+							else
+							{
+								node_index_type fIdx = xValues.cellIndices.template indices<1>((node_index_type)i)[ f.coIndex() ];
+								if( xScratch.fSet[fIdx] )
+								{
+									const FaceEdges& fe = xValues.faceEdges[ fIdx ];
+									for( int j=0 ; j<fe.count ; j++ ) edges.push_back( IsoEdge( fe.edges[j][flip] , fe.edges[j][1-flip] ) );
+								}
+								else
+								{
+									Key key = faceIndexFunctor( leaf , f );
+									typename LevelSetExtraction::KeyMap< Dim , std::vector< IsoEdge > >::const_iterator iter = xValues.faceEdgeMap.find(key);
+									if( iter!=xValues.faceEdgeMap.end() )
+									{
+										const std::vector< IsoEdge >& _edges = iter->second;
+										for( size_t j=0 ; j<_edges.size() ; j++ ) edges.push_back( IsoEdge( _edges[j][flip] , _edges[j][1-flip] ) );
+									}
+									else MK_THROW( "Invalid faces: " , i , "  " ,  fDir==HyperCube::BACK ? "back" : ( fDir==HyperCube::FRONT ? "front" : ( fDir==HyperCube::CROSS ? "cross" : "unknown" ) ) );
+								}
+							}
+						}
+						// Get the edge loops
+						std::vector< std::vector< Key > > loops;
+						while( edges.size() )
+						{
+							loops.resize( loops.size()+1 );
+							IsoEdge edge = edges.back();
+							edges.pop_back();
+							Key start = edge[0] , current = edge[1];
+							while( current!=start )
+							{
+								int idx;
+								for( idx=0 ; idx<(int)edges.size() ; idx++ ) if( edges[idx][0]==current ) break;
+								if( idx==edges.size() )
+								{
+									typename LevelSetExtraction::KeyMap< Dim , Key >::const_iterator iter;
+									Key pair;
+									if     ( bValues.setVertexPair(current,pair) ) loops.back().push_back( current ) , current = pair;
+									else if( fValues.setVertexPair(current,pair) ) loops.back().push_back( current ) , current = pair;
+									else if( (iter=xValues.vertexPairMap.find(current))!=xValues.vertexPairMap.end() ) loops.back().push_back( current ) , current = iter->second;
+									else MK_THROW( "Failed to close loop for node[" , i , "]: [" , off[0] , " " , off[1] , " " , off[2] , " @ " , d , "] | " , keyGenerator.to_string( current ) , " -- " , keyGenerator.to_string( start ) , " | " , current.to_string() , " -- " , start.to_string() );
+								}
+								else
+								{
+									loops.back().push_back( current );
+									current = edges[idx][1];
+									edges[idx] = edges.back() , edges.pop_back();
+								}
+							}
+							loops.back().push_back( start );
+						}
+						// Add the loops to the mesh
+						for( size_t j=0 ; j<loops.size() ; j++ )
+						{
+							std::vector< std::pair< node_index_type , Vertex > > polygon( loops[j].size() );
+							for( size_t k=0 ; k<loops[j].size() ; k++ )
+							{
+								Key key = loops[j][k];
+								typename LevelSetExtraction::KeyMap< Dim , std::pair< node_index_type , Vertex > >::const_iterator iter;
+								size_t kk = flipOrientation ? loops[j].size()-1-k : k;
+								if     ( bValues.setEdgeVertex( key , polygon[kk] ) );
+								else if( fValues.setEdgeVertex( key , polygon[kk] ) );
+								else if( ( iter=xValues.edgeVertexMap.find( key ) )!=xValues.edgeVertexMap.end() ) polygon[kk] = iter->second;
+								else MK_THROW( "Couldn't find vertex in edge map: " , off[0] , " , " , off[1] , " , " , off[2] , " @ " , depth , " : " , keyGenerator.to_string( key ) , " | " , key.to_string() );
+							}
+							AddIsoPolygons( thread , vertexStream , polygonStream , polygon , polygonMesh , addBarycenter );
+						}
+					}
+				}
+			}
+		} );
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig >
+	static bool GetIsoVertex
+	(
+		const FEMTree< Dim , Real >& tree ,
+		bool nonLinearFit ,
+		bool gradientNormals ,
+		typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > > *pointEvaluator ,
+		const DensityEstimator< WeightDegree > *densityWeights ,
+		const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data ,
+		Real isoValue ,
+		ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey ,
+		ConstPointSupportKey< IsotropicUIntPack< Dim , FEMSignature< DataSig >::Degree > > &dataKey ,
+		const TreeNode *node ,
+		typename HyperCube::template Cube< Dim-1 >::template Element< 1 > _e ,
+		HyperCube::Direction zDir ,
+		const SliceValues& sValues ,
+		Vertex& vertex ,
+		const Data &zeroData
+	)
+	{
+		static const unsigned int DataDegree = FEMSignature< DataSig >::Degree;
+		Point< Real , Dim > position , gradient;
+		int c0 , c1;
+		const typename HyperCube::Cube< Dim-1 >::template Element< 0 > *_c = HyperCubeTables< Dim-1 , 1 , 0 >::OverlapElements[_e.index];
+		c0 = _c[0].index , c1 = _c[1].index;
+
+		const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<0> &idx = sValues.cellIndices.template indices<0>( node );
+		Real x0 = sValues.cornerValues[idx[c0]] , x1 = sValues.cornerValues[idx[c1]];
+		Point< Real , 3 > dx0 , dx1;
+		if( gradientNormals ) dx0 = sValues.cornerGradients[idx[c0]] , dx1 = sValues.cornerGradients[idx[c1]];
+		Point< Real , Dim > s;
+		Real start , width;
+		tree._startAndWidth( node , s , width );
+		int o;
+		{
+			const HyperCube::Direction* dirs = HyperCubeTables< Dim-1 , 1 >::Directions[ _e.index ];
+			for( int d=0 ; d<Dim-1 ; d++ ) if( dirs[d]==HyperCube::CROSS )
+			{
+				o = d;
+				start = s[d];
+				for( int dd=1 ; dd<Dim-1 ; dd++ ) position[(d+dd)%(Dim-1)] = s[(d+dd)%(Dim-1)] + width * ( dirs[(d+dd)%(Dim-1)]==HyperCube::BACK ? 0 : 1 );
+			}
+		}
+		position[ Dim-1 ] = s[Dim-1] + width * ( zDir==HyperCube::BACK ? 0 : 1 );
+
+		double averageRoot;
+		bool rootFound = false;
+		if( nonLinearFit )
+		{
+			double dx0 = sValues.cornerGradients[idx[c0]][o] * width , dx1 = sValues.cornerGradients[idx[c1]][o] * width;
+
+			// The scaling will turn the Hermite Spline into a quadratic
+			double scl = (x1-x0) / ( (dx1+dx0 ) / 2 );
+			dx0 *= scl , dx1 *= scl;
+
+			// Hermite Spline
+			Polynomial< 2 > P;
+			P.coefficients[0] = x0;
+			P.coefficients[1] = dx0;
+			P.coefficients[2] = 3*(x1-x0)-dx1-2*dx0;
+
+			double roots[2];
+			int rCount = 0 , rootCount = P.getSolutions( isoValue , roots , 0 );
+			averageRoot = 0;
+			for( int i=0 ; i<rootCount ; i++ ) if( roots[i]>=0 && roots[i]<=1 ) averageRoot += roots[i] , rCount++;
+			if( rCount ) rootFound = true;
+			averageRoot /= rCount;
+		}
+		if( !rootFound )
+		{
+			// We have a linear function L, with L(0) = x0 and L(1) = x1
+			// => L(t) = x0 + t * (x1-x0)
+			// => L(t) = isoValue <=> t = ( isoValue - x0 ) / ( x1 - x0 )
+			if( x0==x1 ) MK_THROW( "Not a zero-crossing root: " , x0 , " " , x1 );
+			averageRoot = ( isoValue - x0 ) / ( x1 - x0 );
+		}
+		if( averageRoot<=0 || averageRoot>=1 )
+		{
+			_BadRootCount++;
+			if( averageRoot<0 ) averageRoot = 0;
+			if( averageRoot>1 ) averageRoot = 1;
+		}
+		position[o] = Real( start + width*averageRoot );
+		gradient = dx0 * (Real)( 1.-averageRoot ) + dx1 * (Real)averageRoot;
+		Real depth = (Real)1.;
+		Data dataValue;
+		if( densityWeights )
+		{
+			Real weight;
+			tree._getSampleDepthAndWeight( *densityWeights , node , position , weightKey , depth , weight );
+		}
+		if constexpr( HasData ) if( data )
+		{
+			if( DataDegree==0 ) 
+			{
+				Point< Real , 3 > center( s[0] + width/2 , s[1] + width/2 , s[2] + width/2 );
+				ProjectiveData< Data , Real > pValue( zeroData );
+				tree.template _addEvaluation< ProjectiveData< Data , Real > , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > , 0 >( *data , center , *pointEvaluator , dataKey , pValue );
+				dataValue = pValue.weight ? pValue.value() : zeroData;
+			}
+			else
+			{
+				ProjectiveData< Data , Real > pValue( zeroData );
+				tree.template _addEvaluation< ProjectiveData< Data , Real > , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > , 0 >( *data , position , *pointEvaluator , dataKey , pValue );
+				dataValue = pValue.weight ? pValue.value() : zeroData;
+			}
+		}
+		vertex.template get<0>() = position;
+		vertex.template get<1>() = gradient;
+		vertex.template get<2>() = depth;
+		if constexpr( HasData ) vertex.template get<3>() = dataValue;
+		return true;
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig >
+	static bool GetIsoVertex
+	(
+		const FEMTree< Dim , Real > &tree ,
+		bool nonLinearFit ,
+		bool gradientNormals ,
+		typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > > *pointEvaluator ,
+		const DensityEstimator< WeightDegree > *densityWeights ,
+		const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data ,
+		Real isoValue ,
+		ConstPointSupportKey< IsotropicUIntPack< Dim , WeightDegree > > &weightKey ,
+		ConstPointSupportKey< IsotropicUIntPack< Dim , FEMSignature< DataSig >::Degree > > &dataKey ,
+		const TreeNode *node ,
+		typename HyperCube::template Cube< Dim-1 >::template Element< 0 > _c ,
+		Real bCoordinate ,
+		Real fCoordinate ,
+		const SliceValues &bValues ,
+		const SliceValues &fValues ,
+		Vertex &vertex ,
+		const Data &zeroData
+	)
+	{
+		static const unsigned int DataDegree = FEMSignature< DataSig >::Degree;
+		Point< Real , Dim > position , gradient;
+
+		const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<0> &idx0 = bValues.cellIndices.template indices<0>( node );
+		const typename LevelSetExtraction::SliceCellIndexData< Dim >::template CellIndices<0> &idx1 = fValues.cellIndices.template indices<0>( node );
+		Real x0 = bValues.cornerValues[ idx0[_c.index] ] , x1 = fValues.cornerValues[ idx1[_c.index] ];
+		Point< Real , 3 > dx0 , dx1;
+		if( gradientNormals ) dx0 = bValues.cornerGradients[ idx0[_c.index] ] , dx1 = fValues.cornerGradients[ idx1[_c.index] ];
+		Point< Real , Dim > s;
+		Real w;
+		tree._startAndWidth( node , s , w );
+		int x , y;
+		{
+			const HyperCube::Direction* xx = HyperCubeTables< Dim-1 , 0 >::Directions[ _c.index ];
+			x = xx[0]==HyperCube::BACK ? 0 : 1 , y = xx[1]==HyperCube::BACK ? 0 : 1;
+		}
+
+		position[0] = s[0] + w*x;
+		position[1] = s[1] + w*y;
+
+		double averageRoot;
+		bool rootFound = false;
+
+		if( nonLinearFit )
+		{
+			double dx0 = bValues.cornerGradients[ idx0[_c.index] ][2] * (fCoordinate-bCoordinate) , dx1 = fValues.cornerGradients[ idx1[_c.index] ][2] * (fCoordinate-bCoordinate);
+			// The scaling will turn the Hermite Spline into a quadratic
+			double scl = (x1-x0) / ( (dx1+dx0 ) / 2 );
+			dx0 *= scl , dx1 *= scl;
+
+			// Hermite Spline
+			Polynomial< 2 > P;
+			P.coefficients[0] = x0;
+			P.coefficients[1] = dx0;
+			P.coefficients[2] = 3*(x1-x0)-dx1-2*dx0;
+
+			double roots[2];
+			int rCount = 0 , rootCount = P.getSolutions( isoValue , roots , 0 );
+			averageRoot = 0;
+			for( int i=0 ; i<rootCount ; i++ ) if( roots[i]>=0 && roots[i]<=1 ) averageRoot += roots[i] , rCount++;
+			if( rCount ) rootFound = true;
+			averageRoot /= rCount;
+		}
+		if( !rootFound )
+		{
+			// We have a linear function L, with L(0) = x0 and L(1) = x1
+			// => L(t) = x0 + t * (x1-x0)
+			// => L(t) = isoValue <=> t = ( isoValue - x0 ) / ( x1 - x0 )
+			if( x0==x1 ) MK_THROW( "Not a zero-crossing root: " , x0 , " " , x1 );
+			averageRoot = ( isoValue - x0 ) / ( x1 - x0 );
+		}
+		if( averageRoot<=0 || averageRoot>=1 )
+		{
+			_BadRootCount++;
+			if( averageRoot<0 ) averageRoot = 0;
+			if( averageRoot>1 ) averageRoot = 1;
+		}
+		position[2] = Real( bCoordinate + (fCoordinate-bCoordinate)*averageRoot );
+		gradient = dx0 * (Real)( 1.-averageRoot ) + dx1 * (Real)averageRoot;
+		Real depth = (Real)1.;
+		Data dataValue;
+		if( densityWeights )
+		{
+			Real weight;
+			tree._getSampleDepthAndWeight( *densityWeights , node , position , weightKey , depth , weight );
+		}
+		if constexpr( HasData ) if( data )
+		{
+			if( DataDegree==0 ) 
+			{
+				Point< Real , 3 > center( s[0] + w/2 , s[1] + w/2 , (bCoordinate+fCoordinate)/2 );
+				ProjectiveData< Data , Real > pValue( zeroData );
+				tree.template _addEvaluation< ProjectiveData< Data , Real > , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > , 0 >( *data , center , *pointEvaluator , dataKey , pValue );
+				dataValue = pValue.weight ? pValue.value() : zeroData;
+			}
+			else
+			{
+				ProjectiveData< Data , Real > pValue( zeroData );
+				tree.template _addEvaluation< ProjectiveData< Data , Real > , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > , 0 >( *data , position , *pointEvaluator , dataKey , pValue );
+				dataValue = pValue.weight ? pValue.value() : zeroData;
+			}
+		}
+		vertex.template get<0>() = position;
+		vertex.template get<1>() = gradient;
+		vertex.template get<2>() = depth;
+		if constexpr( HasData ) vertex.template get<3>() = dataValue;
+		return true;
+	}
+
+	template< typename VertexStream >
+	static unsigned int AddIsoPolygons( unsigned int thread , VertexStream &vertexStream , OutputDataStream< std::vector< node_index_type > > &polygonStream , std::vector< std::pair< node_index_type , Vertex > >& polygon , bool polygonMesh , bool addBarycenter )
+	{
+		if( polygonMesh )
+		{
+			std::vector< node_index_type > vertices( polygon.size() );
+			for( unsigned int i=0 ; i<polygon.size() ; i++ ) vertices[i] = polygon[polygon.size()-1-i].first;
+			polygonStream.write( thread , vertices );
+			return 1;
+		}
+		if( polygon.size()>3 )
+		{
+			bool isCoplanar = false;
+			std::vector< node_index_type > triangle( 3 );
+
+			if( addBarycenter )
+				for( unsigned int i=0 ; i<polygon.size() ; i++ ) for( unsigned int j=0 ; j<i ; j++ )
+					if( (i+1)%polygon.size()!=j && (j+1)%polygon.size()!=i )
+					{
+						Vertex v1 = polygon[i].second , v2 = polygon[j].second;
+						for( int k=0 ; k<3 ; k++ ) if( v1.template get<0>()[k]==v2.template get<0>()[k] ) isCoplanar = true;
+					}
+			if( isCoplanar )
+			{
+				Vertex c;
+				c *= 0;
+				for( unsigned int i=0 ; i<polygon.size() ; i++ ) c += polygon[i].second;
+				c /= ( typename Vertex::Real )polygon.size();
+
+				node_index_type cIdx = (node_index_type)vertexStream.write( thread , c );
+
+				for( unsigned i=0 ; i<polygon.size() ; i++ )
+				{
+					triangle[0] = polygon[ i                  ].first;
+					triangle[1] = cIdx;
+					triangle[2] = polygon[(i+1)%polygon.size()].first;
+					polygonStream.write( thread , triangle );
+				}
+				return (unsigned int)polygon.size();
+			}
+			else
+			{
+				std::vector< Point< Real , Dim > > vertices( polygon.size() );
+				for( unsigned int i=0 ; i<polygon.size() ; i++ ) vertices[i] = polygon[i].second.template get<0>();
+				std::vector< TriangleIndex< node_index_type > > triangles = MinimalAreaTriangulation< node_index_type , Real , Dim >( ( ConstPointer( Point< Real , Dim > ) )GetPointer( vertices ) , (node_index_type)vertices.size() );
+				if( triangles.size()!=polygon.size()-2 ) MK_THROW( "Minimal area triangulation failed:" , triangles.size() , " != " , polygon.size()-2 );
+				for( unsigned int i=0 ; i<triangles.size() ; i++ )
+				{
+					for( int j=0 ; j<3 ; j++ ) triangle[2-j] = polygon[ triangles[i].idx[j] ].first;
+					polygonStream.write( thread , triangle );
+				}
+			}
+		}
+		else if( polygon.size()==3 )
+		{
+			std::vector< node_index_type > vertices( 3 );
+			for( int i=0 ; i<3 ; i++ ) vertices[2-i] = polygon[i].first;
+			polygonStream.write( thread , vertices );
+		}
+		return (unsigned int)polygon.size()-2;
+	}
+
+	struct Stats
+	{
+		double cornersTime , verticesTime , edgesTime , surfaceTime;
+		double setTableTime;
+		Stats( void ) : cornersTime(0) , verticesTime(0) , edgesTime(0) , surfaceTime(0) , setTableTime(0) {;}
+		std::string toString( void ) const
+		{
+			std::stringstream stream;
+			stream << "Corners / Vertices / Edges / Surface / Set Table: ";
+			stream << std::fixed << std::setprecision(1) << cornersTime << " / " << verticesTime << " / " << edgesTime << " / " << surfaceTime << " / " << setTableTime;
+			stream << " (s)";
+			return stream.str();
+		}
+	};
+
+
+	template< unsigned int WeightDegree , unsigned int DataSig , typename OutputVertexStream , unsigned int ... FEMSigs >
+	static Stats Extract
+	(
+		UIntPack< FEMSigs ... > ,
+		UIntPack< WeightDegree > ,
+		UIntPack< DataSig > ,
+		const FEMTree< Dim , Real > &tree ,
+		int maxKeyDepth ,
+		const DensityEstimator< WeightDegree > *densityWeights ,
+		const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data ,
+		const DenseNodeData< Real , UIntPack< FEMSigs ... > > &coefficients ,
+		Real isoValue ,
+		unsigned int slabDepth ,
+		unsigned int slabStart ,
+		unsigned int slabEnd ,
+		OutputVertexStream &vertexStream ,
+		OutputDataStream< std::vector< node_index_type > > &polygonStream ,
+		const Data &zeroData ,
+		bool nonLinearFit ,
+		bool gradientNormals ,
+		bool addBarycenter ,
+		bool polygonMesh ,
+		bool flipOrientation ,
+		const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions * backBoundary ,
+		const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions *frontBoundary ,
+		const std::vector< std::vector< Real > > &backDValues ,
+		const std::vector< std::vector< Real > > &frontDValues ,
+		bool copyTopology
+	)
+	{
+		if( maxKeyDepth<tree._maxDepth ) MK_THROW( "Max key depth has to be at least tree depth: " , tree._maxDepth , " <= " , maxKeyDepth );
+		if( slabStart>=slabEnd ) MK_THROW( "Slab start cannot excceed slab end: " , slabStart , " < " , slabEnd );
+		if( slabEnd>(1u<<slabDepth) ) MK_THROW( "Slab end cannot exceed slab num: " , slabEnd , " <= " , 1<<slabDepth );
+
+		LevelSetExtraction::KeyGenerator< Dim > keyGenerator( maxKeyDepth );
+		LocalOffset start , end;
+		for( unsigned int d=0 ; d<Dim-1 ; d++ ) start[d] = 0 , end[d] = (1<<slabDepth);
+		start[Dim-1] = slabStart  , end[Dim-1] = slabEnd;
+		LocalDepth fullDepth = tree.getFullDepth( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , slabDepth , start , end );
+		unsigned int maxDepth = std::max< unsigned int >( tree._maxDepth , slabDepth );
+		unsigned int slabStartAtMaxDepth = slabStart << ( maxDepth - slabDepth );
+		unsigned int slabEndAtMaxDepth = slabEnd << ( maxDepth - slabDepth );
+#ifdef SHOW_WARNINGS
+		if( slabDepth>(unsigned int)fullDepth && ( ( slabStart!=0 && !backBoundary ) || ( slabEnd+1!=1<<(slabDepth) && !frontBoundary ) ) ) MK_WARN( "Slab depth exceeds full depth, reconstruction may not be water-tight: " , slabDepth , " <= " , fullDepth , " [ " , slabStart , " , " , slabEnd , " )" );
+#endif // SHOW_WARNINGS
+
+		_BadRootCount = 0u;
+		Stats stats;
+		static_assert( sizeof...(FEMSigs)==Dim , "[ERROR] Number of signatures should match dimension" );
+		tree._setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+		static const unsigned int DataDegree = FEMSignature< DataSig >::Degree;
+		static const int FEMDegrees[] = { FEMSignature< FEMSigs >::Degree ... };
+		for( int d=0 ; d<Dim ; d++ ) if( FEMDegrees[d]==0 && ( nonLinearFit || gradientNormals ) ) MK_THROW( "Constant B-Splines do not support gradient estimation" );
+
+		LevelSetExtraction::SetHyperCubeTables< Dim >();
+		LevelSetExtraction::SetHyperCubeTables< Dim-1 >();
+
+		typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > >* pointEvaluator = NULL;
+		if constexpr( HasData ) if( data ) pointEvaluator = new typename FEMIntegrator::template PointEvaluator< IsotropicUIntPack< Dim , DataSig > , ZeroUIntPack< Dim > >( tree._maxDepth );
+		DenseNodeData< Real , UIntPack< FEMSigs ... > > coarseCoefficients( tree._sNodesEnd( tree._maxDepth-1 ) );
+		memset( coarseCoefficients() , 0 , sizeof(Real)*tree._sNodesEnd( tree._maxDepth-1 ) );
+		ThreadPool::ParallelFor( tree._sNodesBegin(0) , tree._sNodesEnd( tree._maxDepth-1 ) , [&]( unsigned int, size_t i ){ coarseCoefficients[i] = coefficients[i]; } );
+		typename FEMIntegrator::template RestrictionProlongation< UIntPack< FEMSigs ... > > rp;
+		for( LocalDepth d=1 ; d<tree._maxDepth ; d++ ) tree._upSample( UIntPack< FEMSigs ... >() , rp , d , ( ConstPointer(Real) )coarseCoefficients()+tree._sNodesBegin(d-1) , coarseCoefficients()+tree._sNodesBegin(d) );
+
+		std::vector< _Evaluator< UIntPack< FEMSigs ... > , 1 > > evaluators( tree._maxDepth+1 );
+		for( LocalDepth d=0 ; d<=tree._maxDepth ; d++ ) evaluators[d].set( tree._maxDepth );
+
+		std::vector< SlabValues > slabValues( tree._maxDepth+1 );
+		std::vector< std::pair< node_index_type , node_index_type > > backIncidence , frontIncidence;
+		if(  backBoundary )  backIncidence = SetIncidence( tree ,  backBoundary->sliceTree , fullDepth , slabStartAtMaxDepth , maxDepth );
+		if( frontBoundary ) frontIncidence = SetIncidence( tree , frontBoundary->sliceTree , fullDepth , slabEndAtMaxDepth , maxDepth );
+
+		enum BoundarySliceType { BACK , FRONT , NEITHER };
+
+		auto BoundarySlice = [&]( unsigned int sliceAtMaxDepth )
+		{
+			if     (  backBoundary && sliceAtMaxDepth==slabStartAtMaxDepth ) return BoundarySliceType::BACK;
+			else if( frontBoundary && sliceAtMaxDepth==  slabEndAtMaxDepth ) return BoundarySliceType::FRONT;
+			else return BoundarySliceType::NEITHER;
+		};
+
+
+		auto SetCoarseSlice = [&]( unsigned int sliceAtMaxDepth , unsigned int coarseDepth , unsigned int &coarseSlice )
+		{
+			BoundarySliceType bst = BoundarySlice( sliceAtMaxDepth );
+			unsigned dOff = maxDepth - coarseDepth;
+			coarseSlice = sliceAtMaxDepth>>dOff;
+			if( sliceAtMaxDepth!=( coarseSlice<<dOff ) )
+			{
+				if     ( bst==BoundarySliceType::BACK ) ;
+				else if( bst==BoundarySliceType::FRONT ) coarseSlice++;
+				else return false;
+			}
+			return true;
+		};
+
+		auto InteriorSlab = [&]( unsigned int d , unsigned int o )
+		{
+			unsigned int startAtMaxDepth = (o+0)<<(maxDepth-d);
+			unsigned int   endAtMaxDepth = (o+1)<<(maxDepth-d);
+			if(   endAtMaxDepth<=slabStartAtMaxDepth ) return false;
+			if( startAtMaxDepth>=  slabEndAtMaxDepth ) return false;
+			if( startAtMaxDepth<slabStartAtMaxDepth && ! backBoundary ) return false;
+			if(   endAtMaxDepth>  slabEndAtMaxDepth && !frontBoundary ) return false;
+			return true;
+		};
+
+		auto SetSlabBounds = [&]( unsigned int d , unsigned int o , Real &bCoordinate , Real &fCoordinate )
+		{
+			unsigned int start = std::max< unsigned int >( (o+0)<<(maxDepth-d) , slabStartAtMaxDepth );
+			unsigned int   end = std::min< unsigned int >( (o+1)<<(maxDepth-d) ,   slabEndAtMaxDepth );
+			bCoordinate = start/(Real)(1<<maxDepth);
+			fCoordinate =   end/(Real)(1<<maxDepth);
+		};
+
+		// Initializes the indexing tables
+		auto InitSlice = [&]( unsigned int sliceAtMaxDepth )
+		{
+
+			BoundarySliceType bst = BoundarySlice( sliceAtMaxDepth );
+
+			for( LocalDepth d=maxDepth ; d>=fullDepth ; d-- )
+			{
+				unsigned int slice;
+				if( !SetCoarseSlice( sliceAtMaxDepth , d , slice ) ) break;
+				if( d<=tree._maxDepth )
+				{
+					double t = Time();
+					slabValues[d].sliceValues(slice).cellIndices.set( tree._sNodes , tree._localToGlobal( d ) , slice + tree._localInset( d ) );
+					stats.setTableTime += Time()-t;
+
+					slabValues[d].sliceValues(slice).reset( slice , nonLinearFit || gradientNormals );
+
+					slabValues[d].sliceScratch(slice).reset( slabValues[d].sliceValues(slice).cellIndices );
+				}
+			}
+		};
+
+		auto InitSlab = [&]( unsigned int slabAtMaxDepth , bool first )
+		{
+			unsigned int slab = slabAtMaxDepth;
+			for( LocalDepth d=maxDepth ; d>=fullDepth ; d-- , slab>>=1 )
+			{
+				if( d<=tree._maxDepth )
+				{
+					double t = Time();
+					slabValues[d].xSliceValues(slab).cellIndices.set( tree._sNodes , tree._localToGlobal( d ) , slab + tree._localInset( d ) );
+					stats.setTableTime += Time()-t;
+
+					slabValues[d].xSliceValues(slab).reset(slab);
+
+					slabValues[d].xSliceScratch(slab).reset( slabValues[d].xSliceValues(slab).cellIndices );
+				}
+				if( (slab&1) && !first ) break;
+			}
+		};
+
+		auto FinalizeSlice = [&]( unsigned int sliceAtMaxDepth )
+		{
+
+			bool useBoundary = ( ( sliceAtMaxDepth==slabStartAtMaxDepth && backBoundary ) || ( sliceAtMaxDepth==slabEndAtMaxDepth && frontBoundary ) ) && copyTopology;
+			if( !useBoundary )
+			{
+				LocalDepth d ; unsigned int o;
+				for( d=maxDepth , o=sliceAtMaxDepth ; d>=fullDepth ; d-- , o>>=1 )
+				{
+					if( d<=tree._maxDepth )
+					{
+						ThreadPool::ParallelSections
+						(
+							[ &slabValues , d , o ]( void ){ slabValues[d].sliceValues(o).setFromScratch( slabValues[d].sliceScratch(o).vKeyValues ); } ,
+							[ &slabValues , d , o ]( void ){ slabValues[d].sliceValues(o).setFromScratch( slabValues[d].sliceScratch(o).eKeyValues ); } ,
+							[ &slabValues , d , o ]( void ){ slabValues[d].sliceValues(o).setFromScratch( slabValues[d].sliceScratch(o).fKeyValues ); }
+						);
+					}
+					if( o&1 ) break;
+				}
+			}
+		};
+
+		auto FinalizeSlab = [&]( unsigned int slabAtMaxDepth )
+		{
+			LocalDepth d ; unsigned int o;
+			bool boundary = (slabAtMaxDepth+1)==slabEndAtMaxDepth && frontBoundary;
+			for( d=maxDepth , o=slabAtMaxDepth ; d>=fullDepth ; d-- , o>>=1 )
+			{
+				if( d<=tree._maxDepth )
+				{
+					ThreadPool::ParallelSections
+					(
+						[ &slabValues , d , o ]( void ){ slabValues[d].xSliceValues(o).setFromScratch( slabValues[d].xSliceScratch(o).vKeyValues ); } ,
+						[ &slabValues , d , o ]( void ){ slabValues[d].xSliceValues(o).setFromScratch( slabValues[d].xSliceScratch(o).eKeyValues ); } ,
+						[ &slabValues , d , o ]( void ){ slabValues[d].xSliceValues(o).setFromScratch( slabValues[d].xSliceScratch(o).fKeyValues ); }
+					);
+				}
+				if( !(o&1) && !boundary ) break;
+			}
+		};
+
+		auto SetSliceValues = [&]( unsigned int sliceAtMaxDepth )
+		{
+
+			LocalDepth d ; unsigned int o;
+			const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions *boundary = NULL;
+			const std::vector< std::pair< node_index_type , node_index_type > > *incidence = NULL;
+			const std::vector< std::vector< Real > > *dValues = NULL;
+			if     ( sliceAtMaxDepth==slabStartAtMaxDepth ) boundary =  backBoundary , incidence =  &backIncidence , dValues = & backDValues;
+			else if( sliceAtMaxDepth==  slabEndAtMaxDepth ) boundary = frontBoundary , incidence = &frontIncidence , dValues = &frontDValues;
+
+			if( boundary && copyTopology )
+			{
+				double t = Time();
+				for( LocalDepth d=maxDepth ; d>=fullDepth ; d-- ) if( d<=boundary->sliceTree.depth() && d<=tree._maxDepth )
+				{
+					unsigned int slice;
+					if( !SetCoarseSlice( sliceAtMaxDepth , d , slice ) ) MK_THROW( "Could not set coarse slice" );
+					OverwriteCornerValues( *boundary , (*dValues)[d] , tree , d , sliceAtMaxDepth , maxDepth , sliceAtMaxDepth==slabStartAtMaxDepth , slabValues , *incidence );
+					SetMCIndices( tree , isoValue , d , fullDepth , slice , slabValues );
+				}
+				stats.cornersTime += Time()-t , t = Time();
+			}
+			else
+			{
+				double t;
+
+				t = Time();
+				for( d=maxDepth , o=sliceAtMaxDepth ; d>=fullDepth ; d-- , o>>=1 )
+				{
+					if( d<=tree._maxDepth )
+					{
+						if( boundary )
+						{
+							if( d<=boundary->sliceTree.depth() )
+							{
+								OverwriteCornerValues( *boundary , (*dValues)[d] , tree , d , sliceAtMaxDepth , maxDepth , sliceAtMaxDepth==slabStartAtMaxDepth , slabValues , backIncidence );
+								SetMCIndices( tree , isoValue , d , fullDepth , o , slabValues );
+							}
+						}
+						else SetSliceCornerValuesAndMCIndices< FEMSigs ... >( tree , coefficients() , coarseCoefficients() , isoValue , d , fullDepth , o , slabValues , evaluators[d] );				
+					}
+					if( o&1 ) break;
+				}
+				stats.cornersTime += Time()-t;
+			}
+		};
+
+		auto SetSliceIso = [&]( unsigned int sliceAtMaxDepth )
+		{
+			LocalDepth d ; unsigned int o;
+
+			const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions *boundary = NULL;
+			const std::vector< std::pair< node_index_type , node_index_type > > *incidence = NULL;
+			const std::vector< std::vector< Real > > *dValues = NULL;
+			if     ( sliceAtMaxDepth==slabStartAtMaxDepth ) boundary =  backBoundary , incidence =  &backIncidence , dValues = & backDValues;
+			else if( sliceAtMaxDepth==  slabEndAtMaxDepth ) boundary = frontBoundary , incidence = &frontIncidence , dValues = &frontDValues;
+
+			if( boundary && copyTopology )
+			{
+				auto sliceFunctor = [&]( unsigned int depth ) -> SliceValues &
+				{
+					unsigned int slice;
+					if( !SetCoarseSlice( sliceAtMaxDepth , depth , slice ) ) MK_THROW( "Could not set coarse slice" );
+					return slabValues[depth].sliceValues( slice );
+				};
+				auto scratchFunctor = [&]( unsigned int depth ) -> typename SliceValues::Scratch &
+				{
+					unsigned int slice;
+					if( !SetCoarseSlice( sliceAtMaxDepth , depth , slice ) ) MK_THROW( "Could not set coarse slice" );
+					return slabValues[depth].sliceScratch( slice );
+				};
+				CopyIsoStructure< WeightDegree , DataSig >( keyGenerator , *boundary , tree , fullDepth , sliceAtMaxDepth , maxDepth , sliceFunctor , scratchFunctor , *incidence , vertexStream , gradientNormals , pointEvaluator , densityWeights , data , zeroData );
+			}
+			else
+			{
+				double t;
+				// Set the iso-vertices
+				t = Time();
+				for( d=maxDepth , o=sliceAtMaxDepth ; d>=fullDepth ; d-- , o>>=1 )
+				{
+					if( d<=tree._maxDepth )
+					{
+						SetSliceIsoVertices< WeightDegree , DataSig >( keyGenerator , tree , nonLinearFit , gradientNormals , pointEvaluator , densityWeights , data , isoValue , d , fullDepth , o , vertexStream , slabValues , zeroData );
+					}
+					if( o&1 ) break;
+				}
+				stats.verticesTime += Time()-t;
+
+				// Set the iso-edges
+				t = Time();
+				for( d=maxDepth , o=sliceAtMaxDepth ; d>=fullDepth ; d-- , o>>=1 )
+				{
+					if( d<=tree._maxDepth )
+					{
+						if( d<tree._maxDepth ) CopyFinerSliceIsoEdgeKeys( tree , d , fullDepth , o , slabValues );
+						SetSliceIsoEdges( keyGenerator , tree , d , o , slabValues );
+					}
+					if( o&1 ) break;
+				}
+				stats.edgesTime += Time()-t;
+			}
+		};
+
+
+		auto SetSlabIsoVertices = [&]( unsigned int slabAtMaxDepth )
+		{
+			LocalDepth d ; unsigned int o;
+			double t = Time();
+
+			bool boundary = (slabAtMaxDepth+1)==slabEndAtMaxDepth && frontBoundary;
+
+			// Set the iso-edges
+			for( d=maxDepth , o=slabAtMaxDepth ; d>=fullDepth ; d-- , o>>=1 )
+			{
+				if( d<=tree._maxDepth )
+				{
+					if( InteriorSlab( d , o ) ) 
+					{
+						// Set the iso-vertices
+						Real bCoordinate , fCoordinate;
+						SetSlabBounds( d , o , bCoordinate , fCoordinate );
+						SetXSliceIsoVertices< WeightDegree , DataSig >( keyGenerator , tree , nonLinearFit , gradientNormals , pointEvaluator , densityWeights , data , isoValue , d , std::max< unsigned int >( slabDepth , fullDepth ) , o , bCoordinate , fCoordinate , vertexStream , slabValues , zeroData );
+					}
+				}
+
+				if( !(o&1) && !boundary ) break;
+			}
+			stats.edgesTime += Time()-t;
+		};
+
+		auto SetSlabIsoEdges = [&]( unsigned int slabAtMaxDepth )
+		{
+			LocalDepth d ; unsigned int o;
+			double t = Time();
+
+			bool boundary = (slabAtMaxDepth+1)==slabEndAtMaxDepth && frontBoundary;
+
+			// Set the iso-edges
+			for( d=maxDepth , o=slabAtMaxDepth ; d>=fullDepth ; d-- , o>>=1 )
+			{
+				if( d<=tree._maxDepth )
+				{
+					if( InteriorSlab( d , o ) ) 
+					{
+						// Copy the edges from finer
+						if( d<tree._maxDepth )
+						{
+							CopyFinerXSliceIsoEdgeKeys( tree , d , fullDepth , o , slabValues );
+						}
+						SetXSliceIsoEdges( keyGenerator , tree , d , o , slabValues );
+					}
+
+				}
+				if( !(o&1) && !boundary ) break;
+			}
+			stats.edgesTime += Time()-t;
+		};
+
+
+		auto IsoSurface = [&]( unsigned int slabAtMaxDepth )
+		{
+			double t = Time();
+			bool boundary = (slabAtMaxDepth+1)==slabEndAtMaxDepth && frontBoundary;
+			LocalDepth d ; int o;
+			for( d=maxDepth , o=slabAtMaxDepth ; d>=fullDepth ; d-- , o>>=1 )
+			{
+				if( d<=tree._maxDepth )
+				{
+					auto faceIndexFunctor = [&]( const TreeNode *node , typename HyperCube::Cube< Dim >::template Element< 2 > f )
+					{
+						HyperCube::Direction dir ; unsigned int coIndex;
+						f.factor( dir , coIndex );
+						int depth , offset[Dim];
+						tree.depthAndOffset( node , depth , offset );
+						LevelSetExtraction::Key< Dim > key = keyGenerator( depth , offset , f );
+						if     ( dir==HyperCube::BACK  && ( (((unsigned int)offset[Dim-1]+0)<<(maxDepth-depth))<slabStartAtMaxDepth ) ) key[Dim-1] = keyGenerator.cornerIndex( maxDepth , slabStartAtMaxDepth );
+						else if( dir==HyperCube::FRONT && ( (((unsigned int)offset[Dim-1]+1)<<(maxDepth-depth))>  slabEndAtMaxDepth ) ) key[Dim-1] = keyGenerator.cornerIndex( maxDepth , slabEndAtMaxDepth );
+						return key;
+					};
+					if( InteriorSlab( d , o ) ) SetLevelSet( keyGenerator , faceIndexFunctor , tree , d , o , slabValues[d].sliceValues(o) , slabValues[d].sliceValues(o+1) , slabValues[d].xSliceValues(o) , slabValues[d].sliceScratch(o) , slabValues[d].sliceScratch(o+1) , slabValues[d].xSliceScratch(o) , vertexStream , polygonStream , polygonMesh , addBarycenter , flipOrientation );
+				}
+				if( !(o&1) && !boundary ) break;
+			}
+			stats.surfaceTime += Time()-t;
+		};
+
+		InitSlice( slabStartAtMaxDepth );
+		InitSlab( slabStartAtMaxDepth , true );	// This needs to be done in case the slice wants to push iso-vertices down to the slab
+		SetSliceValues( slabStartAtMaxDepth );
+		SetSliceIso( slabStartAtMaxDepth );
+		FinalizeSlice( slabStartAtMaxDepth );
+
+		// Iterate over the slabs at the finest level
+		for( unsigned int slab=slabStartAtMaxDepth ; slab<slabEndAtMaxDepth ; slab++)
+		{
+			// Need to init the slab before setting the slice (in case things need to be pushed down from the slice to the slab)
+			InitSlice( slab+1 );
+			if( slab!=slabStartAtMaxDepth ) InitSlab( slab , false );
+
+			// Need to set the front slice corner values before computing iso-vertices
+			SetSliceValues( slab+1 );
+
+			// Compute the iso-vertices first, so that slice's iso-vertices are set last
+			SetSlabIsoVertices( slab );
+			SetSliceIso( slab+1 );
+
+			// Now compute the iso-edges
+			SetSlabIsoEdges( slab );
+
+			FinalizeSlice( slab+1 );
+			FinalizeSlab( slab );
+
+			IsoSurface( slab );
+		}
+
+		if( pointEvaluator ) delete pointEvaluator;
+		size_t badRootCount = _BadRootCount;
+		if( badRootCount!=0 ) MK_WARN( "bad average roots: " , badRootCount );
+		return stats;
+	}
+};
+
+template< bool HasData , typename Real , typename Data > std::atomic< size_t > _LevelSetExtractor< HasData , Real , 3 , Data >::_BadRootCount;
+
+template< typename Real >
+struct LevelSetExtractor< Real , 3 >
+{
+	static const unsigned int Dim = 3;
+	static const bool HasData = false;
+	typedef unsigned char Data;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::Stats Stats;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::Vertex Vertex;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::TreeNode TreeNode;
+	using OutputVertexStream = typename _LevelSetExtractor< HasData , Real , Dim , Data >::OutputVertexStream;
+	template< unsigned int WeightDegree > using DensityEstimator = typename _LevelSetExtractor< HasData , Real , Dim , Data >::template DensityEstimator< WeightDegree >;
+
+	template< unsigned int WeightDegree , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , const FEMTree< Dim , Real >& tree , const DensityEstimator< WeightDegree > *densityWeights , const DenseNodeData< Real , UIntPack< FEMSigs ... > > &coefficients , Real isoValue , OutputVertexStream &vertexStream , OutputDataStream< std::vector< node_index_type > > &polygonStream , bool nonLinearFit , bool outputGradients , bool addBarycenter , bool polygonMesh , bool flipOrientation )
+	{
+		return Extract( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , tree , densityWeights , coefficients , isoValue , 0 , 0 , 1 , vertexStream , polygonStream , nonLinearFit , outputGradients , addBarycenter , polygonMesh , flipOrientation );
+	}
+
+	template< unsigned int WeightDegree , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , const FEMTree< Dim , Real >& tree , const DensityEstimator< WeightDegree >* densityWeights , const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , Real isoValue , unsigned int slabDepth , unsigned int slabStart , unsigned int slabEnd , OutputVertexStream &vertexStream , OutputDataStream< std::vector< node_index_type > > &polygonStream , bool nonLinearFit , bool outputGradients , bool addBarycenter , bool polygonMesh , bool flipOrientation )
+	{
+		std::vector< std::vector< Real > > dValues;
+		return Extract( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , tree , tree._maxDepth , densityWeights , coefficients , isoValue , slabDepth , slabStart , slabEnd , vertexStream , polygonStream , nonLinearFit , outputGradients , addBarycenter , polygonMesh , flipOrientation , NULL , NULL , dValues , dValues , false );
+	}
+
+	template< unsigned int WeightDegree , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , const FEMTree< Dim , Real >& tree , int maxKeyDepth , const DensityEstimator< WeightDegree >* densityWeights , const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , Real isoValue , unsigned int slabDepth , unsigned int slabStart , unsigned int slabEnd , OutputVertexStream &vertexStream , OutputDataStream< std::vector< node_index_type > > &polygonStream , bool nonLinearFit , bool outputGradients , bool addBarycenter , bool polygonMesh , bool flipOrientation , const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions *backBoundary , const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions *frontBoundary , const std::vector< std::vector< Real > > &backDValues , const std::vector< std::vector< Real > > &frontDValues , bool copyTopology )
+	{
+		static const unsigned int DataSig = FEMDegreeAndBType< 0 , BOUNDARY_FREE >::Signature;
+		const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data = NULL;
+		Data zeroData = 0;
+		return _LevelSetExtractor< HasData , Real , Dim , Data >::template Extract< WeightDegree , DataSig , OutputVertexStream , FEMSigs ... >( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , maxKeyDepth , densityWeights , data , coefficients , isoValue , slabDepth , slabStart , slabEnd , vertexStream , polygonStream , zeroData , nonLinearFit , outputGradients , addBarycenter , polygonMesh , flipOrientation , backBoundary , frontBoundary , backDValues , frontDValues , copyTopology );
+	}
+};
+
+template< typename Real , typename Data >
+struct LevelSetExtractor< Real , 3 , Data >
+{
+	static const unsigned int Dim = 3;
+	static const bool HasData = true;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::Stats Stats;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::Vertex Vertex;
+	typedef typename _LevelSetExtractor< HasData , Real , Dim , Data >::TreeNode TreeNode;
+	using OutputVertexStream = typename _LevelSetExtractor< HasData , Real , Dim , Data >::OutputVertexStream;
+	template< unsigned int WeightDegree > using DensityEstimator = typename _LevelSetExtractor< HasData , Real , Dim , Data >::template DensityEstimator< WeightDegree >;
+
+	template< unsigned int WeightDegree , unsigned int DataSig , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , UIntPack< DataSig > , const FEMTree< Dim , Real >& tree , const DensityEstimator< WeightDegree > *densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > *data , const DenseNodeData< Real , UIntPack< FEMSigs ... > > &coefficients , Real isoValue , OutputVertexStream &vertexStream , OutputDataStream< std::vector< node_index_type > > &polygonStream , const Data &zeroData , bool nonLinearFit , bool outputGradients , bool addBarycenter , bool polygonMesh , bool flipOrientation )
+	{
+		return Extract( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , densityWeights , data , coefficients , isoValue , 0 , 0 , 1 , vertexStream , polygonStream , zeroData , nonLinearFit , outputGradients , addBarycenter , polygonMesh , flipOrientation );
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , UIntPack< DataSig > , const FEMTree< Dim , Real >& tree , const DensityEstimator< WeightDegree >* densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data , const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , Real isoValue , unsigned int slabDepth , unsigned int slabStart , unsigned int slabEnd , OutputVertexStream &vertexStream , OutputDataStream< std::vector< node_index_type > > &polygonStream , const Data &zeroData , bool nonLinearFit , bool outputGradients , bool addBarycenter , bool polygonMesh , bool flipOrientation )
+	{
+		std::vector< std::vector< Real >  > dValues;
+		return Extract( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , tree._maxDepth , densityWeights , data , coefficients , isoValue , slabDepth , slabStart , slabEnd , vertexStream , polygonStream , zeroData , nonLinearFit , outputGradients , addBarycenter , polygonMesh , flipOrientation , NULL , NULL , dValues , dValues , false );
+	}
+
+	template< unsigned int WeightDegree , unsigned int DataSig , unsigned int ... FEMSigs >
+	static Stats Extract( UIntPack< FEMSigs ... > , UIntPack< WeightDegree > , UIntPack< DataSig > , const FEMTree< Dim , Real >& tree , int maxKeyDepth , const DensityEstimator< WeightDegree >* densityWeights , const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > >* data , const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , Real isoValue , unsigned int slabDepth , unsigned int slabStart , unsigned int slabEnd , OutputVertexStream &vertexStream , OutputDataStream< std::vector< node_index_type > > &polygonStream , const Data &zeroData , bool nonLinearFit , bool outputGradients , bool addBarycenter , bool polygonMesh , bool flipOrientation , const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions *backBoundary , const typename LevelSetExtractor< Real , Dim-1 , Point< Real , Dim-1 > >::TreeSliceValuesAndVertexPositions *frontBoundary , const std::vector< std::vector< Real > > &backDValues , const std::vector< std::vector< Real > > &frontDValues , bool copyTopology )
+	{
+		return _LevelSetExtractor< HasData , Real , Dim , Data >::template Extract< WeightDegree , DataSig , OutputVertexStream , FEMSigs ... >( UIntPack< FEMSigs ... >() , UIntPack< WeightDegree >() , UIntPack< DataSig >() , tree , maxKeyDepth , densityWeights , data , coefficients , isoValue , slabDepth , slabStart , slabEnd , vertexStream , polygonStream , zeroData , nonLinearFit , outputGradients , addBarycenter , polygonMesh , flipOrientation , backBoundary , frontBoundary , backDValues , frontDValues , copyTopology );
+	}
+};

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.LevelSet.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.LevelSet.inl
@@ -1,0 +1,842 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+// Level-set extraction data
+namespace LevelSetExtraction
+{
+	/////////
+	// Key //
+	/////////
+	template< unsigned int Dim >
+	struct Key
+	{
+	protected:
+		template< unsigned int _Dim > friend struct KeyGenerator;
+	public:
+		unsigned int idx[Dim];
+
+		Key( void ){ for( unsigned int d=0 ; d<Dim ; d++ ) idx[d] = -1; }
+
+		unsigned int &operator[]( int i ){ return idx[i]; }
+		const unsigned int &operator[]( int i ) const { return idx[i]; }
+
+		bool operator == ( const Key &key ) const
+		{
+			for( unsigned int d=0 ; d<Dim ; d++ ) if( idx[d]!=key[d] ) return false;
+			return true;
+		}
+		bool operator != ( const Key &key ) const { return !operator==( key ); }
+
+		std::string to_string( void ) const
+		{
+			std::stringstream stream;
+			stream << "(";
+			for( unsigned int d=0 ; d<Dim ; d++ )
+			{
+				if( d ) stream << ",";
+				stream << idx[d];
+			}
+			stream << ")";
+			return stream.str();
+		}
+
+		friend std::ostream &operator << ( std::ostream &os , const Key &key ){ return os << key.to_string(); }
+
+		friend Key SetAtomic( volatile Key & value , Key newValue )
+		{
+			Key oldValue;
+			for( unsigned int d=0 ; d<Dim ; d++ ) oldValue.idx[d] = PoissonRecon::SetAtomic( value.idx[d] , newValue.idx[d] );
+			return oldValue;
+		}
+
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Could we hash better?" )
+#endif // SHOW_WARNINGS
+		struct Hasher
+		{
+			size_t operator()( const Key &i ) const
+			{
+				size_t hash = 0;
+				for( unsigned int d=0 ; d<Dim ; d++ ) hash ^= i.idx[d];
+				return hash;
+			}
+		};
+	};
+
+	template< unsigned int Dim , typename Data > using KeyMap = std::unordered_map< Key< Dim > , Data , typename Key< Dim >::Hasher >;
+
+	/////////////
+	// IsoEdge //
+	/////////////
+	template< unsigned int Dim >
+	struct IsoEdge
+	{
+		Key< Dim > vertices[2];
+		IsoEdge( void ) {}
+		IsoEdge( Key< Dim > v1 , Key< Dim > v2 ){ vertices[0] = v1 , vertices[1] = v2; }
+		Key< Dim > &operator[]( int idx ){ return vertices[idx]; }
+		const Key< Dim > &operator[]( int idx ) const { return vertices[idx]; }
+
+		friend IsoEdge SetAtomic( volatile IsoEdge & value , IsoEdge newValue )
+		{
+			IsoEdge oldValue;
+			oldValue.vertices[0] = SetAtomic( value.vertices[0] , newValue.vertices[0] );
+			oldValue.vertices[1] = SetAtomic( value.vertices[1] , newValue.vertices[1] );
+			return oldValue;
+		}
+	};
+
+	/////////////////////
+	// HyperCubeTables //
+	/////////////////////
+	template< unsigned int D , unsigned int ... Ks > struct HyperCubeTables{};
+
+	template< unsigned int D , unsigned int K1 , unsigned int K2 >
+	struct HyperCubeTables< D , K1 , K2 >
+	{
+		// The number of K1-dimensional elements in a D-dimensional cube
+		static constexpr unsigned int ElementNum1 = HyperCube::Cube< D >::template ElementNum< K1 >();
+		// The number of K2-dimensional elements in a D-dimensional cube
+		static constexpr unsigned int ElementNum2 = HyperCube::Cube< D >::template ElementNum< K2 >();
+		// The number of K2-dimensional elements overlapping the K1-dimensional element
+		static constexpr unsigned int OverlapElementNum = HyperCube::Cube< D >::template OverlapElementNum< K1 , K2 >();
+		// The list of K2-dimensional elements overlapping the K1-dimensional element
+		static typename HyperCube::Cube< D >::template Element< K2 > OverlapElements[ ElementNum1 ][ OverlapElementNum ];
+		// Indicates if the K2-dimensional element overlaps the K1-dimensional element
+		static bool Overlap[ ElementNum1 ][ ElementNum2 ];
+
+		static void SetTables( void )
+		{
+			for( typename HyperCube::Cube< D >::template Element< K1 > e ; e<HyperCube::Cube< D >::template ElementNum< K1 >() ; e++ )
+			{
+				for( typename HyperCube::Cube< D >::template Element< K2 > _e ; _e<HyperCube::Cube< D >::template ElementNum< K2 >() ; _e++ )
+					Overlap[e.index][_e.index] = HyperCube::Cube< D >::Overlap( e , _e );
+				HyperCube::Cube< D >::OverlapElements( e , OverlapElements[e.index] );
+			}
+			if( !K2 ) HyperCubeTables< D , K1 >::SetTables();
+		}
+	};
+
+	template< unsigned int D , unsigned int K >
+	struct HyperCubeTables< D , K >
+	{
+		static constexpr unsigned int IncidentCubeNum = HyperCube::Cube< D >::template IncidentCubeNum< K >();
+		static constexpr unsigned int ElementNum = HyperCube::Cube< D >::template ElementNum< K >();
+		static unsigned int CellOffset[ ElementNum ][ IncidentCubeNum ];
+		static unsigned int IncidentElementCoIndex[ ElementNum ][ IncidentCubeNum ];
+		static unsigned int IncidentElementIndex[ ElementNum ][ IncidentCubeNum ];
+		static unsigned int CellOffsetAntipodal[ ElementNum ];
+		static typename HyperCube::Cube< D >::template IncidentCubeIndex< K > IncidentCube[ ElementNum ];
+		static typename HyperCube::Direction Directions[ ElementNum ][ D ];
+
+		static void SetTables( void )
+		{
+			for( typename HyperCube::Cube< D >::template Element< K > e ; e<HyperCube::Cube< D >::template ElementNum< K >() ; e++ )
+			{
+				for( typename HyperCube::Cube< D >::template IncidentCubeIndex< K > i ; i<HyperCube::Cube< D >::template IncidentCubeNum< K >() ; i++ )
+				{
+					CellOffset[e.index][i.index] = HyperCube::Cube< D >::CellOffset( e , i );
+					IncidentElementCoIndex[e.index][i.index] = HyperCube::Cube< D >::IncidentElement( e , i ).coIndex();
+					IncidentElementIndex[e.index][i.index] = HyperCube::Cube< D >::IncidentElement( e , i ).index;
+				}
+				CellOffsetAntipodal[e.index] = HyperCube::Cube< D >::CellOffset( e , HyperCube::Cube< D >::IncidentCube( e ).antipodal() );
+				IncidentCube[ e.index ] = HyperCube::Cube< D >::IncidentCube( e );
+				e.directions( Directions[e.index] );
+			}
+		}
+	};
+
+	template< unsigned int D , unsigned int K1=D , unsigned int K2=D >
+	static void SetHyperCubeTables( void )
+	{
+		if constexpr( K2!=0 )
+		{
+			HyperCubeTables< D , K1 , K2 >::SetTables();
+			SetHyperCubeTables< D , K1 , K2-1 >();
+		}
+		else if constexpr( K1!=0 && K2==0 )
+		{
+			HyperCubeTables< D , K1 , K2 >::SetTables();
+			SetHyperCubeTables< D , K1-1 , D >();
+		}
+		else if constexpr( D!=1 && K1==0 && K2==0 )
+		{
+			HyperCubeTables< D , K1 , K2 >::SetTables();
+			SetHyperCubeTables< D-1 , D-1 , D-1 >();
+		}
+		else HyperCubeTables< D , K1 , K2 >::SetTables();
+	}
+
+	// A helper class for storing a static array
+	template< unsigned int Indices >
+	struct _Indices
+	{
+		node_index_type idx[Indices];
+		_Indices( void ){ for( unsigned int i=0 ; i<Indices ; i++ ) idx[i] = -1; }
+		node_index_type& operator[] ( int i ) { return idx[i]; }
+		const node_index_type& operator[] ( int i ) const { return idx[i]; }
+	};
+
+	template< unsigned int Dim , unsigned int CellDim >
+	struct _CellIndices
+	{
+		static const unsigned int ElementNum = HyperCube::Cube< Dim >::template ElementNum< CellDim >();
+		using Type = _Indices< ElementNum >;
+	};
+
+	// A helper struct for storing arrays of different types of indices
+	template< unsigned int Dim , typename T > struct _Tables{};
+	template< unsigned int Dim , unsigned int ... CellDimensions > struct _Tables< Dim , std::integer_sequence< unsigned int , CellDimensions ... > >
+	{
+		typedef std::tuple< Pointer( typename _CellIndices< Dim , CellDimensions >::Type ) ... > Type;
+	};
+
+	// Temporary data used for tracking ownership of cells shared by different nodes
+	template< unsigned int Dim , unsigned int MaxCellDim >
+	struct _Scratch
+	{
+		Pointer( node_index_type ) maps[MaxCellDim+1];
+		_Scratch( void ) : _reserved(0) { for( unsigned int i=0 ; i<=MaxCellDim ; i++ ) maps[i] = NullPointer( node_index_type ); }
+		~_Scratch( void ){ clear(); }
+		void clear( void ){ for( unsigned int i=0 ; i<=MaxCellDim ; i++ ) DeletePointer( maps[i] ); }
+		void resize( size_t sz )
+		{
+			if( sz>_reserved )
+			{
+				clear();
+				_allocate<0>( sz );
+				_reserved = sz;
+			}
+			_zeroOut<0>( sz );
+		}
+	protected:
+
+		template< unsigned int CellDim >
+		void _allocate( size_t sz )
+		{
+			maps[ CellDim ] = NewPointer< node_index_type >( sz * HyperCube::Cube< Dim >::template ElementNum< CellDim >() );
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _allocate< CellDim+1 >( sz );
+		}
+
+		template< unsigned int CellDim >
+		void _zeroOut( size_t sz )
+		{
+			if( sz && maps[CellDim] ) memset( maps[CellDim] , 0 , sizeof(node_index_type) * sz * HyperCube::Cube< Dim >::template ElementNum< CellDim >() );
+			else if( sz ) MK_THROW( "Traying to zero out null pointer" );
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _zeroOut< CellDim+1 >( sz );
+		}
+		size_t _reserved;
+	};
+
+	///////////////////
+	// CellIndexData //
+	///////////////////
+	// A data-struture that allows us to take a node together with a local cell index and returns the global cell's index
+	template< unsigned int Dim , unsigned int _MaxCellDim >
+	struct CellIndexData
+	{
+		static const unsigned int MaxCellDim = _MaxCellDim;
+		using TreeNode = RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >;
+
+		// Static arrays for holding specific dimension cell indices
+		template< unsigned int CellDim > using CellIndices = typename _CellIndices< Dim , CellDim >::Type;
+
+		// A tuple of pointers to cell indices of dimensions {0,...,MaxCellDim}
+		using TablesType = typename _Tables< Dim , std::make_integer_sequence< unsigned int , MaxCellDim+1 > >::Type;
+
+		// The tables holding the cell indices of different dimensions
+		TablesType tables;
+
+		// The count of the different number of cells
+		size_t counts[MaxCellDim+1];
+
+		CellIndexData( void ) : _size(0) , _capacity(0) { _init<0>(); }
+		~CellIndexData( void ){ clear(); }
+
+		void clear( void ){ _clear<0>(); }
+		void resize( size_t sz )
+		{
+			if( sz>_capacity )
+			{
+				_clear<0>();
+				_allocate<0>( sz );
+				_capacity = sz;
+			}
+			else for( unsigned int d=0 ; d<=MaxCellDim ; d++ ) counts[d] = 0;
+			_size = sz;
+		}
+		size_t size( void ) const { return _size; }
+
+		void read( BinaryStream &stream )
+		{
+			if( !stream.read( _size ) ) MK_THROW( "Failed to read node count" );
+			resize( _size );
+			if( _size ) _read<0>( stream );
+		}
+
+		void write( BinaryStream &stream ) const
+		{
+			stream.write( _size );
+			if( _size ) _write<0>( stream );
+		}
+
+	protected:
+		size_t _size , _capacity;
+
+		template< unsigned int CellDim >
+		void _init( void )
+		{
+			counts[CellDim] = 0;
+			std::get< CellDim >( tables ) = NullPointer( CellIndices< CellDim > );
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _init< CellDim+1 >();
+		}
+
+		template< unsigned int CellDim >
+		void _clear( void )
+		{
+			counts[CellDim] = 0;
+			DeletePointer( std::get< CellDim >( tables ) );
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _clear< CellDim+1 >();
+		}
+
+		template< unsigned int CellDim >
+		void _allocate( size_t sz )
+		{
+			std::get< CellDim >( tables ) = NewPointer< CellIndices< CellDim > >( sz );
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _allocate< CellDim+1 >( sz );
+		}
+
+		template< unsigned int CellDim >
+		void _read( BinaryStream &stream )
+		{
+			if( !stream.read( counts[CellDim] ) ) MK_THROW( "Failed to read count at dimension: " , CellDim );
+			if( !stream.read( std::get< CellDim >( tables ) , _size ) ) MK_THROW( "Failed to read table at dimension: " , CellDim );
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _read< CellDim+1 >( stream );
+		}
+
+		template< unsigned int CellDim >
+		void _write( BinaryStream &stream ) const
+		{
+			stream.write( counts[CellDim] );
+			stream.write( std::get< CellDim >( tables ) , _size );
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _write< CellDim+1 >( stream );
+		}
+	};
+
+	///////////////////////
+	// FullCellIndexData //
+	///////////////////////
+	// A data-struture that allows us to take a node together with a local cell index and returns the global cell's index
+	// [WARNING] Do we want to go up to Dim or up to Dim-1?
+	template< unsigned int Dim >
+	struct FullCellIndexData : public CellIndexData< Dim , Dim >
+	{
+		static const unsigned int MaxCellDim = CellIndexData< Dim , Dim >::MaxCellDim;
+		template< unsigned int CellDim > using CellIndices = typename CellIndexData< Dim , Dim >::template CellIndices< CellDim >;
+		using TreeNode = RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >;
+		using ConstOneRingNeighborKey = typename TreeNode::template ConstNeighborKey< IsotropicUIntPack< Dim , 1 > , IsotropicUIntPack< Dim , 1 > >;
+		using ConstNeighbors = typename TreeNode::template ConstNeighbors< IsotropicUIntPack< Dim , 3 > >;
+		using CellIndexData< Dim , Dim >::tables;
+		using CellIndexData< Dim , Dim >::size;
+		using CellIndexData< Dim , Dim >::resize;
+		using CellIndexData< Dim , Dim >::counts;
+
+		node_index_type nodeOffset;
+
+		FullCellIndexData( void ) : nodeOffset(0) {}
+
+		void read( BinaryStream &stream )
+		{
+			if( !stream.read( nodeOffset ) ) MK_THROW( "Failed to read node ofset" );
+			CellIndexData< Dim , MaxCellDim >::read( stream );
+		}
+
+		void write( BinaryStream &stream ) const
+		{
+			stream.write( nodeOffset );
+			CellIndexData< Dim , MaxCellDim >::write( stream );
+		}
+
+		void set( const SortedTreeNodes< Dim > &sNodes , int depth )
+		{
+			std::pair< node_index_type , node_index_type > span( sNodes.begin( depth ) , sNodes.end( depth ) );
+			nodeOffset = (size_t)span.first;
+			resize( (size_t)( span.second-span.first ) );
+			_scratch.resize( size() );
+
+			std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+			for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( depth );
+
+			// Try and get at the nodes outside of the slab through the neighbor key
+			ThreadPool::ParallelFor( sNodes.begin(depth) , sNodes.end(depth) , [&]( unsigned int thread , size_t i )
+				{
+					ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+					const TreeNode *node = sNodes.treeNodes[i];
+					ConstNeighbors &neighbors = neighborKey.getNeighbors( node );
+					_setProcess<0>( neighbors , _scratch.maps );
+				}
+			);
+
+			_setCounts<0>( _scratch.maps );
+			ThreadPool::ParallelFor( 0 , size() , [&]( unsigned int , size_t i ){ _setTables<0>( (unsigned int)i , _scratch.maps ); } );
+		}
+
+		// Maps from tree nodes (and their associated indices) to the associated indices for the cell indices
+		template< unsigned int CellDim >       CellIndices< CellDim > &indices( const TreeNode *node      )       { return std::get< CellDim >( tables )[ node->nodeData.nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim >       CellIndices< CellDim > &indices( node_index_type nodeIndex )       { return std::get< CellDim >( tables )[                nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim > const CellIndices< CellDim > &indices( const TreeNode *node      ) const { return std::get< CellDim >( tables )[ node->nodeData.nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim > const CellIndices< CellDim > &indices( node_index_type nodeIndex ) const { return std::get< CellDim >( tables )[                nodeIndex - nodeOffset ]; }
+
+	protected:
+		_Scratch< Dim , MaxCellDim > _scratch;
+
+		template< unsigned int CellDim >
+		void _setProcess( const ConstNeighbors& neighbors , Pointer( node_index_type ) maps[MaxCellDim+1] )
+		{
+			const TreeNode *node = neighbors.neighbors.data[ WindowIndex< IsotropicUIntPack< Dim , 3 > , IsotropicUIntPack< Dim , 1 > >::Index ];
+			node_index_type i = node->nodeData.nodeIndex;
+
+			// Iterate over the cells in the node
+			for( typename HyperCube::Cube< Dim >::template Element< CellDim > c ; c<HyperCube::Cube< Dim >::template ElementNum< CellDim >() ; c++ )
+			{
+				bool owner = true;
+
+				// The index of the node relative to the cell
+				typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > my_ic = HyperCubeTables< Dim , CellDim >::IncidentCube[c.index];
+
+				// Iterate over the nodes adjacent to the cell
+				for( typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > ic ; ic<HyperCube::Cube< Dim >::template IncidentCubeNum< CellDim >() ; ic++ )
+				{
+					// Get the index of node relative to the cell neighbors
+					unsigned int xx = HyperCubeTables< Dim , CellDim >::CellOffset[c.index][ic.index];
+					// If the neighbor exists and comes before, they own the corner
+					if( IsActiveNode< Dim >( neighbors.neighbors.data[xx] ) && ic<my_ic ){ owner = false ; break; }
+				}
+				if( owner )
+				{
+					node_index_type myCount = ( i - nodeOffset ) * HyperCube::Cube< Dim >::template ElementNum< CellDim >() + c.index;
+					maps[CellDim][ myCount ] = 1;
+					// Set the cell index for all nodes incident on the cell
+					for( typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > ic ; ic<HyperCube::Cube< Dim >::template IncidentCubeNum< CellDim >() ; ic++ )	// Iterate over the nodes adjacent to the cell
+					{
+						unsigned int xx = HyperCubeTables< Dim , CellDim >::CellOffset[c.index][ic.index];
+						// If the neighbor exits, sets its corner
+						if( IsActiveNode< Dim >( neighbors.neighbors.data[xx] ) ) this->template indices< CellDim >( neighbors.neighbors.data[xx] )[ HyperCubeTables< Dim , CellDim >::IncidentElementIndex[c.index][ic.index] ] = myCount;
+					}
+				}
+			}
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _setProcess< CellDim+1 >( neighbors , maps );
+		}
+
+		template< unsigned int CellDim >
+		void _setCounts( Pointer( node_index_type ) maps[MaxCellDim+1] )
+		{
+			node_index_type count = 0;
+			for( node_index_type i=0 ; i<(node_index_type)size() * (node_index_type)HyperCube::Cube< Dim >::template ElementNum< CellDim >() ; i++ )
+				if( maps[CellDim][i] ) maps[CellDim][i] = count++;
+			counts[ CellDim ] = count;
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _setCounts< CellDim+1 >( maps );
+		}
+
+		template< unsigned int CellDim >
+		void _setTables( unsigned int i , Pointer( node_index_type ) maps[MaxCellDim+1] )
+		{
+			for( unsigned int j=0 ; j<HyperCube::Cube< Dim >::template ElementNum< CellDim >() ; j++ )
+				std::get< CellDim >( tables )[i][j] = maps[CellDim][ std::get< CellDim >( tables )[i][j] ];
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _setTables< CellDim+1 >( i , maps );
+		}
+	};
+
+	////////////////////////
+	// SliceCellIndexData //
+	////////////////////////
+	// A data-struture that allows us to take a node adjacent to a slice together with a local cell index and returns the global cell's index
+	template< unsigned int Dim >
+	struct SliceCellIndexData : public CellIndexData< Dim-1 , Dim-1 >
+	{
+		static const unsigned int _Dim = Dim-1;
+		static const unsigned int MaxCellDim = CellIndexData< _Dim , _Dim >::MaxCellDim;
+		template< unsigned int CellDim > using CellIndices = typename CellIndexData< _Dim , _Dim >::template CellIndices< CellDim >;
+		using TreeNode = RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >;
+		using ConstOneRingNeighborKey = typename TreeNode::template ConstNeighborKey< IsotropicUIntPack< Dim , 1 > , IsotropicUIntPack< Dim , 1 > >;
+		using ConstNeighbors = typename TreeNode::template ConstNeighbors< IsotropicUIntPack< Dim , 3 > >;
+		using CellIndexData< _Dim , _Dim >::tables;
+		using CellIndexData< _Dim , _Dim >::size;
+		using CellIndexData< _Dim , _Dim >::resize;
+		using CellIndexData< _Dim , _Dim >::counts;
+
+		node_index_type nodeOffset;
+
+		SliceCellIndexData( void ) : nodeOffset(0) {}
+
+		void read( BinaryStream &stream )
+		{
+			if( !stream.read( nodeOffset ) ) MK_THROW( "Failed to read node ofset" );
+			CellIndexData< _Dim , _Dim >::read( stream );
+		}
+
+		void write( BinaryStream &stream ) const
+		{
+			stream.write( nodeOffset );
+			CellIndexData< _Dim , _Dim >::write( stream );
+		}
+
+		void set( const SortedTreeNodes< Dim > &sNodes , int depth , int slice )
+		{
+			std::pair< node_index_type , node_index_type > span( sNodes.begin( depth , slice-1 ) , sNodes.end( depth , slice ) );
+			nodeOffset = (size_t)span.first;
+			resize( (size_t)( span.second - span.first ) );
+			_scratch.resize( size() );
+
+			std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+			for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( depth );
+
+			// Try and get at the nodes outside of the slab through the neighbor key
+			ThreadPool::ParallelFor( sNodes.begin( depth , slice-1 ) , sNodes.end( depth , slice ) , [&]( unsigned int thread , size_t i )
+				{
+					ConstOneRingNeighborKey &neighborKey = neighborKeys[ thread ];
+					const TreeNode *node = sNodes.treeNodes[i];
+					ConstNeighbors &neighbors = neighborKey.getNeighbors( node );
+					_setProcess<0>( neighbors , i<(size_t)sNodes.end( depth , slice-1 ) , _scratch.maps );
+				}
+			);
+
+			_setCounts<0>( _scratch.maps );
+			ThreadPool::ParallelFor( 0 , size() , [&]( unsigned int , size_t i ){ _setTables<0>( (unsigned int)i , _scratch.maps ); } );
+		}
+
+		// Maps from tree nodes (and their associated indices) to the associated indices for the cell indices
+		template< unsigned int CellDim >       CellIndices< CellDim > &indices( const TreeNode *node      )       { return std::get< CellDim >( tables )[ node->nodeData.nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim >       CellIndices< CellDim > &indices( node_index_type nodeIndex )       { return std::get< CellDim >( tables )[                nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim > const CellIndices< CellDim > &indices( const TreeNode *node      ) const { return std::get< CellDim >( tables )[ node->nodeData.nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim > const CellIndices< CellDim > &indices( node_index_type nodeIndex ) const { return std::get< CellDim >( tables )[                nodeIndex - nodeOffset ]; }
+
+	protected:
+		_Scratch< _Dim , MaxCellDim > _scratch;
+
+		template< unsigned int CellDim >
+		void _setProcess( const ConstNeighbors& neighbors , bool fromBehind , Pointer( node_index_type ) maps[MaxCellDim+1] )
+		{
+			HyperCube::Direction dir = fromBehind ? HyperCube::FRONT : HyperCube::BACK;
+			const TreeNode *node = neighbors.neighbors.data[ WindowIndex< IsotropicUIntPack< Dim , 3 > , IsotropicUIntPack< Dim , 1 > >::Index ];
+			node_index_type i = node->nodeData.nodeIndex;
+
+			// Iterate over the cells in the face
+			for( typename HyperCube::Cube< _Dim >::template Element< CellDim > _c ; _c<HyperCube::Cube< _Dim >::template ElementNum< CellDim >() ; _c++ )
+			{
+				// Get the corresponding index of the cell in the node
+				typename HyperCube::Cube< Dim >::template Element< CellDim > c( dir , _c.index );
+
+				bool owner = true;
+
+				// The index of the node relative to the cell
+				typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > my_ic = HyperCubeTables< Dim , CellDim >::IncidentCube[c.index];
+
+				// Iterate over the nodes adjacent to the cell
+				for( typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > ic ; ic<HyperCube::Cube< Dim >::template IncidentCubeNum< CellDim >() ; ic++ )
+				{
+					// Get the index of node relative to the cell neighbors
+					unsigned int xx = HyperCubeTables< Dim , CellDim >::CellOffset[c.index][ic.index];
+					// If the neighbor exists and comes before, they own the corner
+					if( IsActiveNode< Dim >( neighbors.neighbors.data[xx] ) && ic<my_ic ){ owner = false ; break; }
+				}
+				if( owner )
+				{
+					node_index_type myCount = ( i - nodeOffset ) * HyperCube::Cube< _Dim >::template ElementNum< CellDim >() + _c.index;
+					maps[CellDim][ myCount ] = 1;
+					// Set the cell index for all nodes incident on the cell
+					for( typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > ic ; ic<HyperCube::Cube< Dim >::template IncidentCubeNum< CellDim >() ; ic++ )	// Iterate over the nodes adjacent to the cell
+					{
+						unsigned int xx = HyperCubeTables< Dim , CellDim >::CellOffset[c.index][ic.index];
+						// If the neighbor exits, sets its cell
+						if( IsActiveNode< Dim >( neighbors.neighbors.data[xx] ) ) this->template indices< CellDim >( neighbors.neighbors.data[xx] )[ HyperCubeTables< Dim , CellDim >::IncidentElementCoIndex[c.index][ic.index] ] = myCount;
+					}
+				}
+			}
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _setProcess< CellDim+1 >( neighbors , fromBehind , maps );
+		}
+
+		template< unsigned int CellDim >
+		void _setCounts( Pointer( node_index_type ) maps[MaxCellDim+1] )
+		{
+			node_index_type count = 0;
+			for( node_index_type i=0 ; i<(node_index_type)size() * (node_index_type)HyperCube::Cube< _Dim >::template ElementNum< CellDim >() ; i++ )
+				if( maps[CellDim][i] ) maps[CellDim][i] = count++;
+			counts[ CellDim ] = count;
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _setCounts< CellDim+1 >( maps );
+		}
+
+		template< unsigned int CellDim >
+		void _setTables( unsigned int i , Pointer( node_index_type ) maps[MaxCellDim+1] )
+		{
+			for( unsigned int j=0 ; j<HyperCube::Cube< _Dim >::template ElementNum< CellDim >() ; j++ )
+				std::get< CellDim >( tables )[i][j] = maps[CellDim][ std::get< CellDim >( tables )[i][j] ];
+
+			if constexpr( CellDim==MaxCellDim ) return;
+			else _setTables< CellDim+1 >( i , maps );
+		}
+	};
+
+	///////////////////////
+	// SlabCellIndexData //
+	///////////////////////
+	// A data-struture that allows us to take a node adjacent to together with a local cell index and returns the global cell's index
+	template< unsigned int Dim >
+	struct SlabCellIndexData : public CellIndexData< Dim-1 , Dim-1 >
+	{
+		static const unsigned int _Dim = Dim-1;
+		static const unsigned int _MaxCellDim = CellIndexData< _Dim , _Dim >::MaxCellDim;
+		template< unsigned int _CellDim > using CellIndices = typename CellIndexData< _Dim , _Dim >::template CellIndices< _CellDim >;
+		using TreeNode = RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >;
+		using ConstOneRingNeighborKey = typename TreeNode::template ConstNeighborKey< IsotropicUIntPack< Dim , 1 > , IsotropicUIntPack< Dim , 1 > >;
+		using ConstNeighbors = typename TreeNode::template ConstNeighbors< IsotropicUIntPack< Dim , 3 > >;
+		using CellIndexData< _Dim , _Dim >::tables;
+		using CellIndexData< _Dim , _Dim >::size;
+		using CellIndexData< _Dim , _Dim >::resize;
+		using CellIndexData< _Dim , _Dim >::counts;
+
+		node_index_type nodeOffset;
+
+		SlabCellIndexData( void ) : nodeOffset(0) {}
+
+		void read( BinaryStream &stream )
+		{
+			if( !stream.read( nodeOffset ) ) MK_THROW( "Failed to read node ofset" );
+			CellIndexData< _Dim , _Dim >::read( stream );
+		}
+
+		void write( BinaryStream &stream ) const
+		{
+			stream.write( nodeOffset );
+			CellIndexData< _Dim , _Dim >::write( stream );
+		}
+
+		void set( const SortedTreeNodes< Dim > &sNodes , int depth , int slab )
+		{
+			std::pair< node_index_type , node_index_type > span( sNodes.begin( depth , slab ) , sNodes.end( depth , slab ) );
+			nodeOffset = (size_t)span.first;
+			resize( (size_t)( span.second - span.first ) );
+			_scratch.resize( size() );
+
+			std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+			for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( depth );
+
+			// Try and get at the nodes outside of the slab through the neighbor key
+			ThreadPool::ParallelFor( sNodes.begin( depth , slab ) , sNodes.end( depth , slab ) , [&]( unsigned int thread , size_t i )
+				{
+					ConstOneRingNeighborKey &neighborKey = neighborKeys[ thread ];
+					const TreeNode *node = sNodes.treeNodes[i];
+					ConstNeighbors &neighbors = neighborKey.getNeighbors( node );
+					_setProcess<0>( neighbors , _scratch.maps );
+				}
+			);
+
+			_setCounts<0>( _scratch.maps );
+			ThreadPool::ParallelFor( 0 , size() , [&]( unsigned int , size_t i ){ _setTables<0>( (unsigned int)i , _scratch.maps ); } );
+		}
+
+		// Maps from tree nodes (and their associated indices) to the associated indices for the cell indices
+		template< unsigned int CellDim >       CellIndices< CellDim > &indices( const TreeNode *node      )       { return std::get< CellDim >( tables )[ node->nodeData.nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim >       CellIndices< CellDim > &indices( node_index_type nodeIndex )       { return std::get< CellDim >( tables )[                nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim > const CellIndices< CellDim > &indices( const TreeNode *node      ) const { return std::get< CellDim >( tables )[ node->nodeData.nodeIndex - nodeOffset ]; }
+		template< unsigned int CellDim > const CellIndices< CellDim > &indices( node_index_type nodeIndex ) const { return std::get< CellDim >( tables )[                nodeIndex - nodeOffset ]; }
+
+	protected:
+		_Scratch< _Dim , _MaxCellDim > _scratch;
+
+
+		template< unsigned int _CellDim >
+		void _setProcess( const ConstNeighbors& neighbors , Pointer( node_index_type ) maps[_MaxCellDim+1] )
+		{
+			static const unsigned int CellDim = _CellDim+1;
+			const TreeNode *node = neighbors.neighbors.data[ WindowIndex< IsotropicUIntPack< Dim , 3 > , IsotropicUIntPack< Dim , 1 > >::Index ];
+			node_index_type i = node->nodeData.nodeIndex;
+
+			// Iterate over the cells in the face
+			for( typename HyperCube::Cube< _Dim >::template Element< _CellDim > _c ; _c<HyperCube::Cube< _Dim >::template ElementNum< _CellDim >() ; _c++ )
+			{
+				// Get the index of the extruded cell
+				typename HyperCube::Cube< Dim >::template Element< CellDim > c( HyperCube::CROSS , _c.index );
+				bool owner = true;
+
+				// The index of the node relative to the extruded cell
+				typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > my_ic = HyperCubeTables< Dim , CellDim >::IncidentCube[c.index];
+
+				// Iterate over the nodes adjacent to the cell
+				for( typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > ic ; ic<HyperCube::Cube< Dim >::template IncidentCubeNum< CellDim >() ; ic++ )
+				{
+					// Get the index of node relative to the cell neighbors
+					unsigned int xx = HyperCubeTables< Dim , CellDim >::CellOffset[c.index][ic.index];
+					// If the neighbor exists and comes before, they own the corner
+					if( IsActiveNode< Dim >( neighbors.neighbors.data[xx] ) && ic<my_ic ){ owner = false ; break; }
+				}
+				if( owner )
+				{
+					node_index_type myCount = ( i - nodeOffset ) * HyperCube::Cube< _Dim >::template ElementNum< _CellDim >() + _c.index;
+					maps[_CellDim][ myCount ] = 1;
+					// Set the cell index for all nodes incident on the cell
+					for( typename HyperCube::Cube< Dim >::template IncidentCubeIndex< CellDim > ic ; ic<HyperCube::Cube< Dim >::template IncidentCubeNum< CellDim >() ; ic++ )	// Iterate over the nodes adjacent to the cell
+					{
+						unsigned int xx = HyperCubeTables< Dim , CellDim >::CellOffset[c.index][ic.index];
+						// If the neighbor exits, sets its cell
+						if( IsActiveNode< Dim >( neighbors.neighbors.data[xx] ) )
+							this->template indices< _CellDim >( neighbors.neighbors.data[xx] )[ HyperCubeTables< Dim , CellDim >::IncidentElementCoIndex[c.index][ic.index] ] = myCount;
+					}
+				}
+			}
+
+			if constexpr( _CellDim==_MaxCellDim ) return;
+			else _setProcess< _CellDim+1 >( neighbors , maps );
+		}
+
+		template< unsigned int _CellDim >
+		void _setCounts( Pointer( node_index_type ) maps[_MaxCellDim+1] )
+		{
+			node_index_type count = 0;
+			for( node_index_type i=0 ; i<(node_index_type)size() * (node_index_type)HyperCube::Cube< _Dim >::template ElementNum< _CellDim >() ; i++ )
+				if( maps[_CellDim][i] ) maps[_CellDim][i] = count++;
+			counts[ _CellDim ] = count;
+
+			if constexpr( _CellDim==_MaxCellDim ) return;
+			else _setCounts< _CellDim+1 >( maps );
+		}
+
+		template< unsigned int _CellDim >
+		void _setTables( unsigned int i , Pointer( node_index_type ) maps[_MaxCellDim+1] )
+		{
+			for( unsigned int j=0 ; j<HyperCube::Cube< _Dim >::template ElementNum< _CellDim >() ; j++ )
+				std::get< _CellDim >( tables )[i][j] = maps[_CellDim][ std::get< _CellDim >( tables )[i][j] ];
+
+			if constexpr( _CellDim==_MaxCellDim ) return;
+			else _setTables< _CellDim+1 >( i , maps );
+		}
+	};
+
+	//////////////////
+	// KeyGenerator //
+	//////////////////
+	template< unsigned int Dim >
+	struct KeyGenerator
+	{
+		KeyGenerator( int maxDepth ) : _maxDepth(maxDepth){}
+
+		template< unsigned int CellDim >
+		Key< Dim > operator()( int depth , const int offset[Dim] , typename HyperCube::Cube< Dim >::template Element< CellDim > e ) const
+		{
+			static_assert( ( CellDim<=Dim ) , "[ERROR] Cell dimension cannot exceed total dimension" );
+			Key< Dim > key;
+			const HyperCube::Direction* x = HyperCubeTables< Dim , CellDim >::Directions[ e.index ];
+			for( int dd=0 ; dd<Dim ; dd++ ) key[dd] = index( depth , offset[dd] , x[dd] );
+			return key;
+		}
+
+		Key< Dim > operator()( int depth , int offset , Key< Dim-1 > key ) const
+		{
+			Key< Dim > pKey;
+			if( depth>_maxDepth ) MK_THROW( "Depth cannot exceed max depth: " , depth , " <= " , _maxDepth );
+			for( unsigned int d=0 ; d<Dim-1 ; d++ ) pKey[d] = key[d];
+			pKey[Dim-1] = cornerIndex( depth , offset );
+			return pKey;
+		}
+
+		// The corner indices are divisible by 4
+		unsigned int cornerIndex( unsigned int depth , unsigned int offset ) const { return offset<<( _maxDepth+2-depth); }
+		// The edge indices are odd
+		unsigned int   edgeIndex( unsigned int depth , unsigned int offset ) const { return ( cornerIndex(depth,offset) + cornerIndex(depth,offset+1) )/2+1; }
+		unsigned int       index( unsigned int depth , unsigned int offset , HyperCube::Direction dir ) const
+		{
+			return dir==HyperCube::CROSS ? edgeIndex( depth , offset ) : cornerIndex( depth , offset + ( dir==HyperCube::BACK ? 0 : 1 ) );
+		}
+
+		std::string to_string( Key< Dim > key ) const
+		{
+			std::stringstream stream;
+			stream << "(";
+			for( unsigned int d=0 ; d<Dim ; d++ )
+			{
+				if( d ) stream << ",";
+				if( key[d]&1 )	// If it's odd, it will be an edge
+				{
+					unsigned int depth = _maxDepth;
+					key[d]>>=1;
+					while( !(key[d]&1) ) depth-- , key[d]>>=1;
+					stream << "[" << (((key[d]-1)/2)<<(_maxDepth-depth)) << "," << (((key[d]+1)/2)<<(_maxDepth-depth)) << "]";
+				}
+				else stream << (key[d]>>2);
+			}
+			stream << ")/" << (1<<_maxDepth);
+			return stream.str();
+		}
+
+		int maxDepth( void ) const { return _maxDepth; }
+
+	protected:
+		int _maxDepth;
+	};
+
+	template< unsigned int D , unsigned int K >
+	unsigned int HyperCubeTables< D , K >::CellOffset[ ElementNum ][ IncidentCubeNum ];
+	template< unsigned int D , unsigned int K >
+	unsigned int HyperCubeTables< D , K >::IncidentElementCoIndex[ ElementNum ][ IncidentCubeNum ];
+	template< unsigned int D , unsigned int K >
+	unsigned int HyperCubeTables< D , K >::IncidentElementIndex[ ElementNum ][ IncidentCubeNum ];
+	template< unsigned int D , unsigned int K >
+	unsigned int HyperCubeTables< D , K >::CellOffsetAntipodal[ ElementNum ];
+	template< unsigned int D , unsigned int K >
+	typename HyperCube::Cube< D >::template IncidentCubeIndex < K > HyperCubeTables< D , K >::IncidentCube[ ElementNum ];
+	template< unsigned int D , unsigned int K >
+	typename HyperCube::Direction HyperCubeTables< D , K >::Directions[ ElementNum ][ D ];
+	template< unsigned int D , unsigned int K1 , unsigned int K2 >
+	typename HyperCube::Cube< D >::template Element< K2 > HyperCubeTables< D , K1 , K2 >::OverlapElements[ ElementNum1 ][ OverlapElementNum ];
+	template< unsigned int D , unsigned int K1 , unsigned int K2 >
+	bool HyperCubeTables< D , K1 , K2 >::Overlap[ ElementNum1 ][ ElementNum2 ];
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.SortedTreeNodes.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.SortedTreeNodes.inl
@@ -1,0 +1,167 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+/////////////////////
+// SortedTreeNodes //
+/////////////////////
+template< unsigned int Dim >
+SortedTreeNodes< Dim >::SortedTreeNodes( void )
+{
+	_sliceStart = NullPointer( Pointer( node_index_type ) );
+	treeNodes = NullPointer( TreeNode* );
+	_levels = 0;
+}
+
+template< unsigned int Dim >
+SortedTreeNodes< Dim >::~SortedTreeNodes( void )
+{
+	if( _sliceStart ) for( int d=0 ; d<_levels ; d++ ) FreePointer( _sliceStart[d] );
+	FreePointer( _sliceStart );
+	DeletePointer( treeNodes );
+}
+
+template< unsigned int Dim >
+void SortedTreeNodes< Dim >::write( BinaryStream &stream ) const
+{
+	stream.write( _levels );
+	for( int l=0 ; l<_levels ; l++ )
+	{
+		size_t sz = ((size_t)1<<l)+1;
+		stream.write( _sliceStart[l] , sz );
+	}
+}
+
+template< unsigned int Dim >
+void SortedTreeNodes< Dim >::read( BinaryStream &stream , TreeNode &root )
+{
+	for( int l=0 ; l<_levels ; l++ ) FreePointer( _sliceStart[l] );
+	FreePointer( _sliceStart );
+	DeletePointer( treeNodes );
+
+	_levels = 0;
+	_sliceStart = NullPointer( Pointer( node_index_type ) );
+	treeNodes = NullPointer( TreeNode* );
+
+	if( !stream.read( _levels ) ) MK_THROW( "Failed to read levels" );
+	if( _levels )
+	{
+		_sliceStart = AllocPointer< Pointer( node_index_type ) >( _levels );
+		for( int l=0 ; l<_levels ; l++ )
+		{
+			size_t sz = ((size_t)1<<l)+1;
+			_sliceStart[l] = AllocPointer< node_index_type >( sz );
+			if( !stream.read( _sliceStart[l] , sz ) ) MK_THROW( "Failed to read slices at level: " , l );
+		}
+
+		size_t sz = _sliceStart[_levels-1][(size_t)1<<(_levels-1)];
+		treeNodes = NewPointer< TreeNode* >( sz );
+		auto nodeFunctor = [&]( TreeNode *n ){ 	if( n->nodeData.nodeIndex>=0 && n->nodeData.nodeIndex<(node_index_type)sz ) treeNodes[ n->nodeData.nodeIndex ] = n; };
+		root.processNodes( nodeFunctor );
+	}
+}
+
+template< unsigned int Dim >
+void SortedTreeNodes< Dim >::reset( TreeNode& root , std::vector< node_index_type > &map )
+{
+	_set( root );
+	map.resize( _sliceStart[_levels-1][(size_t)1<<(_levels-1)] , -1 );
+	for( node_index_type i=0 ; i<_sliceStart[_levels-1][(size_t)1<<(_levels-1)] ; i++ )
+	{
+		if( treeNodes[i]->nodeData.nodeIndex>=0 ) map[i] = treeNodes[i]->nodeData.nodeIndex;
+		treeNodes[i]->nodeData.nodeIndex = i;
+	}}
+
+template< unsigned int Dim >
+void SortedTreeNodes< Dim >::set( TreeNode& root )
+{
+	_set( root );
+	for( node_index_type i=0 ; i<_sliceStart[_levels-1][(size_t)1<<(_levels-1)] ; i++ ) treeNodes[i]->nodeData.nodeIndex = i;
+}
+
+template< unsigned int Dim >
+void SortedTreeNodes< Dim >::_set( TreeNode& root )
+{
+	if( _sliceStart ) for( int d=0 ; d<_levels ; d++ ) FreePointer( _sliceStart[d] );
+	FreePointer( _sliceStart );
+	DeletePointer( treeNodes );
+	_levels = root.maxDepth()+1;
+
+	_sliceStart = AllocPointer< Pointer( node_index_type ) >( _levels );
+	for( int l=0 ; l<_levels ; l++ )
+	{
+		_sliceStart[l] = AllocPointer< node_index_type >( ((size_t)1<<l)+1 );
+		memset( _sliceStart[l] , 0 , sizeof(node_index_type)*( ((size_t)1<<l)+1 ) );
+	}
+
+	// Count the number of nodes in each slice
+	auto nodeFunctor = [&]( TreeNode *node )
+	{
+		if( !GetGhostFlag< Dim >( node ) )
+		{
+			int d , off[Dim];
+			node->depthAndOffset( d , off );
+			_sliceStart[d][ off[Dim-1]+1 ]++;
+		}
+	};
+	root.processNodes( nodeFunctor );
+
+	// Get the start index for each slice
+	{
+		node_index_type levelOffset = 0;
+		for( int l=0 ; l<_levels ; l++ )
+		{
+			_sliceStart[l][0] = levelOffset;
+			for( int s=0 ; s<((size_t)1<<l); s++ ) _sliceStart[l][s+1] += _sliceStart[l][s];
+			levelOffset = _sliceStart[l][(size_t)1<<l];
+		}
+	}
+	// Allocate memory for the tree nodes
+	treeNodes = NewPointer< TreeNode* >( _sliceStart[_levels-1][(size_t)1<<(_levels-1)] );
+
+	// Add the tree nodes
+	{
+		auto nodeFunctor = [&]( TreeNode *node )
+		{
+			if( !GetGhostFlag< Dim >( node ) )
+			{
+				int d , off[Dim];
+				node->depthAndOffset( d , off );
+				treeNodes[ _sliceStart[d][ off[Dim-1] ]++ ] = node;
+			}
+		};
+		root.processNodes( nodeFunctor );
+	}
+
+	// Shift the slice offsets up since we incremented as we added
+	for( int l=0 ; l<_levels ; l++ )
+	{
+		for( int s=(1<<l) ; s>0 ; s-- ) _sliceStart[l][s] = _sliceStart[l][s-1];
+		_sliceStart[l][0] = l>0 ? _sliceStart[l-1][(size_t)1<<(l-1)] : 0;
+	}
+}
+

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.System.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.System.inl
@@ -1,0 +1,3484 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+///////////////////////////////////
+// BaseFEMIntegrator::Constraint //
+///////////////////////////////////
+template< unsigned int ... TDegrees , unsigned int ... CDegrees , unsigned int CDim >
+template< bool IterateFirst >
+void BaseFEMIntegrator::Constraint< UIntPack< TDegrees ... > , UIntPack< CDegrees ... > , CDim >::setStencil( CCStencil & stencil ) const
+{
+	static const int Dim = sizeof ... ( TDegrees );
+	int center = ( 1<<_highDepth )>>1;
+	int femOffset[Dim] , cOffset[Dim];
+	static const int overlapStart[] = { ( IterateFirst ? BSplineOverlapSizes< CDegrees , TDegrees >::OverlapStart : BSplineOverlapSizes< TDegrees , CDegrees >::OverlapStart ) ... };
+	if( IterateFirst )
+	{
+		for( int d=0 ; d<Dim ; d++ ) cOffset[d] = center;
+		WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , UIntPack< BSplineOverlapSizes< TDegrees , CDegrees >::OverlapSize ... >() , [&]( int d , int i ){ femOffset[d] = i + center + overlapStart[d]; } , [&]( Point< double , CDim >& p ){ p = ccIntegrate( femOffset , cOffset ); } , stencil() );
+	}
+	else
+	{
+		for( int d=0 ; d<Dim ; d++ ) femOffset[d] = center;
+		WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , UIntPack< BSplineOverlapSizes< TDegrees , CDegrees >::OverlapSize ... >() , [&]( int d , int i ){   cOffset[d] = i + center + overlapStart[d]; } , [&]( Point< double , CDim >& p ){ p = ccIntegrate( femOffset , cOffset );} , stencil() );
+	}
+}
+template< unsigned int ... TDegrees , unsigned int ... CDegrees , unsigned int CDim >
+template< bool IterateFirst >
+void BaseFEMIntegrator::Constraint< UIntPack< TDegrees ... > , UIntPack< CDegrees ... > , CDim >::setStencils( PCStencils& stencils ) const
+{
+	static const int Dim = sizeof ... ( TDegrees );
+	typedef UIntPack< BSplineOverlapSizes< TDegrees, CDegrees >::OverlapSize ... > OverlapSizes;
+	// [NOTE] We want the center to be at the first node of the brood, which is not the case when childDepth is 1.
+	int center = ( 1<<_highDepth )>>1 ; center = ( center>>1 )<<1;	
+	int fineCenter[Dim] , femOffset[Dim] , cOffset[Dim];
+	static const int overlapStart[] = { ( IterateFirst ? BSplineOverlapSizes< CDegrees , TDegrees >::OverlapStart : BSplineOverlapSizes< TDegrees , CDegrees >::OverlapStart ) ... };
+	std::function< void ( int , int )               > outerUpdateState = [&]( int d , int i ){ fineCenter[Dim-d-1] = i+center; };
+	std::function< void ( Point< double , CDim >& ) > innerFunction    = [&]( Point< double , CDim >& p ){ p = pcIntegrate( femOffset , cOffset ); };
+	std::function< void ( int , int )               > innerUpdateState = [&]( int d , int i ){ femOffset[d] = IterateFirst ? (i+center/2+overlapStart[d]) : center/2 , cOffset[d] = IterateFirst ? fineCenter[d] : (i+fineCenter[d]+overlapStart[d]); };
+	std::function< void ( CCStencil& )              > outerFunction    = [&]( CCStencil& s )
+	{
+		WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , OverlapSizes() , innerUpdateState , innerFunction , s() );
+	};
+	WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , IsotropicUIntPack< Dim , 2 >() , outerUpdateState , outerFunction , stencils() );
+}
+template< unsigned int ... TDegrees , unsigned int ... CDegrees , unsigned int CDim >
+template< bool IterateFirst >
+void BaseFEMIntegrator::Constraint< UIntPack< TDegrees ... > , UIntPack< CDegrees ... > , CDim >::setStencils( CPStencils& stencils ) const
+{
+	static const int Dim = sizeof ... ( TDegrees );
+	typedef UIntPack< BSplineOverlapSizes< TDegrees , CDegrees >::OverlapSize ... > OverlapSizes;
+	// [NOTE] We want the center to be at the first node of the brood, which is not the case when childDepth is 1.
+	int center = ( 1<<_highDepth )>>1 ; center = ( center>>1 )<<1;
+	static const int overlapStart[] = { ( IterateFirst ? BSplineOverlapSizes< CDegrees , TDegrees >::OverlapStart : BSplineOverlapSizes< TDegrees , CDegrees >::OverlapStart ) ... };
+	int fineCenter[Dim] , femOffset[Dim] , cOffset[Dim];
+	std::function< void ( int , int )               > outerUpdateState = [&]( int d , int i ){ fineCenter[Dim-d-1] = i+center; };
+	std::function< void ( Point< double , CDim >& ) > innerFunction    = [&]( Point< double , CDim >& p ){ p = cpIntegrate( femOffset , cOffset ); };
+	std::function< void ( int , int )               > innerUpdateState = [&]( int d , int i ){ femOffset[d] = IterateFirst ? (i+fineCenter[d]+overlapStart[d]) : fineCenter[d] , cOffset[d] = IterateFirst ? center/2 : (i+center/2+overlapStart[d]); };
+	std::function< void ( CCStencil& )              > outerFunction    = [&]( CCStencil& s )
+	{
+		WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , OverlapSizes() , innerUpdateState , innerFunction , s() );
+	};
+	WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , IsotropicUIntPack< Dim , 2 >() , outerUpdateState , outerFunction , stencils() );
+}
+
+///////////////////////////////
+// BaseFEMIntegrator::System //
+///////////////////////////////
+template< unsigned int ... TDegrees >
+template< bool IterateFirst >
+void BaseFEMIntegrator::System< UIntPack< TDegrees ... > >::setStencil( CCStencil & stencil ) const
+{
+	static const int Dim = sizeof ... ( TDegrees );
+	int center = ( 1<<_highDepth )>>1;
+	int offset1[Dim] , offset2[Dim];
+	static const int overlapStart[] = { BSplineOverlapSizes< TDegrees , TDegrees >::OverlapStart ... };
+	if( IterateFirst )
+	{
+		for( int d=0 ; d<Dim ; d++ ) offset2[d] = center;
+		WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , UIntPack< BSplineOverlapSizes< TDegrees , TDegrees >::OverlapSize ... >() , [&]( int d , int i ){ offset1[d] = i + center + overlapStart[d]; } , [&]( double& v ){ v = ccIntegrate( offset1 , offset2 ); } , stencil() );
+	}
+	else
+	{
+		for( int d=0 ; d<Dim ; d++ ) offset1[d] = center;
+		WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , UIntPack< BSplineOverlapSizes< TDegrees , TDegrees >::OverlapSize ... >() , [&]( int d , int i ){ offset2[d] = i + center + overlapStart[d]; } , [&]( double& v ){ v = ccIntegrate( offset1 , offset2 ); } , stencil() );
+	}
+}
+template< unsigned int ... TDegrees >
+template< bool IterateFirst >
+void BaseFEMIntegrator::System< UIntPack< TDegrees ... > >::setStencils( PCStencils& stencils ) const
+{
+	static const int Dim = sizeof ... ( TDegrees );
+	typedef UIntPack< BSplineOverlapSizes< TDegrees , TDegrees >::OverlapSize ... > OverlapSizes;
+	// [NOTE] We want the center to be at the first node of the brood
+	// Which is not the case when childDepth is 1.
+	int center = ( 1<<_highDepth )>>1 ; center = ( center>>1 )<<1;
+	static const int overlapStart[] = { BSplineOverlapSizes< TDegrees , TDegrees >::OverlapStart ... };
+	int fineCenter[Dim] , offset1[Dim] , offset2[Dim];
+	std::function< void ( int , int )  > outerUpdateState = [&]( int d , int i ){ fineCenter[Dim-d-1] = i+center; };
+	std::function< void ( double& )    > innerFunction    = [&]( double& v ){ v = pcIntegrate( offset1 , offset2 ); };
+	std::function< void ( int , int )  > innerUpdateState = [&]( int d , int i ){ offset1[d] = IterateFirst ? (i+center/2+overlapStart[d]) : center/2 , offset2[d] = IterateFirst ? fineCenter[d] : (i+fineCenter[d]+overlapStart[d]); };
+	std::function< void ( CCStencil& ) > outerFunction    = [&]( CCStencil& s )
+	{
+		WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , OverlapSizes() , innerUpdateState , innerFunction , s() );
+	};
+	WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , IsotropicUIntPack< Dim , 2 >() , outerUpdateState , outerFunction , stencils() );
+}
+/////////////////////////////////
+// BaseFEMIntegrator::UpSample //
+/////////////////////////////////
+template< unsigned int ... TDegrees >
+void BaseFEMIntegrator::RestrictionProlongation< UIntPack< TDegrees ... > >::setStencil( UpSampleStencil & stencil ) const
+{
+	static constexpr int Dim = sizeof ... ( TDegrees );
+	int highCenter = ( 1<<_highDepth )>>1;
+	int pOff[Dim] , cOff[Dim];
+	static const int upSampleStart[] = { BSplineSupportSizes< TDegrees >::UpSampleStart ... };
+	for( int d=0 ; d<Dim ; d++ ) pOff[d] = highCenter/2;
+	WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , UIntPack< BSplineSupportSizes< TDegrees >::UpSampleSize ... >() , [&]( int d , int i ){ cOff[d] = i + highCenter + upSampleStart[d]; } , [&]( double& v ){ v = upSampleCoefficient( pOff , cOff ); } , stencil() );
+}
+template< unsigned int ... TDegrees >
+void BaseFEMIntegrator::RestrictionProlongation< UIntPack< TDegrees ... > >::setStencils( DownSampleStencils& stencils ) const
+{
+	static constexpr int Dim = sizeof ... ( TDegrees );
+	// [NOTE] We want the center to be at the first node of the brood, which is not the case when childDepth is 1.
+	int highCenter = ( 1<<_highDepth )>>1 ; highCenter = ( highCenter>>1 )<<1;	
+	int pOff[Dim] , cOff[Dim];
+	static const int offsets[] = { BSplineSupportSizes< TDegrees >::DownSample0Start ... };
+	std::function< void ( double& )            > innerFunction    = [&]( double& v ){ v = upSampleCoefficient( pOff , cOff ); };
+	std::function< void ( int , int )          > innerUpdateState = [&]( int d , int i ){ pOff[d] = cOff[d]/2 + i + offsets[d]; };
+	std::function< void ( int , int )          > outerUpdateState = [&]( int d , int i ){ cOff[Dim-d-1] = i+highCenter; };
+	std::function< void ( DownSampleStencil& ) > outerFunction    = [&]( DownSampleStencil& s )
+	{
+		WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , UIntPack< ( - BSplineSupportSizes< TDegrees >::DownSample0Start + BSplineSupportSizes< TDegrees >::DownSample1End + 1 ) ... >() , innerUpdateState , innerFunction , s() );
+	};
+	WindowLoop< Dim >::Run( IsotropicUIntPack< Dim , 0 >() , IsotropicUIntPack< Dim , 2 >() , outerUpdateState , outerFunction , stencils() );
+}
+
+///////////////////////////////
+// FEMIntegrator::Constraint //
+///////////////////////////////
+
+template< unsigned int ... TSignatures , unsigned int ... TDerivatives , unsigned int ... CSignatures , unsigned int ... CDerivatives , unsigned int CDim >
+Point< double , CDim > FEMIntegrator::Constraint< UIntPack< TSignatures ... > , UIntPack< TDerivatives ... > , UIntPack< CSignatures ... > , UIntPack< CDerivatives ... > , CDim >::_integrate( IntegrationType iType , const int off1[] , const int off2[] ) const
+{
+	Point< double , CDim > integral;
+	for( unsigned int i=0 ; i<_weightedIndices.size() ; i++ )
+	{
+		const _WeightedIndices& w = _weightedIndices[i];
+		unsigned int _d1[Dim] , _d2[Dim];
+		TFactorDerivatives( w.d1 , _d1 );
+		CFactorDerivatives( w.d2 , _d2 );
+		double __integral = _integral( iType , off1 , off2 , _d1 , _d2 );
+		for( unsigned int j=0 ; j<w.indices.size() ; j++ ) integral[ w.indices[j].first ] += w.indices[j].second * __integral;
+	}
+	return integral;
+}
+
+#ifndef PR_MODULO
+#define PR_MODULO( a , b ) ( (a)>0 ? (a) % (b) : ( (b) - ( -(a) % (b) ) ) % (b) )
+#endif // PR_MODULO
+
+/////////////
+// FEMTree //
+/////////////
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs >
+void FEMTree< Dim , Real >::setMultiColorIndices( UIntPack< FEMSigs ... > , int depth , std::vector< std::vector< size_t > >& indices ) const
+{
+	_setMultiColorIndices( UIntPack< FEMSigs ... >() , _sNodesBegin(depth) , _sNodesEnd(depth) , indices );
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs >
+void FEMTree< Dim , Real >::_setMultiColorIndices( UIntPack< FEMSigs ... > , node_index_type start , node_index_type end , std::vector< std::vector< size_t > >& indices ) const
+{
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	typedef UIntPack< ( 1 - BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree , FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > Moduli;
+	static const unsigned int Colors = WindowSize< Moduli >::Size;
+	indices.resize( Colors );
+	struct ColorCount
+	{
+		size_t count[ Colors ];
+		ColorCount( void ){ memset( count , 0 , sizeof(count) ); }
+	};
+	std::vector< ColorCount > counts( ThreadPool::NumThreads() );
+	size_t count[ Colors ];
+	memset( count , 0 , sizeof(count) );
+	auto MCIndex = [&] ( const FEMTreeNode* node )
+	{
+		LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node , d , off );
+		int index = 0;
+		for( int dd=0 ; dd<Dim ; dd++ ) index = index * Moduli::Values[Dim-dd-1] + PR_MODULO( off[Dim-dd-1] , Moduli::Values[Dim-dd-1] );
+		return index;
+	};
+	ThreadPool::ParallelFor( start , end , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+		{
+			int idx = MCIndex( _sNodes.treeNodes[i] );
+			counts[thread].count[idx]++;
+		}
+	}
+	);
+	for( size_t t=0 ; t<counts.size() ; t++ ) for( int i=0 ; i<Colors ; i++) count[i] += counts[t].count[i];
+
+	for( int i=0 ; i<Colors ; i++ ) indices[i].reserve( count[i] ) , count[i]=0;
+
+	for( node_index_type i=start ; i<end ; i++ ) if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+	{
+		int idx = MCIndex( _sNodes.treeNodes[i] );
+		indices[idx].push_back( i - start );
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , typename TDotT , typename SORWeights , typename ... InterpolationInfos >
+int FEMTree< Dim , Real >::_solveFullSystemGS( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , Pointer( T ) solution , ConstPointer( T ) prolongedSolution , ConstPointer( T ) constraints , TDotT Dot , int iters , bool coarseToFine , SORWeights sorWeights , _SolverStats& stats , bool computeNorms , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	double& systemTime = stats.systemTime;
+	double&  solveTime = stats. solveTime;
+	systemTime = solveTime = 0.;
+
+	CCStencil< UIntPack< FEMSignature< FEMSigs >::Degree ... > > ccStencil;
+	PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > > pcStencils;
+	F.template setStencil< false >( ccStencil );
+	F.template setStencils< true >( pcStencils );
+	double bNorm=0 , inRNorm=0 , outRNorm=0;
+	if( depth>=0 )
+	{
+		SystemMatrixType< FEMSigs ... > M;
+		double t = Time();
+		Pointer( Real ) D = AllocPointer< Real >( _sNodesEnd( depth ) - _sNodesBegin( depth ) );
+		Pointer( T ) _constraints = AllocPointer< T >( _sNodesSize( depth ) );
+		_getSliceMatrixAndProlongationConstraints( UIntPack< FEMSigs ... >() , F , M , D , bsData , depth , _sNodesBegin( depth ) , _sNodesEnd( depth ) , prolongedSolution , _constraints , ccStencil , pcStencils , interpolationInfos );
+		ThreadPool::ParallelFor( _sNodesBegin(depth) , _sNodesEnd(depth) , [&]( unsigned int , size_t i ){ _constraints[ i - _sNodesBegin(depth) ] = constraints[ _sNodes.treeNodes[i]->nodeData.nodeIndex ] - _constraints[ i - _sNodesBegin(depth) ]; } );
+		{
+			node_index_type begin = _sNodesBegin( depth ) , end = _sNodesEnd( depth );
+			for( node_index_type i=begin ; i<end ; i++ ) if( M.rowSize( i-begin ) ) D[i-begin] *= sorWeights[i];
+		}
+
+		systemTime += Time()-t;
+		// The list of multi-colored indices  for each in-memory slice
+		std::vector< std::vector< size_t > > mcIndices;
+		_setMultiColorIndices( UIntPack< FEMSigs ... >() , _sNodesBegin( depth ) , _sNodesEnd( depth ) , mcIndices );
+
+		ConstPointer( T ) B = _constraints;
+		Pointer( T ) X = GetPointer( &solution[0] + _sNodesBegin( depth ) , _sNodesSize( depth ) );
+		if( computeNorms )
+		{
+			std::vector< double > bNorms( ThreadPool::NumThreads() , 0 ) , inRNorms( ThreadPool::NumThreads() , 0 );
+			ThreadPool::ParallelFor( 0 , M.rows() , [&]( unsigned int thread , size_t j )
+			{
+				T temp = {};
+				ConstPointer( MatrixEntry< Real , matrix_index_type > ) start = M[j];
+				ConstPointer( MatrixEntry< Real , matrix_index_type > ) end = start + M.rowSize(j);
+				ConstPointer( MatrixEntry< Real , matrix_index_type > ) e;
+				for( e=start ; e!=end ; e++ ) temp += X[ e->N ] * e->Value;
+				bNorms[thread] += Dot( B[j] , B[j] );
+				inRNorms[thread] += Dot( temp - B[j] , temp - B[j] );
+			}
+			);
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) bNorm += bNorms[t] , inRNorm += inRNorms[t];
+		}
+
+		t = Time();
+		for( int i=0 ; i<iters ; i++ ) M.gsIteration( mcIndices , ( ConstPointer( Real ) )D , B , X , coarseToFine , true );
+		FreePointer( D );
+		solveTime += Time() - t;
+
+		if( computeNorms )
+		{
+			std::vector< double > outRNorms( ThreadPool::NumThreads() , 0 );
+			ThreadPool::ParallelFor( 0 , M.rows() , [&]( unsigned int thread , size_t j )
+			{
+				T temp = {};
+				ConstPointer( MatrixEntry< Real , matrix_index_type > ) start = M[j];
+				ConstPointer( MatrixEntry< Real , matrix_index_type > ) end = start + M.rowSize(j);
+				ConstPointer( MatrixEntry< Real , matrix_index_type > ) e;
+				for( e=start ; e!=end ; e++ ) temp += X[ e->N ] * e->Value;
+				outRNorms[thread] += Dot( temp-B[j] , temp-B[j] );
+			}
+			);
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) outRNorm += outRNorms[t];
+		}
+		FreePointer( _constraints );
+	}
+	if( computeNorms ) stats.bNorm2 = bNorm , stats.inRNorm2 = inRNorm , stats.outRNorm2 = outRNorm;
+
+	return iters;
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , typename TDotT , typename SORWeights , typename ... InterpolationInfos >
+int FEMTree< Dim , Real >::_solveSlicedSystemGS( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , Pointer( T ) solution , ConstPointer( T ) prolongedSolution , ConstPointer( T ) constraints , TDotT Dot , int iters , bool coarseToFine , unsigned int sliceBlockSize , SORWeights sorWeights , _SolverStats& stats , bool computeNorms , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	if( sliceBlockSize<=0 ) return _solveFullSystemGS( UIntPack< FEMSigs ... >() , F , bsData , depth , solution , prolongedSolution , constraints , Dot , iters , coarseToFine , sorWeights , stats , computeNorms , interpolationInfos );
+	CCStencil< UIntPack< FEMSignature< FEMSigs >::Degree ... > > ccStencil;
+	PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > > pcStencils;
+	F.template setStencil< false >( ccStencil );
+	F.template setStencils< true >( pcStencils );
+
+	{
+		// Assuming Degree=2 and we are solving forward using two iterations, the pattern of relaxations should look like:
+		//      +--+--+--+--+--+
+		//      *  |  |  |  |  |
+		//     o|  |  |  |  |  |
+		//    o |  |  |  |  |  |
+		//   o  |  |  |  |  |  |
+		//  o   |  |  |  |  |  |
+		// o    |  |  |  |  |  |
+		//      |  *  |  |  |  |
+		//      | *|  |  |  |  |
+		//      |* |  |  |  |  |
+		//      *  |  |  |  |  |
+		//     o|  |  |  |  |  |
+		//    o |  |  |  |  |  |
+		//      |  |  *  |  |  |
+		//      |  | *|  |  |  |
+		//      |  |* |  |  |  |
+		//      |  *  |  |  |  |
+		//      | *|  |  |  |  |
+		//      |* |  |  |  |  |
+		//      |  |  |  *  |  |
+		//      |  |  | *|  |  |
+		//      |  |  |* |  |  |
+		//      |  |  *  |  |  |
+		//      |  | *|  |  |  |
+		//      |  |* |  |  |  |
+		//      |  |  |  |  *  |
+		//      |  |  |  | *|  |
+		//      |  |  |  |* |  |
+		//      |  |  |  *  |  |
+		//      |  |  | *|  |  |
+		//      |  |  |* |  |  |
+		//      |  |  *  |  |  |
+		//      |  |  |  |  |  *
+		//      |  |  |  |  | *|
+		//      |  |  |  |  |* |
+		//      |  |  |  |  *  |
+		//      |  |  |  | *|  |
+		//      |  |  |  |* |  |
+		//      |  |  |  |  |  |  o
+		//      |  |  |  |  |  | o
+		//      |  |  |  |  |  |o
+		//      |  |  |  |  |  *
+		//      |  |  |  |  | *|
+		//      |  |  |  |  |* |
+
+		const int SliceBlockSize = (int)sliceBlockSize;
+		// OverlapRadius = Degree
+		const int OverlapRadii[] = { ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... };
+		const int OverlapBlockRadius = ( OverlapRadii[Dim-1] + SliceBlockSize - 1 ) / SliceBlockSize;
+		static const int LastFEMSig = UIntPack< FEMSigs ... >::template Get< Dim-1 >();
+		int _sliceBegin = _BSplineBegin< LastFEMSig >( depth ) , _sliceEnd = _BSplineEnd< LastFEMSig >( depth );
+
+		int blockBegin = ( _sliceBegin - ( SliceBlockSize - 1 ) ) / SliceBlockSize , blockEnd = ( _sliceEnd + ( SliceBlockSize - 1 ) ) / SliceBlockSize;
+		std::function< int ( int ) > BlockFirst = [&]( int b ){ return std::max< int >( b * SliceBlockSize , _sliceBegin ); };
+		std::function< int ( int ) > BlockLast  = [&]( int b ){ return std::min< int >( b * SliceBlockSize + SliceBlockSize - 1 , _sliceEnd - 1 ); };
+
+		auto BBlock = [&]( int d , int b , ConstPointer( T ) B )
+		{
+			return GetPointer( &B[0] + _sNodesBegin( d , BlockFirst( b ) ) , _sNodesEnd( d , BlockLast( b ) ) - _sNodesBegin( d , BlockFirst( b ) ) );
+		};
+		auto XBlocks = [&]( int d , int b , Pointer( T ) X )
+		{
+			return GetPointer( &X[0] + _sNodesBegin( d , BlockFirst( b ) ) , _sNodesBegin( d , BlockFirst( b - OverlapBlockRadius ) ) - _sNodesBegin( d , BlockFirst( b ) ) , _sNodesEnd( d , BlockLast( b + OverlapBlockRadius ) ) - _sNodesBegin( d , BlockFirst( b ) ) );
+		};
+
+		double& systemTime = stats.systemTime;
+		double&  solveTime = stats. solveTime;
+		systemTime = solveTime = 0.;
+
+		struct BlockWindow
+		{
+		protected:
+			int _begin , _end;
+		public:
+			BlockWindow( int begin , int end )
+			{
+				if( begin<=end ) _begin = begin , _end = end;
+				else             _begin = end+1 , _end = begin+1;
+			}
+			int size( void ) const { return _end-_begin; }
+			BlockWindow& operator += ( int off ){ _begin += off , _end += off ; return *this; }
+			BlockWindow& operator -= ( int off ){ _begin -= off , _end -= off ; return *this; }
+			BlockWindow& operator++ ( void ){ _begin++ , _end++ ; return *this; }
+			BlockWindow& operator-- ( void ){ _begin-- , _end-- ; return *this; }
+			int begin( bool forward ) const { return forward ? _begin : _end-1; }
+			int end  ( bool forward ) const { return forward ? _end : _begin-1; }
+			bool inBlock( int b ) const { return b>=_begin && b<_end; }
+		};
+		double bNorm=0 , inRNorm=0 , outRNorm=0;
+		bool forward = !coarseToFine;
+		int residualOffset = computeNorms ? OverlapBlockRadius : 0;
+		// Set the number of in-memory blocks required for a temporally blocked solver
+		const int ColorModulus = OverlapBlockRadius;
+		// The number of in-core blocks over which we relax
+		// [WARNING] If the block size is larger than one, we may be able to use fewer blocks
+		int solveBlocks = std::max< int >( 0 , std::min< int >( ColorModulus*iters - ( ColorModulus-1 ) , blockEnd-blockBegin ) );
+		// The number of in-core blocks over which we either solve or compute residuals
+		int matrixBlocks = std::max< int >( 1 , std::min< int >( solveBlocks+2*residualOffset , blockEnd-blockBegin ) );
+		// The list of matrices for each in-memory block
+		Pointer( SystemMatrixType< FEMSigs ... > ) _M = NewPointer< SystemMatrixType< FEMSigs ... > >( matrixBlocks );
+		Pointer( Pointer( Real ) ) _D = AllocPointer< Pointer( Real ) >( matrixBlocks );
+		std::vector< Pointer( T ) > _constraints( matrixBlocks );
+		for( int i=0 ; i<matrixBlocks ; i++ ) _D[i] = NullPointer( Real ) , _constraints[i] = NullPointer( T );
+		// The list of multi-colored indices  for each in-memory block
+		Pointer( std::vector< std::vector< size_t > > ) mcIndices = NewPointer< std::vector< std::vector< size_t > > >( solveBlocks );
+		int dir = forward ? 1 : -1 , start = forward ? blockBegin : blockEnd-1 , end = forward ? blockEnd : blockBegin-1;
+		const BlockWindow FullWindow( blockBegin , blockEnd );
+		BlockWindow residualWindow( FullWindow.begin(forward) , FullWindow.begin(forward) - ( ColorModulus*iters - ( ColorModulus-1 ) ) * dir - 2*residualOffset*dir );
+		BlockWindow solveWindow( FullWindow.begin(forward) - residualOffset*dir , FullWindow.begin(forward) - residualOffset*dir - ( ColorModulus*iters - ( ColorModulus-1 ) ) * dir );
+		// If we are solving forward we start in a block S with S mod ColorModulus = ColorModulus-1
+		// and end in a block E with E mod ColorModulus = 0
+		while( PR_MODULO( solveWindow.begin(!forward) , ColorModulus )!=( forward ? ColorModulus-1 : 0 ) ) solveWindow -= dir , residualWindow -= dir;
+		size_t maxBlockSize = 0;
+		BlockWindow _residualWindow = residualWindow;
+		for( ; _residualWindow.end(!forward)*dir<FullWindow.end(forward)*dir ; _residualWindow += dir )
+		{
+			int b = _residualWindow.begin(!forward);
+			if( FullWindow.inBlock( b ) ) maxBlockSize = std::max< size_t >( maxBlockSize , _sNodesEnd( depth , BlockLast( b ) ) - _sNodesBegin( depth , BlockFirst( b ) ) );
+		}
+		if( maxBlockSize>std::numeric_limits< matrix_index_type >::max() ) MK_THROW( "more entries in a block than can be indexed in " , sizeof(matrix_index_type) , " bytes" );
+		for( int i=0 ; i<matrixBlocks ; i++ ) _constraints[i] = AllocPointer< T >( maxBlockSize ) , _D[i] = AllocPointer< Real >( maxBlockSize );
+		for( ; residualWindow.end(!forward)*dir<FullWindow.end(forward)*dir ; residualWindow += dir , solveWindow += dir )
+		{
+			double t;
+			{
+				int frontSolveBlock =    solveWindow.begin(!forward);
+				int residualBlock   = residualWindow.begin(!forward);
+				// Get the leading matrix and compute the constraint norm / initial residual
+				// [WARNNG] This is likely wrong. We probably have to pull this into its own for "for( int _c=0 ; _c<ColorModulus ; _c++ )" loop
+				//          to ensure that adjacent read-only blocks have not been updated yet.
+				if( FullWindow.inBlock( residualBlock ) )
+				{
+					int b = residualBlock , _b = PR_MODULO( b , matrixBlocks );
+
+					t = Time();
+					_getSliceMatrixAndProlongationConstraints( UIntPack< FEMSigs ... >() , F , _M[_b] , _D[_b] , bsData , depth , _sNodesBegin( depth , BlockFirst( b ) ) , _sNodesEnd( depth , BlockLast( b ) ) , prolongedSolution , _constraints[_b] , ccStencil , pcStencils , interpolationInfos );
+					size_t begin = _sNodesBegin( depth , BlockFirst( b ) ) , end = _sNodesEnd( depth , BlockLast( b ) );
+					ThreadPool::ParallelFor( begin , end , [&]( unsigned int , size_t i ){  _constraints[_b][ i-begin ] = constraints[i] - _constraints[_b][ i-begin ]; } );
+					{
+						node_index_type begin = _sNodesBegin( depth , BlockFirst( b ) ) , end = _sNodesEnd( depth , BlockLast( b ) );
+						for( node_index_type i=begin ; i<end ; i++ ) if( _M[_b].rowSize( i-begin ) ) _D[_b][i-begin] *= sorWeights[i];
+					}
+					systemTime += Time()-t;
+					if( computeNorms )
+					{
+						ConstPointer( T ) B = _constraints[_b];
+						ConstPointer( T ) X = XBlocks( depth , b , solution );
+						std::vector< double > bNorms( ThreadPool::NumThreads() , 0 ) , inRNorms( ThreadPool::NumThreads() , 0 );
+						ThreadPool::ParallelFor( 0 , _M[_b].rows() , [&]( unsigned int thread , size_t j )
+						{
+							T temp = {};
+							ConstPointer( MatrixEntry< Real , matrix_index_type > ) start = _M[_b][j];
+							ConstPointer( MatrixEntry< Real , matrix_index_type  > ) end = start + _M[_b].rowSize(j);
+							ConstPointer( MatrixEntry< Real , matrix_index_type  > ) e;
+							for( e=start ; e!=end ; e++ ) temp += X[ e->N ] * e->Value;
+							bNorms[thread] += Dot( B[j] , B[j] );
+							inRNorms[thread] += Dot( temp - B[j] , temp - B[j] );
+						}
+						);
+						for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) bNorm += bNorms[t] , inRNorm += inRNorms[t];
+					}
+				}
+				t = Time();
+				// Get the leading multi-color indices
+				if( iters && FullWindow.inBlock( frontSolveBlock ) )
+				{
+					int b = frontSolveBlock , _b = PR_MODULO( b , matrixBlocks ) , __b = PR_MODULO( b , solveBlocks );
+					for( int i=0 ; i<int( mcIndices[__b].size() ) ; i++ ) mcIndices[__b][i].clear();
+					_setMultiColorIndices( UIntPack< FEMSigs ... >() , _sNodesBegin( depth , BlockFirst( b ) ) , _sNodesEnd( depth , BlockLast( b ) ) , mcIndices[__b] );
+				}
+			}
+
+			// Relax the system
+			for( int block=solveWindow.begin(!forward) ; solveWindow.inBlock(block) ; block-=dir*ColorModulus ) if( FullWindow.inBlock( block ) )
+			{
+				int b = block , _b = PR_MODULO( b , matrixBlocks ) , __b = PR_MODULO( b , solveBlocks );
+				ConstPointer( T ) B = _constraints[_b];
+				Pointer( T ) X = XBlocks( depth , b , solution );
+				_M[_b].gsIteration( mcIndices[__b] , ( ConstPointer( Real ) )_D[_b] , B , X , coarseToFine , true );
+			}
+			solveTime += Time() - t;
+
+			// Compute the final residual
+			{
+				int residualBlock = residualWindow.begin(forward);
+				if( computeNorms && FullWindow.inBlock( residualBlock ) )
+				{
+					int b = residualBlock , _b = PR_MODULO( b , matrixBlocks );
+					ConstPointer( T ) B = _constraints[_b];
+					ConstPointer( T ) X = XBlocks( depth , b , solution );
+					std::vector< double > outRNorms( ThreadPool::NumThreads() , 0 );
+					ThreadPool::ParallelFor( 0 , _M[_b].rows() , [&]( unsigned int thread , size_t j )
+					{
+						T temp = {};
+						ConstPointer( MatrixEntry< Real , matrix_index_type > ) start = _M[_b][j];
+						ConstPointer( MatrixEntry< Real , matrix_index_type > ) end = start + _M[_b].rowSize(j);
+						ConstPointer( MatrixEntry< Real , matrix_index_type > ) e;
+						for( e=start ; e!=end ; e++ ) temp += X[ e->N ] * e->Value;
+						outRNorms[thread] += Dot( temp-B[j] , temp-B[j] );
+					}
+					);
+					for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) outRNorm += outRNorms[t];
+				}
+			}
+		}
+		for( int i=0 ; i<matrixBlocks ; i++ ) FreePointer( _D[i] );
+		for( int i=0 ; i<matrixBlocks ; i++ ) FreePointer( _constraints[i] );
+
+		if( computeNorms ) stats.bNorm2 = bNorm , stats.inRNorm2 = inRNorm , stats.outRNorm2 = outRNorm;
+		DeletePointer( _M );
+		DeletePointer( mcIndices );
+		FreePointer( _D );
+	}
+	return iters;
+}
+#undef PR_MODULO
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , typename TDotT , typename ... InterpolationInfos >
+int FEMTree< Dim , Real >::_solveSystemCG( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , Pointer( T ) solution , ConstPointer( T ) prolongedSolution , ConstPointer( T ) constraints , TDotT Dot , int iters , bool coarseToFine , _SolverStats& stats , bool computeNorms , double accuracy , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	int iter = 0;
+	Pointer( T ) X = GetPointer( &solution[0] + _sNodesBegin(depth) , _sNodesSize(depth) );
+	ConstPointer( T ) B = GetPointer( &constraints[0] + _sNodesBegin(depth) , _sNodesSize(depth) );
+	SystemMatrixType< FEMSigs ... > M;
+
+	double& systemTime = stats.systemTime;
+	double&  solveTime = stats. solveTime;
+	systemTime = solveTime = 0.;
+	// Get the system matrix (and adjust the right-hand-side based on the coarser solution if prolonging)
+	systemTime = Time();
+	Pointer( T ) _constraints = AllocPointer< T >( _sNodesSize( depth ) );
+	B = _constraints;
+	CCStencil< UIntPack< FEMSignature< FEMSigs >::Degree ... > > ccStencil;
+	PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > > pcStencils;
+	F.template setStencil< false >( ccStencil );
+	F.template setStencils< true >( pcStencils );
+	_getSliceMatrixAndProlongationConstraints( UIntPack< FEMSigs ... >() , F , M , NullPointer( Real ) , bsData , depth , _sNodesBegin( depth ) , _sNodesEnd( depth ) , prolongedSolution , _constraints , ccStencil , pcStencils , interpolationInfos );
+	ThreadPool::ParallelFor( _sNodesBegin(depth) , _sNodesEnd(depth) , [&]( unsigned int , size_t i ){ _constraints[ i - _sNodesBegin(depth) ] = constraints[i] - _constraints[ i - _sNodesBegin(depth) ]; } );
+	systemTime = Time()-systemTime;
+	solveTime = Time();
+	// Solve the linear system
+	accuracy = Real( accuracy / 100000 ) * M.rows();
+	int dims[] = { ( _BSplineEnd< FEMSigs >( depth ) - _BSplineBegin< FEMSigs >( depth ) ) ... };
+	size_t nonZeroRows = 0;
+	for( matrix_index_type i=0 ; i<(matrix_index_type)M.rows() ; i++ ) if( M.rowSize(i) ) nonZeroRows++;
+	size_t totalDim = 1;
+	for( int d=0 ; d<Dim ; d++ ) totalDim *= dims[d];
+	BoundaryType bTypes[] = { FEMSignature< FEMSigs >::BType ... };
+	bool hasPartitionOfUnity = true;
+	for( int d=0 ; d<Dim ; d++ ) hasPartitionOfUnity &= HasPartitionOfUnity( bTypes[d] );
+	bool addDCTerm = ( nonZeroRows==totalDim && !ConstrainsDCTerm( interpolationInfos ) && hasPartitionOfUnity && F.vanishesOnConstants() );
+	double bNorm = 0 , inRNorm = 0 , outRNorm = 0;
+	if( computeNorms )
+	{
+		std::vector< double > bNorms( ThreadPool::NumThreads() , 0 ) , inRNorms( ThreadPool::NumThreads() , 0 );
+		ThreadPool::ParallelFor( 0 , M.rows() , [&]( unsigned int thread , size_t j )
+		{
+			T temp = {};
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) start = M[j];
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) end = start + M.rowSize(j);
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) e;
+			for( e=start ; e!=end ; e++ ) temp += X[ e->N ] * e->Value;
+			bNorms[thread] += Dot( B[j] , B[j] );
+			inRNorms[thread] += Dot( temp-B[j] , temp-B[j] );
+		}
+		);
+		for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) bNorm += bNorms[t] , inRNorm += inRNorms[t];
+	}
+
+	iters = (int)std::min< size_t >( nonZeroRows , iters );
+	struct SPDFunctor
+	{
+	protected:
+		const SystemMatrixType< FEMSigs ... > &_M;
+		bool _addDCTerm;
+	public:
+		SPDFunctor( const SystemMatrixType< FEMSigs ... > &M , bool addDCTerm ) : _M(M) , _addDCTerm(addDCTerm){ }
+		void operator()( ConstPointer( T ) in , Pointer( T ) out ) const
+		{
+			_M.multiply( in , out );
+			if( _addDCTerm )
+			{
+				T average = {};
+				for( matrix_index_type i=0 ; i<(matrix_index_type)_M.rows() ; i++ ) average += in[i];
+				average /= _M.rows();
+				for( matrix_index_type i=0 ; i<(matrix_index_type)_M.rows() ; i++ ) out[i] += average;
+			}
+		}
+	};
+	if( iters ) iter = (int)SolveCG< SPDFunctor , T , Real >( SPDFunctor( M , addDCTerm ) , M.rows() , ( ConstPointer( T ) )B , iters , X , Real( accuracy ) , Dot );
+
+	solveTime = Time()-solveTime;
+	if( computeNorms )
+	{
+		std::vector< double > outRNorms( ThreadPool::NumThreads() , 0 );
+		ThreadPool::ParallelFor( 0 , M.rows() , [&]( unsigned int thread , size_t j )
+		{
+			T temp = {};
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) start = M[j];
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) end = start + M.rowSize(j);
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) e;
+			for( e=start ; e!=end ; e++ ) temp += X[ e->N ] * e->Value;
+			outRNorms[thread] += Dot( temp-B[j] , temp-B[j] );
+		}
+		);
+		for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) outRNorm += outRNorms[t];
+		stats.bNorm2 = bNorm , stats.inRNorm2 = inRNorm , stats.outRNorm2 = outRNorm;
+	}
+	FreePointer( _constraints );
+	return iter;
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int ... FEMSigs >
+void FEMTree< Dim , Real >::pushToBaseDepth( DenseNodeData< T , UIntPack< FEMSigs ... > >& coefficients ) const
+{
+	Pointer( T ) prolongedCoefficients = AllocPointer< Real >( _sNodesEnd( _baseDepth ) );
+	for( LocalDepth d=1 ; d<=_baseDepth ; d++ )
+	{
+		SparseMatrix< Real , matrix_index_type > P = downSampleMatrix( UIntPack< FEMSigs ... >() , d ).transpose();
+		P.multiply( coefficients() + _sNodesBegin(d-1) , prolongedCoefficients + _sNodesBegin(d) );
+		for( node_index_type i=_sNodesBegin(d-1) ; i<_sNodesEnd(d-1) ; i++ ) coefficients[i] *= 0;
+		for( node_index_type i=_sNodesBegin(d) ; i<_sNodesEnd(d) ; i++ ) coefficients[i] += prolongedCoefficients[i];
+	}
+	FreePointer( prolongedCoefficients );
+	for( node_index_type i=_sNodesBegin(_baseDepth) ; i<_sNodesEnd(_maxDepth) ; i++ ) if( _sNodes.treeNodes[i]->nodeData.getDirichletElementFlag() ) coefficients[i] *= 0;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , typename TDotT , typename ... InterpolationInfos >
+void FEMTree< Dim , Real >::_solveRegularMG( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth maxSolveDepth , Pointer( T ) solution , ConstPointer( T ) constraints , TDotT Dot , int vCycles , int iters , _SolverStats& stats , bool computeNorms , double cgAccuracy , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	if( maxSolveDepth>_baseDepth ) MK_THROW( "Regular MG depth cannot exceed base depth: " , maxSolveDepth , " <= " , _baseDepth );
+	double& systemTime = stats.systemTime;
+	double&  solveTime = stats. solveTime;
+
+	std::vector< SparseMatrix< Real , matrix_index_type > > P( _baseDepth ) , R( _baseDepth ) , M( _baseDepth+1 );
+	std::vector< Pointer( Real ) > D( _baseDepth+1 );
+	std::vector< Pointer( T ) > B( _baseDepth+1 ) , X( _baseDepth+1 ) , MX( _baseDepth+1 );
+	std::vector< std::vector< std::vector< size_t > > > multiColorIndices( _baseDepth+1 );
+
+	systemTime = Time();
+	M.back() = systemMatrix( UIntPack< FEMSigs ... >() , F , _baseDepth , interpolationInfos );
+	for( int d=_baseDepth ; d>0 ; d-- )
+	{
+		R[d-1] = downSampleMatrix( UIntPack< FEMSigs ... >() , d );
+		P[d-1] = R[d-1].transpose( M[d].rows() );
+		M[d-1] = R[d-1] * M[d] * P[d-1];
+	}
+	for( int d=0 ; d<=_baseDepth ; d++ )
+	{
+		size_t dim = M[d].rows();
+		D[d]  = AllocPointer< Real >( dim );
+		MX[d] = AllocPointer< T >( dim );
+		M[d].setDiagonalR( D[d] );
+		setMultiColorIndices( UIntPack< FEMSigs ... >() , d , multiColorIndices[d] );
+		if( d<_baseDepth )
+		{
+			X[d]  = AllocPointer< T >( dim );
+			B[d]  = AllocPointer< T >( dim );
+		}
+	}
+	X.back() = solution + nodesBegin( _baseDepth );
+	B.back() = ( Pointer( T ) )( constraints + nodesBegin( _baseDepth ) );
+	ConstPointer( T ) _B = constraints + nodesBegin( _baseDepth );
+	systemTime = Time() - systemTime;
+
+	solveTime = Time();
+
+	double bNorm = 0 , inRNorm = 0 , outRNorm = 0;
+	if( computeNorms )
+	{
+		const SparseMatrix< Real , matrix_index_type >& _M = M.back();
+		ConstPointer( T ) _X = X.back();
+		std::vector< double > bNorms( ThreadPool::NumThreads() , 0 ) , inRNorms( ThreadPool::NumThreads() , 0 );
+		ThreadPool::ParallelFor( 0 , _M.rows() , [&]( unsigned int thread , size_t j )
+		{
+			T temp = {};
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) start = _M[j];
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) end = start + _M.rowSize(j);
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) e;
+			for( e=start ; e!=end ; e++ ) temp += _X[ e->N ] * e->Value;
+			bNorms[thread] += Dot( _B[j] , _B[j] );
+			inRNorms[thread] += Dot( temp-_B[j] , temp-_B[j] );
+		}
+		);
+		for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) bNorm += bNorms[t] , inRNorm += inRNorms[t];
+	}
+
+	for( int v=0 ; v<vCycles ; v++ )
+	{
+		// Restriction
+		for( int d=_baseDepth ; d>0 ; d-- )
+		{
+			ConstPointer( T ) __B = d==_baseDepth ? _B : B[d];
+			if( d<=maxSolveDepth ) for( int i=0 ; i<iters ; i++ ) M[d].gsIteration( multiColorIndices[d] , D[d] , __B , X[d] , true , true );
+			M[d].multiply( X[d] , MX[d] );
+			for( matrix_index_type i=0 ; i<(matrix_index_type)M[d].rows() ; i++ ) MX[d][i] = __B[i] - MX[d][i];
+			R[d-1].multiply( MX[d] , B[d-1] );
+			memset( X[d-1] , 0 , sizeof( T )*M[d-1].rows() );
+		}
+
+		// Base
+		{
+			int d = 0;
+			ConstPointer( T ) __B = d==_baseDepth ? _B : B[d];
+			struct SPDFunctor
+			{
+			protected:
+				const SparseMatrix< Real , matrix_index_type >& _M;
+				bool _addDCTerm;
+			public:
+				SPDFunctor( const SparseMatrix< Real , matrix_index_type  >& M , bool addDCTerm ) : _M(M) , _addDCTerm(addDCTerm){ }
+				void operator()( ConstPointer( T ) in , Pointer( T ) out ) const
+				{
+					_M.multiply( in , out );
+					if( _addDCTerm )
+					{
+						T average = {};
+						for( matrix_index_type i=0 ; i<(matrix_index_type)_M.rows() ; i++ ) average += in[i];
+						average /= _M.rows();
+						for( matrix_index_type i=0 ; i<(matrix_index_type)_M.rows() ; i++ ) out[i] += average;
+					}
+				}
+			};
+			size_t nonZeroRows = 0;
+			for( matrix_index_type i=0 ; i<(matrix_index_type)M[d].rows() ; i++ ) if( M[d].rowSize(i) ) nonZeroRows++;
+			size_t totalDim = 1;
+			int dims[] = { ( _BSplineEnd< FEMSigs >( _baseDepth ) - _BSplineBegin< FEMSigs >( _baseDepth ) ) ... };
+			for( int dd=0 ; dd<Dim ; dd++ ) totalDim *= dims[dd];
+			BoundaryType bTypes[] = { FEMSignature< FEMSigs >::BType ... };
+			bool hasPartitionOfUnity = true;
+			for( int dd=0 ; dd<Dim ; dd++ ) hasPartitionOfUnity &= HasPartitionOfUnity( bTypes[dd] );
+			bool addDCTerm = ( nonZeroRows==totalDim && !ConstrainsDCTerm( interpolationInfos ) && hasPartitionOfUnity && F.vanishesOnConstants() );
+
+			SolveCG< SPDFunctor , T , Real >( SPDFunctor( M[d] , addDCTerm ) , M[d].rows() , ( ConstPointer( T ) )__B , nonZeroRows , X[d] , Real( cgAccuracy ) , Dot );
+		}
+
+		// Prolongation
+		for( int d=1 ; d<=_baseDepth ; d++ )
+		{
+			ConstPointer( T ) __B = d==_baseDepth ? _B : B[d];
+			P[d-1].multiply( X[d-1] , X[d] , MULTIPLY_ADD );
+			for( matrix_index_type i=0 ; i<(matrix_index_type)M[d-1].rows() ; i++ ) X[d-1][i] *= 0;
+			if( d<=maxSolveDepth ) for( int i=0 ; i<iters ; i++ ) M[d].gsIteration( multiColorIndices[d] , D[d] , __B , X[d] , false , true );
+		}
+	}
+	if( computeNorms )
+	{
+		const SparseMatrix< Real , matrix_index_type >& _M = M.back();
+		ConstPointer( T ) _X = X.back();
+		std::vector< double > outRNorms( ThreadPool::NumThreads() , 0 );
+		ThreadPool::ParallelFor( 0 , _M.rows() , [&]( unsigned int thread , size_t j )
+		{
+			T temp = {};
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) start = _M[j];
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) end = start + _M.rowSize(j);
+			ConstPointer( MatrixEntry< Real , matrix_index_type > ) e;
+			for( e=start ; e!=end ; e++ ) temp += _X[ e->N ] * e->Value;
+			outRNorms[thread] += Dot( temp-_B[j] , temp-_B[j] );
+		}
+		);
+		for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) outRNorm += outRNorms[t];
+		stats.bNorm2 = bNorm , stats.inRNorm2 = inRNorm , stats.outRNorm2 = outRNorm;
+	}
+	solveTime = Time() - solveTime;
+
+	for( int d=0 ; d<=_baseDepth ; d++ )
+	{
+		FreePointer( D[d] );
+		FreePointer( MX[d] );
+		if( d<_baseDepth )
+		{
+			FreePointer( X[d] );
+			FreePointer( B[d] );
+		}
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs >
+int FEMTree< Dim , Real >::_getProlongedMatrixRowSize( const FEMTreeNode* node , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors ) const
+{
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+	typedef UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > OverlapSizes;
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] This change needs to be validated" )
+#endif // SHOW_WARNINGS
+	int count = 0;
+	static const WindowLoopData< OverlapSizes > loopData( []( int c , int* start , int*end ){ _SetParentOverlapBounds( FEMDegrees() , FEMDegrees() , c , start , end );} );
+	if( node->parent )
+	{
+		int c =  (int)( node - node->parent->children );
+		const unsigned int size = loopData.size[c];
+		const unsigned int* indices = loopData.indices[c];
+		ConstPointer( FEMTreeNode * const ) nodes = pNeighbors.neighbors().data;
+		for( unsigned int i=0 ; i<size ; i++ ) if( _isValidFEM1Node( nodes[ indices[i] ] ) ) count++;
+	}
+	return count;
+}
+
+
+// Given a node:
+// -- For each of its neighbors:
+// ---- Compute the weighted sum of the product of the evaluations of the associated basis functions over the points
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+void FEMTree< Dim , Real >::_addPointValues( UIntPack< FEMSigs ... > , StaticWindow< Real , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pointValues , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , const InterpolationInfo< T , PointD >* interpolationInfo ) const
+{
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+	typedef UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > OverlapSizes;
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	typedef UIntPack< ( -BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportStart ) ... > LeftSupportRadii;
+	typedef UIntPack<    BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportEnd     ... > RightSupportRadii;
+	typedef UIntPack<    BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportEnd     ... > LeftPointSupportRadii;
+	typedef UIntPack< ( -BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportStart ) ... > RightPointSupportRadii;
+	typedef UIntPack<    BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize    ... > SupportSizes;
+
+	if( !( FEMDegrees() >= IsotropicUIntPack< Dim , PointD >() ) ) MK_THROW( "Insufficient derivatives" );
+	if( !interpolationInfo ) return;
+	const InterpolationInfo< T , PointD >& iInfo = *interpolationInfo;
+
+
+	const FEMTreeNode* node = neighbors.neighbors.data[ WindowIndex< OverlapSizes , OverlapRadii >::Index ];
+	LocalDepth d ; LocalOffset off;
+	_localDepthAndOffset( node , d , off );
+
+	PointEvaluatorState< UIntPack< FEMSigs ... > , IsotropicUIntPack< Dim , PointD > > peState;
+
+	int idx[Dim];	// The coordinates of the node containing the point _relative_ to the center node
+	int _idx[Dim==1 ? 1 : Dim-1];
+	CumulativeDerivativeValues< double , Dim , PointD > dualValues;
+
+	auto outerFunction = [&]( const FEMTreeNode* _node  )
+	{
+		if( _isValidSpaceNode( _node ) )
+		{
+			LocalOffset pOff;	// The coordinates of the node containing the point
+			for( int d=0 ; d<Dim ; d++ ) pOff[d] = off[d] + idx[d];
+			size_t begin , end;
+			iInfo.range( _node , begin , end );
+			for( size_t pIndex=begin ; pIndex<end ; pIndex++ )
+			{
+				const DualPointInfo< Dim , Real , T , PointD >& pData = iInfo[ pIndex ];
+				CumulativeDerivativeValues< double , Dim , PointD > values;
+				{
+					Real weight = pData.weight;
+					Point< Real , Dim > p = pData.position;
+					// Compute the partial evaluation of all B-splines (and derivatives) that are supported on the point
+					bsData.initEvaluationState( p , d , pOff , peState );
+
+					// The value (and derivatives) of the function of the center node at this point
+					values = peState.template dValues< Real , CumulativeDerivatives< Dim , PointD > >( off );
+				}
+				dualValues = iInfo( pIndex , values ) * pData.weight;
+				if( Dim==1 )
+				{
+					Point< double , PointD+1 > partialDot = peState.template partialDotDValues< Real , CumulativeDerivatives< Dim , PointD > >( dualValues , _idx );
+					Pointer( Real ) _pointValues = GetPointer( pointValues.data + idx[Dim-1] + OverlapRadii::Values[Dim-1] , - idx[Dim-1] - (int)OverlapRadii::Values[Dim-1] , pointValues.Size() - idx[Dim-1] - (int)OverlapRadii::Values[Dim-1] );
+
+					int _i = idx[Dim-1] + (int)OverlapRadii::Values[Dim-1] - (int)LeftPointSupportRadii::Values[Dim-1];
+					const double (*splineValues)[PointD+1] = peState.template values< Dim-1 >();
+					for( unsigned int i=0 ; i<SupportSizes::Values[Dim-1] ; i++ ) if( _isValidFEM1Node( neighbors.neighbors.data[ _i + i ] ) )
+						for( int d=0 ; d<=PointD ; d++ ) _pointValues[(int)i-(int)LeftPointSupportRadii::Values[Dim-1]] += (Real)( splineValues[i][d] * partialDot[d] );
+				}
+				else
+				{
+					int start[Dim==1 ? 1 : Dim-1] , end[Dim==1 ? 1 : Dim-1];
+					// Compute the bounds of nodes which can be supported on the point
+					for( int d=0 ; d<Dim-1 ; d++ ) start[d] = idx[d] + (int)OverlapRadii::Values[d] - (int)LeftPointSupportRadii::Values[d] , end[d] = idx[d] + (int)OverlapRadii::Values[d] + (int)RightPointSupportRadii::Values[d] + 1;
+					Window::Loop< Dim , Dim-1 >::Run
+					(
+						start , end , 
+						[&]( int d , int i ){ _idx[d] = i - (int)OverlapRadii::Values[d] + off[d]; } ,
+						[&]( const WindowSlice< Real , UIntPack< OverlapSizes::template Get< Dim-1 >() > > pointValues , ConstWindowSlice< const FEMTreeNode* , UIntPack< OverlapSizes::template Get< Dim-1 >() > > neighbors )
+						{
+							Point< double , PointD+1 > partialDot = peState.template partialDotDValues< Real , CumulativeDerivatives< Dim , PointD > >( dualValues , _idx );
+							Pointer( Real ) _pointValues = pointValues.data + idx[Dim-1] + OverlapRadii::Values[Dim-1];
+
+							int _i = idx[Dim-1] + (int)OverlapRadii::Values[Dim-1] - (int)LeftPointSupportRadii::Values[Dim-1];
+							const double (*splineValues)[PointD+1] = peState.template values< Dim-1 >();
+							for( unsigned int i=0 ; i<SupportSizes::Values[Dim-1] ; i++ ) if( _isValidFEM1Node( neighbors[ _i + i ] ) )
+								for( int d=0 ; d<=PointD ; d++ ) _pointValues[(int)i-(int)LeftPointSupportRadii::Values[Dim-1]] += (Real)( splineValues[i][d] * partialDot[d] );
+						} ,
+						pointValues() , neighbors.neighbors()
+					);
+				}
+			}
+		}
+	};
+	// Loop over all nodes which are supported on the center
+	WindowLoop< Dim >::Run
+	(
+		OverlapRadii() - LeftSupportRadii() , OverlapRadii() + RightSupportRadii() + IsotropicUIntPack< Dim , 1 >() ,
+		[&]( int d , int i ){ idx[d] = i - (int)OverlapRadii::Values[d]; } ,
+		outerFunction ,
+		neighbors.neighbors()
+	);
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int ... FEMSigs , typename ... InterpolationInfos , typename MatrixType >
+T FEMTree< Dim , Real >::_setMatrixRowAndGetConstraintFromProlongation( UIntPack< FEMSigs ... > , const BaseSystem< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , size_t idx , MatrixType &M , node_index_type offset , const PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& pcStencils , const CCStencil< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& ccStencil , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , ConstPointer( T ) prolongedSolution , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	T constraint ={};
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	typedef UIntPack<    BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize    ... > OverlapSizes;
+
+	int count = 0;
+	const FEMTreeNode* node = neighbors.neighbors.data[ WindowIndex< OverlapSizes , OverlapRadii >::Index ];
+	MatrixEntry< Real , matrix_index_type > row[ WindowSize< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >::Size ];
+
+	if( node->nodeData.getDirichletElementFlag() )
+	{
+		M.setRowSize( idx , count );
+		return constraint;
+	}
+
+	LocalDepth d ; LocalOffset off;
+	_localDepthAndOffset( node , d , off );
+	if( d>0 && prolongedSolution )
+	{
+		int cIdx = (int)( node - node->parent->children );
+		constraint = _getConstraintFromProlongedSolution( UIntPack< FEMSigs ... >() , F , neighbors , pNeighbors , node , prolongedSolution , pcStencils.data[cIdx] , bsData , interpolationInfos );
+	}
+
+	bool isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , UIntPack< FEMSignature< FEMSigs >::Degree ... >() , d , off );
+
+	StaticWindow< Real , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > > pointValues;
+	memset( pointValues.data , 0 , sizeof(Real)*WindowSize< OverlapSizes >::Size );
+	_addPointValues< 0 >( UIntPack< FEMSigs ... >() , pointValues , neighbors , bsData , interpolationInfos );
+	node_index_type nodeIndex = node->nodeData.nodeIndex;
+	if( isInterior ) // General case, so try to make fast
+	{
+		const FEMTreeNode* const * _nodes = neighbors.neighbors.data;
+		ConstPointer( double ) _stencil = ccStencil.data;
+		Real* _values = pointValues.data;
+		row[count++] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( nodeIndex-offset ) , (Real)( _values[ WindowIndex< OverlapSizes , OverlapRadii >::Index ] + _stencil[ WindowIndex< OverlapSizes , OverlapRadii >::Index ] ) );
+		for( int i=0 ; i<WindowSize< OverlapSizes >::Size ; i++ ) if( _isValidFEM1Node( _nodes[i] ) && !_nodes[i]->nodeData.getDirichletElementFlag() )
+		{
+			if( i!=WindowIndex< OverlapSizes , OverlapRadii >::Index ) row[count++] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( _nodes[i]->nodeData.nodeIndex-offset ) , (Real)( _values[i] + _stencil[i] ) );
+		}
+	}
+	else
+	{
+		LocalDepth d ; LocalOffset off;
+		_localDepthAndOffset( node , d , off );
+		Real temp = (Real)F.ccIntegrate( off , off ) + pointValues.data[ WindowIndex< OverlapSizes , OverlapRadii >::Index ];
+
+		row[count++] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( nodeIndex-offset ) , temp );
+		LocalOffset _off;
+		WindowLoop< Dim >::Run
+		(
+			ZeroUIntPack< Dim >() , OverlapSizes() ,
+			[&]( int d , int i ){ _off[d] = off[d] - (int)OverlapRadii::Values[d] + i; } ,
+			[&]( const FEMTreeNode* _node , Real pointValue )
+			{
+			if( node!=_node && _isValidFEM1Node( _node ) && !_node->nodeData.getDirichletElementFlag() )
+			{
+					row[count++] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( _node->nodeData.nodeIndex-offset ) , (Real)F.ccIntegrate( _off , off ) + pointValue );
+				}
+			} ,
+			neighbors.neighbors() , pointValues()
+			);
+	}
+	M.setRowSize( idx , count );
+	memcpy( M[idx] , row , sizeof( MatrixEntry< Real , matrix_index_type > ) * count );
+	return constraint;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+void FEMTree< Dim , Real >::_addProlongedPointValues( UIntPack< FEMSigs ... > , WindowSlice< Real , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > > pointValues , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , const InterpolationInfo< T , PointD >* interpolationInfo ) const
+{
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] This code is broken" )
+#endif // SHOW_WARNINGS
+#if 1
+	MK_THROW( "Broken code" );
+#else
+	if( !interpolationInfo ) return;
+	const InterpolationInfo< T , PointD >& iInfo = *interpolationInfo;
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	typedef UIntPack<    BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize    ... > OverlapSizes;
+
+	const FEMTreeNode* node = neighbors.neighbors.data[ WindowIndex< OverlapSizes , OverlapRadii >::Index ];
+
+	LocalDepth d , parentD ; LocalOffset off , parentOff;
+	_localDepthAndOffset( node , d , off );
+	_localDepthAndOffset( node->parent , parentD , parentOff );
+	int fStart , fEnd;
+	BSplineData< FEMSig >::FunctionSpan( d , fStart , fEnd );
+
+	int fIdx[Dim];
+	functionIndex( IsotropicUIntPack< Dim , FEMSig >() , node , fIdx );
+	double       splineValues[ Dim ]               [ PointD+1 ];
+	double parentSplineValues[ Dim ][ SupportSize ][ PointD+1 ];
+	int s[Dim];
+	CumulativeDerivativeValues< Real , Dim , PointD > dualValues;
+	std::function< void ( const FEMTreeNode* , Real& ) > innerFunction = [&]( const FEMTreeNode* pNode , Real& pointValue )
+	{
+		if( _isValidFEM1Node( pNode ) )
+		{
+			CumulativeDerivativeValues< Real , Dim , PointD > values = Evaluate< SupportSize , Dim , Real , PointD >( s , parentSplineValues );
+			pointValue += CumulativeDerivativeValues< Real , Dim , PointD >::Dot( dualValues , values );
+		};
+	};
+	std::function< void ( const FEMTreeNode* ) > outerFunction = [&]( const FEMTreeNode* _node )
+	{
+		if( _isValidSpaceNode( _node ) ) for( const PointData< Dim , Real , T , PointD >* _pData=iInfo.begin( _node ) ; _pData!=iInfo.end( _node ) ; _pData++ )
+		{
+			// Evaluate the node's basis function at the sample
+			const PointData< Dim , Real , T , PointD >& pData = *_pData;
+			_setDValues< FEMSig , PointD , FEMDegree >( pData.position , _node , node , bsData , splineValues );
+			_setDValues< FEMSig , PointD , FEMDegree >( pData.position , _node->parent , bsData , parentSplineValues );
+			dualValues = iInfo.weights * Evaluate< Dim , Real , PointD >( splineValues ) * pData.weight;
+
+			// Get the indices of the parent
+			LocalDepth _parentD ; LocalOffset _parentOff;
+			_localDepthAndOffset( _node->parent , _parentD , _parentOff );
+
+			int _off[Dim];
+			for( int dd=0 ; dd<Dim ; dd++ ) _off[dd] = _parentOff[dd] - parentOff[dd];
+
+			int _start[Dim] , _end[Dim];
+			for( int dd=0 ; dd<Dim ; dd++ ) _start[dd] = OverlapRadius + _off[dd] - LeftPointSupportRadius , _end[dd] = _start[dd] + SupportSize;
+			WindowLoop< Dim >::Run
+			(
+				_start , _end ,
+				[&]( int d , int i ){ s[d] = i + LeftPointSupportRadius - _off[d] - OverlapRadius; } ,
+				innerFunction ,
+				pNeighbors.neighbors() , pointValues
+			);
+		}
+	};
+	int start[Dim] , end[Dim];
+	for( int dd=0 ; dd<Dim ; dd++ ) start[dd] = OverlapRadius - LeftSupportRadius , end[dd] = start[dd] + SupportSize;
+	WindowLoop< Dim >::Run
+	(
+		start , end ,
+		[&]( int , int ){;} ,
+		outerFunction ,
+		neighbors.neighbors()
+	);
+#endif
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int ... FEMSigs , typename ... InterpolationInfos >
+int FEMTree< Dim , Real >::_setProlongedMatrixRow( const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors , Pointer( MatrixEntry< Real , matrix_index_type > ) row , node_index_type offset , const DynamicWindow< double , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& stencil , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , std::tuple< InterpolationInfos *... > interpolationInfo ) const
+{
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	typedef UIntPack<    BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize    ... > OverlapSizes;
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+
+	int count = 0;
+	const FEMTreeNode* node = neighbors.neighbors.data[ WindowIndex< OverlapSizes , OverlapRadii >::Index ];
+	LocalDepth d , parentD ; LocalOffset off , parentOff;
+	_localDepthAndOffset( node , d , off );
+	_localDepthAndOffset( node->parent , parentD , parentOff );
+	bool isInterior = _isInteriorlyOverlapped( FEMDegrees() , FEMDegrees() , node->parent );
+	StaticWindow< Real , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > > pointValues;
+	memset( pointValues.data , 0 , sizeof(Real)*WindowSize< OverlapSizes >::Size );
+	_addProlongedPointValues< 0 >( UIntPack< FEMSigs ... >() , pointValues() , neighbors , pNeighbors , bsData , interpolationInfo );
+
+	node_index_type nodeIndex = node->nodeData.nodeIndex;
+
+	int start[Dim] , end[Dim];
+	_SetParentOverlapBounds( FEMDegrees() , FEMDegrees() , node , start , end );
+	if( isInterior ) // General case, so try to make fast
+	{
+		WindowLoop< Dim >::Run
+		(
+			start , end ,
+			[&]( int , int ){;} ,
+			[&]( const FEMTreeNode* node , const Real& pointValue , const Real& stencilValue )
+			{
+			if( _isValidFEM1Node( node ) ) row[count++] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( node->nodeData.nodeIndex - offset ) , pointValue + stencilValue );
+			} ,
+			pNeighbors.neighbors() , pointValues() , stencil()
+		);
+	}
+	else
+	{
+		LocalDepth d ; LocalOffset off;
+		_localDepthAndOffset( node , d , off );
+		WindowLoop< Dim >::Run
+		(
+			start , end , 
+			[&]( int , int ){;} ,
+			[&]( const FEMTreeNode* node , const Real& pointValue )
+			{
+				if( _isValidFEM1Node( node ) )
+				{
+					LocalDepth d ; LocalOffset _off;
+					_localDepthAndOffset( node , d , _off );
+					row[count++] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( node->nodeData.nodeIndex - offset ) , (Real)F.pcIntegrate( _off , off ) + pointValue );
+				}
+			} ,
+			pNeighbors.neighbors() , pointValues()
+		);
+	}
+	return count;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int FEMDegree1 , unsigned int FEMDegree2 >
+void FEMTree< Dim , Real >::_SetParentOverlapBounds( const FEMTreeNode* node , int start[Dim] , int end[Dim] )
+{
+	const int OverlapStart = BSplineOverlapSizes< FEMDegree1 , FEMDegree2 >::OverlapStart;
+
+	if( node->parent )
+	{
+		int cIdx = (int)( node - node->parent->children );
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			start[d] = BSplineOverlapSizes< FEMDegree1 , FEMDegree2 >::ParentOverlapStart[ (cIdx>>d) & 1 ] - OverlapStart;
+			end  [d] = BSplineOverlapSizes< FEMDegree1 , FEMDegree2 >::ParentOverlapEnd  [ (cIdx>>d) & 1 ] - OverlapStart + 1;
+		}
+	}
+}
+template< unsigned int Dim , class Real >
+template< unsigned int FEMDegree1 , unsigned int FEMDegree2 >
+void FEMTree< Dim , Real >::_SetParentOverlapBounds( int cIdx , int start[Dim] , int end[Dim] )
+{
+	const int OverlapStart = BSplineOverlapSizes< FEMDegree1 , FEMDegree2 >::OverlapStart;
+
+	for( int d=0 ; d<Dim ; d++ )
+	{
+		start[d] = BSplineOverlapSizes< FEMDegree1 , FEMDegree2 >::ParentOverlapStart[ (cIdx>>d) & 1 ] - OverlapStart;
+		end  [d] = BSplineOverlapSizes< FEMDegree1 , FEMDegree2 >::ParentOverlapEnd  [ (cIdx>>d) & 1 ] - OverlapStart + 1;
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+T FEMTree< Dim , Real >::_getInterpolationConstraintFromProlongedSolution( const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const FEMTreeNode* node , ConstPointer( T ) prolongedSolution , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , const InterpolationInfo< T , PointD >* interpolationInfo ) const
+{
+	if( !interpolationInfo ) return T();
+	typedef UIntPack<    BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize    ... > SupportSizes;
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	typedef UIntPack< ( -BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportStart ) ... > LeftSupportRadii;
+	typedef UIntPack<    BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize    ... > OverlapSizes;
+	typedef PointEvaluatorState< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > > _PointEvaluatorState;
+	LocalDepth d ; LocalOffset off;
+	_localDepthAndOffset( node , d , off );
+	T temp = {};
+	if( _isValidFEM1Node( node ) )
+	{
+		int s[Dim];
+#if defined( _WIN32 ) || defined( _WIN64 )
+#ifdef SHOW_WARNINGS
+#pragma message ( "[WARNING] You've got me MSVC" )
+#endif // SHOW_WARNINGS
+		auto  UpdateFunction = [&]( int d , int i ){ s[d] = (int)SupportSizes::Values[d] - 1 - ( i - (int)OverlapRadii::Values[d] + (int)LeftSupportRadii::Values[d] ); };
+		auto ProcessFunction = [&]( const FEMTreeNode* pNode )
+		{
+			if( _isValidSpaceNode( pNode ) )
+			{
+				size_t begin , end;
+				interpolationInfo->range( pNode , begin , end );
+				for( size_t pIndex=begin ; pIndex<end ; pIndex++ )
+				{
+					const DualPointInfo< Dim , Real , T , PointD > _pData = (*interpolationInfo)[ pIndex ];
+					_PointEvaluatorState peState;
+					Point< Real , Dim > p = _pData.position;
+					LocalDepth pD ; LocalOffset pOff;
+					_localDepthAndOffset( pNode , pD , pOff );
+					bsData.initEvaluationState( p , pD , pOff , peState );
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Why is this necessary?" )
+#endif // SHOW_WARNINGS
+					const int *_off = off;
+					CumulativeDerivativeValues< Real , Dim , PointD > values = peState.template dValues< Real , CumulativeDerivatives< Dim , PointD > >( _off );
+					for( int d=0 ; d<CumulativeDerivatives< Dim , PointD >::Size ; d++ ) temp += _pData.dualValues[d] * values[d];
+				}
+			}
+		};
+#endif // _WIN32 || _WIN64
+		WindowLoop< Dim >::Run
+		(
+			OverlapRadii() - LeftSupportRadii() , OverlapRadii() - LeftSupportRadii() + SupportSizes() ,
+#if defined( _WIN32 ) || defined( _WIN64 )
+			UpdateFunction , ProcessFunction ,
+#else // !_WIN32 && !_WIN64
+			[&]( int d , int i ){ s[d] = (int)SupportSizes::Values[d] - 1 - ( i - (int)OverlapRadii::Values[d] + (int)LeftSupportRadii::Values[d] ); } ,
+			[&]( const FEMTreeNode* pNode )
+			{
+				if( _isValidSpaceNode( pNode ) )
+				{
+					size_t begin , end;
+					interpolationInfo->range( pNode , begin , end );
+					for( size_t pIndex=begin ; pIndex<end ; pIndex++ )
+					{
+						const DualPointInfo< Dim , Real , T , PointD > _pData = (*interpolationInfo)[ pIndex ];
+						_PointEvaluatorState peState;
+						Point< Real , Dim > p = _pData.position;
+						LocalDepth pD ; LocalOffset pOff;
+						_localDepthAndOffset( pNode , pD , pOff );
+						bsData.initEvaluationState( p , pD , pOff , peState );
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Why is this necessary?" )
+#endif // SHOW_WARNINGS
+						const int *_off = off;
+						CumulativeDerivativeValues< Real , Dim , PointD > values = peState.template dValues< Real , CumulativeDerivatives< Dim , PointD > >( _off );
+						for( int d=0 ; d<CumulativeDerivatives< Dim , PointD >::Size ; d++ ) temp += _pData.dualValues[d] * values[d];
+					}
+				}
+			} ,
+#endif // _WIN32 || _WIN64
+			neighbors.neighbors()
+		);
+	}
+	return temp;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , typename ... InterpolationInfos >
+T FEMTree< Dim , Real >::_getConstraintFromProlongedSolution( UIntPack< FEMSigs ... > , const BaseSystem< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors , const FEMTreeNode* node , ConstPointer( T ) prolongedSolution , const DynamicWindow< double , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& stencil , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+
+	if( _localDepth( node )<=0 ) return T();
+	// This is a conservative estimate as we only need to make sure that the parent nodes don't overlap the child (not the parent itself)
+	LocalDepth d ; LocalOffset off;
+	_localDepthAndOffset( node->parent , d , off );
+	bool isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( FEMDegrees() , FEMDegrees() , d , off );
+
+	// Offset the constraints using the solution from lower resolutions.
+	T constraint = {};
+	static const WindowLoopData< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > > loopData( []( int c , int* start , int* end ){ BaseFEMIntegrator::ParentOverlapBounds( FEMDegrees() , FEMDegrees() , c , start , end ); } );
+	int cIdx = (int)( node - node->parent->children );
+	unsigned int size = loopData.size[cIdx];
+	const unsigned int* indices = loopData.indices[cIdx];
+	ConstPointer( double ) values = stencil.data;
+	ConstPointer( FEMTreeNode * const ) nodes = pNeighbors.neighbors().data;
+	if( isInterior )
+	{
+		for( unsigned int i=0 ; i<size ; i++ )
+		{
+			unsigned int idx = indices[i];
+			if( _isValidFEM1Node( nodes[idx] ) ) constraint += (T)( prolongedSolution[ nodes[idx]->nodeData.nodeIndex ] * (Real)values[idx] );
+		}
+	}
+	else
+	{
+		LocalDepth d ; LocalOffset off;
+		_localDepthAndOffset( node , d , off );
+		for( unsigned int i=0 ; i<size ; i++ )
+		{
+			unsigned int idx = indices[i];
+			if( _isValidFEM1Node( nodes[idx] ) )
+			{
+				LocalDepth _d ; LocalOffset _off;
+				_localDepthAndOffset( nodes[idx] , _d , _off );
+				constraint += (T)( prolongedSolution[ nodes[idx]->nodeData.nodeIndex ] * (Real)F.pcIntegrate( _off , off ) );
+			}
+
+		}
+	}
+	return constraint + _getInterpolationConstraintFromProlongedSolution< 0 >( neighbors , node , prolongedSolution , bsData , interpolationInfos );
+}
+
+// Given the solution @( depth ) add to the met constraints @( depth-1 )
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T >
+void FEMTree< Dim , Real >::_updateRestrictedIntegralConstraints( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , LocalDepth highDepth , ConstPointer( T ) fineSolution , Pointer( T ) restrictedConstraints ) const
+{
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	typedef UIntPack<    BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize    ... > OverlapSizes;
+
+	if( highDepth<=0 ) return;
+	// Get the stencil describing the Laplacian relating coefficients @(highDepth) with coefficients @(highDepth-1)
+	PCStencils< FEMDegrees > stencils;
+	F.template setStencils< true >(  stencils );
+	node_index_type start = _sNodesBegin(highDepth) , end = _sNodesEnd(highDepth);
+	node_index_type range = end-start;
+	node_index_type lStart = _sNodesBegin(highDepth-1);
+
+	// Iterate over the nodes @(highDepth)
+	std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( highDepth )-1 );
+	ThreadPool::ParallelFor( _sNodesBegin(highDepth) , _sNodesEnd(highDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+		{
+			ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+			FEMTreeNode* node = _sNodes.treeNodes[i];
+
+			// Offset the coarser constraints using the solution from the current resolutions.
+			int cIdx = (int)( node - node->parent->children );
+
+			{
+				typename FEMTreeNode::template ConstNeighbors< OverlapSizes > pNeighbors;
+				neighborKey.getNeighbors( OverlapRadii() , OverlapRadii() , node->parent , pNeighbors );
+				const DynamicWindow< double , OverlapSizes >& stencil = stencils.data[cIdx];
+
+				bool isInterior = _isInteriorlyOverlapped( FEMDegrees() , FEMDegrees() , node->parent );
+				LocalDepth d ; LocalOffset off;
+				_localDepthAndOffset( node , d , off );
+
+				// Offset the constraints using the solution from finer resolutions.
+				int start[Dim] , end[Dim];
+				_SetParentOverlapBounds( FEMDegrees() , FEMDegrees() , node , start , end );
+
+				T solution = fineSolution[ node->nodeData.nodeIndex ];
+				ConstPointer( FEMTreeNode * const ) nodes = pNeighbors.neighbors().data;
+				ConstPointer( double ) stencilValues = stencil.data;
+				if( isInterior )
+				{
+					for( int i=0 ; i<WindowSize< OverlapSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) )
+					{
+						Atomic< T >::Add( restrictedConstraints[ nodes[i]->nodeData.nodeIndex ] , solution * (Real)stencilValues[i] );
+					}
+				}
+				else
+				{
+					for( int i=0 ; i<WindowSize< OverlapSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) )
+					{
+						LocalDepth _d ; LocalOffset _off;
+						_localDepthAndOffset( nodes[i] , _d , _off );
+						Atomic< T >::Add( restrictedConstraints[ nodes[i]->nodeData.nodeIndex ] , solution * (Real)F.pcIntegrate( _off , off ) );
+					}
+				}
+			}
+		}
+	} );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+void FEMTree< Dim , Real >::_setPointValuesFromProlongedSolution( LocalDepth highDepth , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , ConstPointer( T ) prolongedSolution , InterpolationInfo< T , PointD >* iInfo ) const
+{
+	if( !iInfo ) return;
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+	InterpolationInfo< T , PointD >& interpolationInfo = *iInfo;
+
+	LocalDepth lowDepth = highDepth-1;
+	if( lowDepth<0 ) return;
+	// For every node at the current depth
+	std::vector< ConstPointSupportKey< FEMDegrees > > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( lowDepth ) );
+
+	ThreadPool::ParallelFor( _sNodesBegin(highDepth) , _sNodesEnd(highDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+		{
+			ConstPointSupportKey< FEMDegrees >& neighborKey = neighborKeys[ thread ];
+			if( _isValidSpaceNode( _sNodes.treeNodes[i] ) )
+			{
+				size_t begin , end;
+				interpolationInfo.range( _sNodes.treeNodes[i] , begin , end );
+				for( size_t pIndex=begin ; pIndex<end ; pIndex++ )
+				{
+					DualPointInfo< Dim , Real , T , PointD >& pData = interpolationInfo[ pIndex ];
+					neighborKey.getNeighbors( _sNodes.treeNodes[i]->parent );
+#ifdef _MSC_VER
+					pData.dualValues = interpolationInfo( pIndex , _coarserFunctionValues< PointD , T , FEMSigs ... >( UIntPack< FEMSigs ... >() , pData.position , neighborKey , _sNodes.treeNodes[i] , bsData , prolongedSolution ) ) * pData.weight;
+#else // !_MSC_VER
+					pData.dualValues = interpolationInfo( pIndex , _coarserFunctionValues< PointD >( UIntPack< FEMSigs ... >() , pData.position , neighborKey , _sNodes.treeNodes[i] , bsData , prolongedSolution ) ) * pData.weight;
+#endif // _MSC_VER
+				}
+			}
+		}
+	}
+	);
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+void FEMTree< Dim , Real >::_updateRestrictedInterpolationConstraints( const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth highDepth , ConstPointer( T ) solution , Pointer( T ) restrictedConstraints , const InterpolationInfo< T , PointD >* iInfo ) const
+{
+	if( !iInfo ) return;
+	const InterpolationInfo< T , PointD >& interpolationInfo = *iInfo;
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > SupportSizes;
+
+	// Note: We can't iterate over the finer point nodes as the point weights might be
+	// scaled incorrectly, due to the adaptive exponent. So instead, we will iterate
+	// over the coarser nodes and evaluate the finer solution at the associated points.
+	LocalDepth  lowDepth = highDepth-1;
+	if( lowDepth<0 ) return;
+
+	node_index_type start = _sNodesBegin(lowDepth) , end = _sNodesEnd(lowDepth);
+	std::vector< ConstPointSupportKey< FEMDegrees > > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( lowDepth ) );
+	ThreadPool::ParallelFor( _sNodesBegin(lowDepth) , _sNodesEnd(lowDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidSpaceNode( _sNodes.treeNodes[i] ) ) if( _isValidSpaceNode( _sNodes.treeNodes[i] ) )
+		{
+			ConstPointSupportKey< FEMDegrees >& neighborKey = neighborKeys[ thread ];
+			PointEvaluatorState< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > > peState;
+			const FEMTreeNode* node = _sNodes.treeNodes[i];
+
+			LocalDepth d ; LocalOffset off;
+			_localDepthAndOffset( node , d , off );
+			typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors = neighborKey.getNeighbors( node );
+			size_t begin , end;
+			interpolationInfo.range( node , begin , end );
+			for( size_t pIndex=begin ; pIndex<end ; pIndex++ )
+			{
+				const DualPointInfo< Dim , Real , T , PointD >& pData = interpolationInfo[ pIndex ];
+				Point< Real , Dim > p = pData.position;
+				bsData.initEvaluationState( p , d , off , peState );
+
+#ifdef _MSC_VER
+				CumulativeDerivativeValues< T , Dim , PointD > dualValues = interpolationInfo( pIndex , _finerFunctionValues< PointD , T , FEMSigs ... >( UIntPack< FEMSigs ... >() , pData.position , neighborKey , node , bsData , solution ) ) * pData.weight;
+#else // !_MSC_VER
+				CumulativeDerivativeValues< T , Dim , PointD > dualValues = interpolationInfo( pIndex , _finerFunctionValues< PointD >( UIntPack< FEMSigs ... >() , pData.position , neighborKey , node , bsData , solution ) ) * pData.weight;
+#endif // _MSC_VER
+				// Update constraints for all nodes @( depth-1 ) that overlap the point
+				int s[Dim];
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , SupportSizes() ,
+					[&]( int d , int i ){ s[d] = i; } ,
+					[&]( const FEMTreeNode* node )
+					{
+						if( _isValidFEM1Node( node ) )
+						{
+							LocalDepth d ; LocalOffset off;
+							_localDepthAndOffset( node , d , off );
+							CumulativeDerivativeValues< Real , Dim , PointD > values = peState.template dValues< Real , CumulativeDerivatives< Dim , PointD > >( off );
+							T temp = {};
+							for( int d=0 ; d<CumulativeDerivatives< Dim , PointD >::Size ; d++ ) temp += dualValues[d] * values[d];
+							Atomic< T >::Add( restrictedConstraints[ node->nodeData.nodeIndex ] , temp );
+						}
+					} ,
+					neighbors.neighbors()
+				);
+			}
+		}
+	}
+	);
+}
+
+template< unsigned int Dim , class Real >
+template< class C , unsigned int ... FEMSigs >
+DenseNodeData< C , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::coarseCoefficients( const DenseNodeData< C , UIntPack< FEMSigs ... > >& coefficients ) const
+{
+	DenseNodeData< C , UIntPack< FEMSigs ... > > coarseCoefficients( _sNodesEnd(_maxDepth-1) );
+	memset( coarseCoefficients() , 0 , sizeof(Real)*_sNodesEnd(_maxDepth-1) );
+	ThreadPool::ParallelFor( _sNodesBegin(0) , _sNodesEnd(_maxDepth-1) , [&]( unsigned int , size_t i ){ coarseCoefficients[i] = coefficients[i]; } );
+	typename FEMIntegrator::template RestrictionProlongation< UIntPack< FEMSigs ... > > rp;
+	for( LocalDepth d=1 ; d<_maxDepth ; d++ ) _upSample( UIntPack< FEMSigs ... >() , rp , d , ( ConstPointer(C) )coarseCoefficients()+_sNodesBegin(d-1) , coarseCoefficients()+_sNodesBegin(d) );
+	return coarseCoefficients;
+}
+
+template< unsigned int Dim , class Real >
+template< class C , unsigned int ... FEMSigs >
+DenseNodeData< C , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::coarseCoefficients( const SparseNodeData< C , UIntPack< FEMSigs ... > >& coefficients ) const
+{
+	DenseNodeData< C , UIntPack< FEMSigs ... > > coarseCoefficients( _sNodesEnd(_maxDepth-1) );
+	memset( coarseCoefficients() , 0 , sizeof(C)*_sNodesEnd(_maxDepth-1) );
+	ThreadPool::ParallelFor( _sNodesBegin(0) , _sNodesEnd(_maxDepth-1) , [&]( unsigned int , size_t i )
+	{
+		const C* c = coefficients( _sNodes.treeNodes[i] );
+		if( c ) coarseCoefficients[i] = *c;
+	}
+	);
+	typename FEMIntegrator::template RestrictionProlongation< UIntPack< FEMSigs ... > > rp;
+	for( LocalDepth d=1 ; d<_maxDepth ; d++ ) _upSample( UIntPack< FEMSigs ... >() , rp , d , coarseCoefficients()+_sNodesBegin(d-1) , coarseCoefficients()+_sNodesBegin(d) );
+	return coarseCoefficients;
+}
+
+template< unsigned int Dim , class Real >
+template< class C , unsigned int ... FEMSigs >
+DenseNodeData< C , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::denseCoefficients( const SparseNodeData< C , UIntPack< FEMSigs ... > >& coefficients ) const
+{
+	DenseNodeData< C , UIntPack< FEMSigs ... > > denseCoefficients( _sNodesEnd(_maxDepth) );
+	memset( denseCoefficients() , 0 , sizeof(C)*_sNodesEnd(_maxDepth) );
+	ThreadPool::ParallelFor( _sNodesBegin(0) , _sNodesEnd(_maxDepth) , [&]( unsigned int , size_t i )
+	{
+		const C* c = coefficients( _sNodes.treeNodes[i] );
+		if( c ) denseCoefficients[i] = *c;
+	}
+	);
+	return denseCoefficients;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int PointD , typename T , unsigned int ... FEMSigs >
+CumulativeDerivativeValues< T , Dim , PointD > FEMTree< Dim , Real >::_coarserFunctionValues( UIntPack< FEMSigs ... > , Point< Real , Dim > p , const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* pointNode , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , ConstPointer( T ) solution ) const
+{
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > SupportSizes;
+
+	CumulativeDerivativeValues< T , Dim , PointD > values;
+	LocalDepth depth = _localDepth( pointNode );
+	if( depth<0 ) return values;
+	// Iterate over all basis functions that overlap the point at the coarser resolutions
+	{
+
+		PointEvaluatorState< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > > peState;
+		LocalDepth _d ; LocalOffset _off;
+		_localDepthAndOffset( pointNode->parent , _d , _off );
+		bsData.initEvaluationState( p , _d , _off , peState );
+		const typename FEMTreeNode::template ConstNeighbors< SupportSizes >& neighbors = neighborKey.neighbors[ _localToGlobal( depth-1 ) ];
+		ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+
+		for( unsigned int i=0 ; i<WindowSize< SupportSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) )
+		{
+			LocalDepth d ; LocalOffset off;
+			_localDepthAndOffset( nodes[i] , d , off );
+			CumulativeDerivativeValues< Real , Dim , PointD > temp = peState.template dValues< Real , CumulativeDerivatives< Dim , PointD > >( off );
+			const T& _solution = solution[ nodes[i]->nodeData.nodeIndex ];
+			for( int s=0 ; s<CumulativeDerivatives< Dim , PointD >::Size ; s++ ) values[s] += _solution * temp[s];
+		}
+	}
+	return values;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int PointD , typename T , unsigned int ... FEMSigs >
+CumulativeDerivativeValues< T , Dim , PointD > FEMTree< Dim , Real >::_finerFunctionValues( UIntPack< FEMSigs ... > , Point< Real , Dim > p , const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* pointNode , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , ConstPointer( T ) solution ) const
+{
+	typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > > childNeighbors;
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree  >::SupportSize ... > SupportSizes;
+
+	CumulativeDerivativeValues< T , Dim , PointD > values;
+	LocalDepth depth = _localDepth( pointNode );
+	neighborKey.getChildNeighbors( _childIndex( pointNode , p ) , _localToGlobal( depth ) , childNeighbors );
+	PointEvaluatorState< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > > peState;
+	LocalDepth d ; LocalOffset off;
+	_localDepthAndOffset( pointNode , d , off );
+	int cIdx = _childIndex( pointNode , p );
+	d++;
+	for( int dd=0 ; dd<Dim ; dd++ ) off[dd] = (off[dd]<<1) | ( (cIdx>>dd) & 1 );
+	bsData.initEvaluationState( p , d , off , peState );
+	int s[Dim];
+	WindowLoop< Dim >::Run
+	(
+		ZeroUIntPack< Dim >() , SupportSizes() ,
+		[&]( int d , int i ){ s[d] = i; } ,
+		[&]( const FEMTreeNode* node )
+		{
+			if( _isValidFEM1Node( node ) )
+			{
+				LocalDepth d ; LocalOffset off;
+				_localDepthAndOffset( node , d , off );
+				CumulativeDerivativeValues< Real , Dim , PointD > dValues = peState.template dValues< Real , CumulativeDerivatives< Dim , PointD > >( off );
+				const T& _solution = solution[ node->nodeData.nodeIndex ];
+				for( int s=0 ; s<CumulativeDerivatives< Dim , PointD >::Size ; s++ ) values[s] += _solution * dValues[s];
+			}
+		} ,
+		childNeighbors.neighbors()
+	);
+	return values;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , typename ... InterpolationInfos >
+int FEMTree< Dim , Real >::_getSliceMatrixAndProlongationConstraints( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , SystemMatrixType< FEMSigs ... > &matrix , Pointer( Real ) diagonalR , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , node_index_type nBegin , node_index_type nEnd , ConstPointer( T ) prolongedSolution , Pointer( T ) constraints , const CCStencil< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& ccStencil , const PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& pcStencils , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+	typedef UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > OverlapSizes;
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	size_t range = nEnd - nBegin;
+	matrix.resize( range );
+	std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( depth ) );
+	ThreadPool::ParallelFor( 0 , range , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i+nBegin] ) )
+		{
+			ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+			FEMTreeNode* node = _sNodes.treeNodes[i+nBegin];
+			// Get the matrix row size	
+			typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors , pNeighbors;
+			neighborKey.getNeighbors( OverlapRadii() , OverlapRadii() , node , pNeighbors , neighbors );
+			// Set the row entries
+			if( constraints ) constraints[i] = _setMatrixRowAndGetConstraintFromProlongation( UIntPack< FEMSigs ... >() , F , pNeighbors , neighbors , i , matrix , nBegin , pcStencils , ccStencil , bsData , prolongedSolution , interpolationInfos );
+			else                               _setMatrixRowAndGetConstraintFromProlongation( UIntPack< FEMSigs ... >() , F , pNeighbors , neighbors , i , matrix , nBegin , pcStencils , ccStencil , bsData , prolongedSolution , interpolationInfos );
+			if( diagonalR )
+				if( _sNodes.treeNodes[i+nBegin]->nodeData.getDirichletElementFlag() ) diagonalR[i] = (Real)0.;
+				else                                                                  diagonalR[i] = (Real)1. / matrix[i][0].Value;
+		}
+		else if( constraints ) constraints[i] = T();
+	}
+	);
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Why do we care if the node is not valid?" )
+#endif // SHOW_WARNINGS
+#if !defined( _WIN32 ) && !defined( _WIN64 )
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] I'm not sure how expensive this system call is on non-Windows system. (You may want to comment this out.)" )
+#endif // SHOW_WARNINGS
+#endif // !_WIN32 && !_WIN64
+	return 1;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+SparseMatrix< Real , matrix_index_type > FEMTree< Dim , Real >::systemMatrix( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , LocalDepth depth , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	typedef typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > > BaseSystem;
+	if( depth<0 || depth>_maxDepth ) MK_THROW( "System depth out of bounds: 0 <= " , depth , " <= " , _maxDepth );
+	SparseMatrix< Real , matrix_index_type > matrix;
+	F.init( depth );
+	PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > > bsData( depth );
+
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	typedef UIntPack<    BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize    ... > OverlapSizes;
+
+	CCStencil< UIntPack< FEMSignature< FEMSigs >::Degree ... > > stencil;
+	PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > > stencils;
+
+	F.template setStencil< false >( stencil );
+
+	matrix.resize( _sNodesSize(depth) );
+	std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( depth ) );
+	ThreadPool::ParallelFor( _sNodesBegin(depth) , _sNodesEnd( depth ) , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+		{
+			node_index_type ii = (node_index_type)i - _sNodesBegin(depth);
+			ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+			typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors;
+			neighborKey.getNeighbors( OverlapRadii() , OverlapRadii() , _sNodes.treeNodes[i] , neighbors );
+			_setMatrixRowAndGetConstraintFromProlongation( UIntPack< FEMSigs ... >() , F ,  neighbors , neighbors , ii , matrix , _sNodesBegin(depth) , stencils , stencil , bsData , ( ConstPointer( Real ) )NullPointer( Real ) , interpolationInfos );
+		}
+	}
+	);
+	return matrix;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+SparseMatrix< Real , matrix_index_type > FEMTree< Dim , Real >::prolongedSystemMatrix( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack<FEMSignature< FEMSigs >::Degree ... > >& F , LocalDepth highDepth , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	if( highDepth<=0 || highDepth>_maxDepth ) MK_THROW( "System depth out of bounds: 0 < " , highDepth , " <= " , _maxDepth );
+
+	LocalDepth lowDepth = highDepth-1;
+	SparseMatrix< Real , matrix_index_type > matrix;
+	F.init( highDepth );
+	PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > > bsData( highDepth );
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ) ... > OverlapRadii;
+	typedef UIntPack<    BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize    ... > OverlapSizes;
+
+	PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > > stencils;
+	F.template setStencils< true >( stencils );
+
+	matrix.resize( _sNodesSize(highDepth) );
+	std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( highDepth ) );
+	ThreadPool::ParallelFor( _sNodesBegin(highDepth) , _sNodesEnd(highDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+		{
+			node_index_type ii = i - _sNodesBegin(highDepth);
+			int cIdx = (int)( _sNodes.treeNodes[i]-_sNodes.treeNodes[i]->parent->children );
+
+			ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+			typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors , pNeighbors;
+			neighborKey.getNeighbors( OverlapRadii() , OverlapRadii() , _sNodes.treeNodes[i] , neighbors );
+			neighborKey.getNeighbors( OverlapRadii() , OverlapRadii() , _sNodes.treeNodes[i]->parent , pNeighbors );
+
+			matrix.setRowSize( ii , _getProlongedMatrixRowSize< FEMSigs ... >( _sNodes.treeNodes[i] , pNeighbors ) );
+			_setProlongedMatrixRow< Real >( F , neighbors , pNeighbors , matrix[ii] , _sNodesBegin(lowDepth) , stencils.data[cIdx] , bsData , interpolationInfos );
+		}
+	}
+	);
+	return matrix;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename ValidNodeFunctor >
+SparseMatrix< Real , matrix_index_type > FEMTree< Dim , Real >::_downSampleMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth , ValidNodeFunctor validNodeFunctor ) const
+{
+	SparseMatrix< Real , matrix_index_type > matrix;
+	typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleSize ... > UpSampleSizes;
+	typedef IntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleStart ... > UpSampleStarts;
+	typedef typename FEMTreeNode::template ConstNeighborKey< UIntPack< -BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleStart ... > , UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleEnd ... > > UpSampleKey;
+
+	LocalDepth lowDepth = highDepth-1;
+	if( lowDepth<0 ) return matrix;
+
+	matrix.resize( _sNodesSize( lowDepth ) );
+
+	typename EvaluationData::UpSampleEvaluator* upSampleEvaluators[] = { new typename BSplineEvaluationData< FEMSigs >::UpSampleEvaluator() ... };
+	for( int d=0 ; d<Dim ; d++ ) upSampleEvaluators[d]->set( lowDepth );
+	std::vector< UpSampleKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( lowDepth ) );
+
+	DynamicWindow< double , UpSampleSizes > upSampleStencil;
+	int lowCenter = ( 1<<lowDepth )>>1;
+	double value[Dim+1] ; value[0] = 1;
+	WindowLoop< Dim >::Run
+	(
+		ZeroUIntPack< Dim >() , UpSampleSizes() ,
+		[&]( int d , int i ){ value[d+1] = value[d] * upSampleEvaluators[d]->value( lowCenter , 2*lowCenter + i + UpSampleStarts::Values[d] ); } ,
+		[&]( double&  stencilValue ){ stencilValue = value[Dim]; } ,
+		upSampleStencil()
+	);
+
+	ThreadPool::ParallelFor( _sNodesBegin(lowDepth) , _sNodesEnd(lowDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( validNodeFunctor( _sNodes.treeNodes[i] ) )
+		{
+			node_index_type _i = (node_index_type)i - _sNodesBegin(lowDepth);
+			FEMTreeNode* pNode = _sNodes.treeNodes[i];
+
+			UpSampleKey& neighborKey = neighborKeys[ thread ];
+			LocalDepth d ; LocalOffset off;
+			_localDepthAndOffset( pNode , d , off );
+			neighborKey.getNeighbors( pNode );
+			typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleSize ... > > neighbors;
+			neighborKey.getChildNeighbors( 0 , _localToGlobal( d ) , neighbors );
+
+			int rowSize = 0;
+			ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+			for( int i=0 ; i<WindowSize< UpSampleSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) ) rowSize++;
+
+			matrix.setRowSize( _i , rowSize );
+			matrix.rowSizes[_i] = 0;
+
+			// Want to make sure test if contained children are interior.
+			// This is more conservative because we are test that overlapping children are interior
+			bool isInterior = _isInteriorlyOverlapped( FEMDegrees() , FEMDegrees() , pNode );
+
+			if( isInterior )
+			{
+				ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+				ConstPointer( double ) stencilValues = upSampleStencil().data;
+				for( int i=0 ; i<WindowSize< UpSampleSizes >::Size ; i++ ) if( validNodeFunctor( nodes[i] ) )
+					matrix[_i][ matrix.rowSizes[_i]++ ] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( nodes[i]->nodeData.nodeIndex - _sNodesBegin(highDepth) ) , (Real)stencilValues[i] );
+			}
+			else
+			{
+				double upSampleValues[Dim][ UpSampleSizes::Max() ];
+
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , UpSampleSizes() ,
+					[&]( int d , int i ){ upSampleValues[d][i] = upSampleEvaluators[d]->value( off[d] , 2*off[d] + i + UpSampleStarts::Values[d] ); } ,
+					[&]( void ){}
+				);
+
+				double values[Dim+1] ; values[0] = 1;
+				WindowLoop< Dim >::Run
+				(
+					ZeroUIntPack< Dim >() , UpSampleSizes() ,
+					[&]( int d , int i ){ values[d+1] = values[d] * upSampleValues[d][i]; } ,
+					[&]( const FEMTreeNode* node ){ if( validNodeFunctor( node ) ) matrix[_i][ matrix.rowSizes[_i]++ ] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( node->nodeData.nodeIndex - _sNodesBegin(highDepth) ) , (Real)values[Dim] ); } ,
+					neighbors.neighbors()
+				);
+			}
+		}
+	}
+	);
+	for( int d=0 ; d<Dim ; d++ ) delete upSampleEvaluators[d];
+	return matrix;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename ValidNodeFunctor >
+SparseMatrix< Real , matrix_index_type > FEMTree< Dim , Real >::_upSampleMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth , ValidNodeFunctor validNodeFunctor ) const
+{
+	SparseMatrix< Real , matrix_index_type > matrix;
+	matrix.resize( _sNodesSize( highDepth ) );
+	LocalDepth lowDepth = highDepth-1;
+	if( lowDepth<0 ) return matrix;
+
+	typedef typename BaseFEMIntegrator::RestrictionProlongation< UIntPack< FEMSignature< FEMSigs >::Degree ... > > BaseRestrictionProlongation;
+	typedef typename FEMTreeNode::template ConstNeighborKey< UIntPack< - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start ... > , UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End ... > > DownSampleKey;
+	typedef typename FEMTreeNode::template ConstNeighbors< UIntPack< ( - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start + BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End + 1 ) ... > > DownSampleNeighbors;
+	typedef UIntPack< ( - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start + BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End + 1 ) ... > DownSampleSizes;
+
+	std::vector< DownSampleKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( lowDepth ) );
+
+	typename FEMIntegrator::template RestrictionProlongation< UIntPack< FEMSigs ... > > rp;
+	( ( BaseRestrictionProlongation& )rp ).init( highDepth );
+	typename BaseRestrictionProlongation::DownSampleStencils downSampleStencils;
+	rp.setStencils( downSampleStencils );
+
+	const int Start[2][Dim] = { { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start ... } , { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1Start ... } };
+	const int   End[2][Dim] = { { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0End   ... } , { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End   ... } };
+
+	static const WindowLoopData< UIntPack< ( - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start + BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End + 1 ) ... > > loopData
+	( []( int c , int* start , int* end )
+	{
+		const int Start[2][Dim] = { { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start ... } , { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1Start ... } };
+		const int   End[2][Dim] = { { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0End   ... } , { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End   ... } };
+		for( int d=0 ; d<Dim ; d++ ) start[d] = Start[(c>>d)&1][d] - Start[0][d] , end[d] = - Start[0][d] + End[(c>>d)&1][d] + 1;
+	} 
+	);
+
+	// For Dirichlet constraints, can't get to all children from parents because boundary nodes are invalid
+	ThreadPool::ParallelFor( _sNodesBegin(highDepth) , _sNodesEnd(highDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( validNodeFunctor( _sNodes.treeNodes[i] ) )
+		{
+			node_index_type _i = (node_index_type)i - _sNodesBegin(highDepth);
+
+			FEMTreeNode *cNode = _sNodes.treeNodes[i];
+			int c = (int)( cNode-cNode->parent->children );
+
+			DownSampleKey& neighborKey = neighborKeys[ thread ];
+			DownSampleNeighbors neighbors = neighborKey.getNeighbors( cNode->parent );
+			// Want to make sure test if contained children are interior.
+			// This is more conservative because we are test that overlapping children are interior
+			bool isInterior;
+			{
+				LocalDepth d ; LocalOffset off;
+				_localDepthAndOffset( cNode->parent , d , off );
+				isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , UIntPack< FEMSignature< FEMSigs >::Degree ... >() , d , off );
+			}
+
+			unsigned int size = loopData.size[c];
+			const unsigned int *indices = loopData.indices[c];
+			typename BaseRestrictionProlongation::DownSampleStencil& downSampleStencil = downSampleStencils.data[c];
+			Pointer( const FEMTreeNode* ) nodes = neighbors.neighbors().data;
+			Pointer( double ) downSampleValues = downSampleStencil.data;
+
+			int rowSize = 0;
+			for( unsigned int i=0 ; i<size ; i++ )
+			{
+				unsigned int idx = indices[i];
+				if( validNodeFunctor( nodes[idx] ) ) rowSize++;
+			}
+			matrix.setRowSize( _i , rowSize );
+			matrix.rowSizes[_i] = 0;
+
+
+			if( isInterior )
+			{
+				for( unsigned int i=0 ; i<size ; i++ )
+				{
+					unsigned int idx = indices[i];
+					if( validNodeFunctor( nodes[idx] ) ) matrix[_i][ matrix.rowSizes[_i]++ ] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( nodes[idx]->nodeData.nodeIndex - _sNodesBegin(lowDepth) ) , (Real)downSampleValues[idx] );
+				}
+			}
+			else
+			{
+				LocalDepth d ; LocalOffset off;
+				_localDepthAndOffset( cNode , d , off );
+				for( unsigned int i=0 ; i<size ; i++ )
+				{
+					unsigned int idx = indices[i];
+					if( validNodeFunctor( nodes[idx] ) )
+					{
+						LocalDepth _d ; LocalOffset _off;
+						_localDepthAndOffset( nodes[idx] , _d , _off );
+						matrix[_i][ matrix.rowSizes[_i]++ ] = MatrixEntry< Real , matrix_index_type >( (matrix_index_type)( nodes[idx]->nodeData.nodeIndex - _sNodesBegin(lowDepth) ) , (Real)rp.upSampleCoefficient( _off , off ) );
+					}
+				}
+			}
+		}
+	}
+	);
+	return matrix;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename ValidNodeFunctor >
+SparseMatrix< Real , matrix_index_type > FEMTree< Dim , Real >::_restrictSystemMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth , const SparseMatrix< Real , matrix_index_type > &highM , ValidNodeFunctor validNodeFunctor ) const
+{
+	SparseMatrix< Real , matrix_index_type > lowM , R , P;
+	LocalDepth lowDepth = highDepth-1;
+	if( lowDepth<0 ) return lowM;
+	R = _downSampleMatrix( UIntPack< FEMSigs ... >() , highDepth , validNodeFunctor );
+	P = _upSampleMatrix( UIntPack< FEMSigs ... >() , highDepth , validNodeFunctor );
+#if 1
+	static const int StartOffset[] = { BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapStart ... };
+	static const unsigned int Size = WindowSize< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >::Size;
+
+	lowM.resize( _sNodesSize( lowDepth ) );
+
+	// Compute the window indices of all nodes at the coarser resolution
+	static const unsigned int StartOffsetIndex = GetWindowIndex( UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... >() , StartOffset );
+	std::vector< unsigned int > windowIndices( _sNodesSize(lowDepth) );
+	ThreadPool::ParallelFor( _sNodesBegin(lowDepth) , _sNodesEnd(lowDepth) , [&]( unsigned int thread , size_t i )
+	{
+		node_index_type _i = (node_index_type)i - _sNodesBegin(lowDepth);
+		LocalDepth d ; LocalOffset off;
+		_sNodes.treeNodes[i]->depthAndOffset( d , off );
+		windowIndices[_i] = GetWindowIndex( UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... >() , off );
+	} );
+
+	// Iterate over all low-depth nodes
+	ThreadPool::ParallelFor( _sNodesBegin(lowDepth) , _sNodesEnd(lowDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( validNodeFunctor( _sNodes.treeNodes[i] ) )
+		{
+			MatrixEntry< Real , matrix_index_type > row[Size];
+			for( int s=0 ; s<Size ; s++ ) row[s] = MatrixEntry< Real , matrix_index_type >( -1 , (Real)0 );
+
+			// Indices of the form "_X" are depth-local
+			node_index_type _i = (node_index_type)i - _sNodesBegin(lowDepth);
+
+			unsigned int _ii = windowIndices[_i] + StartOffsetIndex;
+			// Iterate over all child nodes
+			for( int j=0 ; j<R.rowSizes[_i] ; j++ )
+			{
+				node_index_type _j = (node_index_type)R[_i][j].N;
+				// Iterate over all neighbors of the child node
+				for( int k=0 ; k<highM.rowSizes[_j] ; k++ ) if( highM[_j][k].Value )
+				{
+					node_index_type _k = highM[_j][k].N;
+					Real _matrixValue = highM[_j][k].Value * R[_i][j].Value;
+					// Iterate over everything the neighbor node restrict to
+					for( int l=0 ; l<P.rowSizes[_k] ; l++ )
+					{
+						node_index_type _l = (node_index_type)P[_k][l].N;
+						Real __matrixValue = _matrixValue * P[_k][l].Value;
+						int ii = windowIndices[_l] - _ii;
+						row[ii].N = (matrix_index_type)_l;
+						row[ii].Value += __matrixValue;
+					}
+				}
+			}
+			int rowSize = 0;
+			for( int s=0 ; s<Size ; s++ ) if( row[s].N!=-1 ) rowSize++;
+			lowM.setRowSize( _i , rowSize );
+			lowM.rowSizes[_i] = 0;
+			for( int s=0 ; s<Size ; s++ ) if( row[s].N!=-1 ) lowM[_i][ lowM.rowSizes[_i]++ ] = row[s];
+		}
+	} );
+	return lowM;
+#else
+	return R * highM * P;
+#endif
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs >
+SparseMatrix< Real , matrix_index_type > FEMTree< Dim , Real >::upSampleMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth ) const
+{
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	return _upSampleMatrix( UIntPack< FEMSigs ... >() , highDepth , [&]( const FEMTreeNode *node ){ return _isValidFEM1Node( node ) && ( _localDepth(node)<_baseDepth || !node->nodeData.getDirichletElementFlag() ); } );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs >
+SparseMatrix< Real , matrix_index_type > FEMTree< Dim , Real >::downSampleMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth ) const
+{
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	return _downSampleMatrix( UIntPack< FEMSigs ... >() , highDepth , [&]( const FEMTreeNode *node ){ return _isValidFEM1Node( node ) && ( _localDepth(node)<_baseDepth || !node->nodeData.getDirichletElementFlag() ); } );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+SparseMatrix< Real , matrix_index_type > FEMTree< Dim , Real >::fullSystemMatrix( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , LocalDepth depth , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	SparseMatrix< Real , matrix_index_type > M;
+	std::vector< SparseMatrix< Real , matrix_index_type > >                  systemMatrices( depth+1 );
+	std::vector< SparseMatrix< Real , matrix_index_type > >         prolongedSystemMatrices( depth   );
+	std::vector< std::vector< SparseMatrix< Real , matrix_index_type > > > upSampleMatrices( depth-1 );
+
+	for( int d=0 ; d<depth-1 ; d++ ) upSampleMatrices[d].resize( depth );
+	node_index_type size = _sNodesEnd( depth );
+	for( int d=0 ; d<=depth ; d++ )
+	{
+		SparseMatrix< Real , matrix_index_type >& M = systemMatrices[d];
+		M.resize( size );
+		SparseMatrix< Real , matrix_index_type > _M = systemMatrix< Real >( UIntPack< FEMSigs ... >() , F , d , interpolationInfos );
+		ThreadPool::ParallelFor( 0 , _M.rows() , [&]( unsigned int , size_t i )
+		{
+			M.setRowSize( (matrix_index_type)( i + _sNodesBegin(d) ) , _M.rowSize(i) );
+			for( int j=0 ; j<_M.rowSize(i) ; j++ ) M[i+_sNodesBegin(d)][j] = MatrixEntry< Real , matrix_index_type >( _M[i][j].N + (matrix_index_type)_sNodesBegin(d) , _M[i][j].Value );
+		}
+		);
+	}
+	for( int d=0 ; d<depth ; d++ )
+	{
+		SparseMatrix< Real , matrix_index_type >& M = prolongedSystemMatrices[d];
+		M.resize( size );
+		SparseMatrix< Real , matrix_index_type > _M = prolongedSystemMatrix< Real >( UIntPack< FEMSigs ... >() , F , d+1 , interpolationInfos );
+		ThreadPool::ParallelFor( 0 , _M.rows() , [&]( unsigned int , size_t i )
+		{
+			M.setRowSize( i + (matrix_index_type)_sNodesBegin(d+1) , _M.rowSize(i) );
+			for( int j=0 ; j<_M.rowSize(i) ; j++ ) M[i+_sNodesBegin(d+1)][j] = MatrixEntry< Real , matrix_index_type >( _M[i][j].N + (matrix_index_type)_sNodesBegin(d) , _M[i][j].Value );
+		}
+		);
+	}
+	for( int d=0 ; d<depth-1 ; d++ )
+	{
+		SparseMatrix< Real , matrix_index_type >& M = upSampleMatrices[d][d+1];
+		M.resize( size );
+		SparseMatrix< Real , matrix_index_type > _M = downSampleMatrix( UIntPack< FEMSigs ... >() , d+1 ).transpose( _sNodesSize( d+1 ) );
+		ThreadPool::ParallelFor( 0 , _M.rows() , [&]( unsigned int , size_t i )
+		{
+			M.setRowSize( i + (matrix_index_type)_sNodesBegin(d+1) , _M.rowSize(i) );
+			for( int j=0 ; j<_M.rowSize(i) ; j++ ) M[i+_sNodesBegin(d+1)][j] = MatrixEntry< Real , matrix_index_type >( _M[i][j].N + (matrix_index_type)_sNodesBegin(d) , _M[i][j].Value );
+		}
+		);
+		for( int dd=0 ; dd<d ; dd++ ) upSampleMatrices[dd][d+1] = upSampleMatrices[d][d+1] * upSampleMatrices[dd][d];
+	}
+
+	auto Matrix = [&]( int d1 , int d2 )
+	{
+		SparseMatrix< Real , matrix_index_type > _M;
+		int _d1 = d1<d2 ? d1 : d2 , _d2 = d2<d1 ? d1 : d2;
+		if     ( _d1==_d2   ) _M =          systemMatrices[_d1];
+		else if( _d2==_d1+1 ) _M = prolongedSystemMatrices[_d2-1];
+		else                  _M = prolongedSystemMatrices[_d2-1] * upSampleMatrices[_d1][_d2-1];
+		if( d2<d1 ) return _M.transpose( size );
+		else        return _M;
+	};
+
+	for( int d1=0 ; d1<=depth ; d1++ )
+	{
+		M += Matrix( d1 , d1 );
+		for( int d2=0 ; d2<=depth ; d2++ ) if( d1!=d2 )
+		{
+			SparseMatrix< Real , matrix_index_type > _M = Matrix( d1 , d2 );
+			ThreadPool::ParallelFor( 0 , _M.rows() , [&]( unsigned int , size_t i )
+			{
+				if( _M.rowSize(i) )
+				{
+					size_t oldSize = M.rowSize(i);
+					M.resetRowSize( i , oldSize + _M.rowSize(i) );
+					for( int j=0 ; j<_M.rowSize(i) ; j++ ) M[i][oldSize+j] = _M[i][j];
+				}
+			}
+			);
+		}
+	}
+	return M;
+}
+
+template< unsigned int Dim , class Real >
+template< class C , typename ArrayWrapper , unsigned int ... Degrees , unsigned int ... FEMSigs >
+void FEMTree< Dim , Real >::_downSample( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< Degrees ... > >& rp , LocalDepth highDepth , ArrayWrapper finerConstraints , Pointer( C ) coarserConstraints ) const
+{
+	LocalDepth lowDepth = highDepth-1;
+	if( lowDepth<0 ) return;
+
+	typedef typename BaseFEMIntegrator::RestrictionProlongation< UIntPack< Degrees ... > > BaseRestrictionProlongation;
+	typedef typename FEMTreeNode::template ConstNeighborKey< UIntPack< ( - BSplineSupportSizes< Degrees >::UpSampleStart ) ... > , UIntPack< BSplineSupportSizes< Degrees >::UpSampleEnd ... > > UpSampleKey;
+	typedef typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineSupportSizes< Degrees >::UpSampleSize ... > > UpSampleNeighbors;
+	typedef UIntPack< BSplineSupportSizes< Degrees >::UpSampleSize ... > UpSampleSizes;
+
+	std::vector< UpSampleKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( lowDepth ) );
+
+	( ( BaseRestrictionProlongation& )rp ).init( highDepth );
+	typename BaseRestrictionProlongation::UpSampleStencil upSampleStencil;
+	rp.setStencil( upSampleStencil );
+
+	ThreadPool::ParallelFor( _sNodesBegin(lowDepth) , _sNodesEnd(lowDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+		{
+			FEMTreeNode* pNode = _sNodes.treeNodes[i];
+			UpSampleKey& neighborKey = neighborKeys[ thread ];
+			LocalDepth d ; LocalOffset off;
+			_localDepthAndOffset( pNode , d , off );
+
+			neighborKey.getNeighbors( pNode );
+			UpSampleNeighbors neighbors;
+			neighborKey.getChildNeighbors( 0 , _localToGlobal( d ) , neighbors );
+
+			C &coarseConstraint = coarserConstraints[ i-_sNodesBegin(lowDepth) ];
+
+			// Want to make sure test if contained children are interior.
+			// This is more conservative because we are test that overlapping children are interior
+			bool isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< Degrees ... >() , UIntPack< Degrees ... >() , d , off );
+			if( isInterior )
+			{
+				Pointer( const FEMTreeNode* ) nodes = neighbors.neighbors().data;
+				Pointer( double ) stencilValues = upSampleStencil.data;
+				for( unsigned int i=0 ; i<WindowSize< UpSampleSizes >::Size ; i++ )
+					if( _isValidFEM1Node( nodes[i] ) ) coarseConstraint += (C)( finerConstraints[ nodes[i]->nodeData.nodeIndex - _sNodesBegin(highDepth) ] * (Real)stencilValues[i] );
+			}
+			else
+			{
+				ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+				for( int i=0 ; i<WindowSize< UpSampleSizes >::Size ; i++ ) if( _isValidFEM1Node( nodes[i] ) )
+				{
+					LocalDepth _d ; LocalOffset _off;
+					_localDepthAndOffset( nodes[i] , _d , _off );
+					coarseConstraint += (C)( finerConstraints[ nodes[i]->nodeData.nodeIndex - _sNodesBegin(highDepth) ] * (Real)rp.upSampleCoefficient( off , _off ) );
+				}
+			}
+		}
+	}
+	);
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs >
+DenseNodeData< Real , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::supportWeights( UIntPack< FEMSigs ... > ) const
+{
+	typedef typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > > BaseSystem;
+	typedef typename BaseFEMIntegrator::template Constraint< UIntPack< FEMSignature< FEMSigs >::Degree ... > , IsotropicUIntPack< Dim , 0 > , 1 > BaseConstraint;
+	typedef UIntPack< (  BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree , 0 >::OverlapSize  ) ... >          OverlapSizes;
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree , 0 >::OverlapStart ) ... >  LeftFEMCOverlapRadii;
+	typedef UIntPack< (  BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree , 0 >::OverlapEnd   ) ... > RightFEMCOverlapRadii;
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	typename FEMIntegrator::template ScalarConstraint< UIntPack< FEMSigs ... > , ZeroUIntPack< Dim > , IsotropicUIntPack< Dim , FEMTrivialSignature > , ZeroUIntPack< Dim > > F( {1.} );
+	DenseNodeData< Real , UIntPack< FEMSigs ... > > weights = initDenseNodeData( UIntPack< FEMSigs ... >() );
+	typename BaseConstraint::CCStencil stencil;
+	std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+	for( int d=0 ; d<=_maxDepth ; d++ )
+	{
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( d ) );
+		F.init( d );
+		F.template setStencil< false >( stencil );
+		ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int thread , size_t i )
+		{
+			if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+			{
+				ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+
+				FEMTreeNode* node = _sNodes.treeNodes[i];
+				typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors;
+				LocalOffset off;
+				{
+					LocalDepth d ; _localDepthAndOffset( node , d , off );
+				}
+				neighborKey.getNeighbors( LeftFEMCOverlapRadii() , RightFEMCOverlapRadii() , node , neighbors );
+				bool isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , ZeroUIntPack< Dim >() , d , off );
+				double sum=0 , totalSum=0;
+				if( isInterior )
+				{
+					ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+					ConstPointer( Point< double , 1 > ) stencilValues = stencil.data;
+					for( int i=0 ; i<WindowSize< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree , 0 >::OverlapSize ... > >::Size ; i++ )
+					{
+						double s = stencilValues[i][0];
+						totalSum += s;
+						if( isValidSpaceNode( nodes[i] ) ) sum += s;
+					}
+				}
+				else
+				{
+					static const int OverlapStart [] = { BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree , 0 >::OverlapStart ... };
+					LocalOffset _off;
+					WindowLoop< Dim >::Run
+					(
+						IsotropicUIntPack< Dim , 0 >() , OverlapSizes() ,
+						[&]( int d , int i ){ _off[d] = off[d]+i+OverlapStart[d]; } ,
+						[&]( const FEMTreeNode* node )
+					{
+						double s = F.ccIntegrate( off , _off )[0];
+						totalSum += s;
+						if( isValidSpaceNode( node ) ) sum += s;
+					} ,
+						neighbors.neighbors()
+						);
+				}
+				weights[i] = (Real)( sum / totalSum );
+			}
+		}
+		);
+	}
+	return weights;
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs >
+DenseNodeData< Real , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::prolongationWeights( UIntPack< FEMSigs ... > , bool prolongToChildren ) const
+{
+	DenseNodeData< Real , UIntPack< FEMSigs ... > > weights = initDenseNodeData( UIntPack< FEMSigs ... >() );
+
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	typedef typename BaseFEMIntegrator::RestrictionProlongation< UIntPack< FEMSignature< FEMSigs >::Degree ... > > BaseRestrictionProlongation;
+	typedef typename     FEMIntegrator::template RestrictionProlongation< UIntPack< FEMSigs ... > > RestrictionProlongation;
+
+	typename BaseRestrictionProlongation::DownSampleStencils downSampleStencils;
+	RestrictionProlongation rp;
+
+	typedef typename FEMTreeNode::template ConstNeighborKey< UIntPack< ( - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleStart ) ... > , UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleEnd ... > > UpSampleKey;
+	typedef typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleSize ... > > UpSampleNeighbors;
+	typedef typename FEMTreeNode::template ConstNeighborKey< UIntPack< - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start ... > , UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End ... > > DownSampleKey;
+	typedef typename FEMTreeNode::template ConstNeighbors< UIntPack< ( - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start + BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End + 1 ) ... > > DownSampleNeighbors;
+	const int      UpSampleStart[] =   { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleStart    ... };
+	const int DownSampleStart[2][Dim] = { { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start ... } , { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1Start ... } };
+	const int   DownSampleEnd[2][Dim] = { { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0End   ... } , { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End   ... } };
+
+	std::vector< UpSampleKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( _maxDepth-1 ) );
+
+	ThreadPool::ParallelFor( _sNodesBegin(_maxDepth) , _sNodesEnd(_maxDepth) , [&]( unsigned int , size_t i ){ weights[i] = (Real)0.; } );
+
+	for( int lowDepth=0 ; lowDepth<_maxDepth ; lowDepth++ )
+	{
+		( ( BaseRestrictionProlongation& )rp ).init( lowDepth+1 );
+		typename BaseRestrictionProlongation::UpSampleStencil upSampleStencil;
+		rp.setStencil( upSampleStencil );
+
+		ThreadPool::ParallelFor( _sNodesBegin(lowDepth) , _sNodesEnd(lowDepth) , [&]( unsigned int thread , size_t i )
+		{
+			if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+			{
+				FEMTreeNode* pNode = _sNodes.treeNodes[i];
+				UpSampleKey& neighborKey = neighborKeys[ thread ];
+				LocalDepth d ; LocalOffset pOff;
+				_localDepthAndOffset( pNode , d , pOff );
+
+				neighborKey.getNeighbors( pNode );
+				UpSampleNeighbors neighbors;
+				neighborKey.getChildNeighbors( 0 , _localToGlobal( d ) , neighbors );
+
+				double partialSum = 0 , totalSum = 0;
+
+				// Want to make sure test if contained children are interior.
+				// This is more conservative because we are test that overlapping children are interior
+				bool isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , UIntPack< FEMSignature< FEMSigs >::Degree ... >() , d , pOff );
+
+				LocalOffset cOff;
+				if( isInterior )
+				{
+					WindowLoop< Dim >::Run
+					(
+						IsotropicUIntPack< Dim , 0 >() , UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleSize ... >() ,
+						[&]( int d , int i ){ cOff[d] = UpSampleStart[d] + pOff[d]*2 + i; } ,
+						[&]( const FEMTreeNode* node , double stencilValue )
+					{
+						if( FEMIntegrator::IsValidFEMNode( UIntPack< FEMSigs ... >() , lowDepth+1 , cOff ) )
+						{
+							totalSum += stencilValue;
+							if( _isValidFEM1Node( node ) ) partialSum += stencilValue;
+						}
+					} ,
+						neighbors.neighbors() , upSampleStencil()
+						);
+				}
+				else
+				{
+					WindowLoop< Dim >::Run
+					(
+						IsotropicUIntPack< Dim , 0 >() , UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::UpSampleSize ... >() ,
+						[&]( int d , int i ){ cOff[d] = UpSampleStart[d] + pOff[d]*2 + i; } ,
+						[&]( const FEMTreeNode* node )
+					{
+						if( FEMIntegrator::IsValidFEMNode( UIntPack< FEMSigs ... >() , lowDepth+1 , cOff ) )
+						{
+							double stencilValue = rp.upSampleCoefficient( pOff , cOff );
+							totalSum += stencilValue;
+							if( _isValidFEM1Node( node ) ) partialSum += stencilValue;
+						}
+					} ,
+						neighbors.neighbors() 
+						);
+				}
+				weights[i] = (Real)( partialSum / totalSum );
+			}
+		}
+		);
+	}
+	if( prolongToChildren )
+	{
+		std::vector< DownSampleKey > neighborKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( _maxDepth-1 ) );
+
+		for( int lowDepth=_maxDepth-1 ; lowDepth>=0 ; lowDepth-- )
+		{
+			( ( BaseRestrictionProlongation& )rp ).init( lowDepth+1 );
+			typename BaseRestrictionProlongation::DownSampleStencils downSampleStencils;
+			rp.setStencils( downSampleStencils );
+
+			ThreadPool::ParallelFor( _sNodesBegin(lowDepth+1) , _sNodesEnd(lowDepth+1) , [&]( unsigned int thread , size_t i )
+			{
+				if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+				{
+					FEMTreeNode *cNode = _sNodes.treeNodes[i];
+					int c = (int)( cNode-cNode->parent->children );
+
+					DownSampleKey& neighborKey = neighborKeys[ thread ];
+					LocalDepth d ; LocalOffset cOff;
+					_localDepthAndOffset( cNode , d , cOff );
+					DownSampleNeighbors neighbors = neighborKey.getNeighbors( cNode->parent );
+					// Want to make sure test if contained children are interior.
+					// This is more conservative because we are test that overlapping children are interior
+					bool isInterior;
+					{
+						LocalDepth d ; LocalOffset pOff;
+						_localDepthAndOffset( cNode->parent , d , pOff );
+						isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< FEMSignature< FEMSigs >::Degree ... >() , UIntPack< FEMSignature< FEMSigs >::Degree ... >() , d , pOff );
+					}
+
+					typename BaseRestrictionProlongation::DownSampleStencil& downSampleStencil = downSampleStencils.data[c];
+					int start[Dim] , end[Dim];
+					for( int d=0 ; d<Dim ; d++ ) start[d] = DownSampleStart[(c>>d)&1][d] - DownSampleStart[0][d] , end[d] = - DownSampleStart[0][d] + DownSampleEnd[(c>>d)&1][d] + 1;
+
+					double partialSum = 0 , totalSum = 0;
+					if( isInterior )
+					{
+						WindowLoop< Dim >::Run
+						(
+							start , end ,
+							[&]( int , int ){ } ,
+							[&]( const FEMTreeNode* node , double stencilValue ){ if( _isValidFEM1Node( node ) ) totalSum += stencilValue , partialSum += weights[ node->nodeData.nodeIndex ] * stencilValue; } ,
+							neighbors.neighbors() , downSampleStencil()
+						);
+					}
+					else
+					{
+						WindowLoop< Dim >::Run
+						(
+							start , end ,
+							[&]( int , int ){ } ,
+							[&]( const FEMTreeNode* node )
+						{
+							if( _isValidFEM1Node( node ) )
+							{
+								LocalDepth d ; LocalOffset pOff;
+								_localDepthAndOffset( node , d , pOff );
+								double stencilValue = rp.upSampleCoefficient( pOff , cOff );
+								totalSum += stencilValue , partialSum += weights[ node->nodeData.nodeIndex ] * stencilValue;
+							}
+						} ,
+							neighbors.neighbors()
+							);
+					}
+					weights[i] = (Real)( partialSum / totalSum );
+				}
+			}
+			);
+		}
+	}
+	return weights;
+}
+
+template< unsigned int Dim , class Real >
+template< class C , typename ArrayWrapper , unsigned int ... Degrees , unsigned int ... FEMSigs >
+void FEMTree< Dim , Real >::_upSample( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< Degrees ... > >& rp , LocalDepth highDepth , ArrayWrapper coarserCoefficients , Pointer( C ) finerCoefficients ) const
+{
+	LocalDepth lowDepth = highDepth-1;
+	if( lowDepth<0 ) return;
+	typedef typename BaseFEMIntegrator::RestrictionProlongation< UIntPack< Degrees ... > > BaseRestrictionProlongation;
+	typedef typename FEMTreeNode::template ConstNeighborKey< UIntPack< - BSplineSupportSizes< Degrees >::DownSample0Start ... > , UIntPack< BSplineSupportSizes< Degrees >::DownSample1End ... > > DownSampleKey;
+	typedef typename FEMTreeNode::template ConstNeighbors< UIntPack< ( - BSplineSupportSizes< Degrees >::DownSample0Start + BSplineSupportSizes< Degrees >::DownSample1End + 1 ) ... > > DownSampleNeighbors;
+	typedef UIntPack< ( - BSplineSupportSizes< Degrees >::DownSample0Start + BSplineSupportSizes< Degrees >::DownSample1End + 1 ) ... > DownSampleSizes;
+
+	std::vector< DownSampleKey > neighborKeys( ThreadPool::NumThreads() );
+	for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( lowDepth ) );
+
+	( ( BaseRestrictionProlongation& )rp ).init( highDepth );
+	typename BaseRestrictionProlongation::DownSampleStencils downSampleStencils;
+	rp.setStencils( downSampleStencils );
+
+	const int Start[2][Dim] = { { BSplineSupportSizes< Degrees >::DownSample0Start ... } , { BSplineSupportSizes< Degrees >::DownSample1Start ... } };
+	const int   End[2][Dim] = { { BSplineSupportSizes< Degrees >::DownSample0End   ... } , { BSplineSupportSizes< Degrees >::DownSample1End   ... } };
+
+	static const WindowLoopData< UIntPack< ( - BSplineSupportSizes< Degrees >::DownSample0Start + BSplineSupportSizes< Degrees >::DownSample1End + 1 ) ... > > loopData
+	( []( int c , int* start , int* end )
+	{
+		const int Start[2][Dim] = { { BSplineSupportSizes< Degrees >::DownSample0Start ... } , { BSplineSupportSizes< Degrees >::DownSample1Start ... } };
+		const int   End[2][Dim] = { { BSplineSupportSizes< Degrees >::DownSample0End   ... } , { BSplineSupportSizes< Degrees >::DownSample1End   ... } };
+		for( int d=0 ; d<Dim ; d++ ) start[d] = Start[(c>>d)&1][d] - Start[0][d] , end[d] = - Start[0][d] + End[(c>>d)&1][d] + 1;
+	} 
+	);
+	// For Dirichlet constraints, can't get to all children from parents because boundary nodes are invalid
+	ThreadPool::ParallelFor( _sNodesBegin(highDepth) , _sNodesEnd(highDepth) , [&]( unsigned int thread , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+		{
+			FEMTreeNode *cNode = _sNodes.treeNodes[i];
+			int c = (int)( cNode-cNode->parent->children );
+
+			DownSampleKey& neighborKey = neighborKeys[ thread ];
+			DownSampleNeighbors neighbors = neighborKey.getNeighbors( cNode->parent );
+			// Want to make sure test if contained children are interior.
+			// This is more conservative because we are test that overlapping children are interior
+			bool isInterior;
+			{
+				LocalDepth d ; LocalOffset off;
+				_localDepthAndOffset( cNode->parent , d , off );
+				isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< Degrees ... >() , UIntPack< Degrees ... >() , d , off );
+			}
+
+			C &fineCoefficient = finerCoefficients[ cNode->nodeData.nodeIndex - _sNodesBegin(highDepth) ];
+
+			typename BaseRestrictionProlongation::DownSampleStencil& downSampleStencil = downSampleStencils.data[c];
+			unsigned int size = loopData.size[c];
+			const unsigned int* indices = loopData.indices[c];
+			Pointer( const FEMTreeNode* ) nodes = neighbors.neighbors().data;
+			Pointer( double ) downSampleValues = downSampleStencil.data;
+			if( isInterior )
+			{
+				for( unsigned int i=0 ; i<size ; i++ )
+				{
+					unsigned int idx = indices[i];
+					if( _isValidFEM1Node( nodes[idx] ) ) fineCoefficient += (C)( coarserCoefficients[ nodes[idx]->nodeData.nodeIndex - _sNodesBegin(lowDepth) ] * (Real)downSampleValues[idx] );
+				}
+			}
+			else
+			{
+				LocalDepth d ; LocalOffset off;
+				_localDepthAndOffset( cNode , d , off );
+				for( unsigned int i=0 ; i<size ; i++ )
+				{
+					unsigned int idx = indices[i];
+					if( _isValidFEM1Node( nodes[idx] ) )
+					{
+						LocalDepth _d ; LocalOffset _off;
+						_localDepthAndOffset( nodes[idx] , _d , _off );
+						fineCoefficient += (C)( coarserCoefficients[ nodes[idx]->nodeData.nodeIndex - _sNodesBegin(lowDepth) ] * (Real)rp.upSampleCoefficient( _off , off ) );
+					}
+				}
+			}
+		}
+	}
+	);
+}
+
+template< unsigned int Dim , class Real >
+template< bool XMajor , class C , unsigned int ... FEMSigs >
+void FEMTree< Dim , Real >::_RegularGridUpSample( UIntPack< FEMSigs ... > , LocalDepth highDepth , ConstPointer( C ) lowCoefficients , Pointer( C ) highCoefficients )
+{
+	LocalDepth lowDepth = highDepth - 1;
+	if( lowDepth<0 ) return;
+
+	int lowBegin[Dim] , lowEnd[Dim] , highBegin[Dim] , highEnd[Dim];
+	FEMIntegrator::BSplineBegin( UIntPack< FEMSigs ... >() ,  lowDepth ,  lowBegin );
+	FEMIntegrator::BSplineEnd  ( UIntPack< FEMSigs ... >() ,  lowDepth ,  lowEnd   );
+	FEMIntegrator::BSplineBegin( UIntPack< FEMSigs ... >() , highDepth , highBegin );
+	FEMIntegrator::BSplineEnd  ( UIntPack< FEMSigs ... >() , highDepth , highEnd   );
+
+	_RegularGridUpSample< XMajor >( UIntPack< FEMSigs ... >() , lowBegin , lowEnd , highBegin , highEnd , highDepth , lowCoefficients , highCoefficients );
+}
+template< unsigned int Dim , class Real >
+template< bool XMajor , class C , unsigned int ... FEMSigs >
+void FEMTree< Dim , Real >::_RegularGridUpSample( UIntPack< FEMSigs ... > , const int lowBegin[] , const int lowEnd[] , const int highBegin[] , const int highEnd[] , LocalDepth highDepth , ConstPointer( C ) lowCoefficients , Pointer( C ) highCoefficients )
+{
+	// Note: In contrast to the standard grid indexing, where x is the major index in (x,y,z,...)
+	//       For our representation of the grid, x is the minor index
+	LocalDepth lowDepth = highDepth - 1;
+	if( lowDepth<0 ) return;
+
+	static const          int LeftDownSampleRadii[] = { -( ( BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start < BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1Start ) ? BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start : BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1Start ) ... };
+	static const          int DownSampleStart[][ sizeof...(FEMSigs) ] = { { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start ... } , { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1Start ... } };
+	static const unsigned int DownSampleSize [][ sizeof...(FEMSigs) ] = { { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Size  ... } , { BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1Size  ... } };
+	typedef UIntPack< ( - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start + BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End + 1 ) ... > DownSampleSizes;
+	typedef typename     FEMIntegrator::template RestrictionProlongation< UIntPack< FEMSigs ...                         > >     RestrictionProlongation;
+	typedef typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< FEMSignature< FEMSigs >::Degree ... > > BaseRestrictionProlongation;
+
+	RestrictionProlongation rp;
+	typename BaseRestrictionProlongation::DownSampleStencils downSampleStencils;
+	rp.init( highDepth );
+	rp.setStencils( downSampleStencils );
+
+	struct LoopData
+	{
+		unsigned int size[1<<Dim];
+		unsigned int indices[1<<Dim][ WindowSize< UIntPack< ( - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start + BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End + 1 ) ... > >::Size ];
+		long long offsets[1<<Dim][ WindowSize< UIntPack< ( - BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample0Start + BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::DownSample1End + 1 ) ... > >::Size ];
+		LoopData( const int lowBegin[] , const int lowEnd[] , const int highBegin[] , const int highEnd[] )
+		{
+			int start[Dim] , end[Dim] , lowDim[Dim] , highDim[Dim];
+			for( int d=0 ; d<Dim ; d++ ) lowDim[d] = lowEnd[d] - lowBegin[d] , highDim[d] = highEnd[d] - highBegin[d];
+
+			int lowDimMultiplier[Dim] , highDimMultiplier[Dim];
+			if( XMajor )
+			{
+				lowDimMultiplier[0] = highDimMultiplier[0] = 1;
+				for( int d=1 ; d<Dim ; d++ ) lowDimMultiplier[d] = lowDimMultiplier[d-1] * (lowEnd[d-1]-lowBegin[d-1]) , highDimMultiplier[d] = highDimMultiplier[d-1] * (highEnd[d-1]-highBegin[d-1]);
+			}
+			else
+			{
+				lowDimMultiplier[Dim-1] = highDimMultiplier[Dim-1] = 1;
+				for( int d=Dim-2 ; d>=0 ; d-- ) lowDimMultiplier[d] = lowDimMultiplier[d+1] * (lowEnd[d+1]-lowBegin[d+1]) , highDimMultiplier[d] = highDimMultiplier[d+1] * (highEnd[d+1]-highBegin[d+1]);
+			}
+
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+			{
+				size[c] = 0;
+				for( int d=0 ; d<Dim ; d++ ) start[d] = DownSampleStart[(c>>d)&1][d] + LeftDownSampleRadii[d] , end[d] = start[d] + DownSampleSize[(c>>d)&1][d];
+
+				unsigned int idx[Dim];
+				long long off[Dim+1];
+				off[0] = 0;
+				WindowLoop< Dim >::Run
+				(
+					start , end ,
+					[&]( int d , int i ){ idx[d] = i ; off[d+1] = off[d] + ( i - LeftDownSampleRadii[d] - lowBegin[d] ) * lowDimMultiplier[d]; } ,
+					[&]( void ){ indices[c][ size[c] ] = GetWindowIndex( DownSampleSizes() , idx ) , offsets[c][ size[c] ] = off[Dim] ; size[c]++; }
+				);
+			}
+		}
+	};
+	const LoopData loopData( lowBegin , lowEnd , highBegin , highEnd );
+	int lowDim[Dim] , highDim[Dim];
+	for( int d=0 ; d<Dim ; d++ ) lowDim[d] = lowEnd[d] - lowBegin[d] , highDim[d] = highEnd[d] - highBegin[d];
+	int Zero[Dim];
+	for( int d=0 ; d<Dim ; d++ ) Zero[d] = 0;
+	int lowDimMultiplier[Dim] , highDimMultiplier[Dim];
+	if( XMajor )
+	{
+		lowDimMultiplier[0] = highDimMultiplier[0] = 1;
+		for( int d=1 ; d<Dim ; d++ ) lowDimMultiplier[d] = lowDimMultiplier[d-1] * (lowEnd[d-1]-lowBegin[d-1]) , highDimMultiplier[d] = highDimMultiplier[d-1] * (highEnd[d-1]-highBegin[d-1]);
+	}
+	else
+	{
+		lowDimMultiplier[Dim-1] = highDimMultiplier[Dim-1] = 1;
+		for( int d=Dim-2 ; d>=0 ; d-- ) lowDimMultiplier[d] = lowDimMultiplier[d+1] * (lowEnd[d+1]-lowBegin[d+1]) , highDimMultiplier[d] = highDimMultiplier[d+1] * (highEnd[d+1]-highBegin[d+1]);
+	}
+
+
+	struct UpdateData
+	{
+		typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > Degrees;
+		LocalOffset pOff , cOff;
+		int c;
+		long long lowIndex[Dim+1] , highIndex[Dim+1];
+		bool isInterior[Dim+1];
+		int start[Dim] , end[Dim];
+		void init( int lowDepth , const int lowBegin[] , const int lowEnd[] , const int highBegin[] , const int highEnd[] )
+		{
+			c = 0;
+			lowIndex[0] = highIndex[0] = 0;
+			isInterior[0] = true;
+			this->lowBegin = lowBegin , this->lowEnd = lowEnd , this->highBegin = highBegin , this->highEnd = highEnd;
+			if( XMajor )
+			{
+				_lowDim[0] = _highDim[0] = 1;
+				for( int d=1 ; d<Dim ; d++ ) _lowDim[d] = _lowDim[d-1] * (lowEnd[d-1]-lowBegin[d-1]) , _highDim[d] = _highDim[d-1] * (highEnd[d-1]-highBegin[d-1]);
+			}
+			else
+			{
+				_lowDim[Dim-1] = _highDim[Dim-1] = 1;
+				for( int d=Dim-2 ; d>=0 ; d-- ) _lowDim[d] = _lowDim[d+1] * (lowEnd[d+1]-lowBegin[d+1]) , _highDim[d] = _highDim[d+1] * (highEnd[d+1]-highBegin[d+1]);
+			}
+			BaseFEMIntegrator::InteriorOverlappedSpan( Degrees() , Degrees() , lowDepth , _begin , _end );
+		}
+		void set( int d , int i )
+		{
+			int ii = i + highBegin[d];
+			cOff[d] = ii;
+			pOff[d] = (ii>>1);
+			c = ( c & ( ~(1<<d) ) ) | (ii&1)<<d;
+			lowIndex[d+1] = lowIndex[d] + pOff[d] * _lowDim[d];
+			highIndex[d+1] = highIndex[d] + i * _highDim[d];
+			start[d] = DownSampleStart[(c>>d)&1][d] + LeftDownSampleRadii[d] , end[d] = start[d] + DownSampleSize[(c>>d)&1][d];
+			isInterior[d+1] = isInterior[d] && ( pOff[d] + start[d] - LeftDownSampleRadii[d] )>=lowBegin[d] && ( pOff[d] + end[d] - LeftDownSampleRadii[d] )<lowEnd[d] && pOff[d]>=_begin[d] && pOff[d]<_end[d];
+		}
+	protected:
+		const int *lowBegin , *lowEnd , *highBegin , *highEnd;
+		int _lowDim[Dim] , _highDim[Dim] , _begin[Dim] , _end[Dim];
+	};
+	std::vector< UpdateData > updateData( ThreadPool::NumThreads() );
+	for( int i=0 ; i<updateData.size() ; i++ ) updateData[i].init( lowDepth , lowBegin , lowEnd , highBegin , highEnd );
+	WindowLoop< Dim >::RunParallel
+	(
+		Zero , highDim ,
+		[&]( unsigned int t , int d , size_t i ){ updateData[t].set( d , (int)i ); } ,
+		[&]( unsigned int t )
+		{
+		const UpdateData& data = updateData[t];
+			const long long highIdx = data.highIndex[Dim] , lowIndex = data.lowIndex[Dim];
+			const int c = data.c;
+			const bool isInterior = data.isInterior[Dim];
+
+			C highCoefficient = {};
+
+			if( isInterior )
+			{
+				typename BaseRestrictionProlongation::DownSampleStencil& downSampleStencil = downSampleStencils.data[c];
+				const unsigned int size = loopData.size[c];
+				const unsigned int* idx = loopData.indices[c];
+				const long long* off = loopData.offsets[c];
+				ConstPointer( double ) stencilValues = downSampleStencil.data;
+				ConstPointer( C ) _lowCoefficients = lowCoefficients + lowIndex;
+				for( unsigned int i=0 ; i<size ; i++ ) highCoefficient += (C)( _lowCoefficients[ off[i] ] * (Real)stencilValues[ idx[i] ] );
+			}
+			else
+			{
+				const LocalOffset& pOff = data.pOff;
+				const LocalOffset& cOff = data.cOff;
+				const int* start = data.start;
+				const int* end = data.end;
+				long long lowIdx[ Dim+1 ] ; lowIdx[0] = 0;
+				bool isValid[Dim+1] ; isValid[0] = true;
+				int _pOff[Dim];
+
+				WindowLoop< Dim >::Run
+				(
+					start , end ,
+					[&]( int d , int i )
+					{
+						_pOff[d] = pOff[d] + i - LeftDownSampleRadii[d];
+						lowIdx[d+1] = lowIdx[d] + lowDimMultiplier[d] * ( _pOff[d] - lowBegin[d] );
+						isValid[d+1] = isValid[d] && ( _pOff[d]>=lowBegin[d] && _pOff[d]<lowEnd[d] );
+					} ,
+					[&]( void ){ if( isValid[Dim] ) highCoefficient += (C)( lowCoefficients[ lowIdx[Dim] ] * (Real)rp.upSampleCoefficient( _pOff , cOff ) ); }
+				);
+			}
+			highCoefficients[ highIdx ] += highCoefficient;
+		}
+	);
+}
+
+
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , typename TDotT , typename ... InterpolationInfos >
+DenseNodeData< T , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::solveSystem( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , TDotT Dot , LocalDepth minSolveDepth , LocalDepth maxSolveDepth , const typename FEMTree< Dim , Real >::SolverInfo& solverInfo , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	DenseNodeData< T , UIntPack< FEMSigs ... > > solution;
+	solveSystem( UIntPack< FEMSigs ... >() , F , constraints , solution , Dot , minSolveDepth , maxSolveDepth , solverInfo , interpolationInfos );
+	return solution;
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs , typename T , typename TDotT , typename ... InterpolationInfos >
+void FEMTree< Dim , Real >::solveSystem( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , DenseNodeData< T , UIntPack< FEMSigs ... > >& solution , TDotT Dot , LocalDepth minSolveDepth , LocalDepth maxSolveDepth , const typename FEMTree< Dim , Real >::SolverInfo& solverInfo , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+{
+	static_assert( Dim==sizeof ... ( FEMSigs ) , "[ERROR] FEMTree:solveSystem: Dimensions and number of signatures don't match" );
+
+	if( maxSolveDepth>_maxDepth )
+	{
+		MK_WARN( "Solver depth should not exceed maximum depth: " , maxSolveDepth , " <= " , _maxDepth );
+		maxSolveDepth = _maxDepth;
+	}
+	if( minSolveDepth>maxSolveDepth ) return;
+	else if( minSolveDepth<_baseDepth )
+	{
+		MK_WARN( "Minimum solver depth should not be smaller than base solver depth: " , minSolveDepth , " >= " , _baseDepth );
+		minSolveDepth = _baseDepth;
+	}
+
+	// Mark all nodes that define valid finite elements
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > > bsData( sizeof...(InterpolationInfos)==0 ? 0 : maxSolveDepth );
+
+	if( solverInfo.clearSolution ) solution = initDenseNodeData< T >( UIntPack< FEMSigs ... >() );
+	else if( solution.size()!=_sNodesEnd( _maxDepth ) ) MK_THROW( "Solution is the wrong size: " , solution.size() , " != " , _sNodesEnd(_maxDepth) );
+
+	// The initial estimate of the solution (may be empty or may come in with an initial guess)
+	Pointer( T ) _solution = solution();
+	// The constraints
+	ConstPointer( T ) _constraints = constraints();
+
+	// _residualConstraints:
+	// -- stores the difference between the initial constraints and the constraints met by the current solution at all _other_ levels
+	// **** This could implemented in one of two ways:
+	// **** (1) Repeatedly computing the difference using the entire solution
+	// **** (2) Iteratively updating using the change in the solution
+	// **** We have opted for #1 to avoid having to compute/store the change in the solution after each solve
+	Pointer( T ) _residualConstraints = AllocPointer< T >( _sNodesEnd( _maxDepth-1 ) );
+	// The constraints met during the restriction phase
+	Pointer( T ) _restrictedConstraints = NullPointer( T );
+	// The solution obtained during the prolongation phase
+	Pointer( T ) _prolongedSolution = AllocPointer< T >( _sNodesEnd( _maxDepth-1 ) );
+
+	memset( _prolongedSolution , 0 , sizeof(T) * _sNodesEnd( _maxDepth-1 ) );
+	if( !( solverInfo.clearSolution && solverInfo.vCycles==1 && solverInfo.cascadic ) )
+	{
+		_restrictedConstraints = AllocPointer< T >( _sNodesEnd( _maxDepth-1 ) );
+		memset( _restrictedConstraints , 0 , sizeof(T) * _sNodesEnd( _maxDepth-1 ) );
+	}
+
+	Pointer( double ) _bNorm2 = NullPointer( double );
+	if( solverInfo.showGlobalResidual!=SHOW_GLOBAL_RESIDUAL_NONE )
+	{
+		_bNorm2 = AllocPointer< double >( _maxDepth+1 );
+		memset( _bNorm2 , 0 , sizeof(double) * ( _maxDepth+1 ) );
+		for( LocalDepth d=_baseDepth ; d<=maxSolveDepth ; d++ ) for( node_index_type i=_sNodesBegin(d) ; i<_sNodesEnd(d) ; i++ ) _bNorm2[d] += Dot( _constraints[i] , _constraints[i] );
+	}
+
+	auto UpdateProlongation = [&] ( int depth )
+	{
+		if( depth==_maxDepth ) return;
+
+		if     ( depth< _baseDepth ){}
+		else if( depth==_baseDepth ) ThreadPool::ParallelFor( _sNodesBegin(depth) , _sNodesEnd(depth) , [&]( unsigned int , size_t i ){ _prolongedSolution[i] = solution[i]; } );
+		else if( depth< _maxDepth )
+		{
+			// Clear the prolonged solution @(depth)
+			memset( _prolongedSolution + _sNodesBegin( depth ) , 0 , sizeof( T ) * _sNodesSize( depth ) );
+
+			// Up-sample the prolonged solution @(depth-1) into the prolonged solution @(depth)
+			F.init( depth );
+			_upSample( UIntPack< FEMSigs ... >() , F.restrictionProlongation() , depth , ( ConstPointer(T) )_prolongedSolution+_sNodesBegin(depth-1) , _prolongedSolution+_sNodesBegin(depth) );
+
+			// Add in the solution @(depth) to the prolonged solution
+			ThreadPool::ParallelFor( _sNodesBegin(depth) , _sNodesEnd(depth) , [&]( unsigned int , size_t i ){ _prolongedSolution[i] += solution[i]; } );
+		}
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Should this be here or in SetResidualConstraints" )
+#endif // SHOW_WARNINGS
+		if( depth+1>_baseDepth && depth+1<=_maxDepth && _prolongedSolution ) _setPointValuesFromProlongedSolution< 0 >( depth+1 , bsData , ( ConstPointer( T ) )_prolongedSolution , interpolationInfos );
+	};
+	auto UpdateRestriction = [&]( int depth )
+	{
+		if( depth>_baseDepth && _restrictedConstraints )
+		{
+			memset( _restrictedConstraints + _sNodesBegin( depth-1 ) , 0 , sizeof( T ) * _sNodesSize( depth-1 ) );
+			// Update the restricted constraints @(depth-1) based on the solution @(depth)
+			F.init( depth );
+			_updateRestrictedIntegralConstraints( UIntPack< FEMSigs ... >() , F , depth , ( ConstPointer(T) )_solution , _restrictedConstraints );
+			_updateRestrictedInterpolationConstraints< 0 >( bsData , depth , ( ConstPointer( T ) )_solution , _restrictedConstraints , interpolationInfos );
+			// Down-sample the restricted constraints @(depth) into the restricted constraints @(depth-1)
+			if( depth<_maxDepth ) _downSample( UIntPack< FEMSigs ... >() , F.restrictionProlongation() , depth , ( ConstPointer(T) )_restrictedConstraints + _sNodesBegin(depth) , _restrictedConstraints + _sNodesBegin(depth-1) );
+		}
+	};
+	auto SetResidualConstraints = [&]( int depth )
+	{
+		// Copy the constraints
+		if( depth<_maxDepth ) memcpy( _residualConstraints + _sNodesBegin(depth) , _constraints + _sNodesBegin(depth) , sizeof( T ) * _sNodesSize(depth) );
+
+		// Update the constraints @(depth) using the restriced residual @(depth)
+		if( depth<_maxDepth && _restrictedConstraints )
+			ThreadPool::ParallelFor( _sNodesBegin(depth) , _sNodesEnd(depth) , [&]( unsigned int , size_t i ){ _residualConstraints[i] -= _restrictedConstraints[i]; } );
+	};
+	auto OutputSolverStats = [&] ( int cycle , int depth , const _SolverStats& sStats , bool showResidual , int actualIters )
+	{
+		if( solverInfo.verbose )
+		{
+			node_index_type femNodes = (node_index_type)validUnlockedFEMNodes( UIntPack< FEMSigs ... >() , depth );
+			if( maxSolveDepth<10 )
+				if( solverInfo.vCycles<10 ) printf( "Cycle[%d] Depth[%d/%d]:\t" , cycle , depth , maxSolveDepth );
+				else                        printf( "Cycle[%2d] Depth[%d/%d]:\t" , cycle , depth , maxSolveDepth );
+			else 
+				if( solverInfo.vCycles<10 ) printf( "Cycle[%d] Depth[%2d/%d]:\t" , cycle , depth , maxSolveDepth );
+				else                        printf( "Cycle[%2d] Depth[%2d/%d]:\t" , cycle , depth , maxSolveDepth );
+			printf( "Updated constraints / Got system / Solved in: %6.3f / %6.3f / %6.3f\t(%d MB)\tNodes: %llu\n" , sStats.constraintUpdateTime , sStats.systemTime , sStats.solveTime , MemoryInfo::PeakMemoryUsageMB() , (unsigned long long)femNodes );
+		}
+		if( solverInfo.showResidual && showResidual )
+		{
+			for( int d=_baseDepth ; d<depth ; d++ ) printf( "  " );
+			if     ( depth==_baseDepth )         printf( "MG x %d" , solverInfo.baseVCycles );
+			else if( depth<=solverInfo.cgDepth ) printf( "    CG" );
+			else                                 printf( "    GS" );
+			printf( ": %.4e -> %.4e -> %.4e (%.1e) [%d]\n" , sqrt( sStats.bNorm2 ) , sqrt( sStats.inRNorm2 ) , sqrt( sStats.outRNorm2 ) , sqrt( sStats.outRNorm2  / sStats.inRNorm2 ) , actualIters );
+		}
+	};
+
+	// Set the cumulative solution
+	if( !solverInfo.clearSolution ) for( LocalDepth d=_baseDepth ; d<maxSolveDepth ; d++ ) UpdateProlongation( d );
+
+	_SolverStats sStats;
+	bool showResidual;
+	int actualIters;
+	double t;
+
+	struct TrivialSORWeights{ Real operator[] ( node_index_type idx ) const { return (Real)1; } };
+	struct SORWeights
+	{
+		DenseNodeData< Real,  UIntPack< FEMSigs ... > > supportWeights , prolongationSupportWeights;
+		std::function< Real (Real,Real) > sorFunction;
+		Real operator[] ( node_index_type idx ) const
+		{
+			if     ( supportWeights() && prolongationSupportWeights() ) return sorFunction( supportWeights[idx] , prolongationSupportWeights[idx] );
+			else if( supportWeights()                                 ) return sorFunction( supportWeights[idx] , 1                               );
+			else if(                     prolongationSupportWeights() ) return sorFunction( 1                   , prolongationSupportWeights[idx] );
+			else                                                        return sorFunction( 1                   , 1                               );
+		}
+	};
+	SORWeights sorWeights;
+	if( solverInfo.useSupportWeights ) sorWeights.supportWeights = supportWeights( UIntPack< FEMSigs ... >() );
+	if( solverInfo.useProlongationSupportWeights ) sorWeights.prolongationSupportWeights = prolongationWeights( UIntPack< FEMSigs ... >() , false );
+
+	auto SolveRestriction = [&]( int v , int depth )
+	{
+		sorWeights.sorFunction = solverInfo.sorRestrictionFunction;
+		// The restriction phase
+		if( solverInfo.cascadic )
+		{
+			showResidual = false;
+			if( !solverInfo.clearSolution || v>0 ) for( LocalDepth d=depth ; d>=_baseDepth ; d-- ) { F.init( d ) ; UpdateRestriction( d ); }
+		}
+		else
+		{
+			bool coarseToFine = false;
+			for( LocalDepth d=depth ; d>=minSolveDepth ; d-- )
+			{
+				sStats.constraintUpdateTime = 0;
+				showResidual = ( d!=_baseDepth );
+				int iters = solverInfo.iters( v , true , d );
+				t = Time();
+				F.init( d );
+				SetResidualConstraints( d );
+				sStats.constraintUpdateTime += Time()-t;
+				actualIters = iters;
+				// In the restriction phase we do not solve at the coarsest resolution since we will do so in the prolongation phase
+				if( d==_baseDepth )
+				{
+					if( solverInfo.baseVCycles ) _solveRegularMG( UIntPack< FEMSigs ... >() , F , bsData , std::min< LocalDepth >( _baseDepth , maxSolveDepth ) , _solution , d==_maxDepth ? _constraints : _residualConstraints , Dot , solverInfo.baseVCycles , iters , sStats , solverInfo.showResidual , solverInfo.cgAccuracy , interpolationInfos );
+				}
+				else
+				{
+					if( d>solverInfo.cgDepth ) actualIters = _solveSystemGS( UIntPack< FEMSigs ... >() , Dim!=1 , F , bsData , d , _solution , ( ConstPointer( T ) )_prolongedSolution , d==_maxDepth ? _constraints : _residualConstraints , Dot , iters , coarseToFine , solverInfo.sliceBlockSize , sorWeights , sStats , solverInfo.showResidual ,                         interpolationInfos );
+					else                       actualIters = _solveSystemCG( UIntPack< FEMSigs ... >() ,          F , bsData , d , _solution , ( ConstPointer( T ) )_prolongedSolution , d==_maxDepth ? _constraints : _residualConstraints , Dot , iters , coarseToFine ,                                          sStats , solverInfo.showResidual , solverInfo.cgAccuracy , interpolationInfos );
+				}
+				t = Time();
+				UpdateRestriction( d );
+				sStats.constraintUpdateTime += Time()-t;
+				OutputSolverStats( v , d , sStats , showResidual , actualIters );
+			}
+		}
+	};
+
+	auto SolveProlongation = [&]( int v , int depth )
+	{
+		sorWeights.sorFunction = solverInfo.sorProlongationFunction;
+		showResidual = true;
+		bool coarseToFine = true;
+		for( LocalDepth d=minSolveDepth ; d<=depth ; d++ )
+		{
+			sStats.constraintUpdateTime = 0;
+			int iters = solverInfo.iters( v , false , d );
+			t = Time();
+			F.init( d );
+			SetResidualConstraints( d );
+			sStats.constraintUpdateTime += Time()-t;
+			actualIters = iters;
+			if( d==_baseDepth )
+			{
+				if( solverInfo.baseVCycles ) _solveRegularMG( UIntPack< FEMSigs ... >() , F , bsData , std::min< LocalDepth >( _baseDepth , maxSolveDepth ) , _solution , d==_maxDepth ? _constraints : _residualConstraints , Dot , solverInfo.baseVCycles , iters , sStats , solverInfo.showResidual , solverInfo.cgAccuracy , interpolationInfos );
+			}
+			else
+			{
+				if( d>solverInfo.cgDepth ) actualIters = _solveSystemGS( UIntPack< FEMSigs ... >() , Dim!=1 , F , bsData , d , _solution , ( ConstPointer( T ) )_prolongedSolution , d==_maxDepth ? _constraints : _residualConstraints , Dot , iters , coarseToFine , solverInfo.sliceBlockSize , sorWeights , sStats , solverInfo.showResidual , interpolationInfos );
+				else                       actualIters = _solveSystemCG( UIntPack< FEMSigs ... >() ,          F , bsData , d , _solution , ( ConstPointer( T ) )_prolongedSolution , d==_maxDepth ? _constraints : _residualConstraints , Dot , iters , coarseToFine , sStats , solverInfo.showResidual , solverInfo.cgAccuracy , interpolationInfos );
+			}
+			t = Time();
+			UpdateProlongation( d );
+			sStats.constraintUpdateTime += Time()-t;
+			OutputSolverStats( v , d , sStats , showResidual , actualIters );
+		}
+	};
+
+	for( int v=0 ; v<solverInfo.vCycles ; v++ )
+	{
+		if( solverInfo.wCycle )
+		{
+			for( int d=maxSolveDepth ; d>minSolveDepth ; d-- )
+			{
+				SolveRestriction ( v , d   );
+				SolveProlongation( v , d-1 );
+			}
+			for( int d=_baseDepth+1 ; d<=maxSolveDepth ; d++ )
+			{
+				SolveRestriction ( v , d-1 );
+				SolveProlongation( v , d   );
+			}
+		}
+		else
+		{
+			SolveRestriction ( v , std::max< LocalDepth >( _baseDepth , maxSolveDepth ) );
+			SolveProlongation( v , std::max< LocalDepth >( _baseDepth , maxSolveDepth ) );
+		}
+		if( solverInfo.showGlobalResidual==SHOW_GLOBAL_RESIDUAL_ALL || ( solverInfo.showGlobalResidual==SHOW_GLOBAL_RESIDUAL_LAST && v==solverInfo.vCycles-1 ) )
+		{
+			bool coarseToFine = false;
+			std::vector< double > rNorms( maxSolveDepth+1 );
+			for( LocalDepth d=maxSolveDepth ; d>=minSolveDepth ; d-- )
+			{
+				F.init( d );
+				SetResidualConstraints( d );
+				_solveSystemGS( UIntPack< FEMSigs ... >() , Dim!=1 , F , bsData , d , _solution , ( ConstPointer( T ) )_prolongedSolution , d==_maxDepth ? _constraints : _residualConstraints , Dot , 0 , coarseToFine , solverInfo.sliceBlockSize , TrivialSORWeights() , sStats , true , interpolationInfos );
+				UpdateRestriction( d );
+				rNorms[d] = sqrt( sStats.outRNorm2 / _bNorm2[d] );
+			}
+			printf( "%3d" , v+1 );
+			for( int d=_baseDepth ; d<=maxSolveDepth ; d++ ) printf( "\t%.4e" , rNorms[d] );
+			printf( "\n" );
+		}
+	}
+
+	FreePointer( _residualConstraints );
+	FreePointer( _restrictedConstraints );
+	FreePointer( _prolongedSolution );
+	FreePointer( _bNorm2 );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs >
+DenseNodeData< Real , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::initDenseNodeData( UIntPack< FEMSigs ... > ) const
+{
+	DenseNodeData< Real , UIntPack< FEMSigs ... > > constraints( _sNodes.size() );
+	memset( constraints() , 0 , sizeof(Real)*_sNodes.size() );
+	return constraints;
+}
+template< unsigned int Dim , class Real >
+template< class Data , unsigned int ... FEMSigs >
+DenseNodeData< Data , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::initDenseNodeData( UIntPack< FEMSigs ... > ) const
+{
+	DenseNodeData< Data , UIntPack< FEMSigs ... > > constraints( _sNodes.size() );
+	memset( constraints() , 0 , sizeof(Data)*_sNodes.size() );
+	return constraints;
+}
+
+template< unsigned int Dim , class Real > template< class SReal , class Data , unsigned int _Dim > Data FEMTree< Dim , Real >::_StencilDot( Point< SReal , _Dim > p1 , Point< Data , _Dim > p2 ){ Data dot={} ; for( int d=0 ; d<_Dim ; d++ ) dot += p2[d] * (Real)p1[d] ; return dot; }
+template< unsigned int Dim , class Real > template< class SReal , class Data                     > Data FEMTree< Dim , Real >::_StencilDot( Point< SReal , 1 >    p1 , Point< Data , 1 >    p2 ){ return p2[0] * (Real)p1[0]; }
+template< unsigned int Dim , class Real > template< class SReal , class Data                     > Data FEMTree< Dim , Real >::_StencilDot( SReal                 p1 , Point< Data , 1 >    p2 ){ return p2[0] * (Real)p1; }
+template< unsigned int Dim , class Real > template< class SReal , class Data                     > Data FEMTree< Dim , Real >::_StencilDot( Point< SReal , 1 >    p1 , Data                 p2 ){ return p2 * (Real)p1[0]; }
+template< unsigned int Dim , class Real > template< class SReal , class Data                     > Data FEMTree< Dim , Real >::_StencilDot( SReal                 p1 , Data                 p2 ){ return p2*(Real)p1; }
+template< unsigned int Dim , class Real > template< class Real1 , unsigned int _Dim > bool FEMTree< Dim , Real >::_IsZero( Point< Real1 , _Dim > p ){ for( int d=0 ; d<_Dim ; d++ ) if( !_IsZero( p[d] ) ) return false ; return true; }
+template< unsigned int Dim , class Real > template< class Real1 > bool FEMTree< Dim , Real >::_IsZero( Real1 p ){ return p==0; }
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int ... FEMSigs , unsigned int ... CSigs , unsigned int ... FEMDegrees , unsigned int ... CDegrees , unsigned int CDim , class Coefficients >
+void FEMTree< Dim , Real >::_addFEMConstraints( UIntPack< FEMSigs ... > , UIntPack< CSigs ... > , typename BaseFEMIntegrator::template Constraint< UIntPack< FEMDegrees ... > , UIntPack< CDegrees ... > , CDim >& F , const Coefficients& coefficients , Pointer( T ) constraints , LocalDepth maxDepth ) const
+{
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	_setFEM2ValidityFlags( UIntPack<   CSigs ... >() );
+	typedef typename BaseFEMIntegrator::template Constraint< UIntPack< FEMDegrees ... > , UIntPack< CDegrees ... > , CDim > BaseConstraint;
+	typedef typename Coefficients::data_type D;
+	typedef UIntPack< (  BSplineOverlapSizes< CDegrees , FEMDegrees >::OverlapSize  ) ... >          OverlapSizes;
+	typedef UIntPack< ( -BSplineOverlapSizes< CDegrees , FEMDegrees >::OverlapStart ) ... >  LeftCFEMOverlapRadii;
+	typedef UIntPack< (  BSplineOverlapSizes< CDegrees , FEMDegrees >::OverlapEnd   ) ... > RightCFEMOverlapRadii;
+	typedef UIntPack< ( -BSplineOverlapSizes< FEMDegrees , CDegrees >::OverlapStart ) ... >  LeftFEMCOverlapRadii;
+	typedef UIntPack< (  BSplineOverlapSizes< FEMDegrees , CDegrees >::OverlapEnd   ) ... > RightFEMCOverlapRadii;
+
+	// To set the constraints, we iterate over the splatted normals and compute the dot-product of the divergence of the normal field with all the basis functions.
+	// Within the same depth: set directly as a gather 
+	// Coarser depths 
+	maxDepth = std::min< LocalDepth >( maxDepth , _maxDepth );
+	Pointer( T ) _constraints = AllocPointer< T >( _sNodesEnd( maxDepth-1 ) );
+	memset( _constraints , 0 , sizeof(T)*( _sNodesEnd(maxDepth-1) ) );
+
+	static const WindowLoopData< UIntPack< BSplineOverlapSizes< CDegrees , FEMDegrees >::OverlapSize ... > > cfemLoopData( []( int c , int* start , int* end ){ BaseFEMIntegrator::ParentOverlapBounds( UIntPack< CDegrees ... >() , UIntPack< FEMDegrees ... >() , c , start , end ); } );
+	static const WindowLoopData< UIntPack< BSplineOverlapSizes< FEMDegrees , CDegrees >::OverlapSize ... > > femcLoopData( []( int c , int* start , int* end ){ BaseFEMIntegrator::ParentOverlapBounds( UIntPack< FEMDegrees ... >() , UIntPack< CDegrees ... >() , c , start , end ); } );
+
+	std::atomic< bool > hasCoarserCoefficients = true;
+	// Iterate from fine to coarse, setting the constraints @(depth) and the cumulative constraints @(depth-1)
+	for( LocalDepth d=maxDepth ; d>=0 ; d-- )
+	{
+		typename BaseConstraint::CCStencil  stencil;
+		typename BaseConstraint::PCStencils stencils;
+		F.init( d );
+		F.template setStencil < false >( stencil  );
+		F.template setStencils< true  >( stencils );
+		std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( d ) );
+		ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d)  , [&]( unsigned int thread , size_t i )
+		{
+			if( d<maxDepth ) constraints[i] += _constraints[i];
+			ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+			FEMTreeNode* node = _sNodes.treeNodes[i];
+			int start[Dim] , end[] = { BSplineOverlapSizes< CDegrees , FEMDegrees >::OverlapSize ... };
+			memset( start , 0 , sizeof( start ) );
+			typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors;
+			neighborKey.getNeighbors( LeftFEMCOverlapRadii() , RightFEMCOverlapRadii() , node , neighbors );
+			bool isInterior , isInterior2;
+			{
+				LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node , d , off );
+				isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< FEMDegrees ... >() , UIntPack< CDegrees ... >() , d , off );
+			}
+			{
+				LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node->parent , d , off );
+				isInterior2 = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< CDegrees ... >() , UIntPack< FEMDegrees ... >() , d , off );
+			}
+
+			LocalDepth d ; LocalOffset off;
+			_localDepthAndOffset( node , d , off );
+
+			// Set constraints from current depth
+			// Gather the constraints from _node into the constraint stored with node
+			if( _isValidFEM1Node( node ) )
+			{
+				if( isInterior )
+				{
+					unsigned int size = neighbors.neighbors.Size();
+					Pointer( const FEMTreeNode* ) nodes = neighbors.neighbors().data;
+					Pointer( Point< double , CDim > ) stencilValues = stencil.data;
+					for( unsigned int j=0 ; j<size ; j++ )
+					{
+						if( _isValidFEM2Node( nodes[j] ) )
+						{
+							const D* _data = coefficients( nodes[j] );
+							if( _data ) constraints[i] += _StencilDot< double , T , CDim >( stencilValues[j] , *_data );
+						}
+					}
+				}
+				else
+				{
+					unsigned int size = neighbors.neighbors.Size();
+					Pointer( const FEMTreeNode* ) nodes = neighbors.neighbors().data;
+					for( unsigned int j=0 ; j<size ; j++ )
+					{
+						if( _isValidFEM2Node( nodes[j] ) )
+						{
+							const D* _data = coefficients( nodes[j] );
+							if( _data )
+							{
+								LocalDepth _d ; LocalOffset _off ; _localDepthAndOffset( nodes[j] , _d , _off );
+								constraints[i] += _StencilDot< double , T , CDim >( F.ccIntegrate( off , _off ) , *_data );
+							}
+						}
+					}
+				}
+				BaseFEMIntegrator::ParentOverlapBounds( UIntPack< CDegrees ... >() , UIntPack< FEMDegrees ... >() , d , off , start , end );
+			}
+			if( !_isValidFEM2Node( node ) ) return;
+			const D* _data = coefficients( node );
+			if( !_data ) return;
+			else if( d<maxDepth ) hasCoarserCoefficients = true;
+			const D& data = *_data;
+			if( _IsZero( data ) ) return;
+
+			// Set the _constraints for the parents
+			if( d>0 )
+			{
+				int cIdx = (int)( node - node->parent->children );
+				const typename BaseConstraint::CCStencil& _stencil = stencils.data[cIdx];
+				neighborKey.getNeighbors( LeftCFEMOverlapRadii() , RightCFEMOverlapRadii() , node->parent , neighbors );
+
+				unsigned int size = cfemLoopData.size[cIdx];
+				const unsigned int* indices = cfemLoopData.indices[cIdx];
+				ConstPointer( Point< double , CDim > ) stencilValues = _stencil.data;
+				Pointer( const FEMTreeNode* ) nodes = neighbors.neighbors().data;
+				if( isInterior2 )
+				{
+					for( unsigned int i=0 ; i<size ; i++ )
+					{
+						unsigned int idx = indices[i];
+						if( nodes[idx] )
+						{
+							Atomic< T >::Add( _constraints[ nodes[idx]->nodeData.nodeIndex ] , _StencilDot< double , T , CDim >( stencilValues[idx] , data ) );
+						}
+					}
+				}
+				else
+				{
+					for( unsigned int i=0 ; i<size ; i++ )
+					{
+						unsigned int idx = indices[i];
+						if( nodes[idx] )
+						{
+							LocalDepth _d ; LocalOffset _off ; _localDepthAndOffset( nodes[idx] , _d , _off );
+							Atomic< T >::Add( _constraints[ nodes[idx]->nodeData.nodeIndex ] , _StencilDot< double , T , CDim >( F.pcIntegrate( _off , off ) , data ) );
+						}
+					}
+				}
+			}
+		}
+		);
+		if( d>0 && d<maxDepth ) _downSample( UIntPack< FEMSigs ... >() , F.tRestrictionProlongation() , d , ( ConstPointer(T) )_constraints + _sNodesBegin(d) , _constraints + _sNodesBegin(d-1) );
+	}
+	FreePointer( _constraints );
+	if( hasCoarserCoefficients )
+	{
+		Pointer( D ) _coefficients = AllocPointer< D >( _sNodesEnd( maxDepth-1 ) );
+		memset( _coefficients , 0 , sizeof(D) * _sNodesEnd(maxDepth-1) );
+		for( LocalDepth d=maxDepth-1 ; d>=0 ; d-- )
+		{
+			ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int , size_t i )
+			{
+				const D* d = coefficients( _sNodes.treeNodes[i] );
+				if( d ) _coefficients[i] += *d;
+			}
+			);
+		}
+
+		// Coarse-to-fine up-sampling of coefficients
+		for( LocalDepth d=1 ; d<maxDepth ; d++ ) _upSample< D >( UIntPack< FEMSigs ... >() , F.tRestrictionProlongation() , d , ( ConstPointer(D) )_coefficients+_sNodesBegin(d-1) , _coefficients+_sNodesBegin(d) );
+		// Compute the contribution from all coarser depths
+		for( LocalDepth d=1 ; d<=maxDepth ; d++ )
+		{
+			node_index_type start = _sNodesBegin( d ) , end = _sNodesEnd( d );
+			size_t range = end - start;
+			typename BaseConstraint::CPStencils stencils;
+			F.init( d );
+			F.template setStencils< false >( stencils );
+			std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+			for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( d-1 ) );
+
+			ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int thread , size_t i )
+			{
+				if( _isValidFEM1Node( _sNodes.treeNodes[i] ) )
+				{
+					ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+					FEMTreeNode* node = _sNodes.treeNodes[i];
+					int start[Dim] , end[Dim];
+					typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors;
+					typename FEMTreeNode::template ConstNeighbors< OverlapSizes > pNeighbors;
+					bool isInterior;
+					{
+						BaseFEMIntegrator::ParentOverlapBounds( UIntPack< FEMDegrees ... >() , UIntPack< CDegrees ... >() , (int)( node - node->parent->children ) , start , end );
+					}
+					{
+						LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node->parent , d , off );
+						neighborKey.getNeighbors( LeftFEMCOverlapRadii() , RightFEMCOverlapRadii() , node->parent , pNeighbors );
+						isInterior = BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< FEMDegrees ... >() , UIntPack< CDegrees ... >() , d , off );
+					}
+					int cIdx = (int)( node - node->parent->children );
+					const typename BaseConstraint::CCStencil& _stencil = stencils.data[cIdx];
+
+					T constraint = {};
+
+					LocalDepth d ; LocalOffset off;
+					_localDepthAndOffset( node , d , off );
+					int corner = (int)( node - node->parent->children );
+					unsigned int size = femcLoopData.size[corner];
+					const unsigned int* indices = femcLoopData.indices[corner];
+					Pointer( const FEMTreeNode* ) nodes = pNeighbors.neighbors().data;
+					Pointer( Point< double , CDim > ) stencilValues = _stencil.data;
+					if( isInterior )
+						for( unsigned int i=0 ; i<size ; i++ )
+						{
+							unsigned int idx = indices[i];
+							if( _isValidFEM2Node( nodes[idx] ) ) constraint += _StencilDot< double , T , CDim >( stencilValues[idx] , _coefficients[ nodes[idx]->nodeData.nodeIndex ] );
+						}
+					else
+						for( unsigned int i=0 ; i<size ; i++ )
+						{
+							unsigned int idx = indices[i];
+							if( _isValidFEM2Node( nodes[idx] ) )
+							{
+								LocalDepth _d ; LocalOffset _off ; _localDepthAndOffset ( nodes[idx] , _d , _off );
+								constraint += _StencilDot< double , T , CDim >( F.cpIntegrate( off , _off ) , _coefficients[ nodes[idx]->nodeData.nodeIndex ] );
+							}
+						}
+					constraints[i] += constraint;
+				}
+			}
+			);
+		}
+		FreePointer( _coefficients );
+	}
+
+	ThreadPool::ParallelFor( _sNodesBegin(0) , _sNodesEnd(_maxDepth) , [&]( unsigned int , size_t i )
+	{
+		if( _isValidFEM1Node( _sNodes.treeNodes[i] ) && _sNodes.treeNodes[i]->nodeData.getDirichletElementFlag() ) constraints[i] *= (Real)0;
+	} );
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int ... FEMSigs , unsigned int PointD >
+void FEMTree< Dim , Real >::_addInterpolationConstraints( DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , LocalDepth maxDepth , const InterpolationInfo< T , PointD > *interpolationInfo ) const
+{
+	_setFEM1ValidityFlags( UIntPack< FEMSigs ... >() );
+	typedef typename FEMIntegrator::template PointEvaluator< UIntPack< FEMSigs ... > , IsotropicUIntPack< Dim , PointD > > PointEvaluator;
+	PointEvaluator evaluator( std::min< LocalDepth >( maxDepth , _maxDepth ) );
+
+	typedef typename FEMTreeNode::template ConstNeighborKey< UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportEnd ... > , UIntPack< ( -BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportStart ) ...  > > PointSupportKey;
+	maxDepth = std::min< LocalDepth >( maxDepth , _maxDepth );
+	{
+		typedef UIntPack< (-BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportStart ) ... >       LeftSupportRadii;
+		typedef UIntPack< ( BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportEnd   ) ... >  LeftPointSupportRadii;
+		typedef UIntPack< (-BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportStart ) ... > RightPointSupportRadii;
+		typedef UIntPack<   BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize    ... > SupportSizes;
+
+		for( int d=0 ; d<=maxDepth ; d++ )
+		{
+			std::vector< PointSupportKey > neighborKeys( ThreadPool::NumThreads() );
+			for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( maxDepth ) );
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Why do I have to wrap the template in a lambda?" )
+#endif // SHOW_WARNINGS
+			typedef PointEvaluatorState< UIntPack< FEMSigs ... > , IsotropicUIntPack< Dim , PointD > > _PointEvaluatorState;
+			auto WrapperLambda = []( const _PointEvaluatorState &eState , LocalOffset off )
+			{
+				return eState.template dValues< Real , CumulativeDerivatives< Dim , PointD > >( off );
+			};
+			ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int thread , size_t i )
+			{
+				if( _isValidSpaceNode( _sNodes.treeNodes[i] ) )
+				{
+					_PointEvaluatorState eState;
+					FEMTreeNode* node = _sNodes.treeNodes[i];
+
+					PointSupportKey& neighborKey = neighborKeys[ thread ];
+					typename FEMTreeNode::template ConstNeighbors< SupportSizes > neighbors;
+					neighborKey.getNeighbors( LeftPointSupportRadii() , RightPointSupportRadii() , node , neighbors );
+					LocalDepth d ; LocalOffset off;
+					_localDepthAndOffset( node , d , off );
+
+					size_t begin , end;
+					interpolationInfo->range( node , begin , end );
+					for( size_t pIndex=begin ; pIndex<end ; pIndex++ )
+					{
+						const DualPointInfo< Dim , Real , T , PointD >& pData = (*interpolationInfo)[ pIndex ];
+						Point< Real , Dim > p = pData.position;
+						evaluator.initEvaluationState( p , d , off , eState );
+
+						int s[Dim];
+						WindowLoop< Dim >::Run
+						(
+							IsotropicUIntPack< Dim , 0 >() , SupportSizes() ,
+							[&]( int d , int i ){ s[d] = i; } ,
+							[&]( const FEMTreeNode* _node )
+							{
+								if( _isValidFEM1Node( _node ) && !_node->nodeData.getDirichletElementFlag() )
+								{
+									LocalDepth _d ; LocalOffset _off ; _localDepthAndOffset( _node , _d , _off );
+									CumulativeDerivativeValues< Real , Dim , PointD > values = WrapperLambda( eState , _off );
+									T dot = {};
+									for( int s=0 ; s<CumulativeDerivatives< Dim , PointD >::Size ; s++ ) dot += pData.dualValues[s] * values[s];
+									Atomic< T >::Add( constraints[ _node->nodeData.nodeIndex ] , dot );
+								}
+							} ,
+							neighbors.neighbors()
+						);
+					}
+				}
+			}
+			);
+		}
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , typename TDotT , unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , class Coefficients1 , class Coefficients2 , unsigned int PointD >
+double FEMTree< Dim , Real >::_interpolationDot( UIntPack< FEMSigs1 ... > , UIntPack< FEMSigs2 ... > , const Coefficients1& coefficients1 , const Coefficients2& coefficients2 , TDotT Dot , const InterpolationInfo< T , PointD >* iInfo ) const
+{
+	typedef UIntPack< FEMSignature< FEMSigs1 >::Degree ... > FEMDegrees1;
+	typedef UIntPack< FEMSignature< FEMSigs2 >::Degree ... > FEMDegrees2;
+	typedef UIntPack< FEMSigs1 ... > FEMSignatures1;
+	typedef UIntPack< FEMSigs2 ... > FEMSignatures2;
+	double dot = 0;
+	if( iInfo )
+	{
+		MultiThreadedEvaluator< FEMSignatures1 , PointD , T > mt1( this , coefficients1 );
+		MultiThreadedEvaluator< FEMSignatures2 , PointD , T > mt2( this , coefficients2 );
+
+		size_t begin , end;
+		iInfo->range( _spaceRoot , begin , end );
+		std::vector< double > dots( ThreadPool::NumThreads() , 0 );
+		ThreadPool::ParallelFor( begin , end , [&]( unsigned int thread , size_t i )
+		{
+			Point< Real , Dim > p = (*iInfo)[i].position;
+			Real w = (*iInfo)[i].weight;
+			CumulativeDerivativeValues< T , Dim , PointD > v1 = (*iInfo)( i , mt1.values( p , thread ) );
+			CumulativeDerivativeValues< T , Dim , PointD > v2 = mt2.values( p , thread );
+			for( int dd=0 ; dd<CumulativeDerivatives< Dim , PointD >::Size ; dd++ ) dots[thread] += Dot( v1[dd] , v2[dd] ) * w;
+		}
+		);
+		for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) dot += dots[t];
+	}
+	return dot;
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , typename TDotT , unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , unsigned int ... Degrees1 , unsigned int ... Degrees2 , class Coefficients1 , class Coefficients2 >
+double FEMTree< Dim , Real >::_dot( UIntPack< FEMSigs1 ... > , UIntPack< FEMSigs2 ... > , typename BaseFEMIntegrator::template Constraint< UIntPack< Degrees1 ... > , UIntPack< Degrees2 ... > , 1 >& F , const Coefficients1& coefficients1 , const Coefficients2& coefficients2 , TDotT Dot ) const
+{
+	_setFEM1ValidityFlags( UIntPack< FEMSigs1 ... >() );
+	_setFEM2ValidityFlags( UIntPack< FEMSigs2 ... >() );
+	typedef typename BaseFEMIntegrator::template Constraint< UIntPack< Degrees1 ... > , UIntPack< Degrees2 ... > , 1 > BaseConstraint;
+	double dot = 0;
+	// Calculate the contribution from @(depth,depth)
+	{
+		typedef UIntPack<  BSplineOverlapSizes< Degrees1 , Degrees2 >::OverlapSize  ... >      OverlapSizes;
+		typedef UIntPack< -BSplineOverlapSizes< Degrees1 , Degrees2 >::OverlapStart ... >  LeftOverlapRadii;
+		typedef UIntPack<  BSplineOverlapSizes< Degrees1 , Degrees2 >::OverlapEnd   ... > RightOverlapRadii;
+
+		for( LocalDepth d=0 ; d<=_maxDepth ; d++ )
+		{
+			typename BaseConstraint::CCStencil stencil;
+			F.init( d );
+			F.template setStencil< false >( stencil );
+
+			std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+			for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( d ) );
+
+			std::vector< double > dots( ThreadPool::NumThreads() , 0 );
+			ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int thread , size_t i )
+			{
+				double &dot = dots[thread];
+				const FEMTreeNode* node = _sNodes.treeNodes[i];
+				const T* _data1;
+				if( _isValidFEM1Node( node ) && ( _data1=coefficients1(node) ) )
+				{
+					ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+					typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors;
+					neighborKey.getNeighbors( LeftOverlapRadii() , RightOverlapRadii() , node , neighbors );
+					bool isInterior = _isInteriorlyOverlapped( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , node );
+
+					LocalDepth d ; LocalOffset off;
+					_localDepthAndOffset( node , d , off );
+					ConstPointer( FEMTreeNode * const ) nodes = neighbors.neighbors().data;
+					ConstPointer( Point< double , 1 > ) stencilValues = stencil.data;
+					if( isInterior )
+					{
+						for( int i=0 ; i<WindowSize< UIntPack< BSplineOverlapSizes< Degrees1 , Degrees2 >::OverlapSize ... > >::Size ; i++  )
+						{
+							const T* _data2;
+							if( _isValidFEM2Node( nodes[i] ) && ( _data2=coefficients2( nodes[i] ) ) ) dot += Dot( *_data1 , *_data2 ) * stencilValues[i][0];
+						}
+					}
+					else
+					{
+						for( int i=0 ; i<WindowSize< UIntPack< BSplineOverlapSizes< Degrees1 , Degrees2 >::OverlapSize ... > >::Size ; i++  )
+						{
+							const T* _data2;
+							if( _isValidFEM2Node( nodes[i] ) && ( _data2=coefficients2( nodes[i] ) ) )
+							{
+								LocalDepth _d ; LocalOffset _off ; _localDepthAndOffset( nodes[i] , _d , _off );
+								dot += Dot( *_data1 , *_data2 ) * F.ccIntegrate( off , _off )[0];
+							}
+						}
+					}
+				}
+			}
+			);
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) dot += dots[t];
+		}
+	}
+	// Calculate the contribution from @(<depth,depth)
+	{
+		typedef UIntPack<  BSplineOverlapSizes< Degrees2 , Degrees1 >::OverlapSize  ... >      OverlapSizes;
+		typedef UIntPack< -BSplineOverlapSizes< Degrees2 , Degrees1 >::OverlapStart ... >  LeftOverlapRadii;
+		typedef UIntPack<  BSplineOverlapSizes< Degrees2 , Degrees1 >::OverlapEnd   ... > RightOverlapRadii;
+
+		DenseNodeData< T , UIntPack< FEMSigs1 ... > > cumulative1( _sNodesEnd( _maxDepth-1 ) );
+		if( _maxDepth>0 ) memset( cumulative1() , 0 , sizeof(T) * _sNodesEnd( _maxDepth-1 ) );
+
+		for( LocalDepth d=1 ; d<=_maxDepth ; d++ )
+		{
+			// Update the cumulative coefficients with the coefficients @(depth-1)
+			ThreadPool::ParallelFor( _sNodesBegin(d-1) , _sNodesEnd(d-1) , [&]( unsigned int , size_t i )
+			{
+				const T* _data1 = coefficients1( _sNodes.treeNodes[i] );
+				if( _data1 ) cumulative1[i] += *_data1;
+			}
+			);
+
+			typename BaseConstraint::PCStencils stencils;
+			F.init( d );
+			F.template setStencils< true >( stencils );
+
+			std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+			for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( d-1 ) );
+
+			std::vector< double > dots( ThreadPool::NumThreads() , 0 );
+			ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int thread , size_t i )
+			{
+				double &dot = dots[thread];
+				const FEMTreeNode* node = _sNodes.treeNodes[i];
+				const T* _data2;
+				if( _isValidFEM2Node( node ) && ( _data2=coefficients2( node ) ) )
+				{
+					ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+					bool isInterior = _isInteriorlyOverlapped( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , node->parent );
+
+					LocalDepth d ; LocalOffset off;
+					_localDepthAndOffset( node , d , off );
+
+					int cIdx = (int)( node - node->parent->children );
+					typename BaseConstraint::CCStencil& _stencil = stencils.data[cIdx];
+					typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors;
+					neighborKey.getNeighbors( LeftOverlapRadii() , RightOverlapRadii() , node->parent , neighbors );
+
+					int start[Dim] , end[Dim];
+					_SetParentOverlapBounds( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , node , start , end );
+					WindowLoop< Dim >::Run
+					(
+						start , end ,
+						[&]( int , int ){;} ,
+						[&]( const FEMTreeNode* node , Point< double , 1 > stencilValue )
+						{
+							const T* _data1;
+							if( _isValidFEM1Node( node ) && ( _data1=cumulative1(node) ) )
+							{
+								if( isInterior ) dot += Dot( *_data1 , *_data2 ) * stencilValue[0];
+								else
+								{
+									LocalDepth _d ; LocalOffset _off ; _localDepthAndOffset( node , _d , _off );
+									dot += Dot ( *_data1 , *_data2 ) * F.pcIntegrate( _off , off )[0];
+								}
+							}
+						} ,
+						neighbors.neighbors() , _stencil()
+					);
+				}
+			}
+			);
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) dot += dots[t];
+			// Up sample the cumulative coefficients for the next level
+			if( d<_maxDepth ) _upSample( UIntPack< FEMSigs1 ... >() , F.tRestrictionProlongation() , d , cumulative1()+_sNodesBegin(d-1) , cumulative1()+_sNodesBegin(d) );
+		}
+	}
+
+	// Calculate the contribution from @(>depth,depth)
+	{
+	typedef UIntPack<  BSplineOverlapSizes< Degrees1 , Degrees2 >::OverlapSize  ... >      OverlapSizes;
+	typedef UIntPack< -BSplineOverlapSizes< Degrees1 , Degrees2 >::OverlapStart ... >  LeftOverlapRadii;
+	typedef UIntPack<  BSplineOverlapSizes< Degrees1 , Degrees2 >::OverlapEnd   ... > RightOverlapRadii;
+
+	DenseNodeData< T , UIntPack< FEMSigs2 ... > > cumulative2( _sNodesEnd( _maxDepth-1 ) );
+	if( _maxDepth>0 ) memset( cumulative2() , 0 , sizeof(T) * _sNodesEnd( _maxDepth-1 ) );
+
+		for( LocalDepth d=_maxDepth ; d>0 ; d-- )
+		{
+			typename BaseConstraint::CPStencils stencils;
+			F.init( d );
+			F.template setStencils< false >( stencils );
+
+			std::vector< ConstOneRingNeighborKey > neighborKeys( ThreadPool::NumThreads() );
+			for( size_t i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( d-1 ) );
+
+			// Update the cumulative constraints @(depth-1) from @(depth)
+			std::vector< double > dots( ThreadPool::NumThreads() , 0 );
+			ThreadPool::ParallelFor( _sNodesBegin(d) , _sNodesEnd(d) , [&]( unsigned int thread , size_t i )
+			{
+				double &dot = dots[thread];
+				const FEMTreeNode* node = _sNodes.treeNodes[i];
+				const T* _data1;
+				if( _isValidFEM1Node( node ) && ( _data1=coefficients1( node ) ) )
+				{
+					ConstOneRingNeighborKey& neighborKey = neighborKeys[ thread ];
+					bool isInterior = _isInteriorlyOverlapped( UIntPack< Degrees2 ... >() , UIntPack< Degrees1 ... >() , node->parent );
+
+					LocalDepth d ; LocalOffset off;
+					_localDepthAndOffset( node , d , off );
+
+					int cIdx = (int)( node - node->parent->children );
+					typename BaseConstraint::CCStencil& _stencil = stencils.data[cIdx];
+					typename FEMTreeNode::template ConstNeighbors< OverlapSizes > neighbors;
+					neighborKey.getNeighbors( LeftOverlapRadii() , RightOverlapRadii() , node->parent , neighbors );
+
+					int start[Dim] , end[Dim];
+					_SetParentOverlapBounds( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , node , start , end );
+
+#ifdef __clang__
+#ifdef SHOW_WARNINGS
+#pragma message ( "[WARNING] You've got me clang" )
+#endif // SHOW_WARNINGS
+					std::function< void (int,int) > updateFunction = [](int,int){};
+#endif // __clang__
+
+					WindowLoop< Dim >::Run
+					(
+						start , end ,
+#ifdef __clang__
+						updateFunction ,
+#else // !__clang__
+						[&]( int , int ){;} ,
+#endif // __clang__
+						[&]( const FEMTreeNode* node , Point< double , 1 > stencilValue )
+						{
+						if( _isValidFEM2Node( node ) )
+							{
+								T _dot;
+								if( isInterior ) _dot = (*_data1) * stencilValue[0];
+								else
+								{
+									LocalDepth _d ; LocalOffset _off ; _localDepthAndOffset( node , _d , _off );
+									_dot = (*_data1) * F.cpIntegrate( off , _off )[0];
+								}
+								Atomic< T >::Add( cumulative2[ node->nodeData.nodeIndex ] , _dot );
+							}
+						} ,
+						neighbors.neighbors() , _stencil()
+					);
+				}
+			}
+			);
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) dot += dots[t];
+			// Update the dot-product using the cumulative constraints @(depth-1)
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) dots[t] = 0;
+			ThreadPool::ParallelFor( _sNodesBegin(d-1) , _sNodesEnd(d-1) , [&]( unsigned int thread , size_t i )
+			{
+				double &dot = dots[thread];
+				const FEMTreeNode* node = _sNodes.treeNodes[i];
+				const T* _data2;
+				if( _isValidFEM2Node( node ) && ( _data2=coefficients2( node ) ) ) dot += Dot( cumulative2[ node->nodeData.nodeIndex ] , *_data2 );
+			}
+			);
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) dot += dots[t];
+
+			// Down-sample the cumulative constraints from @(depth-1) to @(depth-2) for the next pass
+			if( d-1>0 ) _downSample( UIntPack< FEMSigs2 ... >() , F.cRestrictionProlongation() , d-1 , GetPointer( &cumulative2[0] , cumulative2.size() ) + _sNodesBegin(d-1) , GetPointer( &cumulative2[0] , cumulative2.size() ) + _sNodesBegin(d-2)  );
+		}
+	}
+	return dot;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.WeightedSamples.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.WeightedSamples.inl
@@ -1,0 +1,515 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+template< class Real , unsigned int DataDegree , unsigned int ... DataDegrees > typename std::enable_if< sizeof ... ( DataDegrees )==0 >::type __SetBSplineComponentValues( const Real* position , const Real* start , Real width , double* values , unsigned int stride )
+{
+	Polynomial< DataDegree >::BSplineComponentValues( ( position[0] - start[0] ) / width , values );
+}
+template< class Real , unsigned int DataDegree , unsigned int ... DataDegrees > typename std::enable_if< sizeof ... ( DataDegrees )!=0 >::type __SetBSplineComponentValues( const Real* position , const Real* start , Real width , double* values , unsigned int stride )
+{
+	Polynomial< DataDegree >::BSplineComponentValues( ( position[0] - start[0] ) / width , values );
+	__SetBSplineComponentValues< Real , DataDegrees ... >( position+1 , start+1 , width , values + stride , stride );
+}
+
+
+// evaluate the result of splatting along a plane and then evaluating at a point on the plane.
+template< unsigned int Dim , class Real >
+template< unsigned int CoDim , unsigned int Degree >
+Real FEMTree< Dim , Real >::_GetScaleValue( Point< Real , Dim > p ) const
+{
+	static_assert( ( Dim>=CoDim) , "[ERROR] Co-dimension exceeds dimension" );
+	static const int PointSupportStart = -BSplineSupportSizes< Degree >::SupportEnd , PointSupportEnd = -BSplineSupportSizes< Degree >::SupportStart;
+	static const int PointSupportSize = PointSupportEnd - PointSupportStart + 1;
+	static const int BSplineSupportStart = BSplineSupportSizes< Degree >::SupportStart , BSplineSupportEnd = BSplineSupportSizes< Degree >::SupportEnd;
+	static const int BSplineSupportSize = BSplineSupportEnd - BSplineSupportStart + 1;
+	double splineValues[Dim][Degree+1];
+
+	// Evaluate the B-spline component functions at the position
+	for( int d=0 ; d<Dim ; d++ ) Polynomial< Degree >::BSplineComponentValues( p[d] , splineValues[d] );
+
+	StaticWindow< double , IsotropicUIntPack< Dim , PointSupportSize > > splatValues , densityValues;
+
+	// Get the values with which the center point splats into its neighbors
+	{
+		double scratch[Dim+1];
+		scratch[0] = 1.;
+		int idx[Dim];
+		WindowLoop< Dim >::Run
+		(
+			PointSupportStart , PointSupportEnd+1 ,
+			[&]( int d , int i ){ scratch[d+1] = scratch[d] * splineValues[d][i-PointSupportStart] ,  idx[d] = i; } ,
+			[&]( void )
+		{
+			int _idx[Dim];
+			for( int d=0 ; d<Dim ; d++ ) _idx[d] = idx[d] - PointSupportStart;
+			splatValues( _idx ) = scratch[ Dim ] , densityValues( _idx ) = 0;
+		}
+		);
+	}
+
+	// Splat from points along the hyperplane
+	// A point at node i will contribute to the evaluation of a point at node 0 if:
+	//		0 <= i + PointSupportEnd + BSplineSupportEnd
+	// and
+	//		0 >= i + PointSupportStart + BSplineSupportStart
+	// Or, equivalently:
+	//		- PointSupportEnd - BSplineSupportEnd <= i <= - PointSupportStart - BSplineSupportStart
+	{
+		int neighborPointIndex[Dim];
+		// Iterate over all points that can contribute
+		WindowLoop< Dim >::Run
+		(
+			- PointSupportEnd - BSplineSupportEnd , - PointSupportStart - BSplineSupportStart + 1 ,
+			[&]( int d , int i ){ neighborPointIndex[d] = i; } ,
+			[&]( void )
+		{
+			// Check that the neighboring point's node lies on the hyperplane
+			bool validNeighbor = true;
+			for( int d=0 ; d<CoDim ; d++ ) if( neighborPointIndex[d]!=0 ) validNeighbor = false;
+
+			if( validNeighbor )
+			{
+				int splineIndex[Dim] , _splineIndex[Dim];
+				// Iterate over all B-Splines supported on the neighboring point
+				WindowLoop< Dim >::Run
+				(
+					PointSupportStart , PointSupportEnd+1 ,
+					[&]( int d , int i ){ splineIndex[d] = neighborPointIndex[d] + i , _splineIndex[d] = i; } ,
+					[&]( void )
+				{
+					int idx[Dim] , _idx[Dim];
+					bool inRange = true;
+					for( int d=0 ; d<Dim ; d++ )
+					{
+						idx[d] = splineIndex[d] - PointSupportStart;
+						_idx[d] = _splineIndex[d] - PointSupportStart;
+						if( idx[d]<0 || idx[d]>=PointSupportSize ) inRange = false;
+					}
+					if( inRange ) densityValues( idx ) += splatValues( _idx );
+				}
+				);
+			}
+		}
+		);
+	}
+
+	double scaleValue = 0;
+	{
+		int idx[Dim];
+		WindowLoop< Dim >::Run
+		(
+			PointSupportStart , PointSupportEnd+1 ,
+			[&]( int d , int i ){ idx[d] = i - PointSupportStart; } ,
+			[&]( void ){ scaleValue += splatValues(idx) * densityValues(idx); }
+		);
+	}
+
+	return (Real)( 1./scaleValue );
+}
+
+// Evaluate the result of splatting along a hyper-plane of co-dimension CoDim through points in the interior of the node and then evaluating at those points.
+template< unsigned int Dim , class Real >
+template< unsigned int CoDim , unsigned int Degree > Real FEMTree< Dim , Real >::_GetScaleValue( unsigned int res ) const
+{
+	Point< Real , Dim > p;
+	Real dx = (Real)(1./res);
+	unsigned int count = 0;
+	Real scaleValueSum = 0;
+
+	WindowLoop< Dim >::Run
+	(
+		0 , res ,
+		[&]( int d , int i ){ p[d] = dx/2 + dx*i; } ,
+		[&]( void ){ count++ ; scaleValueSum += _GetScaleValue< CoDim , Degree >(p); }
+	);
+	return scaleValueSum / count;
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe , unsigned int CoDim , unsigned int WeightDegree >
+void FEMTree< Dim , Real >::_addWeightContribution( Allocator< FEMTreeNode > *nodeAllocator , DensityEstimator< WeightDegree >& densityWeights , FEMTreeNode* node , Point< Real , Dim > position , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , Real weight )
+{
+	static const Real ScaleValue = _GetScaleValue< CoDim , WeightDegree >( 10 );
+	double values[ Dim ][ BSplineSupportSizes< WeightDegree >::SupportSize ];
+	typename FEMTreeNode::template Neighbors< IsotropicUIntPack< Dim , BSplineSupportSizes< WeightDegree >::SupportSize > >& neighbors = weightKey.template getNeighbors< true , ThreadSafe >( node , nodeAllocator , _nodeInitializer );
+
+	densityWeights.reserve( nodeCount() );
+
+	// Evaluate the B-spline components at the position
+	{
+		Point< Real , Dim > start;
+		Real w;
+		node->startAndWidth( start , w );
+		for( int dim=0 ; dim<Dim ; dim++ ) Polynomial< WeightDegree >::BSplineComponentValues( ( position[dim]-start[dim] ) / w , values[dim] );
+	}
+
+	weight *= (Real)ScaleValue;
+	double scratch[Dim+1];
+	scratch[0] = weight;
+	WindowLoop< Dim >::Run
+	(
+		IsotropicUIntPack< Dim , 0 >() , IsotropicUIntPack< Dim , BSplineSupportSizes< WeightDegree >::SupportSize >() ,
+		[&]( int d , int i ){ scratch[d+1] = scratch[d] * values[d][i]; } ,
+		[&]( FEMTreeNode* node )
+	{
+		if( node )
+		{
+			AddAtomic( densityWeights[ node ] , (Real)scratch[Dim] );
+		}
+	} ,
+		neighbors.neighbors()
+	);
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int WeightDegree , class PointSupportKey >
+Real FEMTree< Dim , Real >::_getSamplesPerNode( const DensityEstimator< WeightDegree >& densityWeights , const FEMTreeNode* node , Point< Real , Dim > position , PointSupportKey& weightKey ) const
+{
+	Real weight = 0;
+	typedef typename PointSupportKey::NeighborType Neighbors;
+	double values[ Dim ][ BSplineSupportSizes< WeightDegree >::SupportSize ];
+	Neighbors neighbors = weightKey.getNeighbors( node );
+	Point< Real , Dim > start;
+	Real w;
+	_startAndWidth( node , start , w );
+
+	for( int dim=0 ; dim<Dim ; dim++ ) Polynomial< WeightDegree >::BSplineComponentValues( ( position[dim]-start[dim] ) / w , values[dim] );
+	double scratch[Dim+1];
+	scratch[0] = 1;
+	WindowLoop< Dim >::Run
+	(
+		IsotropicUIntPack< Dim , 0 >() , IsotropicUIntPack< Dim , BSplineSupportSizes< WeightDegree >::SupportSize >() ,
+		[&]( int d , int i ){ scratch[d+1] = scratch[d] * values[d][i]; } ,
+		[&]( typename Neighbors::StaticWindow::data_type node ){ if( node ){ const Real *w = densityWeights( node ) ; if( w ) weight += (Real)( scratch[Dim] * (*w) ); } } ,
+		neighbors.neighbors()
+	);
+	return weight;
+}
+template< unsigned int Dim , class Real >
+template< unsigned int WeightDegree , class PointSupportKey >
+void FEMTree< Dim , Real >::_getSampleDepthAndWeight( const DensityEstimator< WeightDegree >& densityWeights , const FEMTreeNode* node , Point< Real , Dim > position , PointSupportKey& weightKey , Real& depth , Real& weight ) const
+{
+	const FEMTreeNode* temp = node;
+	while( _localDepth( temp )>densityWeights.kernelDepth() ) temp = temp->parent;
+	// Goal:
+	// Find the depth d at which the number of samples per node is equal to densityWeights.samplesPerNode.
+	// Assume that the number of samples per node grows by a factor of 2^( Dim-CoDim ) as the depth is decreased by 1.
+	// That is:
+	//		SamplesPerNode( d ) = C / 2^( d * ( Dim - CoDim ) )
+	// So, given a target spd, we have:
+	//		spd = C / 2^( d * ( Dim - CoDim ) )
+	//		log( spd ) = log( C ) / log( 2^( d * ( Dim - CoDim ) ) )
+	//		log( spd ) = log( C ) - log( 2 ) * ( d * ( Dim - CoDim ) ) )
+	//		d = [ log( C ) - log( spd ) ] / [ log(2) * ( Dim-CoDim ) ]
+	// To get C, we note that if we know that we have spd_0 at depth d_0, this gives:
+	//		spd_0 = C / 2^( d_0 * ( Dim - CoDim ) )
+	//		C = spd_0 * 2^( d_0 * ( Dim - CoDim ) )
+	// Putting these together, we get:
+	//		d = [ log( spd_0 * 2^( d_0 * ( Dim - CoDim ) ) ) - log( spd ) ] / [ log(2) * ( Dim-CoDim ) ]
+	//		d = [ log( spd_0 ) - log( spd ) + log(2) * ( d_0 * ( Dim - CoDim ) ) ) ] / [ log(2) * ( Dim-CoDim ) ]
+	//		d = [ log( spd_0 / spd ) ] / [ log(2) * ( Dim-CoDim ) ]  + d_0
+
+	Real samplesPerNode = _getSamplesPerNode( densityWeights , temp , position , weightKey );
+	if( samplesPerNode>=densityWeights.samplesPerNode() ) depth = Real( _localDepth( temp ) + log( samplesPerNode / densityWeights.samplesPerNode() ) / ( log(2.) * ( Dim-densityWeights.coDimension() ) ) );
+	else
+	{
+		Real fineSamplesPerNode , coarseSamplesPerNode;
+		fineSamplesPerNode = coarseSamplesPerNode = samplesPerNode;
+		while( coarseSamplesPerNode<densityWeights.samplesPerNode() && _localDepth(temp) )
+		{
+			temp = temp->parent;
+			fineSamplesPerNode = coarseSamplesPerNode;
+			coarseSamplesPerNode = _getSamplesPerNode( densityWeights , temp , position , weightKey );
+		}
+		// Rather than assuming that the number of samples per node scales by a factor of 2^(Dim-CoDim),
+		// use the fact that between the coarse and fine levels the samples per node scaled by coarseSamplesPerNode / fineSamplesPerNode
+		depth = Real( _localDepth( temp ) + log( coarseSamplesPerNode / densityWeights.samplesPerNode() ) / log( coarseSamplesPerNode / fineSamplesPerNode ) );
+		samplesPerNode = coarseSamplesPerNode;
+	}
+	Real nodeWidth = (Real)( 1. / (1<<_localDepth(temp) ) );
+	weight = (Real)pow( nodeWidth , Dim-densityWeights.coDimension() ) / samplesPerNode;
+}
+template< unsigned int Dim , class Real >
+template< unsigned int WeightDegree , class PointSupportKey >
+void FEMTree< Dim , Real >::_getSampleDepthAndWeight( const DensityEstimator< WeightDegree >& densityWeights , Point< Real , Dim > position , PointSupportKey& weightKey , Real& depth , Real& weight ) const
+{
+	FEMTreeNode* temp;
+	Point< Real,  Dim > myCenter;
+	for( int d=0 ; d<Dim ; d++ ) myCenter[d] = (Real)0.5;
+	Real myWidth = Real( 1. );
+
+	// Get the finest node with depth less than or equal to the splat depth that contains the point
+	temp = _spaceRoot;
+	while( _localDepth( temp )<densityWeights.kernelDepth() )
+	{
+		if( !IsActiveNode< Dim >( temp->children ) ) break; // MK_THROW( "" );
+		int cIndex = FEMTreeNode::ChildIndex( myCenter , position );
+		temp = temp->children + cIndex;
+		myWidth /= 2;
+		for( int d=0 ; d<Dim ; d++ )
+			if( (cIndex>>d) & 1 ) myCenter[d] += myWidth/2;
+			else                  myCenter[d] -= myWidth/2;
+	}
+	return _getSampleDepthAndWeight( densityWeights , temp , position , weightKey , depth , weight );
+}
+
+template< unsigned int Dim , class Real >
+template< bool CreateNodes , bool ThreadSafe , class V , unsigned int ... DataSigs >
+void FEMTree< Dim , Real >::_splatPointData( V zero , Allocator< FEMTreeNode > *nodeAllocator , FEMTreeNode* node , Point< Real , Dim > position , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& dataInfo , PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey )
+{
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > SupportSizes;
+	double values[ Dim ][ SupportSizes::Max() ];
+	typename FEMTreeNode::template Neighbors< UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > >& neighbors = dataKey.template getNeighbors< CreateNodes , ThreadSafe >( node , nodeAllocator , _nodeInitializer );
+	Point< Real , Dim > start;
+	Real w;
+	_startAndWidth( node , start , w );
+	__SetBSplineComponentValues< Real , FEMSignature< DataSigs >::Degree ... >( &position[0] , &start[0] , w , &values[0][0] , SupportSizes::Max() );
+	double scratch[Dim+1];
+	scratch[0] = 1;
+	WindowLoop< Dim >::Run
+	(
+		ZeroUIntPack< Dim >() , UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... >() ,
+		[&]( int d , int i ){ scratch[d+1] = scratch[d] * values[d][i]; } ,
+		[&]( FEMTreeNode* node ){ if( IsActiveNode< Dim >( node ) ) Atomic< V >::Add( dataInfo.at( node , zero ) , v * (Real)scratch[Dim] ); } ,
+		neighbors.neighbors()
+	);
+}
+template< unsigned int Dim , class Real >
+template< bool CreateNodes , bool ThreadSafe , unsigned int WeightDegree , class V , unsigned int ... DataSigs >
+Point< Real , 2 > FEMTree< Dim , Real >::_splatPointData( V zero , Allocator< FEMTreeNode > *nodeAllocator , const DensityEstimator< WeightDegree >& densityWeights , Real minDepthCutoff , Point< Real , Dim > position , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& dataInfo , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , LocalDepth minDepth , LocalDepth maxDepth , int dim , Real depthBias )
+{
+	// Get the depth and weight at position
+	Real weight , depth;
+	FEMTreeNode *temp = _spaceRoot;
+	Point< Real , Dim > myCenter;
+	Real myWidth;
+	{
+		for( int d=0 ; d<Dim ; d++ ) myCenter[d] = (Real)0.5;
+		myWidth = (Real)1.;
+		while( _localDepth( temp )<densityWeights.kernelDepth() )
+		{
+			if( !IsActiveNode< Dim >( temp->children ) ) break;
+			int cIndex = FEMTreeNode::ChildIndex( myCenter , position );
+			temp = temp->children + cIndex;
+			myWidth /= 2;
+			for( int d=0 ; d<Dim ; d++ )
+				if( (cIndex>>d) & 1 ) myCenter[d] += myWidth/2;
+				else                  myCenter[d] -= myWidth/2;
+		}
+		_getSampleDepthAndWeight( densityWeights , temp , position , weightKey , depth , weight );
+		depth += depthBias;
+	}
+
+	if( depth<minDepthCutoff ) return Point< Real , 2 >( (Real)-1. , (Real)0. );
+	Real rawDepth = depth;
+
+	if( depth<minDepth ) depth = Real(minDepth);
+	if( depth>maxDepth ) depth = Real(maxDepth);
+	int topDepth = (int)ceil(depth);
+
+	double dx = 1.0-(topDepth-depth);
+	if     ( topDepth<=minDepth ) topDepth = minDepth , dx = 1;
+	else if( topDepth> maxDepth ) topDepth = maxDepth , dx = 1;
+
+	while( _localDepth( temp )>topDepth ) temp=temp->parent;
+	while( _localDepth( temp )<topDepth )
+	{
+		if( !temp->children ) temp->template initChildren< ThreadSafe >( nodeAllocator , _nodeInitializer );
+		int cIndex = FEMTreeNode::ChildIndex( myCenter , position );
+		temp = &temp->children[cIndex];
+		myWidth/=2;
+		for( int d=0 ; d<Dim ; d++ )
+			if( (cIndex>>d) & 1 ) myCenter[d] += myWidth/2;
+			else                  myCenter[d] -= myWidth/2;
+	}
+
+	auto Splat = [&]( FEMTreeNode *node , Real dx )
+	{
+		double width = 1.0 / ( 1<<_localDepth( temp ) );
+		// Scale by:
+		//		weight: the area/volume associated with the sample
+		//		dx: the fraction of the sample splatted into the current depth
+		//		pow( width , -dim ): So that each sample is splatted with a unit volume
+		V _v = v * weight / Real( pow( width , dim ) ) * dx;
+//		V _v = v / Length(v) * dx;
+#if defined( __GNUC__ ) && __GNUC__ < 5
+#ifdef SHOW_WARNINGS
+#warning "you've got me gcc version<5"
+#endif // SHOW_WARNINGS
+		_splatPointData< CreateNodes , ThreadSafe , V >( zero , nodeAllocator , temp , position , _v , dataInfo , dataKey );
+#else // !__GNUC__ || __GNUC__ >=5
+		_splatPointData< CreateNodes , ThreadSafe , V ,  DataSigs ... >( zero , nodeAllocator , temp , position , _v , dataInfo , dataKey );
+#endif // __GNUC__ || __GNUC__ < 4
+	};
+	Splat( temp , (Real)dx );
+	if( fabs(1.-dx)>1e-6 ) Splat( temp->parent , (Real)(1.-dx) );
+	return Point< Real , 2 >( rawDepth , weight );
+}
+
+template< unsigned int Dim , class Real >
+template< bool CreateNodes , bool ThreadSafe , unsigned int WeightDegree , class V , unsigned int ... DataSigs >
+Point< Real , 2 > FEMTree< Dim , Real >::_splatPointData( V zero , Allocator< FEMTreeNode > *nodeAllocator , const DensityEstimator< WeightDegree >& densityWeights , Real minDepthCutoff , Point< Real , Dim > position , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& dataInfo , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , LocalDepth minDepth , std::function< int ( Point< Real , Dim > ) > &pointDepthFunctor , int dim , Real depthBias )
+{
+	// Get the depth and weight at position
+	Real sampleWeight , sampleDepth;
+	FEMTreeNode *temp = _spaceRoot;
+	Point< Real , Dim > myCenter;
+	Real myWidth;
+
+	int maxDepth = pointDepthFunctor( position );
+	{
+		int depth = 0;
+		for( int d=0 ; d<Dim ; d++ ) myCenter[d] = (Real)0.5;
+		myWidth = (Real)1.;
+		while( depth<maxDepth && depth<densityWeights.kernelDepth() )
+		{
+			if( !IsActiveNode< Dim >( temp->children ) ) break;
+			int cIndex = FEMTreeNode::ChildIndex( myCenter , position );
+			temp = temp->children + cIndex;
+			myWidth /= 2;
+			for( int d=0 ; d<Dim ; d++ )
+				if( (cIndex>>d) & 1 ) myCenter[d] += myWidth/2;
+				else                  myCenter[d] -= myWidth/2;
+			depth++;
+		}
+		_getSampleDepthAndWeight( densityWeights , temp , position , weightKey , sampleDepth , sampleWeight );
+		sampleDepth += depthBias;
+	}
+
+	if( sampleDepth<minDepthCutoff ) return Point< Real , 2 >( (Real)-1. , (Real)0. );
+	Real rawSampleDepth = sampleDepth;
+
+	if( sampleDepth<minDepth ) sampleDepth = (Real)minDepth;
+	if( sampleDepth>maxDepth ) sampleDepth = (Real)maxDepth;
+	int topDepth = (int)ceil(sampleDepth);
+
+	double dx = 1.0-(topDepth-sampleDepth);
+	if     ( topDepth<=minDepth ) topDepth = minDepth , dx = 1;
+	else if( topDepth> maxDepth ) topDepth = maxDepth , dx = 1;
+
+	while( _localDepth( temp )>topDepth ) temp=temp->parent;
+	while( _localDepth( temp )<topDepth )
+	{
+		if( !temp->children ) temp->template initChildren< ThreadSafe >( nodeAllocator , _nodeInitializer );
+		int cIndex = FEMTreeNode::ChildIndex( myCenter , position );
+		temp = &temp->children[cIndex];
+		myWidth/=2;
+		for( int d=0 ; d<Dim ; d++ )
+			if( (cIndex>>d) & 1 ) myCenter[d] += myWidth/2;
+			else                  myCenter[d] -= myWidth/2;
+	}
+
+	auto Splat = [&]( FEMTreeNode *node , Real dx )
+	{
+		double width = 1.0 / ( 1<<_localDepth( temp ) );
+		// Scale by:
+		//		weight: the area/volume associated with the sample
+		//		dx: the fraction of the sample splatted into the current depth
+		//		pow( width , -dim ): So that each sample is splatted with a unit volume
+		V _v = v * sampleWeight / Real( pow( width , dim ) ) * dx;
+		//		V _v = v / Length(v) * dx;
+#if defined( __GNUC__ ) && __GNUC__ < 5
+#ifdef SHOW_WARNINGS
+		#warning "you've got me gcc version<5"
+#endif // SHOW_WARNINGS
+		_splatPointData< CreateNodes , ThreadSafe , V >( zero , nodeAllocator , temp , position , _v , dataInfo , dataKey );
+#else // !__GNUC__ || __GNUC__ >=5
+		_splatPointData< CreateNodes , ThreadSafe , V ,  DataSigs ... >( zero , nodeAllocator , temp , position , _v , dataInfo , dataKey );
+#endif // __GNUC__ || __GNUC__ < 4
+	};
+	Splat( temp , (Real)dx );
+	if( fabs(1.-dx)>1e-6 ) Splat( temp->parent , (Real)(1.-dx) );
+	return Point< Real , 2 >( rawSampleDepth , sampleWeight );
+}
+
+template< unsigned int Dim , class Real >
+template< bool CreateNodes , bool ThreadSafe , unsigned int WeightDegree , class V , unsigned int ... DataSigs >
+Point< Real , 2 > FEMTree< Dim , Real >::_multiSplatPointData( V zero , Allocator< FEMTreeNode > *nodeAllocator , const DensityEstimator< WeightDegree >* densityWeights , FEMTreeNode* node , Point< Real , Dim > position , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& dataInfo , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , int dim )
+{
+	typedef UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > SupportSizes;
+	Real _depth , weight;
+	if( densityWeights ) _getSampleDepthAndWeight( *densityWeights , position , weightKey , _depth , weight );
+	else _depth=(Real)-1. , weight = (Real)1.;
+	V _v = v * weight;
+
+	double values[ Dim ][ SupportSizes::Max() ];
+	dataKey.template getNeighbors< CreateNodes , ThreadSafe >( node , nodeAllocator , _nodeInitializer );
+
+	for( FEMTreeNode* _node=node ; _localDepth( _node )>=0 ; _node=_node->parent )
+	{
+		V __v = _v * (Real)pow( 1<<_localDepth( _node ) , dim );
+		Point< Real , Dim > start;
+		Real w;
+		_startAndWidth( _node , start , w );
+		__SetBSplineComponentValues< Real , FEMSignature< DataSigs >::Degree ... >( &position[0] , &start[0] , w , &values[0][0] , SupportSizes::Max() );
+		typename FEMTreeNode::template Neighbors< UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... > >& neighbors = dataKey.neighbors[ _localToGlobal( _localDepth( _node ) ) ];
+		double scratch[Dim+1];
+		scratch[0] = 1.;
+		WindowLoop< Dim >::Run
+		(
+			ZeroUIntPack< Dim >() , UIntPack< BSplineSupportSizes< FEMSignature< DataSigs >::Degree >::SupportSize ... >() ,
+			[&]( int d , int i ){ scratch[d+1] = scratch[d] * values[d][i]; } ,
+			[&]( FEMTreeNode* node ){ if( IsActiveNode< Dim >( node ) ) Atomic< V >::Add( dataInfo.at( node , zero ) , __v * (Real)scratch[Dim] ) ; } ,
+			neighbors.neighbors()
+		);
+	}
+	return Point< Real , 2 >( _depth , weight );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int WeightDegree , class V , unsigned int ... DataSigs >
+Real FEMTree< Dim , Real >::_nearestMultiSplatPointData( V zero , const DensityEstimator< WeightDegree >* densityWeights , FEMTreeNode* node , Point< Real , Dim > position , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& dataInfo , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , int dim )
+{
+	Real _depth , weight;
+	if( densityWeights ) _getSampleDepthAndWeight( *densityWeights , position , weightKey , _depth , weight );
+	else weight = (Real)1.;
+	V _v = v * weight;
+
+	for( FEMTreeNode* _node=node ; _localDepth( _node )>=0 ; _node=_node->parent ) if( IsActiveNode< Dim >( _node ) ) Atomic< V >::Add( dataInfo.at( _node , zero ) , _v * (Real)pow( 1<<_localDepth( _node ) , dim ) );
+	return weight;
+}
+//////////////////////////////////
+// MultiThreadedWeightEvaluator //
+//////////////////////////////////
+template< unsigned int Dim , class Real >
+template< unsigned int DensityDegree >
+FEMTree< Dim , Real >::MultiThreadedWeightEvaluator< DensityDegree >::MultiThreadedWeightEvaluator( const FEMTree< Dim , Real >* tree , const DensityEstimator< DensityDegree >& density , int threads ) : _density( density ) , _tree( tree )
+{
+	_threads = std::max< int >( 1 , threads );
+	_neighborKeys.resize( _threads );
+	for( int t=0 ; t<_neighborKeys.size() ; t++ ) _neighborKeys[t].set( tree->_localToGlobal( density.kernelDepth() ) );
+}
+template< unsigned int Dim , class Real >
+template< unsigned int DensityDegree >
+Real FEMTree< Dim , Real >::MultiThreadedWeightEvaluator< DensityDegree >::weight( Point< Real , Dim > p , int thread )
+{
+	ConstPointSupportKey< IsotropicUIntPack< Dim , DensityDegree > >& nKey = _neighborKeys[thread];
+	Real depth , weight;
+	_tree->_getSampleDepthAndWeight( _density , p , nKey , depth , weight );
+	return weight;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.h
@@ -1,0 +1,3171 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+// -- [TODO] Make as many of the functions (related to the solver) const as possible.
+// -- [TODO] Move the point interpolation constraint scaling by 1<<maxDepth
+// -- [TODO] Add support for staggered-grid test functions
+// -- [TODO] Store signatures with constraints/systems/restriction-prolongations
+// -- [TODO] Make a virtual evaluation that only needs to know the degree
+// -- [TODO] Modify (public) functions so that template parameters don't need to be passed when they are called
+// -- [TODO] Confirm that whenever _isValidFEM*Node is called, the flags have already been set.
+// -- [TODO] Make weight evaluation more efficient in _getSamplesPerNode by reducing the number of calls to getNeighbors
+// -- [TODO] For point evaluation:
+//        1. Have the evaluator store stencils for all depths [DONE]
+//        2. When testing centers/corners, don't use generic evaluation
+// -- [TODO] Support nested parallelism with thread pools
+// -- [TODO] Make the node flags protected
+// -- [TODO] Identify members that are only valid after finalization
+// -- [TODO] Force the MaxDegree and finite-element degrees into the template parameters for the FEMTree so that root vs space-root are set up on construction
+
+#ifndef FEM_TREE_INCLUDED
+#define FEM_TREE_INCLUDED
+
+#include <atomic>
+#ifdef SANITIZED_PR
+#include <shared_mutex>
+#endif // SANITIZED_PR
+#include "MyMiscellany.h"
+#include "BSplineData.h"
+#include "Geometry.h"
+#include "DataStream.h"
+#include "RegularTree.h"
+#include "SparseMatrix.h"
+#include "NestedVector.h"
+#include "Rasterizer.h"
+#include <limits>
+#include <functional>
+#include <string>
+#include <tuple>
+#include <functional>
+#include <cmath>
+#include <climits>
+#include "MarchingCubes.h"
+#include <sstream>
+#include <sstream>
+#include <iomanip>
+#include <unordered_map>
+#include "MAT.h"
+
+namespace PoissonRecon
+{
+
+#ifdef BIG_DATA
+	// The integer type used for indexing the nodes in the octree
+	typedef long long node_index_type;
+	// The integer type used for indexing the entries of the matrix
+	typedef int matrix_index_type;
+#else // !BIG_DATA
+	typedef int node_index_type;
+	typedef int matrix_index_type;
+#endif // BIG_DATA
+#ifdef USE_DEEP_TREE_NODES
+	// The integer type used for storing the depth and offset within an octree node
+	typedef unsigned int depth_and_offset_type;
+#else // !USE_DEEP_TREE_NODES
+	typedef unsigned short depth_and_offset_type;
+#endif // USE_DEEP_TREE_NODES
+
+	template< unsigned int Dim , class Real > class FEMTree;
+
+	enum
+	{
+		SHOW_GLOBAL_RESIDUAL_NONE ,
+		SHOW_GLOBAL_RESIDUAL_LAST ,
+		SHOW_GLOBAL_RESIDUAL_ALL  ,
+		SHOW_GLOBAL_RESIDUAL_COUNT
+	};
+	static const char* ShowGlobalResidualNames[] = { "show none" , "show last" , "show all" };
+
+	class FEMTreeNodeData
+	{
+	public:
+		enum
+		{
+			SPACE_FLAG               = 1 << 0 , // Part of the partition of the unit cube
+			FEM_FLAG_1               = 1 << 1 ,	// Indexes a valid finite element
+			FEM_FLAG_2               = 1 << 2 ,	// Indexes a valid finite element
+			DIRICHLET_NODE_FLAG      = 1 << 3 ,	// The finite elements should evaluate to zero on this node
+			DIRICHLET_ELEMENT_FLAG   = 1 << 4 ,	// Coefficient of this node should be locked to zero
+			GEOMETRY_SUPPORTED_FLAG  = 1 << 5 ,	// The finite element defined by this node has support overlapping geometry constraints
+			GHOST_FLAG               = 1 << 6 ,	// Children are pruned out
+			SCRATCH_FLAG             = 1 << 7 ,
+		};
+		node_index_type nodeIndex;
+#ifdef SANITIZED_PR
+		mutable std::atomic< unsigned char > flags;
+#else // !SANITIZED_PR
+		mutable char flags;
+#endif // SANITIZED_PR
+		void setGhostFlag( bool f ) const { if( f ) flags |= GHOST_FLAG ; else flags &= ~GHOST_FLAG; }
+		bool getGhostFlag( void ) const { return ( flags & GHOST_FLAG )!=0; }
+		void setDirichletNodeFlag( bool f ) const { if( f ) flags |= DIRICHLET_NODE_FLAG ; else flags &= ~DIRICHLET_NODE_FLAG; }
+		bool getDirichletNodeFlag( void ) const { return ( flags & DIRICHLET_NODE_FLAG )!=0; }
+		void setDirichletElementFlag( bool f ) const { if( f ) flags |= DIRICHLET_ELEMENT_FLAG ; else flags &= ~DIRICHLET_ELEMENT_FLAG; }
+		bool getDirichletElementFlag( void ) const { return ( flags & DIRICHLET_ELEMENT_FLAG )!=0; }
+		void setScratchFlag( bool f ) const { if( f ) flags |= SCRATCH_FLAG ; else flags &= (unsigned char)~SCRATCH_FLAG; }
+		bool getScratchFlag( void ) const { return ( flags & SCRATCH_FLAG )!=0; }
+		inline FEMTreeNodeData( void );
+		inline ~FEMTreeNodeData( void );
+#ifdef SANITIZED_PR
+		inline FEMTreeNodeData &operator = ( const FEMTreeNodeData &data );
+#endif // SANITIZED_PR
+	};
+
+	template< unsigned int Dim >
+	class SortedTreeNodes
+	{
+		typedef RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > TreeNode;
+	protected:
+		Pointer( Pointer( node_index_type ) ) _sliceStart;
+		int _levels;
+
+		void _set( TreeNode& root );
+	public:
+		Pointer( TreeNode* ) treeNodes;
+		node_index_type begin( int depth ) const { return _sliceStart[depth][0]; }
+		node_index_type   end( int depth ) const { return _sliceStart[depth][(size_t)1<<depth]; }
+		node_index_type begin( int depth , int slice ) const { return _sliceStart[depth][ slice<0 ? 0 : ( slice>(1<<depth) ? (1<<depth) : slice ) ]; }
+		node_index_type   end( int depth , int slice ) const { return begin( depth , slice+1 ); }
+		size_t size( void ) const { return _levels ? _sliceStart[_levels-1][(size_t)1<<(_levels-1)] : 0; }
+		size_t size( int depth ) const
+		{
+			if( depth<0 || depth>=_levels ) MK_THROW( "bad depth: 0 <= " , depth , " < " , _levels );
+			return _sliceStart[depth][(size_t)1<<depth] - _sliceStart[depth][0];
+		}
+		size_t size( int depth , int slice ) const { return end( depth , slice ) - begin( depth , slice ); }
+		int levels( void ) const { return _levels; }
+
+		SortedTreeNodes( void );
+		~SortedTreeNodes( void );
+		// Resets the sorted tree nodes and sets map[i] to the index previously stored with the i-th node.
+		void reset( TreeNode& root , std::vector< node_index_type > &map );
+		void set( TreeNode& root );
+
+		void write( BinaryStream &stream ) const;
+		void read( BinaryStream &stream , TreeNode &root );
+	};
+
+	template< typename T > struct DotFunctor{};
+	template< > struct DotFunctor< float >
+	{
+		double operator()( float  v1 , float  v2 ){ return v1*v2; }
+		unsigned int dimension( void ) const { return 1; }
+	};
+	template< > struct DotFunctor< double >
+	{
+		double operator()( double v1 , double v2 ){ return v1*v2; }
+		unsigned int dimension( void ) const { return 1; }
+	};
+	template< class Real , unsigned int Dim > struct DotFunctor< Point< Real , Dim > >
+	{
+		double operator()( Point< Real , Dim > v1 , Point< Real , Dim > v2 ){ return Point< Real , Dim >::Dot( v1 , v2 ); }
+		unsigned int dimension( void ) const { return Dim; }
+	};
+
+	template< typename Pack > struct SupportKey{ };
+	template< unsigned int ... Degrees >
+	struct SupportKey< UIntPack< Degrees ... > > : public RegularTreeNode< sizeof...(Degrees) , FEMTreeNodeData , depth_and_offset_type >::template NeighborKey< UIntPack< (-BSplineSupportSizes< Degrees >::SupportStart) ... > , UIntPack< BSplineSupportSizes< Degrees >::SupportEnd ... > >
+	{
+		typedef UIntPack< (-BSplineSupportSizes< Degrees >::SupportStart ) ... > LeftRadii;
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::SupportEnd   ) ... > RightRadii;
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::SupportSize  ) ... > Sizes; 
+	};
+
+	template< typename Pack > struct ConstSupportKey{ };
+	template< unsigned int ... Degrees >
+	struct ConstSupportKey< UIntPack< Degrees ... > > : public RegularTreeNode< sizeof...(Degrees) , FEMTreeNodeData , depth_and_offset_type >::template ConstNeighborKey< UIntPack< (-BSplineSupportSizes< Degrees >::SupportStart ) ... > , UIntPack< BSplineSupportSizes< Degrees >::SupportEnd ... > >
+	{
+		typedef UIntPack< (-BSplineSupportSizes< Degrees >::SupportStart ) ... > LeftRadii;
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::SupportEnd   ) ... > RightRadii;
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::SupportSize  ) ... > Sizes; 
+	};
+
+	template< typename Pack > struct OverlapKey{ };
+	template< unsigned int ... Degrees >
+	struct OverlapKey< UIntPack< Degrees ... > > : public RegularTreeNode< sizeof...(Degrees) , FEMTreeNodeData , depth_and_offset_type >::template NeighborKey< UIntPack< (-BSplineOverlapSizes< Degrees , Degrees >::OverlapStart ) ... > , UIntPack< BSplineOverlapSizes< Degrees , Degrees >::OverlapEnd ... > >
+	{
+		typedef UIntPack< (-BSplineOverlapSizes< Degrees , Degrees >::OverlapStart ) ... > LeftRadii;
+		typedef UIntPack< ( BSplineOverlapSizes< Degrees , Degrees >::OverlapEnd   ) ... > RightRadii;
+		typedef UIntPack< ( BSplineOverlapSizes< Degrees , Degrees >::OverlapSize  ) ... > Sizes; 
+	};
+
+	template< typename Pack > struct ConstOverlapKey{ };
+	template< unsigned int ... Degrees >
+	struct ConstOverlapKey< UIntPack< Degrees ... > > : public RegularTreeNode< sizeof...(Degrees) , FEMTreeNodeData , depth_and_offset_type >::template ConstNeighborKey< UIntPack< (-BSplineOverlapSizes< Degrees , Degrees >::OverlapStart ) ... > , UIntPack< BSplineOverlapSizes< Degrees , Degrees >::OverlapEnd ... > >
+	{
+		typedef UIntPack< (-BSplineOverlapSizes< Degrees , Degrees >::OverlapStart ) ... > LeftRadii;
+		typedef UIntPack< ( BSplineOverlapSizes< Degrees , Degrees >::OverlapEnd   ) ... > RightRadii;
+		typedef UIntPack< ( BSplineOverlapSizes< Degrees , Degrees >::OverlapSize  ) ... > Sizes; 
+	};
+
+	template< typename Pack > struct PointSupportKey{ };
+	template< unsigned int ... Degrees >
+	struct PointSupportKey< UIntPack< Degrees ... > > : public RegularTreeNode< sizeof...(Degrees) , FEMTreeNodeData , depth_and_offset_type >::template NeighborKey< UIntPack< BSplineSupportSizes< Degrees >::SupportEnd ... > , UIntPack< (-BSplineSupportSizes< Degrees >::SupportStart ) ... > >
+	{
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::SupportEnd   ) ... > LeftRadii;
+		typedef UIntPack< (-BSplineSupportSizes< Degrees >::SupportStart ) ... > RightRadii;
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::SupportEnd - BSplineSupportSizes< Degrees >::SupportStart + 1 ) ... > Sizes; 
+	};
+
+	template< typename Pack > struct ConstPointSupportKey{ };
+	template< unsigned int ... Degrees >
+	struct ConstPointSupportKey< UIntPack< Degrees ... > > : public RegularTreeNode< sizeof...(Degrees) , FEMTreeNodeData , depth_and_offset_type >::template ConstNeighborKey< UIntPack< BSplineSupportSizes< Degrees >::SupportEnd ... > , UIntPack< (-BSplineSupportSizes< Degrees >::SupportStart ) ... > >
+	{
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::SupportEnd   ) ... > LeftRadii;
+		typedef UIntPack< (-BSplineSupportSizes< Degrees >::SupportStart ) ... > RightRadii;
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::SupportEnd - BSplineSupportSizes< Degrees >::SupportStart + 1 ) ... > Sizes; 
+	};
+
+	template< typename Pack > struct CornerSupportKey{ };
+	template< unsigned int ... Degrees >
+	struct CornerSupportKey< UIntPack< Degrees ... > > : public RegularTreeNode< sizeof...(Degrees) , FEMTreeNodeData , depth_and_offset_type >::template NeighborKey< UIntPack< BSplineSupportSizes< Degrees >::BCornerEnd ... > , UIntPack< ( -BSplineSupportSizes< Degrees >::BCornerStart + 1 ) ... > >
+	{
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::BCornerEnd       ) ... > LeftRadii;
+		typedef UIntPack< (-BSplineSupportSizes< Degrees >::BCornerStart + 1 ) ... > RightRadii;
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::BCornerSize  + 1 ) ... > Sizes; 
+	};
+
+	template< typename Pack > struct ConstCornerSupportKey{ };
+	template< unsigned int ... Degrees >
+	struct ConstCornerSupportKey< UIntPack< Degrees ... > > : public RegularTreeNode< sizeof...(Degrees) , FEMTreeNodeData , depth_and_offset_type >::template ConstNeighborKey< UIntPack< BSplineSupportSizes< Degrees >::BCornerEnd ... > , UIntPack< ( -BSplineSupportSizes< Degrees >::BCornerStart + 1 ) ... > >
+	{
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::BCornerEnd       ) ... > LeftRadii;
+		typedef UIntPack< (-BSplineSupportSizes< Degrees >::BCornerStart + 1 ) ... > RightRadii;
+		typedef UIntPack< ( BSplineSupportSizes< Degrees >::BCornerSize  + 1 ) ... > Sizes; 
+	};
+
+
+	template< class Data , typename Pack > struct _SparseOrDenseNodeData{};
+	template< class Data , unsigned int ... FEMSigs >
+	struct _SparseOrDenseNodeData< Data , UIntPack< FEMSigs ... > >
+	{
+		static const unsigned int Dim = sizeof ... ( FEMSigs );
+		typedef UIntPack< FEMSigs ... > FEMSignatures;
+		typedef Data data_type;
+
+		// Methods for accessing as an array
+		virtual size_t size( void ) const = 0;
+		virtual const Data& operator[] ( size_t idx ) const = 0;
+		virtual Data& operator[] ( size_t idx ) = 0;
+
+		// Method for accessing (and inserting if necessary) using a node
+		virtual Data& operator[]( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *node ) = 0;
+		// Methods for accessing using a node
+		virtual Data* operator()( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *node ) = 0;
+		virtual const Data* operator()( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ) const = 0;
+
+		// Method for getting the actual index associated with a node
+		virtual node_index_type index( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ) const = 0;
+	};
+
+	template< class Data , typename Pack > struct SparseNodeData{};
+	template< class Data , unsigned int ... FEMSigs >
+	struct SparseNodeData< Data , UIntPack< FEMSigs ... > > : public _SparseOrDenseNodeData< Data , UIntPack< FEMSigs ... > >
+	{
+		static const unsigned int Dim = sizeof ... ( FEMSigs );
+
+		static void WriteSignatures( BinaryStream &stream )
+		{
+			unsigned int dim = sizeof ... ( FEMSigs );
+			stream.write( dim );
+			unsigned int femSigs[] = { FEMSigs ... };
+			stream.write( femSigs , dim );
+		}
+		void write( BinaryStream &stream , const Serializer< Data > &serializer ) const
+		{
+			_indices.write( stream );
+			_data.write( stream , serializer );
+		}
+		void read( BinaryStream &stream , const Serializer< Data > &serializer )
+		{
+			_indices.read( stream );
+			_data.read( stream , serializer );
+		}
+		void write( BinaryStream &stream ) const
+		{
+			_indices.write( stream );
+			_data.write( stream );
+		}
+		void read( BinaryStream &stream )
+		{
+			_indices.read( stream );
+			_data.read( stream );
+		}
+		SparseNodeData( void ){}
+		SparseNodeData( BinaryStream &stream ){ read(stream); }
+		SparseNodeData( BinaryStream &stream , const Serializer< Data > &serializer ){ read(stream,serializer); }
+		// [WARNING] Default constructing the mutex
+		SparseNodeData( const SparseNodeData &d ) : _indices(d._indices) , _data(d._data){};
+		SparseNodeData( SparseNodeData &&d ) : _indices(d._indices) , _data(d._data){};
+		// [WARNING] Not copying the mutex
+		SparseNodeData &operator = ( const SparseNodeData &d ){ _indices = d._indices , _data = d._data ; return *this; }
+		SparseNodeData &operator = ( SparseNodeData &&d ){ std::swap( _indices , d._indices ) , std::swap( _data , d._data ); return *this; }
+
+		size_t size( void ) const { return _data.size(); }
+		const Data& operator[] ( size_t idx ) const { return _data[idx]; }
+		Data& operator[] ( size_t idx ) { return _data[idx]; }
+
+		void reserve( size_t sz ){ if( sz>_indices.size() ) _indices.resize( sz , -1 ); }
+		size_t reserved( void ) const { return _indices.size(); } 
+		Data* operator()( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ){ return ( node->nodeData.nodeIndex<0 || node->nodeData.nodeIndex>=(node_index_type)_indices.size() || _indices[ node->nodeData.nodeIndex ]==-1 ) ? NULL : &_data[ _indices[ node->nodeData.nodeIndex ] ]; }
+		const Data* operator()( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ) const { return ( node->nodeData.nodeIndex<0 || node->nodeData.nodeIndex>=(node_index_type)_indices.size() || _indices[ node->nodeData.nodeIndex ]==-1 ) ? NULL : &_data[ _indices[ node->nodeData.nodeIndex ] ]; }
+
+		Data& operator[]( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ){ return at( node ); }
+		Data &at( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *node , Data zero=Data() )
+		{
+			_indices.resize( node->nodeData.nodeIndex+1 , -1 );
+
+			// If the node hasn't been allocated yet
+#ifdef SANITIZED_PR
+			volatile node_index_type *indexPtr = &_indices[ node->nodeData.nodeIndex ];
+			node_index_type _index = ReadAtomic( *indexPtr );
+#else // !SANITIZED_PR
+			volatile node_index_type &_index = _indices[ node->nodeData.nodeIndex ];
+#endif // SANITIZED_PR
+			if( _index==-1 )
+			{
+				std::lock_guard< std::mutex > lock( _updateMutex );
+#ifdef SANITIZED_PR
+				_index = ReadAtomic( *indexPtr );
+#endif // SANITIZED_PR
+				if( _index==-1 )
+				{
+					size_t sz = _data.size();
+					_data.resize( sz+1 , zero );
+#ifdef SANITIZED_PR
+					_index = (node_index_type)sz;
+					SetAtomic( *indexPtr , _index );
+#else // !SANITIZED_PR
+					*(node_index_type*)&_index = (node_index_type)sz;
+#endif // SANITIZED_PR
+				}
+			}
+			return _data[ _index ];
+		}
+		node_index_type index( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *node ) const
+		{
+			if( !node || node->nodeData.nodeIndex<0 || node->nodeData.nodeIndex>=(node_index_type)_indices.size() ) return -1;
+			else return _indices[ node->nodeData.nodeIndex ];
+		}
+
+		node_index_type index( node_index_type idx ) const
+		{
+			if( idx<0 || idx>=(node_index_type)_indices.size() ) return -1;
+			else return _indices[ idx ];
+		}
+
+		void merge( const SparseNodeData &data ){ return merge( data , []( const Data &data ){ return data; } ); }
+
+		template< typename MergeFunctor >
+		void merge( const SparseNodeData &data , const MergeFunctor &mergeFunctor )
+		{
+			size_t sz = _indices.size();
+			node_index_type newDataCount = 0;
+			for( unsigned int j=0 ; j<data._indices.size() ; j++ ) if( data._indices[j]!=-1 && data._indices[j]<(node_index_type)sz && _indices[j]==-1 ) newDataCount++;
+			size_t oldSize = _data.size();
+			_data.resize( oldSize + newDataCount );
+			newDataCount = 0;
+			for( unsigned int j=0 ; j<data._indices.size() ; j++ ) if( data._indices[j]!=-1 && data._indices[j]<(node_index_type)sz )
+				if( _indices[j]==-1 )
+				{
+					_indices[j] = (node_index_type)oldSize + newDataCount;
+					_data[ oldSize + newDataCount ] = mergeFunctor( data._data[ data._indices[j] ] );
+					newDataCount++;
+				}
+				else _data[ _indices[j] ] += mergeFunctor( data._data[ data._indices[j] ] );
+		}
+
+		template< typename TargetToSourceFunctor >
+		void mergeFromTarget( const SparseNodeData &data , const TargetToSourceFunctor &targetToSourceFunctor ){ return mergeFromTarget( data , targetToSourceFunctor , []( const Data &data ){ return data; } ); }
+
+		template< typename TargetToSourceFunctor , typename MergeFunctor >
+		void mergeFromTarget( const SparseNodeData &target , const TargetToSourceFunctor &targetToSourceFunctor , const MergeFunctor &mergeFunctor )
+		{
+			size_t sz = _indices.size();
+			node_index_type newDataCount = 0;
+			for( unsigned int j=0 ; j<target._indices.size() ; j++ ) if( target._indices[j]!=-1 && target._indices[j]<(node_index_type)sz && _indices[ targetToSourceFunctor(j) ]==-1 ) newDataCount++;
+			size_t oldSize = _data.size();
+			_data.resize( oldSize + newDataCount );
+			newDataCount = 0;
+			for( unsigned int j=0 ; j<target._indices.size() ; j++ ) if( target._indices[j]!=-1 && target._indices[j]<(node_index_type)sz )
+			{
+				node_index_type _j = targetToSourceFunctor( j );
+				if( _indices[_j]==-1 )
+				{
+					_indices[_j] = (node_index_type)oldSize + newDataCount;
+					_data[ oldSize + newDataCount ] = mergeFunctor( target._data[ target._indices[j] ] );
+					newDataCount++;
+				}
+				else _data[ _indices[_j] ] += mergeFunctor( target._data[ target._indices[j] ] );
+			}
+		}
+
+		template< typename SourceToTargetFunctor >
+		void mergeToSource( const SparseNodeData &data , const SourceToTargetFunctor &sourceToTargetFunctor ){ return mergeToSource( data , sourceToTargetFunctor , []( const Data &data ){ return data; } ); }
+
+		template< typename SourceToTargetFunctor , typename MergeFunctor >
+		void mergeToSource( const SparseNodeData &target , const SourceToTargetFunctor &sourceToTargetFunctor , const MergeFunctor &mergeFunctor )
+		{
+			size_t _sz = target._indices.size();
+			node_index_type newDataCount = 0;
+			for( unsigned int j=0 ; j<_indices.size() ; j++ ) if( _indices[j]==-1 )
+			{
+				unsigned int _j = sourceToTargetFunctor( j );
+				if( _j<(node_index_type)_sz && target._indices[_j]!=-1 ) newDataCount++;
+			}
+			size_t oldSize = _data.size();
+			_data.resize( oldSize + newDataCount );
+			newDataCount = 0;
+			for( unsigned int j=0 ; j<_indices.size() ; j++ )
+			{
+				unsigned int _j = sourceToTargetFunctor( j );
+				if( _j<(node_index_type)_sz && target._indices[_j]!=-1 )
+					if( _indices[j]==-1 )
+					{
+						_indices[j] = (node_index_type)oldSize + newDataCount;
+						_data[ oldSize + newDataCount ] = mergeFunctor( target._data[ target._indices[_j] ] );
+						newDataCount++;
+					}
+					else _data[ _indices[j] ] += mergeFunctor( target._data[ target._indices[_j] ] );
+			}
+		}
+
+	protected:
+		template< unsigned int _Dim , class _Real > friend class FEMTree;
+
+		// Map should be the size of the new number of entries and map[i] should give the old index of the i-th node
+		void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount )
+		{
+			NestedVector< node_index_type , NESTED_VECTOR_LEVELS > newIndices;
+			newIndices.resize( newNodeCount );
+			for( node_index_type i=0 ; i<(node_index_type)newNodeCount ; i++ )
+			{
+				newIndices[i] = -1;
+				if( oldNodeIndices[i]!=-1 && oldNodeIndices[i]<(node_index_type)_indices.size() ) newIndices[i] = _indices[ oldNodeIndices[i] ];
+			}
+			std::swap( _indices , newIndices );
+		}
+
+		SparseNodeData _trim( node_index_type endIndex ) const
+		{
+			size_t dataCount = 0;
+			for( node_index_type i=0 ; i<endIndex ; i++ ) if( _indices[i]!=-1 ) dataCount++;
+			SparseNodeData sparseNodeData;
+			sparseNodeData._indices.resize( endIndex );
+			sparseNodeData._data.resize( dataCount );
+			node_index_type idx = 0;
+			for( node_index_type i=0 ; i<endIndex ; i++ )
+				if( _indices[i]!=-1 )
+				{
+					sparseNodeData._indices[i] = idx;
+					sparseNodeData._data[idx] = _data[ _indices[i] ];
+					idx++;
+				}
+				else sparseNodeData._indices[i] = -1;
+			return sparseNodeData;
+		}
+
+		std::mutex _updateMutex;
+		NestedVector< node_index_type , NESTED_VECTOR_LEVELS > _indices;
+		NestedVector< Data , NESTED_VECTOR_LEVELS > _data;
+	};
+
+	template< class Data , typename Pack > struct DenseNodeData{};
+	template< class Data , unsigned int ... FEMSigs >
+	struct DenseNodeData< Data , UIntPack< FEMSigs ... > > : public _SparseOrDenseNodeData< Data , UIntPack< FEMSigs ... > >
+	{
+		static const unsigned int Dim = sizeof ... ( FEMSigs );
+		DenseNodeData( void ) { _data = NullPointer( Data ) ; _sz = 0; }
+		DenseNodeData( size_t sz ){ _sz = sz ; if( sz ) _data = NewPointer< Data >( sz ) ; else _data = NullPointer( Data ); }
+		DenseNodeData( const DenseNodeData&  d ) : DenseNodeData() { _resize( d._sz ) ; if( _sz ) memcpy( _data , d._data , sizeof(Data) * _sz ); }
+		DenseNodeData(       DenseNodeData&& d ){ _data = d._data , _sz = d._sz ; d._data = NullPointer( Data ) , d._sz = 0; }
+		DenseNodeData& operator = ( const DenseNodeData&  d ){ _resize( d._sz ) ; if( _sz ) memcpy( _data , d._data , sizeof(Data) * _sz ) ; return *this; }
+		DenseNodeData& operator = (       DenseNodeData&& d ){ size_t __sz = _sz ; Pointer( Data ) __data = _data ; _data = d._data , _sz = d._sz ; d._data = __data , d._sz = __sz ; return *this; }
+		DenseNodeData( BinaryStream &stream ) : DenseNodeData() { read(stream); }
+		~DenseNodeData( void ){ DeletePointer( _data ) ; _sz = 0; }
+		void resize( size_t sz ){ DeletePointer( _data ) ; _sz = sz ; if( sz ) _data = NewPointer< Data >( sz ) ; else _data = NullPointer( Data ); }
+		static void WriteSignatures( BinaryStream &stream )
+		{
+			unsigned int dim = sizeof ... ( FEMSigs );
+			stream.write( dim );
+			unsigned int femSigs[] = { FEMSigs ... };
+			stream.write( GetPointer( femSigs , dim ) , dim );
+		}
+		void write( BinaryStream &stream ) const
+		{
+			stream.write( _sz );
+			stream.write( _data , _sz );
+		}
+		void read( BinaryStream &stream )
+		{
+			if( !stream.read( _sz ) ) MK_THROW( "Failed to read size" );
+			_data = NewPointer< Data >( _sz );
+			if( !stream.read( _data , _sz ) ) MK_THROW( "failed to read data" );
+		}
+
+		Data& operator[] ( size_t idx ) { return _data[idx]; }
+		const Data& operator[] ( size_t idx ) const { return _data[idx]; }
+		size_t size( void ) const { return _sz; }
+		Data& operator[]( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ) { return _data[ node->nodeData.nodeIndex ]; }
+		Data* operator()( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ) { return ( node==NULL || node->nodeData.nodeIndex>=(node_index_type)_sz ) ? NULL : &_data[ node->nodeData.nodeIndex ]; }
+		const Data* operator()( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ) const { return ( node==NULL || node->nodeData.nodeIndex>=(node_index_type)_sz ) ? NULL : &_data[ node->nodeData.nodeIndex ]; }
+		node_index_type index( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ) const { return ( !node || node->nodeData.nodeIndex<0 || node->nodeData.nodeIndex>=(node_index_type)_sz ) ? -1 : node->nodeData.nodeIndex; }
+		Pointer( Data ) operator()( void ) { return _data; }
+		ConstPointer( Data ) operator()( void ) const { return ( ConstPointer( Data ) )_data; }
+	protected:
+		template< unsigned int _Dim , class _Real > friend class FEMTree;
+
+		// Map should be the size of the new number of entries and map[i] should give the old index of the i-th node
+		void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount )
+		{
+			Pointer( Data ) newData = NewPointer< Data >( newNodeCount );
+			memset( newData , 0 , sizeof(Data)*newNodeCount );
+			for( size_t i=0 ; i<newNodeCount ; i++ ) if( oldNodeIndices[i]>=0 && oldNodeIndices[i]<(node_index_type)_sz ) newData[i] = _data[ oldNodeIndices[i] ];
+			DeletePointer( _data );
+			_data = newData;
+			_sz = newNodeCount;
+		}
+
+		DenseNodeData _trim( node_index_type endIndex ) const
+		{
+			DenseNodeData denseNodeData;
+			denseNodeData._sz = endIndex;
+			denseNodeData._data = NewPointer< Data >( endIndex );
+			memcpy( denseNodeData._data , _data , sizeof(Data) * denseNodeData._sz );
+			return denseNodeData;
+		}
+
+		size_t _sz;
+		void _resize( size_t sz ){ DeletePointer( _data ) ; if( sz ) _data = NewPointer< Data >( sz ) ; else _data = NullPointer( Data ) ; _sz = sz; }
+		Pointer( Data ) _data;
+	};
+
+	enum FEMTreeRealType
+	{
+		FEM_TREE_REAL_FLOAT ,
+		FEM_TREE_REAL_DOUBLE ,
+		FEM_TREE_REAL_COUNT
+	};
+	static const char *FEMTreeRealNames[] = { "float" , "double" };
+
+	inline void ReadFEMTreeParameter( BinaryStream &stream , FEMTreeRealType& realType , unsigned int &dimension )
+	{
+		if( !stream.read( realType ) ) MK_THROW( "Failed to read real type" );
+		if( !stream.read( dimension ) ) MK_THROW( "Failed to read dimension" );
+	}
+
+	inline unsigned int* ReadDenseNodeDataSignatures( BinaryStream &stream , unsigned int &dim )
+	{
+		if( !stream.read( dim ) ) MK_THROW( "Failed to read dimension" );
+		unsigned int* femSigs = new unsigned int[dim];
+		if( !stream.read( GetPointer( femSigs , dim ) , dim ) ) MK_THROW( "Failed to read signatures" );
+		return femSigs;
+	}
+
+	// The Derivative method needs static members:
+	//		Dim: the dimensionality of the space in which derivatives are evaluated
+	//		Size: the total number of derivatives
+	// and static methods:
+	//		Index: takes the number of partials along each dimension and returns the index
+	//		Factor: takes an index and sets the number of partials along each dimension
+
+	template< typename T > struct TensorDerivatives{ };
+	template< class Real , typename T > struct TensorDerivativeValues{ };
+
+	// Specify the derivatives for each dimension separately
+	template< unsigned int D , unsigned int ... Ds >
+	struct TensorDerivatives< UIntPack< D , Ds ... > >
+	{
+		typedef TensorDerivatives< UIntPack< Ds ... > > _TensorDerivatives;
+		static const unsigned int LastDerivative = UIntPack< D , Ds ... >::template Get< sizeof ... (Ds) >();
+		static const unsigned int Dim = _TensorDerivatives::Dim + 1;
+		static const unsigned int Size = _TensorDerivatives::Size * ( D+1 );
+		static void Factor( unsigned int idx , unsigned int derivatives[Dim] ){ derivatives[0] = idx / _TensorDerivatives::Size ; _TensorDerivatives::Factor( idx % _TensorDerivatives::Size , derivatives+1 ); }
+		static unsigned int Index( const unsigned int derivatives[Dim] ){ return _TensorDerivatives::Index( derivatives + 1 ) + _TensorDerivatives::Size * derivatives[0]; }
+	};
+	template< unsigned int D >
+	struct TensorDerivatives< UIntPack< D > >
+	{
+		static const unsigned int LastDerivative = D;
+		static const unsigned int Dim = 1;
+		static const unsigned int Size = D+1;
+		static void Factor( unsigned int idx , unsigned int derivatives[1] ){ derivatives[0] = idx; }
+		static unsigned int Index( const unsigned int derivatives[1] ){ return derivatives[0]; }
+	};
+	template< class Real , unsigned int ... Ds > struct TensorDerivativeValues< Real , UIntPack< Ds ... > > : public Point< Real , TensorDerivatives< UIntPack< Ds ... > >::Size >{ };
+
+	// Specify the sum of the derivatives
+	template< unsigned int Dim , unsigned int D >
+	struct CumulativeDerivatives
+	{
+		typedef CumulativeDerivatives< Dim , D-1 > _CumulativeDerivatives;
+		static const unsigned int LastDerivative = D;
+		static const unsigned int Size = _CumulativeDerivatives::Size * Dim + 1;
+		static void Factor( unsigned int idx , unsigned int d[Dim] )
+		{
+			if( idx<_CumulativeDerivatives::Size ) return _CumulativeDerivatives::Factor( idx , d );
+			else _Factor( idx - _CumulativeDerivatives::Size , d );
+		}
+		static unsigned int Index( const unsigned int derivatives[Dim] )
+		{
+			unsigned int dCount = 0;
+			for( unsigned int d=0 ; d<Dim ; d++ ) dCount += derivatives[d];
+			if( dCount>=D ) MK_THROW( "More derivatives than allowed" );
+			else if( dCount<D ) return _CumulativeDerivatives::Index( derivatives );
+			else                return _CumulativeDerivatives::Size + _Index( derivatives );
+		}
+	protected:
+		static const unsigned int _Size = _CumulativeDerivatives::_Size * Dim;
+		static void _Factor( unsigned int idx , unsigned int d[Dim] )
+		{
+			_CumulativeDerivatives::_Factor( idx % _CumulativeDerivatives::_Size , d );
+			d[ idx / _CumulativeDerivatives::_Size ]++;
+		}
+		static unsigned int _Index( const unsigned int d[Dim] )
+		{
+			unsigned int _d[Dim];
+			memcpy( _d , d , sizeof(_d) );
+			for( unsigned int i=0 ; i<Dim ; i++ ) if( _d[i] )
+			{
+				_d[i]--;
+				return _CumulativeDerivatives::Index( _d ) * Dim + i;
+			}
+			MK_THROW( "No derivatives specified" );
+			return -1;
+		}
+		friend CumulativeDerivatives< Dim , D+1 >;
+	};
+	template< unsigned int Dim >
+	struct CumulativeDerivatives< Dim , 0 >
+	{
+		static const unsigned int LastDerivative = 0;
+		static const unsigned int Size = 1;
+		static void Factor( unsigned int idx , unsigned int d[Dim] ){ memset( d , 0 , sizeof(unsigned int)*Dim ); }
+		static unsigned int Index( const unsigned int derivatives[Dim] ){ return 0; }
+	protected:
+		static const unsigned int _Size = 1;
+		static void _Factor( unsigned int idx , unsigned int d[Dim] ){ memset( d , 0 , sizeof(unsigned int)*Dim ); }
+		friend CumulativeDerivatives< Dim , 1 >;
+	};
+	template< typename Real , unsigned int Dim , unsigned int D > using CumulativeDerivativeValues = Point< Real , CumulativeDerivatives< Dim , D >::Size >;
+
+
+	template< unsigned int Dim , class Real , unsigned int D >
+	CumulativeDerivativeValues< Real , Dim , D > Evaluate( const double dValues[Dim][D+1] )
+	{
+		CumulativeDerivativeValues< Real , Dim , D > v;
+		unsigned int _d[Dim];
+		for( unsigned int d=0 ; d<CumulativeDerivatives< Dim , D >::Size ; d++ )
+		{
+			CumulativeDerivatives< Dim , D >::Factor( d , _d );
+			double value = dValues[0][ _d[0] ];
+			for( unsigned int dd=1 ; dd<Dim ; dd++ ) value *= dValues[dd][ _d[dd] ];
+			v[d] = (Real)value;
+		}
+		return v;
+	}
+
+	template< unsigned int Dim , class Real , typename T , unsigned int D >
+	struct DualPointInfo
+	{
+		Point< Real , Dim > position;
+		Real weight;
+		CumulativeDerivativeValues< T , Dim , D > dualValues;
+		DualPointInfo  operator +  ( const DualPointInfo& p ) const { return DualPointInfo( position + p.position , dualValues + p.dualValues , weight + p.weight ); }
+		DualPointInfo& operator += ( const DualPointInfo& p ){ position += p.position ; weight += p.weight , dualValues += p.dualValues ; return *this; }
+		DualPointInfo  operator *  ( Real s ) const { return DualPointInfo( position*s , weight*s , dualValues*s ); }
+		DualPointInfo& operator *= ( Real s ){ position *= s , weight *= s , dualValues *= s ; return *this; }
+		DualPointInfo  operator /  ( Real s ) const { return DualPointInfo( position/s , weight/s , dualValues/s ); }
+		DualPointInfo& operator /= ( Real s ){ position /= s , weight /= s , dualValues /= s ; return *this; }
+		DualPointInfo( void ) : weight(0) { }
+		DualPointInfo( Point< Real , Dim > p , CumulativeDerivativeValues< T , Dim , D > c , Real w ) { position = p , dualValues = c , weight = w; }
+	};
+	template< unsigned int Dim , class Real , typename Data , typename T , unsigned int D >
+	struct DualPointAndDataInfo
+	{
+		DualPointInfo< Dim , Real , T , D > pointInfo;
+		Data data;
+		DualPointAndDataInfo  operator +  ( const DualPointAndDataInfo& p ) const { return DualPointAndDataInfo( pointInfo + p.pointInfo , data + p.data ); }
+		DualPointAndDataInfo  operator *  ( Real s )                        const { return DualPointAndDataInfo( pointInfo * s , data * s ); }
+		DualPointAndDataInfo  operator /  ( Real s )                        const { return DualPointAndDataInfo( pointInfo / s , data / s ); }
+		DualPointAndDataInfo& operator += ( const DualPointAndDataInfo& p ){ pointInfo += p.pointInfo ; data += p.data ; return *this; }
+		DualPointAndDataInfo& operator *= ( Real s )                       { pointInfo *= s , data *= s ; return *this; }
+		DualPointAndDataInfo& operator /= ( Real s )                       { pointInfo /= s , data /= s ; return *this; }
+		DualPointAndDataInfo( void ){ }
+		DualPointAndDataInfo( DualPointInfo< Dim , Real , T , D > p , Data d ) { pointInfo = p , data = d; }
+	};
+	template< unsigned int Dim , class Real , typename T , unsigned int D >
+	struct DualPointInfoBrood
+	{
+		DualPointInfo< Dim , Real , T , D >& operator[]( size_t idx ){ return _dpInfo[idx]; }
+		const DualPointInfo< Dim , Real , T , D >& operator[]( size_t idx ) const { return _dpInfo[idx]; }
+		void finalize( void ){ _size = 0 ; for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) if( _dpInfo[i].weight>0 ) _dpInfo[_size++] = _dpInfo[i]; }
+		unsigned int size( void ) const { return _size; }
+
+		DualPointInfoBrood  operator +  ( const DualPointInfoBrood& p ) const { DualPointInfoBrood d ; for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) d._dpInfo[i] = _dpInfo[i] + p._dpInfo[i] ;  return d; }
+		DualPointInfoBrood  operator *  ( Real s )                      const { DualPointInfoBrood d ; for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) d._dpInfo[i] = _dpInfo[i] * s            ;  return d; }
+		DualPointInfoBrood  operator /  ( Real s )                      const { DualPointInfoBrood d ; for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) d._dpInfo[i] = _dpInfo[i] / s            ;  return d; }
+		DualPointInfoBrood& operator += ( const DualPointInfoBrood& p ){ for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) _dpInfo[i] += p._dpInfo[i] ; return *this; }
+		DualPointInfoBrood& operator *= ( Real s )                     { for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) _dpInfo[i] *= s            ; return *this; }
+		DualPointInfoBrood& operator /= ( Real s )                     { for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) _dpInfo[i] /= s            ; return *this; }
+	protected:
+		DualPointInfo< Dim , Real , T , D > _dpInfo[1<<Dim];
+		unsigned int _size;
+	};
+	template< unsigned int Dim , class Real , typename Data , typename T , unsigned int D >
+	struct DualPointAndDataInfoBrood
+	{
+		DualPointAndDataInfo< Dim , Real , Data , T , D >& operator[]( size_t idx ){ return _dpInfo[idx]; }
+		const DualPointAndDataInfo< Dim , Real , Data , T , D >& operator[]( size_t idx ) const { return _dpInfo[idx]; }
+		void finalize( void ){ _size = 0 ; for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) if( _dpInfo[i].pointInfo.weight>0 ) _dpInfo[_size++] = _dpInfo[i]; }
+		unsigned int size( void ) const { return _size; }
+
+		DualPointAndDataInfoBrood  operator +  ( const DualPointAndDataInfoBrood& p ) const { DualPointAndDataInfoBrood d ; for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) d._dpInfo[i] = _dpInfo[i] + p._dpInfo[i] ;  return d; }
+		DualPointAndDataInfoBrood  operator *  ( Real s )                             const { DualPointAndDataInfoBrood d ; for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) d._dpInfo[i] = _dpInfo[i] * s            ;  return d; }
+		DualPointAndDataInfoBrood  operator /  ( Real s )                             const { DualPointAndDataInfoBrood d ; for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) d._dpInfo[i] = _dpInfo[i] / s            ;  return d; }
+		DualPointAndDataInfoBrood& operator += ( const DualPointAndDataInfoBrood& p ){ for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) _dpInfo[i] += p._dpInfo[i] ; return *this; }
+		DualPointAndDataInfoBrood& operator *= ( Real s )                            { for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) _dpInfo[i] *= s ; return *this; }
+		DualPointAndDataInfoBrood& operator /= ( Real s )                            { for( unsigned int i=0 ; i<(1<<Dim) ; i++ ) _dpInfo[i] /= s ; return *this; }
+	protected:
+		DualPointAndDataInfo< Dim , Real , Data , T , D > _dpInfo[1<<Dim];
+		unsigned int _size;
+	};
+
+
+	////////////////////////////
+	// The virtual integrator //
+	////////////////////////////
+	struct BaseFEMIntegrator
+	{
+		template< typename TDegreePack                                            > struct                  System{};
+		template< typename TDegreePack                                            > struct RestrictionProlongation{};
+		template< typename TDegreePack , typename CDegreePack , unsigned int CDim > struct              Constraint{};
+		template< typename TDegreePack                                            > struct        SystemConstraint{};
+		template< typename TDegreePack                                            > struct          PointEvaluator{};
+
+	protected:
+		template< unsigned int Degree , unsigned int ... Degrees >
+		static typename std::enable_if< sizeof ... ( Degrees )==0 , bool >::type _IsSupported( UIntPack< Degree , Degrees ... > , unsigned int femDepth , const int femOffset[] , unsigned int spaceDepth , const int spaceOffset[] )
+		{
+			int femRes = 1<<femDepth , spaceRes = 1<<spaceDepth;
+			int   femBegin = ( 0 +   femOffset[0] + BSplineSupportSizes< Degree >::SupportStart ) * spaceRes;
+			int   femEnd   = ( 1 +   femOffset[0] + BSplineSupportSizes< Degree >::SupportEnd   ) * spaceRes; 
+			int spaceBegin = ( 0 + spaceOffset[0] + BSplineSupportSizes< 0      >::SupportStart ) *   femRes;
+			int spaceEnd   = ( 1 + spaceOffset[0] + BSplineSupportSizes< 0      >::SupportEnd   ) *   femRes;
+			return spaceBegin<femEnd && spaceEnd>femBegin;
+		}
+		template< unsigned int Degree , unsigned int ... Degrees >
+		static typename std::enable_if< sizeof ... ( Degrees )!=0 , bool >::type _IsSupported( UIntPack< Degree , Degrees ... > , unsigned int femDepth , const int femOffset[] , unsigned int spaceDepth , const int spaceOffset[] )
+		{
+			int femRes = 1<<femDepth , spaceRes = 1<<spaceDepth;
+			int   femBegin = ( 0 +   femOffset[0] + BSplineSupportSizes< Degree >::SupportStart ) * spaceRes;
+			int   femEnd   = ( 1 +   femOffset[0] + BSplineSupportSizes< Degree >::SupportEnd   ) * spaceRes; 
+			int spaceBegin = ( 0 + spaceOffset[0] + BSplineSupportSizes< 0      >::SupportStart ) *   femRes;
+			int spaceEnd   = ( 1 + spaceOffset[0] + BSplineSupportSizes< 0      >::SupportEnd   ) *   femRes;
+			return ( spaceBegin<femEnd && spaceEnd>femBegin ) && _IsSupported( UIntPack< Degrees ... >() , femDepth , femOffset+1 , spaceDepth , spaceOffset+1 );
+		}
+		template< unsigned int Degree , unsigned int ... Degrees >
+		static typename std::enable_if< sizeof ... ( Degrees )==0 , bool >::type _IsInteriorlySupported( UIntPack< Degree , Degrees ... > , unsigned int depth , const int off[] )
+		{
+			int begin , end;
+			BSplineSupportSizes< Degree >::InteriorSupportedSpan( depth , begin , end );
+			return off[0]>=begin && off[0]<end;
+		}
+		template< unsigned int Degree , unsigned int ... Degrees >
+		static typename std::enable_if< sizeof ... ( Degrees )!=0 , bool >::type _IsInteriorlySupported( UIntPack< Degree , Degrees ... > , unsigned int depth , const int off[] )
+		{
+			int begin , end;
+			BSplineSupportSizes< Degree >::InteriorSupportedSpan( depth , begin , end );
+			return ( off[0]>=begin && off[0]<end ) && _IsInteriorlySupported( UIntPack< Degrees ... >() , depth , off+1 );
+		}
+		template< unsigned int Degree , unsigned int ... Degrees >
+		static typename std::enable_if< sizeof ... ( Degrees )==0 , bool >::type _IsInteriorlySupported( UIntPack< Degree , Degrees ... > , unsigned int depth , const int off[] , const double begin[] , const double end[] )
+		{
+			int res = 1<<depth;
+			double b = ( 0. + off[0] + BSplineSupportSizes< Degree >::SupportStart ) / res;
+			double e = ( 1. + off[0] + BSplineSupportSizes< Degree >::SupportEnd   ) / res; 
+			return b>=begin[0] && e<=end[0];
+		}
+		template< unsigned int Degree , unsigned int ... Degrees >
+		static typename std::enable_if< sizeof ... ( Degrees )!=0 , bool >::type _IsInteriorlySupported( UIntPack< Degree , Degrees ... > , unsigned int depth , const int off[] , const double begin[] , const double end[] )
+		{
+			int res = 1<<depth;
+			double b = ( 0. + off[0] + BSplineSupportSizes< Degree >::SupportStart ) / res;
+			double e = ( 1. + off[0] + BSplineSupportSizes< Degree >::SupportEnd   ) / res; 
+			return b>=begin[0] && e<=end[0] && _IsInteriorlySupported( UIntPack< Degrees ... >() , depth , off+1 , begin+1 , end+1 );
+		}
+		template< unsigned int Degree1 , unsigned int ... Degrees1 , unsigned int Degree2 , unsigned int ... Degrees2 >
+		static typename std::enable_if< sizeof ... ( Degrees1 )==0 >::type _InteriorOverlappedSpan( UIntPack< Degree1 , Degrees1 ... > , UIntPack< Degree2 , Degrees2 ... > , int depth , int begin[] , int end[] )
+		{
+			BSplineIntegrationData< FEMDegreeAndBType< Degree1 , BOUNDARY_NEUMANN >::Signature , FEMDegreeAndBType< Degree2 , BOUNDARY_NEUMANN >::Signature >::InteriorOverlappedSpan( depth , begin[0] , end[0] );
+		}
+		template< unsigned int Degree1 , unsigned int ... Degrees1 , unsigned int Degree2 , unsigned int ... Degrees2 >
+		static typename std::enable_if< sizeof ... ( Degrees1 )!=0 >::type _InteriorOverlappedSpan( UIntPack< Degree1 , Degrees1 ... > , UIntPack< Degree2 , Degrees2 ... > , int depth , int begin[] , int end[] )
+		{
+			BSplineIntegrationData< FEMDegreeAndBType< Degree1 , BOUNDARY_NEUMANN >::Signature , FEMDegreeAndBType< Degree2 , BOUNDARY_NEUMANN >::Signature >::InteriorOverlappedSpan( depth , begin[0] , end[0] );
+			_InteriorOverlappedSpan( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , depth , begin+1 , end+1 );
+		}
+		template< unsigned int Degree1 , unsigned int ... Degrees1 , unsigned int Degree2 , unsigned int ... Degrees2 >
+		static typename std::enable_if< sizeof ... ( Degrees1 )==0 , bool >::type _IsInteriorlyOverlapped( UIntPack< Degree1 , Degrees1 ... > , UIntPack< Degree2 , Degrees2 ... > , unsigned int depth , const int off[] )
+		{
+			int begin , end;
+			BSplineIntegrationData< FEMDegreeAndBType< Degree1 , BOUNDARY_NEUMANN >::Signature , FEMDegreeAndBType< Degree2 , BOUNDARY_NEUMANN >::Signature >::InteriorOverlappedSpan( depth , begin , end );
+			return off[0]>= begin && off[0]<end;
+		}
+		template< unsigned int Degree1 , unsigned int ... Degrees1 , unsigned int Degree2 , unsigned int ... Degrees2 >
+		static typename std::enable_if< sizeof ... ( Degrees1 )!=0 , bool >::type _IsInteriorlyOverlapped( UIntPack< Degree1 , Degrees1 ... > , UIntPack< Degree2 , Degrees2 ... > , unsigned int depth , const int off[] )
+		{
+			int begin , end;
+			BSplineIntegrationData< FEMDegreeAndBType< Degree1 , BOUNDARY_NEUMANN >::Signature , FEMDegreeAndBType< Degree2 , BOUNDARY_NEUMANN >::Signature >::InteriorOverlappedSpan( depth , begin , end );
+			return ( off[0]>= begin && off[0]<end ) && _IsInteriorlyOverlapped( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , depth , off+1 );
+		}
+		template< unsigned int Degree1 , unsigned int ... Degrees1 , unsigned int Degree2 , unsigned int ... Degrees2 >
+		static typename std::enable_if< sizeof ... ( Degrees1 )==0 >::type _ParentOverlapBounds( UIntPack< Degree1 , Degrees1 ... > , UIntPack< Degree2 , Degrees2 ... > , unsigned int depth , const int off[] , int start[] , int end[] )
+		{
+			const int OverlapStart = BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart;
+			start[0] = BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapStart[ off[0] & 1 ] - OverlapStart;
+			end  [0] = BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapEnd  [ off[0] & 1 ] - OverlapStart + 1;
+		}
+		template< unsigned int Degree1 , unsigned int ... Degrees1 , unsigned int Degree2 , unsigned int ... Degrees2 >
+		static typename std::enable_if< sizeof ... ( Degrees1 )!=0 >::type _ParentOverlapBounds( UIntPack< Degree1 , Degrees1 ... > , UIntPack< Degree2 , Degrees2 ... > , unsigned int depth , const int off[] , int start[] , int end[] )
+		{
+			const int OverlapStart = BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart;
+			start[0] = BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapStart[ off[0] & 1 ] - OverlapStart;
+			end  [0] = BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapEnd  [ off[0] & 1 ] - OverlapStart + 1;
+			_ParentOverlapBounds( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , depth , off+1 , start+1 , end+1 );
+		}
+		template< unsigned int Degree1 , unsigned int ... Degrees1 , unsigned int Degree2 , unsigned int ... Degrees2 >
+		static typename std::enable_if< sizeof ... ( Degrees1 )==0 >::type _ParentOverlapBounds( UIntPack< Degree1 , Degrees1 ... > , UIntPack< Degree2 , Degrees2 ... > , int corner , int start[] , int end[] )
+		{
+			const int OverlapStart = BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart;
+			start[0] = BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapStart[ corner & 1 ] - OverlapStart;
+			end  [0] = BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapEnd  [ corner & 1 ] - OverlapStart + 1;
+		}
+		template< unsigned int Degree1 , unsigned int ... Degrees1 , unsigned int Degree2 , unsigned int ... Degrees2 >
+		static typename std::enable_if< sizeof ... ( Degrees1 )!=0 >::type _ParentOverlapBounds( UIntPack< Degree1 , Degrees1 ... > , UIntPack< Degree2 , Degrees2 ... > , int corner , int start[] , int end[] )
+		{
+			const int OverlapStart = BSplineOverlapSizes< Degree1 , Degree2 >::OverlapStart;
+			start[0] = BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapStart[ corner & 1 ] - OverlapStart;
+			end  [0] = BSplineOverlapSizes< Degree1 , Degree2 >::ParentOverlapEnd  [ corner & 1 ] - OverlapStart + 1;
+			_ParentOverlapBounds( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , corner>>1 , start+1 , end+1 );
+		}
+
+	public:
+		template< unsigned int ... Degrees >
+		static bool IsSupported( UIntPack< Degrees ... > , int femDepth , const int femOffset[] , int spaceDepth , const int spaceOffset[] ){ return femDepth>=0 && spaceDepth>=0 && _IsSupported( UIntPack< Degrees ... >() , femDepth , femOffset , spaceDepth , spaceOffset ); }
+		template< unsigned int ... Degrees >
+		static bool IsInteriorlySupported( UIntPack< Degrees ... > , int depth , const int offset[] ){ return depth>=0 && _IsInteriorlySupported( UIntPack< Degrees ... >() , depth , offset ); }
+		template< unsigned int ... Degrees >
+		static bool IsInteriorlySupported( UIntPack< Degrees ... > , int depth , const int offset[] , const double begin[] , const double end[] ){ return depth>=0 && _IsInteriorlySupported( UIntPack< Degrees ... >() , depth , offset , begin , end ); }
+
+		template< unsigned int ... Degrees1 , unsigned int ... Degrees2 >
+		static void InteriorOverlappedSpan( UIntPack< Degrees1 ... > , UIntPack< Degrees2 ... > , int depth , int begin[] , int end[] )
+		{
+			static_assert( sizeof ... ( Degrees1 ) == sizeof ... ( Degrees2 ) , "[ERROR] Dimensions don't match" );
+			_InteriorOverlappedSpan( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , depth , begin , end );
+		}
+		template< unsigned int ... Degrees1 , unsigned int ... Degrees2 >
+		static bool IsInteriorlyOverlapped( UIntPack< Degrees1 ... > , UIntPack< Degrees2 ... > , int depth , const int offset[] )
+		{
+			static_assert( sizeof ... ( Degrees1 ) == sizeof ... ( Degrees2 ) , "[ERROR] Dimensions don't match" );
+			return depth>=0 && _IsInteriorlyOverlapped( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , depth , offset );
+		}
+
+		template< unsigned int ... Degrees1 , unsigned int ... Degrees2 >
+		static void ParentOverlapBounds( UIntPack< Degrees1 ... > , UIntPack< Degrees2 ... > , int depth , const int offset[] , int start[] , int end[] )
+		{
+			static_assert( sizeof ... ( Degrees1 ) == sizeof ... ( Degrees2 ) , "[ERROR] Dimensions don't match" );
+			if( depth>0 ) _ParentOverlapBounds( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , depth , offset , start , end );
+		}
+		template< unsigned int ... Degrees1 , unsigned int ... Degrees2 >
+		static void ParentOverlapBounds( UIntPack< Degrees1 ... > , UIntPack< Degrees2 ... > , int corner , int start[] , int end[] )
+		{
+			static_assert( sizeof ... ( Degrees1 ) == sizeof ... ( Degrees2 ) , "[ERROR] Dimensions don't match" );
+			_ParentOverlapBounds( UIntPack< Degrees1 ... >() , UIntPack< Degrees2 ... >() , corner , start , end );
+		}
+
+		template< unsigned int Dim >
+		struct PointEvaluatorState
+		{
+			virtual double value( const int offset[] , const unsigned int d[] ) const = 0;
+			virtual double subValue( const int offset[] , const unsigned int d[] ) const = 0;
+			template< class Real , typename DerivativeType >
+			Point< Real , DerivativeType::Size > dValues( const int offset[] ) const
+			{
+				Point< Real , DerivativeType::Size > v;
+				unsigned int _d[Dim];
+				for( int d=0 ; d<DerivativeType::Size ; d++ )
+				{
+					DerivativeType::Factor( d , _d );
+					v[d] = (Real)value( offset , _d );
+				}
+				return v;
+			}
+			template< class Real , typename DerivativeType >
+			Point< Real , DerivativeType::LastDerivative+1 > partialDotDValues( Point< Real , DerivativeType::Size > v , const int offset[] ) const
+			{
+				Point< Real , DerivativeType::LastDerivative+1 > dot;
+				unsigned int _d[Dim];
+				for( int d=0 ; d<DerivativeType::Size ; d++ )
+				{
+					DerivativeType::Factor( d , _d );
+					dot[ _d[Dim-1] ] += (Real)( subValue( offset , _d ) * v[d] );
+				}
+				return dot;
+			}
+		};
+
+		template< unsigned int ... TDegrees >
+		struct PointEvaluator< UIntPack< TDegrees ... > >
+		{
+			static const unsigned int Dim = sizeof ... ( TDegrees );
+		};
+
+		template< unsigned int ... TDegrees >
+		struct RestrictionProlongation< UIntPack< TDegrees ... > >
+		{
+			virtual void init( void ){ }
+			virtual double upSampleCoefficient( const int pOff[] , const int cOff[] ) const = 0;
+
+			typedef DynamicWindow< double , UIntPack< ( - BSplineSupportSizes< TDegrees >::DownSample0Start + BSplineSupportSizes< TDegrees >::DownSample1End + 1 ) ... > > DownSampleStencil;
+			struct   UpSampleStencil  : public DynamicWindow< double , UIntPack< BSplineSupportSizes< TDegrees >::UpSampleSize ... > > { };
+			struct DownSampleStencils : public DynamicWindow< DownSampleStencil , IsotropicUIntPack< sizeof ... ( TDegrees ) , 2 > > { };
+
+			void init( int highDepth ){ _highDepth = highDepth ; init(); }
+			void setStencil (   UpSampleStencil & stencil  ) const;
+			void setStencils( DownSampleStencils& stencils ) const;
+			int highDepth( void ) const { return _highDepth; }
+
+		protected:
+			int _highDepth;
+		};
+
+
+		template< unsigned int ... TDegrees >
+		struct System< UIntPack< TDegrees ... > >
+		{
+			virtual void init( void ){ }
+			virtual double ccIntegrate( const int off1[] , const int off2[] ) const = 0;
+			virtual double pcIntegrate( const int off1[] , const int off2[] ) const = 0;
+			virtual bool vanishesOnConstants( void ) const { return false; }
+			virtual RestrictionProlongation< UIntPack< TDegrees ... > >& restrictionProlongation( void ) = 0;
+
+			struct CCStencil : public DynamicWindow< double , UIntPack< BSplineOverlapSizes< TDegrees , TDegrees >::OverlapSize ... > >{ };
+#ifdef SHOW_WARNINGS
+#pragma message ( "[WARNING] Why are the parent/child stencils so big?" )
+#endif // SHOW_WARNINGS
+			struct PCStencils : public DynamicWindow< CCStencil , IsotropicUIntPack< sizeof ... ( TDegrees ) , 2 > >{ };
+
+			void init( int highDepth ){ _highDepth = highDepth ; init(); }
+			template< bool IterateFirst > void setStencil ( CCStencil & stencil  ) const;
+			template< bool IterateFirst > void setStencils( PCStencils& stencils ) const;
+			int highDepth( void ) const { return _highDepth; }
+
+		protected:
+			int _highDepth;
+		};
+
+		template< unsigned int ... TDegrees , unsigned int ... CDegrees , unsigned int CDim >
+		struct Constraint< UIntPack< TDegrees ... > , UIntPack< CDegrees ... > , CDim >
+		{
+			static_assert( sizeof...(TDegrees)==sizeof...(CDegrees) , "[ERROR] BaseFEMIntegrator::Constraint: Test and constraint dimensions don't match" );
+
+			virtual void init( void ){ ; }
+			virtual Point< double , CDim > ccIntegrate( const int off1[] , const int off2[] ) const = 0;
+			virtual Point< double , CDim > pcIntegrate( const int off1[] , const int off2[] ) const = 0;
+			virtual Point< double , CDim > cpIntegrate( const int off1[] , const int off2[] ) const = 0;
+			virtual RestrictionProlongation< UIntPack< TDegrees ... > >& tRestrictionProlongation( void ) = 0;
+			virtual RestrictionProlongation< UIntPack< CDegrees ... > >& cRestrictionProlongation( void ) = 0;
+
+			struct CCStencil : public DynamicWindow< Point< double , CDim > , UIntPack< BSplineOverlapSizes< TDegrees , CDegrees >::OverlapSize ... > >{ };
+#ifdef SHOW_WARNINGS
+#pragma message ( "[WARNING] Why are the parent/child stencils so big?" )
+#endif // SHOW_WARNINGS
+			struct PCStencils : public DynamicWindow< CCStencil , IsotropicUIntPack< sizeof ... ( TDegrees ) , 2 > >{ };
+			struct CPStencils : public DynamicWindow< CCStencil , IsotropicUIntPack< sizeof ... ( TDegrees ) , 2 > >{ };
+
+			void init( int highDepth ){ _highDepth = highDepth ; init(); }
+			template< bool IterateFirst > void setStencil ( CCStencil & stencil  ) const;
+			template< bool IterateFirst > void setStencils( PCStencils& stencils ) const;
+			template< bool IterateFirst > void setStencils( CPStencils& stencils ) const;
+			int highDepth( void ) const { return _highDepth; }
+
+		protected:
+			int _highDepth;
+		};
+
+		template< unsigned int ... TDegrees >
+		struct SystemConstraint< UIntPack< TDegrees ... > > :  public Constraint< UIntPack< TDegrees ... > , UIntPack< TDegrees ... > , 1 >
+		{
+			typedef  Constraint< UIntPack< TDegrees ... > , UIntPack< TDegrees ... > , 1 > Base;
+			SystemConstraint( System< UIntPack< TDegrees ... > >& sys ) : _sys( sys ){;}
+			void init( void ){ _sys.init( Base::highDepth() ) ; _sys.init(); }
+			Point< double , 1 > ccIntegrate( const int off1[] , const int off2[] ) const{ return Point< double , 1 >( _sys.ccIntegrate( off1 , off2 ) ); }
+			Point< double , 1 > pcIntegrate( const int off1[] , const int off2[] ) const{ return Point< double , 1 >( _sys.pcIntegrate( off1 , off2 ) ); }
+			Point< double , 1 > cpIntegrate( const int off1[] , const int off2[] ) const{ return Point< double , 1 >( _sys.pcIntegrate( off2 , off1 ) ); }
+			RestrictionProlongation< UIntPack< TDegrees ... > >& tRestrictionProlongation( void ){ return _sys.restrictionProlongation(); }
+			RestrictionProlongation< UIntPack< TDegrees ... > >& cRestrictionProlongation( void ){ return _sys.restrictionProlongation(); }
+		protected:
+			System< UIntPack< TDegrees ... > >& _sys;
+		};
+	};
+
+	/////////////////////////////////////////////////
+	// An implementation of the virtual integrator //
+	/////////////////////////////////////////////////
+	struct FEMIntegrator
+	{
+	protected:
+		template< unsigned int FEMSig , unsigned int ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )==0 , bool >::type _IsValidFEMNode( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , const int offset[] )
+		{
+			return !BSplineEvaluationData< FEMSig >::OutOfBounds( depth , offset[0] );
+		}
+		template< unsigned int FEMSig , unsigned int ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )!=0 , bool >::type _IsValidFEMNode( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , const int offset[] )
+		{
+			return !BSplineEvaluationData< FEMSig >::OutOfBounds( depth , offset[0] ) && _IsValidFEMNode( UIntPack< FEMSigs ... >() , depth , offset+1 );
+		}
+		template< unsigned int FEMSig , unsigned ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )==0 , bool >::type _IsOutOfBounds( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , const int offset[] )
+		{
+			return BSplineEvaluationData< FEMSig >::OutOfBounds( depth , offset[0] );
+		}
+		template< unsigned int FEMSig , unsigned ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )!=0 , bool >::type _IsOutOfBounds( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , const int offset[] )
+		{
+			return BSplineEvaluationData< FEMSig >::OutOfBounds( depth , offset[0] ) || _IsOutOfBounds( UIntPack< FEMSigs ... >() , depth , offset+1 );
+		}
+		template< unsigned int FEMSig , unsigned int ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )==0 >::type _BSplineBegin( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , int begin[] )
+		{
+			begin[0] = BSplineEvaluationData< FEMSig >::Begin( depth );
+		}
+		template< unsigned int FEMSig , unsigned int ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )!=0 >::type _BSplineBegin( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , int begin[] )
+		{
+			begin[0] = BSplineEvaluationData< FEMSig >::Begin( depth ) ; _BSplineBegin( UIntPack< FEMSigs ... >() , depth , begin+1 );
+		}
+		template< unsigned int FEMSig , unsigned int ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )==0 >::type _BSplineEnd( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , int end[] )
+		{
+			end[0] = BSplineEvaluationData< FEMSig >::End( depth );
+		}
+		template< unsigned int FEMSig , unsigned int ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )!=0 >::type _BSplineEnd( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , int end[] )
+		{
+			end[0] = BSplineEvaluationData< FEMSig >::End( depth ) ; _BSplineEnd( UIntPack< FEMSigs ... >() , depth , end+1 );
+		}
+		template< unsigned int FEMSig , unsigned int ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )==0 , double >::type _Integral( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , const int offset[] , const double begin[] , const double end[] )
+		{
+			return BSplineEvaluationData< FEMSig >::Integral( depth , offset[0] , begin[0] , end[0] , 0 );
+		}
+		template< unsigned int FEMSig , unsigned int ... FEMSigs >
+		static typename std::enable_if< sizeof ... ( FEMSigs )!=0 , double >::type _Integral( UIntPack< FEMSig , FEMSigs ... > , unsigned int depth , const int offset[] , const double begin[] , const double end[] )
+		{
+			return BSplineEvaluationData< FEMSig >::Integral( depth , offset[0] , begin[0] , end[0] , 0 ) * _Integral( UIntPack< FEMSigs ... >() , depth , offset+1 , begin+1 , end+1 );
+		}
+	public:
+		template< unsigned int ... FEMSigs >
+		static double Integral( UIntPack< FEMSigs ... > , int depth , const int offset[] , const double begin[] , const double end[] )
+		{
+			if( depth<0 ) return 0;
+			else return _Integral( UIntPack< FEMSigs ... >() , depth , offset , begin , end );
+		}
+		template< unsigned int ... FEMSigs > static bool IsValidFEMNode( UIntPack< FEMSigs ... > , int depth , const int offset[] ){ return _IsValidFEMNode( UIntPack< FEMSigs ... >() , depth , offset ); }
+		template< unsigned int ... FEMSigs > static bool IsOutOfBounds( UIntPack< FEMSigs ... > , int depth , const int offset[] ){ return depth<0 || _IsOutOfBounds( UIntPack< FEMSigs ... >() , depth , offset ); }
+		template< unsigned int ... FEMSigs > static void BSplineBegin( UIntPack< FEMSigs ... > , int depth , int begin[] ){ if( depth>=0 ) _BSplineBegin( UIntPack< FEMSigs ... >() , depth , begin ); }
+		template< unsigned int ... FEMSigs > static void BSplineEnd  ( UIntPack< FEMSigs ... > , int depth , int end  [] ){ if( depth>=0 ) _BSplineEnd  ( UIntPack< FEMSigs ... >() , depth , end   ); }
+
+		template< typename TSignatures , typename TDerivatives                                                                    > struct                  System{};
+		template< typename TSignatures , typename TDerivatives , typename CSignatures , typename CDerivatives , unsigned int CDim > struct              Constraint{};
+		template< typename TSignatures , typename TDerivatives , typename CSignatures , typename CDerivatives                     > struct        ScalarConstraint{};
+		template< typename TSignatures                                                                                            > struct RestrictionProlongation{};
+		template< typename TSignatures , typename TDerivatives                                                                    > struct          PointEvaluator{};
+		template< typename TSignatures , typename TDerivatives                                                                    > struct     PointEvaluatorState{};
+
+		template< unsigned int ... TSignatures , unsigned int ... TDs >
+		struct PointEvaluatorState< UIntPack< TSignatures ... > , UIntPack< TDs ... > > : public BaseFEMIntegrator::template PointEvaluatorState< sizeof ... ( TSignatures ) >
+		{
+			static_assert( sizeof...(TSignatures)==sizeof...(TDs) , "[ERROR] Degree and derivative dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMSignature< TSignatures >::Degree ... > , UIntPack< TDs ... > >::GreaterThanOrEqual , "[ERROR] PointEvaluatorState: More derivatives than degrees" );
+
+			static const unsigned int Dim = sizeof...(TSignatures);
+
+			double value   ( const int offset[] , const unsigned int derivatives[] ) const { return _value< Dim   >( offset , derivatives ); }
+			double subValue( const int offset[] , const unsigned int derivatives[] ) const { return _value< Dim-1 >( offset , derivatives ); }
+			// Bypassing the "auto" keyword 
+			template< unsigned int _Dim >
+			const double (*(values)( void ) const )[ UIntPack< TDs ... >::template Get< _Dim >()+1 ] { return std::template get< _Dim >( _oneDValues ).values; }
+		protected:
+			int _pointOffset[Dim];
+
+			template< unsigned int Degree , unsigned int D > struct _OneDValues
+			{
+				double values[ BSplineSupportSizes< Degree >::SupportSize ][ D+1 ];
+				double value( int dOff , unsigned int d ) const
+				{
+					if( dOff>=-BSplineSupportSizes< Degree >::SupportEnd && dOff<=-BSplineSupportSizes< Degree >::SupportStart && d<=D ) return values[ dOff+BSplineSupportSizes< Degree >::SupportEnd][d];
+					else return 0;
+				}
+			};
+			std::tuple< _OneDValues< FEMSignature< TSignatures >::Degree , TDs > ... > _oneDValues;
+			template< unsigned int MaxDim=Dim , unsigned int I=0 > typename std::enable_if< I==MaxDim , double >::type _value( const int off[] , const unsigned int d[] ) const { return 1.; }
+			template< unsigned int MaxDim=Dim , unsigned int I=0 > typename std::enable_if< I!=MaxDim , double >::type _value( const int off[] , const unsigned int d[] ) const { return std::get< I >( _oneDValues ).value( off[I]-_pointOffset[I] , d[I] ) * _value< MaxDim , I+1 >( off , d ); }
+			template< typename T1 , typename T2 > friend struct PointEvaluator;
+		};
+
+		template< unsigned int ... TSignatures , unsigned int ... TDs >
+		struct PointEvaluator< UIntPack< TSignatures ... > , UIntPack< TDs ... > > : public BaseFEMIntegrator::template PointEvaluator< UIntPack< FEMSignature< TSignatures >::Degree ... > >
+		{
+			static_assert( sizeof...(TSignatures)==sizeof...(TDs) , "[ERROR] PointEvaluator: Degree and derivative dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMSignature< TSignatures >::Degree ... > , UIntPack< TDs ... > >::GreaterThanOrEqual , "[ERROR] PointEvaluator: More derivatives than degrees" );
+
+			static const unsigned int Dim = sizeof ... ( TSignatures );
+
+			typedef typename BaseFEMIntegrator::template PointEvaluator< UIntPack< FEMSignature< TSignatures >::Degree ... > > Base;
+
+			PointEvaluator( unsigned int maxDepth ) : _maxDepth( maxDepth ) { _init(); }
+			template< unsigned int ... EDs >
+			void initEvaluationState( Point< double , Dim > p , unsigned int depth , PointEvaluatorState< UIntPack< TSignatures ... > , UIntPack< EDs ... > >& state ) const
+			{
+				unsigned int res = 1<<depth;
+				for( int d=0 ; d<Dim ; d++ ) state._pointOffset[d] = (int)( p[d] * res );
+				initEvaluationState( p , depth , state._pointOffset , state );
+			}
+			template< unsigned int ... EDs >
+			void initEvaluationState( Point< double , Dim > p , unsigned int depth , const int* offset , PointEvaluatorState< UIntPack< TSignatures ... > , UIntPack< EDs ... > >& state ) const
+			{
+				static_assert( ParameterPack::Comparison< UIntPack< TDs ... > , UIntPack< EDs ... > >::GreaterThanOrEqual , "[ERROR] PointEvaluator::init: More evaluation derivatives than stored derivatives" );
+				for( int d=0 ; d<Dim ; d++ ) state._pointOffset[d] = (int)offset[d];
+				_initEvaluationState( UIntPack< TSignatures ... >() , UIntPack< EDs ... >() , &p[0] , depth , state );
+			}
+		protected:
+			unsigned int _maxDepth;
+			std::tuple< BSplineData< TSignatures , TDs > ... > _bSplineData;
+			template< unsigned int I=0 > typename std::enable_if< I==Dim >::type _init( void ){}
+			template< unsigned int I=0 > typename std::enable_if< (I<Dim) >::type _init( void ){ std::get< I >( _bSplineData ).reset( _maxDepth ) ; _init< I+1 >( ); }
+
+			template< unsigned int I , unsigned int TSig , unsigned int D , typename State >
+			void _setEvaluationState( const double* p , unsigned int depth , State& state ) const
+			{
+				static const int       LeftSupportRadius = -BSplineSupportSizes< FEMSignature< TSig >::Degree >::SupportStart;
+				static const int  LeftPointSupportRadius =  BSplineSupportSizes< FEMSignature< TSig >::Degree >::SupportEnd  ;
+				static const int      RightSupportRadius =  BSplineSupportSizes< FEMSignature< TSig >::Degree >::SupportEnd  ;
+				static const int RightPointSupportRadius = -BSplineSupportSizes< FEMSignature< TSig >::Degree >::SupportStart;
+				for( int s=-LeftPointSupportRadius ; s<=RightPointSupportRadius ; s++ )
+				{
+					int pIdx = state._pointOffset[I];
+					int fIdx = state._pointOffset[I]+s;
+					double _p = p[I];
+					const Polynomial< FEMSignature< TSig >::Degree >* components = std::get< I >( _bSplineData )[depth].polynomialsAndOffset( _p , pIdx , fIdx );
+					for( int d=0 ; d<=D ; d++ ) std::get< I >( state._oneDValues ).values[ s+LeftPointSupportRadius ][d] = components[d]( _p );
+				}
+			}
+			template< typename State , unsigned int TSig , unsigned int ... TSigs , unsigned int D , unsigned int ... Ds >
+			typename std::enable_if< sizeof...(TSigs)==0 >::type _initEvaluationState( UIntPack< TSig , TSigs ... > , UIntPack< D , Ds ... > , const double* p , unsigned int depth , State& state ) const
+			{
+				_setEvaluationState< Dim-1 , TSig , D >( p , depth , state );
+			}
+			template< typename State , unsigned int TSig , unsigned int ... TSigs , unsigned int D , unsigned int ... Ds >
+			typename std::enable_if< sizeof...(TSigs)!=0 >::type _initEvaluationState( UIntPack< TSig , TSigs ... > , UIntPack< D , Ds ... > , const double* p , unsigned int depth , State& state ) const
+			{
+				_setEvaluationState< Dim-1-sizeof...(TSigs) , TSig , D >( p , depth , state );
+				_initEvaluationState( UIntPack< TSigs ... >() , UIntPack< Ds ... >() , p , depth , state );
+			}
+		};
+
+		template< unsigned int ... TSignatures >
+		struct RestrictionProlongation< UIntPack< TSignatures ... > > : public BaseFEMIntegrator::template RestrictionProlongation< UIntPack< FEMSignature< TSignatures >::Degree ... > >
+		{
+			static const unsigned int Dim = sizeof ... ( TSignatures );
+			typedef typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< FEMSignature< TSignatures >::Degree ... > > Base;
+
+			double upSampleCoefficient( const int pOff[] , const int cOff[] ) const { return _coefficient( pOff , cOff ); }
+			void init( unsigned int depth ){ Base::init( depth ); }
+			void init( void ){ _init( Base::highDepth() ); }
+
+		protected:
+			std::tuple< typename BSplineEvaluationData< TSignatures >::UpSampleEvaluator ... > _upSamplers;
+
+			template< unsigned int D=0 > typename std::enable_if< D==Dim >::type _init( int highDepth ){ }
+			template< unsigned int D=0 > typename std::enable_if< D< Dim >::type _init( int highDepth ){ std::get< D >( _upSamplers ).set( highDepth-1 ) ; _init< D+1 >( highDepth ); }
+			template< unsigned int D=0 > typename std::enable_if< D==Dim , double >::type _coefficient( const int pOff[] , const int cOff[] ) const { return 1.; }
+			template< unsigned int D=0 > typename std::enable_if< D< Dim , double >::type _coefficient( const int pOff[] , const int cOff[] ) const { return _coefficient< D+1 >( pOff , cOff ) * std::get< D >( _upSamplers ).value( pOff[D] , cOff[D] ); }
+		};
+
+		template< unsigned int ... TSignatures , unsigned int ... TDerivatives , unsigned int ... CSignatures , unsigned int ... CDerivatives , unsigned int CDim >
+		struct Constraint< UIntPack< TSignatures ... > , UIntPack< TDerivatives ... > , UIntPack< CSignatures ... > , UIntPack< CDerivatives ... > , CDim > : public BaseFEMIntegrator::template Constraint< UIntPack< FEMSignature< TSignatures >::Degree ... > , UIntPack< FEMSignature< CSignatures >::Degree ... > , CDim >
+		{
+			static_assert( sizeof ... ( TSignatures ) == sizeof ... ( CSignatures ) , "[ERROR] Test signatures and contraint signatures must have the same dimension" );
+			static_assert( sizeof ... ( TSignatures ) == sizeof ... ( TDerivatives ) , "[ERROR] Test signatures and derivatives must have the same dimension" );
+			static_assert( sizeof ... ( CSignatures ) == sizeof ... ( CDerivatives ) , "[ERROR] Constraint signatures and derivatives must have the same dimension" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMSignature< TSignatures >::Degree ... > , UIntPack< TDerivatives ... > >::GreaterThanOrEqual , "[ERROR] Test functions cannot have more derivatives than the degree" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMSignature< CSignatures >::Degree ... > , UIntPack< CDerivatives ... > >::GreaterThanOrEqual , "[ERROR] Test functions cannot have more derivatives than the degree" );
+
+			static const unsigned int Dim = sizeof ... ( TSignatures );
+			typedef typename BaseFEMIntegrator::template Constraint< UIntPack< FEMSignature< TSignatures >::Degree ... > , UIntPack< FEMSignature< CSignatures >::Degree ... > , CDim > Base;
+
+			static const unsigned int TDerivativeSize = TensorDerivatives< UIntPack< TDerivatives ... > >::Size;
+			static const unsigned int CDerivativeSize = TensorDerivatives< UIntPack< CDerivatives ... > >::Size;
+			static inline void TFactorDerivatives( unsigned int idx , unsigned int d[ Dim ] ){ TensorDerivatives< UIntPack< TDerivatives ... > >::Factor( idx , d ); }
+			static inline void CFactorDerivatives( unsigned int idx , unsigned int d[ Dim ] ){ TensorDerivatives< UIntPack< CDerivatives ... > >::Factor( idx , d ); }
+			static inline unsigned int TDerivativeIndex( const unsigned int d[ Dim ] ){ return TensorDerivatives< UIntPack< TDerivatives ... > >::Index( d ); }
+			static inline unsigned int CDerivativeIndex( const unsigned int d[ Dim ] ){ return TensorDerivatives< UIntPack< CDerivatives ... > >::Index( d ); }
+			Matrix< double , TDerivativeSize , CDerivativeSize > weights[CDim];
+
+			Point< double , CDim > ccIntegrate( const int off1[] , const int off2[] ) const { return _integrate( INTEGRATE_CHILD_CHILD  , off1 , off2 ); }
+			Point< double , CDim > pcIntegrate( const int off1[] , const int off2[] ) const { return _integrate( INTEGRATE_PARENT_CHILD , off1 , off2 ); }
+			Point< double , CDim > cpIntegrate( const int off1[] , const int off2[] ) const { return _integrate( INTEGRATE_CHILD_PARENT , off1 , off2 ); }
+
+			void init( unsigned int depth ){ Base::init( depth ); }
+			void init( void )
+			{
+
+				_init( Base::highDepth() );
+				_weightedIndices.resize(0);
+				for( unsigned int d1=0 ; d1<TDerivativeSize ; d1++ ) for( unsigned int d2=0 ; d2<CDerivativeSize ; d2++ )
+				{
+					_WeightedIndices w(d1,d2);
+					for( unsigned int c=0 ; c<CDim ; c++ ) if( weights[c](d1,d2)>0 ) w.indices.push_back( std::pair< unsigned int , double >( c , weights[c](d1,d2) ) );
+					if( w.indices.size() ) _weightedIndices.push_back(w);
+				}
+			}
+			typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< FEMSignature< TSignatures >::Degree ... > >& tRestrictionProlongation( void ){ return _tRestrictionProlongation; }
+			typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< FEMSignature< CSignatures >::Degree ... > >& cRestrictionProlongation( void ){ return _cRestrictionProlongation; }
+		protected:
+			RestrictionProlongation< UIntPack< TSignatures ... > > _tRestrictionProlongation;
+			RestrictionProlongation< UIntPack< CSignatures ... > > _cRestrictionProlongation;
+			struct _WeightedIndices
+			{
+				_WeightedIndices( unsigned int _d1=0 , unsigned int _d2=0 ) : d1(_d1) , d2(_d2) { ; }
+				unsigned int d1 , d2;
+				std::vector< std::pair< unsigned int , double > > indices;
+			};
+			std::vector< _WeightedIndices > _weightedIndices;
+			enum IntegrationType
+			{
+				INTEGRATE_CHILD_CHILD ,
+				INTEGRATE_PARENT_CHILD ,
+				INTEGRATE_CHILD_PARENT
+			};
+
+			template< unsigned int _TSig , unsigned int _TDerivatives , unsigned int _CSig , unsigned int _CDerivatives >
+			struct _Integrators
+			{
+				typename BSplineIntegrationData< _TSig , _CSig >::FunctionIntegrator::template      Integrator< _TDerivatives , _CDerivatives > ccIntegrator;
+				typename BSplineIntegrationData< _TSig , _CSig >::FunctionIntegrator::template ChildIntegrator< _TDerivatives , _CDerivatives > pcIntegrator;
+				typename BSplineIntegrationData< _CSig , _TSig >::FunctionIntegrator::template ChildIntegrator< _CDerivatives , _TDerivatives > cpIntegrator;
+			};
+			std::tuple< _Integrators< TSignatures , TDerivatives , CSignatures , CDerivatives > ... > _integrators;
+
+			template< unsigned int D=0 >
+			typename std::enable_if< D==Dim >::type _init( int depth ){ ; }
+			template< unsigned int D=0 >
+			typename std::enable_if< D< Dim >::type _init( int depth )
+			{
+				std::get< D >( _integrators ).ccIntegrator.set( depth );
+				if( depth ) std::get< D >( _integrators ).pcIntegrator.set( depth-1 ) , std::get< D >( _integrators ).cpIntegrator.set( depth-1 );
+				_init< D+1 >( depth );
+			}
+			template< unsigned int D=0 >
+			typename std::enable_if< D==Dim , double >::type _integral( IntegrationType iType , const int off1[] , const int off2[] , const unsigned int d1[] , const unsigned int d2[] ) const { return 1.; }
+			template< unsigned int D=0 >
+			typename std::enable_if< D< Dim , double >::type _integral( IntegrationType iType , const int off1[] , const int off2[] , const unsigned int d1[] , const unsigned int d2[] ) const
+			{
+				double remainingIntegral = _integral< D+1 >( iType , off1 , off2 , d1 , d2 );
+				switch( iType )
+				{
+				case INTEGRATE_CHILD_CHILD:  return std::get< D >( _integrators ).ccIntegrator.dot( off1[D] , off2[D] , d1[D] , d2[D] ) * remainingIntegral;
+				case INTEGRATE_PARENT_CHILD: return std::get< D >( _integrators ).pcIntegrator.dot( off1[D] , off2[D] , d1[D] , d2[D] ) * remainingIntegral;
+				case INTEGRATE_CHILD_PARENT: return std::get< D >( _integrators ).cpIntegrator.dot( off2[D] , off1[D] , d2[D] , d1[D] ) * remainingIntegral;
+				default: MK_THROW( "Undefined integration type" );
+				}
+				return 0;
+			}
+			Point< double , CDim > _integrate( IntegrationType iType , const int off1[] , const int off[] ) const;
+		};
+
+		template< unsigned int ... TSignatures , unsigned int ... TDerivatives , unsigned int ... CSignatures , unsigned int ... CDerivatives >
+		struct ScalarConstraint< UIntPack< TSignatures ... > , UIntPack< TDerivatives ... > , UIntPack< CSignatures ... > , UIntPack< CDerivatives ... > > : public Constraint< UIntPack< TSignatures ... > , UIntPack< TDerivatives ... > , UIntPack< CSignatures ... > , UIntPack< CDerivatives ... > , 1 >
+		{
+			static const unsigned int Dim = sizeof ... ( TSignatures );
+			typedef typename BaseFEMIntegrator::template Constraint<  UIntPack< FEMSignature< TSignatures >::Degree ... > , UIntPack< FEMSignature< CSignatures >::Degree ... > , 1 > Base;
+
+			typedef Constraint< UIntPack< TSignatures ... > , UIntPack< TDerivatives ... > , UIntPack< CSignatures ... > , UIntPack< CDerivatives ... > , 1 > FullConstraint;
+			using FullConstraint::weights;
+			// [NOTE] We define the constructor using a recursive function call to take into account multiplicity (e.g. so that d^2/dxdy and d^2/dydx each contribute)
+			ScalarConstraint( const std::initializer_list< double >& w )
+			{
+				std::function< void ( unsigned int[] , const double[] , unsigned int ) > SetDerivativeWeights = [&]( unsigned int derivatives[Dim] , const double w[] , unsigned int d )
+					{
+						unsigned int idx1 = FullConstraint::TDerivativeIndex( derivatives ) , idx2 = FullConstraint::CDerivativeIndex( derivatives );
+						weights[0][idx1][idx2] += w[0];
+						if( d>0 ) for( int dd=0 ; dd<Dim ; dd++ ){ derivatives[dd]++ ; SetDerivativeWeights( derivatives , w+1 , d-1 ) ; derivatives[dd]--; }
+					};
+				static const unsigned int DMax = std::min< unsigned int >( UIntPack< TDerivatives ... >::Min() , UIntPack< CDerivatives ... >::Min() );
+
+				unsigned int derivatives[Dim];
+				double _w[DMax+1];
+				memset( _w , 0 , sizeof(_w) );
+				{
+					unsigned int dd=0;
+					for( typename std::initializer_list< double >::const_iterator iter=w.begin() ; iter!=w.end() && dd<=DMax ; dd++ , iter++ ) _w[dd] = *iter;
+				}
+				for( int d=0 ; d<Dim ; d++ ) derivatives[d] = 0;
+				if( w.size() ) SetDerivativeWeights( derivatives , _w , std::min< unsigned int >( DMax+1 , (unsigned int)w.size() )-1 );
+			}
+		};
+
+		template< unsigned int ... TSignatures , unsigned int ... TDerivatives >
+		struct System< UIntPack< TSignatures ... > , UIntPack< TDerivatives ... > > : public BaseFEMIntegrator::template System< UIntPack< FEMSignature< TSignatures >::Degree... > >
+		{
+			static_assert( sizeof ... ( TSignatures ) == sizeof ... ( TDerivatives ) , "[ERROR] Test signatures and derivatives must have the same dimension" );
+
+			static const unsigned int Dim = sizeof ... ( TSignatures );
+			typedef typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< TSignatures >::Degree... > > Base;
+
+			System( const std::initializer_list< double >& w ) : _sc( w ){ ; }
+			void init( unsigned int depth ){ Base::init( depth ); }
+			void init( void ){ ( (BaseFEMIntegrator::template Constraint< UIntPack< FEMSignature< TSignatures >::Degree ... > , UIntPack< FEMSignature< TSignatures >::Degree ... > , 1 >&)_sc ).init( BaseFEMIntegrator::template System< UIntPack< FEMSignature< TSignatures >::Degree... > >::_highDepth ); }
+			double ccIntegrate( const int off1[] , const int off2[] ) const { return _sc.ccIntegrate( off1 , off2 )[0]; }
+			double pcIntegrate( const int off1[] , const int off2[] ) const { return _sc.pcIntegrate( off1 , off2 )[0]; }
+			bool vanishesOnConstants( void ) const { return _sc.weights[0][0][0]==0; }
+
+			typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< FEMSignature< TSignatures >::Degree ... > >& restrictionProlongation( void ){ return _sc.tRestrictionProlongation(); }
+
+		protected:
+			ScalarConstraint< UIntPack< TSignatures ... > , UIntPack< TDerivatives ... >  , UIntPack< TSignatures ... > , UIntPack< TDerivatives ... > > _sc;
+		};
+	};
+
+	//////////////////////////////////////////
+
+	template< unsigned int Dim > inline void SetGhostFlag(       RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node , bool flag ){ if( node && node->parent ) node->parent->nodeData.setGhostFlag( flag ); }
+	template< unsigned int Dim > inline bool GetGhostFlag( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ){ return node==NULL || node->parent==NULL || node->parent->nodeData.getGhostFlag( ); }
+	template< unsigned int Dim > inline bool IsActiveNode( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* node ){ return !GetGhostFlag( node ); }
+
+	// A class representing an extractot with and without auxiliary data
+	template< typename Real , unsigned int Dim , typename ... Params > struct LevelSetExtractor;
+
+	// A helper class which consolidates the two extractors, templated over HasData
+	template< bool HasData , typename Real , unsigned int Dim , typename Data > struct _LevelSetExtractor;
+
+	template< unsigned int Dim , class Data >
+	struct NodeSample
+	{
+		RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *node;
+		Data data;
+	};
+	template< unsigned int Dim , class Real >
+	struct NodeAndPointSample
+	{
+		RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *node;
+		ProjectiveData< Point< Real , Dim > , Real > sample;
+	};
+	template< unsigned int Dim , class Real > using NodeSimplices = NodeSample< Dim , std::vector< std::pair< node_index_type , Simplex< Real , Dim , Dim-1 > > > >;
+
+
+	template< typename T > struct WindowLoopData{ };
+
+	template< unsigned int ... Sizes >
+	struct WindowLoopData< UIntPack< Sizes ... > >
+	{
+		static const int Dim = sizeof ... ( Sizes );
+		unsigned int size[1<<Dim];
+		unsigned int indices[1<<Dim][ WindowSize< UIntPack< Sizes ... > >::Size ];
+		template< typename BoundsFunction >
+		WindowLoopData( const BoundsFunction &boundsFunction )
+		{
+			int start[Dim] , end[Dim];
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+			{
+				size[c] = 0;
+				boundsFunction( c , start , end );
+				unsigned int idx[Dim];
+				WindowLoop< Dim >::Run
+				(
+					start , end ,
+					[&]( int d , int i ){ idx[d] = i; } ,
+					[&]( void ){ indices[c][ size[c]++ ] = Window::GetIndex< Sizes ... >( idx ); }
+				);
+			}
+		}
+	};
+
+	template< class Real , unsigned int Dim >
+	struct Atomic< Point< Real , Dim > >
+	{
+		using Value = Point< Real , Dim >;
+		static void Add( volatile Value &a , const Value &b ){ for( unsigned int d=0 ; d<Dim ; d++ ) AddAtomic( a.coords[d] , b[d] ); }
+	};
+
+	template< class Real >
+	struct Atomic< Point< Real > >
+	{
+		using Value = Point< Real >;
+		static void Add( volatile Value &a , const Value &b )
+		{
+			if( a._dim !=b._dim ) MK_THROW( "Sizes don't match: " , a._dim , " != " , b._dim );
+			for( unsigned int d=0 ; d<a._dim && d<b.dim() ; d++ ) AddAtomic( a._coords[d] , b[d] );
+		}
+	};
+
+	template< typename Data , typename Real >
+	struct Atomic< ProjectiveData< Data , Real > >
+	{
+		using Value = ProjectiveData< Data , Real >;
+		static void Add( volatile Value &a , const Value &b ){ Atomic< Real >::Add( a.weight , b.weight ) ; Atomic< Data >::Add( a.data , b.data ); }
+	};
+
+	template< typename Real , typename FirstType , typename ... RestTypes >
+	struct Atomic< DirectSum< Real , FirstType , RestTypes... > > 
+	{
+		using Value = DirectSum< Real , FirstType , RestTypes... >;
+		static void Add( volatile Value &a , const Value &b )
+		{
+			Atomic< FirstType >::Add( a._first , b._first );
+			Atomic< DirectSum< Real , RestTypes... > >::Add( a._rest , b._rest );
+		}
+	};
+
+	template< typename Real >
+	struct Atomic< DirectSum< Real > > 
+	{
+		using Value = DirectSum< Real >;
+		static void Add( volatile Value &a , const Value &b ){}
+	};
+
+	template< class Real , unsigned int Dim >
+	Point< Real , Dim > ReadAtomic( const volatile Point< Real , Dim > & a )
+	{
+		Point< Real , Dim > p;
+		for( int d=0 ; d<Dim ; d++ ) p[d] = ReadAtomic( a.coords[d] );
+		return p;
+	}
+
+	template< class Real , unsigned int Dim >
+	Point< Real , Dim > SetAtomic( volatile Point< Real , Dim > & p , Point< Real , Dim > newP )
+	{
+		Point< Real , Dim > oldP;
+		for( int d=0 ; d<Dim ; d++ ) oldP[d] = SetAtomic( p.coords[d] , newP[d] );
+		return oldP;
+	}
+
+	template< class Data >
+	bool IsZero( const Data& data ){ return false; }
+	template< class Real , unsigned int Dim >
+	bool IsZero( const Point< Real , Dim >& d )
+	{
+		bool zero = true;
+		for( int i=0 ; i<Dim ; i++ ) zero &= (d[i]==0); 
+		return zero;
+	}
+	inline bool IsZero( const float& f ){ return f==0.f; }
+	inline bool IsZero( const double& f ){ return f==0.; }
+
+	template< unsigned int Dim , class Real >
+	class FEMTree
+	{
+	public:
+		typedef RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > FEMTreeNode;
+		template< unsigned int ... FEMSigs > using SystemMatrixType = SparseMatrix< Real , matrix_index_type , WindowSize< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >::Size >;
+		std::vector< Allocator< FEMTreeNode > * > nodeAllocators;
+	protected:
+		template< unsigned int _Dim , class _Real > friend class FEMTree;
+		struct SubTreeExtractor : public FEMTreeNode::SubTreeExtractor
+		{
+			SubTreeExtractor( FEMTreeNode &node , int &depthOffset ) : FEMTreeNode::SubTreeExtractor( node ) , _depthOffset( depthOffset )
+			{
+				_depthOffsetValue = _depthOffset;
+				_depthOffset = 0;
+			}
+			SubTreeExtractor( FEMTreeNode *node , int &depthOffset ) : SubTreeExtractor( *node , depthOffset ){}
+			~SubTreeExtractor( void ){ _depthOffset = _depthOffsetValue; }
+		protected:
+			int &_depthOffset , _depthOffsetValue;
+		};
+
+		// Don't need this first one
+		template< typename _Real , unsigned int _Dim , typename ... _Params > friend struct LevelSetExtractor;
+		template< bool _HasData , typename _Real , unsigned int _Dim , typename _Data > friend struct _LevelSetExtractor;
+		std::atomic< node_index_type > _nodeCount;
+		struct _NodeInitializer
+		{
+			FEMTree& femTree;
+			_NodeInitializer( FEMTree& f ) : femTree(f){;}
+			void operator() ( FEMTreeNode& node ){ node.nodeData.nodeIndex = femTree._nodeCount++; }
+		};
+		_NodeInitializer _nodeInitializer;
+	public:
+		typedef int LocalDepth;
+		typedef int LocalOffset[Dim];
+
+		node_index_type nodeCount( void ) const { return _nodeCount; }
+
+		typedef NodeAndPointSample< Dim , Real > PointSample;
+
+		typedef typename FEMTreeNode::template      NeighborKey< IsotropicUIntPack< Dim , 1 > , IsotropicUIntPack< Dim , 1 > >      OneRingNeighborKey;
+		typedef typename FEMTreeNode::template ConstNeighborKey< IsotropicUIntPack< Dim , 1 > , IsotropicUIntPack< Dim , 1 > > ConstOneRingNeighborKey;
+		typedef typename FEMTreeNode::template      Neighbors< IsotropicUIntPack< Dim , 3 > >      OneRingNeighbors;
+		typedef typename FEMTreeNode::template ConstNeighbors< IsotropicUIntPack< Dim , 3 > > ConstOneRingNeighbors;
+
+		template< typename FEMDegreePack >                        using BaseSystem          = typename BaseFEMIntegrator::template System< FEMDegreePack >;
+		template< typename FEMSigPack , typename DerivativePack > using PointEvaluator      = typename     FEMIntegrator::template PointEvaluator< FEMSigPack , DerivativePack >;
+		template< typename FEMSigPack , typename DerivativePack > using PointEvaluatorState = typename     FEMIntegrator::template PointEvaluatorState< FEMSigPack , DerivativePack >;	
+		template< typename FEMDegreePack > using CCStencil  = typename BaseSystem< FEMDegreePack >::CCStencil;
+		template< typename FEMDegreePack > using PCStencils = typename BaseSystem< FEMDegreePack >::PCStencils;
+
+		template< unsigned int ... FEMSigs > bool isValidFEMNode( UIntPack< FEMSigs ... > , const FEMTreeNode* node ) const;
+		bool isValidSpaceNode( const FEMTreeNode* node ) const;
+		const FEMTreeNode* leaf( Point< Real , Dim > p ) const;
+	protected:
+		template< bool ThreadSafe >
+		FEMTreeNode* _leaf( Allocator< FEMTreeNode > *nodeAllocator , Point< Real , Dim > p , LocalDepth maxDepth=-1 );
+		template< bool ThreadSafe >
+		FEMTreeNode* _leaf( Allocator< FEMTreeNode > *nodeAllocator , Point< Real , Dim > p , std::function< int ( Point< Real , Dim > ) > &pointDepthFunctor );
+	public:
+
+		// [NOTE] In the case that T != double, we require both operators() for computing the system dual
+		template< typename T , unsigned int PointD >
+		struct InterpolationInfo
+		{
+			virtual void range( const FEMTreeNode* node , size_t& begin , size_t& end ) const = 0;
+			virtual Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const = 0;
+			virtual Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< T , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const = 0;
+			virtual Point< double , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< double , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const = 0;
+			virtual const DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIdx ) const = 0;
+			virtual bool constrainsDCTerm( void ) const = 0;
+			virtual ~InterpolationInfo( void ){}
+
+			DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIndex ){ return const_cast< DualPointInfo< Dim , Real , T , PointD >& >( ( ( const InterpolationInfo* )this )->operator[]( pointIndex ) ); }
+		protected:
+			virtual void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount ) = 0;
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< unsigned int PointD >
+		struct InterpolationInfo< double , PointD >
+		{
+			virtual void range( const FEMTreeNode* node , size_t& begin , size_t& end ) const = 0;
+			virtual Point< double , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const = 0;
+			virtual Point< double , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< double , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const = 0;
+			virtual const DualPointInfo< Dim , Real , double , PointD >& operator[]( size_t pointIdx ) const = 0;
+			virtual bool constrainsDCTerm( void ) const = 0;
+			virtual ~InterpolationInfo( void ){}
+
+			DualPointInfo< Dim , Real , double , PointD >& operator[]( size_t pointIndex ){ return const_cast< DualPointInfo< Dim , Real , double , PointD >& >( ( ( const InterpolationInfo* )this )->operator[]( pointIndex ) ); }
+		protected:
+			virtual void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount ) = 0;
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< typename T , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct ApproximatePointInterpolationInfo : public InterpolationInfo< T , PointD >
+		{
+			using Data = DualPointInfo< Dim , Real , T , PointD >;
+			void range( const FEMTreeNode *node , size_t &begin , size_t &end ) const
+			{
+				node_index_type idx = iData.index( node );
+				if( idx==-1 ) begin = end = 0;
+				else begin = idx , end = idx+1;
+			}
+			bool constrainsDCTerm( void ) const { return _constrainsDCTerm; }
+			const DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIdx ) const { return iData[ pointIdx ]; }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const { return _constraintDual( iData[ pointIdx ].position ); }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< T , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( iData[ pointIdx ].position , dValues ); }
+			Point< double , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< double , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( iData[ pointIdx ].position , dValues ); }
+
+			ApproximatePointInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _constraintDual( constraintDual ) , _systemDual( systemDual ) , _constrainsDCTerm( constrainsDCTerm ) { }
+
+			void write( BinaryStream &stream ) const
+			{
+				unsigned char constrainsDCTerm = _constrainsDCTerm ? 1 : 0;
+				stream.write( constrainsDCTerm );
+				stream.write( _constraintDual );
+				stream.write( _systemDual );
+				iData.write( stream );
+			}
+			void read( BinaryStream &stream )
+			{
+				unsigned char constrainsDCTerm;
+				if( !stream.read( constrainsDCTerm ) ) MK_THROW( "Failed to read constrainsDCTerm" );
+				_constrainsDCTerm = constrainsDCTerm!=0;
+				if( !stream.read( _constraintDual ) ) MK_THROW( "Failed to read _constraintDual" );
+				if( !stream.read( _systemDual ) ) MK_THROW( "Failed to read _systemDual" );
+				iData.read( stream );
+			}
+			ApproximatePointInterpolationInfo( BinaryStream &stream ){ read(stream); }
+			ApproximatePointInterpolationInfo( void ){}
+
+			SparseNodeData< DualPointInfo< Dim , Real , T , PointD > , ZeroUIntPack< Dim > > iData;
+
+		protected:
+
+			bool _constrainsDCTerm;
+			ConstraintDual _constraintDual;
+			SystemDual _systemDual;
+
+			void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount ){ iData._remapIndices( oldNodeIndices , newNodeCount ); }
+
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct ApproximatePointInterpolationInfo< double , PointD , ConstraintDual , SystemDual > : public InterpolationInfo< double , PointD >
+		{
+			typedef double T;
+			using Data = DualPointInfo< Dim , Real , T , PointD >;
+			void range( const FEMTreeNode* node , size_t& begin , size_t& end ) const
+			{
+				node_index_type idx = iData.index( node );
+				if( idx==-1 ) begin = end = 0;
+				else begin = idx , end = idx+1;
+			}
+			bool constrainsDCTerm( void ) const { return _constrainsDCTerm; }
+			const DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIdx ) const { return iData[ pointIdx ]; }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const { return _constraintDual( iData[ pointIdx ].position ); }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< T , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( iData[ pointIdx ].position , dValues ); }
+
+			ApproximatePointInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _constraintDual( constraintDual ) , _systemDual( systemDual ) , _constrainsDCTerm( constrainsDCTerm ) { }
+
+			void write( BinaryStream &stream ) const
+			{
+				unsigned char constrainsDCTerm = _constrainsDCTerm ? 1 : 0;
+				stream.write( constrainsDCTerm );
+				stream.write( _constraintDual );
+				stream.write( _systemDual );
+				iData.write( stream );
+			}
+			void read( BinaryStream &stream )
+			{
+				unsigned char constrainsDCTerm;
+				if( !stream.read( constrainsDCTerm ) ) MK_THROW( "Failed to read constrainsDCTerm" );
+				_constrainsDCTerm = constrainsDCTerm!=0;
+				if( !stream.read( _constraintDual ) ) MK_THROW( "Failed to read _constraintDual" );
+				if( !stream.read( _systemDual ) ) MK_THROW( "Failed to read _systemDual" );
+				iData.read( stream );
+			}
+			ApproximatePointInterpolationInfo( BinaryStream &stream ){ read(stream); }
+			ApproximatePointInterpolationInfo( void ){}
+
+			SparseNodeData< DualPointInfo< Dim , Real , T , PointD > , ZeroUIntPack< Dim > > iData;
+
+		protected:
+
+			bool _constrainsDCTerm;
+			ConstraintDual _constraintDual;
+			SystemDual _systemDual;
+
+			void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount ){ iData._remapIndices( oldNodeIndices , newNodeCount ); }
+
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct ApproximatePointAndDataInterpolationInfo : public InterpolationInfo< T , PointD >
+		{
+			void range( const FEMTreeNode* node , size_t& begin , size_t& end ) const
+			{
+				node_index_type idx = iData.index( node );
+				if( idx==-1 ) begin = end = 0;
+				else begin = idx , end = idx+1;
+			}
+			bool constrainsDCTerm( void ) const { return _constrainsDCTerm; }
+			const DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIdx ) const { return iData[ pointIdx ].pointInfo; }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const { return _constraintDual( iData[ pointIdx ].pointInfo.position , iData[ pointIdx ].data ); }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< T , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( iData[ pointIdx ].pointInfo.position , iData[ (int)pointIdx ].data , dValues ); }
+			typename std::enable_if< !std::is_same< T , double >::value , Point< double , CumulativeDerivatives< Dim , PointD >::Size > >::type operator() ( size_t pointIdx , const Point< double , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( iData[ (int)pointIdx ].pointInfo.position , iData[ (int)pointIdx ].data , dValues ); }
+
+			ApproximatePointAndDataInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _constraintDual( constraintDual ) , _systemDual( systemDual ) , _constrainsDCTerm( constrainsDCTerm ) { }
+
+			void write( BinaryStream &stream ) const
+			{
+				unsigned char constrainsDCTerm = _constrainsDCTerm ? 1 : 0;
+				stream.write( constrainsDCTerm );
+				stream.write( _constraintDual );
+				stream.write( _systemDual );
+				iData.write( stream );
+			}
+			void read( BinaryStream &stream )
+			{
+				unsigned char constrainsDCTerm;
+				if( !stream.read( constrainsDCTerm ) ) MK_THROW( "Failed to read constrainsDCTerm" );
+				_constrainsDCTerm = constrainsDCTerm!=0;
+				if( !stream.read( _constraintDual ) ) MK_THROW( "Failed to read _constraintDual" );
+				if( !stream.read( _systemDual ) ) MK_THROW( "Failed to read _systemDual" );
+				iData.read( stream );
+			}
+			ApproximatePointAndDataInterpolationInfo( BinaryStream &stream ){ read(stream); }
+
+			SparseNodeData< DualPointAndDataInfo< Dim , Real , Data , T , PointD > , ZeroUIntPack< Dim > > iData;
+
+		protected:
+
+			bool _constrainsDCTerm;
+			ConstraintDual _constraintDual;
+			SystemDual _systemDual;
+
+			void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount ){ iData._remapIndices( oldNodeIndices , newNodeCount ); }
+
+			ApproximatePointAndDataInterpolationInfo( void ){}
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct ApproximatePointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual > : public InterpolationInfo< double , PointD >
+		{
+			typedef double T;
+			void range( const FEMTreeNode* node , size_t& begin , size_t& end ) const
+			{
+				node_index_type idx = iData.index( node );
+				if( idx==-1 ) begin = end = 0;
+				else begin = idx , end = idx+1;
+			}
+			bool constrainsDCTerm( void ) const { return _constrainsDCTerm; }
+			const DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIdx ) const { return iData[ pointIdx ].pointInfo; }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const { return _constraintDual( iData[ pointIdx ].pointInfo.position , iData[ pointIdx ].data ); }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< T , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( iData[ pointIdx ].pointInfo.position , iData[ pointIdx ].data , dValues ); }
+
+			ApproximatePointAndDataInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _constraintDual( constraintDual ) , _systemDual( systemDual ) , _constrainsDCTerm( constrainsDCTerm ) { }
+
+			void write( BinaryStream &stream ) const
+			{
+				unsigned char constrainsDCTerm = _constrainsDCTerm ? 1 : 0;
+				stream.write( constrainsDCTerm );
+				stream.write( _constraintDual );
+				stream.write( _systemDual );
+				iData.write( stream );
+			}
+			void read( BinaryStream &stream )
+			{
+				unsigned char constrainsDCTerm;
+				if( !stream.read( constrainsDCTerm ) ) MK_THROW( "Failed to read constrainsDCTerm" );
+				_constrainsDCTerm = constrainsDCTerm!=0;
+				if( !stream.read( _constraintDual ) ) MK_THROW( "Failed to read _constraintDual" );
+				if( !stream.read( _systemDual ) ) MK_THROW( "Failed to read _systemDual" );
+				iData.read( stream );
+			}
+
+			ApproximatePointAndDataInterpolationInfo( BinaryStream &stream ){ read(stream); }
+
+			SparseNodeData< DualPointAndDataInfo< Dim , Real , Data , T , PointD > , ZeroUIntPack< Dim > > iData;
+
+		protected:
+
+			bool _constrainsDCTerm;
+			ConstraintDual _constraintDual;
+			SystemDual _systemDual;
+
+			void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount ){ iData._remapIndices( oldNodeIndices , newNodeCount ); }
+
+			ApproximatePointAndDataInterpolationInfo( void ){}
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< typename T , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct ExactPointInterpolationInfo : public InterpolationInfo< T , PointD >
+		{
+			void range( const FEMTreeNode *node , size_t &begin , size_t &end ) const { begin = _sampleSpan[ node->nodeData.nodeIndex ].first , end = _sampleSpan[ node->nodeData.nodeIndex ].second; }
+			bool constrainsDCTerm( void ) const { return _constrainsDCTerm; }
+			const DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIdx ) const { return _iData[ pointIdx ]; }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const { return _constraintDual( _iData[ pointIdx ].position ); }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< T , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( _iData[ pointIdx ].position , dValues ); }
+			typename std::enable_if< !std::is_same< T , double >::value , Point< double , CumulativeDerivatives< Dim , PointD >::Size > >::type operator() ( size_t pointIdx , const Point< double , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( _iData[ pointIdx ].position , dValues ); }
+
+			ExactPointInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _constraintDual( constraintDual ) , _systemDual( systemDual ) , _constrainsDCTerm( constrainsDCTerm ) { }
+		protected:
+			void _init( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , bool noRescale );
+
+			std::vector< std::pair< node_index_type , node_index_type > > _sampleSpan;
+			std::vector< DualPointInfo< Dim , Real , T , PointD > > _iData;
+			bool _constrainsDCTerm;
+			ConstraintDual _constraintDual;
+			SystemDual _systemDual;
+
+			void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount )
+			{
+				std::vector< std::pair< node_index_type , node_index_type > > _newSampleSpan( newNodeCount );
+				for( size_t i=0 ; i<newNodeCount ; i++ ) if( oldNodeIndices[i]!=-1 && oldNodeIndices[i]<(node_index_type)_sampleSpan.size() ) _newSampleSpan[i] = _sampleSpan[ oldNodeIndices[i] ];
+				_sampleSpan = _newSampleSpan;
+			}
+
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct ExactPointInterpolationInfo< double , PointD , ConstraintDual , SystemDual > : public InterpolationInfo< double , PointD >
+		{
+			typedef double T;
+			void range( const FEMTreeNode* node , size_t& begin , size_t& end ) const { begin = _sampleSpan[ node->nodeData.nodeIndex ].first , end = _sampleSpan[ node->nodeData.nodeIndex ].second; }
+			bool constrainsDCTerm( void ) const { return _constrainsDCTerm; }
+			const DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIdx ) const { return _iData[ pointIdx ]; }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const { return _constraintDual( _iData[ pointIdx ].position ); }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< T , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( _iData[ pointIdx ].position , dValues ); }
+
+			ExactPointInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _constraintDual( constraintDual ) , _systemDual( systemDual ) , _constrainsDCTerm( constrainsDCTerm ) { }
+		protected:
+			void _init( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , bool noRescale );
+
+			std::vector< std::pair< node_index_type , node_index_type > > _sampleSpan;
+			std::vector< DualPointInfo< Dim , Real , T , PointD > > _iData;
+			bool _constrainsDCTerm;
+			ConstraintDual _constraintDual;
+			SystemDual _systemDual;
+
+			void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount )
+			{
+				std::vector< std::pair< node_index_type , node_index_type > > _newSampleSpan( newNodeCount );
+				for( size_t i=0 ; i<newNodeCount ; i++ ) if( oldNodeIndices[i]!=-1 && oldNodeIndices[i]<(node_index_type)_sampleSpan.size() ) _newSampleSpan[i] = _sampleSpan[ oldNodeIndices[i] ];
+				_sampleSpan = _newSampleSpan;
+			}
+
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct _ExactPointAndDataInterpolationInfo : public InterpolationInfo< T , PointD >
+		{
+			_ExactPointAndDataInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _constraintDual( constraintDual ) , _systemDual( systemDual ) , _constrainsDCTerm( constrainsDCTerm ) { }
+
+		protected:
+			void _init( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , bool noRescale );
+
+			std::vector< std::pair< node_index_type , node_index_type > > _sampleSpan;
+			std::vector< DualPointAndDataInfo< Dim , Real , Data , T , PointD > > _iData;
+			bool _constrainsDCTerm;
+			ConstraintDual _constraintDual;
+			SystemDual _systemDual;
+
+			void _remapIndices( ConstPointer( node_index_type )oldNodeIndices , size_t newNodeCount )
+			{
+				std::vector< std::pair< node_index_type , node_index_type > > _newSampleSpan( newNodeCount );
+				for( size_t i=0 ; i<newNodeCount ; i++ ) if( oldNodeIndices[i]!=-1 && oldNodeIndices[i]<(node_index_type)_sampleSpan.size() ) _newSampleSpan[i] = _sampleSpan[ oldNodeIndices[i]  ];
+				_sampleSpan = _newSampleSpan;
+			}
+
+			friend class FEMTree< Dim , Real >;
+		};
+
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct ExactPointAndDataInterpolationInfo : public _ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >
+		{
+			using _ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >::_sampleSpan;
+			using _ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >::_constrainsDCTerm;
+			using _ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >::_iData;
+			using _ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >::_constraintDual;
+			using _ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >::_systemDual;
+			void range( const FEMTreeNode* node , size_t& begin , size_t& end ) const { begin = _sampleSpan[ node->nodeData.nodeIndex ].first , end = _sampleSpan[ node->nodeData.nodeIndex ].second; }
+			bool constrainsDCTerm( void ) const { return _constrainsDCTerm; }
+			const DualPointInfo< Dim , Real , T , PointD >& operator[]( size_t pointIdx ) const { return _iData[ pointIdx ].pointInfo; }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const { return _constraintDual( _iData[ pointIdx ].pointInfo.position , _iData[ pointIdx ].data ); }
+			Point< T , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< T , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( _iData[ pointIdx ].pointInfo.position , _iData[ pointIdx ].data , dValues ); }
+			Point< double , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< double , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( _iData[ pointIdx ].pointInfo.position , _iData[ (int)pointIdx ].data , dValues ); }
+
+			ExactPointAndDataInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >( constraintDual , systemDual , constrainsDCTerm ) { }
+		};
+
+		template< typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		struct ExactPointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual > : public _ExactPointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual >
+		{
+			using _ExactPointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual >::_sampleSpan;
+			using _ExactPointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual >::_constrainsDCTerm;
+			using _ExactPointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual >::_iData;
+			using _ExactPointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual >::_constraintDual;
+			using _ExactPointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual >::_systemDual;
+			void range( const FEMTreeNode* node , size_t& begin , size_t& end ) const { begin = _sampleSpan[ node->nodeData.nodeIndex ].first , end = _sampleSpan[ node->nodeData.nodeIndex ].second; }
+			bool constrainsDCTerm( void ) const { return _constrainsDCTerm; }
+			const DualPointInfo< Dim , Real , double , PointD >& operator[]( size_t pointIdx ) const { return _iData[ pointIdx ].pointInfo; }
+			Point< double , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx ) const { return _constraintDual( _iData[ pointIdx ].pointInfo.position , _iData[ pointIdx ].data ); }
+			Point< double , CumulativeDerivatives< Dim , PointD >::Size > operator() ( size_t pointIdx , const Point< double , CumulativeDerivatives< Dim , PointD >::Size >& dValues ) const { return _systemDual( _iData[ pointIdx ].pointInfo.position , _iData[ (int)pointIdx ].data , dValues ); }
+
+			ExactPointAndDataInterpolationInfo( ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm ) : _ExactPointAndDataInterpolationInfo< double , Data , PointD , ConstraintDual , SystemDual >( constraintDual , systemDual , constrainsDCTerm ) { }
+		};
+
+		template< typename T ,                 unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		static ApproximatePointInterpolationInfo< T ,            PointD , ConstraintDual , SystemDual >* InitializeApproximatePointInterpolationInfo( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm , LocalDepth maxDepth , int adaptiveExponent )
+		{
+			ApproximatePointInterpolationInfo< T , PointD , ConstraintDual , SystemDual >* a = new ApproximatePointInterpolationInfo< T , PointD , ConstraintDual , SystemDual >( constraintDual , systemDual , constrainsDCTerm );
+			a->iData = tree._densifyInterpolationInfoAndSetDualConstraints< T , PointD >( samples , constraintDual , maxDepth , adaptiveExponent );
+			return a;
+		}
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		static ApproximatePointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >* InitializeApproximatePointAndDataInterpolationInfo( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm , LocalDepth maxDepth , int adaptiveExponent )
+		{
+			ApproximatePointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >* a = new ApproximatePointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >( constraintDual , systemDual , constrainsDCTerm );
+			a->iData = tree._densifyInterpolationInfoAndSetDualConstraints< T , Data , PointD >( samples , sampleData , constraintDual , maxDepth , adaptiveExponent );
+			return a;
+		}
+
+		template< typename T , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		static ExactPointInterpolationInfo< T , PointD , ConstraintDual , SystemDual >* InitializeExactPointInterpolationInfo( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm , bool noRescale )
+		{
+			ExactPointInterpolationInfo< T , PointD , ConstraintDual , SystemDual >* e = new ExactPointInterpolationInfo< T , PointD , ConstraintDual , SystemDual >( constraintDual , systemDual , constrainsDCTerm );
+			e->_init( tree , samples , noRescale );
+			return e;
+		}
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		static ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >* InitializeExactPointAndDataInterpolationInfo( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , ConstraintDual constraintDual , SystemDual systemDual , bool constrainsDCTerm , bool noRescale )
+		{
+			ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >* e = new ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >( constraintDual , systemDual , constrainsDCTerm );
+			e->_init( tree , samples , sampleData , noRescale );
+			return e;
+		}
+
+		template< typename T , unsigned int PointD , typename ConstraintDual , typename SystemDual > friend struct ExactPointInterpolationInfo;
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual > friend struct ExactPointAndDataInterpolationInfo;
+
+		template< typename ... InterpolationInfos >
+		static bool ConstrainsDCTerm( std::tuple< InterpolationInfos *... > interpolationInfos ){ return _ConstrainsDCTerm< 0 >( interpolationInfos ); }
+	protected:
+		template< unsigned int Idx , typename ... InterpolationInfos >
+		static typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) , bool >::type _ConstrainsDCTerm( std::tuple< InterpolationInfos *... > interpolationInfos ){ return false; }
+		template< unsigned int Idx , typename ... InterpolationInfos >
+		static typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) , bool >::type _ConstrainsDCTerm( std::tuple< InterpolationInfos *... > interpolationInfos )
+		{
+			if(  std::get< Idx >( interpolationInfos ) ) return _ConstrainsDCTerm< Idx+1 >( interpolationInfos ) || std::get< Idx >( interpolationInfos )->constrainsDCTerm();
+			else                                         return _ConstrainsDCTerm< Idx+1 >( interpolationInfos );
+		}
+	public:
+
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] This should not be isotropic" )
+#endif // SHOW_WARNINGS
+		template< unsigned int DensityDegree > struct DensityEstimator : public SparseNodeData< Real , IsotropicUIntPack< Dim , FEMDegreeAndBType< DensityDegree >::Signature > >
+		{
+			DensityEstimator( int kernelDepth , int coDimension , Real samplesPerNode ) : _kernelDepth( kernelDepth ) , _coDimension( coDimension ) , _samplesPerNode( samplesPerNode ){ }
+			Real samplesPerNode( void ) const { return _samplesPerNode; }
+			int coDimension( void ) const { return _coDimension; }
+			int kernelDepth( void ) const { return _kernelDepth; }
+
+			void write( BinaryStream &stream ) const
+			{
+				stream.write( _kernelDepth );
+				stream.write( _coDimension );
+				stream.write( _samplesPerNode );
+				SparseNodeData< Real , IsotropicUIntPack< Dim , FEMDegreeAndBType< DensityDegree >::Signature > >::write( stream );
+			}
+			void read( BinaryStream &stream )
+			{
+				if( !stream.read( _kernelDepth ) ) MK_THROW( "Failed to read _kernelDepth" );
+				if( !stream.read( _coDimension ) ) MK_THROW( "Failed to read _coDimension" );
+				if( !stream.read( _samplesPerNode ) ) MK_THROW( "Failed to read _samplesPerNode" );
+				SparseNodeData< Real , IsotropicUIntPack< Dim , FEMDegreeAndBType< DensityDegree >::Signature > >::read( stream );
+			}
+			DensityEstimator( BinaryStream &stream ){ read(stream); }
+
+		protected:
+			Real _samplesPerNode;
+			int _kernelDepth , _coDimension;
+		};
+
+	protected:
+		bool _isValidSpaceNode( const FEMTreeNode* node ) const { return !GetGhostFlag< Dim >( node ) && ( node->nodeData.flags & FEMTreeNodeData::SPACE_FLAG ); }
+		bool _isValidFEM1Node ( const FEMTreeNode* node ) const { return !GetGhostFlag< Dim >( node ) && ( node->nodeData.flags & FEMTreeNodeData::FEM_FLAG_1 ); }
+		bool _isValidFEM2Node ( const FEMTreeNode* node ) const { return !GetGhostFlag< Dim >( node ) && ( node->nodeData.flags & FEMTreeNodeData::FEM_FLAG_2 ); }
+
+		FEMTreeNode _tree;
+		mutable FEMTreeNode* _spaceRoot;
+		SortedTreeNodes< Dim > _sNodes;
+		LocalDepth _maxDepth;
+		int _depthOffset;
+		LocalDepth _baseDepth;
+#ifdef USE_EXACT_PROLONGATION
+		LocalDepth _exactDepth;
+#endif // USE_EXACT_PROLONGATION
+		mutable unsigned int _femSigs1[ Dim ];
+		mutable unsigned int _femSigs2[ Dim ];
+		void _init( void );
+
+		static bool _InBounds( Point< Real , Dim > p );
+		int _localToGlobal( LocalDepth d ) const { return d + _depthOffset; }
+		LocalDepth _globalToLocal( int d ) const { return d - _depthOffset; }
+		LocalDepth _localDepth( const FEMTreeNode* node ) const { return node->depth() - _depthOffset; }
+		int _localInset( LocalDepth d ) const { return _depthOffset==0 ? 0 : 1<<( d + _depthOffset - 1 ); }
+		void _localDepthAndOffset( const FEMTreeNode* node , LocalDepth& d , LocalOffset& off ) const
+		{
+			node->depthAndOffset( d , off );
+			d -= _depthOffset;
+			if( d<0 ) for( int d=0 ; d<Dim ; d++ ) off[d] = -1;
+			else
+			{
+				int inset = _localInset( d );
+				for( int d=0 ; d<Dim ; d++ ) off[d] -= inset;
+			}
+		}
+		template< unsigned int FEMSig > static int _BSplineBegin( LocalDepth depth ){ return BSplineEvaluationData< FEMSig >::Begin( depth ); }
+		template< unsigned int FEMSig > static int _BSplineEnd  ( LocalDepth depth ){ return BSplineEvaluationData< FEMSig >::End  ( depth ); }
+		template< unsigned int ... FEMSigs >
+		bool _outOfBounds( UIntPack< FEMSigs ... > , const FEMTreeNode* node ) const
+		{
+			if( !node ) return true;
+			LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node , d , off );
+			return FEMIntegrator::IsOutOfBounds( UIntPack< FEMSigs ... >() , d , off );
+		}
+		node_index_type _sNodesBegin( LocalDepth d )             const { return _sNodes.begin( _localToGlobal( d ) ); }
+		node_index_type _sNodesBegin( LocalDepth d , int slice ) const { return _sNodes.begin( _localToGlobal( d ) , slice + _localInset( d ) ); }
+		node_index_type _sNodesBeginSlice( LocalDepth d )        const { return _localInset(d); }
+		node_index_type _sNodesEnd( LocalDepth d )             const { return _sNodes.end  ( _localToGlobal( d ) ); }
+		node_index_type _sNodesEnd( LocalDepth d , int slice ) const { return _sNodes.end  ( _localToGlobal( d ) , slice + _localInset( d ) ); }
+		node_index_type _sNodesEndSlice( LocalDepth d ) const{ return ( 1<<_localToGlobal(d) ) - _localInset(d) - 1; }
+		size_t _sNodesSize( LocalDepth d )             const { return _sNodes.size( _localToGlobal( d ) ); }
+		size_t _sNodesSize( LocalDepth d , int slice ) const { return _sNodes.size( _localToGlobal( d ) , slice + _localInset( d ) ); }
+
+		template< unsigned int ... FEMDegrees > static bool _IsSupported( UIntPack< FEMDegrees ... > , LocalDepth femDepth , const LocalOffset femOffset , LocalDepth spaceDepth , const LocalOffset spaceOffset){ return BaseFEMIntegrator::IsSupported( UIntPack< FEMDegrees ... >() , femDepth , femOffset , spaceDepth , spaceOffset ); }
+		template< unsigned int ... FEMDegrees > bool _isSupported( UIntPack< FEMDegrees ... > , const FEMTreeNode *femNode , const FEMTreeNode *spaceNode ) const
+		{
+			if( !femNode || !spaceNode ) return false;
+			LocalDepth femDepth , spaceDepth ; LocalOffset femOffset , spaceOffset;
+			_localDepthAndOffset( femNode , femDepth , femOffset ) , _localDepthAndOffset( spaceNode , spaceDepth , spaceOffset );
+			return _IsSupported( UIntPack< FEMDegrees ... >() , femDepth , femOffset , spaceDepth , spaceOffset );
+		}
+
+		template< unsigned int FEMDegree > static bool _IsInteriorlySupported( LocalDepth depth , const LocalOffset off )
+		{
+			if( depth>=0 )
+			{
+				int begin , end;
+				BSplineSupportSizes< FEMDegree >::InteriorSupportedSpan( depth , begin , end );
+				bool interior = true;
+				for( int dd=0 ; dd<Dim ; dd++ ) interior &= off[dd]>=begin && off[dd]<end;
+				return interior;
+			}
+			else return false;
+		}
+
+		template< unsigned int FEMDegree > bool _isInteriorlySupported( const FEMTreeNode* node ) const
+		{
+			if( !node ) return false;
+			LocalDepth d ; LocalOffset off;
+			_localDepthAndOffset( node , d , off );
+			return _IsInteriorlySupported< FEMDegree >( d , off );
+		}
+		template< unsigned int ... FEMDegrees > static bool _IsInteriorlySupported( UIntPack< FEMDegrees ... > , LocalDepth depth , const LocalOffset off ){ return BaseFEMIntegrator::IsInteriorlySupported( UIntPack< FEMDegrees ... >() , depth , off ); }
+		template< unsigned int ... FEMDegrees > bool _isInteriorlySupported( UIntPack< FEMDegrees ... > , const FEMTreeNode* node ) const
+		{
+			if( !node ) return false;
+			LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node , d , off );
+			return _IsInteriorlySupported< FEMDegrees ... >( UIntPack< FEMDegrees ... >() , d , off );
+		}
+		template< unsigned int FEMDegree1 , unsigned int FEMDegree2 > static bool _IsInteriorlyOverlapped( LocalDepth depth , const LocalOffset off )
+		{
+			if( depth>=0 )
+			{
+				int begin , end;
+				BSplineIntegrationData< FEMDegreeAndBType< FEMDegree1 , BOUNDARY_NEUMANN >::Signature , FEMDegreeAndBType< FEMDegree2 , BOUNDARY_NEUMANN >::Signature >::InteriorOverlappedSpan( depth , begin , end );
+				bool interior = true;
+				for( int dd=0 ; dd<Dim ; dd++ ) interior &= off[dd]>=begin && off[dd]<end;
+				return interior;
+			}
+			else return false;
+		}
+
+		template< unsigned int FEMDegree1 , unsigned int FEMDegree2 > bool _isInteriorlyOverlapped( const FEMTreeNode* node ) const
+		{
+			if( !node ) return false;
+			LocalDepth d ; LocalOffset off;
+			_localDepthAndOffset( node , d , off );
+			return _IsInteriorlyOverlapped< FEMDegree1 , FEMDegree2 >( d , off );
+		}
+		template< unsigned int ... FEMDegrees1 , unsigned int ... FEMDegrees2 > static bool _IsInteriorlyOverlapped( UIntPack< FEMDegrees1 ... > , UIntPack< FEMDegrees2 ... > , LocalDepth depth , const LocalOffset off ){ return BaseFEMIntegrator::IsInteriorlyOverlapped( UIntPack< FEMDegrees1 ... >() , UIntPack< FEMDegrees2 ... >() , depth , off ); }
+		template< unsigned int ... FEMDegrees1 , unsigned int ... FEMDegrees2 > bool _isInteriorlyOverlapped( UIntPack< FEMDegrees1 ... > , UIntPack< FEMDegrees2 ... > , const FEMTreeNode* node ) const
+		{
+			if( !node ) return false;
+			LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node , d , off );
+			return _IsInteriorlyOverlapped( UIntPack< FEMDegrees1 ... >() , UIntPack< FEMDegrees2 ... >() , d , off );
+		}
+
+		void _startAndWidth( const FEMTreeNode* node , Point< Real , Dim >& start , Real& width ) const
+		{
+			LocalDepth d ; LocalOffset off;
+			_localDepthAndOffset( node , d , off );
+			if( d>=0 ) width = Real( 1.0 / (1<<  d ) );
+			else       width = Real( 1.0 * (1<<(-d)) );
+			for( int dd=0 ; dd<Dim ; dd++ ) start[dd] = Real( off[dd] ) * width;
+		}
+
+		void _centerAndWidth( const FEMTreeNode* node , Point< Real , Dim >& center , Real& width ) const
+		{
+			int d , off[Dim];
+			_localDepthAndOffset( node , d , off );
+			width = Real( 1.0 / (1<<d) );
+			for( int dd=0 ; dd<Dim ; dd++ ) center[dd] = Real( off[dd] + 0.5 ) * width;
+		}
+
+		int _childIndex( const FEMTreeNode* node , Point< Real , Dim > p ) const
+		{
+			Point< Real , Dim > c ; Real w;
+			_centerAndWidth( node , c , w );
+			int cIdx = 0;
+			for( int d=0 ; d<Dim ; d++ ) if( p[d]>=c[d] ) cIdx |= (1<<d);
+			return cIdx;
+		}
+
+		template< bool ThreadSafe , unsigned int ... Degrees > void _setFullDepth( UIntPack< Degrees ... > , Allocator< FEMTreeNode > *nodeAllocator , FEMTreeNode* node , LocalDepth depth );
+		template< bool ThreadSafe , unsigned int ... Degrees > void _setFullDepth( UIntPack< Degrees ... > , Allocator< FEMTreeNode > *nodeAllocator , LocalDepth depth );
+		template< unsigned int ... Degrees > LocalDepth _getFullDepth( UIntPack< Degrees ... > , const FEMTreeNode* node ) const;
+		template< unsigned int ... Degrees > LocalDepth _getFullDepth( UIntPack< Degrees ... > , const LocalDepth depth , const LocalOffset begin , const LocalOffset end , const FEMTreeNode *node ) const;
+
+		template< bool ThreadSafe , typename AddNodeFunctor , unsigned int ... Degrees > void _refine( UIntPack< Degrees ... > , Allocator< FEMTreeNode > *nodeAllocator , const AddNodeFunctor &addNodeFunctor , FEMTreeNode *node );
+		template< bool ThreadSafe , typename AddNodeFunctor , unsigned int ... Degrees > void _refine( UIntPack< Degrees ... > , Allocator< FEMTreeNode > *nodeAllocator , const AddNodeFunctor &addNodeFunctor );
+
+	public:
+		template< unsigned int ... Degrees > LocalDepth getFullDepth( UIntPack< Degrees ... > ) const;
+		template< unsigned int ... Degrees > LocalDepth getFullDepth( UIntPack< Degrees ... > , const LocalDepth depth , const LocalOffset begin , const LocalOffset end ) const;
+
+		LocalDepth depth( const FEMTreeNode* node ) const { return _localDepth( node ); }
+		void depthAndOffset( const FEMTreeNode* node , LocalDepth& depth , LocalOffset& offset ) const { _localDepthAndOffset( node , depth , offset ); }
+
+		size_t nodesSize( void ) const { return _sNodes.size(); }
+		node_index_type nodesBegin( LocalDepth d ) const { return _sNodes.begin( _localToGlobal( d ) ); }
+		node_index_type nodesEnd  ( LocalDepth d ) const { return _sNodes.end  ( _localToGlobal( d ) ); }
+		size_t nodesSize ( LocalDepth d ) const { return _sNodes.size ( _localToGlobal( d ) ); }
+		node_index_type nodesBegin( LocalDepth d , int slice ) const { return _sNodes.begin( _localToGlobal( d ) , slice + _localInset( d ) ); }
+		node_index_type nodesEnd  ( LocalDepth d , int slice ) const { return _sNodes.end  ( _localToGlobal( d ) , slice + _localInset( d ) ); }
+		size_t nodesSize ( LocalDepth d , int slice ) const { return _sNodes.size ( _localToGlobal( d ) , slice + _localInset( d ) ); }
+		const FEMTreeNode* node( node_index_type idx ) const { return _sNodes.treeNodes[idx]; }
+		void centerAndWidth( node_index_type idx , Point< Real , Dim >& center , Real& width ) const { _centerAndWidth( _sNodes.treeNodes[idx] , center , width ); }
+		void  startAndWidth( node_index_type idx , Point< Real , Dim >& center , Real& width ) const {  _startAndWidth( _sNodes.treeNodes[idx] , center , width ); }
+		void centerAndWidth( const FEMTreeNode* node , Point< Real , Dim >& center , Real& width ) const { _centerAndWidth( node , center , width ); }
+		void  startAndWidth( const FEMTreeNode* node , Point< Real , Dim >& start  , Real& width ) const {  _startAndWidth( node , start  , width ); }
+
+	protected:
+		/////////////////////////////////////
+		// System construction code        //
+		// MultiGridFEMTreeData.System.inl //
+		/////////////////////////////////////
+	public:
+		template< unsigned int ... FEMSigs > void setMultiColorIndices( UIntPack< FEMSigs ... > , int depth , std::vector< std::vector< size_t > >& indices ) const;
+	protected:
+		template< unsigned int ... FEMSigs > void _setMultiColorIndices( UIntPack< FEMSigs ... > , node_index_type start , node_index_type end , std::vector< std::vector< size_t > >& indices ) const;
+
+		struct _SolverStats
+		{
+			double constraintUpdateTime , systemTime , solveTime;
+			double bNorm2 , inRNorm2 , outRNorm2;
+		};
+
+		// For some reason MSVC has trouble determining the template parameters when using:
+		//		template< unsigned int Idx , unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		template< unsigned int Idx , typename UIntPackFEMSigs , typename StaticWindow , typename ConstNeighbors , typename PointEvaluator , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) >::type _addPointValues( UIntPackFEMSigs , StaticWindow &pointValues , const ConstNeighbors &neighbors , const PointEvaluator &bsData , std::tuple< InterpolationInfos *... > interpolationInfos ) const {}
+		template< unsigned int Idx , typename UIntPackFEMSigs , typename StaticWindow , typename ConstNeighbors , typename PointEvaluator , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) >::type _addPointValues( UIntPackFEMSigs , StaticWindow &pointValues , const ConstNeighbors &neighbors , const PointEvaluator &bsData , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			_addPointValues( UIntPackFEMSigs() , pointValues , neighbors , bsData , std::get< Idx >( interpolationInfos ) );
+			_addPointValues< Idx+1 >( UIntPackFEMSigs() , pointValues , neighbors , bsData , interpolationInfos );
+		}
+		template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+		void _addPointValues( UIntPack< FEMSigs ... > , StaticWindow< Real , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pointValues , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , const InterpolationInfo< T , PointD >* interpolationInfo ) const;
+
+		template< unsigned int Idx , typename UIntPackFEMSigs , typename WindowSlice , typename ConstNeighbors , typename PointEvaluator , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) >::type _addProlongedPointValues( UIntPackFEMSigs , WindowSlice pointValues , const ConstNeighbors &neighbors , const ConstNeighbors &pNeighbors , const PointEvaluator &bsData , std::tuple< InterpolationInfos *... > interpolationInfos ) const {}
+		template< unsigned int Idx , typename UIntPackFEMSigs , typename WindowSlice , typename ConstNeighbors , typename PointEvaluator , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) >::type _addProlongedPointValues( UIntPackFEMSigs , WindowSlice pointValues , const ConstNeighbors &neighbors , const ConstNeighbors &pNeighbors , const PointEvaluator&bsData , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			_addProlongedPointValues( UIntPackFEMSigs() , pointValues , neighbors , pNeighbors , bsData , std::get< Idx >( interpolationInfos ) );
+			_addProlongedPointValues< Idx+1 >( UIntPackFEMSigs() , pointValues , neighbors , pNeighbors , bsData , interpolationInfos );
+		}
+		template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+		void _addProlongedPointValues( UIntPack< FEMSigs ... > , WindowSlice< Real , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > > pointValues , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , const InterpolationInfo< T , PointD >* iInfo ) const;
+
+		template< unsigned int Idx , typename PointEvaluator , typename T , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) >::type _setPointValuesFromProlongedSolution( LocalDepth highDepth , const PointEvaluator &bsData , ConstPointer( T ) prolongedSolution , std::tuple< InterpolationInfos *... > interpolationInfos ) const {}
+		template< unsigned int Idx , typename PointEvaluator , typename T , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) >::type _setPointValuesFromProlongedSolution( LocalDepth highDepth , const PointEvaluator &bsData , ConstPointer( T ) prolongedSolution , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			_setPointValuesFromProlongedSolution( highDepth , bsData , prolongedSolution , std::get< Idx >( interpolationInfos ) );
+			_setPointValuesFromProlongedSolution< Idx+1 >( highDepth , bsData , prolongedSolution , interpolationInfos );
+		}
+		template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+		void _setPointValuesFromProlongedSolution( LocalDepth highDepth , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , ConstPointer( T ) prolongedSolution , InterpolationInfo< T , PointD >* interpolationInfo ) const;
+
+		template< unsigned int Idx , typename ConstNeighbors , typename T , typename PointEvaluator , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) , T >::type _getInterpolationConstraintFromProlongedSolution( const ConstNeighbors &neighbors , const FEMTreeNode* node , ConstPointer( T ) prolongedSolution , const PointEvaluator &bsData , std::tuple< InterpolationInfos ... > interpolationInfos ) const { return T{}; }
+		template< unsigned int Idx , typename ConstNeighbors , typename T , typename PointEvaluator , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) , T >::type _getInterpolationConstraintFromProlongedSolution( const ConstNeighbors &neighbors , const FEMTreeNode* node , ConstPointer( T ) prolongedSolution , const PointEvaluator &bsData , std::tuple< InterpolationInfos ... > interpolationInfos ) const
+		{
+			return
+				_getInterpolationConstraintFromProlongedSolution( neighbors , node , prolongedSolution , bsData , std::get< Idx >( interpolationInfos ) ) +
+				_getInterpolationConstraintFromProlongedSolution< Idx+1 >( neighbors , node , prolongedSolution , bsData , interpolationInfos );
+		}
+		template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+		T _getInterpolationConstraintFromProlongedSolution( const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const FEMTreeNode* node , ConstPointer( T ) prolongedSolution , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , const InterpolationInfo< T , PointD >* iInfo ) const;
+
+		template< unsigned int Idx , typename PointEvaluator , typename T , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) >::type _updateRestrictedInterpolationConstraints( const PointEvaluator &bsData , LocalDepth highDepth , ConstPointer( T ) solution , Pointer( T ) cumulativeConstraints , std::tuple< InterpolationInfos ... > interpolationInfos ) const {}
+		template< unsigned int Idx , typename PointEvaluator , typename T , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) >::type _updateRestrictedInterpolationConstraints( const PointEvaluator &bsData , LocalDepth highDepth , ConstPointer( T ) solution , Pointer( T ) cumulativeConstraints , std::tuple< InterpolationInfos ... > interpolationInfos ) const
+		{
+			_updateRestrictedInterpolationConstraints( bsData , highDepth , solution , cumulativeConstraints , std::get< Idx >( interpolationInfos ) );
+			_updateRestrictedInterpolationConstraints< Idx+1 >( bsData , highDepth , solution , cumulativeConstraints , interpolationInfos );
+		}
+		template< unsigned int ... FEMSigs , typename T , unsigned int PointD >
+		void _updateRestrictedInterpolationConstraints( const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth highDepth , ConstPointer( T ) solution , Pointer( T ) cumulativeConstraints , const InterpolationInfo< T , PointD >* interpolationInfo ) const;
+
+		template< unsigned int FEMDegree1 , unsigned int FEMDegree2 > static void _SetParentOverlapBounds( const FEMTreeNode* node , int start[Dim] , int end[Dim] );
+		template< unsigned int FEMDegree1 , unsigned int FEMDegree2 > static void _SetParentOverlapBounds( int cIdx , int start[Dim] , int end[Dim] );
+		template< unsigned int ... FEMDegrees1 , unsigned int ... FEMDegrees2 > static void _SetParentOverlapBounds( UIntPack< FEMDegrees1 ... > , UIntPack< FEMDegrees2 ... > , const FEMTreeNode* node , int start[Dim] , int end[Dim] )
+		{
+			if( node )
+			{
+				int d , off[Dim] ; node->depthAndOffset( d , off );
+				BaseFEMIntegrator::ParentOverlapBounds( UIntPack< FEMDegrees1 ... >() , UIntPack< FEMDegrees2 ... >() , d , off , start , end );
+			}
+		}
+		template< unsigned int ... FEMDegrees1 , unsigned int ... FEMDegrees2 > static void _SetParentOverlapBounds( UIntPack< FEMDegrees1 ... > , UIntPack< FEMDegrees2 ... > , int cIdx , int start[Dim] , int end[Dim] )
+		{
+			BaseFEMIntegrator::ParentOverlapBounds( UIntPack< FEMDegrees1 ... >() , UIntPack< FEMDegrees2 ... >() , cIdx , start , end );
+		}
+
+		template< unsigned int ... FEMSigs >
+		int _getProlongedMatrixRowSize( const FEMTreeNode* node , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors ) const;
+		template< typename T , unsigned int ... FEMSigs , typename ... InterpolationInfos , typename MatrixType >
+		T _setMatrixRowAndGetConstraintFromProlongation( UIntPack< FEMSigs ... > , const BaseSystem< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , size_t idx , MatrixType &M , node_index_type offset , const PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& pcStencils , const CCStencil< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& ccStencil , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , ConstPointer( T ) prolongedSolution , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+		template< typename T , unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		int _setProlongedMatrixRow( const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors , Pointer( MatrixEntry< Real , matrix_index_type > ) row , node_index_type offset , const DynamicWindow< double , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& stencil , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+
+		// Updates the constraints @(depth) based on the solution coefficients @(depth-1)
+		template< unsigned int ... FEMSigs , typename T , typename ... InterpolationInfos >
+		T _getConstraintFromProlongedSolution( UIntPack< FEMSigs ... > , const BaseSystem< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& neighbors , const typename FEMTreeNode::template ConstNeighbors< UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& pNeighbors , const FEMTreeNode* node , ConstPointer( T ) prolongedSolution , const DynamicWindow< double , UIntPack< BSplineOverlapSizes< FEMSignature< FEMSigs >::Degree >::OverlapSize ... > >& stencil , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+
+		template< unsigned int ... FEMSigs , typename T , typename TDotT , typename SORWeights , typename ... InterpolationInfos >
+		int _solveFullSystemGS( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , Pointer( T ) solution , ConstPointer( T ) prolongedSolution , ConstPointer( T ) constraints , TDotT Dot , int iters , bool coarseToFine , SORWeights sorWeights , _SolverStats& stats , bool computeNorms , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+		template< unsigned int ... FEMSigs , typename T , typename TDotT , typename SORWeights , typename ... InterpolationInfos >
+		int _solveSlicedSystemGS( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , Pointer( T ) solution , ConstPointer( T ) prolongedSolution , ConstPointer( T ) constraints , TDotT Dot , int iters , bool coarseToFine , unsigned int sliceBlockSize , SORWeights sorWeights , _SolverStats& stats , bool computeNorms , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+		template< unsigned int ... FEMSigs , typename T , typename TDotT , typename SORWeights , typename ... InterpolationInfos >
+		int _solveSystemGS( UIntPack< FEMSigs ... > , bool sliced , const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , Pointer( T ) solution , ConstPointer( T ) prolongedSolution , ConstPointer( T ) constraints , TDotT Dot , int iters , bool coarseToFine , unsigned int sliceBlockSize , SORWeights sorWeights , _SolverStats& stats , bool computeNorms , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			if( sliced ) return _solveSlicedSystemGS( UIntPack< FEMSigs ... >() , F , bsData , depth , solution , prolongedSolution , constraints , Dot , iters , coarseToFine , sliceBlockSize , sorWeights , stats , computeNorms , interpolationInfos );
+			else         return _solveFullSystemGS  ( UIntPack< FEMSigs ... >() , F , bsData , depth , solution , prolongedSolution , constraints , Dot , iters , coarseToFine ,                  sorWeights , stats , computeNorms , interpolationInfos );
+		}
+		template< unsigned int ... FEMSigs , typename T , typename TDotT , typename ... InterpolationInfos >
+		int _solveSystemCG( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , Pointer( T ) solution , ConstPointer( T ) prolongedSolution , ConstPointer( T ) constraints , TDotT Dot , int iters , bool coarseToFine , _SolverStats& stats , bool computeNorms , double cgAccuracy , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+		template< unsigned int ... FEMSigs , typename T , typename TDotT , typename ... InterpolationInfos >
+		void _solveRegularMG( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , Pointer( T ) solution , ConstPointer( T ) constraints , TDotT Dot , int vCycles , int iters , _SolverStats& stats , bool computeNorms , double cgAccuracy , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+
+		// Updates the cumulative integral constraints @(depth-1) based on the change in solution coefficients @(depth)
+		template< unsigned int ... FEMSigs , typename T >
+		void _updateRestrictedIntegralConstraints( UIntPack< FEMSigs ... > , const typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , LocalDepth highDepth , ConstPointer( T ) solution , Pointer( T ) cumulativeConstraints ) const;
+
+		template< unsigned int PointD , typename T , unsigned int ... FEMSigs >
+		CumulativeDerivativeValues< T , Dim , PointD > _coarserFunctionValues( UIntPack< FEMSigs ... > , Point< Real , Dim > p , const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , ConstPointer( T ) coefficients ) const;
+		template< unsigned int PointD , typename T , unsigned int ... FEMSigs >
+		CumulativeDerivativeValues< T , Dim , PointD >   _finerFunctionValues( UIntPack< FEMSigs ... > , Point< Real , Dim > p , const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , ConstPointer( T ) coefficients ) const;
+
+		template< unsigned int ... FEMSigs , typename T , typename ... InterpolationInfos >
+		int _getSliceMatrixAndProlongationConstraints( UIntPack< FEMSigs ... > , const BaseSystem< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , SystemMatrixType< FEMSigs ... > &matrix , Pointer( Real ) diagonalR , const PointEvaluator< UIntPack< FEMSigs ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >& bsData , LocalDepth depth , node_index_type nBegin , node_index_type nEnd , ConstPointer( T ) prolongedSolution , Pointer( T ) constraints , const CCStencil < UIntPack< FEMSignature< FEMSigs >::Degree ... > >& ccStencil , const PCStencils< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& pcStencils , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+
+		// Down samples constraints @(depth) to constraints @(depth-1)
+		template< class C , typename ArrayWrapper , unsigned ... Degrees , unsigned int ... FEMSigs > void _downSample( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< Degrees ... > >& RP , LocalDepth highDepth , ArrayWrapper finerConstraints , Pointer( C ) coarserConstraints ) const;
+		// Up samples coefficients @(depth-1) to coefficients @(depth)
+		template< class C , typename ArrayWrapper , unsigned ... Degrees , unsigned int ... FEMSigs > void   _upSample( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template RestrictionProlongation< UIntPack< Degrees ... > >& RP , LocalDepth highDepth , ArrayWrapper coarserCoefficients , Pointer( C ) finerCoefficients ) const;
+
+		template< unsigned int ... FEMSigs , typename ValidNodeFunctor >
+		SparseMatrix< Real , matrix_index_type > _downSampleMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth , ValidNodeFunctor validNodeFunctor ) const;
+		template< unsigned int ... FEMSigs , typename ValidNodeFunctor >
+		SparseMatrix< Real , matrix_index_type > _upSampleMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth , ValidNodeFunctor validNodeFunctor ) const;
+		template< unsigned int ... FEMSigs , typename ValidNodeFunctor >
+		SparseMatrix< Real , matrix_index_type > _restrictSystemMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth , const SparseMatrix< Real , matrix_index_type > &M , ValidNodeFunctor validNodeFunctor ) const;
+
+		template< bool XMajor , class C , unsigned int ... FEMSigs > static void _RegularGridUpSample( UIntPack< FEMSigs ... > ,                                                                                           LocalDepth highDepth , ConstPointer( C ) lowCoefficients , Pointer( C ) highCoefficients );
+		template< bool XMajor , class C , unsigned int ... FEMSigs > static void _RegularGridUpSample( UIntPack< FEMSigs ... > , const int lowBegin[] , const int lowEnd[] , const int highBegin[] , const int highEnd[] , LocalDepth highDepth , ConstPointer( C ) lowCoefficients , Pointer( C ) highCoefficients );
+	public:
+		template< class C , unsigned int ... FEMSigs > DenseNodeData< C , UIntPack< FEMSigs ... > > coarseCoefficients( const  DenseNodeData< C , UIntPack< FEMSigs ... > >& coefficients ) const;
+		template< class C , unsigned int ... FEMSigs > DenseNodeData< C , UIntPack< FEMSigs ... > > coarseCoefficients( const SparseNodeData< C , UIntPack< FEMSigs ... > >& coefficients ) const;
+		template< class C , unsigned int ... FEMSigs > DenseNodeData< C , UIntPack< FEMSigs ... > > denseCoefficients( const SparseNodeData< C , UIntPack< FEMSigs ... > >& coefficients ) const;
+
+		void trimToDepth( LocalDepth coarseDepth );
+
+		template< class C , unsigned int ... FEMSigs >  DenseNodeData< C , UIntPack< FEMSigs ... > > trimToDepth( const  DenseNodeData< C , UIntPack< FEMSigs ... > >& coefficients , LocalDepth coarseDepth ) const;
+		template< class C , unsigned int ... FEMSigs > SparseNodeData< C , UIntPack< FEMSigs ... > > trimToDepth( const SparseNodeData< C , UIntPack< FEMSigs ... > >& coefficients , LocalDepth coarseDepth ) const;
+
+		template< typename T , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		ApproximatePointInterpolationInfo< T , PointD , ConstraintDual , SystemDual > trimToDepth( const ApproximatePointInterpolationInfo< T , PointD , ConstraintDual , SystemDual > &iInfo , LocalDepth coarseDepth ) const;
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+		ApproximatePointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual > trimToDepth( const ApproximatePointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual > &iInfo , LocalDepth coarseDepth ) const;
+
+		// For each (valid) fem node, compute the ratio of the sum of active prolongation weights to the sum of total prolongation weights
+		// If the prolongToChildren flag is set, then these weights are pushed to the children by computing the ratio of the prolongation of the above weights to the prolongation of unity weights 
+
+		template< unsigned int ... FEMSigs > DenseNodeData< Real , UIntPack< FEMSigs ... > > supportWeights( UIntPack< FEMSigs ... > ) const;
+		template< unsigned int ... FEMSigs > DenseNodeData< Real , UIntPack< FEMSigs ... > > prolongationWeights( UIntPack< FEMSigs ... > , bool prolongToChildren ) const;
+
+	protected:
+
+		//////////////////////////////////////////////
+		// Code for splatting point-sample data     //
+		// MultiGridFEMTreeData.WeightedSamples.inl //
+		//////////////////////////////////////////////
+		template< unsigned int CoDim , unsigned int Degree >
+		Real _GetScaleValue( unsigned int res ) const;
+		template< unsigned int CoDim , unsigned int Degree >
+		Real _GetScaleValue( Point< Real , Dim > p ) const;
+		template< bool ThreadSafe , unsigned int CoDim , unsigned int WeightDegree >
+		void _addWeightContribution( Allocator< FEMTreeNode > *nodeAllocator , DensityEstimator< WeightDegree >& densityWeights , FEMTreeNode* node , Point< Real , Dim > position , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , Real weight=Real(1.0) );
+		template< unsigned int WeightDegree , class PointSupportKey >
+		Real _getSamplesPerNode( const DensityEstimator< WeightDegree >& densityWeights , const FEMTreeNode* node , Point< Real , Dim > position , PointSupportKey& weightKey ) const;
+		template< unsigned int WeightDegree , class WeightKey >
+		void _getSampleDepthAndWeight( const DensityEstimator< WeightDegree >& densityWeights , const FEMTreeNode* node , Point< Real , Dim > position , WeightKey& weightKey , Real& depth , Real& weight ) const;
+		template< unsigned int WeightDegree , class WeightKey >
+		void _getSampleDepthAndWeight( const DensityEstimator< WeightDegree >& densityWeights ,                           Point< Real , Dim > position , WeightKey& weightKey , Real& depth , Real& weight ) const;
+
+		template< bool CreateNodes , bool ThreadSafe ,                             class V , unsigned int ... DataSigs > void                   _splatPointData( V zero , Allocator< FEMTreeNode > *nodeAllocator ,                                                          FEMTreeNode* node   , Point< Real , Dim > point , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& data ,                                                                         PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey );
+		template< bool CreateNodes , bool ThreadSafe , unsigned int WeightDegree , class V , unsigned int ... DataSigs > Point< Real , 2 >      _splatPointData( V zero , Allocator< FEMTreeNode > *nodeAllocator , const DensityEstimator< WeightDegree >& densityWeights , Real minDepthCutoff , Point< Real , Dim > point , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& data , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , LocalDepth minDepth , LocalDepth maxDepth , int dim , Real depthBias );
+		template< bool CreateNodes , bool ThreadSafe , unsigned int WeightDegree , class V , unsigned int ... DataSigs > Point< Real , 2 >      _splatPointData( V zero , Allocator< FEMTreeNode > *nodeAllocator , const DensityEstimator< WeightDegree >& densityWeights , Real minDepthCutoff , Point< Real , Dim > point , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& data , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , LocalDepth minDepth , std::function< int ( Point< Real , Dim > ) > &pointDepthFunctor , int dim , Real depthBias );
+		template< bool CreateNodes , bool ThreadSafe , unsigned int WeightDegree , class V , unsigned int ... DataSigs > Point< Real , 2 > _multiSplatPointData( V zero , Allocator< FEMTreeNode > *nodeAllocator , const DensityEstimator< WeightDegree >* densityWeights , FEMTreeNode* node   , Point< Real , Dim > point , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& data , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , int dim );
+		template<                                      unsigned int WeightDegree , class V , unsigned int ... DataSigs > Real       _nearestMultiSplatPointData( V zero ,                                           const DensityEstimator< WeightDegree >* densityWeights , FEMTreeNode* node   , Point< Real , Dim > point , V v , SparseNodeData< V , UIntPack< DataSigs ... > >& data , PointSupportKey< IsotropicUIntPack< Dim , WeightDegree > >& weightKey , int dim=Dim );
+		template< class V , class Coefficients , unsigned int D , unsigned int ... DataSigs >
+		void _addEvaluation( const Coefficients& coefficients , Point< Real , Dim > p ,                         const PointEvaluator< UIntPack< DataSigs ... > , IsotropicUIntPack< Dim , D > >& pointEvaluator , const ConstPointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , V &value ) const;
+		template< class V , class Coefficients , unsigned int D , unsigned int ... DataSigs >
+		void _addEvaluation( const Coefficients& coefficients , Point< Real , Dim > p , LocalDepth pointDepth , const PointEvaluator< UIntPack< DataSigs ... > , IsotropicUIntPack< Dim , D > >& pointEvaluator , const ConstPointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , V &value ) const;
+		template< typename V , typename Coefficients , unsigned int D , typename AccumulationFunctor /*=std::function< void ( const V & , Real s ) > */ , unsigned int ... DataSigs >
+		void _accumulate( const Coefficients& coefficients , Point< Real , Dim > p ,                         const PointEvaluator< UIntPack< DataSigs ... > , IsotropicUIntPack< Dim , D > >& pointEvaluator , const ConstPointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , AccumulationFunctor &AF ) const;
+		template< typename V , typename Coefficients , unsigned int D , typename AccumulationFunctor /*=std::function< void ( const V & , Real s ) > */ , unsigned int ... DataSigs >
+		void _accumulate( const Coefficients& coefficients , Point< Real , Dim > p , LocalDepth pointDepth , const PointEvaluator< UIntPack< DataSigs ... > , IsotropicUIntPack< Dim , D > >& pointEvaluator , const ConstPointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > >& dataKey , AccumulationFunctor &AF ) const;
+
+	public:
+
+		template< bool XMajor , class V , unsigned int ... DataSigs > Pointer( V ) regularGridEvaluate( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , int& res , LocalDepth depth=-1 , bool primal=false ) const;
+		template< bool XMajor , class V , unsigned int ... DataSigs > Pointer( V ) regularGridEvaluate( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , const unsigned int begin[Dim] , const unsigned int end[Dim] , unsigned int res[Dim] , bool primal=false ) const;
+		template< bool XMajor , class V , unsigned int ... DataSigs > Pointer( V ) regularGridUpSample( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , LocalDepth depth=-1 ) const;
+		template< bool XMajor , class V , unsigned int ... DataSigs > Pointer( V ) regularGridUpSample( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , const int begin[Dim] , const int end[Dim] , LocalDepth depth=-1 ) const;
+		template< class V , unsigned int ... DataSigs > V average( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients ) const;
+		template< class V , unsigned int ... DataSigs > V average( const DenseNodeData< V , UIntPack< DataSigs ... > >& coefficients , const Real begin[Dim] , const Real end[Dim] ) const;
+		template< typename T > struct HasNormalDataFunctor{};
+		template< unsigned int ... NormalSigs >
+		struct HasNormalDataFunctor< UIntPack< NormalSigs ... > >
+		{
+			const SparseNodeData< Point< Real , Dim > , UIntPack< NormalSigs ... > >& normalInfo;
+			HasNormalDataFunctor( const SparseNodeData< Point< Real , Dim > , UIntPack< NormalSigs ... > >& ni ) : normalInfo( ni ){ ; }
+			bool operator() ( const FEMTreeNode* node ) const
+			{
+				const Point< Real , Dim >* n = normalInfo( node );
+				if( n )
+				{
+					const Point< Real , Dim >& normal = *n;
+					for( int d=0 ; d<Dim ; d++ ) if( normal[d]!=0 ) return true;
+				}
+				if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) if( (*this)( node->children + c ) ) return true;
+				return false;
+			}
+		};
+		struct TrivialHasDataFunctor{ bool operator() ( const FEMTreeNode* node ) const { return true; } };
+	protected:
+		// [NOTE] The input/output for this method is pre-scaled by weight
+		template< typename T > bool _setInterpolationInfoFromChildren( FEMTreeNode* node , SparseNodeData< T , IsotropicUIntPack< Dim , FEMTrivialSignature > >& iInfo ) const;
+		template< typename T ,                 unsigned int PointD , typename ConstraintDual > SparseNodeData< DualPointInfo       < Dim , Real ,        T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > _densifyInterpolationInfoAndSetDualConstraints( const std::vector< PointSample >& samples ,                                   ConstraintDual constraintDual , LocalDepth maxDepth , int adaptiveExponent ) const;
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual > SparseNodeData< DualPointAndDataInfo< Dim , Real , Data , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > _densifyInterpolationInfoAndSetDualConstraints( const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , ConstraintDual constraintDual , LocalDepth maxDepth , int adaptiveExponent ) const;
+		template< typename T ,                 unsigned int PointD , typename ConstraintDual > void _densifyInterpolationInfoAndSetDualConstraints( SparseNodeData< DualPointInfo       < Dim , Real ,        T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > &iInfo , const std::vector< PointSample >& samples ,                                   ConstraintDual constraintDual , LocalDepth maxDepth , int adaptiveExponent ) const;
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual > void _densifyInterpolationInfoAndSetDualConstraints( SparseNodeData< DualPointAndDataInfo< Dim , Real , Data , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > &iInfo , const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , ConstraintDual constraintDual , LocalDepth maxDepth , int adaptiveExponent ) const;
+		template< typename T ,                 unsigned int PointD , typename ConstraintDual > SparseNodeData< DualPointInfoBrood       < Dim , Real ,        T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > _densifyChildInterpolationInfoAndSetDualConstraints( const std::vector< PointSample >& samples ,                                   ConstraintDual constraintDual , bool noRescale ) const;
+		template< typename T , typename Data , unsigned int PointD , typename ConstraintDual > SparseNodeData< DualPointAndDataInfoBrood< Dim , Real , Data , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > _densifyChildInterpolationInfoAndSetDualConstraints( const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , ConstraintDual constraintDual , bool noRescale ) const;
+
+		void _setSpaceValidityFlags( void ) const;
+		template< unsigned int ... FEMSigs1 > void _setFEM1ValidityFlags( UIntPack< FEMSigs1 ... > ) const;
+		template< unsigned int ... FEMSigs2 > void _setFEM2ValidityFlags( UIntPack< FEMSigs2 ... > ) const;
+		template< class HasDataFunctor > void _clipTree( const HasDataFunctor& f , LocalDepth fullDepth );
+
+	public:
+
+		template< unsigned int PointD , unsigned int ... FEMSigs > SparseNodeData< CumulativeDerivativeValues< Real , Dim , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > leafValues( const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , int maxDepth=-1 ) const;
+
+	protected:
+
+		/////////////////////////////////////
+		// Evaluation Methods              //
+		// MultiGridFEMTreeData.Evaluation //
+		/////////////////////////////////////
+		static const unsigned int CHILDREN = 1<<Dim;
+		template< typename Pack , unsigned int PointD > struct _Evaluator{ };
+		template< unsigned int ... FEMSigs , unsigned int PointD >
+		struct _Evaluator< UIntPack< FEMSigs ... > , PointD >
+		{
+			static_assert( Dim == sizeof...(FEMSigs) , "[ERROR] Number of signatures doesn't match dimension" );
+
+			typedef DynamicWindow< CumulativeDerivativeValues< double , Dim , PointD > , UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > > CenterStencil;
+			typedef DynamicWindow< CumulativeDerivativeValues< double , Dim , PointD > , UIntPack< BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::SupportSize ... > > CornerStencil;
+			typedef DynamicWindow< CumulativeDerivativeValues< double , Dim , PointD > , UIntPack< ( BSplineSupportSizes< FEMSignature< FEMSigs >::Degree >::BCornerSize + 1 ) ... > > BCornerStencil;
+
+			typedef std::tuple< typename BSplineEvaluationData< FEMSigs >::template      Evaluator< PointD > ... >      Evaluators;
+			typedef std::tuple< typename BSplineEvaluationData< FEMSigs >::template ChildEvaluator< PointD > ... > ChildEvaluators;
+			struct StencilData
+			{
+				CenterStencil ccCenterStencil , pcCenterStencils[CHILDREN];
+				CornerStencil ccCornerStencil[CHILDREN] , pcCornerStencils[CHILDREN][CHILDREN];
+				BCornerStencil ccBCornerStencil[CHILDREN] , pcBCornerStencils[CHILDREN][CHILDREN];
+			};
+			Pointer( StencilData ) stencilData;
+			Pointer(      Evaluators )      evaluators;
+			Pointer( ChildEvaluators ) childEvaluators;
+
+			void set( LocalDepth depth );
+			_Evaluator( void ){ _pointEvaluator = NULL ; stencilData = NullPointer( StencilData ) , evaluators = NullPointer( Evaluators ) , childEvaluators = NullPointer( ChildEvaluators ); }
+			~_Evaluator( void ){ if( _pointEvaluator ) delete _pointEvaluator , _pointEvaluator = NULL ; if( stencilData ) DeletePointer( stencilData ) ; if( evaluators ) DeletePointer( evaluators ) ; if( childEvaluators ) DeletePointer( childEvaluators ); }
+		protected:
+			enum _CenterOffset{ CENTER=-1 , BACK=0 , FRONT=1 };
+			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< double , Dim , _PointD >       _values( unsigned int d , const int fIdx[Dim] , const int idx[Dim] , const _CenterOffset off[Dim] , bool parentChild ) const;
+			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< double , Dim , _PointD > _centerValues( unsigned int d , const int fIdx[Dim] , const int idx[Dim] ,                                bool parentChild ) const;
+			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< double , Dim , _PointD > _cornerValues( unsigned int d , const int fIdx[Dim] , const int idx[Dim] , int corner ,                   bool parentChild ) const;
+			template< unsigned int _PointD=PointD , unsigned int I=0 > typename std::enable_if< I==Dim >::type _setDValues( unsigned int d , const int fIdx[] , const int cIdx[] , const _CenterOffset off[] , bool pc , double dValues[][_PointD+1] ) const{ }
+			template< unsigned int _PointD=PointD , unsigned int I=0 > typename std::enable_if< (I<Dim) >::type _setDValues( unsigned int d , const int fIdx[] , const int cIdx[] , const _CenterOffset off[] , bool pc , double dValues[][_PointD+1] ) const
+			{
+				if( pc ) for( int dd=0 ; dd<=_PointD ; dd++ ) dValues[I][dd] = off[I]==CENTER ? std::get< I >( childEvaluators[d] ).centerValue( fIdx[I] , cIdx[I] , dd ) : std::get< I >( childEvaluators[d] ).cornerValue( fIdx[I] , cIdx[I]+off[I] , dd );
+				else     for( int dd=0 ; dd<=_PointD ; dd++ ) dValues[I][dd] = off[I]==CENTER ? std::get< I >(      evaluators[d] ).centerValue( fIdx[I] , cIdx[I] , dd ) : std::get< I >(      evaluators[d] ).cornerValue( fIdx[I] , cIdx[I]+off[I] , dd );
+				_setDValues< _PointD , I+1 >( d , fIdx , cIdx , off , pc , dValues );
+			}
+
+			template< unsigned int I=0 > typename std::enable_if< I==Dim >::type _setEvaluators( unsigned int maxDepth ){ }
+			template< unsigned int I=0 > typename std::enable_if< (I<Dim) >::type _setEvaluators( unsigned int maxDepth )
+			{
+				static const unsigned int FEMSig = UIntPack< FEMSigs ... >::template Get< I >();
+				for( unsigned int d=0 ; d<=maxDepth ; d++ ) BSplineEvaluationData< FEMSig >::     SetEvaluator( std::template get< I >(      evaluators[d] ) , d   );
+				for( unsigned int d=1 ; d<=maxDepth ; d++ ) BSplineEvaluationData< FEMSig >::SetChildEvaluator( std::template get< I >( childEvaluators[d] ) , d-1 );
+				_setEvaluators< I+1 >( maxDepth );
+			}
+			typename FEMIntegrator::template PointEvaluator< UIntPack< FEMSigs ... > , IsotropicUIntPack< Dim , PointD > >* _pointEvaluator;
+			friend FEMTree;
+		};
+
+		template< class V , unsigned int _PointD , unsigned int ... FEMSigs , unsigned int PointD >
+		CumulativeDerivativeValues< V , Dim , _PointD > _getCenterValues( const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node ,                         ConstPointer( V ) solution , ConstPointer( V ) coarseSolution , const _Evaluator< UIntPack< FEMSigs ... > , PointD >& evaluator , int maxDepth , bool isInterior ) const;
+		template< class V , unsigned int _PointD , unsigned int ... FEMSigs , unsigned int PointD >
+		CumulativeDerivativeValues< V , Dim , _PointD > _getCornerValues( const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , int corner            , ConstPointer( V ) solution , ConstPointer( V ) coarseSolution , const _Evaluator< UIntPack< FEMSigs ... > , PointD >& evaluator , int maxDepth , bool isInterior ) const;
+		template< class V , unsigned int _PointD , unsigned int ... FEMSigs , unsigned int PointD >
+		CumulativeDerivativeValues< V , Dim , _PointD > _getValues      ( const ConstPointSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , Point< Real , Dim > p , ConstPointer( V ) solution , ConstPointer( V ) coarseSolution , const _Evaluator< UIntPack< FEMSigs ... > , PointD >& evaluator , int maxDepth ) const;
+		template< class V , unsigned int _PointD , unsigned int ... FEMSigs , unsigned int PointD >
+		CumulativeDerivativeValues< V , Dim , _PointD > _getCornerValues( const ConstCornerSupportKey< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& neighborKey , const FEMTreeNode* node , int corner            , ConstPointer( V ) solution , ConstPointer( V ) coarseSolution , const _Evaluator< UIntPack< FEMSigs ... > , PointD >& evaluator , int maxDepth , bool isInterior ) const;
+		template< unsigned int ... SupportSizes >
+		struct CornerLoopData
+		{
+			typedef UIntPack< SupportSizes ... > _SupportSizes;
+			//		static const unsigned int supportSizes[] = { SupportSizes ... };
+			static const unsigned int supportSizes[];
+			unsigned int ccSize[1<<Dim] , pcSize[1<<Dim][1<<Dim];
+			unsigned int ccIndices[1<<Dim]        [ WindowSize< _SupportSizes >::Size ];
+			unsigned int pcIndices[1<<Dim][1<<Dim][ WindowSize< _SupportSizes >::Size ];
+			CornerLoopData( void )
+			{
+				int start[Dim] , end[Dim] , _start[Dim] , _end[Dim];
+				for( int c=0 ; c<(1<<Dim) ; c++ )
+				{
+					ccSize[c] = 0;
+					for( int dd=0 ; dd<Dim ; dd++ ) 
+					{
+						start[dd] = 0 , end[dd] = supportSizes[dd];
+						if( (c>>dd) & 1 ) start[dd]++;
+						else              end  [dd]--;
+					}
+					unsigned int idx[Dim];
+					WindowLoop< Dim >::Run
+					(
+						start , end ,
+						[&]( int d , int i ){ idx[d] = i; } ,
+						[&]( void ){ ccIndices[c][ ccSize[c]++ ] = GetWindowIndex( _SupportSizes() , idx ); }
+					);
+
+					for( int _c=0 ; _c<(1<<Dim) ; _c++ )
+					{
+						pcSize[c][_c] = 0;
+						for( int dd=0 ; dd<Dim ; dd++ ) 
+						{
+							if( ( (_c>>dd) & 1 ) != ( (c>>dd) & 1 ) ) _start[dd] = 0 , _end[dd] = supportSizes[dd];
+							else _start[dd] = start[dd] , _end[dd] = end[dd];
+						}
+
+						unsigned int idx[Dim];
+						WindowLoop< Dim >::Run
+						(
+							_start , _end ,
+							[&]( int d , int i ){ idx[d] = i; } ,
+							[&]( void ){ pcIndices[c][_c][ pcSize[c][_c]++ ] = GetWindowIndex( _SupportSizes() , idx ); }
+						);
+					}
+				}
+			}
+		};
+	public:
+		template< typename Pack , unsigned int PointD , typename T > struct _MultiThreadedEvaluator{ };
+		template< unsigned int ... FEMSigs , unsigned int PointD , typename T >
+		struct _MultiThreadedEvaluator< UIntPack< FEMSigs ... > , PointD , T >
+		{
+			typedef UIntPack< FEMSigs ... > FEMSignatures;
+			typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+			const FEMTree* _tree;
+			int _threads;
+			std::vector< ConstPointSupportKey< FEMDegrees > > _pointNeighborKeys;
+			std::vector< ConstCornerSupportKey< FEMDegrees > > _cornerNeighborKeys;
+			_Evaluator< FEMSignatures , PointD > _evaluator;
+			const DenseNodeData< T , FEMSignatures >& _coefficients;
+			DenseNodeData< T , FEMSignatures > _coarseCoefficients;
+		public:
+			_MultiThreadedEvaluator( const FEMTree* tree , const DenseNodeData< T , FEMSignatures >& coefficients , int threads=ThreadPool::NumThreads() );
+			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > values( Point< Real , Dim > p , int thread=0 , const FEMTreeNode* node=NULL );
+			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > centerValues( const FEMTreeNode* node , int thread=0 );
+			template< unsigned int _PointD=PointD > CumulativeDerivativeValues< T , Dim , _PointD > cornerValues( const FEMTreeNode* node , int corner , int thread=0 );
+		};
+		template< typename Pack , unsigned int PointD , typename T=Real > using MultiThreadedEvaluator = _MultiThreadedEvaluator< Pack , PointD , T >;
+		template< unsigned int DensityDegree >
+		struct MultiThreadedWeightEvaluator
+		{
+			const FEMTree* _tree;
+			int _threads;
+			std::vector< ConstPointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > > _neighborKeys;
+			const DensityEstimator< DensityDegree >& _density;
+		public:
+			MultiThreadedWeightEvaluator( const FEMTree* tree , const DensityEstimator< DensityDegree >& density , int threads=ThreadPool::NumThreads() );
+			Real weight( Point< Real , Dim > p , int thread=0 );
+		};
+
+		template< typename Pack , typename T > struct MultiThreadedSparseEvaluator{ };
+		template< unsigned int ... FEMSigs , typename T >
+		struct MultiThreadedSparseEvaluator< UIntPack< FEMSigs ... > , T >
+		{
+			typedef UIntPack< FEMSigs ... > FEMSignatures;
+			typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > FEMDegrees;
+			const FEMTree* _tree;
+			int _threads;
+			std::vector< ConstPointSupportKey< FEMDegrees > > _pointNeighborKeys;
+			typename FEMIntegrator::template PointEvaluator< UIntPack< FEMSigs ... > , ZeroUIntPack< Dim > > *_pointEvaluator;
+			const SparseNodeData< T , FEMSignatures >& _coefficients;
+		public:
+			MultiThreadedSparseEvaluator( const FEMTree* tree , const SparseNodeData< T , FEMSignatures >& coefficients , int threads=ThreadPool::NumThreads() );
+			~MultiThreadedSparseEvaluator( void ){ if( _pointEvaluator ) delete _pointEvaluator; }
+			void addValue( Point< Real , Dim > p , T &t , int thread=0 , const FEMTreeNode* node=NULL );
+			template< typename AccumulationFunctor/*=std::function< void ( const T & , Real s ) > */ >
+			void accumulate( Point< Real , Dim > p , AccumulationFunctor &Accumulate , int thread=0 , const FEMTreeNode* node=NULL );
+		};
+
+	protected:
+
+		template< unsigned int Idx , typename ... DenseOrSparseNodeData >
+		typename std::enable_if< ( Idx==sizeof...(DenseOrSparseNodeData) ) >::type _reorderDenseOrSparseNodeData( ConstPointer( node_index_type ) map , size_t sz , std::tuple< DenseOrSparseNodeData* ... > data ){}
+		template< unsigned int Idx , typename ... DenseOrSparseNodeData >
+		typename std::enable_if< ( Idx <sizeof...(DenseOrSparseNodeData) ) >::type _reorderDenseOrSparseNodeData( ConstPointer( node_index_type ) map , size_t sz , std::tuple< DenseOrSparseNodeData* ... > data )
+		{
+			if( std::get<Idx>( data ) ) std::get<Idx>( data )->_remapIndices( map , sz );
+			_reorderDenseOrSparseNodeData< Idx+1 >( map , sz , data );
+		}
+
+		template< unsigned int Idx , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) >::type _reorderInterpolationInfo( ConstPointer( node_index_type ) map , size_t sz , std::tuple< InterpolationInfos* ... > interpolationInfos ){}
+		template< unsigned int Idx , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) >::type _reorderInterpolationInfo( ConstPointer( node_index_type ) map , size_t sz , std::tuple< InterpolationInfos* ... > interpolationInfos )
+		{
+			if( std::get<Idx>( interpolationInfos ) ) std::get<Idx>( interpolationInfos )->_remapIndices( map , sz );
+			_reorderInterpolationInfo< Idx+1 >( map , sz , interpolationInfos );
+		}
+
+	public:
+
+		FEMTree( size_t blockSize );
+		FEMTree( BinaryStream &stream , size_t blockSize );
+		template< unsigned int CrossDegree , unsigned int Pad >
+		static FEMTree< Dim , Real > *Slice( const FEMTree< Dim+1 , Real > &tree , unsigned int sliceDepth , unsigned int sliceIndex , bool includeBounds , size_t blockSize );
+
+		static FEMTree< Dim , Real > *Merge( const FEMTree< Dim , Real > &tree1 , const FEMTree< Dim , Real > &tree2 , size_t blockSize );
+		~FEMTree( void )
+		{
+			_tree.cleanChildren( !nodeAllocators.size() );
+			for( size_t i=0 ; i<nodeAllocators.size() ; i++ ) delete nodeAllocators[i];
+		}
+		void write( BinaryStream &stream , bool serialize ) const;
+		static void WriteParameter( BinaryStream &stream )
+		{
+			FEMTreeRealType realType;
+			if     ( typeid( Real )==typeid( float  ) ) realType=FEM_TREE_REAL_FLOAT;
+			else if( typeid( Real )==typeid( double ) ) realType=FEM_TREE_REAL_DOUBLE;
+			else MK_THROW( "Unrecognized real type" );
+			stream.write( realType );
+			int dim = Dim;
+			stream.write( dim );
+		}
+
+		template< unsigned int LeftRadius , unsigned int RightRadius , bool CreateNodes , typename ProcessingNodeFunctor , typename ... DenseOrSparseNodeData , typename InitializeFunctor > void processNeighbors( ProcessingNodeFunctor processNodes ,     std::tuple< DenseOrSparseNodeData *... > data , InitializeFunctor initialize );
+		template< unsigned int LeftRadius , unsigned int RightRadius , bool CreateNodes ,                                  typename ... DenseOrSparseNodeData , typename InitializeFunctor > void processNeighbors( FEMTreeNode** nodes , size_t nodeCount , std::tuple< DenseOrSparseNodeData *... > data , InitializeFunctor initialize );
+		template< unsigned int Radius                                , bool CreateNodes , typename ProcessingNodeFunctor , typename ... DenseOrSparseNodeData , typename InitializeFunctor > void processNeighbors( ProcessingNodeFunctor processNodes     , std::tuple< DenseOrSparseNodeData *... > data , InitializeFunctor initialize ){ processNeighbors< Radius , Radius , CreateNodes >( processNodes , data , initialize ); }
+		template< unsigned int Radius                                , bool CreateNodes ,                                  typename ... DenseOrSparseNodeData , typename InitializeFunctor > void processNeighbors( FEMTreeNode** nodes , size_t nodeCount , std::tuple< DenseOrSparseNodeData *... > data , InitializeFunctor initialize ){ processNeighbors< Radius , Radius , CreateNodes >( nodes , nodeCount , data , initialize ); }
+
+		template< unsigned int LeftRadius , unsigned int RightRadius , bool CreateNodes , typename ProcessingNodeFunctor , typename ... DenseOrSparseNodeData >                              void processNeighbors( ProcessingNodeFunctor processNodes     , std::tuple< DenseOrSparseNodeData *... > data                                ){ return processNeighbors< LeftRadius , RightRadius , CreateNodes >( processNodes , data , []( const FEMTreeNode * ){} ); }
+		template< unsigned int LeftRadius , unsigned int RightRadius , bool CreateNodes ,                                  typename ... DenseOrSparseNodeData >                              void processNeighbors( FEMTreeNode** nodes , size_t nodeCount , std::tuple< DenseOrSparseNodeData *... > data                                ){ return processNeighbors< LeftRadius , RightRadius , CreateNodes >( nodes , nodeCount , data , []( const FEMTreeNode * ){} ); }
+		template< unsigned int Radius                                , bool CreateNodes , typename ProcessingNodeFunctor , typename ... DenseOrSparseNodeData >                              void processNeighbors( ProcessingNodeFunctor processNodes     , std::tuple< DenseOrSparseNodeData *... > data                                ){ return processNeighbors< Radius , CreateNodes >( processNodes , data , []( const FEMTreeNode * ){} ); }
+		template< unsigned int Radius                                , bool CreateNodes ,                                  typename ... DenseOrSparseNodeData >                              void processNeighbors( FEMTreeNode** nodes , size_t nodeCount , std::tuple< DenseOrSparseNodeData *... > data                                ){ return processNeighbors< Radius , CreateNodes >( nodes , nodeCount , data , []( const FEMTreeNode * ){} ) ; }
+
+		template< unsigned int LeftRadius , unsigned int RightRadius , typename IsProcessingNodeFunctor , typename ProcessingKernel > void processNeighboringLeaves( IsProcessingNodeFunctor isProcessingNode , ProcessingKernel kernel , bool processSubTree );
+		template< unsigned int LeftRadius , unsigned int RightRadius                                    , typename ProcessingKernel > void processNeighboringLeaves( FEMTreeNode** nodes , size_t nodeCount   , ProcessingKernel kernel , bool processSubTree );
+		template< unsigned int Radius                                , typename IsProcessingNodeFunctor , typename ProcessingKernel > void processNeighboringLeaves( IsProcessingNodeFunctor isProcessingNode , ProcessingKernel kernel , bool processSubTree ){ return processNeighboringLeaves< Radius , Radius >( isProcessingNode , kernel , processSubTree ); }
+		template< unsigned int Radius                                                                   , typename ProcessingKernel > void processNeighboringLeaves( FEMTreeNode** nodes , size_t nodeCount   , ProcessingKernel kernel , bool processSubTree ){ return processNeighboringLeaves< Radius , Radius >( nodes , nodeCount , kernel , processSubTree ); }
+
+		template< unsigned int CoDim , unsigned int DensityDegree >
+		typename FEMTree::template DensityEstimator< DensityDegree > *setDensityEstimator( const std::vector< PointSample >& samples , LocalDepth splatDepth , Real samplesPerNode );
+		template< unsigned int CoDim , unsigned int DensityDegree >
+		void updateDensityEstimator( typename FEMTree::template DensityEstimator< DensityDegree > &density , const std::vector< PointSample >& samples , LocalDepth minSplatDepth , LocalDepth maxSplatDepth );
+		template< unsigned int CoDim , unsigned int DensityDegree >
+		typename FEMTree::template DensityEstimator< DensityDegree > *setDensityEstimator( const std::vector< PointSample >& samples , LocalDepth splatDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Real samplesPerNode );
+		template< unsigned int CoDim , unsigned int DensityDegree >
+		void updateDensityEstimator( typename FEMTree::template DensityEstimator< DensityDegree > &density , const std::vector< PointSample >& samples , LocalDepth minSplatDepth , LocalDepth maxSplatDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor );
+
+		template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+		SparseNodeData< OutData , UIntPack< DataSigs ... > > setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData & , Real & ) > ConversionAndBiasFunction );
+#if defined(_WIN32) || defined(_WIN64)
+		template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+		SparseNodeData< OutData , UIntPack< DataSigs ... > > setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData & ) > ConversionFunction , std::function< Real ( InData ) > BiasFunction = []( InData ){ return 0.f; } );
+#else // !_WIN32 && !_WIN64
+		template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+		SparseNodeData< OutData , UIntPack< DataSigs ... > > setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData & ) > ConversionFunction , std::function< Real ( InData ) > BiasFunction = []( InData ){ return (Real)0; } );
+#endif // _WIN32 || _WIN64
+		template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+		SparseNodeData< OutData , UIntPack< DataSigs ... > > setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData & , Real & ) > ConversionAndBiasFunction );
+#if defined(_WIN32) || defined(_WIN64)
+		template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+		SparseNodeData< OutData , UIntPack< DataSigs ... > > setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData & ) > ConversionFunction , std::function< Real ( InData ) > BiasFunction = []( InData ){ return 0.f; } );
+#else // !_WIN32 && !_WIN64
+		template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+		SparseNodeData< OutData , UIntPack< DataSigs ... > > setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData & ) > ConversionFunction , std::function< Real ( InData ) > BiasFunction = []( InData ){ return (Real)0; } );
+#endif // _WIN32 || _WIN64
+
+		template< unsigned int DataSig , bool CreateNodes , unsigned int DensityDegree , class Data >
+		SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > setExtrapolatedDataField( Data zero , const std::vector< PointSample >& samples , const std::vector< Data >& sampleData , const DensityEstimator< DensityDegree >* density , bool nearest=false );
+		template< unsigned int DataSig , bool CreateNodes , unsigned int DensityDegree , class Data >
+		void updateExtrapolatedDataField( Data zero , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > &dataField , const std::vector< PointSample >& samples , const std::vector< Data >& sampleData , const DensityEstimator< DensityDegree >* density , bool nearest=false );
+		template< unsigned int DataSig , bool CreateNodes , unsigned int DensityDegree , class Data , class SampleFunctor /* = std::function< const PointSample & (size_t) >*/ , class SampleDataFunctor /* = std::function< const Data & (size_t) > */ >
+		SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > setExtrapolatedDataField( Data zero , size_t sampleNum , SampleFunctor sampleFunctor , SampleDataFunctor sampleDataFunctor , const DensityEstimator< DensityDegree >* density , bool nearest=false );
+		template< unsigned int DataSig , bool CreateNodes , unsigned int DensityDegree , class Data , class SampleFunctor /* = std::function< const PointSample & (size_t) >*/ , class SampleDataFunctor /* = std::function< const Data & (size_t) > */ >
+		void updateExtrapolatedDataField( Data zero , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > &dataField , size_t sampleNum , SampleFunctor sampleFunctor , SampleDataFunctor sampleDataFunctor , const DensityEstimator< DensityDegree >* density , bool nearest=false );
+
+		template< unsigned int MaxDegree , unsigned int SystemDegree , typename AddNodeFunctor , typename HasDataFunctor , typename IsDirichletLeafFunctor , typename ... InterpolationInfos , typename ... DenseOrSparseNodeData > std::vector< node_index_type > finalizeForMultigridWithDirichlet( LocalDepth baseDepth , const AddNodeFunctor addNodeFunctor , const HasDataFunctor hasDataFunctor , const IsDirichletLeafFunctor isDirichletLeafFunctor , std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data );
+		template< unsigned int MaxDegree , unsigned int SystemDegree , typename AddNodeFunctor , typename HasDataFunctor , typename IsDirichletLeafFunctor , typename ... InterpolationInfos                                      > std::vector< node_index_type > finalizeForMultigridWithDirichlet( LocalDepth baseDepth , const AddNodeFunctor addNodeFunctor , const HasDataFunctor hasDataFunctor , const IsDirichletLeafFunctor isDirichletLeafFunctor , std::tuple< InterpolationInfos *... > interpolationInfos ){ return finalizeForMultigridWithDirichlet< MaxDegree , SystemDegree , AddNodeFunctor , HasDataFunctor >( baseDepth , addNodeFunctor , hasDataFunctor , isDirichletLeafFunctor , interpolationInfos , std::make_tuple() ); }
+
+		template< unsigned int MaxDegree , unsigned int SystemDegree , typename AddNodeFunctor , typename HasDataFunctor , typename ... InterpolationInfos , typename ... DenseOrSparseNodeData > std::vector< node_index_type > finalizeForMultigrid( LocalDepth baseDepth , const AddNodeFunctor addNodeFunctor , const HasDataFunctor hasDataFunctor , std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data );
+		template< unsigned int MaxDegree , unsigned int SystemDegree , typename AddNodeFunctor , typename HasDataFunctor , typename ... InterpolationInfos                                      > std::vector< node_index_type > finalizeForMultigrid( LocalDepth baseDepth , const AddNodeFunctor addNodeFunctor , const HasDataFunctor hasDataFunctor , std::tuple< InterpolationInfos *... > interpolationInfos ){ return finalizeForMultigrid< MaxDegree , SystemDegree , AddNodeFunctor , HasDataFunctor >( baseDepth , addNodeFunctor , hasDataFunctor , interpolationInfos , std::make_tuple() ); }
+
+	protected:
+		template< bool HasDirichlet , unsigned int MaxDegree , unsigned int SystemDegree , typename AddNodeFunctor , typename HasDataFunctor , typename IsDirichletLeafFunctor , typename ... InterpolationInfos , typename ... DenseOrSparseNodeData >
+		std::vector< node_index_type > _finalizeForMultigrid( LocalDepth baseDepth , const AddNodeFunctor addNodeFunctor , const HasDataFunctor hasDataFunctor , const IsDirichletLeafFunctor isDirichletLeafFunctor , std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data );
+	public:
+		template< typename ... InterpolationInfos , typename ... DenseOrSparseNodeData > std::vector< node_index_type > setSortedTreeNodes( std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data );
+		template< typename ... InterpolationInfos                                      > std::vector< node_index_type > setSortedTreeNodes( std::tuple< InterpolationInfos *... > interpolationInfos ){ return setSortedTreeNodes( interpolationInfos , std::make_tuple() ); }
+
+		template< class ... DenseOrSparseNodeData > void resetIndices( std::tuple< DenseOrSparseNodeData *... > data );
+
+		template< typename PruneChildrenFunctor , typename ... InterpolationInfos , typename ... DenseOrSparseNodeData >
+		void pruneChildren( const PruneChildrenFunctor pruneChildren , std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data );
+
+		template< unsigned int ... FEMSigs > DenseNodeData< Real , UIntPack< FEMSigs ... > > initDenseNodeData( UIntPack< FEMSigs ... > ) const;
+		template< class Data , unsigned int ... FEMSigs > DenseNodeData< Data , UIntPack< FEMSigs ... > > initDenseNodeData( UIntPack< FEMSigs ... > ) const;
+
+		template< unsigned int Pad , unsigned int FEMSig , unsigned int ... FEMSigs , typename Data >
+		void slice( const FEMTree< Dim+1 , Real > &tree , unsigned int d , const DenseNodeData< Data , UIntPack< FEMSigs ... , FEMSig > > &coefficients , DenseNodeData< Data , UIntPack< FEMSigs ... > > &sliceCoefficients , unsigned int sliceDepth , unsigned int sliceIndex ) const;
+
+		template< unsigned int ... FEMSigs , typename Data >
+		void merge( const FEMTree< Dim , Real > &tree , const DenseNodeData< Data , UIntPack< FEMSigs ... > > &coefficients , DenseNodeData< Data , UIntPack< FEMSigs ... > > &mergedCoefficients ) const;
+
+		// Add multiple-dimensions -> one-dimension constraints
+		template< typename T , unsigned int ... FEMDegrees , unsigned int ... FEMSigs , unsigned int ... CDegrees , unsigned int ... CSigs , unsigned int CDim >
+		void addFEMConstraints( typename BaseFEMIntegrator::template Constraint< UIntPack< FEMDegrees ... > , UIntPack< CDegrees ... > , CDim >& F , const _SparseOrDenseNodeData< Point< T , CDim > , UIntPack< CSigs ... > >& coefficients , DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , LocalDepth maxDepth ) const
+		{
+			typedef SparseNodeData< Point< T , CDim > , UIntPack< CSigs ... > > SparseType;
+			typedef  DenseNodeData< Point< T , CDim > , UIntPack< CSigs ... > >  DenseType;
+			static_assert( sizeof...( FEMDegrees )==Dim && sizeof...( FEMSigs )==Dim && sizeof...( CDegrees )==Dim && sizeof...( CSigs )==Dim , "[ERROR] Dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >::Equal , "[ERROR] FEM signature and degrees don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack<   CDegrees ... > , UIntPack< FEMSignature<   CSigs >::Degree ... > >::Equal , "[ERROR] Constraint signature and degrees don't match" );
+			if     ( typeid(coefficients)==typeid(SparseType) ) return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< CSigs ... >() , F , static_cast< const SparseType& >( coefficients ) , constraints() , maxDepth );
+			else if( typeid(coefficients)==typeid( DenseType) ) return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< CSigs ... >() , F , static_cast< const  DenseType& >( coefficients ) , constraints() , maxDepth );
+			else                                                return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< CSigs ... >() , F ,                                   coefficients   , constraints() , maxDepth );
+		}
+		// Add one-dimensions -> one-dimension constraints (with distinct signatures)
+		template< typename T , unsigned int ... FEMDegrees , unsigned int ... FEMSigs , unsigned int ... CDegrees , unsigned int ... CSigs >
+		void addFEMConstraints( typename BaseFEMIntegrator::template Constraint< UIntPack< FEMDegrees ... > , UIntPack< CDegrees ... > , 1 >& F , const _SparseOrDenseNodeData< T , UIntPack< CSigs ... > >& coefficients , DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , LocalDepth maxDepth ) const
+		{
+			typedef SparseNodeData< T , UIntPack< CSigs ... > > SparseType;
+			typedef  DenseNodeData< T , UIntPack< CSigs ... > >  DenseType;
+			static_assert( sizeof...( FEMDegrees )==Dim && sizeof...( FEMSigs )==Dim && sizeof...( CDegrees )==Dim && sizeof...( CSigs )==Dim  , "[ERROR] Dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >::Equal , "[ERROR] FEM signature and degrees don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack<   CDegrees ... > , UIntPack< FEMSignature<   CSigs >::Degree ... > >::Equal , "[ERROR] Constaint signature and degrees don't match" );
+			if     ( typeid(coefficients)==typeid(SparseType) ) return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< CSigs ... >() , F , static_cast< const SparseType& >( coefficients ) , constraints() , maxDepth );
+			else if( typeid(coefficients)==typeid( DenseType) ) return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< CSigs ... >() , F , static_cast< const  DenseType& >( coefficients ) , constraints() , maxDepth );
+			else                                                return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< CSigs ... >() , F ,                                   coefficients   , constraints() , maxDepth );
+		}
+		// Add one-dimensions -> one-dimension constraints (with the same signatures)
+		template< typename T , unsigned int ... FEMDegrees , unsigned int ... FEMSigs >
+		void addFEMConstraints( typename BaseFEMIntegrator::template System< UIntPack< FEMDegrees ... > >& F , const _SparseOrDenseNodeData< T , UIntPack< FEMSigs ... > >& coefficients , DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , LocalDepth maxDepth ) const
+		{
+			typedef SparseNodeData< T , UIntPack< FEMSigs ... > > SparseType;
+			typedef  DenseNodeData< T , UIntPack< FEMSigs ... > >  DenseType;
+			static_assert( sizeof...( FEMDegrees )==Dim && sizeof...( FEMSigs )==Dim , "[ERROR] Dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >::Equal , "[ERROR] FEM signatures and degrees don't match" );
+			typename BaseFEMIntegrator::template SystemConstraint< UIntPack< FEMDegrees ... > > _F( F );
+			if     ( typeid(coefficients)==typeid(SparseType) ) return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const SparseType& >( coefficients ) , constraints() , maxDepth );
+			else if( typeid(coefficients)==typeid( DenseType) ) return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const  DenseType& >( coefficients ) , constraints() , maxDepth );
+			else                                                return _addFEMConstraints< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F ,                                   coefficients   , constraints() , maxDepth );
+		}
+
+	protected:
+		template< unsigned int MaxDegree > void _supportApproximateProlongation( void );
+		template< unsigned int SystemDegree > void _markInexactInterpolationElements( void);
+		template< unsigned int SystemDegree > void _addAndMarkExactInterpolationElements( void );
+		template< unsigned int SystemDegree > void _markNonBaseDirichletElements( void );
+		template< unsigned int SystemDegree > void _markBaseDirichletElements( void );
+
+		template< unsigned int Idx , typename T , unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) >::type _addInterpolationConstraints( DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , LocalDepth maxDepth , std::tuple< InterpolationInfos *... > interpolationInfos ) const {}
+		template< unsigned int Idx , typename T , unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) >::type _addInterpolationConstraints( DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , LocalDepth maxDepth , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			_addInterpolationConstraints( constraints , maxDepth , std::get< Idx >( interpolationInfos ) );
+			_addInterpolationConstraints< Idx+1 >( constraints , maxDepth , interpolationInfos );
+		}
+		template< typename T , unsigned int ... FEMSigs , unsigned int PointD >
+		void _addInterpolationConstraints( DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , LocalDepth maxDepth , const InterpolationInfo< T , PointD > *interpolationInfo ) const;
+	public:
+		template< typename T , unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		void addInterpolationConstraints( DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , LocalDepth maxDepth , std::tuple< InterpolationInfos *... > interpolationInfos ) const { return _addInterpolationConstraints< 0 >( constraints , maxDepth , interpolationInfos ); }
+
+		// Real
+		template< unsigned int ... FEMDegrees1 , unsigned int ... FEMSigs1 , unsigned int ... FEMDegrees2 , unsigned int ... FEMSigs2 >
+		double dot( typename BaseFEMIntegrator::Constraint< UIntPack< FEMDegrees1 ... > , UIntPack< FEMDegrees2 ... > , 1 >& F , const _SparseOrDenseNodeData< Real , UIntPack< FEMSigs1 ... > >& coefficients1 , const _SparseOrDenseNodeData< Real , UIntPack< FEMSigs2 ... > >& coefficients2 ) const
+		{
+			typedef SparseNodeData< Real , UIntPack< FEMSigs1 ... > > SparseType1;
+			typedef  DenseNodeData< Real , UIntPack< FEMSigs1 ... > >  DenseType1;
+			typedef SparseNodeData< Real , UIntPack< FEMSigs2 ... > > SparseType2;
+			typedef  DenseNodeData< Real , UIntPack< FEMSigs2 ... > >  DenseType2;
+			static_assert( sizeof...( FEMDegrees1 )==Dim && sizeof...( FEMSigs1 )==Dim && sizeof...( FEMDegrees2 )==Dim && sizeof...( FEMSigs2 )==Dim  , "[ERROR] Dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees1 ... > , UIntPack< FEMSignature< FEMSigs1 >::Degree ... > >::Equal , "[ERROR] FEM signature and degrees don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees2 ... > , UIntPack< FEMSignature< FEMSigs2 >::Degree ... > >::Equal , "[ERROR] FEM signature and degrees don't match" );
+			if     ( typeid(coefficients1)==typeid(SparseType1) && typeid(coefficients2)==typeid(SparseType2) ) return _dot< Real >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F , static_cast< const SparseType1& >( coefficients1 ) , static_cast< const SparseType2& >( coefficients2 ) , []( Real v ,  Real w ){ return v*w; } );
+			else if( typeid(coefficients1)==typeid(SparseType1) && typeid(coefficients2)==typeid( DenseType2) ) return _dot< Real >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F , static_cast< const SparseType1& >( coefficients1 ) , static_cast< const  DenseType2& >( coefficients2 ) , []( Real v ,  Real w ){ return v*w; } );
+			else if( typeid(coefficients1)==typeid( DenseType1) && typeid(coefficients2)==typeid( DenseType2) ) return _dot< Real >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F , static_cast< const  DenseType1& >( coefficients1 ) , static_cast< const  DenseType2& >( coefficients2 ) , []( Real v ,  Real w ){ return v*w; } );
+			else if( typeid(coefficients1)==typeid( DenseType1) && typeid(coefficients2)==typeid(SparseType2) ) return _dot< Real >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F , static_cast< const  DenseType1& >( coefficients1 ) , static_cast< const SparseType2& >( coefficients2 ) , []( Real v ,  Real w ){ return v*w; } );
+			else                                                                                                return _dot< Real >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F ,                                    coefficients1   ,                                    coefficients2   , []( Real v ,  Real w ){ return v*w; } );
+		}
+		template< unsigned int ... FEMDegrees , unsigned int ... FEMSigs >
+		double dot( typename BaseFEMIntegrator::System< UIntPack< FEMDegrees ... > >& F , const _SparseOrDenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients1 , const _SparseOrDenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients2 ) const
+		{
+			typedef SparseNodeData< Real , UIntPack< FEMSigs ... > > SparseType;
+			typedef  DenseNodeData< Real , UIntPack< FEMSigs ... > >  DenseType;
+			static_assert( sizeof...( FEMDegrees )==Dim && sizeof...( FEMSigs )==Dim , "[ERROR] Dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >::Equal , "[ERROR] FEM signatures and degrees don't match" );
+			typename BaseFEMIntegrator::template SystemConstraint< UIntPack< FEMDegrees ... > > _F( F );
+			if     ( typeid(coefficients1)==typeid(SparseType) && typeid(coefficients2)==typeid(SparseType) ) return _dot< Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const SparseType& >( coefficients1 ) , static_cast< const SparseType& >( coefficients2 ) , []( Real v ,  Real w ){ return v*w; } );
+			else if( typeid(coefficients1)==typeid(SparseType) && typeid(coefficients2)==typeid( DenseType) ) return _dot< Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const SparseType& >( coefficients1 ) , static_cast< const  DenseType& >( coefficients2 ) , []( Real v ,  Real w ){ return v*w; } );
+			else if( typeid(coefficients1)==typeid( DenseType) && typeid(coefficients2)==typeid( DenseType) ) return _dot< Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const  DenseType& >( coefficients1 ) , static_cast< const  DenseType& >( coefficients2 ) , []( Real v ,  Real w ){ return v*w; } );
+			else if( typeid(coefficients1)==typeid( DenseType) && typeid(coefficients2)==typeid(SparseType) ) return _dot< Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const  DenseType& >( coefficients1 ) , static_cast< const SparseType& >( coefficients2 ) , []( Real v ,  Real w ){ return v*w; } );
+			else                                                                                              return _dot< Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F ,                                   coefficients1   ,                                   coefficients2   , []( Real v ,  Real w ){ return v*w; } );
+		}
+		template< unsigned int ... FEMDegrees , unsigned int ... FEMSigs >
+		double squareNorm( typename BaseFEMIntegrator::template System< UIntPack< FEMDegrees ... > >& F , const _SparseOrDenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients ) const
+		{
+			typedef SparseNodeData< Real , UIntPack< FEMSigs ... > > SparseType;
+			typedef  DenseNodeData< Real , UIntPack< FEMSigs ... > >  DenseType;
+			typename BaseFEMIntegrator::template SystemConstraint< UIntPack< FEMDegrees ... > > _F( F );
+			if     ( typeid(coefficients)==typeid(SparseType) ) return _dot< Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const SparseType& >( coefficients ) , static_cast< const SparseType& >( coefficients ) , []( Real v ,  Real w ){ return v*w; } );
+			else if( typeid(coefficients)==typeid( DenseType) ) return _dot< Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const  DenseType& >( coefficients ) , static_cast< const  DenseType& >( coefficients ) , []( Real v ,  Real w ){ return v*w; } );
+			else                                                return _dot< Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F ,                                   coefficients   ,                                   coefficients   , []( Real v ,  Real w ){ return v*w; } );
+		}
+
+		template< unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , typename ... InterpolationInfos >
+		double interpolationDot( const DenseNodeData< Real , UIntPack< FEMSigs1 ... > >& coefficients1 , const DenseNodeData< Real , UIntPack< FEMSigs2 ... > >& coefficients2 , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			static_assert( sizeof...( FEMSigs1 )==Dim && sizeof...( FEMSigs2 )==Dim , "[ERROR] Dimensions don't match" );
+			return _interpolationDot< 0 >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , coefficients1 , coefficients2 , []( Real v ,  Real w ){ return v*w; } , interpolationInfos );
+		}
+		template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		double interpolationSquareNorm( const DenseNodeData< Real , UIntPack< FEMSigs ... > >& coefficients , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			static_assert( sizeof...( FEMSigs )==Dim , "[ERROR] Dimensions don't match" );
+			return _interpolationDot< 0 , Real >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , coefficients , coefficients , []( Real v ,  Real w ){ return v*w; } , interpolationInfos );
+		}
+
+		// Generic
+		template< typename T , typename TDotT , unsigned int ... FEMDegrees1 , unsigned int ... FEMSigs1 , unsigned int ... FEMDegrees2 , unsigned int ... FEMSigs2 >
+		double dot( TDotT Dot , typename BaseFEMIntegrator::Constraint< UIntPack< FEMDegrees1 ... > , UIntPack< FEMDegrees2 ... > , 1 >& F , const _SparseOrDenseNodeData< T , UIntPack< FEMSigs1 ... > >& coefficients1 , const _SparseOrDenseNodeData< T , UIntPack< FEMSigs2 ... > >& coefficients2 ) const
+		{
+			typedef SparseNodeData< T , UIntPack< FEMSigs1 ... > > SparseType1;
+			typedef  DenseNodeData< T , UIntPack< FEMSigs1 ... > >  DenseType1;
+			typedef SparseNodeData< T , UIntPack< FEMSigs2 ... > > SparseType2;
+			typedef  DenseNodeData< T , UIntPack< FEMSigs2 ... > >  DenseType2;
+			static_assert( sizeof...( FEMDegrees1 )==Dim && sizeof...( FEMSigs1 )==Dim && sizeof...( FEMDegrees2 )==Dim && sizeof...( FEMSigs2 )==Dim  , "[ERROR] Dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees1 ... > , UIntPack< FEMSignature< FEMSigs1 >::Degree ... > >::Equal , "[ERROR] FEM signature and degrees don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees2 ... > , UIntPack< FEMSignature< FEMSigs2 >::Degree ... > >::Equal , "[ERROR] FEM signature and degrees don't match" );
+			if     ( typeid(coefficients1)==typeid(SparseType1) && typeid(coefficients2)==typeid(SparseType2) ) return _dot< T >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F , static_cast< const SparseType1& >( coefficients1 ) , static_cast< const SparseType2& >( coefficients2 ) , Dot );
+			else if( typeid(coefficients1)==typeid(SparseType1) && typeid(coefficients2)==typeid( DenseType2) ) return _dot< T >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F , static_cast< const SparseType1& >( coefficients1 ) , static_cast< const  DenseType2& >( coefficients2 ) , Dot );
+			else if( typeid(coefficients1)==typeid( DenseType1) && typeid(coefficients2)==typeid( DenseType2) ) return _dot< T >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F , static_cast< const  DenseType1& >( coefficients1 ) , static_cast< const  DenseType2& >( coefficients2 ) , Dot );
+			else if( typeid(coefficients1)==typeid( DenseType1) && typeid(coefficients2)==typeid(SparseType2) ) return _dot< T >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F , static_cast< const  DenseType1& >( coefficients1 ) , static_cast< const SparseType2& >( coefficients2 ) , Dot );
+			else                                                                                                return _dot< T >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , F ,                                    coefficients1   ,                                    coefficients2   , Dot );
+		}
+		template< typename T , typename TDotT , unsigned int ... FEMDegrees , unsigned int ... FEMSigs >
+		double dot( TDotT Dot , typename BaseFEMIntegrator::System< UIntPack< FEMDegrees ... > >& F , const _SparseOrDenseNodeData< T , UIntPack< FEMSigs ... > >& coefficients1 , const _SparseOrDenseNodeData< T , UIntPack< FEMSigs ... > >& coefficients2 ) const
+		{
+			typedef SparseNodeData< T , UIntPack< FEMSigs ... > > SparseType;
+			typedef  DenseNodeData< T , UIntPack< FEMSigs ... > >  DenseType;
+			static_assert( sizeof...( FEMDegrees )==Dim && sizeof...( FEMSigs )==Dim , "[ERROR] Dimensions don't match" );
+			static_assert( ParameterPack::Comparison< UIntPack< FEMDegrees ... > , UIntPack< FEMSignature< FEMSigs >::Degree ... > >::Equal , "[ERROR] FEM signatures and degrees don't match" );
+			typename BaseFEMIntegrator::template SystemConstraint< UIntPack< FEMDegrees ... > > _F( F );
+			if     ( typeid(coefficients1)==typeid(SparseType) && typeid(coefficients2)==typeid(SparseType) ) return _dot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const SparseType& >( coefficients1 ) , static_cast< const SparseType& >( coefficients2 ) , Dot );
+			else if( typeid(coefficients1)==typeid(SparseType) && typeid(coefficients2)==typeid( DenseType) ) return _dot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const SparseType& >( coefficients1 ) , static_cast< const  DenseType& >( coefficients2 ) , Dot );
+			else if( typeid(coefficients1)==typeid( DenseType) && typeid(coefficients2)==typeid( DenseType) ) return _dot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const  DenseType& >( coefficients1 ) , static_cast< const  DenseType& >( coefficients2 ) , Dot );
+			else if( typeid(coefficients1)==typeid( DenseType) && typeid(coefficients2)==typeid(SparseType) ) return _dot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const  DenseType& >( coefficients1 ) , static_cast< const SparseType& >( coefficients2 ) , Dot );
+			else                                                                                              return _dot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F ,                                   coefficients1   ,                                   coefficients2   , Dot );
+		}
+		template< typename T , typename TDotT , unsigned int ... FEMDegrees , unsigned int ... FEMSigs >
+		double squareNorm( TDotT Dot , typename BaseFEMIntegrator::template System< UIntPack< FEMDegrees ... > >& F , const _SparseOrDenseNodeData< T , UIntPack< FEMSigs ... > >& coefficients ) const
+		{
+			typedef SparseNodeData< T , UIntPack< FEMSigs ... > > SparseType;
+			typedef  DenseNodeData< T , UIntPack< FEMSigs ... > >  DenseType;
+			typename BaseFEMIntegrator::template SystemConstraint< UIntPack< FEMDegrees ... > > _F( F );
+			if     ( typeid(coefficients)==typeid(SparseType) ) return _dot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const SparseType& >( coefficients ) , static_cast< const SparseType& >( coefficients ) , Dot );
+			else if( typeid(coefficients)==typeid( DenseType) ) return _dot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F , static_cast< const  DenseType& >( coefficients ) , static_cast< const  DenseType& >( coefficients ) , Dot );
+			else                                                return _dot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , _F ,                                   coefficients   ,                                   coefficients   , Dot );
+		}
+
+		template< typename T , typename TDotT , unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , typename ... InterpolationInfos >
+		double interpolationDot( TDotT Dot , const DenseNodeData< T , UIntPack< FEMSigs1 ... > >& coefficients1 , const DenseNodeData< T , UIntPack< FEMSigs2 ... > >& coefficients2 , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			static_assert( sizeof...( FEMSigs1 )==Dim && sizeof...( FEMSigs2 )==Dim , "[ERROR] Dimensions don't match" );
+			return _interpolationDot< T >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , coefficients1 , coefficients2 , Dot , interpolationInfos );
+		}
+		template< typename T , typename TDotT , unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		double interpolationSquareNorm( TDotT Dot , const DenseNodeData< T , UIntPack< FEMSigs ... > >& coefficients , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			static_assert( sizeof...( FEMSigs )==Dim , "[ERROR] Dimensions don't match" );
+			return _interpolationDot< T >( UIntPack< FEMSigs ... >() , UIntPack< FEMSigs ... >() , coefficients , coefficients , Dot , interpolationInfos );
+		}
+
+		template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		SparseMatrix< Real , matrix_index_type > systemMatrix( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , LocalDepth depth , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+		template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		SparseMatrix< Real , matrix_index_type > prolongedSystemMatrix( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , LocalDepth highDepth , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+		template< unsigned int ... FEMSigs >
+		SparseMatrix< Real , matrix_index_type > downSampleMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth ) const;
+		template< unsigned int ... FEMSigs >
+		SparseMatrix< Real , matrix_index_type > upSampleMatrix( UIntPack< FEMSigs ... > , LocalDepth highDepth ) const;
+		template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		SparseMatrix< Real , matrix_index_type > fullSystemMatrix( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , LocalDepth depth , std::tuple< InterpolationInfos *... > interpolationInfos ) const;
+
+		template< typename T , unsigned int ... FEMSigs >
+		void pushToBaseDepth( DenseNodeData< T , UIntPack< FEMSigs ... > >& coefficients ) const;
+
+		struct SolverInfo
+		{
+		protected:
+			struct _IterFunction
+			{
+				_IterFunction( int i ) : _i0(i) , _type(0) {}
+				_IterFunction( std::function< int (              int ) > iFunction ) : _i1(iFunction) , _type(1) {}
+				_IterFunction( std::function< int (       bool , int ) > iFunction ) : _i2(iFunction) , _type(2) {}
+				_IterFunction( std::function< int ( int , bool , int ) > iFunction ) : _i3(iFunction) , _type(3) {}
+				_IterFunction& operator = ( int i ){ *this = _IterFunction(i) ; return *this; }
+				_IterFunction& operator = ( std::function< int (              int ) > iFunction ){ *this = _IterFunction(iFunction) ; return *this; }
+				_IterFunction& operator = ( std::function< int (       bool , int ) > iFunction ){ *this = _IterFunction(iFunction) ; return *this; }
+				_IterFunction& operator = ( std::function< int ( int , bool , int ) > iFunction ){ *this = _IterFunction(iFunction) ; return *this; }
+
+				int operator()( int vCycle , bool restriction , int depth ) const
+				{
+					switch( _type )
+					{
+					case 0: return _i0;
+					case 1: return _i1( depth );
+					case 2: return _i2( restriction , depth );
+					case 3: return _i3( vCycle , restriction , depth );
+					default: return 0;
+					}
+				}
+			protected:
+				int _i0;
+				std::function< int ( int ) > _i1;
+				std::function< int ( bool , int ) > _i2;
+				std::function< int ( int i3 , bool , int ) > _i3;
+				int _type;
+			};
+		public:
+			// How to solve
+			bool wCycle;
+			LocalDepth cgDepth;
+			bool cascadic;
+			unsigned int sliceBlockSize;
+			bool useSupportWeights , useProlongationSupportWeights;
+			std::function< Real ( Real , Real ) > sorRestrictionFunction;
+			std::function< Real ( Real , Real ) > sorProlongationFunction;
+			_IterFunction iters;
+			int vCycles;
+			double cgAccuracy;
+			bool clearSolution;
+			int baseVCycles;
+			// What to output
+			bool verbose , showResidual;
+			int showGlobalResidual;
+
+			SolverInfo( void ) : cgDepth(0) , wCycle(false) , cascadic(true) , iters(1) , vCycles(1) , cgAccuracy(0.) , verbose(false) , showResidual(false) , showGlobalResidual(SHOW_GLOBAL_RESIDUAL_NONE) , sliceBlockSize(1) , sorRestrictionFunction( []( Real , Real ){ return (Real)1; } ) , sorProlongationFunction( []( Real , Real ){ return (Real)1; } ) , useSupportWeights( false ) , useProlongationSupportWeights( false ) , baseVCycles(1) , clearSolution(true) { }
+		};
+		// Solve the linear system
+		// There are several depths playing into the solver:
+		// 1. maxDepth: The maximum depth of the tree
+		// 2. solveDepth: The depth up to which we can solve (solveDepth<=maxDepth)
+		// 3. fullDepth: The depth up to which the octree is completely refined (fullDepth<=maxDepth)
+		// 4. baseDepth: The depth up to which the system is defined through the regular prolongation operators (baseDepth<=fullDepth)
+		template< unsigned int ... FEMSigs , typename T , typename TDotT , typename ... InterpolationInfos >
+		void solveSystem( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , DenseNodeData< T , UIntPack< FEMSigs ... > >& solution , TDotT Dot , LocalDepth minSolveDepth , LocalDepth maxSolveDepth , const SolverInfo& solverInfo , std::tuple< InterpolationInfos *... > interpolationInfos=std::make_tuple() ) const;
+		template< unsigned int ... FEMSigs , typename T , typename TDotT , typename ... InterpolationInfos >
+		DenseNodeData< T , UIntPack< FEMSigs ... > > solveSystem( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const DenseNodeData< T , UIntPack< FEMSigs ... > >& constraints , TDotT Dot , LocalDepth minSolveDepth , LocalDepth maxSolveDepth , const SolverInfo& solverInfo , std::tuple< InterpolationInfos *... > interpolationInfos=std::make_tuple() ) const;
+		template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		void solveSystem( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const DenseNodeData< Real , UIntPack< FEMSigs ... > >& constraints , DenseNodeData< Real , UIntPack< FEMSigs ... > >& solution , LocalDepth minSolveDepth , LocalDepth maxSolveDepth , const SolverInfo& solverInfo , std::tuple< InterpolationInfos *... > interpolationInfos=std::make_tuple() ) const
+		{
+			return solveSystem< FEMSigs ... , Real >( UIntPack< FEMSigs ... >() , F , constraints , solution , []( Real v , Real w ){ return v*w; } , minSolveDepth , maxSolveDepth , solverInfo , interpolationInfos );
+		}
+		template< unsigned int ... FEMSigs , typename ... InterpolationInfos >
+		DenseNodeData< Real , UIntPack< FEMSigs ... > > solveSystem( UIntPack< FEMSigs ... > , typename BaseFEMIntegrator::template System< UIntPack< FEMSignature< FEMSigs >::Degree ... > >& F , const DenseNodeData< Real , UIntPack< FEMSigs ... > >& constraints , LocalDepth minSolveDepth , LocalDepth maxSolveDepth , const SolverInfo& solverInfo , std::tuple< InterpolationInfos *... > interpolationInfos=std::make_tuple() ) const
+		{
+			return solveSystem( UIntPack< FEMSigs ... >() , F , constraints , []( Real v , Real w ){ return v*w; } , minSolveDepth , maxSolveDepth , solverInfo , interpolationInfos );
+		}
+
+		FEMTreeNode& spaceRoot( void ){ return *_spaceRoot; }
+		const FEMTreeNode &spaceRoot( void ) const { return *_spaceRoot; }
+		const FEMTreeNode& tree( void ) const { return _tree; }
+		_NodeInitializer &initializer( void ){ return _nodeInitializer; }
+		size_t leaves( void ) const { return _tree.leaves(); }
+		size_t allNodes              ( void ) const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *  ){ count++; } ) ; return count; }
+		size_t activeNodes           ( void ) const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( IsActiveNode< Dim >( n ) ) count++; } ) ; return count; }
+		size_t ghostNodes            ( void ) const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( !IsActiveNode< Dim >( n ) ) count++; } ) ; return count; }
+		size_t dirichletNodes        ( void ) const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( n->nodeData.getDirichletNodeFlag() ) count++; } ) ; return count; }
+		size_t dirichletElements     ( void ) const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( n->nodeData.getDirichletElementFlag() ) count++; } ) ; return count; }
+		inline size_t validSpaceNodes( void ) const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( isValidSpaceNode( n ) ) count++; } ) ; return count; }
+		inline size_t validSpaceNodes( LocalDepth d ) const { size_t count = 0 ; _tree.process( [&]( const FEMTreeNode *n ){ if( _localDepth(n)==d && isValidSpaceNode( n ) ) count++; } ) ; return count; }
+		template< unsigned int ... FEMSigs > size_t validFEMNodes        ( UIntPack< FEMSigs ... > )                const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( isValidFEMNode( UIntPack< FEMSigs ... >() , n ) ) count++; } ) ; return count; }
+		template< unsigned int ... FEMSigs > size_t validFEMNodes        ( UIntPack< FEMSigs ... > , LocalDepth d ) const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( _localDepth(n)==d && isValidFEMNode( UIntPack< FEMSigs ... >() , n ) ) count++; } ) ; return count; }
+		template< unsigned int ... FEMSigs > size_t validUnlockedFEMNodes( UIntPack< FEMSigs ... > )                const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( isValidFEMNode( UIntPack< FEMSigs ... >() , n ) && !n->nodeData.getDirichletSupportedFlag() ) count++; } ) ; return count; }
+		template< unsigned int ... FEMSigs > size_t validUnlockedFEMNodes( UIntPack< FEMSigs ... > , LocalDepth d ) const { size_t count = 0 ; _tree.processNodes( [&]( const FEMTreeNode *n ){ if( _localDepth(n)==d && isValidFEMNode( UIntPack< FEMSigs ... >() , n ) && !n->nodeData.getDirichletElementFlag() ) count++; } ) ; return count; }
+		LocalDepth depth( void ) const { return _spaceRoot->maxDepth(); }
+		LocalDepth maxDepth( void ) const { return _maxDepth; }
+		template< typename ... DenseOrSparseNodeData >
+		node_index_type resetNodeIndices( char flagsToClear , std::tuple< DenseOrSparseNodeData *... > data )
+		{
+			char mask = ~flagsToClear;
+			if( sizeof...( DenseOrSparseNodeData ) )
+			{
+				std::vector< node_index_type > map( _nodeCount );
+				_nodeCount = 0;
+				auto nodeFunctor = [&]( FEMTreeNode *node )
+					{
+						node_index_type idx = node->nodeData.nodeIndex;
+						_nodeInitializer( *node );
+						if( node->nodeData.nodeIndex!=-1 ) map[ node->nodeData.nodeIndex ] = idx;
+						node->nodeData.flags &= mask;
+					};
+				_tree.processNodes( nodeFunctor );
+
+				_reorderDenseOrSparseNodeData< 0 >( GetPointer( map ) , (size_t)_nodeCount , data );
+			}
+			else
+			{
+				_nodeCount = 0;
+				auto nodeFunctor = [&]( FEMTreeNode *node )
+					{
+						_nodeInitializer( *node );
+						node->nodeData.flags &= mask;
+					};
+				_tree.processNodes( nodeFunctor );
+			}
+			return _nodeCount;
+		}
+		node_index_type resetNodeIndices( char flagsToClear ){ return resetNodeIndices( flagsToClear , std::make_tuple() ); }
+
+		std::vector< node_index_type > merge( FEMTree* tree );
+	protected:
+		template< class Real1 , unsigned int _Dim > static bool _IsZero( Point< Real1 , _Dim > p );
+		template< class Real1 >                     static bool _IsZero( Real1 p );
+		template< class SReal , class Data , unsigned int _Dim > static Data _StencilDot( Point< SReal , _Dim > p1 , Point< Data , _Dim > p2 );
+		template< class SReal , class Data >                     static Data _StencilDot( Point< SReal , 1 >    p1 , Point< Data , 1 >    p2 );
+		template< class SReal , class Data >                     static Data _StencilDot( SReal                 p1 , Point< Data , 1 >    p2 );
+		template< class SReal , class Data >                     static Data _StencilDot( Point< SReal , 1 >    p1 , Data                 p2 );
+		template< class SReal , class Data >                     static Data _StencilDot( SReal                 p1 , Data                 p2 );
+
+		// We need the signatures to test if nodes are valid
+		template< typename T , unsigned int ... FEMSigs , unsigned int ... CSigs , unsigned int ... FEMDegrees , unsigned int ... CDegrees , unsigned int CDim , class Coefficients >
+		void _addFEMConstraints( UIntPack< FEMSigs ... > , UIntPack< CSigs ... > , typename BaseFEMIntegrator::Constraint< UIntPack< FEMDegrees ... > , UIntPack< CDegrees ... > , CDim >& F , const Coefficients& coefficients , Pointer( T ) constraints , LocalDepth maxDepth ) const;
+		template< typename T , typename TDotT , unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , unsigned int ... Degrees1 , unsigned int ... Degrees2 , class Coefficients1 , class Coefficients2 >
+		double _dot( UIntPack< FEMSigs1 ... > , UIntPack< FEMSigs2 ... > , typename BaseFEMIntegrator::Constraint< UIntPack< Degrees1 ... > , UIntPack< Degrees2 ... > , 1 >& F , const Coefficients1& coefficients1 , const Coefficients2& coefficients2 , TDotT Dot ) const;
+		template< typename T , typename TDotT , unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , class Coefficients1 , class Coefficients2 , unsigned int PointD >
+		double _interpolationDot( UIntPack< FEMSigs1 ... > , UIntPack< FEMSigs2 ... > , const Coefficients1& coefficients1 , const Coefficients2& coefficients2 , TDotT Dot , const InterpolationInfo< T , PointD >* iInfo ) const;
+		template< unsigned int Idx , typename T , typename TDotT , unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , class Coefficients1 , class Coefficients2 , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx==sizeof...(InterpolationInfos) ) , double >::type _interpolationDot( UIntPack< FEMSigs1 ... > , UIntPack< FEMSigs2 ... > , const Coefficients1& coefficients1 , const Coefficients2& coefficients2 , TDotT Dot , std::tuple< InterpolationInfos *... > interpolationInfos ) const { return 0.; }
+		template< unsigned int Idx , typename T , typename TDotT , unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , class Coefficients1 , class Coefficients2 , typename ... InterpolationInfos >
+		typename std::enable_if< ( Idx <sizeof...(InterpolationInfos) ) , double >::type _interpolationDot( UIntPack< FEMSigs1 ... > , UIntPack< FEMSigs2 ... > , const Coefficients1& coefficients1 , const Coefficients2& coefficients2 , TDotT Dot , std::tuple< InterpolationInfos *... > interpolationInfos ) const
+		{
+			return _interpolationDot< T >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , coefficients1 , coefficients2 , Dot , std::get< Idx >( interpolationInfos ) ) + _interpolationDot< Idx+1 , T >( UIntPack< FEMSigs1 ... >() , UIntPack< FEMSigs2 ... >() , coefficients1 , coefficients2 , Dot , interpolationInfos );
+		}
+		template< typename T , typename TDotT , unsigned int ... FEMSigs1 , unsigned int ... FEMSigs2 , class Coefficients1 , class Coefficients2 > double _interpolationDot( UIntPack< FEMSigs1 ... > , UIntPack< FEMSigs2 ... > , const Coefficients1& coefficients1 , const Coefficients2& coefficients2 , TDotT Dot ) const{ return 0; }
+	};
+
+
+	template< unsigned int Dim , class Real >
+	struct FEMTreeInitializer
+	{
+		typedef RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > FEMTreeNode;
+		typedef NodeAndPointSample< Dim , Real > PointSample;
+
+		template< class Data >
+		struct DerivativeStream
+		{
+			virtual void resolution( unsigned int res[] ) const = 0;
+			virtual bool nextDerivative( unsigned int idx[] , unsigned int& dir , Data& dValue ) = 0;
+		};
+
+		// Initialize the tree using a refinement avatar
+		static size_t Initialize( FEMTreeNode& root , int maxDepth , std::function< bool ( int , int[] ) > Refine , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+
+		// Initialize the tree using a point stream
+		template< typename Data >
+		struct InputPointStream
+		{
+			typedef Data DataType;
+			typedef DirectSum< Real , Point< Real , Dim > , Data > PointAndDataType;
+			typedef InputDataStream< PointAndDataType > StreamType;
+			static       Point< Real , Dim > &GetPoint(       PointAndDataType &pd ){ return pd.template get<0>(); }
+			static const Point< Real , Dim > &GetPoint( const PointAndDataType &pd ){ return pd.template get<0>(); }
+			static       DataType &GetData(       PointAndDataType &pd ){ return pd.template get<1>(); }
+			static const DataType &GetData( const PointAndDataType &pd ){ return pd.template get<1>(); }
+
+			static void BoundingBox( StreamType &stream , Data d , Point< Real , Dim >& min , Point< Real , Dim >& max )
+			{
+				PointAndDataType p;
+				p.template get<1>() = d;
+				for( unsigned int d=0 ; d<Dim ; d++ ) min[d] = std::numeric_limits< Real >::infinity() , max[d] = -std::numeric_limits< Real >::infinity();
+				while( stream.read( p ) ) for( unsigned int d=0 ; d<Dim ; d++ ) min[d] = std::min< Real >( min[d] , p.template get<0>()[d] ) , max[d] = std::max< Real >( max[d] , p.template get<0>()[d] );
+				stream.reset();
+			}
+		};
+
+		template< typename Data >
+		struct OutputPointStream
+		{
+			typedef Data DataType;
+			typedef DirectSum< Real , Point< Real , Dim > , Data > PointAndDataType;
+			typedef OutputDataStream< PointAndDataType > StreamType;
+			static       Point< Real , Dim > &GetPoint(       PointAndDataType &pd ){ return pd.template get<0>(); }
+			static const Point< Real , Dim > &GetPoint( const PointAndDataType &pd ){ return pd.template get<0>(); }
+			static       DataType &GetData(       PointAndDataType &pd ){ return pd.template get<1>(); }
+			static const DataType &GetData( const PointAndDataType &pd ){ return pd.template get<1>(); }
+		};
+
+		struct StreamInitializationData
+		{
+			friend FEMTreeInitializer;
+		protected:
+			std::vector< node_index_type > _nodeToIndexMap;
+		};
+
+		template< typename IsValidFunctor/*=std::function< bool ( const Point< Real , Dim > & , AuxData &... ) >*/ , typename ProcessFunctor/*=std::function< bool ( FEMTreeNode & , const Point< Real , Dim > & , AuxData &... ) >*/ , typename ... AuxData >
+		static size_t Initialize( FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData ... > &pointStream , AuxData ... zeroData , int maxDepth ,                                                                  Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , IsValidFunctor IsValid , ProcessFunctor Process );
+		template< typename IsValidFunctor/*=std::function< bool ( const Point< Real , Dim > & , AuxData &... ) >*/ , typename ProcessFunctor/*=std::function< bool ( FEMTreeNode & , const Point< Real , Dim > & , AuxData &... ) >*/ , typename ... AuxData >
+		static size_t Initialize( FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData ... > &pointStream , AuxData ... zeroData , int maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , IsValidFunctor IsValid , ProcessFunctor Process );
+
+		template< typename AuxData >
+		static size_t Initialize( struct StreamInitializationData &sid , FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData > &pointStream , AuxData zeroData , int maxDepth ,                                                                  std::vector< PointSample >& samplePoints , std::vector< AuxData > &sampleData , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< Real ( const Point< Real , Dim > & , AuxData & ) > ProcessData = []( const Point< Real , Dim > & , AuxData & ){ return (Real)1.; } );
+		template< typename AuxData >
+		static size_t Initialize( struct StreamInitializationData &sid , FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData > &pointStream , AuxData zeroData , int maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , std::vector< PointSample >& samplePoints , std::vector< AuxData > &sampleData , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< Real ( const Point< Real , Dim > & , AuxData & ) > ProcessData = []( const Point< Real , Dim > & , AuxData & ){ return (Real)1.; } );
+		template< typename AuxData >
+		static size_t Initialize( FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData > &pointStream , AuxData zeroData , int maxDepth ,                                                                  std::vector< PointSample >& samplePoints , std::vector< AuxData > &sampleData , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< Real ( const Point< Real , Dim > & , AuxData & ) > ProcessData = []( const Point< Real , Dim > & , AuxData & ){ return (Real)1.; } );
+		template< typename AuxData >
+		static size_t Initialize( FEMTreeNode &root , InputDataStream< Point< Real , Dim > , AuxData > &pointStream , AuxData zeroData , int maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , std::vector< PointSample >& samplePoints , std::vector< AuxData > &sampleData , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< Real ( const Point< Real , Dim > & , AuxData & ) > ProcessData = []( const Point< Real , Dim > & , AuxData & ){ return (Real)1.; } );
+
+		// Initialize the tree using simplices
+		static void Initialize( FEMTreeNode& root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , int maxDepth , std::vector< PointSample >& samples , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		static void Initialize( FEMTreeNode& root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , unsigned int regularGridDepth , unsigned int maxDepth , std::vector< NodeSimplices< Dim , Real > >& nodeSimplices , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+
+		struct GeometryNodeType
+		{
+			enum Type : char
+			{
+				UNKNOWN ,
+				INTERIOR ,
+				BOUNDARY ,
+				EXTERIOR
+			};
+			Type type;
+			GeometryNodeType( Type t=UNKNOWN ) : type( t ){}
+			bool operator== ( GeometryNodeType gnt ) const { return type==gnt.type; }
+			bool operator!= ( GeometryNodeType gnt ) const { return type!=gnt.type; }
+			bool operator== ( Type type ) const { return this->type==type; }
+			bool operator!= ( Type type ) const { return this->type!=type; }
+
+			friend std::ostream &operator << ( std::ostream &os , const GeometryNodeType &type )
+			{
+				if     ( type.type==UNKNOWN  ) return os << "unknown";
+				else if( type.type==INTERIOR ) return os << "interior";
+				else if( type.type==BOUNDARY ) return os << "boundary";
+				else if( type.type==EXTERIOR ) return os << "exterior";
+				return os;
+			}
+		};
+
+		template< unsigned int _Dim=Dim >
+		static typename std::enable_if< _Dim!=1 , DenseNodeData< GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > >::type GetGeometryNodeDesignators( FEMTreeNode *root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , unsigned int regularGridDepth , unsigned int maxDepth , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		template< unsigned int _Dim=Dim >
+		static typename std::enable_if< _Dim==1 , DenseNodeData< GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > >::type GetGeometryNodeDesignators( FEMTreeNode *root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , unsigned int regularGridDepth , unsigned int maxDepth , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		static void TestGeometryNodeDesignators( const FEMTreeNode *root , const DenseNodeData< GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > &geometryNodeDesignators );
+		static void PushGeometryNodeDesignatorsToFiner( const FEMTreeNode *root , DenseNodeData< GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > &geometryNodeDesignators , unsigned int maxDepth=-1 );
+		static void PullGeometryNodeDesignatorsFromFiner( const FEMTreeNode *root , DenseNodeData< GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > &geometryNodeDesignators , unsigned int maxDepth=-1 );
+
+		// Initialize the tree using weighted points
+		static void Initialize( FEMTreeNode &root , const std::vector< ProjectiveData< Point< Real , Dim > , Real > > &points , int maxDepth , std::vector< PointSample >& samples , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		static void Initialize( FEMTreeNode &root , const std::vector< ProjectiveData< Point< Real , Dim > , Real > > &points , int maxDepth , std::vector< PointSample >& samples );
+
+		template< class Data , class _Data , bool Dual=true >
+		static size_t Initialize( FEMTreeNode& root , ConstPointer( Data ) values , ConstPointer( int ) labels , int resolution[Dim] , std::vector< NodeSample< Dim , _Data > > derivatives[Dim] , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer , std::function< _Data ( const Data& ) > DataConverter = []( const Data& d ){ return (_Data)d; }	);
+		template< bool Dual , class Data >
+		static unsigned int Initialize( FEMTreeNode& root , DerivativeStream< Data >& dStream , Data zeroData , std::vector< NodeSample< Dim , Data > > derivatives[Dim] , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+
+	protected:
+		static size_t _Initialize( FEMTreeNode &node , int maxDepth , std::function< bool ( int , int[] ) > Refine , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		template< bool ThreadSafe > static size_t _AddSimplex( FEMTreeNode& root , Simplex< Real , Dim , Dim-1 >& s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		template< bool ThreadSafe > static size_t _AddSimplex( FEMTreeNode* node , Simplex< Real , Dim , Dim-1 >& s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		template< bool ThreadSafeAllocation , bool ThreadSafeSimplices > static size_t _AddSimplex( FEMTreeNode& root , node_index_type id , Simplex< Real , Dim , Dim-1 >& s , int maxDepth , std::vector< NodeSimplices< Dim , Real > >& simplices , std::vector< node_index_type >& nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		template< bool ThreadSafeAllocation , bool ThreadSafeSimplices > static size_t _AddSimplex( FEMTreeNode* node , node_index_type id , Simplex< Real , Dim , Dim-1 >& s , int maxDepth , std::vector< NodeSimplices< Dim , Real > >& simplices , std::vector< node_index_type >& nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		template< bool ThreadSafe > static size_t _AddSample( FEMTreeNode& root , ProjectiveData< Point< Real , Dim > , Real > s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap , Allocator< FEMTreeNode >* nodeAllocator , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+		static size_t _AddSample( FEMTreeNode& root , ProjectiveData< Point< Real , Dim > , Real > s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap );
+		static size_t _AddSample( FEMTreeNode* node , ProjectiveData< Point< Real , Dim > , Real > s , int maxDepth , std::vector< PointSample >& samples , std::vector< node_index_type >* nodeToIndexMap );
+		static DenseNodeData< GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > _GetGeometryNodeDesignators( FEMTreeNode *root , const std::vector< Point< Real , Dim > >& vertices , const std::vector< SimplexIndex< Dim-1 , node_index_type > >& simplices , const std::vector< Point< Real , Dim > > &normals , unsigned int regularGridDepth , unsigned int maxDepth , std::vector< Allocator< FEMTreeNode > * > &nodeAllocators , std::function< void ( FEMTreeNode& ) > NodeInitializer );
+	};
+	template< unsigned int Dim , class Real >
+	template< unsigned int ... SupportSizes >
+	const unsigned int FEMTree< Dim , Real >::CornerLoopData< SupportSizes ... >::supportSizes[] = { SupportSizes ... };
+
+
+#include "FEMTree.inl"
+#include "FEMTree.SortedTreeNodes.inl"
+#include "FEMTree.WeightedSamples.inl"
+#include "FEMTree.System.inl"
+#include "FEMTree.Evaluation.inl"
+#include "FEMTree.LevelSet.inl"
+#include "FEMTree.LevelSet.2D.inl"
+#include "FEMTree.LevelSet.3D.inl"
+#include "FEMTree.Initialize.inl"
+}
+
+#endif // FEM_TREE_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/FEMTree.inl
@@ -1,0 +1,1987 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+/////////////////////
+// FEMTreeNodeData //
+/////////////////////
+#ifdef SANITIZED_PR
+FEMTreeNodeData::FEMTreeNodeData( void ) : flags(0){}
+FEMTreeNodeData &FEMTreeNodeData::operator = ( const FEMTreeNodeData &data )
+{
+	nodeIndex = data.nodeIndex;
+	flags = data.flags.load();
+	return *this;
+}
+#else // !SANITIZED_PR
+FEMTreeNodeData::FEMTreeNodeData( void ){ flags = 0; }
+#endif // SANITIZED_PR
+FEMTreeNodeData::~FEMTreeNodeData( void ) { }
+
+
+/////////////
+// FEMTree //
+/////////////
+
+template< unsigned int Dim , class Real >
+void FEMTree< Dim , Real >::_init( void )
+{
+	// Reset the depths and offsets
+	int offset[Dim];
+	for( int d=0 ; d<Dim ; d++ ) offset[d] = 0;
+	RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >::ResetDepthAndOffset( &_tree , 0 , offset );
+
+	// Set the _spaceRoot
+	_spaceRoot = &_tree;
+	for( int d=0 ; d<_depthOffset ; d++ )
+	{
+		if( !_spaceRoot->children ) MK_THROW( "Expected child node: " , d , " / " , _depthOffset );
+		else if( d==0 ) _spaceRoot = _spaceRoot->children + (1<<Dim)-1;
+		else            _spaceRoot = _spaceRoot->children;
+	}
+}
+
+template< unsigned int Dim , class Real >
+FEMTree< Dim , Real > *FEMTree< Dim , Real >::Merge( const FEMTree< Dim , Real > &tree1 , const FEMTree< Dim , Real > &tree2 , size_t blockSize )
+{
+	if( tree1._baseDepth != tree2._baseDepth ) MK_THROW( "Base depths differ: " , tree1._baseDepth , " != " , tree2._baseDepth );
+	if( tree1._depthOffset != tree2._depthOffset ) MK_THROW( "Depth offsets differ: " , tree1._depthOffset , " != " , tree2._depthOffset );
+	FEMTree< Dim , Real > *mergeTree = new FEMTree( blockSize );
+
+	// have support overlapping the slice.
+	std::function< void ( const FEMTreeNode *node1 , const FEMTreeNode *node2 , FEMTreeNode *mergeNode ) > mergeTrees =
+		[&]( const FEMTreeNode *node1 , const FEMTreeNode *node2 , FEMTreeNode *mergeNode )
+	{
+		if( ( node1 && node1->children ) || ( node2 && node2->children ) )
+		{
+			if( !mergeNode->children ) mergeNode->template initChildren< false >( mergeTree->nodeAllocators.size() ? mergeTree->nodeAllocators[0] : NULL , mergeTree->_nodeInitializer );
+
+			for( unsigned int c=0 ; c<(1<<Dim) ; c++ )
+				if     ( node1 && node1->children && node2 && node2->children ) mergeTrees( node1->children+c , node2->children+c , mergeNode->children+c );
+				else if( node1 && node1->children                             ) mergeTrees( node1->children+c , NULL              , mergeNode->children+c );
+				else if(                             node2 && node2->children ) mergeTrees( NULL              , node2->children+c , mergeNode->children+c );
+		}
+	};
+	mergeTrees( &tree1._tree , &tree2._tree , &mergeTree->_tree );
+
+	int d=0 , off[Dim];
+	for( int d=0 ; d<Dim ; d++ ) off[d] = 0;
+	FEMTreeNode::ResetDepthAndOffset( &mergeTree->_tree , d , off );
+	mergeTree->_depthOffset = tree1._depthOffset;
+	mergeTree->_baseDepth = tree1._baseDepth;
+
+	mergeTree->_init();
+	mergeTree->_maxDepth = mergeTree->_spaceRoot->maxDepth();
+
+	std::vector< node_index_type > map;
+	mergeTree->_sNodes.reset( mergeTree->_tree , map );
+	mergeTree->_setSpaceValidityFlags();
+
+	return mergeTree;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int CrossDegree , unsigned int Pad >
+FEMTree< Dim , Real > *FEMTree< Dim , Real >::Slice( const FEMTree< Dim+1 , Real > &tree , unsigned int sliceDepth , unsigned int sliceIndex , bool includeBounds , size_t blockSize )
+{
+	if( sliceIndex>(unsigned int)(1<<sliceDepth) ) MK_THROW( "Slice index out of bounds: 0 <= " , sliceIndex , " <= " , (1<<sliceDepth) );
+	FEMTree< Dim , Real > *sliceTree = new FEMTree( blockSize );
+
+	unsigned int maxDepth = tree.maxDepth();
+	if( sliceDepth<maxDepth+1 )
+	{
+		sliceIndex <<= ( maxDepth+1-sliceDepth );
+		sliceDepth = maxDepth+1;
+	}
+	const int StartOffset = BSplineSupportSizes< CrossDegree >::SupportStart-(int)Pad;
+	const int   EndOffset = BSplineSupportSizes< CrossDegree >::SupportEnd+1+(int)Pad;
+
+	// A function returning true if the function indexed by the node has support overlapping the slice
+	auto OverlapsSlice = [&]( const typename FEMTree< Dim+1 , Real >::FEMTreeNode *node )
+	{
+		typename FEMTree< Dim+1 , Real >::LocalDepth d ; typename FEMTree< Dim+1 , Real >::LocalOffset off;
+		tree.depthAndOffset( node , d , off );
+		if( d<0 ) return true;
+		else
+		{
+			int start = ( off[Dim] + StartOffset )<<(sliceDepth-d);
+			int end   = ( off[Dim] +   EndOffset )<<(sliceDepth-d);
+			if( includeBounds ) return (int)sliceIndex>=start && (int)sliceIndex<=end;
+			else                return (int)sliceIndex> start && (int)sliceIndex< end;
+		}
+	};
+
+	// Walk through the two trees in tandem, adding children to the slice-tree if the associated children in the full tree
+	// have support overlapping the slice.
+	std::function< void ( const typename FEMTree< Dim+1 , Real >::FEMTreeNode *node , typename FEMTree< Dim , Real >::FEMTreeNode *sliceNode ) > refineSliceTree =
+		[&]( const typename FEMTree< Dim+1 , Real >::FEMTreeNode *node , typename FEMTree< Dim , Real >::FEMTreeNode *sliceNode )
+	{
+		if( !GetGhostFlag( node->children ) )
+		{
+			bool overlaps = false;
+			for( unsigned int c=0 ; c<(1<<(Dim+1)) ; c++ ) overlaps |= OverlapsSlice( node->children+c );
+			if( overlaps )
+			{
+				if( !sliceNode->children ) sliceNode->template initChildren< false >( sliceTree->nodeAllocators.size() ? sliceTree->nodeAllocators[0] : NULL , sliceTree->_nodeInitializer );
+				for( unsigned int c=0 ; c<(1<<Dim) ; c++ )
+				{
+					refineSliceTree( node->children+( c|(1<<Dim) ) , sliceNode->children+c );
+					refineSliceTree( node->children+( c          ) , sliceNode->children+c );
+				}
+			}
+		}
+	};
+
+	refineSliceTree( &tree._tree , &sliceTree->_tree );
+
+	int d=0 , off[Dim];
+	for( int d=0 ; d<Dim ; d++ ) off[d] = 0;
+	FEMTreeNode::ResetDepthAndOffset( &sliceTree->_tree , d , off );
+	sliceTree->_depthOffset = tree._depthOffset;
+	sliceTree->_baseDepth = tree._baseDepth;
+
+	sliceTree->_init();
+	sliceTree->_maxDepth = sliceTree->_spaceRoot->maxDepth();
+
+	std::vector< node_index_type > map;
+	sliceTree->_sNodes.reset( sliceTree->_tree , map );
+	sliceTree->_setSpaceValidityFlags();
+	return sliceTree;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs  , typename Data >
+void FEMTree< Dim , Real >::merge( const FEMTree< Dim , Real > &tree , const DenseNodeData< Data , UIntPack< FEMSigs ... > > &coefficients , DenseNodeData< Data , UIntPack< FEMSigs ... > > &mergeCoefficients ) const
+{
+	static_assert( sizeof ... ( FEMSigs )==Dim , "[ERROR] Signature count and dimension don't match" );
+
+	std::function< void ( const FEMTreeNode * , const FEMTreeNode * ) > accumulateCoefficients =
+		[&]( const FEMTreeNode *node , const FEMTreeNode *mergeNode )
+	{
+		if( node && node->nodeData.nodeIndex!=-1 )
+		{
+			if( !mergeNode || mergeNode->nodeData.nodeIndex==-1 ) MK_THROW( "Merge node not set" );
+			LocalDepth d ; LocalOffset off;
+			tree.depthAndOffset( node , d , off );
+			mergeCoefficients[ mergeNode->nodeData.nodeIndex ] += coefficients[ node->nodeData.nodeIndex ];
+		}
+		if( node && node->children ) for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) accumulateCoefficients( node->children+c , mergeNode->children+c );
+	};
+	accumulateCoefficients( &tree._tree , &_tree );
+}
+
+template< unsigned int Dim , class Real , unsigned int Pad , unsigned int FEMSig >
+struct SliceEvaluator
+{
+	struct _SliceEvaluator
+	{
+		const int StartOffset = BSplineSupportSizes< FEMSignature< FEMSig >::Degree >::SupportStart-(int)Pad;
+		const int   EndOffset = BSplineSupportSizes< FEMSignature< FEMSig >::Degree >::SupportEnd+1+(int)Pad;
+		int start;
+		Real values[ BSplineSupportSizes< FEMSignature< FEMSig >::Degree >::SupportSize+2*Pad ];
+		void init( unsigned int depth , double x , unsigned int d )
+		{
+			// off @ depthsupports the slice if 
+			//		x>(off+StartOffset)/(1<<depth) && x<(off+EndOffset)/(1<<depth)
+			// <=>	x*(1<<depth)-StartOffset>off && x*(1<<depth)-EndOfset<off
+			// <=>	off \in ( x*(1<<depth)-EndOffset , x*(1<<depth)-StartOffset )
+			// <=	off \in [ ceil( x*(1<<depth) )-EndOffset , ceil( x*(1<<depth) ) - StartOffset )
+			start = (int)ceil( x*(1<<depth)-EndOffset );
+
+			// The derivative is lower than the degree, the derivative will be continuous so we can evaluate it directly
+			if( d<FEMSignature< FEMSig >::Degree ) for( int i=0 ; i<EndOffset-StartOffset ; i++ ) values[i] = (Real)BSplineEvaluationData< FEMSig >::Value( depth , start+i , x , d );
+			else if( d==FEMSignature< FEMSig >::Degree )
+			{
+				double eps = 1e-4/(1<<depth);
+#ifdef SHOW_WARNINGS
+				MK_WARN_ONCE( "Using discrete derivative: " , eps );
+#endif // SHOW_WARNINGS
+				// If we are dealing with a degree-zero polynomial, we offset
+				if( d==0 )
+				{
+					for( int i=0 ; i<EndOffset-StartOffset ; i++ )
+					{
+						double value = 0;
+						value += BSplineEvaluationData< FEMSig >::Value( depth , start+i , x-eps , d );
+						value += BSplineEvaluationData< FEMSig >::Value( depth , start+i , x+eps , d );
+						values[i] = (Real)(value/2);
+					}
+				}
+				else // Otherwise we compute the discrete derivative
+				{
+					for( int i=0 ; i<EndOffset-StartOffset ; i++ )
+					{
+						double value = 0;
+						value += BSplineEvaluationData< FEMSig >::Value( depth , start+i , x , d-1 ) - BSplineEvaluationData< FEMSig >::Value( depth , start+i , x-eps , d-1 );
+						value += BSplineEvaluationData< FEMSig >::Value( depth , start+i , x+eps , d-1 ) - BSplineEvaluationData< FEMSig >::Value( depth , start+i , x , d-1 );
+						values[i] = (Real)(value/(2*eps) );
+					}
+				}
+
+			}
+			else MK_THROW( "Derivative exceeds degree: " , d , " > " , FEMSignature< FEMSig >::Degree );
+		}
+		Real operator()( int off ) const
+		{
+			if( off<start || off>=start+(EndOffset-StartOffset ) ) return 0;
+			else return values[off-start];
+		}
+	};
+
+	std::vector< _SliceEvaluator > evaluators;
+	void init( unsigned int maxDepth , double x , unsigned int d )
+	{
+		evaluators.resize( maxDepth+1 );
+		for( unsigned int depth=0 ; depth<=maxDepth ; depth++ ) evaluators[depth].init( depth , x , d );
+	}
+	Real operator()( int d , int off ) const
+	{
+		if( d<0 || d>=(int)evaluators.size() ) return 0;
+		else return evaluators[d]( off );
+	}
+};
+
+template< unsigned int Dim , class Real >
+template< unsigned int Pad , unsigned int FEMSig , unsigned int ... FEMSigs , typename Data >
+void FEMTree< Dim , Real >::slice( const FEMTree< Dim+1 , Real > &tree , unsigned int d , const DenseNodeData< Data , UIntPack< FEMSigs ... , FEMSig > > &coefficients , DenseNodeData< Data , UIntPack< FEMSigs ... > > &sliceCoefficients , unsigned int sliceDepth , unsigned int sliceIndex ) const
+{
+	static_assert( sizeof ... ( FEMSigs )==Dim , "[ERROR] Signature count and dimension don't match" );
+#ifdef __GNUC__
+#ifdef SHOW_WARNINGS
+	#warning "you've got me gcc version<5"
+#endif // SHOW_WARNINGS
+#else // !__GNUC__
+	static const unsigned int CrossDegree = FEMSignature< FEMSig >::Degree;
+	static const unsigned int _Pad = Pad;
+#endif // __GNUC__
+
+	unsigned int maxDepth = tree.maxDepth();
+	if( sliceDepth<maxDepth+1 )
+	{
+		sliceIndex <<= ( maxDepth+1-sliceDepth );
+		sliceDepth = maxDepth+1;
+	}
+
+	double s = (double)sliceIndex/(1<<sliceDepth);
+
+#ifdef __GNUC__
+	const int StartOffset = BSplineSupportSizes< FEMSignature< FEMSig >::Degree >::SupportStart-(int)Pad;
+	const int   EndOffset = BSplineSupportSizes< FEMSignature< FEMSig >::Degree >::SupportEnd+1+(int)Pad;
+#else // !__GNUC__
+	const int StartOffset = BSplineSupportSizes< CrossDegree >::SupportStart-(int)Pad;
+	const int   EndOffset = BSplineSupportSizes< CrossDegree >::SupportEnd+1+(int)Pad;
+#endif // __GNUC__
+
+	SliceEvaluator< Dim , Real , Pad , FEMSig > sliceEvaluator;
+	sliceEvaluator.init( maxDepth , s , d );
+
+	// A function return true if the function indexed by the node has support overlapping the slice
+	auto OverlapsSlice = [&]( const typename FEMTree< Dim+1 , Real >::FEMTreeNode *node )
+	{
+		typename FEMTree< Dim+1 , Real >::LocalDepth d ; typename FEMTree< Dim+1 , Real >::LocalOffset off;
+		tree.depthAndOffset( node , d , off );
+		if( d<0 ) return true;
+		else
+		{
+			int start = ( off[Dim] + StartOffset )<<(sliceDepth-d);
+			int end   = ( off[Dim] +   EndOffset )<<(sliceDepth-d);
+			return (int)sliceIndex>start && (int)sliceIndex<end;
+		}
+	};
+
+	std::function< void ( const typename FEMTree< Dim+1 , Real >::FEMTreeNode * , const typename FEMTree< Dim , Real >::FEMTreeNode * ) > accumulateSliceCoefficients =
+		[&]( const typename FEMTree< Dim+1 , Real >::FEMTreeNode *node , const typename FEMTree< Dim , Real >::FEMTreeNode *sliceNode )
+	{
+		if( node->nodeData.nodeIndex!=-1 )
+		{
+			if( sliceNode->nodeData.nodeIndex==-1 ) MK_THROW( "Slice node not set" );
+			typename FEMTree< Dim+1 , Real >::LocalDepth d ; typename FEMTree< Dim+1 , Real >::LocalOffset off;
+			tree.depthAndOffset( node , d , off );
+			sliceCoefficients[ sliceNode->nodeData.nodeIndex ] += coefficients[ node->nodeData.nodeIndex ] * sliceEvaluator( d , off[Dim] );
+		}
+		if( !GetGhostFlag( node->children ) )
+		{
+			if( OverlapsSlice( node->children          ) ) for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) accumulateSliceCoefficients( node->children+( c          ) , sliceNode->children+c );
+			if( OverlapsSlice( node->children+(1<<Dim) ) ) for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) accumulateSliceCoefficients( node->children+( c|(1<<Dim) ) , sliceNode->children+c );
+		}
+	};
+	accumulateSliceCoefficients( &tree._tree , &_tree );
+}
+
+template< unsigned int Dim , class Real >
+FEMTree< Dim , Real >::FEMTree( size_t blockSize ) : _nodeInitializer( *this ) , _depthOffset(1)
+{
+	if( blockSize )
+	{
+		nodeAllocators.resize( ThreadPool::NumThreads() );
+		for( size_t i=0 ; i<nodeAllocators.size() ; i++ )
+		{
+			nodeAllocators[i] = new Allocator< FEMTreeNode >();
+			nodeAllocators[i]->set( blockSize );
+		}
+	}
+	_nodeCount = 0;
+	// Initialize the root
+	_nodeInitializer( _tree );
+	_tree.template initChildren< false >( nodeAllocators.size() ? nodeAllocators[0] : NULL , _nodeInitializer );
+	_init();
+	memset( _femSigs1 , -1 , sizeof( _femSigs1 ) );
+	memset( _femSigs2 , -1 , sizeof( _femSigs2 ) );
+}
+
+template< unsigned int Dim , class Real >
+FEMTree< Dim , Real >::FEMTree( BinaryStream &stream , size_t blockSize ) : FEMTree( blockSize )
+{
+	Allocator< FEMTreeNode > *nodeAllocator = nodeAllocators.size() ? nodeAllocators[0] : NULL;
+	node_index_type nodeCount;
+	if( !stream.read( nodeCount ) ) MK_THROW( "Failed to read nodeCount" );
+	_nodeCount = nodeCount;
+	if( !stream.read( _maxDepth ) ) MK_THROW( "Failed to read _maxDepth" );
+	if( !stream.read( _depthOffset ) ) MK_THROW( "Failed to read _depthOffset" );
+	if( !stream.read( _baseDepth ) ) MK_THROW( "Failed to read _baseDepth" );
+	_tree.read( stream , nodeAllocator );
+	_init();
+	_sNodes.read( stream , _tree );
+}
+
+template< unsigned int Dim , class Real > void FEMTree< Dim , Real >::write( BinaryStream &stream , bool serialize ) const
+{
+	node_index_type nodeCount = _nodeCount;
+	stream.write( nodeCount );
+	stream.write( _maxDepth );
+	stream.write( _depthOffset );
+	stream.write( _baseDepth );
+	_tree.write( stream , serialize );
+	_sNodes.write( stream );
+}
+
+template< unsigned int Dim , class Real >
+const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* FEMTree< Dim , Real >::leaf( Point< Real , Dim > p ) const
+{
+	if( !_InBounds( p ) ) return NULL;
+	Point< Real , Dim > center;
+	for( int d=0 ; d<Dim ; d++ ) center[d] = (Real)0.5;
+	Real width = Real(1.0);
+	FEMTreeNode* node = _spaceRoot;
+	while( node->children )
+	{
+		int cIndex = FEMTreeNode::ChildIndex( center , p );
+		node = node->children + cIndex;
+		width /= 2;
+		for( int d=0 ; d<Dim ; d++ )
+			if( (cIndex>>d) & 1 ) center[d] += width/2;
+			else                  center[d] -= width/2;
+	}
+	return node;
+}
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe >
+RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* FEMTree< Dim , Real >::_leaf( Allocator< FEMTreeNode > *nodeAllocator , Point< Real , Dim > p , LocalDepth maxDepth )
+{
+	if( !_InBounds( p ) ) return NULL;
+	Point< Real , Dim > center;
+	for( int d=0 ; d<Dim ; d++ ) center[d] = (Real)0.5;
+	Real width = Real(1.0);
+	FEMTreeNode* node = _spaceRoot;
+	LocalDepth d = _localDepth( node );
+	while( ( d<0 && node->children ) || ( d>=0 && d<maxDepth ) )
+	{
+		if( !node->children ) node->template initChildren< ThreadSafe >( nodeAllocator , _nodeInitializer );
+		int cIndex = FEMTreeNode::ChildIndex( center , p );
+		node = node->children + cIndex;
+		d++;
+		width /= 2;
+		for( int d=0 ; d<Dim ; d++ )
+			if( (cIndex>>d) & 1 ) center[d] += width/2;
+			else                  center[d] -= width/2;
+	}
+	return node;
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe >
+RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* FEMTree< Dim , Real >::_leaf( Allocator< FEMTreeNode > *nodeAllocator , Point< Real , Dim > p , std::function< int ( Point< Real , Dim > ) > &pointDepthFunctor )
+{
+	if( !_InBounds( p ) ) return NULL;
+	int maxDepth = pointDepthFunctor( p );
+	Point< Real , Dim > center;
+	for( int d=0 ; d<Dim ; d++ ) center[d] = (Real)0.5;
+	Real width = Real(1.0);
+	FEMTreeNode* node = _spaceRoot;
+	LocalDepth depth = 0;
+	int cIndex = FEMTreeNode::ChildIndex( center , p );
+
+	while( depth<maxDepth )
+	{
+		if( !node->children ) node->template initChildren< ThreadSafe >( nodeAllocator , _nodeInitializer );
+		int cIndex = FEMTreeNode::ChildIndex( center , p );
+		node = node->children + cIndex;
+
+		depth++;
+		width /= 2;
+		for( int d=0 ; d<Dim ; d++ )
+			if( (cIndex>>d) & 1 ) center[d] += width/2;
+			else                  center[d] -= width/2;
+	}
+	return node;
+}
+
+template< unsigned int Dim , class Real > bool FEMTree< Dim , Real >::_InBounds( Point< Real , Dim > p ){ for( int d=0 ; d<Dim ; d++ ) if( p[d]<0 || p[d]>1 ) return false ; return true; }
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSignatures >
+bool FEMTree< Dim , Real >::isValidFEMNode( UIntPack< FEMSignatures ... > , const FEMTreeNode* node ) const
+{
+	if( GetGhostFlag< Dim >( node ) ) return false;
+	LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node , d , off );
+	if( d<0 ) return false;
+	return FEMIntegrator::IsValidFEMNode( UIntPack< FEMSignatures ... >() , d , off );
+}
+template< unsigned int Dim , class Real >
+bool FEMTree< Dim , Real >::isValidSpaceNode( const FEMTreeNode* node ) const
+{
+	if( !node ) return false;
+	LocalDepth d ; LocalOffset off ; _localDepthAndOffset( node , d , off );
+	if( d<0 ) return false;
+	int res = 1<<d;
+	for( int dd=0 ; dd<Dim ; dd++ ) if( off[dd]<0 || off[dd]>=res ) return false;
+	return true;
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe , typename AddNodeFunctor , unsigned int ... Degrees >
+void FEMTree< Dim , Real >::_refine( UIntPack< Degrees ... > , Allocator< FEMTreeNode > *nodeAllocator , const AddNodeFunctor &addNodeFunctor , FEMTreeNode *node )
+{
+	LocalDepth d , _d ; LocalOffset off , _off;
+	_localDepthAndOffset( node , d , off );
+	_d = d+1;
+
+	bool refine = d<0;
+	for( int c=0 ; c<(1<<Dim) ; c++ )
+	{
+		for( int d=0 ; d<Dim ; d++ )
+			if( c&(1<<d) ) _off[d] = off[d]*2+1;
+			else           _off[d] = off[d]*2+0;
+		refine |= !FEMIntegrator::IsOutOfBounds( UIntPack< FEMDegreeAndBType< Degrees , BOUNDARY_FREE >::Signature ... >() , _d , _off ) && addNodeFunctor( _d , _off );
+	}
+	if( refine )
+	{
+		if( !node->children ) node->template initChildren< ThreadSafe >( nodeAllocator , _nodeInitializer );
+		for( int c=0 ; c<(1<<Dim) ; c++ ) _refine< ThreadSafe >( UIntPack< Degrees ... >() , nodeAllocator , addNodeFunctor , node->children+c );
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe , typename AddNodeFunctor , unsigned int ... Degrees >
+void FEMTree< Dim , Real >::_refine( UIntPack< Degrees ... > , Allocator< FEMTreeNode > *nodeAllocator , const AddNodeFunctor &addNodeFunctor )
+{
+	if( !_tree.children ) _tree.template initChildren< ThreadSafe >( nodeAllocator , _nodeInitializer );
+	for( int c=0 ; c<(1<<Dim) ; c++ ) _refine< ThreadSafe >( UIntPack< Degrees ... >() , nodeAllocator , addNodeFunctor , _tree.children+c );
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe , unsigned int ... Degrees >
+void FEMTree< Dim , Real >::_setFullDepth( UIntPack< Degrees ... > , Allocator< FEMTreeNode > *nodeAllocator , FEMTreeNode* node , LocalDepth depth )
+{
+	LocalDepth d ; LocalOffset off;
+	_localDepthAndOffset( node , d , off );
+	bool refine = d<depth && ( d<0 || !FEMIntegrator::IsOutOfBounds( UIntPack< FEMDegreeAndBType< Degrees , BOUNDARY_FREE >::Signature ... >() , d , off ) );
+	if( refine )
+	{
+		if( !node->children ) node->template initChildren< ThreadSafe >( nodeAllocator , _nodeInitializer );
+		for( int c=0 ; c<(1<<Dim) ; c++ ) _setFullDepth< ThreadSafe >( UIntPack< Degrees ... >() , nodeAllocator , node->children+c , depth );
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< bool ThreadSafe , unsigned int ... Degrees >
+void FEMTree< Dim , Real >::_setFullDepth( UIntPack< Degrees ... > , Allocator< FEMTreeNode > *nodeAllocator , LocalDepth depth )
+{
+	if( !_tree.children ) _tree.template initChildren< ThreadSafe >( nodeAllocator , _nodeInitializer );
+	for( int c=0 ; c<(1<<Dim) ; c++ ) _setFullDepth< ThreadSafe >( UIntPack< Degrees ... >() , nodeAllocator , _tree.children+c , depth );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... Degrees >
+typename FEMTree< Dim , Real >::LocalDepth FEMTree< Dim , Real >::_getFullDepth( UIntPack< Degrees ... > , const FEMTreeNode* node ) const
+{
+	LocalDepth d ; LocalOffset off;
+	_localDepthAndOffset( node , d , off );
+	bool refine = d<0 || !FEMIntegrator::IsOutOfBounds( UIntPack< FEMDegreeAndBType< Degrees , BOUNDARY_FREE >::Signature ... >() , d , off );
+
+	if( refine )
+	{
+		if( !node->children ) return d;
+		else
+		{
+			LocalDepth depth = INT_MAX;
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+			{
+				LocalDepth d = _getFullDepth( UIntPack< Degrees ... >() , node->children+c );
+				if( d<depth ) depth = d;
+			}
+			return depth;
+		}
+	}
+	else return INT_MAX;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... Degrees >
+typename FEMTree< Dim , Real >::LocalDepth FEMTree< Dim , Real >::_getFullDepth( UIntPack< Degrees ... > , const LocalDepth depth , const LocalOffset begin , const LocalOffset end , const FEMTreeNode* node ) const
+{
+	LocalDepth d ; LocalOffset off;
+	_localDepthAndOffset( node , d , off );
+
+	// [NOTE]: Changing closed interval to half open interval
+	const int StartOffsets[] = { BSplineSupportSizes< Degrees >::SupportStart ... };
+	const int   EndOffsets[] = { BSplineSupportSizes< Degrees >::SupportEnd + 1 ... };
+
+	auto IsSupported = [&]( LocalDepth d , LocalOffset off )
+	{
+		if( d>depth ) return false;
+		LocalOffset supportStart , supportEnd;
+		for( unsigned int dim=0 ; dim<Dim ; dim++ )
+		{
+			supportStart[dim] = ( off[dim] + StartOffsets[dim] )*(1<<(depth-d));
+			supportEnd  [dim] = ( off[dim] +   EndOffsets[dim] )*(1<<(depth-d));
+		}
+		if( d>=0 ) for( unsigned int dim=0 ; dim<Dim ; dim++ ) if( supportStart[dim]>=end[dim] || supportEnd[dim]<=begin[dim] ) return false;
+		return true;
+	};
+
+	{
+		if( !node->children )
+		{
+			LocalDepth _d=d+1;
+			LocalOffset _off;
+			bool childrenSupported = false;
+			for( unsigned int c=0 ; c<(1<<Dim) ; c++ )
+			{
+				for( int dim=0 ; dim<Dim ; dim++ )
+#ifdef SANITIZED_PR
+					if( c&(1<<dim) ) _off[dim] = off[dim]*2 + 1;
+					else             _off[dim] = off[dim]*2 + 0;
+#else // !SANITIZED_PR
+					if( c&(1<<dim) ) _off[dim] = (off[dim]<<1) | 1;
+					else             _off[dim] = (off[dim]<<1);
+#endif // SANITIZED_PR
+				childrenSupported |= IsSupported( _d , _off );
+			}
+			if( childrenSupported ) return d;
+			else return INT_MAX;
+		}
+		else
+		{
+			LocalDepth minDepth = INT_MAX;
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+			{
+				LocalDepth d = _getFullDepth( UIntPack< Degrees ... >() , depth , begin , end , node->children+c );
+				if( d<minDepth ) minDepth = d;
+			}
+			return minDepth;
+		}
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... Degrees >
+typename FEMTree< Dim , Real >::LocalDepth FEMTree< Dim , Real >::getFullDepth( UIntPack< Degrees ... > ) const
+{
+	if( !_tree.children ) return -1;
+	LocalDepth depth = INT_MAX;
+	for( int c=0 ; c<(1<<Dim) ; c++ )
+	{
+		LocalDepth d = _getFullDepth( UIntPack< Degrees ... >() , _tree.children+c );
+		if( d<depth ) depth = d;
+	}
+	return depth;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... Degrees >
+typename FEMTree< Dim , Real >::LocalDepth FEMTree< Dim , Real >::getFullDepth( UIntPack< Degrees ... > , const LocalDepth depth , const LocalOffset begin , const LocalOffset end ) const
+{
+	// [NOTE] Need "+1" because _getFullDepth will test children of leaves
+	LocalDepth maxDepth = this->maxDepth() + 1;
+	LocalDepth _depth ; LocalOffset _begin , _end;
+	for( unsigned int d=0 ; d<Dim ; d++ )
+	{
+		if( begin[d]>end[d] ) MK_THROW( "Bad bounds [" , d , "]: " , begin[d] , " <= " , end[d] );
+		if( begin[d]<0 ) MK_THROW( "Start bound cannot be negative [" , d , "]: 0 <= " , begin[d]  );
+		if( end[d]>(1<<depth) ) MK_THROW( "End bound cannot exceed resolution [" , d , "]: " , end[d] , " <=" , (1<<depth) );
+
+		// Push to max depth
+		if( depth<maxDepth )
+		{
+			_begin[d] = begin[d]<<(maxDepth-depth);
+			_end  [d] = end  [d]<<(maxDepth-depth);
+		}
+		else
+		{
+			_begin[d] = begin[d];
+			_end  [d] = end  [d];
+		}
+	}
+	if( depth<maxDepth ) _depth = maxDepth;
+	else                 _depth = depth;
+
+	if( !_tree.children ) return -1;
+
+	LocalDepth minDepth = INT_MAX;
+	for( int c=0 ; c<(1<<Dim) ; c++ )
+	{
+		LocalDepth d = _getFullDepth( UIntPack< Degrees ... >() , _depth , _begin , _end , _tree.children+c );
+		if( d<minDepth ) minDepth = d;
+	}
+
+	return minDepth;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int LeftRadius , unsigned int RightRadius , bool CreateNodes , typename ProcessingNodeFunctor , typename ... DenseOrSparseNodeData , typename InitializeFunctor >
+void FEMTree< Dim , Real >::processNeighbors( ProcessingNodeFunctor processingNode , std::tuple< DenseOrSparseNodeData *... > data , InitializeFunctor initialize )
+{
+	std::vector< FEMTreeNode * > nodes;
+	nodes.reserve( _spaceRoot->nodes() );
+	_spaceRoot->processNodes( [&]( FEMTreeNode *node ){ if( processingNode(node) ) nodes.push_back( node ); } );
+	processNeighbors< LeftRadius , RightRadius , CreateNodes >( &nodes[0] , nodes.size() , data , initialize );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int LeftRadius , unsigned int RightRadius , bool CreateNodes , typename ... DenseOrSparseNodeData , typename InitializeFunctor >
+void FEMTree< Dim , Real >::processNeighbors( FEMTreeNode **nodes , size_t nodeCount, std::tuple< DenseOrSparseNodeData *... > data , InitializeFunctor initialize )
+{
+	int maxDepth = 0;
+	for( size_t i=0 ; i<nodeCount ; i++ ) maxDepth = std::max( maxDepth , nodes[i]->depth() );
+	std::vector< node_index_type > map( _nodeCount );
+	for( node_index_type i=0 ; i<_nodeCount ; i++ ) map[i] = i;
+	typedef typename RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >::template NeighborKey< IsotropicUIntPack< Dim , LeftRadius > , IsotropicUIntPack< Dim , RightRadius > > NeighborKey;
+
+	Allocator< FEMTreeNode > *nodeAllocator = nodeAllocators.size() ? nodeAllocators[0] : NULL;
+	//	typename RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >::template NeighborKey< IsotropicUIntPack< Dim , LeftRadius > , IsotropicUIntPack< Dim , RightRadius > > neighborKey;
+	NeighborKey neighborKey;
+	neighborKey.set( maxDepth );
+	for( size_t i=0 ; i<nodeCount ; i++ )
+	{
+		auto neighbors = neighborKey.template getNeighbors< CreateNodes , false >( nodes[i] , nodeAllocator , _nodeInitializer );
+		for( unsigned int j=0 ; j<neighbors.neighbors.Size() ; j++ ) if( neighbors.neighbors.data[j] ) initialize( neighbors.neighbors.data[j] );
+	}
+
+	_reorderDenseOrSparseNodeData< 0 >( GetPointer( map ) , _nodeCount , data );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int LeftRadius , unsigned int RightRadius , typename IsProcessingNodeFunctor , typename ProcessingKernel >
+void FEMTree< Dim , Real >::processNeighboringLeaves( IsProcessingNodeFunctor isProcessingNode , ProcessingKernel kernel , bool processSubTree )
+{
+	std::vector< FEMTreeNode * > nodes;
+	nodes.reserve( _spaceRoot->nodes() );
+	_spaceRoot->processNodes( [&]( FEMTreeNode *node ){ if( isProcessingNode(node) ) nodes.push_back( node ); } );
+	processNeighboringLeaves< LeftRadius , RightRadius >( &nodes[0] , nodes.size() , kernel , processSubTree );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int LeftRadius , unsigned int RightRadius , typename ProcessingKernel >
+void FEMTree< Dim , Real >::processNeighboringLeaves( FEMTreeNode **nodes , size_t nodeCount  , ProcessingKernel kernel , bool processSubTree )
+{
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] may process the same leaf multiple times, if it is coarser" )
+#endif // SHOW_WARNINGS
+	typedef typename RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >::template NeighborKey< IsotropicUIntPack< Dim , LeftRadius > , IsotropicUIntPack< Dim , RightRadius > > NeighborKey;
+	// Suppose that we have a node at index I and we want the leaf nodes supported on the (possibly virtual) node K away
+	// Case 1: The K-th neighbor exists
+	// ---> Iterate over the leaf nodes of the sub-tree rooted at the K-th neighbor
+	// Case 2: The K-th neighbor does not exist
+	// ---> The index of the K-th neighbor is I+K
+	// ---> The index of the parent is floor( I/2 )
+	// ---> The index of the K-th neighbors parent is floor( (I+K)/2 )
+	// ---> The parent of the K-th neighbor is the [ floor( (I+k)/2 ) - floor( I/2 ) ]-th neighbor of the parent
+
+	std::function< void ( FEMTreeNode * ) > ProcessSubTree = [&]( FEMTreeNode *node )
+	{
+		if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) ProcessSubTree( node->children+c );
+		kernel( node );
+	};
+
+	unsigned int maxDepth=0;
+	for( size_t i=0 ; i<nodeCount ; i++ ) maxDepth = std::max( maxDepth , (unsigned int)nodes[i]->depth() );
+
+	std::vector< NeighborKey > neighborKeys( ThreadPool::NumThreads() );
+	for( int i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( maxDepth );
+
+	ThreadPool::ParallelFor( 0 , nodeCount , [&]( unsigned int t , size_t  i )
+		{
+			typedef StaticWindow< FEMTreeNode * , IsotropicUIntPack< Dim , LeftRadius+RightRadius+1 > > NeighborLeafNodes;
+			NeighborLeafNodes neighborLeafNodes;
+			neighborKeys[t].setLeafNeighbors( nodes[i] , neighborLeafNodes );
+			for( unsigned int i=0 ; i<NeighborLeafNodes::Size() ; i++ ) if( neighborLeafNodes.data[i] )
+				if( processSubTree ) ProcessSubTree( neighborLeafNodes.data[i] );
+				else kernel( neighborLeafNodes.data[i] );
+		} );
+}
+
+template< unsigned int Dim , class Real >
+template< class C , unsigned int ... FEMSigs >
+DenseNodeData< C , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::trimToDepth( const DenseNodeData< C , UIntPack< FEMSigs ... > >& data , LocalDepth coarseDepth ) const
+{
+	if( coarseDepth>_maxDepth ) return data;
+	return data._trim( _sNodesEnd( coarseDepth ) );
+}
+
+template< unsigned int Dim , class Real >
+template< class C , unsigned int ... FEMSigs >
+SparseNodeData< C , UIntPack< FEMSigs ... > > FEMTree< Dim , Real >::trimToDepth( const SparseNodeData< C , UIntPack< FEMSigs ... > >& data , LocalDepth coarseDepth ) const
+{
+	if( coarseDepth>_maxDepth ) return data;
+	return data._trim( _sNodesEnd( coarseDepth ) );
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+typename FEMTree< Dim , Real >::template ApproximatePointInterpolationInfo< T , PointD , ConstraintDual , SystemDual > FEMTree< Dim , Real >::trimToDepth( const ApproximatePointInterpolationInfo< T , PointD , ConstraintDual , SystemDual > &iInfo , LocalDepth coarseDepth ) const
+{
+	ApproximatePointInterpolationInfo< T , PointD , ConstraintDual , SystemDual > _iInfo;
+	if( coarseDepth<_maxDepth ) _iInfo.iData = iInfo.iData._trim( _sNodesEnd( coarseDepth ) );
+	else                        _iInfo.iData = iInfo.iData;
+	_iInfo._constrainsDCTerm = iInfo._constrainsDCTerm;
+	_iInfo._constraintDual = iInfo._constraintDual;
+	_iInfo._systemDual = iInfo._systemDual;
+	return _iInfo;
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+typename FEMTree< Dim , Real >::template ApproximatePointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual > FEMTree< Dim , Real >::trimToDepth( const ApproximatePointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual > &iInfo , LocalDepth coarseDepth ) const
+{
+	ApproximatePointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual > _iInfo;
+	if( coarseDepth<_maxDepth ) _iInfo.iData = iInfo.iData._trim( _sNodesEnd( coarseDepth ) );
+	else                        _iInfo.iData = iInfo.iData;
+	_iInfo._constrainsDCTerm = iInfo._constrainsDCTerm;
+	_iInfo._constraintDual = iInfo._constraintDual;
+	_iInfo._systemDual = iInfo._systemDual;
+	return _iInfo;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int CoDim , unsigned int DensityDegree >
+void FEMTree< Dim , Real >::updateDensityEstimator( typename FEMTree< Dim , Real >::template DensityEstimator< DensityDegree > &density , const std::vector< PointSample >& samples , LocalDepth minSplatDepth , LocalDepth maxSplatDepth )
+{
+	//	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( _spaceRoot );
+	SubTreeExtractor subtreeExtractor( _spaceRoot , _depthOffset );
+	Allocator< FEMTreeNode > *nodeAllocator = nodeAllocators.size() ? nodeAllocators[0] : NULL;
+	LocalDepth maxDepth = _spaceRoot->maxDepth();
+	maxSplatDepth = std::max< LocalDepth >( 0 , std::min< LocalDepth >( maxSplatDepth , maxDepth ) );
+	minSplatDepth = std::max< LocalDepth >( 0 , std::min< LocalDepth >( minSplatDepth , maxDepth ) );
+	if( minSplatDepth>maxSplatDepth ) MK_THROW( "Minimum splat depth exceeds maximum splat depth" );
+	PointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > densityKey;
+	densityKey.set( maxSplatDepth );
+
+	std::vector< node_index_type > sampleMap( nodeCount() , -1 );
+
+	// Initialize the map from node indices to samples
+	ThreadPool::ParallelFor( 0 , samples.size() , [&]( unsigned int , size_t i ){ if( samples[i].sample.weight>0 ) sampleMap[ samples[i].node->nodeData.nodeIndex ] = (node_index_type)i; } );
+
+	std::function< ProjectiveData< Point< Real , Dim > , Real > ( FEMTreeNode* ) > SetDensity = [&] ( FEMTreeNode* node )
+	{
+		ProjectiveData< Point< Real , Dim > , Real > sample;
+		LocalDepth d = node->depth();
+		node_index_type idx = node->nodeData.nodeIndex;
+		if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) sample += SetDensity( node->children + c );
+		if( idx<(node_index_type)sampleMap.size() && sampleMap[idx]!=-1 ) sample += samples[ sampleMap[ idx ] ].sample;
+		if( d>=minSplatDepth && d<=maxSplatDepth && sample.weight>0 ) _addWeightContribution< true , CoDim >( nodeAllocator , density , node , sample.data / sample.weight , densityKey , sample.weight );
+		return sample;
+	};
+	SetDensity( _spaceRoot );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int CoDim , unsigned int DensityDegree >
+void FEMTree< Dim , Real >::updateDensityEstimator( typename FEMTree< Dim , Real >::template DensityEstimator< DensityDegree > &density , const std::vector< PointSample >& samples , LocalDepth minSplatDepth , LocalDepth maxSplatDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor )
+{
+	//	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( _spaceRoot );
+	SubTreeExtractor subtreeExtractor( _spaceRoot , _depthOffset );
+	Allocator< FEMTreeNode > *nodeAllocator = nodeAllocators.size() ? nodeAllocators[0] : NULL;
+	LocalDepth maxDepth = _spaceRoot->maxDepth();
+	maxSplatDepth = std::max< LocalDepth >( 0 , std::min< LocalDepth >( maxSplatDepth , maxDepth ) );
+	minSplatDepth = std::max< LocalDepth >( 0 , std::min< LocalDepth >( minSplatDepth , maxDepth ) );
+	if( minSplatDepth>maxSplatDepth ) MK_THROW( "Minimum splat depth exceeds maximum splat depth" );
+	PointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > densityKey;
+	densityKey.set( maxSplatDepth );
+
+	std::vector< node_index_type > sampleMap( nodeCount() , -1 );
+
+	// Initialize the map from node indices to samples
+	ThreadPool::ParallelFor( 0 , samples.size() , [&]( unsigned int , size_t i ){ if( samples[i].sample.weight>0 ) sampleMap[ samples[i].node->nodeData.nodeIndex ] = (node_index_type)i; } );
+
+	std::function< ProjectiveData< Point< Real , Dim > , Real > ( FEMTreeNode* ) > SetDensity = [&] ( FEMTreeNode* node )
+	{
+		ProjectiveData< Point< Real , Dim > , Real > sample;
+		LocalDepth d = node->depth();
+		node_index_type idx = node->nodeData.nodeIndex;
+		if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) sample += SetDensity( node->children + c );
+		if( idx<(node_index_type)sampleMap.size() && sampleMap[idx]!=-1 ) sample += samples[ sampleMap[ idx ] ].sample;
+
+		if( d>=minSplatDepth && d<=maxSplatDepth && sample.weight>0 )
+		{
+			// The average position of samples accumulated in the node
+			Point< Real , Dim > p = sample.data / sample.weight;
+			if( d<=pointDepthFunctor( p ) ) _addWeightContribution< true , CoDim >( nodeAllocator , density , node , p , densityKey , sample.weight );
+		}
+		return sample;
+	};
+	SetDensity( _spaceRoot );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int CoDim , unsigned int DensityDegree >
+typename FEMTree< Dim , Real >::template DensityEstimator< DensityDegree >* FEMTree< Dim , Real >::setDensityEstimator( const std::vector< PointSample >& samples , LocalDepth splatDepth , Real samplesPerNode )
+{
+	LocalDepth maxDepth = _spaceRoot->maxDepth();
+	splatDepth = std::max< LocalDepth >( 0 , std::min< LocalDepth >( splatDepth , maxDepth ) );
+	DensityEstimator< DensityDegree > *density = new DensityEstimator< DensityDegree >( splatDepth , CoDim , samplesPerNode );
+	this->template updateDensityEstimator< CoDim , DensityDegree >( *density , samples , 0 , splatDepth );
+
+	return density;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int CoDim , unsigned int DensityDegree >
+typename FEMTree< Dim , Real >::template DensityEstimator< DensityDegree >* FEMTree< Dim , Real >::setDensityEstimator( const std::vector< PointSample >& samples , LocalDepth splatDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Real samplesPerNode )
+{
+	LocalDepth maxDepth = _spaceRoot->maxDepth();
+	splatDepth = std::max< LocalDepth >( 0 , std::min< LocalDepth >( splatDepth , maxDepth ) );
+	DensityEstimator< DensityDegree > *density = new DensityEstimator< DensityDegree >( splatDepth , CoDim , samplesPerNode );
+	this->template updateDensityEstimator< CoDim , DensityDegree >( *density , samples , 0 , splatDepth , pointDepthFunctor );
+
+	return density;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+SparseNodeData< OutData , UIntPack< DataSigs ... > > FEMTree< Dim , Real >::setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData& ) > ConversionFunction , std::function< Real ( InData ) > BiasFunction )
+{
+	std::function< bool ( InData , OutData & , Real & ) > ConversionAndBiasFunction = [&]( InData in , OutData &out , Real &bias )
+	{
+		if( ConversionFunction( in , out ) )
+		{
+			bias = BiasFunction( in );
+			return true;
+		}
+		else return false;
+	};
+	return setInterpolatedDataField( zero , UIntPack< DataSigs ... >() , samples , data , density , minDepth , maxDepth , minDepthCutoff , pointDepthAndWeight , ConversionAndBiasFunction );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+SparseNodeData< OutData , UIntPack< DataSigs ... > > FEMTree< Dim , Real >::setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData & , Real & ) > ConversionAndBiasFunction )
+{
+	//	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( _spaceRoot );
+	SubTreeExtractor subtreeExtractor( _spaceRoot , _depthOffset );
+
+	typedef PointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > DensityKey;
+	typedef UIntPack< FEMSignature< DataSigs >::Degree ... > DataDegrees;
+	typedef PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > > DataKey;
+	std::vector< DensityKey > densityKeys( ThreadPool::NumThreads() );
+	std::vector<    DataKey >    dataKeys( ThreadPool::NumThreads() );
+	bool oneKey = DensityDegree==DataDegrees::Min() && DensityDegree==DataDegrees::Max();
+	for( size_t i=0 ; i<densityKeys.size() ; i++ ) densityKeys[i].set( _localToGlobal( maxDepth ) );
+	if( !oneKey ) for( size_t i=0 ; i<dataKeys.size() ; i++ ) dataKeys[i].set( _localToGlobal( maxDepth ) );
+	std::vector< Real > depthAndWeightSums( ThreadPool::NumThreads() , 0 );
+	pointDepthAndWeight.data = Point< Real , 2 >();
+	pointDepthAndWeight.weight = 0;
+	SparseNodeData< OutData , UIntPack< DataSigs ... > > dataField;
+	std::vector< Point< Real , 2 > > pointDepthAndWeightSums( ThreadPool::NumThreads() , Point< Real , 2 >() );
+	ThreadPool::ParallelFor( 0 , samples.size() , [&]( unsigned int thread , size_t i )
+		{
+			DensityKey& densityKey = densityKeys[ thread ];
+			DataKey& dataKey = dataKeys[ thread ];
+			const ProjectiveData< Point< Real , Dim > , Real >& sample = samples[i].sample;
+			if( sample.weight>0 )
+			{
+				Point< Real , Dim > p = sample.data / sample.weight;
+				InData in = data[i] / sample.weight;
+				OutData out;
+
+				Real depthBias;
+				if( !_InBounds(p) ) MK_WARN( "Point sample is out of bounds" );
+				else if( ConversionAndBiasFunction( in , out , depthBias ) )
+				{
+					depthAndWeightSums[thread] += sample.weight;
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Should the next line be commented out?" )
+#endif // SHOW_WARNINGS
+					out *= sample.weight;
+					Allocator< FEMTreeNode > *nodeAllocator = nodeAllocators.size() ? nodeAllocators[ thread ] : NULL;
+#if defined( __GNUC__ ) && __GNUC__ < 5
+#ifdef SHOW_WARNINGS
+#warning "you've got me gcc version<5"
+#endif // SHOW_WARNINGS
+					if( density ) pointDepthAndWeightSums[thread] += _splatPointData< true , true , DensityDegree , OutData >( zero , nodeAllocator , *density , minDepthCutoff , p , out , dataField , densityKey , oneKey ? *( (DataKey*)&densityKey ) : dataKey , minDepth , maxDepth , Dim , depthBias ) * sample.weight;
+#else // !__GNUC__ || __GNUC__ >=5
+					if( density ) pointDepthAndWeightSums[thread] += _splatPointData< true , true , DensityDegree , OutData , DataSigs ... >( zero , nodeAllocator , *density , minDepthCutoff , p , out , dataField , densityKey , oneKey ? *( (DataKey*)&densityKey ) : dataKey , minDepth , maxDepth , Dim , depthBias ) * sample.weight;
+#endif // __GNUC__ && __GNUC__ < 5
+					else
+					{
+						Real width = (Real)( 1.0 / ( 1<<maxDepth ) );
+#if defined( __GNUC__ ) && __GNUC__ < 5
+#ifdef SHOW_WARNINGS
+						#warning "you've got me gcc version<5"
+#endif // SHOW_WARNINGS
+						_splatPointData< true , true , OutData >( zero , nodeAllocator , _leaf< true >( nodeAllocator , p , maxDepth ) , p , out / (Real)pow( width , Dim ) , dataField , oneKey ? *( (DataKey*)&densityKey ) : dataKey );
+#else // !__GNUC__ || __GNUC__ >=5
+						_splatPointData< true , true , OutData , DataSigs ... >( zero , nodeAllocator , _leaf< true >( nodeAllocator , p , maxDepth ) , p , out / (Real)pow( width , Dim ) , dataField , oneKey ? *( (DataKey*)&densityKey ) : dataKey );
+#endif // __GNUC__ && __GNUC__ < 5
+						pointDepthAndWeightSums[thread] += Point< Real , 2 >( (Real)1. , (Real)maxDepth ) * sample.weight;
+					}
+				}
+			}
+		}
+	);
+	pointDepthAndWeight.data = Point< Real , 2 >();
+	for( unsigned int i=0 ; i<depthAndWeightSums.size() ; i++ ) pointDepthAndWeight.data += pointDepthAndWeightSums[i];
+	pointDepthAndWeight.weight = 0;
+	for( unsigned int i=0 ; i<depthAndWeightSums.size() ; i++ ) pointDepthAndWeight.weight += depthAndWeightSums[i];
+	return dataField;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+SparseNodeData< OutData , UIntPack< DataSigs ... > > FEMTree< Dim , Real >::setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData& ) > ConversionFunction , std::function< Real ( InData ) > BiasFunction )
+{
+	std::function< bool ( InData , OutData & , Real & ) > ConversionAndBiasFunction = [&]( InData in , OutData &out , Real &bias )
+	{
+		if( ConversionFunction( in , out ) )
+		{
+			bias = BiasFunction( in );
+			return true;
+		}
+		else return false;
+	};
+	return setInterpolatedDataField( zero , UIntPack< DataSigs ... >() , samples , data , density , minDepth , maxDepth , pointDepthFunctor , minDepthCutoff , pointDepthAndWeight , ConversionAndBiasFunction );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int ... DataSigs , unsigned int DensityDegree , class InData , class OutData >
+SparseNodeData< OutData , UIntPack< DataSigs ... > > FEMTree< Dim , Real >::setInterpolatedDataField( OutData zero , UIntPack< DataSigs ... > , const std::vector< PointSample >& samples , const std::vector< InData >& data , const DensityEstimator< DensityDegree >* density , LocalDepth minDepth , LocalDepth maxDepth , std::function< int ( Point< Real , Dim > ) > pointDepthFunctor , Real minDepthCutoff , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::function< bool ( InData , OutData & , Real & ) > ConversionAndBiasFunction )
+{
+	//	typename FEMTreeNode::SubTreeExtractor subtreeExtractor( _spaceRoot );
+	SubTreeExtractor subtreeExtractor( _spaceRoot , _depthOffset );
+
+	typedef PointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > DensityKey;
+	typedef UIntPack< FEMSignature< DataSigs >::Degree ... > DataDegrees;
+	typedef PointSupportKey< UIntPack< FEMSignature< DataSigs >::Degree ... > > DataKey;
+	std::vector< DensityKey > densityKeys( ThreadPool::NumThreads() );
+	std::vector<    DataKey >    dataKeys( ThreadPool::NumThreads() );
+	bool oneKey = DensityDegree==DataDegrees::Min() && DensityDegree==DataDegrees::Max();
+	for( size_t i=0 ; i<densityKeys.size() ; i++ ) densityKeys[i].set( _localToGlobal( maxDepth ) );
+	if( !oneKey ) for( size_t i=0 ; i<dataKeys.size() ; i++ ) dataKeys[i].set( _localToGlobal( maxDepth ) );
+	std::vector< Real > depthAndWeightSums( ThreadPool::NumThreads() , 0 );
+	pointDepthAndWeight.data = Point< Real , 2 >();
+	pointDepthAndWeight.weight = 0;
+	SparseNodeData< OutData , UIntPack< DataSigs ... > > dataField;
+	std::vector< Point< Real , 2 > > pointDepthAndWeightSums( ThreadPool::NumThreads() , Point< Real , 2 >() );
+	ThreadPool::ParallelFor( 0 , samples.size() , [&]( unsigned int thread , size_t i )
+		{
+			DensityKey& densityKey = densityKeys[ thread ];
+			DataKey& dataKey = dataKeys[ thread ];
+			const ProjectiveData< Point< Real , Dim > , Real >& sample = samples[i].sample;
+			if( sample.weight>0 )
+			{
+				Point< Real , Dim > p = sample.data / sample.weight;
+				InData in = data[i] / sample.weight;
+				OutData out;
+
+				Real depthBias;
+				if( !_InBounds(p) ) MK_WARN( "Point sample is out of bounds" );
+				else if( ConversionAndBiasFunction( in , out , depthBias ) )
+				{
+					depthAndWeightSums[thread] += sample.weight;
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Should the next line be commented out?" )
+#endif // SHOW_WARNINGS
+					out *= sample.weight;
+					Allocator< FEMTreeNode > *nodeAllocator = nodeAllocators.size() ? nodeAllocators[ thread ] : NULL;
+#if defined( __GNUC__ ) && __GNUC__ < 5
+#ifdef SHOW_WARNINGS
+#warning "you've got me gcc version<5"
+#endif // SHOW_WARNINGS
+					if( density ) pointDepthAndWeightSums[thread] += _splatPointData< true , true , DensityDegree , OutData >( zero , nodeAllocator , *density , minDepthCutoff , p , out , dataField , densityKey , oneKey ? *( (DataKey*)&densityKey ) : dataKey , minDepth , pointDepthFunctor , Dim , depthBias ) * sample.weight;
+#else // !__GNUC__ || __GNUC__ >=5
+					if( density ) pointDepthAndWeightSums[thread] += _splatPointData< true , true , DensityDegree , OutData , DataSigs ... >( zero , nodeAllocator , *density , minDepthCutoff , p , out , dataField , densityKey , oneKey ? *( (DataKey*)&densityKey ) : dataKey , minDepth , pointDepthFunctor , Dim , depthBias ) * sample.weight;
+#endif // __GNUC__ && __GNUC__ < 5
+					else
+					{
+						Real width = (Real)( 1.0 / ( 1<<maxDepth ) );
+#if defined( __GNUC__ ) && __GNUC__ < 5
+#ifdef SHOW_WARNINGS
+						#warning "you've got me gcc version<5"
+#endif // SHOW_WARNINGS
+						_splatPointData< true , true , OutData >( zero , nodeAllocator , _leaf< true >( nodeAllocator , p , pointDepthFunctor ) , p , out / (Real)pow( width , Dim ) , dataField , oneKey ? *( (DataKey*)&densityKey ) : dataKey );
+#else // !__GNUC__ || __GNUC__ >=5
+						_splatPointData< true , true , OutData , DataSigs ... >( zero , nodeAllocator , _leaf< true >( nodeAllocator , p , pointDepthFunctor ) , p , out / (Real)pow( width , Dim ) , dataField , oneKey ? *( (DataKey*)&densityKey ) : dataKey );
+#endif // __GNUC__ && __GNUC__ < 5
+						pointDepthAndWeightSums[thread] += Point< Real , 2 >( (Real)1 , (Real)maxDepth ) * sample.weight;
+					}
+				}
+			}
+		}
+	);
+	pointDepthAndWeight.data = Point< Real , 2 >();
+	for( unsigned int i=0 ; i<pointDepthAndWeightSums.size() ; i++ ) pointDepthAndWeight.data += pointDepthAndWeightSums[i];
+	pointDepthAndWeight.weight = 0;
+	for( unsigned int i=0 ; i<depthAndWeightSums.size() ; i++ ) pointDepthAndWeight.weight += depthAndWeightSums[i];
+	return dataField;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int DataSig , bool CreateNodes , unsigned int DensityDegree , class Data >
+SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > FEMTree< Dim , Real >::setExtrapolatedDataField( Data zero , const std::vector< PointSample >& samples , const std::vector< Data >& sampleData , const DensityEstimator< DensityDegree >* density , bool nearest )
+{
+	return this->template setExtrapolatedDataField< DataSig , CreateNodes , DensityDegree , Data >( zero , samples.size() , [&]( size_t i ) -> const PointSample & { return samples[i]; } , [&]( size_t i ) -> const Data & { return sampleData[i]; } , density , nearest );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int DataSig , bool CreateNodes , unsigned int DensityDegree , class Data >
+void FEMTree< Dim , Real >::updateExtrapolatedDataField( Data zero , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > &dataField , const std::vector< PointSample >& samples , const std::vector< Data >& sampleData , const DensityEstimator< DensityDegree >* density , bool nearest )
+{
+	return this->template updateExtrapolatedDataField< DataSig , CreateNodes , DensityDegree , Data >( zero , dataField , samples.size() , [&]( size_t i ) -> const PointSample & { return samples[i]; } , [&]( size_t i ) -> const Data & { return sampleData[i]; } , density , nearest );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int DataSig , bool CreateNodes , unsigned int DensityDegree , class Data , class SampleFunctor /* = std::function< const PointSample & (size_t) >*/ , class SampleDataFunctor /* = std::function< const Data & (size_t) > */ >
+SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > FEMTree< Dim , Real >::setExtrapolatedDataField( Data zero , size_t sampleNum , SampleFunctor sampleFunctor , SampleDataFunctor sampleDataFunctor , const DensityEstimator< DensityDegree >* density , bool nearest )
+{
+	SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > dataField;
+	this->template updateExtrapolatedDataField< DataSig , CreateNodes , DensityDegree , Data >( zero , dataField , sampleNum , sampleFunctor , sampleDataFunctor , density , nearest );
+	return dataField;
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int DataSig , bool CreateNodes , unsigned int DensityDegree , class Data , class SampleFunctor /* = std::function< const PointSample & (size_t) >*/ , class SampleDataFunctor /* = std::function< const Data & (size_t) > */ >
+void FEMTree< Dim , Real >::updateExtrapolatedDataField( Data zero , SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim , DataSig > > &dataField , size_t sampleNum , SampleFunctor sampleFunctor , SampleDataFunctor sampleDataFunctor , const DensityEstimator< DensityDegree >* density , bool nearest )
+{
+	Allocator< FEMTreeNode > *nodeAllocator = nodeAllocators.size() ? nodeAllocators[0] : NULL;
+	LocalDepth maxDepth = _spaceRoot->maxDepth();
+
+	if constexpr( CreateNodes )
+	{
+		PointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > densityKey;
+		PointSupportKey< IsotropicUIntPack< Dim , FEMSignature< DataSig >::Degree > > dataKey;
+		densityKey.set( _localToGlobal( maxDepth ) ) , dataKey.set( _localToGlobal( maxDepth ) );
+		for( node_index_type i=0 ; i<(node_index_type)sampleNum ; i++ )
+		{
+			const PointSample &sampleAndNode = sampleFunctor(i);
+			const ProjectiveData< Point< Real , Dim > , Real >& sample = sampleAndNode.sample;
+			const Data& data = sampleDataFunctor(i);
+			Point< Real , Dim > p = sample.weight==0 ? sample.data : sample.data / sample.weight;
+			if( !_InBounds(p) )
+			{
+				MK_WARN( "Point is out of bounds" );
+				continue;
+			}
+			if( nearest ) _nearestMultiSplatPointData< DensityDegree >( ProjectiveData< Data , Real >( zero ) , density , (FEMTreeNode*)sampleAndNode.node , p , ProjectiveData< Data , Real >( data , sample.weight ) , dataField , densityKey , 2 );
+			else          _multiSplatPointData< CreateNodes , false , DensityDegree >( ProjectiveData< Data , Real >( zero ) , nodeAllocator , density , (FEMTreeNode*)sampleAndNode.node , p , ProjectiveData< Data , Real >( data , sample.weight ) , dataField , densityKey , dataKey , 2 );
+		}
+	}
+	else
+	{
+		std::vector< PointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > > densityKeys( ThreadPool::NumThreads() );
+		std::vector< PointSupportKey< IsotropicUIntPack< Dim , FEMSignature< DataSig >::Degree > > > dataKeys( ThreadPool::NumThreads() );
+		for( unsigned int i=0 ; i<ThreadPool::NumThreads() ; i++ ) densityKeys[i].set( _localToGlobal( maxDepth ) ) , dataKeys[i].set( _localToGlobal( maxDepth ) );
+
+		ThreadPool::ParallelFor( 0 , sampleNum , [&]( unsigned int thread , size_t i ) {
+			PointSupportKey< IsotropicUIntPack< Dim , DensityDegree > > &densityKey = densityKeys[thread];
+			PointSupportKey< IsotropicUIntPack< Dim , FEMSignature< DataSig >::Degree > > &dataKey = dataKeys[thread];
+
+			const PointSample &sampleAndNode = sampleFunctor(i);
+			const ProjectiveData< Point< Real , Dim > , Real >& sample = sampleAndNode.sample;
+			const Data& data = sampleDataFunctor(i);
+			Point< Real , Dim > p = sample.weight==0 ? sample.data : sample.data / sample.weight;
+			if( !_InBounds(p) ) MK_WARN( "Point is out of bounds" );
+			else
+			{
+				if( nearest ) _nearestMultiSplatPointData< DensityDegree >( ProjectiveData< Data , Real >( zero ) , density , (FEMTreeNode*)sampleAndNode.node , p , ProjectiveData< Data , Real >( data , sample.weight ) , dataField , densityKey , 2 );
+				else          _multiSplatPointData< CreateNodes , false , DensityDegree >( ProjectiveData< Data , Real >( zero ) , nodeAllocator , density , (FEMTreeNode*)sampleAndNode.node , p , ProjectiveData< Data , Real >( data , sample.weight ) , dataField , densityKey , dataKey , 2 );
+			}
+		} );
+	}
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int MaxDegree >
+void FEMTree< Dim , Real >::_supportApproximateProlongation( void )
+{
+	// Refine the tree so that if an active element exists @{d}, all supporting elements exist @{d-1}
+	const int OverlapRadius = -BSplineOverlapSizes< MaxDegree , MaxDegree >::OverlapStart;
+	typedef typename FEMTreeNode::template NeighborKey< IsotropicUIntPack< Dim , OverlapRadius > , IsotropicUIntPack< Dim , OverlapRadius > > NeighborKey;
+
+	std::vector< NeighborKey > neighborKeys( ThreadPool::NumThreads() );
+	for( int i=0 ; i<neighborKeys.size() ; i++ ) neighborKeys[i].set( _localToGlobal( _maxDepth-1 ) );
+
+	for( LocalDepth d=_maxDepth-1 ; d>_baseDepth ; d-- )
+	{
+		// Compute the set of nodes at depth d that have (non-ghost) children at depth d+1.
+		std::vector< FEMTreeNode* > nodes;
+		_tree.processNodes( [&]( FEMTreeNode *node ){ if( _localDepth( node )==d && IsActiveNode( node->children ) ) nodes.push_back( node ) ; return _localDepth(node)<d; } );
+
+		// Make sure that all finite elements whose support overlaps the support of the finite elements indexed by those nodes are in the tree.
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] This may be overkill as we only need to check if the support overlaps the support of the children" )
+#endif // SHOW_WARNINGS
+		ThreadPool::ParallelFor( 0 , nodes.size() , [&]( unsigned int thread , size_t i )
+			{
+				NeighborKey& neighborKey = neighborKeys[ thread ];
+				FEMTreeNode *node = nodes[i];
+
+				// Create the neighbors if they are not already in the tree
+				neighborKey.template getNeighbors< true , true >( node , nodeAllocators.size() ? nodeAllocators[ thread ] : NULL , _nodeInitializer );
+
+				// Mark the neighbors as active
+				Pointer( FEMTreeNode* ) nodes = neighborKey.neighbors[ _localToGlobal(d) ].neighbors().data;
+				unsigned int size = neighborKey.neighbors[ _localToGlobal(d) ].neighbors.Size();
+				for( unsigned int i=0 ; i<size ; i++ ) SetGhostFlag( nodes[i] , false );
+			}
+		);
+	}
+}
+
+template< unsigned int Dim , typename Real >
+template< unsigned int SystemDegree >
+void FEMTree< Dim , Real >::_markNonBaseDirichletElements( void )
+{
+	const int LeftSupportRadius = -BSplineSupportSizes< SystemDegree >::SupportStart;
+	const int RightSupportRadius = BSplineSupportSizes< SystemDegree >::SupportEnd;
+	typedef typename FEMTreeNode::template NeighborKey< IsotropicUIntPack< Dim , LeftSupportRadius > , IsotropicUIntPack< Dim , RightSupportRadius > > SupportKey;
+	typedef StaticWindow< FEMTreeNode * , IsotropicUIntPack< Dim , LeftSupportRadius + RightSupportRadius + 1 > > NeighborLeaves;
+
+	std::vector< NeighborLeaves > neighborLeaves( ThreadPool::NumThreads() );
+	std::vector< SupportKey > supportKeys( ThreadPool::NumThreads() );
+	for( int i=0 ; i<supportKeys.size() ; i++ ) supportKeys[i].set( _localToGlobal( _maxDepth ) );
+
+	// Get the list of nodes @{_baseDepth)
+	std::vector< FEMTreeNode * > baseNodes;
+	_tree.processNodes( [&]( FEMTreeNode *node ){ if( _localDepth( node )==_baseDepth ) baseNodes.push_back( node ); } );
+
+	// Process the sub-tree rooted at the node:
+	// -- For each non-ghost node in the sub-tree check if the finite element associated to the node is supported on a Dirichlet node.
+	//    If it is, mark the node as a Dirichlet element node.
+	std::function< void ( FEMTreeNode * , SupportKey & , NeighborLeaves & ) > ProcessSubTree = [&]( FEMTreeNode *node , SupportKey &supportKey , NeighborLeaves &neighborLeaves )
+	{
+		if( !node->nodeData.getGhostFlag() )
+		{
+			supportKey.setLeafNeighbors( node , neighborLeaves );
+			bool hasDirichletNeighbor = false;
+			for( unsigned int i=0 ; i<NeighborLeaves::Size() ; i++ ) if( neighborLeaves.data[i] && neighborLeaves.data[i]->nodeData.getDirichletNodeFlag() ) hasDirichletNeighbor = true;
+			node->nodeData.setDirichletElementFlag( hasDirichletNeighbor );
+
+			if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) ProcessSubTree( node->children+c , supportKey , neighborLeaves );
+		}
+	};
+
+	ThreadPool::ParallelFor( 0 , baseNodes.size() , [&]( unsigned int t , size_t i ){ ProcessSubTree( baseNodes[i] , supportKeys[t] , neighborLeaves[t] ); } );
+}
+
+template< unsigned int Dim , typename Real >
+template< unsigned int SystemDegree >
+void FEMTree< Dim , Real >::_markBaseDirichletElements( void )
+{
+	const int LeftSupportRadius = BSplineSupportSizes< SystemDegree >::SupportEnd;
+	const int RightSupportRadius = -BSplineSupportSizes< SystemDegree >::SupportStart;
+
+	typedef typename FEMTreeNode::template NeighborKey< IsotropicUIntPack< Dim , LeftSupportRadius > , IsotropicUIntPack< Dim , RightSupportRadius > > SupportKey;
+	std::vector< SupportKey > supportKeys( ThreadPool::NumThreads() );
+	for( int i=0 ; i<supportKeys.size() ; i++ ) supportKeys[i].set( _localToGlobal( _baseDepth ) );
+
+	std::vector< FEMTreeNode* > nodes;
+	_tree.processNodes( [&]( FEMTreeNode *node ){ if( _localDepth( node )==_baseDepth && node->nodeData.getDirichletNodeFlag() ) nodes.push_back( node ) ; return _localDepth(node)<_baseDepth; } );
+
+	ThreadPool::ParallelFor( 0 , nodes.size() , [&]( unsigned int thread , size_t i )
+		{
+			SupportKey &supportKey = supportKeys[ thread ];
+			FEMTreeNode *node = nodes[i];
+			supportKey.getNeighbors( node );
+			for( LocalDepth d=0 ; d<=_baseDepth ; d++ )
+			{
+				Pointer( FEMTreeNode* ) _nodes = supportKey.neighbors[ _localToGlobal(d) ].neighbors().data;
+				unsigned int size = supportKey.neighbors[ _localToGlobal(d) ].neighbors.Size();
+				for( unsigned int i=0 ; i<size ; i++ ) if( _nodes[i] ) SetGhostFlag( _nodes[i] , false ) , _nodes[i]->nodeData.setDirichletElementFlag( true );
+			}
+		} );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int MaxDegree , unsigned int SystemDegree , typename AddNodeFunctor , typename HasDataFunctor , typename ... InterpolationInfos , typename ... DenseOrSparseNodeData >
+std::vector< node_index_type > FEMTree< Dim , Real >::finalizeForMultigrid( LocalDepth baseDepth , const AddNodeFunctor addNodeFunctor , const HasDataFunctor hasDataFunctor , std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data )
+{
+	auto isDirichletLeafFunctor = []( const FEMTreeNode * ){ return false; };
+	return _finalizeForMultigrid< false , MaxDegree , SystemDegree >( baseDepth , addNodeFunctor , hasDataFunctor , isDirichletLeafFunctor , interpolationInfos , data );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int MaxDegree , unsigned int SystemDegree , typename AddNodeFunctor , typename HasDataFunctor , typename IsDirichletLeafFunctor , typename ... InterpolationInfos , typename ... DenseOrSparseNodeData >
+std::vector< node_index_type > FEMTree< Dim , Real >::finalizeForMultigridWithDirichlet( LocalDepth baseDepth , const AddNodeFunctor addNodeFunctor , const HasDataFunctor hasDataFunctor , const IsDirichletLeafFunctor isDirichletLeafFunctor , std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data )
+{
+	return _finalizeForMultigrid< true , MaxDegree , SystemDegree >( baseDepth , addNodeFunctor , hasDataFunctor , isDirichletLeafFunctor , interpolationInfos , data );
+}
+
+
+template< unsigned int Dim , class Real >
+template< bool HasDirichlet , unsigned int MaxDegree , unsigned int SystemDegree , typename AddNodeFunctor , typename HasDataFunctor , typename IsDirichletLeafFunctor , typename ... InterpolationInfos , typename ... DenseOrSparseNodeData >
+std::vector< node_index_type > FEMTree< Dim , Real >::_finalizeForMultigrid( LocalDepth baseDepth , const AddNodeFunctor addNodeFunctor , const HasDataFunctor hasDataFunctor , const IsDirichletLeafFunctor isDirichletLeafFunctor , std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data )
+{
+	std::function< void ( FEMTreeNode * ) > pushFullDirichletFlag = [&]( FEMTreeNode *node )
+	{
+		if( node->children )
+		{
+			if( node->nodeData.getDirichletNodeFlag() )
+			{
+				for( int c=0 ; c<(1<<Dim) ; c++ ) node->children[c].nodeData.setDirichletNodeFlag( true );
+				node->nodeData.setDirichletNodeFlag( false );
+			}
+			for( int c=0 ; c<(1<<Dim) ; c++ ) pushFullDirichletFlag( node->children + c );
+		}
+	};
+
+	std::function< bool ( FEMTreeNode * ) > pullPartialDirichletFlag = [&]( FEMTreeNode *node )
+	{
+		if( node->children )
+		{
+			bool childDirichlet = false;
+			for( int c=0 ; c<(1<<Dim) ; c++ ) childDirichlet |= pullPartialDirichletFlag( node->children + c );
+			node->nodeData.setDirichletNodeFlag( childDirichlet );
+		}
+		return node->nodeData.getDirichletNodeFlag();
+	};
+
+	std::function< void ( FEMTreeNode * , node_index_type , bool ) > pushDirichletFlag = [&]( FEMTreeNode *node , node_index_type newNodeIndex , bool isDirichletNode )
+	{
+		if( node->nodeData.nodeIndex>=newNodeIndex ) node->nodeData.setDirichletNodeFlag( isDirichletNode );
+		isDirichletNode = node->nodeData.getDirichletNodeFlag();
+		if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) pushDirichletFlag( node->children+c , newNodeIndex , isDirichletNode );
+	};
+
+	_baseDepth = baseDepth;
+	// Expand the tree to ensure supporting finite elements can be indexed by octree nodes
+
+	Allocator< FEMTreeNode > *nodeAllocator = nodeAllocators.size() ? nodeAllocators[0] : NULL;
+
+	while( _localInset( 0 ) + BSplineEvaluationData< FEMDegreeAndBType< MaxDegree >::Signature >::Begin( 0 )<0 || _localInset( 0 ) + BSplineEvaluationData< FEMDegreeAndBType< MaxDegree >::Signature >::End( 0 )>(1<<_depthOffset) )
+	{
+		//                       +-+-+-+-+-+-+-+-+
+		//                       | | | | | | | | |
+		//                       +-+-+-+-+-+-+-+-+
+		//                       | | | | | | | | |
+		//          +-+-+-+-+    +-+-+-+-+-+-+-+-+
+		//          | | | | |    | | | | | | | | |
+		// +-+-+    +-+-+-+-+    +-+-+-+-+-+-+-+-+
+		// |*| |    | | | | |    | | | | | | | | |
+		// +-o-+ -> +-+-o-+-+ -> +-+-+-+-o-+-+-+-+
+		// | | |    | | |*| |    | | | | |*| | | |
+		// +-+-+    +-+-+-+-+    +-+-+-+-+-+-+-+-+
+		//          | | | | |    | | | | | | | | |
+		//          +-+-+-+-+    +-+-+-+-+-+-+-+-+
+		//                       | | | | | | | | |
+		//                       +-+-+-+-+-+-+-+-+
+		//                       | | | | | | | | |
+		//                       +-+-+-+-+-+-+-+-+
+
+		// Insert a new brood between the root of the tree and its (old) children:
+		// -- Make the old children sit off the last node of the brood
+		// -- Swap the children sitting off the last node of the old children to the first node of the old children
+		FEMTreeNode *oldChildren = _tree.children;
+		FEMTreeNode *newChildren = FEMTreeNode::NewBrood( nodeAllocator , _nodeInitializer );
+		if( !oldChildren ) MK_THROW( "Expected children" );
+		{
+			if( oldChildren[(1<<Dim)-1].children )
+			{
+				for( int c=0 ; c<(1<<Dim) ; c++ ) oldChildren[(1<<Dim)-1].children[c].parent = oldChildren;
+				oldChildren[0].children = oldChildren[(1<<Dim)-1].children;
+				oldChildren[(1<<Dim)-1].children = NULL;
+			}
+			for( int c=0 ; c<(1<<Dim) ; c++ ) oldChildren[c].parent = newChildren+(1<<Dim)-1;
+			newChildren[(1<<Dim)-1].children = oldChildren;
+		}
+
+		for( int c=0 ; c<(1<<Dim) ; c++ ) newChildren[c].parent = &_tree;
+		_tree.children = newChildren;
+
+		_depthOffset++;
+	}
+	_init();
+
+	_maxDepth = _spaceRoot->maxDepth();
+
+	// Mark leaf nodes that are Dirichlet constraints so they do not get clipped out.
+	// Need to do this before introducing new nodes into the tree  (since isDirichletLeaf depends on the structure at input).
+	if constexpr( HasDirichlet ) _spaceRoot->processLeaves( [&]( FEMTreeNode *leaf ){ leaf->nodeData.setDirichletNodeFlag( isDirichletLeafFunctor( leaf ) ); } );
+
+	// Make the low-resolution part of the tree be complete
+	_setFullDepth< false >( IsotropicUIntPack< Dim , MaxDegree >() , nodeAllocator , _baseDepth );
+	_refine< false >( IsotropicUIntPack< Dim , MaxDegree >() , nodeAllocator , addNodeFunctor );
+
+	if constexpr( HasDirichlet )
+	{
+		// Mark new leaf nodes
+		pushFullDirichletFlag( _spaceRoot );
+
+		// Pull the Dirichlet designator from the leaves so that nodes are now marked if they contain (possibly partial Dirichlet constraints
+		pullPartialDirichletFlag( _spaceRoot );
+
+		// Use the node Dirichlet designators to set the coarser finite element Dirichlet designators
+		_markBaseDirichletElements< SystemDegree >();
+	}
+
+	// Clear all the flags and make everything that is not low-res a ghost node, and clip the tree
+	auto _addNodeFunctor = [&]( const FEMTreeNode *node )
+	{
+		LocalDepth d ; LocalOffset off;
+		_localDepthAndOffset( node , d , off );
+		return addNodeFunctor( d , off );
+	};
+
+	auto nodeFunctor = [&]( FEMTreeNode *node )
+	{
+		if constexpr( HasDirichlet ) node->nodeData.flags &= ( FEMTreeNodeData::SCRATCH_FLAG | FEMTreeNodeData::DIRICHLET_NODE_FLAG | FEMTreeNodeData::DIRICHLET_ELEMENT_FLAG );
+		else                         node->nodeData.flags &= ( FEMTreeNodeData::SCRATCH_FLAG );
+		SetGhostFlag( node , !_addNodeFunctor( node ) && _localDepth( node )>_baseDepth );
+	};
+	_tree.processNodes( nodeFunctor );
+
+	// Clip off nodes that not have data and do not contain geometry or Dirichlet constraints below the exactDepth
+	if constexpr( HasDirichlet ) _clipTree( [&]( const FEMTreeNode *node ){ return _addNodeFunctor(node) || hasDataFunctor(node) || ( ( node->nodeData.getDirichletNodeFlag() || node->nodeData.getDirichletElementFlag() ) && _localDepth(node)<=_baseDepth ); } , _baseDepth );
+	else                         _clipTree( [&]( const FEMTreeNode *node ){ return _addNodeFunctor(node) || hasDataFunctor(node); } , _baseDepth );
+
+	// It is possible for the tree to have become shallower after clipping
+	_maxDepth = _tree.maxDepth() - _depthOffset;
+
+	node_index_type oldNodeCount = _nodeCount;
+
+	// Refine the node so that finite elements @{depth-1} whose support overlaps finite elements @{depth} are in the tree
+	_supportApproximateProlongation< MaxDegree >();
+
+	// Mark new leaf nodes
+	if constexpr( HasDirichlet )
+	{
+		pushDirichletFlag( _spaceRoot , oldNodeCount , _spaceRoot->nodeData.getDirichletNodeFlag() );
+		_markNonBaseDirichletElements< SystemDegree >();
+	}
+	_markNonBaseDirichletElements< SystemDegree >();
+
+	return setSortedTreeNodes( interpolationInfos , data );
+}
+
+template< unsigned int Dim , class Real >
+template< typename ... InterpolationInfos , typename ... DenseOrSparseNodeData >
+std::vector< node_index_type > FEMTree< Dim , Real >::setSortedTreeNodes( std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data )
+{
+	_maxDepth = _tree.maxDepth() - _depthOffset;
+	std::vector< node_index_type > map;
+	_sNodes.reset( _tree , map );
+	_setSpaceValidityFlags();
+	_tree.processNodes( [&]( FEMTreeNode *node ){ if( !IsActiveNode( node ) ) node->nodeData.nodeIndex = -1; } );
+	_reorderDenseOrSparseNodeData< 0 >( GetPointer( map ) , _sNodes.size() , data );
+	_reorderInterpolationInfo< 0 >( GetPointer( map ) , _sNodes.size() , interpolationInfos );
+	memset( _femSigs1 , -1 , sizeof( _femSigs1 ) );
+	memset( _femSigs2 , -1 , sizeof( _femSigs2 ) );
+	return map;
+}
+
+template< unsigned int Dim , class Real >
+template< class ... DenseOrSparseNodeData >
+void FEMTree< Dim , Real >::resetIndices( std::tuple< DenseOrSparseNodeData *... > data )
+{
+	std::vector< node_index_type > map;
+	_sNodes.reset( _tree , map );
+	_setSpaceValidityFlags();
+	_tree.processNodes( [&]( FEMTreeNode *node ){ if( !IsActiveNode< Dim >( node ) ) node->nodeData.nodeIndex = -1; } );
+	_reorderDenseOrSparseNodeData< 0 >( GetPointer( map ) , _sNodes.size() , data );
+}
+
+template< unsigned int Dim , class Real >
+template< typename PruneChildrenFunctor , typename ... InterpolationInfos , typename ... DenseOrSparseNodeData >
+void FEMTree< Dim , Real >::pruneChildren( const PruneChildrenFunctor pruneChildren , std::tuple< InterpolationInfos *... > interpolationInfos , std::tuple< DenseOrSparseNodeData *... > data )
+{
+	_tree.pruneChildren( pruneChildren , false );
+	std::vector< node_index_type > map;
+	_sNodes.reset( _tree , map );
+	_setSpaceValidityFlags();
+	_tree.processNodes( [&]( FEMTreeNode *node ){ if( !IsActiveNode< Dim >( node ) ) node->nodeData.nodeIndex = -1; } );
+	_reorderDenseOrSparseNodeData< 0 >( GetPointer( map ) , _sNodes.size() , data );
+	_reorderInterpolationInfo< 0 >( GetPointer( map ) , _sNodes.size() , interpolationInfos );
+}
+
+template< unsigned int Dim , class Real >
+void FEMTree< Dim , Real >::_setSpaceValidityFlags( void ) const
+{
+	const unsigned char MASK = ~( FEMTreeNodeData::SPACE_FLAG );
+	ThreadPool::ParallelFor( 0 , _sNodes.size() , [&]( unsigned int , size_t i )
+		{
+			_sNodes.treeNodes[i]->nodeData.flags &= MASK;
+			if( isValidSpaceNode( _sNodes.treeNodes[i] ) ) _sNodes.treeNodes[i]->nodeData.flags |= FEMTreeNodeData::SPACE_FLAG;
+		}
+	);
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs1 >
+void FEMTree< Dim , Real >::_setFEM1ValidityFlags( UIntPack< FEMSigs1 ... > ) const
+{
+	bool needToReset;
+	unsigned int femSigs1[] = { FEMSigs1 ... };
+	{
+		static std::mutex m;
+		std::lock_guard< std::mutex > lock( m );
+		needToReset = memcmp( femSigs1 , _femSigs1 , sizeof( _femSigs1 ) )!=0;
+		if( needToReset ) memcpy( _femSigs1 , femSigs1 , sizeof( _femSigs1 ) );
+	}
+	if( needToReset )
+		for( node_index_type i=0 ; i<(node_index_type)_sNodes.size() ; i++ )
+		{
+			const unsigned char MASK = ~( FEMTreeNodeData::FEM_FLAG_1 );
+			_sNodes.treeNodes[i]->nodeData.flags &= MASK;
+			if( isValidFEMNode( UIntPack< FEMSigs1 ... >() , _sNodes.treeNodes[i] ) ) _sNodes.treeNodes[i]->nodeData.flags |= FEMTreeNodeData::FEM_FLAG_1;
+		}
+
+}
+template< unsigned int Dim , class Real >
+template< unsigned int ... FEMSigs2 >
+void FEMTree< Dim , Real >::_setFEM2ValidityFlags( UIntPack< FEMSigs2 ... > ) const
+{
+	bool needToReset;
+	unsigned int femSigs2[] = { FEMSigs2 ... };
+	{
+		static std::mutex m;
+		std::lock_guard< std::mutex > lock(m);
+		needToReset = memcmp( femSigs2 , _femSigs2 , sizeof( _femSigs2 ) )!=0;
+		if( needToReset ) memcpy( _femSigs2 , femSigs2 , sizeof( _femSigs2 ) );
+	}
+	if( needToReset )
+		for( node_index_type i=0 ; i<(node_index_type)_sNodes.size() ; i++ )
+		{
+			const unsigned char MASK = ~( FEMTreeNodeData::FEM_FLAG_2 );
+			_sNodes.treeNodes[i]->nodeData.flags &= MASK;
+			if( isValidFEMNode( UIntPack< FEMSigs2 ... >() , _sNodes.treeNodes[i] ) ) _sNodes.treeNodes[i]->nodeData.flags |= FEMTreeNodeData::FEM_FLAG_2;
+		}
+}
+
+template< unsigned int Dim , class Real >
+template< class HasDataFunctor >
+void FEMTree< Dim , Real >::_clipTree( const HasDataFunctor& f , LocalDepth fullDepth )
+{
+	std::vector< FEMTreeNode * > regularNodes;
+	_tree.processNodes( [&]( FEMTreeNode *node ){ if( _localDepth( node )==fullDepth ) regularNodes.push_back( node ) ; return _localDepth( node )<fullDepth; } );
+
+	// Get the data status of each node
+	// [NOTE] Have to use an array of chars instead of bools because the latter is not thread safe
+	node_index_type sz = nodeCount();
+	Pointer( char ) nodeHasData = NewPointer< char >( sz );
+	for( node_index_type i=0 ; i<sz ; i++ ) nodeHasData[i] = 0;
+	ThreadPool::ParallelFor( 0 , regularNodes.size() , [&]( unsigned int , size_t i )
+		{
+			regularNodes[i]->processNodes( [&]( FEMTreeNode *node ){ if( node->nodeData.nodeIndex!=-1 ) nodeHasData[node->nodeData.nodeIndex] = f( node ) ? 1 : 0; } );
+		} );
+
+	// Pull the data status from the leaves
+	std::function< char ( const FEMTreeNode * ) > PullHasDataFromChildren = [&]( const FEMTreeNode *node )
+	{
+		if( node->nodeData.nodeIndex==-1 ) return (char)0;
+		char hasData = nodeHasData[node->nodeData.nodeIndex];
+		if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) hasData |= PullHasDataFromChildren( node->children+c );
+		nodeHasData[node->nodeData.nodeIndex] = hasData;
+		return hasData;
+	};
+
+	ThreadPool::ParallelFor( 0 , regularNodes.size() , [&]( unsigned int , size_t i ){ PullHasDataFromChildren( regularNodes[i] ); } );
+
+	// Mark all children of a node as ghost if none of them have data
+	ThreadPool::ParallelFor( 0 , regularNodes.size() , [&]( unsigned int , size_t i )
+		{
+			auto nodeFunctor = [&]( FEMTreeNode *node )
+			{
+				if( node->children )
+				{
+					char childHasData = 0;
+					for( int c=0 ; c<(1<<Dim) ; c++ ) if( node->children[c].nodeData.nodeIndex!=-1 ) childHasData |= nodeHasData[node->children[c].nodeData.nodeIndex];
+					for( int c=0 ; c<(1<<Dim) ; c++ ) SetGhostFlag< Dim >( node->children+c , !childHasData );
+				}
+			};
+			regularNodes[i]->processNodes( nodeFunctor );
+		} );
+	DeletePointer( nodeHasData );
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , typename Data , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+void FEMTree< Dim , Real >::_ExactPointAndDataInterpolationInfo< T , Data , PointD , ConstraintDual , SystemDual >::_init( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , bool noRescale )
+{
+	_sampleSpan.resize( tree.nodesSize() );
+	ThreadPool::ParallelFor( 0 , tree.nodesSize() , [&]( unsigned int , size_t i ){ _sampleSpan[i] = std::pair< node_index_type , node_index_type >( 0 , 0 ); } );
+	for( node_index_type i=0 ; i<(node_index_type)samples.size() ; i++ )
+	{
+		const FEMTreeNode* leaf = samples[i].node;
+		while( leaf && !tree._isValidSpaceNode( leaf ) ) leaf = leaf->parent;
+		if( leaf && tree._isValidSpaceNode( leaf ) ) _sampleSpan[ leaf->nodeData.nodeIndex ].second++;
+	}
+	_iData.resize( samples.size() );
+
+	std::function< void ( FEMTreeNode* , node_index_type & ) > SetRange = [&] ( FEMTreeNode* node , node_index_type &start )
+	{
+		std::pair< node_index_type , node_index_type >& span = _sampleSpan[ node->nodeData.nodeIndex ];
+		if( tree._isValidSpaceNode( node->children ) )
+		{
+			for( int c=0 ; c<(1<<Dim) ; c++ ) SetRange( node->children + c , start );
+			span.first  = _sampleSpan[ node->children[0           ].nodeData.nodeIndex ].first;
+			span.second = _sampleSpan[ node->children[ (1<<Dim)-1 ].nodeData.nodeIndex ].second;
+		}
+		else
+		{
+			span.second = start + span.second - span.first;
+			span.first = start;
+			start += span.second - span.first;
+		}
+	};
+
+	node_index_type start = 0;
+	SetRange( tree._spaceRoot , start );
+	auto nodeFunctor = [&]( FEMTreeNode *node )
+	{
+		if( tree._isValidSpaceNode( node ) && !tree._isValidSpaceNode( node->children ) ) _sampleSpan[ node->nodeData.nodeIndex ].second = _sampleSpan[ node->nodeData.nodeIndex ].first;
+	};
+	tree._spaceRoot->processNodes( nodeFunctor );
+
+	for( node_index_type i=0 ; i<(node_index_type)samples.size() ; i++ )
+	{
+		const FEMTreeNode* leaf = samples[i].node;
+		while( leaf && !tree._isValidSpaceNode( leaf ) ) leaf = leaf->parent;
+		if( leaf && tree._isValidSpaceNode( leaf ) )
+		{
+			const ProjectiveData< Point< Real , Dim > , Real >& pData = samples[i].sample;
+			DualPointAndDataInfo< Dim , Real , Data , T , PointD >& _pData = _iData[ _sampleSpan[ leaf->nodeData.nodeIndex ].second++ ];
+			_pData.pointInfo.position = pData.data;
+			_pData.pointInfo.weight = pData.weight;
+			_pData.pointInfo.dualValues = _constraintDual( pData.data/pData.weight , sampleData[i]/pData.weight ) * pData.weight;
+			_pData.data = sampleData[i];
+		}
+	}
+
+	ThreadPool::ParallelFor( 0 , _iData.size() , [&]( unsigned int , size_t i  )
+		{
+			Real w = _iData[i].pointInfo.weight;
+			_iData[i] /= w;
+			if( noRescale ) _iData[i].pointInfo.weight = w;
+			else            _iData[i].pointInfo.weight = w * ( 1<<tree._maxDepth );
+			_iData[i].pointInfo.dualValues *= _iData[i].pointInfo.weight;
+		} );
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int PointD , typename ConstraintDual , typename SystemDual >
+void FEMTree< Dim , Real >::ExactPointInterpolationInfo< T , PointD , ConstraintDual , SystemDual >::_init( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , bool noRescale )
+{
+	_sampleSpan.resize( tree._nodeCount );
+	ThreadPool::ParallelFor( 0 , tree.nodesSize() , [&]( unsigned int , size_t i ){ _sampleSpan[i] = std::pair< node_index_type , node_index_type >( 0 , 0 ); } );
+	for( node_index_type i=0 ; i<(node_index_type)samples.size() ; i++ )
+	{
+		const FEMTreeNode* leaf = samples[i].node;
+		while( leaf && !tree._isValidSpaceNode( leaf ) ) leaf = leaf->parent;
+		if( leaf && tree._isValidSpaceNode( leaf ) ) _sampleSpan[ leaf->nodeData.nodeIndex ].second++;
+	}
+	_iData.resize( samples.size() );
+
+	std::function< void ( FEMTreeNode* , node_index_type & ) > SetRange = [&] ( FEMTreeNode* node , node_index_type &start )
+	{
+		std::pair< node_index_type , node_index_type >& span = _sampleSpan[ node->nodeData.nodeIndex ];
+		if( tree._isValidSpaceNode( node->children ) )
+		{
+			for( int c=0 ; c<(1<<Dim) ; c++ ) SetRange( node->children + c , start );
+			span.first  = _sampleSpan[ node->children[0           ].nodeData.nodeIndex ].first;
+			span.second = _sampleSpan[ node->children[ (1<<Dim)-1 ].nodeData.nodeIndex ].second;
+		}
+		else
+		{
+			span.second = start + span.second - span.first;
+			span.first = start;
+			start += span.second - span.first;
+		}
+	};
+
+	node_index_type start=0;
+	SetRange( tree._spaceRoot , start );
+
+	auto nodeFunctor = [&]( FEMTreeNode *node )
+	{
+		if( tree._isValidSpaceNode( node ) && !tree._isValidSpaceNode( node->children ) ) _sampleSpan[ node->nodeData.nodeIndex ].second = _sampleSpan[ node->nodeData.nodeIndex ].first;
+	};
+	tree._spaceRoot->processNodes( nodeFunctor );
+
+	for( node_index_type i=0 ; i<(node_index_type)samples.size() ; i++ )
+	{
+		const FEMTreeNode* leaf = samples[i].node;
+		while( leaf && !tree._isValidSpaceNode( leaf ) ) leaf = leaf->parent;
+		if( leaf && tree._isValidSpaceNode( leaf ) )
+		{
+			const ProjectiveData< Point< Real , Dim > , Real >& pData = samples[i].sample;
+			DualPointInfo< Dim , Real , T , PointD >& _pData = _iData[ _sampleSpan[ leaf->nodeData.nodeIndex ].second++ ];
+			_pData.position = pData.data;
+			_pData.dualValues = _constraintDual( pData.data/pData.weight ) * pData.weight;
+			_pData.weight = pData.weight;
+		}
+	}
+
+	ThreadPool::ParallelFor( 0 , _iData.size() , [&]( unsigned int , size_t i )
+		{
+			Real w = _iData[i].weight;
+			_iData[i] /= w;
+			if( noRescale ) _iData[i].weight = w;
+			else            _iData[i].weight = w * ( 1<<tree._maxDepth );
+			_iData[i].dualValues *= _iData[i].weight;
+		} );
+}
+
+template< unsigned int Dim , class Real >
+template< unsigned int PointD , typename ConstraintDual , typename SystemDual >
+void FEMTree< Dim , Real >::ExactPointInterpolationInfo< double , PointD , ConstraintDual , SystemDual >::_init( const class FEMTree< Dim , Real >& tree , const std::vector< PointSample >& samples , bool noRescale )
+{
+	_sampleSpan.resize( tree._nodeCount );
+	ThreadPool::ParallelFor( 0 , tree.nodesSize() , [&]( unsigned int , size_t i ){ _sampleSpan[i] = std::pair< node_index_type , node_index_type >( 0 , 0 ); } );
+	for( node_index_type i=0 ; i<(node_index_type)samples.size() ; i++ )
+	{
+		const FEMTreeNode* leaf = samples[i].node;
+		while( leaf && !tree._isValidSpaceNode( leaf ) ) leaf = leaf->parent;
+		if( leaf && tree._isValidSpaceNode( leaf ) ) _sampleSpan[ leaf->nodeData.nodeIndex ].second++;
+	}
+	_iData.resize( samples.size() );
+
+	std::function< void ( FEMTreeNode* , node_index_type & ) > SetRange = [&] ( FEMTreeNode *node , node_index_type &start )
+	{
+		std::pair< node_index_type , node_index_type >& span = _sampleSpan[ node->nodeData.nodeIndex ];
+		if( tree._isValidSpaceNode( node->children ) )
+		{
+			for( int c=0 ; c<(1<<Dim) ; c++ ) SetRange( node->children + c , start );
+			span.first  = _sampleSpan[ node->children[0           ].nodeData.nodeIndex ].first;
+			span.second = _sampleSpan[ node->children[ (1<<Dim)-1 ].nodeData.nodeIndex ].second;
+		}
+		else
+		{
+			span.second = start + span.second - span.first;
+			span.first = start;
+			start += span.second - span.first;
+		}
+	};
+
+	node_index_type start = 0;
+	SetRange( tree._spaceRoot , start );
+	auto nodeFunctor = [&]( FEMTreeNode *node )
+	{
+		if( tree._isValidSpaceNode( node ) && !tree._isValidSpaceNode( node->children ) ) _sampleSpan[ node->nodeData.nodeIndex ].second = _sampleSpan[ node->nodeData.nodeIndex ].first;
+	};
+	tree._spaceRoot->processNodes( nodeFunctor );
+
+	for( node_index_type i=0 ; i<(node_index_type)samples.size() ; i++ )
+	{
+		const FEMTreeNode* leaf = samples[i].node;
+		while( leaf && !tree._isValidSpaceNode( leaf ) ) leaf = leaf->parent;
+		if( leaf && tree._isValidSpaceNode( leaf ) )
+		{
+			const ProjectiveData< Point< Real , Dim > , Real >& pData = samples[i].sample;
+			DualPointInfo< Dim , Real , T , PointD >& _pData = _iData[ _sampleSpan[ leaf->nodeData.nodeIndex ].second++ ];
+			_pData.position = pData.data;
+			_pData.dualValues = _constraintDual( pData.data/pData.weight ) * pData.weight;
+			_pData.weight = pData.weight;
+		}
+	}
+
+	ThreadPool::ParallelFor( 0 , _iData.size() , [&]( unsigned int , size_t i )
+		{
+			Real w = _iData[i].weight;
+			_iData[i] /= w;
+			if( noRescale ) _iData[i].weight = w;
+			else            _iData[i].weight = w * ( 1<<tree._maxDepth );
+			_iData[i].dualValues *= _iData[i].weight;
+		}
+	);
+}
+
+template< unsigned int Dim , class Real >
+template< typename T >
+bool FEMTree< Dim , Real >::_setInterpolationInfoFromChildren( FEMTreeNode* node , SparseNodeData< T , IsotropicUIntPack< Dim , FEMTrivialSignature > >& interpolationInfo ) const
+{
+	if( IsActiveNode< Dim >( node->children ) )
+	{
+		bool hasChildData = false;
+		T t = {};
+		for( int c=0 ; c<(1<<Dim) ; c++ )
+			if( _setInterpolationInfoFromChildren( node->children + c , interpolationInfo ) )
+			{
+				t += interpolationInfo[ node->children + c ];
+				hasChildData = true;
+			}
+		if( hasChildData && IsActiveNode< Dim >( node ) ) interpolationInfo[ node ] += t;
+		return hasChildData;
+	}
+	else return interpolationInfo( node )!=NULL;
+}
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int PointD , typename ConstraintDual >
+void FEMTree< Dim , Real >::_densifyInterpolationInfoAndSetDualConstraints( SparseNodeData< DualPointInfo< Dim , Real , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > & iInfo , const std::vector< PointSample >& samples , ConstraintDual constraintDual , LocalDepth maxDepth , int adaptiveExponent ) const
+{
+	for( node_index_type i=0 ; i<(node_index_type)samples.size() ; i++ )
+	{
+		const FEMTreeNode* node = samples[i].node;
+		const ProjectiveData< Point< Real , Dim > , Real >& pData = samples[i].sample;
+		while( !IsActiveNode< Dim >( node ) ) node = node->parent;
+		if( pData.weight )
+		{
+			DualPointInfo< Dim , Real , T , PointD >& _pData = iInfo[node];
+			_pData.position += pData.data;
+			_pData.weight += pData.weight;
+			_pData.dualValues += constraintDual( pData.data/pData.weight ) * pData.weight;
+		}
+	}
+
+	// Set the interior values
+	_setInterpolationInfoFromChildren( _spaceRoot , iInfo );
+
+	ThreadPool::ParallelFor( 0 , iInfo.size() , [&]( unsigned int , size_t i )
+		{
+			Real w = iInfo[i].weight;
+			iInfo[i] /= w ; iInfo[i].weight = w;
+		} );
+
+	// Set the average position and scale the weights
+	auto nodeFunctor = [&]( const FEMTreeNode *node )
+	{
+		if( IsActiveNode< Dim >( node ) )
+		{
+			DualPointInfo< Dim , Real , T , PointD >* pData = iInfo( node );
+			if( pData )
+			{
+				int e = _localDepth( node ) * adaptiveExponent - ( maxDepth ) * (adaptiveExponent-1);
+				if( e<0 ) pData->weight /= Real( 1<<(-e) );
+				else      pData->weight *= Real( 1<<  e  );
+				pData->dualValues *= pData->weight;
+			}
+		}
+	};
+	_tree.processNodes( nodeFunctor );
+}
+template< unsigned int Dim , class Real >
+template< typename T , typename Data , unsigned int PointD , typename ConstraintDual >
+void FEMTree< Dim , Real >::_densifyInterpolationInfoAndSetDualConstraints( SparseNodeData< DualPointAndDataInfo< Dim , Real , Data , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > &iInfo , const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , ConstraintDual constraintDual , LocalDepth maxDepth , int adaptiveExponent  ) const
+{
+	for( node_index_type i=0 ; i<(node_index_type)samples.size() ; i++ )
+	{
+		const FEMTreeNode* node = samples[i].node;
+		const ProjectiveData< Point< Real , Dim > , Real >& pData = samples[i].sample;
+		while( !IsActiveNode< Dim >( node ) ) node = node->parent;
+		if( pData.weight )
+		{
+			DualPointAndDataInfo< Dim , Real , Data , T , PointD >& _pData = iInfo[node];
+			_pData.pointInfo.position += pData.data;
+			_pData.pointInfo.dualValues += constraintDual( pData.data/pData.weight , sampleData[i]/pData.weight ) * pData.weight;
+			_pData.pointInfo.weight += pData.weight;
+			_pData.data += sampleData[i];
+		}
+	}
+
+	// Set the interior values
+	_setInterpolationInfoFromChildren( _spaceRoot , iInfo );
+
+	ThreadPool::ParallelFor( 0 , iInfo.size() , [&]( unsigned int , size_t i )
+		{
+			Real w = iInfo[i].pointInfo.weight;
+			iInfo[i] /= w ; iInfo[i].pointInfo.weight = w;
+		}
+	);
+
+	// Set the average position and scale the weights
+	auto nodeFunctor = [&]( const FEMTreeNode *node )
+	{
+		if( IsActiveNode< Dim >( node ) )
+		{
+			DualPointAndDataInfo< Dim , Real , Data , T , PointD >* pData = iInfo( node );
+			if( pData )
+			{
+				int e = _localDepth( node ) * adaptiveExponent - ( maxDepth ) * (adaptiveExponent-1);
+				if( e<0 ) pData->pointInfo.weight /= Real( 1<<(-e) );
+				else      pData->pointInfo.weight *= Real( 1<<  e  );
+				pData->pointInfo.dualValues *= pData->pointInfo.weight;
+			}
+		}
+	};
+	_tree.processNodes( nodeFunctor );
+}
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int PointD , typename ConstraintDual >
+SparseNodeData< DualPointInfo< Dim , Real , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > FEMTree< Dim , Real >::_densifyInterpolationInfoAndSetDualConstraints( const std::vector< PointSample >& samples , ConstraintDual constraintDual , LocalDepth maxDepth , int adaptiveExponent ) const
+{
+	SparseNodeData< DualPointInfo< Dim , Real , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > iInfo;
+	_densifyInterpolationInfoAndSetDualConstraints( iInfo , samples , constraintDual , maxDepth , adaptiveExponent );
+	return iInfo;
+}
+template< unsigned int Dim , class Real >
+template< typename T , typename Data , unsigned int PointD , typename ConstraintDual >
+SparseNodeData< DualPointAndDataInfo< Dim , Real , Data , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > FEMTree< Dim , Real >::_densifyInterpolationInfoAndSetDualConstraints( const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , ConstraintDual constraintDual , LocalDepth maxDepth , int adaptiveExponent ) const
+{
+	SparseNodeData< DualPointAndDataInfo< Dim , Real , Data , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > iInfo;
+	_densifyInterpolationInfoAndSetDualConstraints( iInfo , samples , sampleData , constraintDual , maxDepth , adaptiveExponent );
+	return iInfo;
+}
+
+
+template< unsigned int Dim , class Real >
+template< typename T , unsigned int PointD , typename ConstraintDual >
+SparseNodeData< DualPointInfoBrood< Dim , Real , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > FEMTree< Dim , Real >::_densifyChildInterpolationInfoAndSetDualConstraints( const std::vector< PointSample >& samples , ConstraintDual constraintDual , bool noRescale ) const
+{
+	SparseNodeData< DualPointInfoBrood< Dim , Real , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > iInfo;
+	for( node_index_type i=0 ; i<samples.size() ; i++ )
+	{
+		const FEMTreeNode* node = samples[i].node;
+		const ProjectiveData< Point< Real , Dim > , Real >& pData = samples[i].sample;
+		while( !IsActiveNode< Dim >( node ) ) node = node->parent;
+		if( pData.weight )
+		{
+			DualPointInfoBrood< Dim , Real , T , PointD >& _pData = iInfo[node];
+			Point< Real , Dim > p = pData.data/pData.weight;
+			int cIdx = _childIndex( node , p );
+			_pData[cIdx].position += pData.data;
+			_pData[cIdx].weight += pData.weight;
+			_pData[cIdx].dualValues += constraintDual( p ) * pData.weight;
+		}
+	}
+
+	// Set the interior values
+	_setInterpolationInfoFromChildren( _spaceRoot , iInfo );
+
+	ThreadPool::ParallelFor( 0 , iInfo.size() , [&]( unsigned int , size_t i )
+		{
+			iInfo[i].finalize();
+			for( size_t c=0 ; c<iInfo[i].size() ; c++ )
+			{
+				iInfo[i][c].position /= iInfo[i][c].weight;
+				if( !noRescale )
+				{
+					iInfo[i][c].weight     *= ( 1<<_maxDepth );
+					iInfo[i][c].dualValues *= ( 1<<_maxDepth );
+				}
+			}
+		}
+	);
+	return iInfo;
+}
+template< unsigned int Dim , class Real >
+template< typename T , typename Data , unsigned int PointD , typename ConstraintDual >
+SparseNodeData< DualPointAndDataInfoBrood< Dim , Real , Data , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > FEMTree< Dim , Real >::_densifyChildInterpolationInfoAndSetDualConstraints( const std::vector< PointSample >& samples , ConstPointer( Data ) sampleData , ConstraintDual constraintDual , bool noRescale ) const
+{
+	SparseNodeData< DualPointAndDataInfoBrood< Dim , Real , Data , T , PointD > , IsotropicUIntPack< Dim , FEMTrivialSignature > > iInfo;
+	for( node_index_type i=0 ; i<samples.size() ; i++ )
+	{
+		const FEMTreeNode* node = samples[i].node;
+		const ProjectiveData< Point< Real , Dim > , Real >& pData = samples[i].sample;
+		while( !IsActiveNode< Dim >( node ) ) node = node->parent;
+		if( pData.weight )
+		{
+			DualPointAndDataInfoBrood< Dim , Real , Data , T , PointD >& _pData = iInfo[node];
+			Point< Real , Dim > p = pData.data/pData.weight;
+			int cIdx = _childIndex( node , p );
+			_pData[cIdx].pointInfo.position += pData.data;
+			_pData[cIdx].pointInfo.dualValues += constraintDual( p , sampleData[i]/pData.weight ) * pData.weight;
+			_pData[cIdx].pointInfo.weight += pData.weight;
+			_pData[cIdx].data += sampleData[i];
+		}
+	}
+
+	// Set the interior values
+	_setInterpolationInfoFromChildren( _spaceRoot , iInfo );
+
+	ThreadPool::ParallelFor( 0 , iInfo.size() , [&]( unsigned int , size_t i )
+		{
+			iInfo[i].finalize();
+			for( size_t c=0 ; c<iInfo[i].size() ; c++ )
+			{
+				iInfo[i][c].pointInfo.position /= iInfo[i][c].pointInfo.weight;
+				iInfo[i][c].data /= iInfo[i][c].pointInfo.weight;
+				if( !noRescale )
+				{
+					iInfo[i][c].pointInfo.weight     *= ( 1<<_maxDepth );
+					iInfo[i][c].pointInfo.dualValues *= ( 1<<_maxDepth );
+					iInfo[i][c].data                 *= ( 1<<_maxDepth );
+				}
+			}
+		}
+	);
+	return iInfo;
+}
+
+
+
+template< unsigned int Dim , class Real >
+std::vector< node_index_type > FEMTree< Dim , Real >::merge( FEMTree* tree )
+{
+	std::vector< node_index_type > map;
+	if( _depthOffset!=tree->_depthOffset ) MK_THROW( "depthOffsets don't match: %d != %d" , _depthOffset , tree->_depthOffset );
+
+	// Compute the next available index
+	node_index_type nextIndex = 0;
+	_tree.processNodes( [&]( const FEMTreeNode *node ){ nextIndex = std::max< node_index_type >( nextIndex , node->nodeData.nodeIndex+1 ); } );
+
+	// Set the size of the map
+	{
+		node_index_type mapSize = 0;
+		tree->_tree.processNodes( [&]( const FEMTreeNode *node ){ mapSize = std::max< node_index_type >( mapSize , node->nodeData.nodeIndex+1 ); } );
+		map.resize( mapSize );
+	}
+
+	std::function< void ( FEMTreeNode* , FEMTreeNode* , std::vector< node_index_type > & , node_index_type & ) > MergeNodes = [&]( FEMTreeNode* node1 , FEMTreeNode* node2 , std::vector< node_index_type > &map , node_index_type &nextIndex )
+	{
+		if( node1 && node2 )
+		{
+			if( node2->nodeData.nodeIndex>=0 )
+			{
+				if( node1->nodeData.nodeIndex<0 ) node1->nodeData.nodeIndex = nextIndex++;
+				map[ node2->nodeData.nodeIndex ] = node1->nodeData.nodeIndex;
+			}
+			if( node1->children && node2->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) MergeNodes( node1->children+c , node2->children+c , map , nextIndex );
+			else if( node2->children )
+			{
+				for( int c=0 ; c<(1<<Dim) ; c++ ) MergeNodes( NULL , node2->children+c , map , nextIndex );
+				node1->children = node2->children;
+				node2->children = NULL;
+				for( int c=0 ; c<(1<<Dim) ; c++ ) node1->children[c].parent = node1;
+			}
+		}
+		else if( node2 )
+		{
+			if( node2->nodeData.nodeIndex>=0 ){ map[ node2->nodeData.nodeIndex ] = nextIndex ; node2->nodeData.nodeIndex = nextIndex++; }
+			if( node2->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) MergeNodes( NULL , node2->children+c , map , nextIndex );
+		}
+	};
+
+	MergeNodes( _tree , tree->_tree , map , nextIndex );
+	return map;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/Factor.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Factor.h
@@ -1,0 +1,156 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef FACTOR_INCLUDED
+#define FACTOR_INCLUDED
+
+#include <math.h>
+#include <complex>
+namespace PoissonRecon
+{
+	static const double SQRT_3 = 1.7320508075688772935;
+
+	inline int Factor( double a1 , double a0 , std::complex< double > roots[1] , double EPS )
+	{
+		if( fabs(a1)<=EPS ) return 0;
+		roots[0] = std::complex< double >( -a0/a1 , 0 );
+		return 1;
+	}
+	inline int Factor( double a2 , double a1 , double a0 , std::complex< double > roots[2] , double EPS )
+	{
+		double d;
+		if( fabs(a2)<=EPS ) return Factor( a1 , a0 , roots , EPS );
+
+		d = a1*a1 - 4*a0*a2;
+		a1 /= (2*a2);
+		if( d<0 )
+		{
+			d=sqrt(-d)/(2*a2);
+			roots[0] = std::complex< double >( -a1 , -d );
+			roots[1] = std::complex< double >( -a1 ,  d );
+		}
+		else
+		{
+			d = sqrt(d)/(2*a2);
+			roots[0] = std::complex< double >( -a1-d , 0 );
+			roots[1] = std::complex< double >( -a1+d , 0 );
+		}
+		return 2;
+	}
+	// Solution taken from: http://mathworld.wolfram.com/CubicFormula.html
+	// and http://www.csit.fsu.edu/~burkardt/f_src/subpak/subpak.f90
+	inline int Factor( double a3 , double a2 , double a1 , double a0 , std::complex< double > roots[3] , double EPS )
+	{
+		double q,r,r2,q3;
+
+		if( fabs(a3)<=EPS ) return Factor( a2 , a1 , a0 , roots , EPS );
+		a2 /= a3 , a1 /= a3 , a0 /= a3;
+
+		q = -(3*a1-a2*a2)/9;
+		r = -(9*a2*a1-27*a0-2*a2*a2*a2)/54;
+		r2 = r*r;
+		q3 = q*q*q;
+
+		if(r2<q3)
+		{
+			double sqrQ = sqrt(q);
+			double theta = acos ( r / (sqrQ*q) );
+			double cTheta=cos(theta/3)*sqrQ;
+			double sTheta=sin(theta/3)*sqrQ*SQRT_3/2;
+			roots[0] = std::complex< double >( -2*cTheta , 0 );
+			roots[1] = std::complex< double >( -2*(-cTheta*0.5-sTheta) , 0 );
+			roots[2] = std::complex< double >( -2*(-cTheta*0.5+sTheta) , 0 );
+		}
+		else
+		{
+			double t , s1 , s2 , sqr=sqrt(r2-q3);
+			t = -r+sqr;
+			if(t<0) s1 = -pow( -t , 1.0/3 );
+			else    s1 =  pow(  t , 1.0/3 );
+			t = -r-sqr;
+			if( t<0 ) s2 = -pow( -t , 1.0/3 );
+			else      s2 =  pow(  t , 1.0/3 );
+			roots[0] = std::complex< double >( s1+s2 , 0 );
+			s1 /= 2 , s2 /= 2;
+			roots[1] = std::complex< double >( -s1-s2 ,  SQRT_3*(s1-s2) );
+			roots[2] = std::complex< double >( -s1-s2 , -SQRT_3*(s1-s2) );
+		}
+		roots[0] -= a2/3;
+		roots[1] -= a2/3;
+		roots[2] -= a2/3;
+		return 3;
+	}
+	// Solution taken from: http://mathworld.wolfram.com/QuarticEquation.html
+	// and http://www.csit.fsu.edu/~burkardt/f_src/subpak/subpak.f90
+	inline int Factor( double a4 , double a3 , double a2 , double a1 , double a0 , std::complex< double > roots[4] , double EPS )
+	{
+		std::complex< double > R , D , E , R2;
+
+		if( fabs(a4)<EPS ) return Factor( a3 , a2 , a1 , a0 , roots , EPS );
+		a3 /= a4 , a2 /= a4 , a1 /= a4 , a0 /= a4;
+
+		Factor( 1.0 , -a2 , a3*a1-4.0*a0 , -a3*a3*a0+4.0*a2*a0-a1*a1 , roots , EPS );
+
+		R2 = std::complex< double >( a3*a3/4.0-a2+roots[0].real() , 0 );
+		R = sqrt( R2 );
+		if( fabs( R.real() )>10e-8 )
+		{
+			std::complex< double > temp1 , temp2 , p1 , p2;
+
+			p1 = std::complex< double >( a3*a3*0.75-2.0*a2-R2.real() , 0 );
+
+			temp2 = std::complex< double >( (4.0*a3*a2-8.0*a1-a3*a3*a3)/4.0 , 0 );
+			p2 = temp2 / R;
+			temp1 = p1+p2;
+			temp2 = p1-p2;
+			D = sqrt( temp1 );
+			E = sqrt( temp2 );
+		}
+		else
+		{
+			R = std::complex< double >( 0 , 0 );
+			std::complex< double > temp1 , temp2;
+			temp1 = std::complex< double >( roots[0].real()*roots[0].real()-4.0*a0 , 0 );
+			temp2 = sqrt( temp1 );
+
+			temp1 = std::complex< double >( a3*a3*0.75-2.0*a2+2.0*temp2.real() ,  2.0*temp2.imag() );
+			D = sqrt( temp1 );
+
+			temp1 = std::complex< double >( a3*a3*0.75-2.0*a2-2.0*temp2.real() , -2.0*temp2.imag() );
+			E = sqrt( temp1 );
+		}
+
+		roots[0] =  R/2. + D/2. - a3/4;
+		roots[1] =  R/2. - D/2. - a3/4;
+		roots[2] = -R/2. + E/2. - a3/4;
+		roots[3] = -R/2. - E/2. - a3/4;
+
+		return 4;
+	}
+}
+#endif // FACTOR_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Geometry.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Geometry.h
@@ -1,0 +1,931 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef GEOMETRY_INCLUDED
+#define GEOMETRY_INCLUDED
+
+#include <stdio.h>
+#include <math.h>
+#include <vector>
+#include <stdlib.h>
+#include <unordered_map>
+#include <string.h>
+#ifdef _WIN32
+#include <io.h>
+#endif // _WIN32
+#include "MyMiscellany.h"
+#include "Array.h"
+
+namespace PoissonRecon
+{
+
+	// An empty type
+	template< typename Real >
+	struct EmptyVectorType
+	{
+		EmptyVectorType& operator += ( const EmptyVectorType& p ){ return *this; }
+		EmptyVectorType& operator -= ( const EmptyVectorType& p ){ return *this; }
+		EmptyVectorType& operator *= ( Real s )                  { return *this; }
+		EmptyVectorType& operator /= ( Real s )                  { return *this; }
+		EmptyVectorType  operator +  ( const EmptyVectorType& p ) const { EmptyVectorType _p = *this ; _p += p ; return _p; }
+		EmptyVectorType  operator -  ( const EmptyVectorType& p ) const { EmptyVectorType _p = *this ; _p -= p ; return _p; }
+		EmptyVectorType  operator *  ( Real s )                   const { EmptyVectorType _p = *this ; _p *= s ; return _p; }
+		EmptyVectorType  operator /  ( Real s )                   const { EmptyVectorType _p = *this ; _p /= s ; return _p; }
+
+		friend std::ostream &operator << ( std::ostream &os , const EmptyVectorType &v ){ return os; }
+	};
+	template< typename Real > EmptyVectorType< Real > operator * ( Real s , EmptyVectorType< Real > v ){ return v*s; }
+
+	template< typename _Real , typename ... VectorTypes > struct DirectSum;
+
+	template< typename _Real , typename FirstType , typename ... RestTypes >
+	struct DirectSum< _Real , FirstType , RestTypes... >
+	{
+		friend Atomic< DirectSum< _Real , FirstType , RestTypes... > >;
+
+		using Real = _Real;
+
+		template< unsigned int I > using VectorType = std::tuple_element_t< I , std::tuple< FirstType , RestTypes ... > >;
+
+		template< unsigned int I > VectorType< I >& get( void )
+		{
+			if constexpr( I==0 ) return _first;
+			else return _rest.template get< I-1 >();
+		}
+		template< unsigned int I > const VectorType< I >& get( void ) const
+		{
+			if constexpr( I==0 ) return _first;
+			else return _rest.template get< I-1 >();
+		}
+
+		DirectSum& operator += ( const DirectSum& p ){ _first += p._first ; _rest += p._rest ; return *this; }
+		DirectSum& operator -= ( const DirectSum& p ){ _first -= p._first ; _rest -= p._rest ; return *this; }
+		DirectSum& operator *= ( Real s )            { _first *= s ; _rest *= s ; return *this; }
+		DirectSum& operator /= ( Real s )            { _first /= s ; _rest /= s ; return *this; }
+		DirectSum  operator +  ( const DirectSum& p ) const { DirectSum _p = *this ; _p += p ; return _p; }
+		DirectSum  operator -  ( const DirectSum& p ) const { DirectSum _p = *this ; _p -= p ; return _p; }
+		DirectSum  operator *  ( Real s )             const { DirectSum _p = *this ; _p *= s ; return _p; }
+		DirectSum  operator /  ( Real s )             const { DirectSum _p = *this ; _p /= s ; return _p; }
+
+		DirectSum( void ){}
+
+		template< typename _FirstType , typename ... _RestTypes >
+		DirectSum( const _FirstType &first , const _RestTypes & ... rest ) : _first(first) , _rest(rest...){}
+
+		template< typename ComponentFunctor /*=std::function< void (VectorTypes&...)>*/ >
+		void process( ComponentFunctor f ){ _process( f ); }
+
+		template< typename ComponentFunctor /*=std::function< void (const VectorTypes&...)>*/ >
+		void process( ComponentFunctor f ) const { _process( f ); }
+
+		friend std::ostream &operator << ( std::ostream &os , const DirectSum &v )
+		{
+			os << "{ ";
+			v._write( os );
+			os << " }";
+			return os;
+		}
+
+	protected:
+		FirstType _first;
+		DirectSum< Real , RestTypes... > _rest;
+
+		void _write( std::ostream &os ) const
+		{
+			os << _first;
+			if constexpr( sizeof...(RestTypes) )
+			{
+				os << " , ";
+				_rest._write( os );
+			}
+		}
+
+		template< typename ComponentFunctor /*=std::function< void ( FirstType& , RestTypes&... )>*/ , typename ... Components >
+		void _process( ComponentFunctor &f , Components ... c )
+		{
+			if constexpr( sizeof...(Components)==sizeof...(RestTypes)+1 ) f( c... );
+			else _process( f , c... , this->template get< sizeof...(Components) >() );
+		}
+		template< typename ComponentFunctor /*=std::function< void ( const FirstType& , const RestTypes&... )>*/ , typename ... Components >
+		void _process( ComponentFunctor &f , Components ... c ) const
+		{
+			if constexpr( sizeof...(Components)==sizeof...(RestTypes)+1 ) f( c... );
+			else _process( f , c... , this->template get< sizeof...(Components) >() );
+		}
+	};
+
+	template< typename _Real >
+	struct DirectSum< _Real >
+	{
+		using Real = _Real;
+
+		DirectSum& operator += ( const DirectSum& p ){ return *this; }
+		DirectSum& operator -= ( const DirectSum& p ){ return *this; }
+		DirectSum& operator *= ( Real s )            { return *this; }
+		DirectSum& operator /= ( Real s )            { return *this; }
+		DirectSum  operator +  ( const DirectSum& p ) const { return DirectSum(); }
+		DirectSum  operator -  ( const DirectSum& p ) const { return DirectSum(); }
+		DirectSum  operator *  ( Real s )             const { return DirectSum(); }
+		DirectSum  operator /  ( Real s )             const { return DirectSum(); }
+
+		DirectSum( void ){}
+
+		template< typename ComponentFunctor /*=std::function< void (VectorTypes&...)>*/ >
+		void process( ComponentFunctor f ){ f(); }
+
+		template< typename ComponentFunctor /*=std::function< void (const VectorTypes&...)>*/ >
+		void process( ComponentFunctor f ) const { f(); }
+
+		friend std::ostream &operator << ( std::ostream &os , const DirectSum &v ){ return os << "{ }"; }
+	};
+
+	template< typename Real , typename ... Vectors >
+	DirectSum< Real , Vectors ... > operator * ( Real s , DirectSum< Real , Vectors ... > vu ){ return vu * s; }
+
+	template< class Real > Real Random( void );
+
+	template< class Real , unsigned int Dim > struct XForm;
+
+
+	template< typename Real , unsigned int ... Dims > struct Point;
+
+	template< class Real , unsigned int Dim >
+	struct Point< Real , Dim >
+	{
+		void _init( unsigned int d )
+		{
+			if( !d ) memset( coords , 0 , sizeof(Real)*Dim );
+			else MK_THROW( "Should never be called" );
+		}
+		template< class _Real , class ... _Reals > void _init( unsigned int d , _Real v , _Reals ... values )
+		{
+			coords[d] = (Real)v;
+			if( d+1<Dim ) _init( d+1 , values... );
+		}
+		template< class ... Points >
+		static void _AddColumnVector( XForm< Real , Dim >& x , unsigned int c , Point point , Points ... points )
+		{
+			for( unsigned int r=0 ; r<Dim ; r++ ) x( c , r ) = point[r];
+			_AddColumnVector( x , c+1 , points ... );
+		}
+		static void _AddColumnVector( XForm< Real , Dim >& x , unsigned int c ){ ; }
+	public:
+		Real coords[Dim];
+		Point( void ) { memset( coords , 0 , sizeof(Real)*Dim ); }
+		Point( const Point& p ){ memcpy( coords , p.coords , sizeof(Real)*Dim ); }
+		template< class ... _Reals > Point( _Reals ... values ){ static_assert( sizeof...(values)==Dim || sizeof...(values)==0 , "[ERROR] Point::Point: Invalid number of coefficients" ) ; _init( 0 , values... ); }
+		template< class _Real > Point( const Point< _Real , Dim >& p ){ for( unsigned int d=0 ; d<Dim ; d++ ) coords[d] = (Real) p.coords[d]; }
+		Point( Real *values ){ for( unsigned int d=0 ; d<Dim ; d++ ) coords[d] = values[d]; }
+		Point( const Real *values ){ for( unsigned int d=0 ; d<Dim ; d++ ) coords[d] = values[d]; }
+		inline       Real& operator[] ( unsigned int i )       { return coords[i]; }
+		inline const Real& operator[] ( unsigned int i ) const { return coords[i]; }
+		inline Point  operator - ( void ) const { Point q ; for( unsigned int d=0 ; d<Dim ; d++ ) q.coords[d] = - coords[d] ; return q; }
+
+		template< class _Real > inline Point& operator += ( Point< _Real , Dim > p )       { for( unsigned int d=0 ; d<Dim ; d++ ) coords[d] += (Real)p.coords[d] ; return *this; }
+		template< class _Real > inline Point  operator +  ( Point< _Real , Dim > p ) const { Point q ; for( unsigned int d=0 ; d<Dim ; d++ ) q.coords[d] = coords[d] + (Real)p.coords[d] ; return q; }
+		template< class _Real > inline Point& operator -= ( Point< _Real , Dim > p )       { return (*this)+=(-p); }
+		template< class _Real > inline Point  operator -  ( Point< _Real , Dim > p ) const { return (*this)+ (-p); }
+		template< class Scalar > inline Point& operator *= ( Scalar r )       { for( unsigned int d=0 ; d<Dim ; d++ ) coords[d] *= r ; return *this; }
+		template< class Scalar > inline Point  operator *  ( Scalar r ) const { Point q ; for( unsigned int d=0 ; d<Dim ; d++ ) q.coords[d] = coords[d] * r ; return q; }
+		template< class Scalar > inline Point& operator /= ( Scalar r )       { for( unsigned int d=0 ; d<Dim ; d++ ) coords[d] /= r ; return *this; }
+		template< class Scalar > inline Point  operator /  ( Scalar r ) const { Point q ; for( unsigned int d=0 ; d<Dim ; d++ ) q.coords[d] = coords[d] / r ; return q; }
+		template< class _Real > inline Point& operator *= ( Point< _Real , Dim > p )       { for( unsigned int d=0 ; d<Dim ; d++ ) coords[d] *= p.coords[d] ; return *this; }
+		template< class _Real > inline Point  operator *  ( Point< _Real , Dim > p ) const { Point q ; for( unsigned int d=0 ; d<Dim ; d++ ) q.coords[d] = coords[d] * p.coords[d] ; return q; }
+		template< class _Real > inline Point& operator /= ( Point< _Real , Dim > p )       { for( unsigned int d=0 ; d<Dim ; d++ ) coords[d] /= p.coords[d] ; return *this; }
+		template< class _Real > inline Point  operator /  ( Point< _Real , Dim > p ) const { Point q ; for( unsigned int d=0 ; d<Dim ; d++ ) q.coords[d] = coords[d] / p.coords[d] ; return q; }
+
+		static Real Dot( const Point& p1 , const Point& p2 ){ Real dot = {} ; for( unsigned int d=0 ; d<Dim ; d++ ) dot += p1.coords[d] * p2.coords[d] ; return dot; }
+		static Real SquareNorm( const Point& p ){ return Dot( p , p ); }
+		template< class ... Points > static Point CrossProduct( Points ... points )
+		{
+			static_assert( sizeof ... ( points )==Dim-1 , "Number of points in cross-product must be one less than the dimension" );
+			XForm< Real , Dim > x;
+			_AddColumnVector( x , 0 , points ... );
+			Point p;
+			for( unsigned int d=0 ; d<Dim ; d++ ) p[d] = ( d&1 ) ? -x.subDeterminant( Dim-1 , d ) : x.subDeterminant( Dim-1 , d );
+			return p;
+		}
+		static Point CrossProduct( const Point* points )
+		{
+			XForm< Real , Dim > x;
+			for( unsigned int d=0 ; d<Dim-1 ; d++ ) for( unsigned int c=0 ; c<Dim ; c++ ) x(d,c) = points[d][c];
+			Point p;
+			for( unsigned int d=0 ; d<Dim ; d++ ) p[d] = ( d&1 ) ? -x.subDeterminant( Dim-1 , d ) : x.subDeterminant( Dim-1 , d );
+			return p;
+		}
+		static Point CrossProduct( Point* points ){ return CrossProduct( ( const Point* )points ); }
+
+		template< class _Real , unsigned int _Dim >
+		friend std::ostream &operator << ( std::ostream &os , const Point< _Real , _Dim > &p );
+	};
+	template< class Real , unsigned int Dim > Point< Real , Dim > operator * ( Real r , Point< Real , Dim > p ){ return p*r; }
+	template< class Real , unsigned int Dim > Point< Real , Dim > operator / ( Real r , Point< Real , Dim > p ){ return p/r; }
+	template< class Real , unsigned int Dim >
+	std::ostream &operator << ( std::ostream &os , const Point< Real , Dim > &p )
+	{
+		os << "( ";
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			if( d ) os << " , ";
+			os << p[d];
+		}
+		return os << " )";
+	}
+
+	// This class represents a point whose is size is allocated dynamically.
+	// The size can be set by:
+	// 1. Construction
+	// 2. Copying
+	// 3. Adding / subtracting (if the size has not been set yet)
+	template< class Real >
+	struct Point< Real >
+	{
+		friend struct Atomic< Point< Real > >;
+
+		Point( void ) : _coords( NullPointer(Real) ) , _dim(0){}
+		Point( size_t dim ) : _coords( NullPointer(Real) ) , _dim(0) { if( dim ){ _resize( (unsigned int)dim ) ; memset( _coords , 0 , sizeof(Real)*_dim ); } }
+		Point( const Point &p ) : _coords( NullPointer(Real) ) , _dim(0) { if( p._dim ){ _resize( p._dim ) ; memcpy( _coords , p._coords , sizeof(Real)*_dim ); } }
+		~Point( void ){ DeletePointer( _coords ); }
+
+		Point &operator = ( const Point &p )
+		{
+			if( !_dim || !p._dim ){ _resize( p._dim ) ; memcpy( _coords , p._coords , sizeof(Real)*_dim ); }
+			else if( _dim==p._dim ) memcpy( _coords , p._coords , sizeof(Real)*_dim );
+			else MK_THROW( "Dimensions don't match: " , _dim , " != " , p._dim );
+			return *this;
+		}
+
+		unsigned int dim( void ) const { return _dim; }
+		Real &operator[]( size_t idx ){ return _coords[idx]; }
+		const Real &operator[]( size_t idx ) const { return _coords[idx]; }
+
+
+		Point& operator += ( const Point& p )
+		{
+			if( !_dim ){ _resize( p._dim ) ; for( unsigned int i=0 ; i<_dim ; i++ ) _coords[i] = p._coords[i]; }
+			else if( _dim==p._dim ) for( unsigned int i=0 ; i<_dim ; i++ ) _coords[i] += p._coords[i];
+			else MK_THROW( "Dimensions don't match: " , _dim , " != " , p._dim );
+			return *this;
+		}
+		Point& operator -= ( const Point& p )
+		{
+			if( !_dim ){ _resize( p._dim ) ; for( unsigned int i=0 ; i<_dim ; i++ ) _coords[i] = -p._coords[i]; }
+			else if( _dim==p._dim ) for( unsigned int i=0 ; i<_dim ; i++ ) _coords[i] -= p._coords[i];
+			else MK_THROW( "Dimensions don't match: " , _dim , " != " , p._dim );
+			return *this;
+		}
+		Point& operator *= ( Real s )
+		{
+			for( unsigned int i=0 ; i<_dim ; i++ ) (*this)[i] *=  s;
+			return *this;
+		}
+		Point& operator /= ( Real s )
+		{
+			for( unsigned int i=0 ; i<_dim ; i++ ) (*this)[i] /=  s;
+			return *this;
+		}
+		Point operator +  ( const Point& p ) const { Point _p = *this ; _p += p ; return _p; }
+		Point operator -  ( const Point& p ) const { Point _p = *this ; _p -= p ; return _p; }
+		Point operator *  ( Real s )         const { Point _p = *this ; _p *= s ; return _p; }
+		Point operator /  ( Real s )         const { Point _p = *this ; _p /= s ; return _p; }
+
+		static Real Dot( const Point &p1 , const Point &p2 )
+		{
+			Real dot;
+			if( p1._dim!=p2._dim ) MK_THROW( "Dimensions differ: " , p1._dim , " != " , p2._dim );
+			for( size_t d=0 ; d<p1._dim ; d++ ) dot += p1[d] * p2[d];
+			return dot;
+		}
+		static Real SquareNorm( const Point& p ){ return Dot( p , p ); }
+
+		friend std::ostream &operator << ( std::ostream &os , const Point &p )
+		{
+			os << "( ";
+			for( size_t i=0 ; i<p._dim ; i++ )
+			{
+				if( i ) os << " , ";
+				os << p[i];
+			}
+			return os << " )";
+		}
+	protected:
+		Pointer( Real ) _coords;
+		unsigned int _dim;
+		void _resize( unsigned int dim )
+		{
+			DeletePointer( _coords );
+			if( dim ) _coords = NewPointer< Real >( dim );
+			_dim = dim;
+		}
+	};
+	template< class Real > Point< Real > operator * ( Real s , Point< Real > p ){ return p*s; }
+
+	/** This templated class represents a Ray.*/
+	template< class Real , unsigned int Dim >
+	class Ray
+	{
+	public:
+		/** The starting point of the ray */
+		Point< Real , Dim > position;
+
+		/** The direction of the ray */
+		Point< Real , Dim > direction;
+
+		/** The default constructor */
+		Ray( void ){}
+
+		/** The constructor settign the the position and direction of the ray */
+		Ray( const Point< Real , Dim > &p , const Point< Real , Dim > &d ) : position(p) , direction(d){}
+
+		/** This method computes the translation of the ray by p and returns the translated ray.*/
+		Ray  operator +  ( const Point< Real , Dim > &p ) const { return Ray( position+p , direction ); }
+
+		/** This method translates the current ray by p.*/
+		Ray &operator += ( const Point< Real , Dim > &p ){ position +=p ; return *this; }
+
+		/** This method computes the translation of the ray by -p and returns the translated ray.*/
+		Ray  operator -  ( const Point< Real , Dim > &p ) const { return Ray( position-p , direction ); }
+
+		/** This method translates the current ray by -p.*/
+		Ray &operator -= ( const Point< Real , Dim > &p ){ position -= p ; return *this; }
+
+		/** This method returns the point at a distance of t along the ray. */
+		Point< Real , Dim > operator() ( double t ) const { return position + direction * (Real)t; }
+	};
+
+	/** This function prints out the ray.*/
+	template< class Real , unsigned int Dim >
+	std::ostream &operator << ( std::ostream &stream , const Ray< Real , Dim > &ray )
+	{
+		stream << "[ " << ray.position << " ] [ " << ray.direction << " ]";
+		return stream;
+	}
+
+	template< class Real , unsigned int _Columns , unsigned int _Rows >
+	struct Matrix
+	{
+		static const unsigned int Columns = _Columns;
+		static const unsigned int Rows = _Rows;
+		Real coords[Columns][Rows];
+		Matrix( void ) { memset( coords , 0 , sizeof(coords) ); }
+		inline       Real& operator() ( unsigned int c , unsigned int r )       { return coords[c][r]; }
+		inline const Real& operator() ( unsigned int c , unsigned int r ) const { return coords[c][r]; }
+		inline       Real* operator[] ( unsigned int c                  )       { return coords[c]   ; }
+		inline const Real* operator[] ( unsigned int c                  ) const { return coords[c]   ; }
+
+		inline Matrix  operator - ( void ) const { Matrix m ; for( unsigned int c=0 ; c<Columns ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) m.coords[c][r] = - coords[c][r] ; return m; }
+
+		inline Matrix& operator += ( const Matrix& m ){ for( unsigned int c=0 ; c<Columns ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) coords[c][r] += m.coords[c][r] ; return *this; }
+		inline Matrix  operator +  ( const Matrix& m ) const { Matrix n ; for( unsigned int c=0 ; c<Columns ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) n.coords[c][r] = coords[c][r] + m.coords[c][r] ; return n; }
+		inline Matrix& operator *= ( Real s ) { for( unsigned int c=0 ; c<Columns ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) coords[c][r] *= s ; return *this; }
+		inline Matrix  operator *  ( Real s ) const { Matrix n ; for( unsigned int c=0 ; c<Columns ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) n.coords[c][r] = coords[c][r] * s ; return n; }
+
+		inline Matrix& operator -= ( const Matrix& m ){ return ( (*this)+=(-m) ); }
+		inline Matrix  operator -  ( const Matrix& m ) const { return (*this)+(-m); }
+		inline Matrix& operator /= ( Real s ){ return ( (*this)*=(Real)(1./s) ); }
+		inline Matrix  operator /  ( Real s ) const { return (*this) * ( (Real)(1./s) ); }
+
+		static Real Dot( const Matrix& m1 , const Matrix& m2 ){ Real dot = (Real)0 ; for( unsigned int c=0 ; c<Columns ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) dot += m1.coords[c][r] * m2.coords[c][r] ; return dot; }
+
+		template< typename T >
+		inline Point< T , Rows > operator* ( const Point< T , Columns >& p ) const { Point< T , Rows > q ; for( unsigned int c=0 ; c<Columns ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) q[r] += (T)( p[c] * coords[c][r] ) ; return q; }
+
+		template< unsigned int Cols >
+		inline Matrix< Real , Cols , Rows > operator * ( const Matrix< Real , Cols , Columns > &M ) const
+		{
+			Matrix< Real , Cols , Rows > prod;
+			for( unsigned int c=0 ; c<Cols ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) for( unsigned int i=0 ; i<Columns ; i++ ) prod(c,r) += coords[i][r] * M(c,i);
+			return prod;
+		}
+
+		inline Matrix< Real , Rows , Columns > transpose( void ) const
+		{
+			Matrix< Real , Rows , Columns > t;
+			for( unsigned int c=0 ; c<Columns ; c++ ) for( unsigned int r=0 ; r<Rows ; r++ ) t(r,c) = coords[c][r];
+			return t;
+		}
+		friend std::ostream &operator << ( std::ostream &os , const Matrix &m )
+		{
+			os << "{ ";
+			for( int r=0 ; r<Rows ; r++ )
+			{
+				if( r ) os << " , ";
+				os << "{ ";
+				for( int c=0 ; c<Columns ; c++ )
+				{
+					if( c ) os << " , ";
+					os << m.coords[c][r];
+				}
+				os << " }";
+			}
+			return os << " }";
+		}
+	};
+
+	template< class Real , unsigned int Dim >
+	struct XForm
+	{
+		Real coords[Dim][Dim];
+		XForm( void ) { memset( coords , 0 , sizeof(Real) * Dim * Dim ); }
+		XForm( const Matrix< Real , Dim , Dim > &M ){ memcpy( coords , M.coords , sizeof(Real)*Dim*Dim ); }
+		XForm( const XForm &M ){ memcpy( coords , M.coords , sizeof(Real)*Dim*Dim ); }
+		XForm( const Matrix< Real , Dim+1 , Dim+1 > &M ){ for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ ) this->operator()(i,j) = M(i,j); }
+		XForm( const XForm< Real , Dim+1 > &M ){ for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ ) this->operator()(i,j) = M(i,j); }
+		XForm &operator = ( const Matrix< Real , Dim , Dim > &M ){ memcpy( coords , M.coords , sizeof(Real)*Dim*Dim ) ; return *this; }
+		XForm &operator = ( const  XForm< Real , Dim >       &M ){ memcpy( coords , M.coords , sizeof(Real)*Dim*Dim ) ; return *this; }
+		XForm &operator = ( const Matrix< Real , Dim+1 , Dim+1> &M ){ for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ ) this->operator()(i,j) = M(i,j) ; return *this; }
+		XForm &operator = ( const  XForm< Real , Dim+1 >        &M ){ for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ ) this->operator()(i,j) = M(i,j) ; return *this; }
+
+		static XForm Identity( void )
+		{
+			XForm xForm;
+			for( unsigned int d=0 ; d<Dim ; d++ ) xForm(d,d) = (Real)1.;
+			return xForm;
+		}
+		Real& operator() ( unsigned int i , unsigned int j ){ return coords[i][j]; }
+		const Real& operator() ( unsigned int i , unsigned int j ) const { return coords[i][j]; }
+		template< class _Real > Point< _Real , Dim-1 > operator * ( const Point< _Real , Dim-1 >& p ) const
+		{
+			Point< _Real , Dim-1 > q;
+			for( unsigned int i=0 ; i<Dim-1 ; i++ )
+			{
+				for( unsigned int j=0 ; j<Dim-1 ; j++ ) q[i] += (_Real)( coords[j][i] * p[j] );
+				q[i] += (_Real)coords[Dim-1][i];
+			}
+			return q;
+		}
+		template< class _Real > Point< _Real , Dim > operator * ( const Point< _Real , Dim >& p ) const
+		{
+			Point< _Real , Dim > q;
+			for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ ) q[i] += (_Real)( coords[j][i] * p[j] );
+			return q;
+		}
+		XForm operator * ( const XForm& m ) const
+		{
+			XForm n;
+			for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ ) for( unsigned int k=0 ; k<Dim ; k++ ) n.coords[i][j] += m.coords[i][k]*coords[k][j];
+			return n;
+		}
+		XForm transpose( void ) const
+		{
+			XForm xForm;
+			for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ ) xForm( i , j ) = coords[j][i];
+			return xForm;
+		}
+		Real determinant( void ) const
+		{
+			Real det = (Real)0.;
+			for( unsigned int d=0 ; d<Dim ; d++ ) 
+				if( d&1 ) det -= coords[d][0] * subDeterminant( d , 0 );
+				else      det += coords[d][0] * subDeterminant( d , 0 );
+			return det;
+		}
+		XForm inverse( void ) const
+		{
+			XForm xForm;
+			Real d = determinant();
+			for( unsigned int i=0 ; i<Dim ; i++ ) for( unsigned int j=0 ; j<Dim ; j++ )
+				if( (i+j)%2==0 ) xForm.coords[j][i] =  subDeterminant( i , j ) / d;
+				else             xForm.coords[j][i] = -subDeterminant( i , j ) / d;
+			return xForm;
+		}
+		Real subDeterminant( unsigned int i , unsigned int j ) const
+		{
+			XForm< Real , Dim-1 > xForm;
+			unsigned int ii[Dim-1] , jj[Dim-1];
+			for( unsigned int a=0 , _i=0 , _j=0 ; a<Dim ; a++ )
+			{
+				if( a!=i ) ii[_i++] = a;
+				if( a!=j ) jj[_j++] = a;
+			}
+			for( unsigned int _i=0 ; _i<Dim-1 ; _i++ ) for( unsigned int _j=0 ; _j<Dim-1 ; _j++ ) xForm( _i , _j ) = coords[ ii[_i] ][ jj[_j] ];
+			return xForm.determinant();
+		}
+
+		inline XForm  operator - ( void ) const { XForm m ; for( unsigned int c=0 ; c<Dim ; c++ ) for( unsigned int r=0 ; r<Dim ; r++ ) m.coords[c][r] = - coords[c][r] ; return m; }
+
+		inline XForm& operator += ( const XForm& m ){ for( unsigned int c=0 ; c<Dim ; c++ ) for( unsigned int r=0 ; r<Dim ; r++ ) coords[c][r] += m.coords[c][r] ; return *this; }
+		inline XForm  operator +  ( const XForm& m ) const { XForm n ; for( unsigned int c=0 ; c<Dim ; c++ ) for( unsigned int r=0 ; r<Dim ; r++ ) n.coords[c][r] = coords[c][r] + m.coords[c][r] ; return n; }
+		inline XForm& operator *= ( Real s ) { for( unsigned int c=0 ; c<Dim ; c++ ) for( unsigned int r=0 ; r<Dim ; r++ ) coords[c][r] *= s ; return *this; }
+		inline XForm  operator *  ( Real s ) const { XForm n ; for( unsigned int c=0 ; c<Dim ; c++ ) for( unsigned int r=0 ; r<Dim ; r++ ) n.coords[c][r] = coords[c][r] * s ; return n; }
+
+		inline XForm& operator -= ( const XForm& m ){ return ( (*this)+=(-m) ); }
+		inline XForm  operator -  ( const XForm& m ) const { return (*this)+(-m); }
+		inline XForm& operator /= ( Real s ){ return ( (*this)*=(Real)(1./s) ); }
+		inline XForm  operator /  ( Real s ) const { return (*this) * ( (Real)(1./s) ); }
+
+		friend std::ostream &operator << ( std::ostream &os , const XForm &x )
+		{
+			os << "{ ";
+			for( int r=0 ; r<Dim ; r++ )
+			{
+				if( r ) os << " , ";
+				os << "{ ";
+				for( int c=0 ; c<Dim ; c++ )
+				{
+					if( c ) os << " , ";
+					os << x.coords[c][r];
+				}
+				os << " }";
+			}
+			return os << " }";
+		}
+	};
+	template<>
+	inline XForm< float , 1 > XForm< float , 1 >::inverse( void ) const
+	{
+		XForm< float , 1 > x;
+		x.coords[0][0] = (float)(1./coords[0][0] );
+		return x;
+	}
+	template<>
+	inline XForm< double , 1 > XForm< double , 1 >::inverse( void ) const
+	{
+		XForm< double , 1 > x;
+		x.coords[0][0] = (double)(1./coords[0][0] );
+		return x;
+	}
+	template<> inline float  XForm< float  , 1 >::determinant( void ) const { return coords[0][0]; }
+	template<> inline double XForm< double , 1 >::determinant( void ) const { return coords[0][0]; }
+
+	template< class Real , unsigned int Dim >
+	struct OrientedPoint
+	{
+		Point< Real , Dim > p , n;
+		OrientedPoint( Point< Real , Dim > pp = Point< Real , Dim >() , Point< Real , Dim > nn=Point< Real , Dim >() ) : p(pp) , n(nn) { ; }
+		template< class _Real > OrientedPoint( const OrientedPoint< _Real , Dim>& p ) : OrientedPoint( Point< Real , Dim >( p.p ) , Point< Real , Dim >( p.n ) ){ ; }
+
+		template< class _Real > inline OrientedPoint& operator += ( OrientedPoint< _Real , Dim > _p ){ p += _p.p , n += _p.n ; return *this; }
+		template< class _Real > inline OrientedPoint  operator +  ( OrientedPoint< _Real , Dim > _p ) const { return OrientedPoint< Real , Dim >( p+_p.p , n+_p.n ); }
+		template< class _Real > inline OrientedPoint& operator *= ( _Real r ) { p *= r , n *= r ; return *this; }
+		template< class _Real > inline OrientedPoint  operator *  ( _Real r ) const { return OrientedPoint< Real , Dim >( p*r , n*r ); }
+
+		template< class _Real > inline OrientedPoint& operator -= ( OrientedPoint< _Real , Dim > p ){ return ( (*this)+=(-p) ); }
+		template< class _Real > inline OrientedPoint  operator -  ( OrientedPoint< _Real , Dim > p ) const { return (*this)+(-p); }
+		template< class _Real > inline OrientedPoint& operator /= ( _Real r ){ return ( (*this)*=Real(1./r) ); }
+		template< class _Real > inline OrientedPoint  operator /  ( _Real r ) const { return (*this) * ( Real(1.)/r ); }
+	};
+
+
+	template< class Data , class Real >
+	struct ProjectiveData
+	{
+		Data data;
+		Real weight;
+		ProjectiveData( Data d=Data() , Real w=(Real)0 ) : data(d) , weight(w) { ; }
+		operator Data (){ return weight!=0 ? data/weight : data*weight; }
+		Data value( void ) const { return weight!=0 ? data/weight : data*weight; }
+		ProjectiveData& operator += ( const ProjectiveData& p ){ data += p.data , weight += p.weight ; return *this; }
+		ProjectiveData& operator -= ( const ProjectiveData& p ){ data -= p.data , weight -= p.weight ; return *this; }
+		ProjectiveData& operator *= ( Real s ){ data *= s , weight *= s ; return *this; }
+		ProjectiveData& operator /= ( Real s ){ data /= s , weight /= s ; return *this; }
+		ProjectiveData  operator +  ( const ProjectiveData& p ) const { return ProjectiveData( data+p.data , weight+p.weight ); }
+		ProjectiveData  operator -  ( const ProjectiveData& p ) const { return ProjectiveData( data-p.data , weight-p.weight ); }
+		ProjectiveData  operator *  ( Real s ) const { return ProjectiveData( data*s , weight*s ); }
+		ProjectiveData  operator /  ( Real s ) const { return ProjectiveData( data/s , weight/s ); }
+	};
+
+	template< class Real , unsigned int Dim > Point< Real , Dim > RandomBallPoint( void );
+	template< class Real , unsigned int Dim > Point< Real , Dim > RandomSpherePoint( void );
+	template< class Real , unsigned int Dim > Real Length( Point< Real , Dim > p ){ return (Real)sqrt( Point< Real , Dim >::SquareNorm( p ) ); }
+	template< class Real , unsigned int Dim > Real SquareLength( Point< Real , Dim > p ){ return Point< Real , Dim >::SquareNorm( p ); }
+	template< class Real , unsigned int Dim > Real Distance( Point< Real , Dim > p1 , Point< Real , Dim > p2 ){ return Length(p1-p2); }
+	template< class Real , unsigned int Dim > Real SquareDistance( Point< Real , Dim > p1 , Point< Real , Dim > p2 ){ return SquareLength( p1-p2 ); }
+	template< class Real > Point< Real , 3 > CrossProduct( Point< Real , 3 > p1 , Point< Real , 3 > p2 ){ return Point< Real , 3 >::CrossProduct( p1 , p2 ); }
+
+	template< class Real , unsigned int Dim > Real SquareArea( Point< Real , Dim > p1 , Point< Real , Dim > p2 , Point< Real , Dim > p3 )
+	{
+		Point< Real , Dim > v1 = p2-p1 , v2 = p3-p1;
+		// Area^2 = ( |v1|^2 * |v2|^2 * sin^2( < v1 ,v2 ) ) / 4
+		//        = ( |v1|^2 * |v2|^2 * ( 1 - cos^2( < v1 ,v2 ) ) ) / 4
+		//        = ( |v1|^2 * |v2|^2 * ( 1 - < v1 , v2 >^2 / ( |v1|^2 * |v2|^2 ) ) ) / 4
+		//        = ( |v1|^2 * |v2|^2 - < v1 , v2 >^2 ) / 4
+		Real dot = Point< Real , Dim >::Dot( v1 , v2 );
+		Real l1 = Point< Real , Dim >::SquareNorm( v1 ) , l2 = Point< Real , Dim >::SquareNorm( v2 );
+		return ( l1 * l2 - dot * dot ) / 4;
+	}
+	template< class Real , unsigned int Dim > Real Area( Point< Real , Dim > p1 , Point< Real , Dim > p2 , Point< Real , Dim > p3 ){ return (Real)sqrt( SquareArea( p1 , p2 , p3 ) ); }
+
+	template< unsigned int K > struct Factorial{ static const unsigned long long Value = Factorial< K-1 >::Value * K; };
+	template<> struct Factorial< 0 >{ static const unsigned long long Value = 1; };
+
+	template< class Real , unsigned int Dim , unsigned int K >
+	struct Simplex
+	{
+		Point< Real , Dim > p[K+1];
+		Simplex( void ){ static_assert( K<=Dim , "[ERROR] Bad simplex dimension" ); }
+		Point< Real , Dim >& operator[]( unsigned int k ){ return p[k]; }
+		const Point< Real , Dim >& operator[]( unsigned int k ) const { return p[k]; }
+		Real measure( void ) const { return (Real)sqrt( squareMeasure() ); }
+		Real squareMeasure( void ) const
+		{
+			XForm< Real , K > mass;
+			for( unsigned int i=1 ; i<=K ; i++ ) for( unsigned int j=1 ; j<=K ; j++ ) mass(i-1,j-1) = Point< Real , Dim >::Dot( p[i]-p[0] , p[j]-p[0] );
+			return mass.determinant() / ( Factorial< K >::Value * Factorial< K >::Value );
+		}
+		Point< Real , Dim > center( void ) const
+		{
+			Point< Real , Dim > c;
+			for( unsigned int k=0 ; k<=K ; k++ ) c += p[k];
+			return c / (K+1);
+		}
+		void split( Point< Real , Dim > pNormal , Real pOffset , std::vector< Simplex >& back , std::vector< Simplex >& front ) const;
+
+		template< unsigned int _K=K >
+		typename std::enable_if< _K==Dim-1 , Point< Real , Dim > >::type normal( void ) const
+		{
+			static_assert( K==Dim-1 , "[ERROR] Co-dimension is not one" );
+			Point< Real , Dim > d[Dim-1];
+			for( int k=1 ; k<Dim ; k++ ) d[k-1] = p[k] - p[0];
+			return Point< Real , Dim >::CrossProduct( d );
+		}
+		template< unsigned int _K=K >
+		typename std::enable_if< _K==Dim-1 , bool >::type intersect( Ray< Real , Dim > ray , Real &t , Real barycentricCoordinates[Dim] ) const
+		{
+			static_assert( K==Dim-1 , "[ERROR] Co-dimension is not one" );
+			Point< Real , Dim > n = normal();
+			Real denominator = Point< Real , Dim >::Dot( n , ray.direction );
+			if( denominator==0 ) return false;
+			// Solve for t s.t. < ray(t) , n > = < p[0] , n >
+			t = Point< Real , Dim >::Dot( n , p[0] - ray.position ) / denominator;
+			Point< Real,  Dim > q = ray(t);
+
+			// Let C be the matrix whose columns are the simplex vertices.
+			// Solve for the barycentric coordinates, b, minimizing:
+			//		E(b) = || C * b - q ||^2
+			//		     = b^t * C^t * C * b - 2 * b^t * C^t * q + || q ||^2
+			// Taking the gradient with respect to b gives:
+			//		   b = ( C^t * C )^{-1} * C^t * q
+			Matrix< Real , Dim-1 , Dim > C;
+			for( int c=0 ; c<Dim-1 ; c++ ) for( int r=0 ; r<Dim ; r++ ) C(c,r) = p[c+1][r] - p[0][r];
+			Matrix< Real , Dim , Dim-1 > C_t = C.transpose();
+			XForm< Real , Dim-1 > M = C_t * C;
+			Point< Real , Dim-1 > bc = M.inverse() * ( C_t * ( q - p[0] ) );
+			barycentricCoordinates[0] = (Real)1.;
+			for( unsigned int d=0 ; d<Dim-1 ; d++ ) barycentricCoordinates[d+1] = bc[d] , barycentricCoordinates[0] -= bc[d];
+			for( unsigned int d=0 ; d<Dim ; d++ ) if( barycentricCoordinates[d]<0 ) return false;
+			return true;
+		}
+
+		template< unsigned int _K=K >
+		static typename std::enable_if< _K==Dim-1 , bool >::type IsInterior( Point< Real , Dim > p , const std::vector< Simplex< Real , Dim , Dim-1 > > &simplices )
+		{
+			if( !simplices.size() ) MK_THROW( "No simplices provided" );
+
+			// Create a ray that intersecting the largest simplex
+			int idx;
+			{
+				Real maxMeasure = 0;
+				for( int i=0 ; i<simplices.size() ; i++ )
+				{
+					Real measure = simplices[i].squareMeasure();
+					if( measure>maxMeasure ) maxMeasure = measure , idx = i;
+				}
+			}
+			Ray< Real , Dim > ray( p , simplices[idx].center() - p );
+			Real l = (Real)Point< Real , Dim >::SquareNorm( ray.direction );
+			if( !l ) MK_THROW( "point is on simplex" );
+			l = (Real)sqrt(l);
+			ray.direction /= l;
+
+			// Make the assessment based on which side of the simplex the point p is
+			Real min_t = l;
+			bool isInside = Point< Real , Dim >::Dot( simplices[idx].normal() , ray.direction )*min_t>0;
+
+			// Look for intersections with closer simplices
+			for( size_t i=0 ; i<simplices.size() ; i++ )
+			{
+				Real t , barycentricCoordinates[ Dim ];
+				if( simplices[i].intersect( ray , t , barycentricCoordinates ) && t<min_t )	min_t = t , isInside = Point< Real , Dim >::Dot( simplices[i].normal() , ray.direction )*t>0;
+			}
+			return isInside;
+		}
+
+		template< unsigned int _K=K >
+		static typename std::enable_if< _K==Dim-1 , bool >::type IsInterior( Point< Real , Dim > p , const std::vector< Simplex< Real , Dim , Dim-1 > > &simplices , const std::vector< Point< Real , Dim > > &normals )
+		{
+			if( !simplices.size() ) MK_THROW( "No simplices provided" );
+
+#if 0
+			// A more conservative approach for ray-tracing, sending a ray for each simplex and using the consensus solution
+			Real insideMeasure = 0;
+			for( int idx=0 ; idx<simplices.size() ; idx++ )
+			{
+				Ray< Real , Dim > ray( p , simplices[idx].center() - p );
+				Real l = (Real)Point< Real , Dim >::SquareNorm( ray.direction );
+				if( !l ){ MK_WARN( "point is on simplex" ) ; continue; }
+				l = (Real)sqrt(l);
+				ray.direction /= l;
+
+				// Make the assessment based on which side of the simplex the point p is
+				Real min_t = l;
+				bool isInside = Point< Real , Dim >::Dot( normals[idx] , ray.direction )*min_t>0;
+
+				// Look for intersections with closer simplices
+				for( size_t i=0 ; i<simplices.size() ; i++ )
+				{
+					Real t , barycentricCoordinates[ Dim ];
+					if( simplices[i].intersect( ray , t , barycentricCoordinates ) && t<min_t )	min_t = t , isInside = Point< Real , Dim >::Dot( normals[i] , ray.direction )*t>0;
+				}
+				Real measure = simplices[idx].measure();
+				if( isInside ) insideMeasure += measure;
+				else           insideMeasure -= measure;
+			}
+			return insideMeasure>0;
+#else
+			// Create a ray that intersecting the largest simplex
+			int idx;
+			{
+				Real maxMeasure = 0;
+				for( int i=0 ; i<simplices.size() ; i++ )
+				{
+					Real measure = simplices[i].squareMeasure();
+					if( measure>maxMeasure ) maxMeasure = measure , idx = i;
+				}
+			}
+			Ray< Real , Dim > ray( p , simplices[idx].center() - p );
+			Real l = (Real)Point< Real , Dim >::SquareNorm( ray.direction );
+			if( !l ) MK_THROW( "point is on simplex" );
+			l = (Real)sqrt(l);
+			ray.direction /= l;
+
+			// Make the assessment based on which side of the simplex the point p is
+			Real min_t = l;
+			bool isInside = Point< Real , Dim >::Dot( normals[idx] , ray.direction )*min_t>0;
+
+			// Look for intersections with closer simplices
+			for( size_t i=0 ; i<simplices.size() ; i++ )
+			{
+				Real t , barycentricCoordinates[ Dim ];
+				if( simplices[i].intersect( ray , t , barycentricCoordinates ) && t<min_t ) min_t = t , isInside = Point< Real , Dim >::Dot( normals[i] , ray.direction )*t>0;
+			}
+			return isInside;
+#endif
+		}
+	};
+
+
+	template< class Real , unsigned int Dim >	
+	struct Simplex< Real , Dim , 0 >
+	{
+		static const unsigned int K=0;
+		Point< Real , Dim > p[1];
+		Point< Real , Dim >& operator[]( unsigned int k ){ return p[k]; }
+		const Point< Real , Dim >& operator[]( unsigned int k ) const { return p[k]; }
+		Real squareMeasure( void ) const { return (Real)1.; }
+		Real measure( void ) const { return (Real)1.; }
+		Point< Real , Dim > center( void ) const { return p[0]; }
+		void split( Point< Real , Dim > pNormal , Real pOffset , std::vector< Simplex >& back , std::vector< Simplex >& front ) const
+		{
+			if( Point< Real , Dim >::Dot( p[0] , pNormal ) < pOffset ) back.push_back( *this );
+			else                                                       front.push_back( *this );
+		}
+		template< unsigned int _K=K >
+		typename std::enable_if< _K==Dim-1 , bool >::type intersect( Ray< Real , Dim > ray , Real &t , Real barycentricCoordinates[Dim] ) const
+		{
+			static_assert( K==Dim-1 , "[ERROR] Co-dimension is not one" );
+			if( !ray.direction[0] ) return false;
+			// Solve for t s.t. ray(t) = p[0]
+			t = ( p[0][0] - ray.position[0] ) / ray.direction[0];
+			barycentricCoordinates[0] = (Real)1.;
+			return true;
+		}
+
+		template< unsigned int _K=0 >
+		static typename std::enable_if< _K==Dim-1 , bool >::type IsInterior( Point< Real , Dim > p , const std::vector< Simplex< Real , Dim , Dim-1 > > &simplices , const std::vector< Point< Real , Dim > > &normals )
+		{
+			if( !simplices.size() ) MK_THROW( "No simplices provided" );
+
+			Ray< Real , Dim > ray( p , simplices[0].center() - p );
+			Real l = (Real)Point< Real , Dim >::SquareNorm( ray.direction );
+			if( !l ) MK_THROW( "point is on simplex" );
+			l = (Real)sqrt(l);
+			ray.direction /= l;
+
+			// Make the assessment based on which side of the simplex the point p is
+			Real min_t = l;
+			bool isInside = Point< Real , Dim >::Dot( normals[0] , ray.direction )*min_t>0;
+
+			// Look for intersections with closer simplices
+			for( size_t i=0 ; i<simplices.size() ; i++ )
+			{
+				Real t , barycentricCoordinates[ Dim ];
+				if( simplices[i].intersect( ray , t , barycentricCoordinates ) && t<min_t ) min_t = t , isInside = Point< Real , Dim >::Dot( normals[i] , ray.direction )*t>0;
+			}
+			return isInside;
+		}
+	};
+	template< typename Real , unsigned int Dim , unsigned int K >
+	std::ostream &operator << ( std::ostream &os , const Simplex< Real , Dim , K > &s )
+	{
+		for( unsigned int k=0 ; k<K ; k++ ) os << s.p[k] << " , ";
+		return os << s.p[K];
+	}
+
+
+	template< class Real , unsigned int Dim > using Edge = Simplex< Real , Dim , 1 >;
+	template< class Real , unsigned int Dim > using Triangle = Simplex< Real , Dim , 2 >;
+
+	template< unsigned int K , typename Index >
+	struct SimplexIndex
+	{
+		Index idx[K+1];
+		template< class ... Ints >
+		SimplexIndex( Ints ... values ){ static_assert( sizeof...(values)==K+1 || sizeof...(values)==0 , "[ERROR] Invalid number of coefficients" ) ; _init( 0 , values ... ); }
+		Index &operator[] ( unsigned int i ) { return idx[i] ;}
+		const Index &operator[] ( unsigned int i ) const { return idx[i]; }
+	protected:
+		void _init( unsigned int k )
+		{
+			if( !k ) memset( idx , 0 , sizeof(idx) );
+			else MK_THROW( "Should never be called" );
+		}
+		template< class ... Ints > void _init( unsigned int k , Index v , Ints ... values )
+		{
+			idx[k] = v;
+			if( k<K ) _init( k+1 , values ... );
+		}
+	};
+	template< typename Index > using EdgeIndex = SimplexIndex< 1 , Index >;
+	template< typename Index > using TriangleIndex = SimplexIndex< 2 , Index >;
+
+	template< typename Real , unsigned int Dim , unsigned int K >
+	struct SimplicialComplex
+	{
+		SimplicialComplex( const std::vector< Simplex< Real , Dim , K > > &simplices ) : _simplices( simplices ){}
+		virtual size_t size( void ) const { return _simplices.size(); }
+		virtual Simplex< Real , Dim , K > operator[]( size_t idx ) const { return _simplices[idx]; }
+	protected:
+		SimplicialComplex( void ) :_simplices(__simplices) {}
+		const std::vector< Simplex< Real , Dim , K > > &_simplices;
+		const std::vector< Simplex< Real , Dim , K > > __simplices;
+	};
+
+	template< typename Real , unsigned int Dim , unsigned int K , typename IndexType >
+	struct IndexedSimplicialComplex : public SimplicialComplex< Real , Dim , K >
+	{
+		IndexedSimplicialComplex( const std::vector< Point< Real , Dim > > &vertices , const std::vector< SimplexIndex< K , IndexType > > &simplices ) : _vertices(vertices) , _simplices(simplices){}
+		IndexedSimplicialComplex( IndexedSimplicialComplex && isc )
+		{
+			std::swap( _vertices , isc._vertices );
+			std::swap( _simplices , isc._simplices );
+		}
+
+		size_t size( void ) const { return _simplices.size(); }
+		Simplex< Real , Dim , K > operator[]( size_t idx ) const
+		{
+			Simplex< Real , Dim , K > s;
+			for( unsigned int k=0 ; k<=K ; k++ ) s[k] = _vertices[ _simplices[idx][k] ];
+			return s;
+		}
+	protected:
+		const std::vector< Point< Real , Dim > > &_vertices;
+		const std::vector< SimplexIndex< K , IndexType > > &_simplices;
+	};
+
+
+	template< typename Index >
+	class TriangulationEdge
+	{
+	public:
+		TriangulationEdge( void ){ pIndex[0] = pIndex[1] = tIndex[0] = tIndex[1] = -1; }
+		Index pIndex[2] , tIndex[2];
+	};
+
+	template< typename Index >
+	class TriangulationTriangle
+	{
+	public:
+		TriangulationTriangle( void ){ eIndex[0] = eIndex[1] = eIndex[2] = -1; }
+		Index eIndex[3];
+	};
+
+#include "Geometry.inl"
+}
+
+#endif // GEOMETRY_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Geometry.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Geometry.inl
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+template< class Real > Real Random( void ){ return Real( rand() )/Real( RAND_MAX ); }
+
+template< class Real , int Dim >
+Point< Real , Dim > RandomBallPoint( void )
+{
+	Point< Real , Dim > p;
+	while(1)
+	{
+		for( int d=0 ; d<Dim ; d++ ) p[d] = Real( 1.0-2.0*Random< Real >() );
+		double l=SquareLength(p);
+		if( SquareLength( p )<=1 ) return p;
+	}
+}
+template< class Real , int Dim >
+Point< Real , Dim > RandomSpherePoint( void )
+{
+	Point< Real , Dim > p = RandomBallPoint< Real , Dim >();
+	return p / (Real)Length( p );
+}
+
+/////////////
+// Simplex //
+/////////////
+template< class Real , unsigned int Dim , unsigned int K >
+void Simplex< Real , Dim , K >::split( Point< Real , Dim > pNormal , Real pOffset , std::vector< Simplex >& back , std::vector< Simplex >& front ) const
+{
+	Real values[K+1];
+	bool frontSet = false , backSet = false;
+
+	// Evaluate the hyper-plane's function at the vertices and mark if strictly front/back vertices have been found
+	for( unsigned int k=0 ; k<=K ; k++ )
+	{
+		values[k] = Point< Real , Dim >::Dot( p[k] , pNormal ) - pOffset;
+		backSet |= ( values[k]<0 ) , frontSet |= ( values[k]>0 );
+	}
+
+	// If all the vertices are behind or on, or all the vertices are in front or on, we are done.
+	if( !frontSet ){ back.push_back( *this ) ; return; }
+	if( !backSet ){ front.push_back( *this ) ; return; }
+
+	// Pick some intersection of the hyper-plane with a simplex edge
+	unsigned int v1 , v2;
+	Point< Real , Dim > midPoint;
+	{
+		for( unsigned int i=0 ; i<K ; i++ ) for( unsigned int j=i+1 ; j<=K ; j++ ) if( values[i]*values[j]<0 )
+		{
+			v1 = i , v2 = j;
+			Real t1 = values[i] / ( values[i] - values[j] ) , t2 = (Real)( 1. - t1 );
+			midPoint = p[j]*t1 + p[i]*t2;
+		}
+	}
+	// Iterate over each face of the simplex, split it with the hyper-plane and connect the sub-simplices to the mid-point
+	for( unsigned int i=0 ; i<=K ; i++ )
+	{
+		if( i!=v1 && i!=v2 ) continue;
+		Simplex< Real , Dim , K-1 > f;		// The face
+		Simplex< Real , Dim , K > s;		// The sub-simplex
+		for( unsigned int j=0 , idx=0 ; j<=K ; j++ )	if( j!=i ) f[idx++] = p[j];
+		std::vector< Simplex< Real , Dim , K-1 > > _back , _front;
+		f.split( pNormal , pOffset , _back , _front );
+		s[i] = midPoint;
+
+		for( unsigned int j=0 ; j<_back.size() ; j++ ) 
+		{
+			for( unsigned int k=0 ; k<K ; k++ ) s[ k<i ? k : k+1 ] = _back[j][k];
+			back.push_back( s );
+		}
+
+		for( unsigned int j=0 ; j<_front.size() ; j++ ) 
+		{
+			for( unsigned int k=0 ; k<K ; k++ ) s[ k<i ? k : k+1 ] = _front[j][k];
+			front.push_back( s );
+		}
+	}
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/LinearSolvers.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/LinearSolvers.h
@@ -1,0 +1,570 @@
+#ifndef LINEAR_SOLVERS_INCLUDE
+#define LINEAR_SOLVERS_INCLUDE
+
+#ifdef USE_CHOLMOD
+#include <Cholmod/cholmod.h>
+#if defined( WIN32 ) || defined( _WIN64 )
+#pragma message( "[WARNING] Need to explicitly exclude VCOMP.lib" )
+#pragma comment( lib , "CHOLMOD_FULL.lib" )
+#endif // WIN32 || _WIN64
+#ifdef DLONG
+typedef long long SOLVER_LONG;
+#define CHOLMOD( name ) cholmod_l_ ## name
+#else // !DLONG
+typedef       int SOLVER_LONG;
+#define CHOLMOD( name ) cholmod_ ## name
+#endif // DLONG
+#elif defined(EIGEN_USE_MKL_ALL)
+#pragma comment( lib , "mkl_core.lib" )
+#pragma comment( lib , "mkl_intel_lp64.lib" )
+#pragma comment( lib , "mkl_intel_thread.lib" )
+#pragma comment( lib , "mkl_blas95_lp64.lib" )
+#pragma comment( lib , "libiomp5md.lib" )
+#endif // USE_CHOLMOD
+
+#include "SparseMatrixInterface.h"
+
+inline double                        SquareNorm( const double* values , int dim ){ double norm2 = 0 ; for( int i=0 ; i<dim ; i++ ) norm2 += values[i] * values[i] ; return norm2; }
+inline double                        SquareNorm( const  float* values , int dim ){ double norm2 = 0 ; for( int i=0 ; i<dim ; i++ ) norm2 += values[i] * values[i] ; return norm2; }
+template< class Type > inline double SquareNorm( const   Type* values , int dim ){ double norm2 = 0 ; for( int i=0 ; i<dim ; i++ ) norm2 += values[dim].squareNorm()  ; return norm2 ; }
+
+inline double                        SquareDifference( const double* values1 , const double* values2 , int dim ){ double norm2 = 0 ; for( int i=0 ; i<dim ; i++ ) norm2 += ( values1[i] - values2[i] ) * ( values1[i] - values2[i] ) ; return norm2; }
+inline double                        SquareDifference( const  float* values1 , const  float* values2 , int dim ){ double norm2 = 0 ; for( int i=0 ; i<dim ; i++ ) norm2 += ( values1[i] - values2[i] ) * ( values1[i] - values2[i] ) ; return norm2; }
+template< class Type > inline double SquareDifference( const   Type* values1 , const   Type* values2 , int dim ){ double norm2 = 0 ; for( int i=0 ; i<dim ; i++ ) norm2 += ( values1[dim] - values2[dim] ).squareNorm()  ; return norm2 ; }
+
+
+// This is the conjugate gradients solver.
+// The assumption is that the class SPDOperator defines a method operator()( const Real* , Real* ) which corresponds to applying a symmetric positive-definite operator.
+template< class Real >
+struct CGScratch
+{
+	Real *r , *d , *q;
+	CGScratch( void ) : r(NULL) , d(NULL) , q(NULL) , _dim(0){ ; }
+	CGScratch( int dim ) : r(NULL) , d(NULL) , q(NULL){ resize(dim); }
+	~CGScratch( void ){ resize(0); }
+	void resize( int dim )
+	{
+		if( dim!=_dim )
+		{
+			if( r ) delete[] r ; r = NULL;
+			if( d ) delete[] d ; d = NULL;
+			if( q ) delete[] q ; q = NULL;
+			if( dim ) r = new Real[dim] , d = new Real[dim] , q = new Real[dim];
+			_dim = dim;
+		}
+	}
+protected:
+	int _dim;
+};
+template< class Real >
+struct PreconditionedCGScratch : public CGScratch< Real >
+{
+	Real *s;
+	PreconditionedCGScratch( void ) : CGScratch< Real >() , s(NULL){ ; }
+	PreconditionedCGScratch( int dim ) : CGScratch< Real >() { resize(dim); }
+	~PreconditionedCGScratch( void ){ resize(0); }
+	void resize( int dim )
+	{
+		if( dim!=CGScratch< Real >::_dim )
+		{
+			if( s ) delete[] s; s = NULL;
+			if( dim ) s = new Real[dim];
+		}
+		CGScratch< Real >::resize( dim );
+	}
+};
+template< class Real >
+struct DiagonalPreconditioner
+{
+	Real* iDiagonal;
+	DiagonalPreconditioner( void ) : iDiagonal(NULL) , _dim(0){ ; }
+	~DiagonalPreconditioner( void ){ if( iDiagonal ) delete[] iDiagonal ; iDiagonal = NULL; }
+	template< class MatrixRowIterator >
+	void set( const SparseMatrixInterface< Real , MatrixRowIterator >& M )
+	{
+		if( _dim!=M.rows() )
+		{
+			_dim = (int)M.rows();
+			if( iDiagonal ) delete[] iDiagonal , iDiagonal = NULL;
+			if( _dim>0 ) iDiagonal = new Real[_dim];
+		}
+		memset( iDiagonal , 0 , sizeof(Real)*_dim );
+#pragma omp parallel for
+		for( int i=0 ; i<M.rows() ; i++ )
+		{
+			for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) if( iter->N==i ) iDiagonal[i] += iter->Value;
+			iDiagonal[i] = (Real)1./iDiagonal[i];
+		}
+	}
+	void operator()( const Real* in , Real* out ) const
+	{
+#pragma omp parallel for
+		for( int i=0 ; i<_dim ; i++ ) out[i] = in[i] * iDiagonal[i];
+	}
+protected:
+	int _dim;
+};
+
+template< class Real , class SPDOperator >
+int SolveCG( SPDOperator& L , int iters , int dim , const Real* b , Real* x , CGScratch< Real >* scratch=NULL , double eps=1e-8 , int threads=1 , bool verbose=false )
+{
+	eps *= eps;
+	Real *r , *d , *q;
+	if( scratch ) r = scratch->r    , d = scratch->d    , q = scratch->q;
+	else          r = new Real[dim] , d = new Real[dim] , q = new Real[dim];
+	memset( r , 0 , sizeof(Real)*dim ) , memset( d , 0 , sizeof(Real)*dim ) , memset( q , 0 , sizeof(Real)*dim );
+	double delta_new = 0 , delta_0;
+
+	L( x , r );
+#pragma omp parallel for num_threads( threads ) reduction( + : delta_new )
+	for( int i=0 ; i<dim ; i++ ) d[i] = r[i] = b[i] - r[i] , delta_new += r[i] * r[i];
+
+	delta_0 = delta_new;
+	if( delta_new<eps )
+	{
+		if( !scratch ) delete[] r , delete[] d , delete[] q;
+		return 0;
+	}
+
+	int ii;
+	for( ii=0 ; ii<iters && delta_new>eps*delta_0 ; ii++ )
+	{
+		L( d , q );
+        double dDotQ = 0;
+#pragma omp parallel for num_threads( threads ) reduction( + : dDotQ )
+		for( int i=0 ; i<dim ; i++ ) dDotQ += d[i] * q[i];
+		Real alpha = Real( delta_new / dDotQ );
+
+		double delta_old = delta_new;
+		delta_new = 0;
+
+		const int RESET_COUNT = 50;
+		if( (ii%RESET_COUNT)==(RESET_COUNT-1) )
+		{
+#pragma omp parallel for num_threads( threads )
+			for( int i=0 ; i<dim ; i++ ) x[i] += d[i] * alpha;
+			L( x , r );
+#pragma omp parallel for num_threads( threads ) reduction ( + : delta_new )
+			for( int i=0 ; i<dim ; i++ ) r[i] = b[i] - r[i] , delta_new += r[i] * r[i];
+		}
+		else
+#pragma omp parallel for num_threads( threads ) reduction( + : delta_new )
+			for( int i=0 ; i<dim ; i++ ) r[i] -= q[i] * alpha , delta_new += r[i] * r[i] , x[i] += d[i] * alpha;
+
+		Real beta = Real( delta_new / delta_old );
+#pragma omp parallel for num_threads( threads )
+		for( int i=0 ; i<dim ; i++ ) d[i] = r[i] + d[i] * beta;
+	}
+	if( verbose )
+	{
+		L( x , r );
+#pragma omp parallel for num_threads( threads )
+		for( int i=0 ; i<dim ; i++ ) r[i] -= b[i];
+		printf( "CG: %d %g -> %g\n" , ii , SquareNorm( b , dim ) , SquareNorm( r , dim ) );
+	}
+	if( !scratch ) delete[] r , delete[] d , delete[] q;
+	return ii;
+}
+template< class Real , class SPDOperator , class SPDPreconditioner >
+int SolvePreconditionedCG( SPDOperator& L , SPDPreconditioner& Pinverse , int iters , int dim , const Real* b , Real* x , PreconditionedCGScratch< Real >* scratch=NULL , double eps=1e-8 , int threads=1 , bool verbose=false )
+{
+	eps *= eps;
+	Real *r , *d , *q , *s;
+	if( scratch ) r = scratch->r    , d = scratch->d    , q = scratch->q , s = scratch->s;
+	else          r = new Real[dim] , d = new Real[dim] , q = new Real[dim] , s = new Real[dim];
+	memset( r , 0 , sizeof(Real)*dim ) , memset( d , 0 , sizeof(Real)*dim ) , memset( q , 0 , sizeof(Real)*dim ) , memset( s , 0 , sizeof(Real)*dim );
+	double delta_new = 0 , delta_0;
+
+	L( x , r );
+#pragma omp parallel for num_threads( threads )
+	for( int i=0 ; i<dim ; i++ ) r[i] = b[i] - r[i];
+	Pinverse( r , d );
+#pragma omp parallel for num_threads( threads ) reduction( + : delta_new )
+	for( int i=0 ; i<dim ; i++ ) delta_new += r[i] * d[i];
+
+	delta_0 = delta_new;
+	if( delta_new<eps )
+	{
+		if( !scratch ) delete[] r , delete[] d , delete[] q;
+		return 0;
+	}
+	int ii;
+	for( ii=0 ; ii<iters && delta_new>eps*delta_0 ; ii++ )
+	{
+		L( d , q );
+        double dDotQ = 0;
+#pragma omp parallel for num_threads( threads ) reduction( + : dDotQ )
+		for( int i=0 ; i<dim ; i++ ) dDotQ += d[i] * q[i];
+		Real alpha = Real( delta_new / dDotQ );
+
+		const int RESET_COUNT = 50;
+#pragma omp parallel for num_threads( threads )
+		for( int i=0 ; i<dim ; i++ ) x[i] += d[i] * alpha;
+		if( (ii%RESET_COUNT)==(RESET_COUNT-1) )
+		{
+			L( x , r );
+#pragma omp parallel for num_threads( threads )
+			for( int i=0 ; i<dim ; i++ ) r[i] = b[i] - r[i];
+		}
+		else
+#pragma omp parallel for num_threads( threads ) reduction( + : delta_new )
+			for( int i=0 ; i<dim ; i++ ) r[i] -= q[i] * alpha;
+		Pinverse( r , s );
+
+		double delta_old = delta_new;
+		delta_new = 0;
+#pragma omp parallel for num_threads( threads ) reduction( + : delta_new )
+		for( int i=0 ; i<dim ; i++ ) delta_new += r[i] * s[i];
+
+		Real beta = Real( delta_new / delta_old );
+#pragma omp parallel for num_threads( threads )
+		for( int i=0 ; i<dim ; i++ ) d[i] = s[i] + d[i] * beta;
+	}
+	if( verbose )
+	{
+		L( x , r );
+#pragma omp parallel for num_threads( threads )
+		for( int i=0 ; i<dim ; i++ ) r[i] -= b[i];
+		printf( "PCCG: %d %g -> %g\n" , ii , SquareNorm( b , dim ) , SquareNorm( r , dim ) );
+	}
+	if( !scratch ) delete[] r , delete[] d , delete[] q , delete[] s;
+	return ii;
+}
+
+
+#ifdef USE_EIGEN
+#define STORE_EIGEN_MATRIX
+#ifdef EIGEN_USE_MKL_ALL
+#include <Eigen/PardisoSupport>
+#else // !EIGEN_USE_MKL_ALL
+#include <Eigen/Sparse>
+#endif // EIGEN_USE_MKL_ALL
+
+template< class Real , class MatrixRowIterator >
+struct EigenSolver
+{
+	virtual void update( const SparseMatrixInterface< Real , MatrixRowIterator >& M ) = 0;
+	virtual void solve( ConstPointer( Real ) b , Pointer( Real ) x ) = 0;
+	virtual size_t dimension( void ) const = 0;
+};
+
+template< class Real , class MatrixRowIterator >
+class EigenSolverCholeskyLLt : public EigenSolver< Real , MatrixRowIterator >
+{
+#ifdef EIGEN_USE_MKL_ALL
+	typedef Eigen::PardisoLLT< Eigen::SparseMatrix< double > > Eigen_Solver;
+	typedef Eigen::VectorXd                                    Eigen_Vector;
+#else // !EIGEN_USE_MKL_ALL
+	typedef Eigen::SimplicialLLT< Eigen::SparseMatrix< double > > Eigen_Solver;
+	typedef Eigen::VectorXd                                       Eigen_Vector;
+#endif // EIGEN_USE_MKL_ALL
+	Eigen_Solver _solver;
+	Eigen_Vector _eigenB;
+#ifdef STORE_EIGEN_MATRIX
+	Eigen::SparseMatrix< double > _eigenM;
+#endif // STORE_EIGEN_MATRIX
+public:
+	EigenSolverCholeskyLLt( const SparseMatrixInterface< Real , MatrixRowIterator >& M , bool analyzeOnly=false )
+	{
+#ifdef STORE_EIGEN_MATRIX
+		_eigenM.resize( int( M.rows() ) , int( M.rows() ) );
+#else // !STORE_EIGEN_MATRIX
+		Eigen::SparseMatrix< double > eigenM( int( M.rows() ) , int( M.rows() ) );
+#endif // STORE_EIGEN_MATRIX
+		std::vector< Eigen::Triplet< double > > triplets;
+		triplets.reserve( M.entries() );
+		for( int i=0 ; i<M.rows() ; i++ ) for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) triplets.push_back( Eigen::Triplet< double >( i , iter->N , iter->Value ) );
+#ifdef STORE_EIGEN_MATRIX
+		_eigenM.setFromTriplets( triplets.begin() , triplets.end() );
+		_solver.analyzePattern( _eigenM );
+#else // !STORE_EIGEN_MATRIX
+		eigenM.setFromTriplets( triplets.begin() , triplets.end() );
+		_solver.analyzePattern( eigenM );
+#endif // STORE_EIGEN_MATRIX
+		if( !analyzeOnly )
+		{
+#ifdef STORE_EIGEN_MATRIX
+			_solver.factorize( _eigenM );
+#else // !STORE_EIGEN_MATRIX
+			_solver.factorize( eigenM );
+#endif // STORE_EIGEN_MATRIX
+			if( _solver.info()!=Eigen::Success ) fprintf( stderr , "[ERROR] EigenSolverCholeskyLLt::EigenSolverCholeskyLLt Failed to factorize matrix\n" ) , exit(0);
+		}
+		_eigenB.resize( M.rows() );
+	}
+	void update( const SparseMatrixInterface< Real , MatrixRowIterator >& M )
+	{
+#ifdef STORE_EIGEN_MATRIX
+#pragma omp parallel for
+		for( int i=0 ; i<M.rows() ; i++ ) for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) _eigenM.coeffRef( i , iter->N ) = iter->Value;
+		_solver.factorize( _eigenM );
+#else // !STORE_EIGEN_MATRIX
+		Eigen::SparseMatrix< double > eigenM( int( M.rows() ) , int( M.rows() ) );
+		std::vector< Eigen::Triplet< double > > triplets;
+		triplets.reserve( M.entries() );
+		for( int i=0 ; i<M.rows() ; i++ ) for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) triplets.push_back( Eigen::Triplet< double >( i , iter->N , iter->Value ) );
+		eigenM.setFromTriplets( triplets.begin() , triplets.end() );
+		_solver.factorize( eigenM );
+#endif // STORE_EIGEN_MATRIX
+		switch( _solver.info() )
+		{
+		case Eigen::Success: break;
+		case Eigen::NumericalIssue: fprintf( stderr , "[ERROR] EigenSolverCholeskyLLt::update Failed to factorize matrix (numerical issue)\n" ) , exit(0);
+		case Eigen::NoConvergence:  fprintf( stderr , "[ERROR] EigenSolverCholeskyLLt::update Failed to factorize matrix (no convergence)\n" ) , exit(0);
+		case Eigen::InvalidInput:   fprintf( stderr , "[ERROR] EigenSolverCholeskyLLt::update Failed to factorize matrix (invalid input)\n" ) , exit(0);
+		default: fprintf( stderr , "[ERROR] EigenSolverCholeskyLLt::update Failed to factorize matrix\n" ) , exit(0);
+		}
+	}
+	void solve( ConstPointer( Real ) b , Pointer( Real ) x )
+	{
+#pragma omp parallel for
+		for( int i=0 ; i<_eigenB.size() ; i++ ) _eigenB[i] = b[i];
+		Eigen_Vector eigenX = _solver.solve( _eigenB );
+#pragma omp parallel for
+		for( int i=0 ; i<eigenX.size() ; i++ ) x[i] = (Real)eigenX[i];
+	}
+	size_t dimension( void ) const { return _eigenB.size(); }
+	static void Solve( const SparseMatrixInterface< Real , MatrixRowIterator >& M , ConstPointer( Real ) b , Pointer( Real ) x ){ EigenSolverCholeskyLLt solver( M ) ; solver.solve( b , x ); }
+};
+template< class Real , class MatrixRowIterator >
+class EigenSolverCholeskyLDLt : public EigenSolver< Real , MatrixRowIterator >
+{
+#ifdef EIGEN_USE_MKL_ALL
+	typedef Eigen::PardisoLDLT< Eigen::SparseMatrix< double > > Eigen_Solver;
+	typedef Eigen::VectorXd                                     Eigen_Vector;
+#else // !EIGEN_USE_MKL_ALL
+	typedef Eigen::SimplicialLDLT< Eigen::SparseMatrix< double > > Eigen_Solver;
+	typedef Eigen::VectorXd                                        Eigen_Vector;
+#endif // EIGEN_USE_MKL_ALL
+	Eigen_Solver _solver;
+	Eigen_Vector _eigenB;
+public:
+	EigenSolverCholeskyLDLt( const SparseMatrixInterface< Real , MatrixRowIterator >& M , bool analyzeOnly=false )
+	{
+		Eigen::SparseMatrix< double > eigenM( int( M.rows() ) , int( M.rows() ) );
+		std::vector< Eigen::Triplet<double> > triplets;
+		triplets.reserve( M.entries() );
+		for( int i=0 ; i<M.rows() ; i++ ) for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) triplets.push_back( Eigen::Triplet< double >( i , iter->N , iter->Value ) );
+		eigenM.setFromTriplets( triplets.begin() , triplets.end() );
+		_solver.analyzePattern( eigenM );
+		if( !analyzeOnly )
+		{
+			_solver.factorize( eigenM );
+			if( _solver.info()!=Eigen::Success ) fprintf( stderr , "[ERROR] EigenSolverCholeskyLDLt::EigenSolverCholeskyLDLt Failed to factorize matrix\n" ) , exit(0);
+		}
+		_eigenB.resize( M.rows() );
+	}
+	void update( const SparseMatrixInterface< Real , MatrixRowIterator >& M )
+	{
+		Eigen::SparseMatrix< double > eigenM( int( M.rows() ) , int( M.rows() ) );
+		std::vector< Eigen::Triplet<double> > triplets;
+		triplets.reserve( M.entries() );
+		for( int i=0 ; i<M.rows() ; i++ ) for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) triplets.push_back( Eigen::Triplet< double >( i , iter->N , iter->Value ) );
+		eigenM.setFromTriplets( triplets.begin() , triplets.end() );
+		_solver.factorize( eigenM );
+		if( _solver.info()!=Eigen::Success ) fprintf( stderr , "[ERROR] EigenSolverCholeskyLDLt::update Failed to factorize matrix\n" ) , exit(0);
+	}
+	void solve( ConstPointer( Real ) b , Pointer( Real ) x )
+	{
+#pragma omp parallel for
+		for( int i=0 ; i<_eigenB.size() ; i++ ) _eigenB[i] = b[i];
+		Eigen_Vector eigenX = _solver.solve( _eigenB );
+#pragma omp parallel for
+		for( int i=0 ; i<eigenX.size() ; i++ ) x[i] = (Real)eigenX[i];
+	}
+	size_t dimension( void ) const { return _eigenB.size(); }
+	static void Solve( const SparseMatrixInterface< Real , MatrixRowIterator >& M , ConstPointer( Real ) b , Pointer( Real ) x ){ EigenSolverCholeskyLDLt solver( M ) ; solver.solve( b , x ); }
+};
+template< class Real , class MatrixRowIterator >
+class EigenSolverCG : public EigenSolver< Real , MatrixRowIterator >
+{
+#if 1
+//	Eigen::ConjugateGradient< Eigen::SparseMatrix< double > , Eigen::Lower , Eigen::IncompleteLUT< double > > _solver;
+	Eigen::ConjugateGradient< Eigen::SparseMatrix< double > > _solver;
+#else
+	Eigen::BiCGSTAB< Eigen::SparseMatrix< double > > _solver;
+#endif
+	Eigen::VectorXd _eigenB , _eigenX;
+	Eigen::SparseMatrix< double > _eigenM;
+public:
+	EigenSolverCG( const SparseMatrixInterface< Real , MatrixRowIterator >& M , int iters=20 , double tolerance=0. )
+	{
+		_eigenM.resize( (int)M.rows() , (int)M.rows() );
+		std::vector< Eigen::Triplet< double > > triplets;
+		triplets.reserve( M.entries() );
+		for( int i=0 ; i<M.rows() ; i++ ) for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) triplets.push_back( Eigen::Triplet< double >( i , iter->N , iter->Value ) );
+		_eigenM.setFromTriplets( triplets.begin() , triplets.end() );
+		_solver.compute( _eigenM );
+		_solver.analyzePattern( _eigenM );
+		if( _solver.info()!=Eigen::Success ) fprintf( stderr , "[ERROR] EigenSolverCG::EigenSolverCG Failed to factorize matrix\n" ) , exit(0);
+		_eigenB.resize( M.rows() ) , _eigenX.resize( M.rows() );
+		_solver.setMaxIterations( iters );
+		_solver.setTolerance( tolerance );
+	}
+	void update( const SparseMatrixInterface< Real , MatrixRowIterator >& M )
+	{
+#pragma omp parallel for
+		for( int i=0 ; i<M.rows() ; i++ ) for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) _eigenM.coeffRef( i , iter->N ) = iter->Value;
+		_solver.compute( _eigenM );
+		_solver.analyzePattern( _eigenM );
+		if( _solver.info()!=Eigen::Success ) fprintf( stderr , "[ERROR] EigenSolverCG::update Failed to factorize matrix\n" ) , exit(0);
+	}
+
+	void setIters( int iters ){ _solver.setMaxIterations( iters ); }
+	void solve( ConstPointer( Real ) b , Pointer( Real ) x )
+	{
+#pragma omp parallel for
+		for( int i=0 ; i<_eigenB.size() ; i++ ) _eigenB[i] = b[i] , _eigenX[i] = x[i];
+		_eigenX = _solver.solveWithGuess( _eigenB , _eigenX );
+#pragma omp parallel for
+		for( int i=0 ; i<_eigenX.size() ; i++ ) x[i] = _eigenX[i];
+	}
+	size_t dimension( void ) const { return _eigenB.size(); }
+	static void Solve( const SparseMatrixInterface< Real , MatrixRowIterator >& M , const Real* b , Real* x , int iters ){ EigenSolverCG solver( M , iters ) ; solver.solve( b , x ); }
+};
+
+#endif // USE_EIGEN
+
+#ifdef USE_CHOLMOD
+class CholmodSolver
+{
+	const static bool LOWER_TRIANGULAR = true;
+	int dim;
+	cholmod_factor* cholmod_L;
+	cholmod_dense*  cholmod_b;
+	cholmod_sparse* cholmod_M;
+	std::vector< bool > flaggedValues;
+	template< class Real , class MatrixRowIterator > void _init( const SparseMatrixInterface< Real , MatrixRowIterator >& M );
+public:
+	static cholmod_common cholmod_C;
+	static bool cholmod_C_set;
+
+	template< class Real , class MatrixRowIterator >
+	CholmodSolver( const SparseMatrixInterface< Real , MatrixRowIterator >& M , bool analyzeOnly=false );
+	~CholmodSolver( void );
+
+	template< class Real > void solve( ConstPointer( Real ) b , Pointer( Real ) x );
+	template< class Real , class MatrixRowIterator > bool update( const SparseMatrixInterface< Real , MatrixRowIterator >& M );
+	int nonZeros( void ) const;
+
+};
+bool CholmodSolver::cholmod_C_set = false;
+cholmod_common CholmodSolver::cholmod_C;
+
+template< class Real , class MatrixRowIterator > CholmodSolver::CholmodSolver( const SparseMatrixInterface< Real , MatrixRowIterator >& M , bool analyzeOnly ){ _init( M ) ; if( !analyzeOnly ) update( M ); }
+template< class Real , class MatrixRowIterator >
+void CholmodSolver::_init( const SparseMatrixInterface< Real , MatrixRowIterator >& M )
+{
+	{
+		if( !cholmod_C_set ) CHOLMOD(start)( &cholmod_C );
+		cholmod_C_set = true;
+	}
+	dim = (int)M.rows();
+
+	int maxEntries;
+	if( LOWER_TRIANGULAR )
+	{
+		maxEntries = (int)( ( M.entries()-M.rows() ) / 2 + M.rows() );
+		cholmod_M = CHOLMOD(allocate_sparse)( dim , dim , maxEntries , 0 , 1 , -1 , CHOLMOD_REAL , &cholmod_C );
+	}
+	else
+	{
+		maxEntries = (int)M.entries();
+		cholmod_M = CHOLMOD(allocate_sparse)( dim , dim , maxEntries , 0 , 1 ,  0 , CHOLMOD_REAL , &cholmod_C );
+	}
+	cholmod_M->i = malloc( sizeof( SOLVER_LONG ) * maxEntries );
+	cholmod_M->x = malloc( sizeof( double ) * maxEntries );
+
+	SOLVER_LONG *_p = (SOLVER_LONG*)cholmod_M->p;
+	SOLVER_LONG *_i = (SOLVER_LONG*)cholmod_M->i;
+
+	int off = 0;
+	dim = 0;
+
+	for( int i=0 ; i<M.rows() ; i++ )
+	{
+		_p[dim++] = off;
+		for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ ) if( !LOWER_TRIANGULAR || iter->N>=i ) _i[off++] = iter->N;
+	}
+	_p[dim] = off;
+
+	cholmod_L = CHOLMOD(analyze)( cholmod_M , &cholmod_C );
+	cholmod_b = CHOLMOD(allocate_dense)( dim , 1 , dim , cholmod_M->xtype , &cholmod_C );
+}
+template< class Real , class MatrixRowIterator >
+bool CholmodSolver::update( const SparseMatrixInterface< Real , MatrixRowIterator >& M )
+{
+	double *_x = (double*)cholmod_M->x;
+	int off = 0;
+
+	SOLVER_LONG *_p = (SOLVER_LONG*)cholmod_M->p;
+#pragma omp parallel for
+	for( int i=0 ; i<M.rows() ; i++ )
+	{
+		int off = (int)_p[i];
+		for( MatrixRowIterator iter=M.begin(i) ; iter!=M.end(i) ; iter++ )if( !LOWER_TRIANGULAR || iter->N>=i ) _x[off++] = double( iter->Value );
+	}
+
+	cholmod_C.print = 0;
+	CHOLMOD(factorize)( cholmod_M , cholmod_L , &cholmod_C );
+	if( cholmod_C.status==CHOLMOD_NOT_POSDEF )
+	{
+		fprintf( stderr , "[WARNING] CholmodSolver::update: Matrix not positive-definite\n" );
+		return false;
+	}
+	else if( cholmod_C.status==CHOLMOD_OUT_OF_MEMORY )
+	{
+		fprintf( stderr , "[WARNING] CholmodSolver::update: CHOLMOD ran out of memory\n" );
+		return false;
+	}
+	else if( cholmod_C.status!=CHOLMOD_OK )
+	{
+		fprintf( stderr , "[WARNING] CholmodSolver::update: CHOLMOD status not OK: %d\n" , cholmod_C.status );
+		return false;
+	}
+	return true;
+}
+CholmodSolver::~CholmodSolver( void )
+{
+	if( cholmod_L ) CHOLMOD(free_factor)( &cholmod_L , &cholmod_C ) , cholmod_L = NULL;
+	if( cholmod_b ) CHOLMOD(free_dense )( &cholmod_b , &cholmod_C ) , cholmod_b = NULL;
+	if( cholmod_M ) CHOLMOD(free_sparse)( &cholmod_M , &cholmod_C ) , cholmod_M = NULL;
+}
+
+template< class Real >
+void CholmodSolver::solve( ConstPointer( Real ) b , Pointer( Real ) x )
+{
+	double* _b = (double*)cholmod_b->x;
+	for( int i=0 ; i<dim ; i++ ) _b[i] = (double)b[i];
+
+	cholmod_dense* cholmod_x = CHOLMOD(solve)( CHOLMOD_A , cholmod_L , cholmod_b , &cholmod_C );
+	double* _x = (double*)cholmod_x->x;
+	for( int i=0 ; i<dim ; i++ ) x[i] = (Real)_x[i];
+
+	CHOLMOD(free_dense)( &cholmod_x , &cholmod_C );
+}
+int CholmodSolver::nonZeros( void ) const
+{
+	long long nz = 0;
+	if( cholmod_L->xtype != CHOLMOD_PATTERN && !(cholmod_L->is_super ) ) for( int i=0 ; i<cholmod_L->n ; i++ ) nz += ((SOLVER_LONG*)cholmod_L->nz)[i];
+	bool examine_super = false;
+	if( cholmod_L->xtype != CHOLMOD_PATTERN ) examine_super = true ;
+	else                                      examine_super = ( ((int*)cholmod_L->s)[0] != (-1));
+	if( examine_super )
+	{
+		/* check and print each supernode */
+		for (int s = 0 ; s < cholmod_L->nsuper ; s++)
+		{
+			int k1 = ((int*)cholmod_L->super) [s] ;
+			int k2 = ((int*)cholmod_L->super) [s+1] ;
+			int psi = ((int*)cholmod_L->pi)[s] ;
+			int psend = ((int*)cholmod_L->pi)[s+1] ;
+			int nsrow = psend - psi ;
+			int nscol = k2 - k1 ;
+			nz += nscol * nsrow - (nscol*nscol - nscol)/2 ;
+		}
+	}
+	return (int)nz;
+}
+#endif // USE_CHOLMOD
+#endif // LINEAR_SOLVERS_INCLUDE

--- a/LiverResections/Algorithm/PoissonRecon/Src/MAT.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/MAT.h
@@ -1,0 +1,66 @@
+/*
+Copyright (c) 2007, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+#ifndef MAT_INCLUDED
+#define MAT_INCLUDED
+#include "Geometry.h"
+#include "Array.h"
+
+namespace PoissonRecon
+{
+
+	template< typename Index , class Real , unsigned int Dim >
+	std::vector< TriangleIndex< Index > > MinimalAreaTriangulation( ConstPointer( Point< Real , Dim > ) vertices , size_t vCount );
+
+	template< typename Index , class Real , unsigned int Dim >
+	class _MinimalAreaTriangulation
+	{
+		Pointer( Real ) _bestTriangulation;
+		Pointer( Index ) _midpoint;
+		size_t _vCount;
+		ConstPointer( Point< Real , Dim > ) _vertices;
+
+		void _set( void );
+		Real _subPolygonArea( Index i , Index j );
+		void _addTriangles( Index i , Index j , std::vector< TriangleIndex< Index > >& triangles ) const;
+		Index _subPolygonIndex( Index i , Index j ) const;
+
+		_MinimalAreaTriangulation( ConstPointer( Point< Real , Dim > ) vertices , size_t vCount );
+		~_MinimalAreaTriangulation( void );
+		std::vector< TriangleIndex< Index > > getTriangulation( void );
+		friend std::vector< TriangleIndex< Index > > MinimalAreaTriangulation< Index , Real , Dim >( ConstPointer( Point< Real , Dim > ) vertices , size_t vCount );
+	};
+	template< typename Index , class Real , unsigned int Dim >
+	std::vector< TriangleIndex< Index > > MinimalAreaTriangulation( ConstPointer( Point< Real , Dim > ) vertices , size_t vCount )
+	{
+		_MinimalAreaTriangulation< Index , Real , Dim > MAT( vertices , vCount );
+		return MAT.getTriangulation();
+	}
+#include "MAT.inl"
+}
+
+#endif // MAT_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/MAT.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/MAT.inl
@@ -1,0 +1,172 @@
+/*
+Copyright (c) 2007, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+//////////////////////////////
+// MinimalAreaTriangulation //
+//////////////////////////////
+template< typename Index , class Real , unsigned int Dim >
+_MinimalAreaTriangulation< Index , Real , Dim >::_MinimalAreaTriangulation( ConstPointer( Point< Real , Dim > ) vertices , size_t vCount ) : _vertices( vertices ) , _vCount( vCount )
+{
+	_bestTriangulation = NullPointer( Real );
+	_midpoint = NullPointer( Index );
+}
+template< typename Index , class Real , unsigned int Dim >
+_MinimalAreaTriangulation< Index , Real , Dim >::~_MinimalAreaTriangulation( void )
+{
+	FreePointer( _bestTriangulation );
+	FreePointer( _midpoint );
+}
+template< typename Index , class Real , unsigned int Dim >
+std::vector< TriangleIndex< Index > > _MinimalAreaTriangulation< Index , Real , Dim >::getTriangulation( void )
+{
+	std::vector< TriangleIndex< Index > > triangles;
+	if( _vCount==3 )
+	{
+		triangles.resize(1);
+		triangles[0].idx[0] = 0;
+		triangles[0].idx[1] = 1;
+		triangles[0].idx[2] = 2;
+		return triangles;
+	}
+	else if( _vCount==4 )
+	{
+		TriangleIndex< Index > tIndex[2][2];
+		Real area[] = { 0 , 0 };
+
+		triangles.resize(2);
+
+		tIndex[0][0].idx[0]=0;
+		tIndex[0][0].idx[1]=1;
+		tIndex[0][0].idx[2]=2;
+		tIndex[0][1].idx[0]=2;
+		tIndex[0][1].idx[1]=3;
+		tIndex[0][1].idx[2]=0;
+
+		tIndex[1][0].idx[0]=0;
+		tIndex[1][0].idx[1]=1;
+		tIndex[1][0].idx[2]=3;
+		tIndex[1][1].idx[0]=3;
+		tIndex[1][1].idx[1]=1;
+		tIndex[1][1].idx[2]=2;
+
+		Point< Real , Dim > p1 , p2;
+		for( int i=0 ; i<2 ; i++ ) for( int j=0 ; j<2 ; j++ ) area[i] = SquareArea( _vertices[ tIndex[i][j].idx[0] ] , _vertices[ tIndex[i][j].idx[1] ] , _vertices[ tIndex[i][j].idx[2] ] );
+		if( area[0]>area[1] ) triangles[0] = tIndex[1][0] , triangles[1] = tIndex[1][1];
+		else                  triangles[0] = tIndex[0][0] , triangles[1] = tIndex[0][1];
+		return triangles;
+	}
+	_set();
+	_addTriangles( 1 , 0 , triangles );
+	return triangles;
+}
+template< typename Index , class Real , unsigned int Dim >
+void _MinimalAreaTriangulation< Index , Real , Dim >::_set( void )
+{
+	FreePointer( _bestTriangulation );
+	FreePointer( _midpoint );
+	_bestTriangulation = AllocPointer< Real >( _vCount * _vCount );
+	_midpoint = AllocPointer< Index >( _vCount * _vCount );
+	for( int i=0 ; i<_vCount*_vCount ; i++ ) _bestTriangulation[i] = -1 , _midpoint[i] = -1;
+	_subPolygonArea( 1 , 0 );
+}
+
+template< typename Index , class Real , unsigned int Dim >
+Index _MinimalAreaTriangulation< Index , Real , Dim >::_subPolygonIndex( Index i , Index j ) const { return (Index)( i*_vCount+j ); }
+
+template< typename Index , class Real , unsigned int Dim >
+void _MinimalAreaTriangulation< Index , Real , Dim >::_addTriangles( Index i , Index j , std::vector< TriangleIndex< Index > >& triangles ) const
+{
+	TriangleIndex< Index > tIndex;
+	if( j<i ) j += (Index)_vCount;
+	if( i==j || i+1==j ) return;
+	Index mid = _midpoint[ _subPolygonIndex( i , j%_vCount ) ];
+	if( mid!=-1 )
+	{
+		tIndex.idx[0] = i;
+		tIndex.idx[1] = mid;
+		tIndex.idx[2] = j%_vCount;
+		triangles.push_back( tIndex );
+		_addTriangles( i , mid , triangles );
+		_addTriangles( mid , j , triangles );
+	}
+}
+
+// Get the minimial area of the sub-polygon [ v_i , ... , v_j ]
+template< typename Index , class Real , unsigned int Dim >
+Real _MinimalAreaTriangulation< Index , Real , Dim >::_subPolygonArea( Index i , Index j )
+{
+	Index idx = _subPolygonIndex( i , j );
+	if( _midpoint[idx]!=-1 ) return _bestTriangulation[idx];
+	Real a = FLT_MAX , temp;
+	if( j<i ) j += (Index)_vCount;
+	// If either i==j or i+1=j, the polygon has trivial area
+	if( i==j || i+1==j )
+	{
+		_bestTriangulation[idx] = 0;
+		return 0;
+	}
+	// If we have already computed the minimal area for this edge
+	if( _midpoint[idx]!=-1 ) return _bestTriangulation[idx];
+	Index mid = -1;
+
+	// For each vertex r \in( i , j ):
+	// -- Construct the triangle ( j , r , i )
+	// -- Compute the Area(j,r,i) + Area( j , ... , r ) + Area( r , ... , i )
+	for( Index r=i+1 ; r<j ; r++ )
+	{
+		Index idx1 = _subPolygonIndex( i , r%_vCount ); // SubPolygon( r , ... , i )
+		Index idx2 = _subPolygonIndex( r%_vCount , j%_vCount ); // SubPolygon( j , ... , r );
+
+		temp = SquareArea( _vertices[i] , _vertices[r%_vCount] , _vertices[j%_vCount] );
+		temp = temp<0 ? 0 : (Real)sqrt(temp);
+		// If we have already computed Area( r , ... , i ), use that.
+		if( _bestTriangulation[idx1]>=0 )
+		{
+			temp += _bestTriangulation[idx1];
+			// If the partial area is already too large, terminate
+			if( temp>a ) continue; // Terminate early
+								   // Otherwise, compute the total area
+			temp += _subPolygonArea( r%_vCount , j%_vCount );
+		}
+		else
+		{
+			// Otherwise, compute it now
+			temp += _subPolygonArea( r%_vCount , j%_vCount );
+			// If the partial area is already too large, terminate
+			if( temp>a ) continue;
+			// Otherwise, compute the total area
+			temp += _subPolygonArea( i , r%_vCount );
+		}
+
+		if( temp<a ) a=temp , mid=r%_vCount;
+	}
+	_bestTriangulation[idx] = a;
+	_midpoint[idx] = mid;
+	return a;
+}
+

--- a/LiverResections/Algorithm/PoissonRecon/Src/MarchingCubes.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/MarchingCubes.h
@@ -1,0 +1,761 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef MARCHING_CUBES_INCLUDED
+#define MARCHING_CUBES_INCLUDED
+
+#include <stdio.h>
+#include <type_traits>
+#include "Geometry.h"
+
+#include "Window.h"
+
+namespace PoissonRecon
+{
+	namespace HyperCube
+	{
+		enum Direction{ BACK , CROSS , FRONT };
+		inline Direction Opposite( Direction dir ){ return dir==BACK ? FRONT : ( dir==FRONT ? BACK : CROSS ); }
+		inline std::string DirectionName( Direction dir )
+		{
+			if( dir==BACK ) return std::string( "back" );
+			else if( dir==CROSS ) return std::string( "cross" );
+			else if( dir==FRONT ) return std::string( "front" );
+			else{ MK_THROW( "Unrecognized direction" ) ; return std::string( "" ); }
+		}
+
+		// The number of k-dimensional elements in a d-dimensional cube is equal to
+		// the number of (k-1)-dimensional elements in a (d-1)-dimensional hypercube plus twice the number of k-dimensional elements in a (d-1)-dimensional hypercube
+
+		// Number of elements of dimension K in a cube of dimension D
+		template< unsigned int D , unsigned int K > struct ElementNum         { static const unsigned int Value = 2 * ElementNum< D-1 , K >::Value + ElementNum< D-1 , K-1 >::Value; };
+		template< unsigned int D                  > struct ElementNum< D , 0 >{ static const unsigned int Value = 2 * ElementNum< D-1 , 0 >::Value; };
+		template< unsigned int D                  > struct ElementNum< D , D >{ static const unsigned int Value = 1; };
+		template<                                 > struct ElementNum< 0 , 0 >{ static const unsigned int Value = 1; };
+		// [WARNING] This shouldn't really happen, but we need to support the definition of OverlapElementNum
+		template<                  unsigned int K > struct ElementNum< 0 , K >{ static const unsigned int Value = K==0 ? 1 : 0; };
+
+		template< unsigned int D , unsigned int K1 , unsigned int K2 > struct OverlapElementNum             { static const unsigned int Value = K1>=K2 ? ElementNum< K1 , K2 >::Value : OverlapElementNum< D-1 , K1 , K2 >::Value + OverlapElementNum< D-1 , K1 , K2-1 >::Value; };
+		template< unsigned int D ,                   unsigned int K  > struct OverlapElementNum< D , D , K >{ static const unsigned int Value = ElementNum< D , K >::Value; };
+		template< unsigned int D                                     > struct OverlapElementNum< D , D , 0 >{ static const unsigned int Value = ElementNum< D , 0 >::Value; };
+		template< unsigned int D , unsigned int K                    > struct OverlapElementNum< D , K , 0 >{ static const unsigned int Value = ElementNum< K , 0 >::Value; };
+		template< unsigned int D , unsigned int K                    > struct OverlapElementNum< D , K , K >{ static const unsigned int Value = 1; };
+		template< unsigned int D , unsigned int K                    > struct OverlapElementNum< D , K , D >{ static const unsigned int Value = 1; };
+		template< unsigned int D                                     > struct OverlapElementNum< D , D , D >{ static const unsigned int Value = 1; };
+		template< unsigned int D                                     > struct OverlapElementNum< D , 0 , 0 >{ static const unsigned int Value = 1; };
+
+		template< unsigned int D >
+		struct Cube
+		{
+			// Corner index (x,y,z,...) -> x + 2*y + 4*z + ...
+			// CROSS -> the D-th axis 
+
+			// Representation of a K-dimensional element of the cube
+			template< unsigned int K >
+			struct Element
+			{
+				static_assert( D>=K , "[ERROR] Element dimension exceeds cube dimension" );
+
+				// The index of the element, sorted as:
+				// 1. All K-dimensional elements contained in the back face
+				// 2. All K-dimensional elements spanning the D-th axis
+				// 3. All K-dimensional elements contained in the front face
+				unsigned int index;
+
+				// Initialize by index
+				Element( unsigned int idx=0 );
+
+				// Initialize by co-index:
+				// 1. A K-dimensional element in either BACK or FRONT
+				// 2. A (K-1)-dimensional element extruded across the D-th axis
+				Element( Direction dir , unsigned int coIndex );
+
+				// Given a K-Dimensional sub-element living inside a DK-dimensional sub-cube, get the element relative to the D-dimensional cube
+				template< unsigned int DK >
+				Element( Element< DK > subCube , typename Cube< DK >::template Element< K > subElement );
+
+				// Initialize by setting the directions
+				Element( const Direction dirs[D] );
+
+				// Print the element to the specified stream
+				void print( FILE* fp=stdout ) const;
+
+				// Sets the direction and co-index of the element
+				void factor( Direction& dir , unsigned int& coIndex ) const;
+
+				// Returns the direction along which the element lives
+				Direction direction( void ) const;
+
+				// Returns the co-index of the element
+				unsigned int coIndex( void ) const;
+
+				// Compute the directions of the element
+				void directions( Direction* dirs ) const;
+
+				// Returns the antipodal element
+				typename Cube< D >::template Element< K > antipodal( void ) const;
+
+				// Comparison operators
+				bool operator <  ( Element e ) const { return index< e.index; }
+				bool operator <= ( Element e ) const { return index<=e.index; }
+				bool operator >  ( Element e ) const { return index> e.index; }
+				bool operator >= ( Element e ) const { return index>=e.index; }
+				bool operator == ( Element e ) const { return index==e.index; }
+				bool operator != ( Element e ) const { return index!=e.index; }
+				bool operator <  ( unsigned int i ) const { return index< i; }
+				bool operator <= ( unsigned int i ) const { return index<=i; }
+				bool operator >  ( unsigned int i ) const { return index> i; }
+				bool operator >= ( unsigned int i ) const { return index>=i; }
+				bool operator == ( unsigned int i ) const { return index==i; }
+				bool operator != ( unsigned int i ) const { return index!=i; }
+
+				// Increment operators
+				Element& operator ++ ( void ) { index++ ; return *this; }
+				Element  operator ++ ( int ) { index++ ; return Element(index-1); }
+			protected:
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< _D!=0 && _K!=0 >::type _setElement( Direction dir , unsigned int coIndex );
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< _D!=0 && _K==0 >::type _setElement( Direction dir , unsigned int coIndex );
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< _D==0 && _K==0 >::type _setElement( Direction dir , unsigned int coIndex );
+
+				template< unsigned int KD > typename std::enable_if< (D> KD) && (KD>K) && K!=0 >::type _setElement( typename Cube< D >::template Element< KD > subCube , typename Cube< KD >::template Element< K > subElement );
+				template< unsigned int KD > typename std::enable_if< (D> KD) && (KD>K) && K==0 >::type _setElement( typename Cube< D >::template Element< KD > subCube , typename Cube< KD >::template Element< K > subElement );
+				template< unsigned int KD > typename std::enable_if< (D==KD) && (KD>K)         >::type _setElement( typename Cube< D >::template Element< KD > subCube , typename Cube< KD >::template Element< K > subElement );
+				template< unsigned int KD > typename std::enable_if< (KD==K)                   >::type _setElement( typename Cube< D >::template Element< KD > subCube , typename Cube< KD >::template Element< K > subElement );
+
+				template< unsigned int _D=D > typename std::enable_if< _D!=0 >::type _setElement( const Direction* dirs );
+				template< unsigned int _D=D > typename std::enable_if< _D==0 >::type _setElement( const Direction* dirs );
+
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< _D==_K          >::type _factor( Direction& dir , unsigned int& coIndex ) const;
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< _D!=_K && _K!=0 >::type _factor( Direction& dir , unsigned int& coIndex ) const;
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< _D!=_K && _K==0 >::type _factor( Direction& dir , unsigned int& coIndex ) const;
+
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< (_D>_K) && _K!=0 >::type _directions( Direction* dirs ) const;
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< (_D>_K) && _K==0 >::type _directions( Direction* dirs ) const;
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< _D==_K           >::type _directions( Direction* dirs ) const;
+
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< (_D>_K) && _K!=0 , Element >::type _antipodal( void ) const;
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< (_D>_K) && _K==0 , Element >::type _antipodal( void ) const;
+				template< unsigned int _D=D , unsigned int _K=K > typename std::enable_if< _D==_K           , Element >::type _antipodal( void ) const;
+			};
+			// A way of indexing the cubes incident on an element
+			template< unsigned int K > using IncidentCubeIndex = typename Cube< D-K >::template Element< 0 >;
+
+			// Number of elements of dimension K
+			template< unsigned int K > static constexpr unsigned int ElementNum( void ){ return HyperCube::ElementNum< D , K >::Value; }
+			// Number of cubes incident to an element of dimension K
+			template< unsigned int K > static constexpr unsigned int IncidentCubeNum( void ){ return HyperCube::ElementNum< D-K , 0 >::Value; }
+			// Number of overlapping elements of dimension K1 / K2
+			template< unsigned int K1 , unsigned int K2 > static constexpr unsigned int OverlapElementNum( void ){ return HyperCube::OverlapElementNum< D , K1 , K2 >::Value; }
+
+			// Is the face outward-facing
+			static bool IsOriented( Element< D-1 > e );
+
+			// Is one element contained in the other?
+			template< unsigned int K1 , unsigned int K2 >
+			static bool Overlap( Element< K1 > e1 , Element< K2 > e2 );
+
+			// If K1>K2: returns all elements contained in e
+			// Else:     returns all elements containing e
+			template< unsigned int K1 , unsigned int K2 >
+			static void OverlapElements( Element< K1 > e , Element< K2 >* es );
+
+			// Returns the marching-cubes index for the set of values
+			template< typename Real >
+			static unsigned int MCIndex( const Real values[ Cube::ElementNum< 0 >() ] , Real iso );
+
+			// Extracts the marching-cubes sub-index for the associated element
+			template< unsigned int K >
+			static unsigned int ElementMCIndex( Element< K > element , unsigned int mcIndex );
+
+			// Does the marching cubes index have a zero-crossing
+			static bool HasMCRoots( unsigned int mcIndex );
+
+			// Sets the offset of the incident cube relative to the center cube, x[i] \in {-1,0,1}
+			template< unsigned int K >
+			static void CellOffset( Element< K > e , IncidentCubeIndex< K > d , int x[D] );
+
+			// Returns the linearized offset of the incident cube relative to the center cube, \in [0,3^D)
+			template< unsigned int K >
+			static unsigned int CellOffset( Element< K > e , IncidentCubeIndex< K > d );
+
+			// Returns the index of the incident cube that is the source
+			template< unsigned int K >
+			static typename Cube< D >::template IncidentCubeIndex< K > IncidentCube( Element< K > e );
+
+			// Returns the corresponding element in the incident cube
+			template< unsigned int K >
+			static typename Cube< D >::template Element< K > IncidentElement( Element< K > e , IncidentCubeIndex< K > d );
+
+		protected:
+			template< unsigned int K1 , unsigned int K2 > static typename std::enable_if< (K1>=K2) , bool >::type _Overlap( Element< K1 > e1 , Element< K2 > e2 );
+			template< unsigned int K1 , unsigned int K2 > static typename std::enable_if< (K1< K2) , bool >::type _Overlap( Element< K1 > e1 , Element< K2 > e2 );
+
+			template< unsigned int K1 , unsigned int K2 > static typename std::enable_if< (K1>=K2)                   >::type _OverlapElements( Element< K1 > e , Element< K2 >* es );
+			template< unsigned int K1 , unsigned int K2 > static typename std::enable_if< (K1< K2) && D==K2          >::type _OverlapElements( Element< K1 > e , Element< K2 >* es );
+			template< unsigned int K1 , unsigned int K2 > static typename std::enable_if< (K1< K2) && D!=K2 && K1!=0 >::type _OverlapElements( Element< K1 > e , Element< K2 >* es );
+			template< unsigned int K1 , unsigned int K2 > static typename std::enable_if< (K1< K2) && D!=K2 && K1==0 >::type _OverlapElements( Element< K1 > e , Element< K2 >* es );
+
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D==K                  , IncidentCubeIndex< K > >::type _IncidentCube( Element< K > e );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && _D!=0 && K!=0 , IncidentCubeIndex< K > >::type _IncidentCube( Element< K > e );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && _D!=0 && K==0 , IncidentCubeIndex< K > >::type _IncidentCube( Element< K > e );
+
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D==K         >::type _CellOffset( Element< K > e , IncidentCubeIndex< K > d , int* x );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && K!=0 >::type _CellOffset( Element< K > e , IncidentCubeIndex< K > d , int* x );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && K==0 >::type _CellOffset( Element< K > e , IncidentCubeIndex< K > d , int* x );
+
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D==K && K==0 , unsigned int >::type _CellOffset( Element< K > e , IncidentCubeIndex< K > d );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D==K && K!=0 , unsigned int >::type _CellOffset( Element< K > e , IncidentCubeIndex< K > d );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && K!=0 , unsigned int >::type _CellOffset( Element< K > e , IncidentCubeIndex< K > d );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && K==0 , unsigned int >::type _CellOffset( Element< K > e , IncidentCubeIndex< K > d );
+
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D==K                  , Element< K > >::type _IncidentElement( Element< K > e , IncidentCubeIndex< K > d );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && _D!=0 && K!=0 , Element< K > >::type _IncidentElement( Element< K > e , IncidentCubeIndex< K > d );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && _D!=0 && K==0 , Element< K > >::type _IncidentElement( Element< K > e , IncidentCubeIndex< K > d );
+
+			template< unsigned int _D=D > static typename std::enable_if< _D!=1 >::type _FactorOrientation( Element< D-1 > e , unsigned int& dim , Direction& dir );
+			template< unsigned int _D=D > static typename std::enable_if< _D==1 >::type _FactorOrientation( Element< D-1 > e , unsigned int& dim , Direction& dir );
+
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && K!=0 , unsigned int >::type _ElementMCIndex( Element< K > element , unsigned int mcIndex );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D!=K && K==0 , unsigned int >::type _ElementMCIndex( Element< K > element , unsigned int mcIndex );
+			template< unsigned int K , unsigned int _D=D > static typename std::enable_if< _D==K         , unsigned int >::type _ElementMCIndex( Element< K > element , unsigned int mcIndex );
+
+			template< unsigned int DD > friend struct Cube;
+		};
+
+		// Specialized class for extracting iso-curves from a square
+		struct MarchingSquares
+		{
+			const static unsigned int MAX_EDGES=2;
+			static const int edges[1<<HyperCube::Cube< 2 >::ElementNum< 0 >()][2*MAX_EDGES+1];
+			static inline int AddEdgeIndices( unsigned char mcIndex , int* edges);
+		};
+
+		///////////////////
+		// Cube::Element //
+		///////////////////
+		template< unsigned int D > template< unsigned int K >
+		Cube< D >::Element< K >::Element( unsigned int idx ) : index( idx ){}
+		template< unsigned int D > template< unsigned int K >
+		Cube< D >::Element< K >::Element( Direction dir , unsigned int coIndex ){ _setElement( dir , coIndex ); }
+		template< unsigned int D > template< unsigned int K > template< unsigned int DK >
+		Cube< D >::Element< K >::Element( Element< DK > subCube , typename Cube< DK >::template Element< K > subElement )
+		{
+			static_assert( DK>=K , "[ERROR] Element::Element: sub-cube dimension cannot be smaller than the sub-element dimension" );
+			static_assert( DK<=D , "[ERROR] Element::Element: sub-cube dimension cannot be larger than the cube dimension" );
+			_setElement( subCube , subElement );
+		}
+		template< unsigned int D > template< unsigned int K >
+		Cube< D >::Element< K >::Element( const Direction dirs[D] ){ _setElement( dirs ); }
+
+		template< unsigned int D > template< unsigned int K > template< unsigned int KD >
+		typename std::enable_if< (D>KD) && (KD>K) && K!=0 >::type Cube< D >::Element< K >::_setElement( typename Cube< D >::template Element< KD > subCube , typename Cube< KD >::template Element< K > subElement )
+		{
+			Direction dir ; unsigned int coIndex;
+			subCube.factor( dir , coIndex );
+			// If the sub-cube lies entirely in the back/front, we can compute the element in the smaller cube.
+			if( dir==BACK || dir==FRONT )
+			{
+				typename Cube< D-1 >::template Element< KD > _subCube( coIndex );
+				typename Cube< D-1 >::template Element< K > _element( _subCube , subElement );
+				*this = Element( dir , _element.index );
+			}
+			else
+			{
+				typename Cube< D-1 >::template Element< KD-1 > _subCube( coIndex );
+
+				Direction _dir ; unsigned int _coIndex;
+				subElement.factor( _dir , _coIndex );
+				// If the sub-element lies entirely in the back/front, we can compute the element in the smaller cube.
+				if( _dir==BACK || _dir==FRONT )
+				{
+					typename Cube< KD-1 >::template Element< K > _subElement( _coIndex );
+					typename Cube< D-1 >::template Element< K > _element( _subCube , _subElement );
+					*this = Element( _dir , _element.index );
+				}
+				// Otherwise
+				else
+				{
+					typename Cube< KD-1 >::template Element< K-1 > _subElement( _coIndex );
+					typename Cube< D-1 >::template Element< K-1 > _element( _subCube , _subElement );
+					*this = Element( _dir , _element.index );
+				}
+			}
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int KD >
+		typename std::enable_if< (D>KD) && (KD>K) && K==0 >::type Cube< D >::Element< K >::_setElement( typename Cube< D >::template Element< KD > subCube , typename Cube< KD >::template Element< K > subElement )
+		{
+			Direction dir ; unsigned int coIndex;
+			subCube.factor( dir , coIndex );
+			// If the sub-cube lies entirely in the back/front, we can compute the element in the smaller cube.
+			if( dir==BACK || dir==FRONT )
+			{
+				typename Cube< D-1 >::template Element< KD > _subCube( coIndex );
+				typename Cube< D-1 >::template Element< K > _element( _subCube , subElement );
+				*this = Element( dir , _element.index );
+			}
+			else
+			{
+				typename Cube< D-1 >::template Element< KD-1 > _subCube( coIndex );
+
+				Direction _dir ; unsigned int _coIndex;
+				subElement.factor( _dir , _coIndex );
+				// If the sub-element lies entirely in the back/front, we can compute the element in the smaller cube.
+				if( _dir==BACK || _dir==FRONT )
+				{
+					typename Cube< KD-1 >::template Element< K > _subElement( _coIndex );
+					typename Cube< D-1 >::template Element< K > _element( _subCube , _subElement );
+					*this = Element( _dir , _element.index );
+				}
+			}
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int KD >
+		typename std::enable_if< (D==KD) && (KD>K) >::type Cube< D >::Element< K >::_setElement( typename Cube< D >::template Element< KD > subCube , typename Cube< KD >::template Element< K > subElement ){ *this = subElement; }
+		template< unsigned int D > template< unsigned int K > template< unsigned int KD >
+		typename std::enable_if< (KD==K) >::type Cube< D >::Element< K >::_setElement( typename Cube< D >::template Element< KD > subCube , typename Cube< KD >::template Element< K > subElement ){ *this = subCube; }
+
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< _D!=0 && _K!=0 >::type Cube< D >::Element< K >::_setElement( Direction dir , unsigned int coIndex )
+		{
+			switch( dir )
+			{
+			case BACK:  index = coIndex ; break;
+			case CROSS: index = coIndex + HyperCube::ElementNum< D-1 , K >::Value ; break;
+			case FRONT: index = coIndex + HyperCube::ElementNum< D-1 , K >::Value + HyperCube::ElementNum< D-1 , K-1 >::Value ; break;
+			default: MK_THROW( "Bad direction: " , dir );
+			}
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< _D!=0 && _K==0 >::type Cube< D >::Element< K >::_setElement( Direction dir , unsigned int coIndex )
+		{
+			switch( dir )
+			{
+			case BACK:  index = coIndex ; break;
+			case FRONT: index = coIndex + HyperCube::ElementNum< D-1 , K >::Value ; break;
+			default: MK_THROW( "Bad direction: " , dir );
+			}
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< _D==0 && _K==0 >::type Cube< D >::Element< K >::_setElement( Direction dir , unsigned int coIndex ){ index = coIndex; }
+
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D >
+		typename std::enable_if< _D!=0 >::type Cube< D >::Element< K>::_setElement( const Direction* dirs )
+		{
+			if( dirs[D-1]==CROSS ) *this = Element( dirs[D-1] , typename Cube< D-1 >::template Element< K-1 >( dirs ).index );
+			else                   *this = Element( dirs[D-1] , typename Cube< D-1 >::template Element< K >( dirs ).index );
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D >
+		typename std::enable_if< _D==0 >::type Cube< D >::Element< K>::_setElement( const Direction* dirs ){}
+
+		template< unsigned int D > template< unsigned int  K >
+		void Cube< D >::Element< K >::print( FILE* fp ) const
+		{
+			Direction dirs[D==0?1:D];
+			directions( dirs );
+			for( int d=0 ; d<D ; d++ ) fprintf( fp , "%c" , dirs[d]==BACK ? 'B' : ( dirs[d]==CROSS ? 'C' : 'F' ) );
+		}
+
+		template< unsigned int D > template< unsigned int K >
+		void Cube< D >::Element< K >::factor( Direction& dir , unsigned int& coIndex ) const { _factor( dir , coIndex ); }
+
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< _D!=_K && _K!=0 >::type Cube< D >::Element< K >::_factor( Direction& dir , unsigned int& coIndex ) const
+		{
+			if     ( index<HyperCube::ElementNum< D-1 , K >::Value )                                             dir = BACK  , coIndex = index;
+			else if( index<HyperCube::ElementNum< D-1 , K >::Value + HyperCube::ElementNum< D-1 , K-1 >::Value ) dir = CROSS , coIndex = index - HyperCube::ElementNum< D-1 , K >::Value;
+			else                                                                                                 dir = FRONT , coIndex = index - HyperCube::ElementNum< D-1 , K >::Value - HyperCube::ElementNum< D-1 , K-1 >::Value;
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< _D!=_K && _K==0 >::type Cube< D >::Element< K >::_factor( Direction& dir , unsigned int& coIndex ) const
+		{
+			if     ( index<HyperCube::ElementNum< D-1 , K >::Value ) dir = BACK  , coIndex = index;
+			else                                                     dir = FRONT , coIndex = index - HyperCube::ElementNum< D-1 , K >::Value;
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< _D==_K >::type Cube< D >::Element< K >::_factor( Direction& dir , unsigned int& coIndex ) const { dir=CROSS , coIndex=0; }
+
+		template< unsigned int D > template< unsigned int K >
+		Direction Cube< D >::Element< K >::direction( void ) const
+		{
+			Direction dir ; unsigned int coIndex;
+			factor( dir , coIndex );
+			return dir;
+		}
+		template< unsigned int D > template< unsigned int K >
+		unsigned int Cube< D >::Element< K >::coIndex( void ) const
+		{
+			Direction dir ; unsigned int coIndex;
+			factor( dir , coIndex );
+			return coIndex;
+		}
+
+		template< unsigned int D > template< unsigned int K >
+		void Cube< D >::Element< K >::directions( Direction* dirs ) const { _directions( dirs ); }
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< (_D>_K) && _K!=0 >::type Cube< D >::Element< K >::_directions( Direction* dirs ) const
+		{
+			unsigned int coIndex;
+			factor( dirs[D-1] , coIndex );
+			if( dirs[D-1]==CROSS ) typename Cube< D-1 >::template Element< K-1 >( coIndex ).directions( dirs );
+			else                   typename Cube< D-1 >::template Element< K   >( coIndex ).directions( dirs );
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< (_D>_K) && _K==0 >::type Cube< D >::Element< K >::_directions( Direction* dirs ) const
+		{
+			unsigned int coIndex;
+			factor( dirs[D-1] , coIndex );
+			if( dirs[D-1]==FRONT || dirs[D-1]==BACK ) typename Cube< D-1 >::template Element< K >( coIndex ).directions( dirs );
+		}
+
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< _D==_K >::type Cube< D >::Element< K >::_directions( Direction* dirs ) const { for( int d=0 ; d<D ; d++ ) dirs[d] = CROSS; }
+
+		template< unsigned int D > template< unsigned int K >
+		typename Cube< D >::template Element< K > Cube< D >::Element< K >::antipodal( void ) const { return _antipodal(); }
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+		typename std::enable_if< (_D>_K) && _K!=0 , typename Cube< D >::template Element< K > >::type Cube< D >::Element< K >::_antipodal( void ) const
+		{
+			Direction dir ; unsigned int coIndex;
+			factor( dir , coIndex );
+			if     ( dir==CROSS ) return Element< K >( CROSS , typename Cube< D-1 >::template Element< K-1 >( coIndex ).antipodal().index );
+			else if( dir==FRONT ) return Element< K >( BACK  , typename Cube< D-1 >::template Element< K   >( coIndex ).antipodal().index );
+			else if( dir==BACK  ) return Element< K >( FRONT , typename Cube< D-1 >::template Element< K   >( coIndex ).antipodal().index );
+			return Element< K >();
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+#ifdef _MSC_VER
+		typename std::enable_if< (_D>_K) && _K==0 , typename Cube< D >::Element< K > >::type Cube< D >::Element< K >::_antipodal( void ) const
+#else // !_MSC_VER
+		typename std::enable_if< (_D>_K) && _K==0 , typename Cube< D >::template Element< K > >::type Cube< D >::Element< K >::_antipodal( void ) const
+#endif // _MSC_VER
+		{
+			Direction dir ; unsigned int coIndex;
+			factor( dir , coIndex );
+			if     ( dir==FRONT ) return Element< K >( BACK  , typename Cube< D-1 >::template Element< K >( coIndex ).antipodal().index );
+			else if( dir==BACK  ) return Element< K >( FRONT , typename Cube< D-1 >::template Element< K >( coIndex ).antipodal().index );
+			return Element< K >();
+		}
+		template< unsigned int D > template< unsigned int K > template< unsigned int _D , unsigned int _K >
+#ifdef _MSC_VER
+		typename std::enable_if< _D==_K , typename Cube< D >::Element< K > >::type Cube< D >::Element< K >::_antipodal( void ) const { return *this; }
+#else // !_MSC_VER
+		typename std::enable_if< _D==_K , typename Cube< D >::template Element< K > >::type Cube< D >::Element< K >::_antipodal( void ) const { return *this; }
+#endif // _MSC_VER
+
+		//////////
+		// Cube //
+		//////////
+		template< unsigned int D > template< unsigned int K1 , unsigned int K2 >
+		bool Cube< D >::Overlap( Element< K1 > e1 , Element< K2 > e2 ){ return _Overlap( e1 , e2 ); }
+		template< unsigned int D > template< unsigned int K1 , unsigned int K2 >
+		typename std::enable_if< (K1>=K2) , bool >::type Cube< D >::_Overlap( Element< K1 > e1 , Element< K2 > e2 )
+		{
+			Direction dir1[ D ] , dir2[ D ];
+			e1.directions( dir1 ) , e2.directions( dir2 );
+			for( int d=0 ; d<D ; d++ ) if( dir1[d]!=CROSS && dir1[d]!=dir2[d] ) return false;
+			return true;
+		}
+		template< unsigned int D > template< unsigned int K1 , unsigned int K2 >
+		typename std::enable_if< (K1< K2) , bool >::type Cube< D >::_Overlap( Element< K1 > e1 , Element< K2 > e2 ){ return _Overlap( e2 , e1 ); }
+
+		template< unsigned int D > template< unsigned int K1 , unsigned int K2 >
+		void Cube< D >::OverlapElements( Element< K1 > e , Element< K2 >* es ){ _OverlapElements( e , es ); }
+		template< unsigned int D > template< unsigned int K1 , unsigned int K2 >
+		typename std::enable_if< (K1>=K2) >::type Cube< D >::_OverlapElements( Element< K1 > e , Element< K2 >* es )
+		{
+			for( typename Cube< K1 >::template Element< K2 > _e ; _e<Cube< K1 >::template ElementNum< K2 >() ; _e++ ) es[_e.index] = Element< K2 >( e , _e );
+		}
+		template< unsigned int D > template< unsigned int K1 , unsigned int K2 >
+		typename std::enable_if< (K1< K2) && D==K2 >::type Cube< D >::_OverlapElements( Element< K1 > e , Element< K2 >* es )
+		{
+			es[0] = Element< D >();
+		}
+		template< unsigned int D > template< unsigned int K1 , unsigned int K2 >
+		typename std::enable_if< (K1< K2) && D!=K2 && K1!=0 >::type Cube< D >::_OverlapElements( Element< K1 > e , Element< K2 >* es )
+		{
+			Direction dir = e.direction() ; unsigned int coIndex;
+			e.factor( dir , coIndex );
+			if( dir==FRONT || dir==BACK )
+			{
+				typename Cube< D-1 >::template Element< K2   > _es1[ HyperCube::OverlapElementNum< D-1 , K1 , K2   >::Value ];
+				typename Cube< D-1 >::template Element< K2-1 > _es2[ HyperCube::OverlapElementNum< D-1 , K1 , K2-1 >::Value ];
+				Cube< D-1 >::OverlapElements( typename Cube< D-1 >::template Element< K1 >( coIndex ) , _es1 );
+				Cube< D-1 >::OverlapElements( typename Cube< D-1 >::template Element< K1 >( coIndex ) , _es2 );
+				for( unsigned int i=0 ; i<HyperCube::OverlapElementNum< D-1 , K1 , K2   >::Value ; i++ ) es[i] = typename Cube< D >::template Element< K2 >( dir   , _es1[i].index );
+				es += HyperCube::OverlapElementNum< D-1 , K1 , K2 >::Value;
+				for( unsigned int i=0 ; i<HyperCube::OverlapElementNum< D-1 , K1 , K2-1 >::Value ; i++ ) es[i] = typename Cube< D >::template Element< K2 >( CROSS , _es2[i].index );
+			}
+			else if( dir==CROSS )
+			{
+				typename Cube< D-1 >::template Element< K2-1 > _es1[ HyperCube::OverlapElementNum< D-1 , K1-1 , K2-1 >::Value ];
+				Cube< D-1 >::OverlapElements( typename Cube< D-1 >::template Element< K1-1 >( coIndex ) , _es1 );
+				for( unsigned int i=0 ; i<HyperCube::OverlapElementNum< D-1 , K1-1 , K2-1 >::Value ; i++ ) es[i] = typename Cube< D >::template Element< K2 >( CROSS , _es1[i].index );
+			}
+		}
+		template< unsigned int D > template< unsigned int K1 , unsigned int K2 >
+		typename std::enable_if< (K1< K2) && D!=K2 && K1==0 >::type Cube< D >::_OverlapElements( Element< K1 > e , Element< K2 >* es )
+		{
+			Direction dir = e.direction() ; unsigned int coIndex;
+			e.factor( dir , coIndex );
+			if( dir==FRONT || dir==BACK )
+			{
+				typename Cube< D-1 >::template Element< K2   > _es1[ HyperCube::OverlapElementNum< D-1 , K1 , K2   >::Value ];
+				typename Cube< D-1 >::template Element< K2-1 > _es2[ HyperCube::OverlapElementNum< D-1 , K1 , K2-1 >::Value ];
+				Cube< D-1 >::OverlapElements( typename Cube< D-1 >::template Element< K1 >( coIndex ) , _es1 );
+				Cube< D-1 >::OverlapElements( typename Cube< D-1 >::template Element< K1 >( coIndex ) , _es2 );
+				for( unsigned int i=0 ; i<HyperCube::OverlapElementNum< D-1 , K1 , K2   >::Value ; i++ ) es[i] = typename Cube< D >::template Element< K2 >( dir   , _es1[i].index );
+				es += HyperCube::OverlapElementNum< D-1 , K1 , K2 >::Value;
+				for( unsigned int i=0 ; i<HyperCube::OverlapElementNum< D-1 , K1 , K2-1 >::Value ; i++ ) es[i] = typename Cube< D >::template Element< K2 >( CROSS , _es2[i].index );
+			}
+		}
+
+		template< unsigned int D > template< unsigned int K >
+		typename Cube< D >::template IncidentCubeIndex< K > Cube< D >::IncidentCube( Element< K > e ){ return _IncidentCube( e ); }
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+#ifdef _MSC_VER
+		typename std::enable_if< _D==K , typename Cube< D >::IncidentCubeIndex< K > >::type Cube< D >::_IncidentCube( Element< K > e ){ return IncidentCubeIndex< D >(); }
+#else // !_MSC_VER
+		typename std::enable_if< _D==K , typename Cube< D >::template IncidentCubeIndex< K > >::type Cube< D >::_IncidentCube( Element< K > e ){ return IncidentCubeIndex< D >(); }
+#endif // _MSC_VER
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+#ifdef _MSC_VER
+		typename std::enable_if< _D!=K && _D!=0 && K!=0 , typename Cube< D >::IncidentCubeIndex< K > >::type Cube< D >::_IncidentCube( Element< K > e )
+#else // !_MSC_VER
+		typename std::enable_if< _D!=K && _D!=0 && K!=0 , typename Cube< D >::template IncidentCubeIndex< K > >::type Cube< D >::_IncidentCube( Element< K > e )
+#endif // _MSC_VER
+		{
+			Direction dir ; unsigned int coIndex;
+			e.factor( dir , coIndex );
+			if     ( dir==CROSS ) return                                 Cube< D-1 >::IncidentCube( typename Cube< D-1 >::template Element< K-1 >( coIndex ) );
+			else if( dir==FRONT ) return IncidentCubeIndex< K >( BACK  , Cube< D-1 >::IncidentCube( typename Cube< D-1 >::template Element< K   >( coIndex ) ).index );
+			else                  return IncidentCubeIndex< K >( FRONT , Cube< D-1 >::IncidentCube( typename Cube< D-1 >::template Element< K   >( coIndex ) ).index );
+		}
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+#ifdef _MSC_VER
+		typename std::enable_if< _D!=K && _D!=0 && K==0 , typename Cube< D >::IncidentCubeIndex< K > >::type Cube< D >::_IncidentCube( Element< K > e )
+#else // !_MSC_VER
+		typename std::enable_if< _D!=K && _D!=0 && K==0 , typename Cube< D >::template IncidentCubeIndex< K > >::type Cube< D >::_IncidentCube( Element< K > e )
+#endif // _MSC_VER
+		{
+			Direction dir ; unsigned int coIndex;
+			e.factor( dir , coIndex );
+			if( dir==FRONT ) return IncidentCubeIndex< K >( BACK  , Cube< D-1 >::IncidentCube( typename Cube< D-1 >::template Element< K >( coIndex ) ).index );
+			else             return IncidentCubeIndex< K >( FRONT , Cube< D-1 >::IncidentCube( typename Cube< D-1 >::template Element< K >( coIndex ) ).index );
+		}
+
+		template< unsigned int D >
+		bool Cube< D >::IsOriented( Element< D-1 > e )
+		{
+			unsigned int dim ; Direction dir;
+			_FactorOrientation( e , dim , dir );
+			return (dir==FRONT) ^ ((D-dim-1)&1);
+		}
+		template< unsigned int D > template< unsigned int _D >
+		typename std::enable_if< _D!=1 >::type Cube< D >::_FactorOrientation( Element< D-1 > e , unsigned int& dim , Direction& dir )
+		{
+			unsigned int coIndex;
+			e.factor( dir , coIndex );
+			if( dir==CROSS ) Cube< D-1 >::_FactorOrientation( typename Cube< D-1 >::template Element< D-2 >( coIndex ) , dim , dir );
+			else dim = D-1;
+		}
+		template< unsigned int D > template< unsigned int _D >
+		typename std::enable_if< _D==1 >::type Cube< D >::_FactorOrientation( Element< D-1 > e , unsigned int& dim , Direction& dir )
+		{
+			unsigned int coIndex;
+			e.factor( dir , coIndex );
+			dim = 0;
+		}
+
+		template< unsigned int D > template< typename Real >
+		unsigned int Cube< D >::MCIndex( const Real values[ Cube< D >::ElementNum< 0 >() ] , Real iso )
+		{
+			unsigned int mcIdx = 0;
+			for( unsigned int c=0 ; c<ElementNum< 0 >() ; c++ ) if( values[c]<iso ) mcIdx |= (1<<c);
+			return mcIdx;
+		}
+
+		template< unsigned int D > template< unsigned int K >
+		unsigned int Cube< D >::ElementMCIndex( Element< K > element , unsigned int mcIndex ){ return _ElementMCIndex( element , mcIndex ); }
+
+		template< unsigned int D >
+		bool Cube< D >::HasMCRoots( unsigned int mcIndex )
+		{
+			static const unsigned int Mask = (1<<(1<<D)) - 1;
+			return mcIndex!=0 && ( mcIndex & Mask )!=Mask;
+		}
+
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D!=K && K!=0 , unsigned int >::type Cube< D >::_ElementMCIndex( Element< K > element , unsigned int mcIndex )
+		{
+			static const unsigned int Mask = ( 1<<( ElementNum< 0 >() / 2 ) ) - 1;
+			static const unsigned int Shift = ElementNum< 0 >() / 2 , _Shift = Cube< K >::template ElementNum< 0 >() / 2;
+			unsigned int mcIndex0 = mcIndex & Mask , mcIndex1 = ( mcIndex>>Shift ) & Mask;
+			Direction dir ; unsigned int coIndex;
+			element.factor( dir , coIndex );
+			if( dir==CROSS ) return Cube< D-1 >::template ElementMCIndex< K-1 >( coIndex , mcIndex0 ) | ( Cube< D-1 >::template ElementMCIndex< K-1 >( coIndex , mcIndex1 )<<_Shift );
+			else             return Cube< D-1 >::template ElementMCIndex< K   >( coIndex , dir==BACK ? mcIndex0 : mcIndex1 );
+		}
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D!=K && K==0 , unsigned int >::type Cube< D >::_ElementMCIndex( Element< K > element , unsigned int mcIndex )
+		{
+			static const unsigned int Mask = ( 1<<( ElementNum< 0 >() / 2 ) ) - 1;
+			static const unsigned int Shift = ElementNum< 0 >() / 2 , _Shift = Cube< K >::template ElementNum< 0 >() / 2;
+			unsigned int mcIndex0 = mcIndex & Mask , mcIndex1 = ( mcIndex>>Shift ) & Mask;
+			Direction dir ; unsigned int coIndex;
+			element.factor( dir , coIndex );
+			return Cube< D-1 >::template ElementMCIndex< K >( typename Cube< D-1 >::template Element< K >( coIndex ) , dir==BACK ? mcIndex0 : mcIndex1 );
+		}
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D==K , unsigned int >::type Cube< D >::_ElementMCIndex( Element< K > element , unsigned int mcIndex ){ return mcIndex; }
+
+		template< unsigned int D > template< unsigned int K >
+		void Cube< D >::CellOffset( Element< K > e , IncidentCubeIndex< K > d , int x[D] ){ _CellOffset( e , d , x ); }
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D==K >::type Cube< D >::_CellOffset( Element< K > e , IncidentCubeIndex< K > d , int *x ){ for( int d=0 ; d<D ; d++ ) x[d] = 0; }
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D!=K && K!=0 >::type Cube< D >::_CellOffset( Element< K > e , IncidentCubeIndex< K > d , int *x )
+		{
+			Direction eDir , dDir ; unsigned int eCoIndex , dCoIndex;
+			e.factor( eDir , eCoIndex ) , d.factor( dDir , dCoIndex );
+			if     ( eDir==CROSS ){ x[D-1] =  0                          ; Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K-1 >( eCoIndex ) , d                                                                 , x ); }
+			else if( eDir==BACK  ){ x[D-1] = -1 + ( dDir==BACK ? 0 : 1 ) ; Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K   >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) , x ); }
+			else if( eDir==FRONT ){ x[D-1] =  0 + ( dDir==BACK ? 0 : 1 ) ; Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K   >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) , x ); }
+		}
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D!=K && K==0 >::type Cube< D >::_CellOffset( Element< K > e , IncidentCubeIndex< K > d , int *x )
+		{
+			Direction eDir , dDir ; unsigned int eCoIndex , dCoIndex;
+			e.factor( eDir , eCoIndex ) , d.factor( dDir , dCoIndex );
+			if     ( eDir==BACK  ){ x[D-1] = -1 + ( dDir==BACK ? 0 : 1 ) ; Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) , x ); }
+			else if( eDir==FRONT ){ x[D-1] =  0 + ( dDir==BACK ? 0 : 1 ) ; Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) , x ); }
+		}
+
+		template< unsigned int D > template< unsigned int K >
+		unsigned int Cube< D >::CellOffset( Element< K > e , IncidentCubeIndex< K > d ){ return _CellOffset( e , d ); }
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D==K && K==0 , unsigned int >::type Cube< D >::_CellOffset( Element< K > e , IncidentCubeIndex< K > d ){ return 0; }
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D==K && K!=0 , unsigned int >::type Cube< D >::_CellOffset( Element< K > e , IncidentCubeIndex< K > d ){ return WindowIndex< IsotropicUIntPack< D , 3 > , IsotropicUIntPack< D , 1 > >::Index; }
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D!=K && K!=0 , unsigned int >::type Cube< D >::_CellOffset( Element< K > e , IncidentCubeIndex< K > d )
+		{
+			Direction eDir , dDir ; unsigned int eCoIndex , dCoIndex;
+			e.factor( eDir , eCoIndex ) , d.factor( dDir , dCoIndex );
+			if     ( eDir==CROSS ){ return 1                          + Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K-1 >( eCoIndex ) , d                                                                 ) * 3; }
+			else if( eDir==BACK  ){ return 0 + ( dDir==BACK ? 0 : 1 ) + Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K   >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) ) * 3; }
+			else if( eDir==FRONT ){ return 1 + ( dDir==BACK ? 0 : 1 ) + Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K   >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) ) * 3; }
+			return 0;
+		}
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+		typename std::enable_if< _D!=K && K==0 , unsigned int >::type Cube< D >::_CellOffset( Element< K > e , IncidentCubeIndex< K > d )
+		{
+			Direction eDir , dDir ; unsigned int eCoIndex , dCoIndex;
+			e.factor( eDir , eCoIndex ) , d.factor( dDir , dCoIndex );
+			if     ( eDir==BACK  ){ return 0 + ( dDir==BACK ? 0 : 1 ) + Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) ) * 3; }
+			else if( eDir==FRONT ){ return 1 + ( dDir==BACK ? 0 : 1 ) + Cube< D-1 >::CellOffset( typename Cube< D-1 >::template Element< K >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) ) * 3; }
+			return 0;
+		}
+
+
+		template< unsigned int D > template< unsigned int K >
+		typename Cube< D >::template Element< K > Cube< D >::IncidentElement( Element< K > e , IncidentCubeIndex< K > d ){ return _IncidentElement( e , d ); }
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+#ifdef _MSC_VER
+		typename std::enable_if< _D==K , typename Cube< D >::Element< K > >::type Cube< D >::_IncidentElement( Element< K > e , IncidentCubeIndex< K > d ){ return e; }
+#else // !_MSC_VER
+		typename std::enable_if< _D==K , typename Cube< D >::template Element< K > >::type Cube< D >::_IncidentElement( Element< K > e , IncidentCubeIndex< K > d ){ return e; }
+#endif // _MSC_VER
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+#ifdef _MSC_VER
+		typename std::enable_if< _D!=K && _D!=0 && K!=0 , typename Cube< D >::Element< K > >::type Cube< D >::_IncidentElement( Element< K > e , IncidentCubeIndex< K > d )
+#else // !_MSC_VER
+		typename std::enable_if< _D!=K && _D!=0 && K!=0 , typename Cube< D >::template Element< K > >::type Cube< D >::_IncidentElement( Element< K > e , IncidentCubeIndex< K > d )
+#endif // _MSC_VER
+		{
+			Direction eDir , dDir ; unsigned int eCoIndex , dCoIndex;
+			e.factor( eDir , eCoIndex ) , d.factor( dDir , dCoIndex );
+			if     ( eDir==CROSS ) return Element< K >(           eDir   , Cube< D-1 >::IncidentElement( typename Cube< D-1 >::template Element< K-1 >( eCoIndex ) , d                                                                 ).index );
+			else if( eDir==dDir  ) return Element< K >( Opposite( eDir ) , Cube< D-1 >::IncidentElement( typename Cube< D-1 >::template Element< K   >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) ).index );
+			else                   return Element< K >(           eDir   , Cube< D-1 >::IncidentElement( typename Cube< D-1 >::template Element< K   >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) ).index );
+		}
+		template< unsigned int D > template< unsigned int K , unsigned int _D >
+#ifdef _MSC_VER
+		typename std::enable_if< _D!=K && _D!=0 && K==0 , typename Cube< D >::Element< K > >::type Cube< D >::_IncidentElement( Element< K > e , IncidentCubeIndex< K > d )
+#else // !_MSC_VER
+		typename std::enable_if< _D!=K && _D!=0 && K==0 , typename Cube< D >::template Element< K > >::type Cube< D >::_IncidentElement( Element< K > e , IncidentCubeIndex< K > d )
+#endif // _MSC_VER
+		{
+			Direction eDir , dDir ; unsigned int eCoIndex , dCoIndex;
+			e.factor( eDir , eCoIndex ) , d.factor( dDir , dCoIndex );
+			if( eDir==dDir ) return Element< K >( Opposite( eDir ) , Cube< D-1 >::IncidentElement( typename Cube< D-1 >::template Element< K >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) ).index );
+			else             return Element< K >(           eDir   , Cube< D-1 >::IncidentElement( typename Cube< D-1 >::template Element< K >( eCoIndex ) , typename Cube< D-1 >::template IncidentCubeIndex< K >( dCoIndex ) ).index );
+		}
+
+
+		/////////////////////
+		// MarchingSquares //
+		/////////////////////
+		const inline int MarchingSquares::edges[][MAX_EDGES*2+1] =
+		{
+			// Positive to the right
+			// Positive in center
+			/////////////////////////////////// (0,0) (1,0) (0,1) (1,1)
+			{ -1 ,  -1 ,  -1 ,  -1 ,  -1 } , //   -     -     -     -  //
+			{  1 ,   0 ,  -1 ,  -1 ,  -1 } , //   +     -     -     -  // (0,0) - (0,1) | (0,0) - (1,0)
+			{  0 ,   2 ,  -1 ,  -1 ,  -1 } , //   -     +     -     -  // (0,0) - (1,0) | (1,0) - (1,1)
+			{  1 ,   2 ,  -1 ,  -1 ,  -1 } , //   +     +     -     -  // (0,0) - (0,1) | (1,0) - (1,1)
+			{  3 ,   1 ,  -1 ,  -1 ,  -1 } , //   -     -     +     -  // (0,1) - (1,1) | (0,0) - (0,1)
+			{  3 ,   0 ,  -1 ,  -1 ,  -1 } , //   +     -     +     -  // (0,1) - (1,1) | (0,0) - (1,0)
+			{  0 ,   1 ,   3 ,   2 ,  -1 } , //   -     +     +     -  // (0,0) - (1,0) | (0,0) - (0,1) & (0,1) - (1,1) | (1,0) - (1,1)
+			{  3 ,   2 ,  -1 ,  -1 ,  -1 } , //   +     +     +     -  // (0,1) - (1,1) | (1,0) - (1,1)
+			{  2 ,   3 ,  -1 ,  -1 ,  -1 } , //   -     -     -     +  // (1,0) - (1,1) | (0,1) - (1,1)
+			{  1 ,   3 ,   2 ,   0 ,  -1 } , //   +     -     -     +  // (0,0) - (0,1) | (0,1) - (1,1) & (1,0) - (1,1) | (0,0) - (1,0)
+			{  0 ,   3 ,  -1 ,  -1 ,  -1 } , //   -     +     -     +  // (0,0) - (1,0) | (0,1) - (1,1)
+			{  1 ,   3 ,  -1 ,  -1 ,  -1 } , //   +     +     -     +  // (0,0) - (0,1) | (0,1) - (1,1)
+			{  2 ,   1 ,  -1 ,  -1 ,  -1 } , //   -     -     +     +  // (1,0) - (1,1) | (0,0) - (0,1)
+			{  2 ,   0 ,  -1 ,  -1 ,  -1 } , //   +     -     +     +  // (1,0) - (1,1) | (0,0) - (1,0)
+			{  0 ,   1 ,  -1 ,  -1 ,  -1 } , //   -     +     +     +  // (0,0) - (1,0) | (0,0) - (0,1)
+			{ -1 ,  -1 ,  -1 ,  -1 ,  -1 } , //   +     +     +     +  //
+		};
+		inline int MarchingSquares::AddEdgeIndices( unsigned char mcIndex , int* isoIndices )
+		{
+			int nEdges = 0;
+			/* Square is entirely in/out of the surface */
+			if( mcIndex==0 || mcIndex==15 ) return 0;
+
+			/* Create the edges */
+			for( int i=0 ; edges[mcIndex][i]!=-1 ; i+=2 )
+			{
+				for( int j=0 ; j<2 ; j++ ) isoIndices[i+j] = edges[mcIndex][i+j];
+				nEdges++;
+			}
+			return nEdges;
+		}
+	}
+}
+
+#endif //MARCHING_CUBES_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/MultiThreading.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/MultiThreading.h
@@ -1,0 +1,190 @@
+/*
+Copyright (c) 2017, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+#ifndef MULTI_THREADING_INCLUDED
+#define MULTI_THREADING_INCLUDED
+
+#include <thread>
+#include <vector>
+#include <atomic>
+#include <functional>
+#include <future>
+#ifdef _OPENMP
+#include <omp.h>
+#endif // _OPENMP
+
+namespace PoissonRecon
+{
+	struct ThreadPool
+	{
+		enum ParallelType
+		{
+#ifdef _OPENMP
+			OPEN_MP ,
+#endif // _OPENMP
+			ASYNC ,
+			NONE
+		};
+		static const std::vector< std::string > ParallelNames;
+
+		enum ScheduleType
+		{
+			STATIC ,
+			DYNAMIC
+		};
+		static const std::vector< std::string > ScheduleNames;
+
+		static unsigned int NumThreads( void ){ return _NumThreads; }
+		static ParallelType ParallelizationType;
+		static size_t ChunkSize;
+		static ScheduleType Schedule;
+
+		template< typename Function , typename ... Functions >
+		static void ParallelSections( const Function &function , const Functions & ... functions )
+		{
+			std::vector< std::future< void > > futures;
+			if constexpr( sizeof ... (Functions) )
+			{
+				futures.reserve( sizeof...(Functions) );
+				_ParallelSections( futures , functions... );
+			}
+			function();
+			for( unsigned int i=0 ; i<futures.size() ; i++ ) futures[i].get();
+		}
+
+		template< typename Function , typename ... Functions >
+		static void ParallelSections( const Function &&function , const Functions && ... functions )
+		{
+			std::vector< std::future< void > > futures;
+			if constexpr( sizeof ... (Functions) )
+			{
+				futures.reserve( sizeof...(Functions) );
+				_ParallelSections( futures , std::move(functions)... );
+			}
+			function();
+			for( unsigned int i=0 ; i<futures.size() ; i++ ) futures[i].get();
+		}
+
+		static void ParallelFor( size_t begin , size_t end , const std::function< void ( unsigned int , size_t ) > &iterationFunction , unsigned int numThreads=_NumThreads , ParallelType pType=ParallelizationType , ScheduleType schedule=Schedule , size_t chunkSize=ChunkSize )
+		{
+			if( begin>=end ) return;
+			size_t range = end - begin;
+			size_t chunks = ( range + chunkSize - 1 ) / chunkSize;
+			std::atomic< size_t > index;
+			index.store( 0 );
+
+			// If the computation is serial, go ahead and run it
+			if( pType==ParallelType::NONE || numThreads<=1 )
+			{
+				for( size_t i=begin ; i<end ; i++ ) iterationFunction( 0 , i );
+				return;
+			}
+
+			// If the chunkSize is too large to satisfy all the threads, lower it
+			if( range<=chunkSize*(numThreads-1) )
+			{
+				chunkSize = ( range + numThreads - 1 ) / numThreads;
+				chunks = numThreads = (unsigned int)( ( range + chunkSize - 1 ) / chunkSize );
+			}
+
+			std::function< void (unsigned int , size_t ) > _ChunkFunction = [ &iterationFunction , begin , end , chunkSize ]( unsigned int thread , size_t chunk )
+				{
+					const size_t _begin = begin + chunkSize*chunk;
+					const size_t _end = std::min< size_t >( end , _begin+chunkSize );
+					for( size_t i=_begin ; i<_end ; i++ ) iterationFunction( thread , i );
+				};
+			std::function< void (unsigned int ) > _StaticThreadFunction = [ &_ChunkFunction , chunks , numThreads ]( unsigned int thread )
+				{
+					for( size_t chunk=thread ; chunk<chunks ; chunk+=numThreads ) _ChunkFunction( thread , chunk );
+				};
+
+			std::function< void (unsigned int ) > _DynamicThreadFunction = [ &_ChunkFunction , chunks , &index ]( unsigned int thread )
+				{
+					size_t chunk;
+					while( ( chunk=index.fetch_add(1) )<chunks ) _ChunkFunction( thread , chunk );
+				};
+
+			std::function< void (unsigned int ) > ThreadFunction;
+			if     ( schedule==ScheduleType::STATIC  ) ThreadFunction = _StaticThreadFunction;
+			else if( schedule==ScheduleType::DYNAMIC ) ThreadFunction = _DynamicThreadFunction;
+
+			if( false ){}
+#ifdef _OPENMP
+			else if( pType==ParallelType::OPEN_MP )
+			{
+				if( schedule==ScheduleType::STATIC )
+#pragma omp parallel for num_threads( numThreads ) schedule( static , 1 )
+					for( int c=0 ; c<chunks ; c++ ) _ChunkFunction( omp_get_thread_num() , c );
+				else if( schedule==ScheduleType::DYNAMIC )
+#pragma omp parallel for num_threads( numThreads ) schedule( dynamic , 1 )
+					for( int c=0 ; c<chunks ; c++ ) _ChunkFunction( omp_get_thread_num() , c );
+			}
+#endif // _OPENMP
+			else if( pType==ParallelType::ASYNC )
+			{
+				static std::vector< std::future< void > > futures;
+				futures.resize( numThreads-1 );
+				for( unsigned int t=1 ; t<numThreads ; t++ ) futures[t-1] = std::async( std::launch::async , ThreadFunction , t );
+				ThreadFunction( 0 );
+				for( unsigned int t=1 ; t<numThreads ; t++ ) futures[t-1].get();
+			}
+		}
+
+	private:
+		static unsigned int _NumThreads;
+
+		template< typename Function , typename ... Functions >
+		static void _ParallelSections( std::vector< std::future< void > > &futures , const Function &function , const Functions & ... functions )
+		{
+			futures.push_back( std::async( std::launch::async , function ) );
+			if constexpr( sizeof...(Functions) ) _ParallelSections( futures , functions... );
+		}
+
+		template< typename Function , typename ... Functions >
+		static void _ParallelSections( std::vector< std::future< void > > &futures , const Function &&function , const Functions && ... functions )
+		{
+			futures.push_back( std::async( std::launch::async , function ) );
+			if constexpr( sizeof...(Functions) ) _ParallelSections( futures , std::move(functions)... );
+		}
+	};
+
+	inline ThreadPool::ParallelType ThreadPool::ParallelizationType = ThreadPool::ParallelType::NONE;
+	inline unsigned int ThreadPool::_NumThreads = std::thread::hardware_concurrency();
+	inline ThreadPool::ScheduleType ThreadPool::Schedule = ThreadPool::DYNAMIC;
+	inline size_t ThreadPool::ChunkSize = 128;
+
+	const inline std::vector< std::string > ThreadPool::ParallelNames =
+	{
+#ifdef _OPENMP
+		"open mp" ,
+#endif // _OPENMP
+		"async" ,
+		"none"
+	};
+	const inline std::vector< std::string > ThreadPool::ScheduleNames = { "static" , "dynamic" };
+}
+#endif // MULTI_THREADING_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/MyAtomic.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/MyAtomic.h
@@ -1,0 +1,377 @@
+/*
+Copyright (c) 2017, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+#ifndef MY_ATOMIC_INCLUDED
+#define MY_ATOMIC_INCLUDED
+
+#if defined( _WIN32 ) || defined( _WIN64 )
+#include <io.h>
+#include <Windows.h>
+#include <Psapi.h>
+#else // !_WIN32 && !_WIN64
+#include <unistd.h>
+#include <sys/time.h> 
+#include <sys/resource.h> 
+#endif // _WIN32 || _WIN64
+#include <mutex>
+
+namespace PoissonRecon
+{
+	template< typename Value > Value ReadAtomic8_( const volatile Value * value );
+	template< typename Value > Value ReadAtomic32_( const volatile Value * value );
+	template< typename Value > Value ReadAtomic64_( const volatile Value * value );
+
+	template< typename Value > Value SetAtomic8_ ( volatile Value * value , Value newValue );
+	template< typename Value > Value SetAtomic32_( volatile Value * value , Value newValue );
+	template< typename Value > Value SetAtomic64_( volatile Value * value , Value newValue );
+
+	template< typename Value > bool SetAtomic8_ ( volatile Value * value , Value newValue , Value oldValue );
+	template< typename Value > bool SetAtomic32_( volatile Value * value , Value newValue , Value oldValue );
+	template< typename Value > bool SetAtomic64_( volatile Value * value , Value newValue , Value oldValue );
+
+	template< typename Value > void AddAtomic8_( volatile Value * a , Value b );
+	template< typename Value > void AddAtomic32_( volatile Value * a , Value b );
+	template< typename Value > void AddAtomic64_( volatile Value * a , Value b );
+
+	template< typename Value >
+	Value SetAtomic( volatile Value & value , Value newValue )
+	{
+		if      constexpr( sizeof(Value)==1 ) return SetAtomic8_ ( &value , newValue );
+		else if constexpr( sizeof(Value)==4 ) return SetAtomic32_( &value , newValue );
+		else if constexpr( sizeof(Value)==8 ) return SetAtomic64_( &value , newValue );
+		else
+		{
+			MK_WARN_ONCE( "should not use this function: " , sizeof(Value) );
+			static std::mutex setAtomicMutex;
+			std::lock_guard< std::mutex > lock( setAtomicMutex );
+			Value oldValue = *(Value*)&value;
+			*(Value*)&value = newValue;
+			return oldValue;
+		}
+	}
+
+	template< typename Value >
+	bool SetAtomic( volatile Value & value , Value newValue , Value oldValue )
+	{
+		if      constexpr( sizeof(Value)==1 ) return SetAtomic8_ ( &value , newValue , oldValue );
+		else if constexpr( sizeof(Value)==4 ) return SetAtomic32_( &value , newValue , oldValue );
+		else if constexpr( sizeof(Value)==8 ) return SetAtomic64_( &value , newValue , oldValue );
+		else
+		{
+			MK_WARN_ONCE( "should not use this function: " , sizeof(Value) );
+			static std::mutex setAtomicMutex;
+			std::lock_guard< std::mutex > lock( setAtomicMutex );
+			if( value==oldValue ){ value = newValue ; return true; }
+			else return false;
+		}
+	}
+
+	template< typename Value >
+	void AddAtomic( volatile Value & a , Value b )
+	{
+		if      constexpr( sizeof(Value)==1 ) return AddAtomic8_ ( &a , b );
+		else if constexpr( sizeof(Value)==4 ) return AddAtomic32_( &a , b );
+		else if constexpr( sizeof(Value)==8 ) return AddAtomic64_( &a , b );
+		else
+		{
+			MK_WARN_ONCE( "should not use this function: " , sizeof(Value) );
+			static std::mutex addAtomicMutex;
+			std::lock_guard< std::mutex > lock( addAtomicMutex );
+			*(Value*)&a += b;
+		}
+	}
+
+	template< typename Value >
+	Value ReadAtomic( const volatile Value & value )
+	{
+		if      constexpr( sizeof(Value)==1 ) return ReadAtomic8_( &value );
+		else if constexpr( sizeof(Value)==4 ) return ReadAtomic32_( &value );
+		else if constexpr( sizeof(Value)==8 ) return ReadAtomic64_( &value );
+		else
+		{
+			MK_WARN_ONCE( "should not use this function: " , sizeof(Value) );
+			static std::mutex readAtomicMutex;
+			std::lock_guard< std::mutex > lock( readAtomicMutex );
+			return *(Value*)&value;
+		}
+	}
+
+	template< typename Value >
+	struct Atomic
+	{
+		static void Add( volatile Value &a , const Value &b )
+		{
+			if constexpr( std::is_pod_v< Value > ) AddAtomic( a , b );
+			else
+			{
+				MK_WARN_ONCE( "should not use this function: " , typeid(Value).name() );
+				static std::mutex addAtomicMutex;
+				std::lock_guard< std::mutex > lock( addAtomicMutex );
+				*(Value*)&a += b;
+			}
+		}
+
+		static Value Set( volatile Value & value , Value newValue )
+		{
+			if constexpr( std::is_pod_v< Value > ) return SetAtomic( value , newValue );
+			else
+			{
+				MK_WARN_ONCE( "should not use this function: " , typeid(Value).name() );
+				static std::mutex setAtomicMutex;
+				std::lock_guard< std::mutex > lock( setAtomicMutex );
+				Value oldValue = *(Value*)&value;
+				*(Value*)&value = newValue;
+				return oldValue;
+			}
+		}
+
+		static bool Set( volatile Value & value , Value newValue , Value oldValue )
+		{
+			if constexpr( std::is_pod_v< Value > ) return SetAtomic( value , newValue , oldValue );
+			else
+			{
+				MK_WARN_ONCE( "should not use this function: " , typeid(Value).name() , " , " , sizeof(Value) );
+				static std::mutex setAtomicMutex;
+				std::lock_guard< std::mutex > lock( setAtomicMutex );
+				if( value==oldValue ){ value = newValue ; return true; }
+				else return false;
+			}
+		}
+
+		static Value Read( const volatile Value & value )
+		{
+			if constexpr( std::is_pod_v< Value > ) return ReadAtomic( value );
+			else
+			{
+				MK_WARN_ONCE( "should not use this function: " , typeid(Value).name() , " , " , sizeof(Value) );
+				static std::mutex readAtomicMutex;
+				std::lock_guard< std::mutex > lock( readAtomicMutex );
+				return *(Value*)&value;
+			}
+		}
+	};
+
+	///////////////////////////////////////////////
+	///////////////////////////////////////////////
+	///////////////////////////////////////////////
+
+	template< typename Value >
+	Value ReadAtomic8_( const volatile Value * value )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		char _value = InterlockedExchangeAdd8( (char*)value , 0 );
+		return *(Value*)(&_value);
+#else // !_WIN32 && !_WIN64
+		uint8_t _value =  __atomic_load_n( (uint8_t *)value , __ATOMIC_SEQ_CST );
+#endif // _WIN32 || _WIN64
+		return *(Value*)(&_value);
+	}
+
+	template< typename Value >
+	Value ReadAtomic32_( const volatile Value * value )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		long _value = InterlockedExchangeAdd( (long*)value , 0 );
+		return *(Value*)(&_value);
+#else // !_WIN32 && !_WIN64
+		uint32_t _value =  __atomic_load_n( (uint32_t *)value , __ATOMIC_SEQ_CST );
+#endif // _WIN32 || _WIN64
+		return *(Value*)(&_value);
+	}
+
+	template< typename Value >
+	Value ReadAtomic64_( const volatile Value * value )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		__int64 _value = InterlockedExchangeAdd64( (__int64*)value , 0 );
+#else // !_WIN32 && !_WIN64
+		uint64_t _value = __atomic_load_n( (uint64_t *)value , __ATOMIC_SEQ_CST );
+#endif // _WIN32 || _WIN64
+		return *(Value*)(&_value);
+	}
+
+	template< typename Value >
+	Value SetAtomic8_( volatile Value *value , Value newValue )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		char *_newValue = (char *)&newValue;
+		char oldValue = InterlockedExchange( (char*)value , *_newValue );
+#else // !_WIN32 && !_WIN64
+		uint8_t *_newValue = (uint8_t *)&newValue;
+		uint8_t oldValue = __atomic_exchange_n( (uint8_t *)value , *_newValue , __ATOMIC_SEQ_CST );
+#endif // _WIN32 || _WIN64
+		return *(Value*)&oldValue;
+	}
+
+	template< typename Value >
+	Value SetAtomic32_( volatile Value *value , Value newValue )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		long *_newValue = (long *)&newValue;
+		long oldValue = InterlockedExchange( (long*)value , *_newValue );
+#else // !_WIN32 && !_WIN64
+		uint32_t *_newValue = (uint32_t *)&newValue;
+		long oldValue = __atomic_exchange_n( (uint32_t *)value , *_newValue , __ATOMIC_SEQ_CST );
+#endif // _WIN32 || _WIN64
+		return *(Value*)&oldValue;
+	}
+
+	template< typename Value >
+	Value SetAtomic64_( volatile Value * value , Value newValue )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		__int64 *_newValue = (__int64 *)&newValue;
+		__int64 oldValue = InterlockedExchange64( (__int64*)value , *_newValue );
+#else // !_WIN32 && !_WIN64
+		uint64_t *_newValue = (uint64_t *)&newValue;
+		uint64_t oldValue = __atomic_exchange_n( (uint64_t *)value , *_newValue , __ATOMIC_SEQ_CST );;
+#endif // _WIN32 || _WIN64
+		return *(Value*)&oldValue;
+	}
+
+	template< typename Value >
+	bool SetAtomic8_( volatile Value *value , Value newValue , Value oldValue )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		char *_oldValue = (char *)&oldValue;
+		char *_newValue = (char *)&newValue;
+		return _InterlockedCompareExchange8( (char*)value , *_newValue , *_oldValue )==*_oldValue;
+#else // !_WIN32 && !_WIN64
+		uint8_t *_newValue = (uint8_t *)&newValue;
+		return __atomic_compare_exchange_n( (uint8_t *)value , (uint8_t *)&oldValue , *_newValue , false , __ATOMIC_SEQ_CST , __ATOMIC_SEQ_CST );
+#endif // _WIN32 || _WIN64
+	}
+
+	template< typename Value >
+	bool SetAtomic32_( volatile Value *value , Value newValue , Value oldValue )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		long *_oldValue = (long *)&oldValue;
+		long *_newValue = (long *)&newValue;
+		return InterlockedCompareExchange( (long*)value , *_newValue , *_oldValue )==*_oldValue;
+#else // !_WIN32 && !_WIN64
+		uint32_t *_newValue = (uint32_t *)&newValue;
+		return __atomic_compare_exchange_n( (uint32_t *)value , (uint32_t *)&oldValue , *_newValue , false , __ATOMIC_SEQ_CST , __ATOMIC_SEQ_CST );
+#endif // _WIN32 || _WIN64
+	}
+
+	template< typename Value >
+	bool SetAtomic64_( volatile Value * value , Value newValue , Value oldValue )
+	{
+#if defined( _WIN32 ) || defined( _WIN64 )
+		__int64 *_oldValue = (__int64 *)&oldValue;
+		__int64 *_newValue = (__int64 *)&newValue;
+		return InterlockedCompareExchange64( (__int64*)value , *_newValue , *_oldValue )==*_oldValue;
+#else // !_WIN32 && !_WIN64
+		uint64_t *_newValue = (uint64_t *)&newValue;
+		return __atomic_compare_exchange_n( (uint64_t *)value , (uint64_t *)&oldValue , *_newValue , false , __ATOMIC_SEQ_CST , __ATOMIC_SEQ_CST );
+#endif // _WIN32 || _WIN64
+	}
+
+	template< typename Value >
+	void AddAtomic8_( volatile Value *a , Value b )
+	{
+		Value current = ReadAtomic8_( a );
+		Value sum = current+b;
+#if defined( _WIN32 ) || defined( _WIN64 )
+		char *_current = (char *)&current;
+		char *_sum = (char *)&sum;
+		while( InterlockedCompareExchange( (char*)a , *_sum , *_current )!=*_current )
+		{
+			current = ReadAtomic8_( a );
+			sum = current + b;
+		}
+#else // !_WIN32 && !_WIN64
+		uint8_t *_current = (uint8_t *)&current;
+		uint8_t *_sum = (uint8_t *)&sum;
+		while( __sync_val_compare_and_swap( (uint8_t *)a , *_current , *_sum )!=*_current )
+		{
+			current = ReadAtomic8_( a );
+			sum = current+b;
+		}
+#endif // _WIN32 || _WIN64
+	}
+
+	template< typename Value >
+	void AddAtomic32_( volatile Value *a , Value b )
+	{
+		Value current = ReadAtomic32_( a );
+		Value sum = current+b;
+#if defined( _WIN32 ) || defined( _WIN64 )
+		long *_current = (long *)&current;
+		long *_sum = (long *)&sum;
+		while( InterlockedCompareExchange( (long*)a , *_sum , *_current )!=*_current )
+		{
+			current = ReadAtomic32_( a );
+			sum = current + b;
+		}
+#else // !_WIN32 && !_WIN64
+		uint32_t *_current = (uint32_t *)&current;
+		uint32_t *_sum = (uint32_t *)&sum;
+		while( __sync_val_compare_and_swap( (uint32_t *)a , *_current , *_sum )!=*_current )
+		{
+			current = ReadAtomic32_( a );
+			sum = current+b;
+		}
+#endif // _WIN32 || _WIN64
+	}
+
+	template< typename Value >
+	void AddAtomic64_( volatile Value * a , Value b )
+	{
+#if 1
+		Value current = ReadAtomic64_( a );
+		Value sum = current+b;
+		while( !SetAtomic64_( a , sum , current ) )
+		{
+			current = ReadAtomic64_( a );
+			sum = current+b;
+		}
+#else
+		Value current = ReadAtomic64_( a );
+		Value sum = current+b;
+#if defined( _WIN32 ) || defined( _WIN64 )
+		__int64 *_current = (__int64 *)&current;
+		__int64 *_sum = (__int64 *)&sum;
+		while( InterlockedCompareExchange64( (__int64*)a , *_sum , *_current )!=*_current )
+		{
+			current = ReadAtomic64_( a );
+			sum = current+b;
+		}
+#else // !_WIN32 && !_WIN64
+		uint64_t *_current = (uint64_t *)&current;
+		uint64_t *_sum = (uint64_t *)&sum;
+		while( __sync_val_compare_and_swap( (uint64_t *)a , *_current , *_sum )!=*_current )
+		{
+			current = ReadAtomic64_( a);
+			sum = current+b;
+		}
+#endif // _WIN32 || _WIN64
+#endif
+	}
+}
+#endif // MY_ATOMIC_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/MyExceptions.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/MyExceptions.h
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2017, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+#ifndef MY_EXCEPTIONS_INCLUDED
+#define MY_EXCEPTIONS_INCLUDED
+
+/////////////////////////////////////
+// Exception, Warnings, and Errors //
+/////////////////////////////////////
+#include <exception>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+
+namespace PoissonRecon
+{
+	template< typename ... Arguments > void _AddToMessageStream( std::stringstream &stream , Arguments ... arguments );
+	inline void _AddToMessageStream( std::stringstream &stream ){ return; }
+	template< typename Argument , typename ... Arguments > void _AddToMessageStream( std::stringstream &stream , Argument argument , Arguments ... arguments )
+	{
+		stream << argument;
+		_AddToMessageStream( stream , arguments ... );
+	}
+
+	template< typename ... Arguments >
+	std::string MakeMessageString( std::string header , std::string fileName , int line , std::string functionName , Arguments ... arguments )
+	{
+		size_t headerSize = header.size();
+		std::stringstream stream;
+
+		// The first line is the header, the file name , and the line number
+		stream << header << " " << fileName << " (Line " << line << ")" << std::endl;
+
+		// Inset the second line by the size of the header and write the function name
+		for( size_t i=0 ; i<=headerSize ; i++ ) stream << " ";
+		stream << functionName << std::endl;
+
+		// Inset the third line by the size of the header and write the rest
+		for( size_t i=0 ; i<=headerSize ; i++ ) stream << " ";
+		_AddToMessageStream( stream , arguments ... );
+
+		return stream.str();
+	}
+	struct Exception : public std::exception
+	{
+		const char *what( void ) const noexcept { return _message.c_str(); }
+		template< typename ... Args >
+		Exception( const char *fileName , int line , const char *functionName , const char *format , Args ... args )
+		{
+			_message = MakeMessageString( "[EXCEPTION]" , fileName , line , functionName , format , args ... );
+		}
+	private:
+		std::string _message;
+	};
+
+	template< typename ... Args > void Throw( const char *fileName , int line , const char *functionName , const char *format , Args ... args ){ throw Exception( fileName , line , functionName , format , args ... ); }
+	template< typename ... Args >
+	void Warn( const char *fileName , int line , const char *functionName , const char *format , Args ... args )
+	{
+		std::cerr << MakeMessageString( "[WARNING]" , fileName , line , functionName , format , args ... ) << std::endl;
+	}
+	template< typename ... Args >
+	void ErrorOut( const char *fileName , int line , const char *functionName , const char *format , Args ... args )
+	{
+		std::cerr << MakeMessageString( "[ERROR]" , fileName , line , functionName , format , args ... ) << std::endl;
+		exit( EXIT_FAILURE );
+	}
+}
+#ifndef MK_WARN
+#define MK_WARN( ... ) Warn( __FILE__ , __LINE__ , __FUNCTION__ , __VA_ARGS__ )
+#endif // MK_WARN
+#ifndef MK_WARN_ONCE
+#define MK_WARN_ONCE( ... ) { static bool firstTime = true ; if( firstTime ) Warn( __FILE__ , __LINE__ , __FUNCTION__ , __VA_ARGS__ ) ; firstTime = false; }
+#endif // MK_WARN_ONCE
+#ifndef MK_THROW
+#define MK_THROW( ... ) Throw( __FILE__ , __LINE__ , __FUNCTION__ , __VA_ARGS__ )
+#endif // MK_THROW
+#ifndef MK_ERROR_OUT
+#define MK_ERROR_OUT( ... ) ErrorOut( __FILE__ , __LINE__ , __FUNCTION__ , __VA_ARGS__ )
+#endif // MK_ERROR_OUT
+
+#endif // MY_EXCEPTIONS_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/MyMiscellany.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/MyMiscellany.h
@@ -1,0 +1,369 @@
+/*
+Copyright (c) 2017, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+#ifndef MY_MISCELLANY_INCLUDED
+#define MY_MISCELLANY_INCLUDED
+
+#include <iostream>
+#include <sstream>
+#include <filesystem>
+#include <string.h>
+#include <sys/timeb.h>
+#include <cstdio>
+#include <ctime>
+#include <chrono>
+#if defined( _WIN32 ) || defined( _WIN64 )
+#include <io.h>
+#include <Windows.h>
+#include <Psapi.h>
+#else // !_WIN32 && !_WIN64
+#include <unistd.h>
+#include <sys/time.h> 
+#include <sys/resource.h> 
+#endif // _WIN32 || _WIN64
+#include <memory>
+#if defined(_WIN32) || defined( _WIN64 )
+#elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__APPLE__) && defined(__MACH__)
+#include <mach/mach.h>
+#elif (defined(_AIX) || defined(__TOS__AIX__)) || (defined(__sun__) || defined(__sun) || defined(sun) && (defined(__SVR4) || defined(__svr4__)))
+#include <fcntl.h>
+#include <procfs.h>
+#elif defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
+#include <stdio.h>
+#endif
+
+#else
+#error "Cannot define getPeakRSS( ) or getCurrentRSS( ) for an unknown OS."
+#endif
+#include "Array.h"
+#include "MyAtomic.h"
+#include "MultiThreading.h"
+
+namespace PoissonRecon
+{
+	////////////////////////////
+	// Formatted float output //
+	////////////////////////////
+	struct StreamFloatPrecision
+	{
+		StreamFloatPrecision( std::ostream &str , unsigned int precision , bool scientific=false ) : _str(str)
+		{
+			_defaultPrecision = (int)_str.precision();
+			_str.precision( precision );
+			if( scientific ) _str << std::scientific;
+			else             _str << std::fixed;
+		}
+		~StreamFloatPrecision( void )
+		{
+			_str << std::defaultfloat;
+			_str.precision( _defaultPrecision );
+		}
+	protected:
+		int _defaultPrecision;
+		std::ostream &_str;
+	};
+
+	////////////////
+	// Time Stuff //
+	////////////////
+	inline double Time( void )
+	{
+#ifdef WIN32
+		struct _timeb t;
+		_ftime( &t );
+		return double( t.time ) + double( t.millitm ) / 1000.0;
+#else // WIN32
+		struct timeval t;
+		gettimeofday( &t , NULL );
+		return t.tv_sec + double( t.tv_usec ) / 1000000;
+#endif // WIN32
+	}
+
+	struct Timer
+	{
+		Timer( void ){ _startCPUClock = std::clock() , _startWallClock = std::chrono::system_clock::now(); }
+		double cpuTime( void ) const{ return (std::clock() - _startCPUClock) / (double)CLOCKS_PER_SEC; };
+		double wallTime( void ) const{ std::chrono::duration<double> diff = (std::chrono::system_clock::now() - _startWallClock) ; return diff.count(); }
+		std::string operator()( bool showCpuTime , unsigned int precision=1 ) const
+		{
+			std::stringstream ss;
+			StreamFloatPrecision sfp( ss , precision );
+			ss << wallTime() << " (s)";
+			if( showCpuTime ) ss << " / " << cpuTime() << " (s)";
+			return ss.str();
+		}
+		friend std::ostream &operator << ( std::ostream &os , const Timer &timer ){ return os << timer(false); }
+	protected:
+		std::clock_t _startCPUClock;
+		std::chrono::time_point< std::chrono::system_clock > _startWallClock;
+	};
+
+	///////////////
+	// I/O Stuff //
+	///////////////
+#if defined( _WIN32 ) || defined( _WIN64 )
+	const char FileSeparator = '\\';
+#else // !_WIN
+	const char FileSeparator = '/';
+#endif // _WIN
+
+#ifndef SetTempDirectory
+#if defined( _WIN32 ) || defined( _WIN64 )
+#define SetTempDirectory( tempDir , sz ) GetTempPath( (sz) , (tempDir) )
+#else // !_WIN32 && !_WIN64
+#define SetTempDirectory( tempDir , sz ) if( std::getenv( "TMPDIR" ) ) strcpy( tempDir , std::getenv( "TMPDIR" ) );
+#endif // _WIN32 || _WIN64
+#endif // !SetTempDirectory
+
+#if defined( _WIN32 ) || defined( _WIN64 )
+	inline void FSync( FILE *fp )
+	{
+		//	FlushFileBuffers( (HANDLE)_fileno( fp ) );
+		_commit( _fileno( fp ) );
+	}
+#else // !_WIN32 && !_WIN64
+	inline void FSync( FILE *fp )
+	{
+		fsync( fileno( fp ) );
+	}
+#endif // _WIN32 || _WIN64
+
+	//////////////////
+	// Memory Stuff //
+	//////////////////
+	size_t getPeakRSS( void );
+	size_t getCurrentRSS( void );
+
+	struct Profiler
+	{
+		Profiler( unsigned int ms=0 )
+		{
+			_t = Time();
+			_currentPeak = 0;
+			_terminate = false;
+			if( ms )
+			{
+				_thread = std::thread( &Profiler::_updatePeakMemoryFunction , std::ref( *this ) , ms );
+				_spawnedSampler = true;
+			}
+			else _spawnedSampler = false;
+		}
+
+		~Profiler( void )
+		{
+			if( _spawnedSampler )
+			{
+				_terminate = true;
+				_thread.join();
+			}
+		}
+
+		void reset( void )
+		{
+			_t = Time();
+			if( _spawnedSampler )
+			{
+				std::lock_guard< std::mutex > lock( _mutex );
+				_currentPeak = 0;
+			}
+			else _currentPeak = 0;
+		}
+
+		void update( void )
+		{
+			size_t currentPeak = getCurrentRSS();
+			if( _spawnedSampler )
+			{
+				std::lock_guard< std::mutex > lock( _mutex );
+				if( currentPeak>_currentPeak ) _currentPeak = currentPeak;
+			}
+			else if( currentPeak>_currentPeak ) _currentPeak = currentPeak;
+		}
+
+		std::string operator()( bool showTime=true ) const
+		{
+			std::stringstream ss;
+			double dt = Time()-_t;
+			double  localPeakMB = ( (double)_currentPeak )/(1<<20);
+			double globalPeakMB = ( (double)getPeakRSS() )/(1<<20);
+			{
+				StreamFloatPrecision sfp( ss , 1 );
+				if( showTime ) ss << dt << " (s), ";
+				ss << localPeakMB << " (MB) / " << globalPeakMB << " (MB)";
+			}
+			return ss.str();
+		}
+
+		friend std::ostream &operator << ( std::ostream &os , const Profiler &profiler ){ return os << profiler(); }
+
+	protected:
+		std::thread _thread;
+		std::mutex _mutex;
+		double _t;
+		std::atomic< bool > _spawnedSampler;
+		std::atomic< size_t > _currentPeak;
+		std::atomic< bool > _terminate;
+
+		void _updatePeakMemoryFunction( unsigned int ms )
+		{
+			while( true )
+			{
+				std::this_thread::sleep_for( std::chrono::milliseconds( ms ) );
+				update();
+				if( _terminate ) return;
+			}
+		};
+	};
+
+	struct MemoryInfo
+	{
+		static size_t Usage( void ){ return getCurrentRSS(); }
+		static int PeakMemoryUsageMB( void ){ return (int)( getPeakRSS()>>20 ); }
+	};
+
+#if defined( _WIN32 ) || defined( _WIN64 )
+	inline void SetPeakMemoryMB( size_t sz )
+	{
+		sz <<= 20;
+		SIZE_T peakMemory = sz;
+		HANDLE h = CreateJobObject( NULL , NULL );
+		AssignProcessToJobObject( h , GetCurrentProcess() );
+
+		JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = { 0 };
+		jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_JOB_MEMORY;
+		jeli.JobMemoryLimit = peakMemory;
+		if( !SetInformationJobObject( h , JobObjectExtendedLimitInformation , &jeli , sizeof( jeli ) ) ) MK_WARN( "Failed to set memory limit" );
+	}
+#else // !_WIN32 && !_WIN64
+	inline void SetPeakMemoryMB( size_t sz )
+	{
+		sz <<= 20;
+		struct rlimit rl;
+		getrlimit( RLIMIT_AS , &rl );
+		rl.rlim_cur = sz;
+		setrlimit( RLIMIT_AS , &rl );
+	}
+#endif // _WIN32 || _WIN64
+
+	/*
+	* Author:  David Robert Nadeau
+	* Site:    http://NadeauSoftware.com/
+	* License: Creative Commons Attribution 3.0 Unported License
+	*          http://creativecommons.org/licenses/by/3.0/deed.en_US
+	*/
+
+	/**
+	* Returns the peak (maximum so far) resident set size (physical
+	* memory use) measured in bytes, or zero if the value cannot be
+	* determined on this OS.
+	*/
+	inline size_t getPeakRSS( )
+	{
+#if defined(_WIN32)
+		/* Windows -------------------------------------------------- */
+		PROCESS_MEMORY_COUNTERS info;
+		GetProcessMemoryInfo( GetCurrentProcess( ), &info, sizeof(info) );
+		return (size_t)info.PeakWorkingSetSize;
+
+#elif (defined(_AIX) || defined(__TOS__AIX__)) || (defined(__sun__) || defined(__sun) || defined(sun) && (defined(__SVR4) || defined(__svr4__)))
+		/* AIX and Solaris ------------------------------------------ */
+		struct psinfo psinfo;
+		int fd = -1;
+		if ( (fd = open( "/proc/self/psinfo", O_RDONLY )) == -1 )
+			return (size_t)0L;      /* Can't open? */
+		if ( read( fd, &psinfo, sizeof(psinfo) ) != sizeof(psinfo) )
+		{
+			close( fd );
+			return (size_t)0L;      /* Can't read? */
+		}
+		close( fd );
+		return (size_t)(psinfo.pr_rssize * 1024L);
+
+#elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
+		/* BSD, Linux, and OSX -------------------------------------- */
+		struct rusage rusage;
+		getrusage( RUSAGE_SELF, &rusage );
+#if defined(__APPLE__) && defined(__MACH__)
+		return (size_t)rusage.ru_maxrss;
+#else
+		return (size_t)(rusage.ru_maxrss * 1024L);
+#endif
+
+#else
+		/* Unknown OS ----------------------------------------------- */
+		return (size_t)0L;          /* Unsupported. */
+#endif
+	}
+
+
+
+
+
+	/**
+	* Returns the current resident set size (physical memory use) measured
+	* in bytes, or zero if the value cannot be determined on this OS.
+	*/
+	inline size_t getCurrentRSS( )
+	{
+#if defined(_WIN32) || defined( _WIN64 )
+		/* Windows -------------------------------------------------- */
+		PROCESS_MEMORY_COUNTERS info;
+		GetProcessMemoryInfo( GetCurrentProcess( ), &info, sizeof(info) );
+		return (size_t)info.WorkingSetSize;
+
+#elif defined(__APPLE__) && defined(__MACH__)
+		/* OSX ------------------------------------------------------ */
+		struct mach_task_basic_info info;
+		mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
+		if ( task_info( mach_task_self( ), MACH_TASK_BASIC_INFO,
+			(task_info_t)&info, &infoCount ) != KERN_SUCCESS )
+			return (size_t)0L;      /* Can't access? */
+		return (size_t)info.resident_size;
+
+#elif defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
+		/* Linux ---------------------------------------------------- */
+		long rss = 0L;
+		FILE* fp = NULL;
+		if ( (fp = fopen( "/proc/self/statm", "r" )) == NULL )
+			return (size_t)0L;      /* Can't open? */
+		if ( fscanf( fp, "%*s%ld", &rss ) != 1 )
+		{
+			fclose( fp );
+			return (size_t)0L;      /* Can't read? */
+		}
+		fclose( fp );
+		return (size_t)rss * (size_t)sysconf( _SC_PAGESIZE);
+
+#else
+		/* AIX, BSD, Solaris, and Unknown OS ------------------------ */
+		return (size_t)0L;          /* Unsupported. */
+#endif
+	}
+}
+
+#endif // MY_MISCELLANY_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/NestedVector.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/NestedVector.h
@@ -1,0 +1,310 @@
+/*
+Copyright (c) 2024, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+
+#ifndef NESTED_VECTOR_INCLUDED
+#define NESTED_VECTOR_INCLUDED
+
+#include <mutex>
+#include "MyAtomic.h"
+#include "MyMiscellany.h"
+
+namespace PoissonRecon
+{
+	// This represents a vector that can only grow in size.
+	// It has the property that once a reference to an element is returned, that reference remains valid until the vector is destroyed.
+	template< typename T , unsigned int Depth , unsigned int LogSize=20 >
+	struct NestedVector;
+
+	// The base case, an array with a maximum of 1<<LogSize
+	template< typename T , unsigned int LogSize >
+	struct NestedVector< T , 0 , LogSize >
+	{
+		static const unsigned int Depth = 0;
+		NestedVector( void ) : _size(0) { _data = new _DataType[ _Size ]; }
+
+		~NestedVector( void ){ delete[] _data; }
+
+		NestedVector( const NestedVector &nv ) : NestedVector()
+		{
+			_size = nv._size.load();
+			for( size_t i=0 ; i<_size ; i++ ) operator[](i) = nv[i];
+		}
+
+		NestedVector &operator = ( const NestedVector & nv )
+		{
+			_size = nv._size.load();
+			for( size_t i=0 ; i<_size ; i++ ) operator[](i) = nv[i];
+			return *this;
+		}
+
+		NestedVector( NestedVector &&nv )
+		{
+			_data = nv._data;
+			_size = nv._size.load();
+			nv._size = 0;
+			nv._data = nullptr;
+		}
+
+		NestedVector& operator = ( NestedVector &&nv )
+		{
+			size_t foo = _size;
+			_size = nv._size.load();
+			nv._size = foo;
+			std::swap( _data , nv._data );
+			return *this;
+		}
+
+		// This function is guaranteed to return a lower-bound on the actual size
+		size_t size( void ) const { return _size; }
+
+		const T& operator[]( size_t idx ) const { return _data[idx]; }
+		T& operator[]( size_t idx ){ return _data[idx]; }
+
+		size_t resize( size_t sz ){ return resize( sz , T{} ); }
+
+		size_t resize( size_t sz , const T &defaultValue )
+		{
+			if( sz>_MaxSize ) MK_THROW( "Resize size exceeds max size, considering increasing nesting: " , sz , " > " , _MaxSize );
+
+			// Quick check to see if anything needs doing
+			if( sz<_size ) return size();
+
+			// Otherwise lock it down and get to work
+			std::lock_guard lock( _mutex );
+
+			// Check if the size got changed
+			if( sz>_size )
+			{
+				for( size_t i=_size ; i<sz ; i++ ) _data[i] = defaultValue;
+				_size = sz;
+			}
+			return size();
+		}
+
+		void write( BinaryStream &stream ) const
+		{
+			size_t sz = _size;
+			stream.write( sz );
+			stream.write( GetPointer( _data , _Size ) , sz );
+		}
+
+		void read( BinaryStream &stream )
+		{
+			size_t sz;
+			if( !stream.read( sz ) ) MK_THROW( "Failed to read _size" );
+			resize( sz );
+			if( !stream.read( GetPointer( _data , _Size ) , _size ) ) MK_THROW( "Failed to read _data" );
+		}
+
+		void write( BinaryStream &stream , const Serializer< T > &serializer ) const
+		{
+			const size_t serializedSize = serializer.size();
+
+			size_t sz = _size;
+			stream.write( sz );
+			if( _size )
+			{
+				char *buffer = new char[ _size * serializedSize ];
+				for( size_t i=0 ; i<_size ; i++ ) serializer.serialize( operator[]( i ) , buffer+i*serializedSize );
+				stream.write( buffer , serializedSize*_size );
+				delete[] buffer ;
+			}
+		}
+		void read( BinaryStream &stream , const Serializer< T > &serializer )
+		{
+			const size_t serializedSize = serializer.size();
+
+			size_t sz;
+			if( !stream.read( sz ) ) MK_THROW( "Failed to read _size" );
+			if( _size )
+			{
+				resize( sz );
+				char *buffer = new char[ _size * serializedSize ];
+				if( !stream.read( buffer , serializedSize*_size ) ) MK_THROW( "Failed tor read in data" );
+				for( size_t i=0 ; i<_size ; i++ ) serializer.deserialize( buffer+i*serializedSize , operator[]( i ) );
+				delete[] buffer;
+			}
+		}
+
+	protected:
+		template< typename _T , unsigned int _Depth , unsigned int _LogSize > friend struct NestedVector;
+
+		using _DataType = T;
+		static const size_t _MaxSize = ((size_t)1)<<LogSize;
+		static const size_t _Size = ((size_t)1)<<LogSize;
+		static const size_t _Mask = _MaxSize-1;
+
+		std::mutex _mutex;
+		std::atomic< size_t > _size;
+		_DataType *_data;
+	};
+
+	// The derived case, an array a maximum of 1<<LogSize elements
+	template< typename T , unsigned int Depth , unsigned int LogSize >
+	struct NestedVector
+	{
+		NestedVector( void ) : _size(0)
+		{
+			_data = new _DataType*[ _Size ];
+			for( size_t i=0 ; i<_Size ; i++ ) _data[i] = nullptr;
+		}
+
+		~NestedVector( void )
+		{
+			for( size_t i=0 ; i<_size ; i++ ) delete _data[i];
+			delete[] _data;
+		}
+
+		NestedVector( const NestedVector &nv ) : NestedVector()
+		{
+			_size = nv._size.load();
+			for( size_t i=0 ; i<_size ; i++ ) _data[i] = new _DataType( *nv._data[i] );
+		}
+
+		NestedVector &operator = ( const NestedVector &nv )
+		{
+			for( size_t i=0 ; i<_size ; i++ ){ delete _data[i] ; _data[i] = nullptr; }
+			_size = nv._size.load();
+			for( size_t i=0 ; i<_size ; i++ ) _data[i] = new _DataType( *nv._data[i] );
+			return *this;
+		}
+
+		NestedVector( NestedVector &&nv )
+		{
+			_size = nv._size.load();
+			_data = nv._data;
+			nv._size = 0;
+			nv._data = nullptr;
+		}
+
+		NestedVector& operator = ( NestedVector &&nv )
+		{
+			size_t foo = _size;
+			_size = nv._size.load();
+			nv._size = foo;
+			std::swap( _data , nv._data );
+			return *this;
+		}
+
+		// This function is guaranteed to return a lower-bound on the actual size
+		size_t size( void ) const
+		{
+			if( !_size ) return 0;
+			else return ( (_size-1)<<(Depth*LogSize) ) + _data[_size-1]->size();
+		}
+
+		const T& operator[]( size_t idx ) const { return ( *_data[ idx>>(LogSize*Depth) ] )[ idx & NestedVector< T , Depth-1 , LogSize >::_Mask ] ; }
+		T& operator[]( size_t idx ){ return ( *( _data[ idx>>(LogSize*Depth) ] ) )[ idx & NestedVector< T , Depth-1 , LogSize >::_Mask ] ; }
+
+		size_t resize( size_t sz ){ return resize( sz , T{} ); }
+
+		size_t resize( size_t sz , const T &defaultValue )
+		{
+			if( sz>_MaxSize ) MK_THROW( "Resize size exceeds max size, considering increasing nesting: " , sz , " > " , _MaxSize );
+
+			size_t _sz = (sz+NestedVector< T , Depth-1 , LogSize >::_Mask)>>(LogSize*Depth);
+
+			// Quick check to see if anything needs doing
+			if( !_sz || _sz<_size ) return size();
+
+			// Otherwise lock it down and get to work
+			std::lock_guard lock( _mutex );
+
+			// Check if the size got changed
+			if( _sz>_size )
+			{
+				// Complete the initialization for the last existing
+				if( _size )
+				{
+					size_t i = _size-1;
+					size_t __sz = _sz==(i+1) ? ( sz - NestedVector< T , Depth-1 , LogSize >::_MaxSize * i ) : ( NestedVector< T , Depth-1 , LogSize >::_MaxSize );
+					_data[i]->resize( __sz , defaultValue );
+				}
+				for( size_t i=_size ; i<_sz ; i++ )
+				{
+					_data[i] = new _DataType();
+					size_t __sz = _sz==(i+1) ? ( sz - NestedVector< T , Depth-1 , LogSize >::_MaxSize * i ) : ( NestedVector< T , Depth-1 , LogSize >::_MaxSize );
+					_data[i]->resize( __sz , defaultValue );
+				}
+				_size = _sz;
+			}
+			else if( _sz==_size )
+			{
+				size_t i = _sz-1;
+				size_t __sz = _sz==(i+1) ? ( sz - NestedVector< T , Depth-1 , LogSize >::_MaxSize * i ) : ( NestedVector< T , Depth-1 , LogSize >::_MaxSize );
+				_data[i]->resize( __sz , defaultValue );
+			}
+			return size();
+		}
+
+		void write( BinaryStream &stream ) const
+		{
+			stream.write( size() );
+			for( size_t i=0 ; i<_size ; i++ ) _data[i]->write( stream );
+		}
+
+		void read( BinaryStream &stream )
+		{
+			size_t sz;
+			if( !stream.read( sz ) ) MK_THROW( "Failed to read _size" );
+			resize( sz );
+			for( size_t i=0 ; i<_size ; i++ ) _data[i]->read(stream);
+		}
+
+		void write( BinaryStream &stream , const Serializer< T > &serializer ) const
+		{
+			const size_t serializedSize = serializer.size();
+
+			stream.write( size() );
+			for( size_t i=0 ; i<_size ; i++ ) _data[i]->write( stream , serializer );
+		}
+		void read( BinaryStream &stream , const Serializer< T > &serializer )
+		{
+			const size_t serializedSize = serializer.size();
+
+			size_t sz;
+			if( !stream.read( sz ) ) MK_THROW( "Failed to read _size" );
+			resize( sz );
+			for( size_t i=0 ; i<_size ; i++ ) _data[i]->read( stream , serializer );
+		}
+
+	protected:
+		template< typename _T , unsigned int _Depth , unsigned int _LogSize > friend struct NestedVector;
+
+		using _DataType = NestedVector< T , Depth-1 , LogSize >;
+		static const size_t _MaxSize = ((size_t)1)<<(LogSize*(Depth+1));
+		static const size_t _Size = ((size_t)1)<<LogSize;
+		static const size_t _Mask = _MaxSize-1;
+
+		std::mutex _mutex;
+		std::atomic< size_t > _size;
+		_DataType **_data;
+	};
+}
+#endif // NESTED_VECTOR_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/PPolynomial.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PPolynomial.h
@@ -1,0 +1,119 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef P_POLYNOMIAL_INCLUDED
+#define P_POLYNOMIAL_INCLUDED
+#include <vector>
+#include "Polynomial.h"
+#include "Array.h"
+#include "Factor.h"
+
+namespace PoissonRecon
+{
+
+	template< int Degree >
+	class StartingPolynomial
+	{
+	public:
+		Polynomial< Degree > p;
+		double start;
+
+		template< int Degree2 >
+		StartingPolynomial< Degree+Degree2 >  operator * ( const StartingPolynomial< Degree2 >& p ) const;
+		StartingPolynomial scale( double s ) const;
+		StartingPolynomial shift( double t ) const;
+		int operator < ( const StartingPolynomial& sp ) const;
+		static int Compare( const void* v1 , const void* v2 );
+	};
+
+	template< int Degree >
+	class PPolynomial
+	{
+	public:
+		size_t polyCount;
+		Pointer( StartingPolynomial< Degree > ) polys;
+
+		PPolynomial( void );
+		PPolynomial( const PPolynomial<Degree>& p );
+		~PPolynomial( void );
+
+		PPolynomial& operator = ( const PPolynomial& p );
+
+		int size( void ) const;
+
+		void set( size_t size );
+		// Note: this method will sort the elements in sps
+		void set( Pointer( StartingPolynomial<Degree> ) sps , int count );
+		void reset( size_t newSize );
+		PPolynomial& compress( double delta=0. );
+
+
+		double operator()( double t ) const;
+		double integral( double tMin , double tMax ) const;
+		double Integral( void ) const;
+
+		template< int Degree2 > PPolynomial< Degree >& operator = ( const PPolynomial< Degree2 >& p );
+
+		PPolynomial  operator + ( const PPolynomial& p ) const;
+		PPolynomial  operator - ( const PPolynomial& p ) const;
+
+		template< int Degree2 > PPolynomial< Degree+Degree2 > operator * ( const  Polynomial< Degree2 >& p ) const;
+		template< int Degree2 >	PPolynomial< Degree+Degree2 > operator * ( const PPolynomial< Degree2 >& p) const;
+
+
+		PPolynomial& operator += ( double s );
+		PPolynomial& operator -= ( double s );
+		PPolynomial& operator *= ( double s );
+		PPolynomial& operator /= ( double s );
+		PPolynomial  operator +  ( double s ) const;
+		PPolynomial  operator -  ( double s ) const;
+		PPolynomial  operator *  ( double s ) const;
+		PPolynomial  operator /  ( double s ) const;
+
+		PPolynomial& addScaled( const PPolynomial& poly , double scale );
+
+		PPolynomial scale( double s ) const;
+		PPolynomial shift( double t ) const;
+		PPolynomial reflect( double r=0. ) const;
+
+		PPolynomial< Degree-1 > derivative(void) const;
+		PPolynomial< Degree+1 > integral(void) const;
+
+		void getSolutions( double c , std::vector< double >& roots , double EPS , double min=-DBL_MAX , double max=DBL_MAX ) const;
+
+		void printnl( void ) const;
+
+		PPolynomial< Degree+1 > MovingAverage( double radius ) const;
+		static PPolynomial BSpline( double radius=0.5 );
+
+		void write( FILE* fp , int samples , double min , double max ) const;
+	};
+#include "PPolynomial.inl"
+}
+
+#endif // P_POLYNOMIAL_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/PPolynomial.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PPolynomial.inl
@@ -1,0 +1,468 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+////////////////////////
+// StartingPolynomial //
+////////////////////////
+template<int Degree>
+template<int Degree2>
+StartingPolynomial<Degree+Degree2> StartingPolynomial<Degree>::operator * (const StartingPolynomial<Degree2>& p) const{
+	StartingPolynomial<Degree+Degree2> sp;
+	if(start>p.start){sp.start=start;}
+	else{sp.start=p.start;}
+	sp.p=this->p*p.p;
+	return sp;
+}
+template<int Degree>
+StartingPolynomial<Degree> StartingPolynomial<Degree>::scale( double s ) const
+{
+	StartingPolynomial q;
+	q.start = start*s;
+	q.p = p.scale(s);
+	return q;
+}
+template<int Degree>
+StartingPolynomial<Degree> StartingPolynomial<Degree>::shift(double s) const{
+	StartingPolynomial q;
+	q.start=start+s;
+	q.p=p.shift(s);
+	return q;
+}
+
+
+template<int Degree>
+int StartingPolynomial<Degree>::operator < (const StartingPolynomial<Degree>& sp) const{
+	if(start<sp.start){return 1;}
+	else{return 0;}
+}
+template<int Degree>
+int StartingPolynomial<Degree>::Compare(const void* v1,const void* v2){
+	double d=((StartingPolynomial*)(v1))->start-((StartingPolynomial*)(v2))->start;
+	if     ( d<0 ) return -1;
+	else if( d>0 ) return  1;
+	else           return  0;
+}
+
+/////////////////
+// PPolynomial //
+/////////////////
+template< int Degree >
+PPolynomial< Degree >::PPolynomial( void )
+{
+	polyCount = 0;
+	polys = NullPointer( StartingPolynomial< Degree > );
+}
+template< int Degree >
+PPolynomial<Degree>::PPolynomial( const PPolynomial<Degree>& p )
+{
+	polyCount = 0;
+	polys = NullPointer( StartingPolynomial< Degree > );
+	set( p.polyCount );
+	memcpy( polys , p.polys , sizeof( StartingPolynomial<Degree> ) * p.polyCount );
+}
+
+template< int Degree >
+PPolynomial< Degree >::~PPolynomial( void )
+{
+	FreePointer( polys );
+	polyCount = 0;
+}
+template< int Degree >
+void PPolynomial< Degree >::set( Pointer( StartingPolynomial< Degree > ) sps , int count )
+{
+	int c=0;
+	set( count );
+	qsort( sps , count , sizeof( StartingPolynomial< Degree > ) , StartingPolynomial< Degree >::Compare );
+	for( int i=0 ; i<count ; i++ )
+	{
+		if( !c || sps[i].start!=polys[c-1].start ) polys[c++] = sps[i];
+		else{polys[c-1].p+=sps[i].p;}
+	}
+	reset( c );
+}
+template< int Degree > int PPolynomial< Degree >::size( void ) const{ return int(sizeof(StartingPolynomial<Degree>)*polyCount); }
+
+template< int Degree >
+void PPolynomial<Degree>::set( size_t size )
+{
+	FreePointer( polys );
+	polyCount = size;
+	if( size )
+	{
+		polys = AllocPointer< StartingPolynomial< Degree > >( size );
+		memset( polys , 0 , sizeof( StartingPolynomial< Degree > )*size );
+	}
+}
+template< int Degree >
+void PPolynomial<Degree>::reset( size_t newSize )
+{
+	polyCount = newSize;
+	polys = ReAllocPointer< StartingPolynomial< Degree > >( polys , newSize );
+}
+template< int Degree >
+PPolynomial< Degree >& PPolynomial< Degree >::compress( double delta )
+{
+	int _polyCount = (int)polyCount;
+	Pointer( StartingPolynomial< Degree > ) _polys = polys;
+
+	polyCount = 1 , polys = NullPointer( StartingPolynomial< Degree > );
+	for( int i=1 ; i<_polyCount ; i++ ) if( _polys[i].start-_polys[i-1].start>delta ) polyCount++;
+	if( polyCount==_polyCount ) polys = _polys;
+	else
+	{
+		polys = AllocPointer< StartingPolynomial< Degree > >( polyCount );
+		polys[0] = _polys[0] , polyCount = 0;
+		for( int i=1 ; i<_polyCount ; i++ )
+		{
+			if( _polys[i].start-_polys[i-1].start>delta ) polys[ ++polyCount ] = _polys[i];
+			else polys[ polyCount ].p += _polys[i].p;
+		}
+		polyCount++;
+		FreePointer( _polys );
+	}
+	return *this;
+}
+
+template< int Degree >
+PPolynomial<Degree>& PPolynomial<Degree>::operator = (const PPolynomial<Degree>& p){
+	set(p.polyCount);
+	memcpy(polys,p.polys,sizeof(StartingPolynomial<Degree>)*p.polyCount);
+	return *this;
+}
+
+template<int Degree>
+template<int Degree2>
+PPolynomial<Degree>& PPolynomial<Degree>::operator  = (const PPolynomial<Degree2>& p){
+	set(p.polyCount);
+	for(int i=0;i<int(polyCount);i++){
+		polys[i].start=p.polys[i].start;
+		polys[i].p=p.polys[i].p;
+	}
+	return *this;
+}
+
+template<int Degree>
+double PPolynomial<Degree>::operator ()( double t ) const
+{
+	double v=0;
+	for( int i=0 ; i<int(polyCount) && t>polys[i].start ; i++ ) v+=polys[i].p(t);
+	return v;
+}
+
+template<int Degree>
+double PPolynomial<Degree>::integral( double tMin , double tMax ) const
+{
+	int m=1;
+	double start,end,s,v=0;
+	start=tMin;
+	end=tMax;
+	if(tMin>tMax){
+		m=-1;
+		start=tMax;
+		end=tMin;
+	}
+	for(int i=0;i<int(polyCount) && polys[i].start<end;i++){
+		if(start<polys[i].start){s=polys[i].start;}
+		else{s=start;}
+		v+=polys[i].p.integral(s,end);
+	}
+	return v*m;
+}
+template<int Degree>
+double PPolynomial<Degree>::Integral(void) const{return integral(polys[0].start,polys[polyCount-1].start);}
+template<int Degree>
+PPolynomial<Degree> PPolynomial<Degree>::operator + (const PPolynomial<Degree>& p) const{
+	PPolynomial q;
+	int i,j;
+	size_t idx=0;
+	q.set(polyCount+p.polyCount);
+	i=j=-1;
+
+	while(idx<q.polyCount){
+		if		(j>=int(p.polyCount)-1)				{q.polys[idx]=  polys[++i];}
+		else if	(i>=int(  polyCount)-1)				{q.polys[idx]=p.polys[++j];}
+		else if(polys[i+1].start<p.polys[j+1].start){q.polys[idx]=  polys[++i];}
+		else										{q.polys[idx]=p.polys[++j];}
+		idx++;
+	}
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree> PPolynomial<Degree>::operator - (const PPolynomial<Degree>& p) const{
+	PPolynomial q;
+	int i,j;
+	size_t idx=0;
+	q.set(polyCount+p.polyCount);
+	i=j=-1;
+
+	while(idx<q.polyCount){
+		if		(j>=int(p.polyCount)-1)				{q.polys[idx]=  polys[++i];}
+		else if	(i>=int(  polyCount)-1)				{q.polys[idx].start=p.polys[++j].start;q.polys[idx].p=p.polys[j].p*(-1.0);}
+		else if(polys[i+1].start<p.polys[j+1].start){q.polys[idx]=  polys[++i];}
+		else										{q.polys[idx].start=p.polys[++j].start;q.polys[idx].p=p.polys[j].p*(-1.0);}
+		idx++;
+	}
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree>& PPolynomial<Degree>::addScaled(const PPolynomial<Degree>& p,double scale){
+	int i,j;
+	StartingPolynomial<Degree>* oldPolys=polys;
+	size_t idx=0,cnt=0,oldPolyCount=polyCount;
+	polyCount=0;
+	polys=NULL;
+	set(oldPolyCount+p.polyCount);
+	i=j=-1;
+	while(cnt<polyCount){
+		if		(j>=int( p.polyCount)-1)				{polys[idx]=oldPolys[++i];}
+		else if	(i>=int(oldPolyCount)-1)				{polys[idx].start= p.polys[++j].start;polys[idx].p=p.polys[j].p*scale;}
+		else if	(oldPolys[i+1].start<p.polys[j+1].start){polys[idx]=oldPolys[++i];}
+		else											{polys[idx].start= p.polys[++j].start;polys[idx].p=p.polys[j].p*scale;}
+		if(idx && polys[idx].start==polys[idx-1].start)	{polys[idx-1].p+=polys[idx].p;}
+		else{idx++;}
+		cnt++;
+	}
+	free(oldPolys);
+	reset(idx);
+	return *this;
+}
+template<int Degree>
+template<int Degree2>
+PPolynomial<Degree+Degree2> PPolynomial<Degree>::operator * (const PPolynomial<Degree2>& p) const{
+	PPolynomial<Degree+Degree2> q;
+	StartingPolynomial<Degree+Degree2> *sp;
+	int i,j,spCount=int(polyCount*p.polyCount);
+
+	sp=(StartingPolynomial<Degree+Degree2>*)malloc(sizeof(StartingPolynomial<Degree+Degree2>)*spCount);
+	for(i=0;i<int(polyCount);i++){
+		for(j=0;j<int(p.polyCount);j++){
+			sp[i*p.polyCount+j]=polys[i]*p.polys[j];
+		}
+	}
+	q.set(sp,spCount);
+	free(sp);
+	return q;
+}
+template<int Degree>
+template<int Degree2>
+PPolynomial<Degree+Degree2> PPolynomial<Degree>::operator * (const Polynomial<Degree2>& p) const{
+	PPolynomial<Degree+Degree2> q;
+	q.set(polyCount);
+	for(int i=0;i<int(polyCount);i++){
+		q.polys[i].start=polys[i].start;
+		q.polys[i].p=polys[i].p*p;
+	}
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree> PPolynomial<Degree>::scale( double s ) const
+{
+	PPolynomial q;
+	q.set( polyCount );
+	for( size_t i=0 ; i<polyCount ; i++ ) q.polys[i] = polys[i].scale(s);
+	if( s<0 ) qsort( q.polys , polyCount , sizeof( StartingPolynomial< Degree > ) , StartingPolynomial< Degree >::Compare );
+	return q;
+}
+template< int Degree >
+PPolynomial< Degree > PPolynomial< Degree >::reflect( double r ) const
+{
+	PPolynomial q;
+	q.set( polyCount );
+	for( size_t i=0 ; i<polyCount ; i++ )
+	{
+		q.polys[i].scale(-1.);
+		if( r ) q.polys[i].shift( 2.*r );
+	}
+	qsort( q.polys , polyCount , sizeof( StartingPolynomial< Degree > ) , StartingPolynomial< Degree >::Compare );
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree> PPolynomial<Degree>::shift( double s ) const
+{
+	PPolynomial q;
+	q.set(polyCount);
+	for(size_t i=0;i<polyCount;i++){q.polys[i]=polys[i].shift(s);}
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree-1> PPolynomial<Degree>::derivative(void) const{
+	PPolynomial<Degree-1> q;
+	q.set(polyCount);
+	for(size_t i=0;i<polyCount;i++){
+		q.polys[i].start=polys[i].start;
+		q.polys[i].p=polys[i].p.derivative();
+	}
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree+1> PPolynomial<Degree>::integral(void) const{
+	int i;
+	PPolynomial<Degree+1> q;
+	q.set(polyCount);
+	for(i=0;i<int(polyCount);i++){
+		q.polys[i].start=polys[i].start;
+		q.polys[i].p=polys[i].p.integral();
+		q.polys[i].p-=q.polys[i].p(q.polys[i].start);
+	}
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree>& PPolynomial<Degree>::operator  += ( double s ) {polys[0].p+=s;}
+template<int Degree>
+PPolynomial<Degree>& PPolynomial<Degree>::operator  -= ( double s ) {polys[0].p-=s;}
+template<int Degree>
+PPolynomial<Degree>& PPolynomial<Degree>::operator  *= ( double s )
+{
+	for(int i=0;i<int(polyCount);i++){polys[i].p*=s;}
+	return *this;
+}
+template<int Degree>
+PPolynomial<Degree>& PPolynomial<Degree>::operator  /= ( double s )
+{
+	for(size_t i=0;i<polyCount;i++){polys[i].p/=s;}
+	return *this;
+}
+template<int Degree>
+PPolynomial<Degree> PPolynomial<Degree>::operator + ( double s ) const
+{
+	PPolynomial q=*this;
+	q+=s;
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree> PPolynomial<Degree>::operator - ( double s ) const
+{
+	PPolynomial q=*this;
+	q-=s;
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree> PPolynomial<Degree>::operator * ( double s ) const
+{
+	PPolynomial q=*this;
+	q*=s;
+	return q;
+}
+template<int Degree>
+PPolynomial<Degree> PPolynomial<Degree>::operator / ( double s ) const
+{
+	PPolynomial q=*this;
+	q/=s;
+	return q;
+}
+
+template<int Degree>
+void PPolynomial<Degree>::printnl(void) const{
+	Polynomial<Degree> p;
+
+	if(!polyCount){
+		Polynomial<Degree> p;
+		printf("[-Infinity,Infinity]\n");
+	}
+	else{
+		for(size_t i=0;i<polyCount;i++){
+			printf("[");
+			if		(polys[i  ].start== DBL_MAX){printf("Infinity,");}
+			else if	(polys[i  ].start==-DBL_MAX){printf("-Infinity,");}
+			else								{printf("%f,",polys[i].start);}
+			if(i+1==polyCount)					{printf("Infinity]\t");}
+			else if (polys[i+1].start== DBL_MAX){printf("Infinity]\t");}
+			else if	(polys[i+1].start==-DBL_MAX){printf("-Infinity]\t");}
+			else								{printf("%f]\t",polys[i+1].start);}
+			p=p+polys[i].p;
+			p.printnl();
+		}
+	}
+	printf("\n");
+}
+template< >
+inline PPolynomial< 0 > PPolynomial< 0 >::BSpline( double radius )
+{
+	PPolynomial q;
+	q.set(2);
+
+	q.polys[0].start=-radius;
+	q.polys[1].start= radius;
+
+	q.polys[0].p.coefficients[0]= 1.0;
+	q.polys[1].p.coefficients[0]=-1.0;
+	return q;
+}
+template< int Degree >
+PPolynomial< Degree > PPolynomial<Degree>::BSpline( double radius )
+{
+	return PPolynomial< Degree-1 >::BSpline().MovingAverage( radius );
+}
+template<int Degree>
+PPolynomial<Degree+1> PPolynomial<Degree>::MovingAverage( double radius ) const
+{
+	PPolynomial<Degree+1> A;
+	Polynomial<Degree+1> p;
+	Pointer( StartingPolynomial< Degree+1 > ) sps;
+	sps = AllocPointer< StartingPolynomial< Degree+1 > >( polyCount*2 );
+
+
+	for(int i=0;i<int(polyCount);i++){
+		sps[2*i  ].start=polys[i].start-radius;
+		sps[2*i+1].start=polys[i].start+radius;
+		p=polys[i].p.integral()-polys[i].p.integral()(polys[i].start);
+		sps[2*i  ].p=p.shift(-radius);
+		sps[2*i+1].p=p.shift( radius)*-1;
+	}
+	A.set( sps , int(polyCount*2) );
+	FreePointer( sps );
+	return A*1.0/(2*radius);
+}
+template<int Degree>
+void PPolynomial<Degree>::getSolutions(double c,std::vector<double>& roots,double EPS,double min,double max) const{
+	Polynomial<Degree> p;
+	std::vector<double> tempRoots;
+
+	p.setZero();
+	for(size_t i=0;i<polyCount;i++){
+		p+=polys[i].p;
+		if(polys[i].start>max){break;}
+		if(i<polyCount-1 && polys[i+1].start<min){continue;}
+		p.getSolutions(c,tempRoots,EPS);
+		for(size_t j=0;j<tempRoots.size();j++){
+			if(tempRoots[j]>polys[i].start && (i+1==polyCount || tempRoots[j]<=polys[i+1].start)){
+				if(tempRoots[j]>min && tempRoots[j]<max){roots.push_back(tempRoots[j]);}
+			}
+		}
+	}
+}
+
+template<int Degree>
+void PPolynomial<Degree>::write(FILE* fp,int samples,double min,double max) const{
+	fwrite(&samples,sizeof(int),1,fp);
+	for(int i=0;i<samples;i++){
+		double x=min+i*(max-min)/(samples-1);
+		float v=(*this)(x);
+		fwrite(&v,sizeof(float),1,fp);
+	}
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/ParameterPack.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/ParameterPack.h
@@ -1,0 +1,349 @@
+/*
+Copyright (c) 2016, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef PARAMETER_PACK_INCLUDED
+#define PARAMETER_PACK_INCLUDED
+
+/////////////////////
+// parameter packs //
+/////////////////////
+
+namespace ParameterPack
+{
+	////////////////////////////
+	////////////////////////////
+	//// Short declarations ////
+	////////////////////////////
+	////////////////////////////
+
+	// A wrapper class for passing unsigned integer parameter packs
+	template< typename IntegralType , IntegralType ... Values > struct Pack;
+
+	// A class that identifies a single entry and its complement
+	template< unsigned int I , typename Pack > struct Selection;
+
+	// A class that splits a Pack into two sub-packs
+	template< unsigned int I , typename Pack > struct Partition;
+
+	// A class for comparing two Packs
+	template< typename Pack1 , typename Pack2 > struct Comparison;
+
+	// A class for adding/subtracting two Packs
+	template< typename Pack1 , typename Pack2 > struct Arithmetic;
+
+	// A helper class for defining a concatenation of multiple Packs
+	template< typename ... Packs > struct _Concatenation;
+
+	// A helper class for defining the permutation of a Pack
+	template< typename Pack , typename PermutationPack > struct _Permutation;
+
+	// A helper class for defining a Pack with the same value repeated Dim times
+	template< typename IntegralType , unsigned int Dim , IntegralType Value > struct _IsotropicPack;
+
+	// A helper class for defining a Pack with sequentially increasing values
+	template< typename IntegralType , unsigned int Dim , IntegralType StartValue > struct _SequentialPack;
+
+	// A Pack that is the concatenation of multiple Packs
+	template< typename ... Packs > using Concatenation = typename _Concatenation< Packs ... >::type;
+
+	// A Pack that is the permtuation of a Pack
+	// [NOTE] The entry in the i-th position  of PermutationPack indicates where the i-th position comes from (not goes to)
+	template< typename Pack , typename PermutationPack > using Permutation = typename _Permutation< Pack , PermutationPack >::type;
+
+	// A Pack that has the same value repeated Dim times
+	template< typename IntegralType , unsigned int Dim , IntegralType Value=0 > using IsotropicPack = typename _IsotropicPack< IntegralType , Dim , Value >::type;
+
+	// A Pack with sequentially increasing values
+	template< typename IntegralType , unsigned int Dim , IntegralType StartValue=0 > using SequentialPack = typename _SequentialPack< IntegralType , Dim , StartValue >::type;
+
+	/////////////////////////
+	/////////////////////////
+	//// Specializations ////
+	/////////////////////////
+	/////////////////////////
+
+	// A pack with int values
+	template< int ... Values > using IntPack = Pack< int , Values... >;
+
+	// A pack with unsigned int values
+	template< unsigned int ... Values > using UIntPack = Pack< unsigned int , Values... >;
+
+	// An isotropic pack with int values
+	template< unsigned int Dim , int Value=0 > using IsotropicIntPack = IsotropicPack< int , Dim , Value >;
+
+	// An isotropic pack with unsigned int values
+	template< unsigned int Dim , unsigned int Value=0 > using IsotropicUIntPack = IsotropicPack< unsigned int , Dim , Value >;
+
+
+	/////////////////////
+	/////////////////////
+	//// Definitions ////
+	/////////////////////
+	/////////////////////
+
+
+	//////////
+	// Pack //
+	//////////
+
+	// The general case
+	template< typename IntegralType , IntegralType _Value , IntegralType ... _Values > struct Pack< IntegralType , _Value , _Values ... >
+	{
+		static const IntegralType First = _Value;
+		typedef Pack< IntegralType , _Values ... > Rest;
+		typedef typename Rest::Transpose::template Append< First > Transpose;
+
+		static const unsigned int Size = 1 + sizeof ... ( _Values );
+
+		template< IntegralType ... __Values > using  Append = Pack< IntegralType , _Value , _Values ... , __Values ... >;
+		template< IntegralType ... __Values > using Prepend = Pack< IntegralType , __Values ... , _Value , _Values ... >;
+
+		static const IntegralType Values[];
+
+		template< unsigned int I > constexpr static IntegralType Get( void )
+		{
+			if constexpr( I==0 ) return _Value;
+			else return Rest::template Get< I-1 >();
+		}
+
+		static constexpr IntegralType Min( void ){ return _Value < Rest::Min() ? _Value : Rest::Min(); }
+		static constexpr IntegralType Max( void ){ return _Value > Rest::Max() ? _Value : Rest::Max(); }
+
+		friend std::ostream &operator << ( std::ostream &os , Pack )
+		{
+			os << "< ";
+			for( unsigned int i=0 ; i<Size ; i++ )
+			{
+				if( i ) os << " , ";
+				os << Values[i];
+			}
+			return os << " >";
+		}
+	};
+
+	// The specialized case with one entry
+	template< typename IntegralType , IntegralType _Value > struct Pack< IntegralType , _Value >
+	{
+		static const IntegralType First = _Value;
+		typedef Pack< IntegralType > Rest;
+		typedef Pack< IntegralType , _Value > Transpose;
+
+		static const unsigned int Size = 1;
+
+		template< IntegralType ... __Values > using  Append = Pack< IntegralType , _Value , __Values ... >;
+		template< IntegralType ... __Values > using Prepend = Pack< IntegralType , __Values ... , _Value >;
+
+		static const IntegralType Values[];
+
+		template< unsigned int I > constexpr static IntegralType Get( void )
+		{
+			static_assert( I==0 , "[ERROR] Pack< IntegralType , Value >::Get called with non-zero index" );
+			return _Value;
+		}
+
+		static constexpr IntegralType Min( void ){ return _Value; }
+		static constexpr IntegralType Max( void ){ return _Value; }
+
+		friend std::ostream &operator << ( std::ostream &os , Pack )
+		{
+			return os << "< " << First << " >";
+		}
+	};
+
+	// The specialized case with no entries
+	template< typename IntegralType > struct Pack< IntegralType >
+	{
+		typedef Pack< IntegralType > Rest;
+		static const unsigned int Size = 0;
+		static constexpr IntegralType Values[] = { 0 };
+		typedef Pack< IntegralType > Transpose;
+		template< IntegralType ... __Values > using  Append = Pack< IntegralType , __Values ... >;
+		template< IntegralType ... __Values > using Prepend = Pack< IntegralType , __Values ... >;
+		friend std::ostream &operator << ( std::ostream &os , Pack ){ return os << "< >"; }
+	};
+
+	template< typename IntegralType , IntegralType _Value , IntegralType ... _Values > const IntegralType Pack< IntegralType , _Value , _Values ... >::Values[] = { _Value , _Values ... };
+	template< typename IntegralType , IntegralType _Value > const IntegralType Pack< IntegralType , _Value >::Values[] = { _Value };
+
+	///////////////
+	// Selection //
+	///////////////
+	template< unsigned int I , typename IntegralType , IntegralType _Value , IntegralType ... _Values >
+	struct Selection< I , Pack< IntegralType , _Value , _Values ... > >
+	{
+		static const IntegralType Value = Selection< I-1 , Pack< IntegralType , _Values ... > >::Value;
+		typedef typename Selection< I-1 , Pack< IntegralType , _Values ... > >::Complement::template Prepend< _Value > Complement;
+	};
+
+	template< typename IntegralType , IntegralType _Value , IntegralType ... _Values >
+	struct Selection< 0 , Pack< IntegralType , _Value , _Values ... > >
+	{
+		static const IntegralType Value = _Value;
+		typedef Pack< IntegralType , _Values ... > Complement;
+	};
+
+	///////////////
+	// Partition //
+	///////////////
+	template< typename IntegralType , IntegralType ... Values >
+	struct Partition< 0 , Pack< IntegralType , Values ... > >
+	{
+		typedef Pack< IntegralType > First;
+		typedef Pack< IntegralType , Values ... > Second;
+	};
+
+	template< unsigned int I , typename IntegralType , IntegralType ... Values >
+	struct Partition< I , Pack< IntegralType , Values ... > >
+	{
+		typedef Concatenation< Pack< IntegralType , Pack< IntegralType , Values ... >::First > , typename Partition< I-1 , typename Pack< IntegralType , Values ... >::Rest >::First > First;
+		typedef typename Partition< I-1 , typename Pack< IntegralType , Values ... >::Rest >::Second Second;
+	};
+
+	////////////////
+	// Arithmetic //
+	////////////////
+	template< typename IntegralType >
+	struct Arithmetic< Pack< IntegralType > , Pack< IntegralType > >
+	{
+		using Sum        = Pack< IntegralType >;
+		using Difference = Pack< IntegralType >;
+	};
+
+	template< typename IntegralType , IntegralType Value1 , IntegralType ... Values1 , IntegralType Value2 , IntegralType ... Values2 >
+	struct Arithmetic< Pack< IntegralType , Value1 , Values1 ... > , Pack< IntegralType , Value2 , Values2 ... > >
+	{
+		using Sum        = Concatenation< Pack< IntegralType , Value1+Value2 > , typename Arithmetic< Pack< IntegralType , Values1 ... > , Pack< IntegralType , Values2... > >::Sum >;
+		using Difference = Concatenation< Pack< IntegralType , Value1-Value2 > , typename Arithmetic< Pack< IntegralType , Values1 ... > , Pack< IntegralType , Values2... > >::Difference >;
+	};
+
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	typename Arithmetic< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::Sum operator + ( Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > ){ return typename Arithmetic< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::Sum(); }
+
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	typename Arithmetic< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::Difference operator - ( Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > ){ return typename Arithmetic< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::Difference(); }
+
+
+	////////////////
+	// Comparison //
+	////////////////
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	struct Comparison< Pack< IntegralType , Values1 ... > , Pack< IntegralType , Values2 ... > >
+	{
+		typedef Pack< IntegralType , Values1 ... > Pack1;
+		typedef Pack< IntegralType , Values2 ... > Pack2;
+		static const bool              Equal = Pack1::First==Pack2::First && Comparison< typename Pack1::Rest , typename Pack2::Rest >::Equal;
+		static const bool           NotEqual = Pack1::First!=Pack2::First || Comparison< typename Pack1::Rest , typename Pack2::Rest >::NotEqual;
+		static const bool    LessThan        = Pack1::First< Pack2::First && Comparison< typename Pack1::Rest , typename Pack2::Rest >::LessThan;
+		static const bool    LessThanOrEqual = Pack1::First<=Pack2::First && Comparison< typename Pack1::Rest , typename Pack2::Rest >::LessThanOrEqual;
+		static const bool GreaterThan        = Pack1::First> Pack2::First && Comparison< typename Pack1::Rest , typename Pack2::Rest >::GreaterThan;
+		static const bool GreaterThanOrEqual = Pack1::First>=Pack2::First && Comparison< typename Pack1::Rest , typename Pack2::Rest >::GreaterThanOrEqual;
+	};
+
+	template< typename IntegralType , IntegralType Value1 , IntegralType Value2 >
+	struct Comparison< Pack< IntegralType , Value1 > , Pack< IntegralType , Value2 > >
+	{
+		static const bool Equal = Value1==Value2;
+		static const bool NotEqual = Value1!=Value2;
+		static const bool LessThan = Value1<Value2;
+		static const bool LessThanOrEqual = Value1<=Value2;
+		static const bool GreaterThan = Value1>Value2;
+		static const bool GreaterThanOrEqual = Value1>=Value2;
+	};
+
+	template< typename IntegralType >
+	struct Comparison< Pack< IntegralType > , Pack< IntegralType > >
+	{
+		static const bool Equal = true;
+		static const bool NotEqual = false;
+		static const bool LessThan = false;
+		static const bool LessThanOrEqual = true;
+		static const bool GreaterThan = false;
+		static const bool GreaterThanOrEqual = true;
+	};
+
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	bool operator==( const Pack< IntegralType , Values1... > , const Pack< IntegralType , Values2... > ){ return Comparison< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::Equal; }
+
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	bool operator!=( const Pack< IntegralType , Values1... > , const Pack< IntegralType , Values2... > ){ return Comparison< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::NotEqual; }
+
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	bool operator<( const Pack< IntegralType , Values1... > , const Pack< IntegralType , Values2... > ){ return Comparison< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::LessThan; }
+
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	bool operator<=( const Pack< IntegralType , Values1... > , const Pack< IntegralType , Values2... > ){ return Comparison< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::LessThanOrEqual; }
+
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	bool operator>( const Pack< IntegralType , Values1... > , const Pack< IntegralType , Values2... > ){ return Comparison< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::GreaterThan; }
+
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 >
+	bool operator>=( const Pack< IntegralType , Values1... > , const Pack< IntegralType , Values2... > ){ return Comparison< Pack< IntegralType , Values1... > , Pack< IntegralType , Values2... > >::GreaterThanOrEqual; }
+
+	////////////////////
+	// _Concatenation //
+	////////////////////
+	template< typename IntegralType , IntegralType ... Values1 , IntegralType ... Values2 , typename ... Packs >
+	struct _Concatenation< Pack< IntegralType , Values1 ... > , Pack< IntegralType , Values2 ... > , Packs ... >
+	{
+		typedef typename _Concatenation< typename Pack< IntegralType , Values1 ... >::template Append< Values2 ... > , Packs ... >::type type;
+	};
+	template< typename IntegralType , IntegralType ... Values >
+	struct _Concatenation< Pack< IntegralType , Values ... > >
+	{
+		typedef Pack< IntegralType , Values ... > type;
+	};
+
+	//////////////////
+	// _Permutation //
+	//////////////////
+	template< typename IntegralType , IntegralType ... Values , unsigned int ... PermutationValues >
+	struct _Permutation< Pack< IntegralType , Values ... > , Pack< unsigned int , PermutationValues ... > >
+	{
+		typedef Pack< IntegralType , PermutationValues ... > PPack;
+		typedef Concatenation< Pack< IntegralType , Selection< PPack::First , Pack< IntegralType , Values ... > >::Value > , typename _Permutation< Pack< IntegralType , Values ... > , typename PPack::Rest >::type > type;
+	};
+	template< typename IntegralType , IntegralType ... Values >
+	struct _Permutation< Pack< IntegralType , Values ... > , Pack< unsigned int > >
+	{
+		typedef Pack< IntegralType > type;
+	};
+
+	////////////////////
+	// _IsotropicPack //
+	////////////////////
+	template< typename IntegralType , unsigned int Dim , IntegralType Value > struct _IsotropicPack                            { typedef typename _IsotropicPack< IntegralType , Dim-1 , Value >::type::template Append< Value > type; };
+	template< typename IntegralType ,                    IntegralType Value > struct _IsotropicPack< IntegralType , 1 , Value >{ typedef Pack< IntegralType , Value > type; };
+	template< typename IntegralType ,                    IntegralType Value > struct _IsotropicPack< IntegralType , 0 , Value >{ typedef Pack< IntegralType > type; };
+
+	/////////////////////
+	// _SequentialPack //
+	/////////////////////
+	template< typename IntegralType , unsigned int Dim , IntegralType Value >   struct _SequentialPack                            { typedef Concatenation< Pack< IntegralType , Value > , typename _SequentialPack< IntegralType , Dim-1 , Value+1 >::type > type; };
+	template< typename IntegralType ,                    IntegralType Value >   struct _SequentialPack< IntegralType , 0 , Value >{ typedef Pack< IntegralType > type; };
+}
+#endif // PARAMETER_PACK_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Ply.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Ply.h
@@ -1,0 +1,124 @@
+/*
+
+Header for PLY polygon files.
+
+- Greg Turk, March 1994
+
+A PLY file contains a single polygonal _object_.
+
+An object is composed of lists of _elements_.  Typical elements are
+vertices, faces, edges and materials.
+
+Each type of element for a given object has one or more _properties_
+associated with the element type.  For instance, a vertex element may
+have as properties three floating-point values x,y,z and three unsigned
+chars for red, green and blue.
+
+---------------------------------------------------------------
+
+Copyright (c) 2020, Georgia Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer. Redistributions in binary form
+must reproduce the above copyright notice, this list of conditions and the
+following disclaimer in the documentation and/or other materials provided with
+the distribution. 
+
+Neither the name of the Georgia Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef PLY_INCLUDED
+#define PLY_INCLUDED
+
+#include <vector>
+#include <string>
+#include <functional>
+#include <math.h>
+#include "PlyFile.h"
+#include "Geometry.h"
+#include "DataStream.h"
+#include "MyMiscellany.h"
+#include "Array.h"
+
+namespace PoissonRecon
+{
+	namespace PLY
+	{
+		// Converts from C-type to PLY type
+		template< class Scalar > int Type( void );
+
+		// Converts from C-type to PLY name
+		template< typename Integer > struct Traits{ static const std::string name; };
+
+		// A structure representing a face
+		template< typename Index >
+		struct Edge
+		{
+			Index v1 , v2;
+			static const PlyProperty Properties[];
+		};
+
+		// A structure representing a face
+		template< typename Index , bool UseCharIndex=false >
+		struct Face
+		{
+			unsigned int nr_vertices;
+			Index *vertices;
+
+			static const PlyProperty Properties[];
+		};
+
+		inline int DefaultFileType( void );
+
+		// PLY read header functionality
+
+		// Get the properties (and return the file type)
+		inline int ReadVertexHeader( std::string fileName , std::vector< PlyProperty > &properties );
+
+		// Test which properties are represented by elements of the vertex factory (and return the file type)
+		template< typename VertexFactory >
+		int ReadVertexHeader( std::string fileName , const VertexFactory &vFactory , bool *readFlags );
+
+		// Test which properties are represented by elements of the vertex factory and add the others to the property list (and return the file type)
+		template< typename VertexFactory >
+		int ReadVertexHeader( std::string fileName , const VertexFactory &vFactory , bool *readFlags , std::vector< PlyProperty > &unprocessedProperties );
+
+		// PLY write mesh functionality
+		template< typename VertexFactory , typename Index , class Real , int Dim , typename OutputIndex=int , bool UseCharIndex=false >
+		void Write( std::string fileName , const VertexFactory &vFactory , size_t vertexNum , size_t polygonNum , InputDataStream< typename VertexFactory::VertexType > &vertexStream , InputDataStream< std::vector< Index > > &polygonStream , int file_type , const std::vector< std::string >& comments );
+
+		template< typename VertexFactory , typename Index , class Real , int Dim , typename OutputIndex=int >
+		void Write( std::string fileName , const VertexFactory &vFactory , size_t vertexNum , size_t edgeNum , InputDataStream< typename VertexFactory::VertexType > &vertexStream , InputDataStream< std::pair< Index , Index > > &edgeStream , int file_type , const std::vector< std::string >& comments );
+
+		template< typename VertexFactory , typename Index , bool UseCharIndex=false >
+		void WritePolygons( std::string fileName , const VertexFactory &vFactory , const std::vector< typename VertexFactory::VertexType > &vertices , const std::vector< std::vector< Index > > &polygons , int file_type , const std::vector< std::string > &comments );
+
+		// PLY read mesh functionality
+		template< typename VertexFactory , typename Index >
+		void ReadPolygons( std::string fileName , const VertexFactory &vFactory , std::vector< typename VertexFactory::VertexType > &vertices , std::vector< std::vector< Index > >& polygons , int &file_type , std::vector< std::string > &comments , bool* readFlags=NULL );
+
+		template< typename VertexFactory , typename Index >
+		void ReadEdges( std::string fileName , const VertexFactory &vFactory , std::vector< typename VertexFactory::VertexType > &vertices , std::vector< std::pair< Index , Index > >& edges , int &file_type , std::vector< std::string > &comments , bool* readFlags=NULL );
+	}
+#include "Ply.inl"
+}
+
+#endif // PLY_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Ply.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Ply.inl
@@ -1,0 +1,546 @@
+/*
+Copyright (c) 2020, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+namespace PLY
+{
+	inline int DefaultFileType( void ){ return PLY_ASCII; }
+
+	template<> inline int Type<          int  >( void ){ return PLY_INT   ; }
+	template<> inline int Type< unsigned int  >( void ){ return PLY_UINT  ; }
+	template<> inline int Type<          char >( void ){ return PLY_CHAR  ; }
+	template<> inline int Type< unsigned char >( void ){ return PLY_UCHAR ; }
+	template<> inline int Type<        float  >( void ){ return PLY_FLOAT ; }
+	template<> inline int Type<        double >( void ){ return PLY_DOUBLE; }
+	template< class Scalar > inline int Type( void )
+	{
+		MK_THROW( "Unrecognized scalar type: " , typeid(Scalar).name() );
+		return -1;
+	}
+
+	template<> const inline std::string Traits<          int >::name="int";
+	template<> const inline std::string Traits< unsigned int >::name="unsigned int";
+	template<> const inline std::string Traits<          long >::name="long";
+	template<> const inline std::string Traits< unsigned long >::name="unsigned long";
+	template<> const inline std::string Traits<          long long >::name="long long";
+	template<> const inline std::string Traits< unsigned long long >::name="unsigned long long";
+
+	template<> const inline PlyProperty Edge<          int       >::Properties[] = { PlyProperty( "v1" , PLY_INT       , PLY_INT       , offsetof( Edge , v1 ) ) , PlyProperty( "v2" , PLY_INT       , PLY_INT       , offsetof( Edge , v2 ) ) };
+	template<> const inline PlyProperty Edge< unsigned int       >::Properties[] = { PlyProperty( "v1" , PLY_UINT      , PLY_UINT      , offsetof( Edge , v1 ) ) , PlyProperty( "v2" , PLY_UINT      , PLY_UINT      , offsetof( Edge , v2 ) ) };
+	template<> const inline PlyProperty Edge<          long long >::Properties[] = { PlyProperty( "v1" , PLY_LONGLONG  , PLY_LONGLONG  , offsetof( Edge , v1 ) ) , PlyProperty( "v2" , PLY_LONGLONG  , PLY_LONGLONG  , offsetof( Edge , v2 ) ) };
+	template<> const inline PlyProperty Edge< unsigned long long >::Properties[] = { PlyProperty( "v1" , PLY_ULONGLONG , PLY_ULONGLONG , offsetof( Edge , v1 ) ) , PlyProperty( "v2" , PLY_ULONGLONG , PLY_ULONGLONG , offsetof( Edge , v2 ) ) };
+
+	template<> const inline PlyProperty Face<          int       , false >::Properties[] = { PlyProperty( "vertex_indices" , PLY_INT       , PLY_INT       , offsetof( Face , vertices ) , 1 , PLY_INT , PLY_INT , offsetof( Face , nr_vertices ) ) };
+	template<> const inline PlyProperty Face< unsigned int       , false >::Properties[] = { PlyProperty( "vertex_indices" , PLY_UINT      , PLY_UINT      , offsetof( Face , vertices ) , 1 , PLY_INT , PLY_INT , offsetof( Face , nr_vertices ) ) };
+	template<> const inline PlyProperty Face<          long long , false >::Properties[] = { PlyProperty( "vertex_indices" , PLY_LONGLONG  , PLY_LONGLONG  , offsetof( Face , vertices ) , 1 , PLY_INT , PLY_INT , offsetof( Face , nr_vertices ) ) };
+	template<> const inline PlyProperty Face< unsigned long long , false >::Properties[] = { PlyProperty( "vertex_indices" , PLY_ULONGLONG , PLY_ULONGLONG , offsetof( Face , vertices ) , 1 , PLY_INT , PLY_INT , offsetof( Face , nr_vertices ) ) };
+	template<> const inline PlyProperty Face<          int       , true  >::Properties[] = { PlyProperty( "vertex_indices" , PLY_INT       , PLY_INT       , offsetof( Face , vertices ) , 1 , PLY_CHAR , PLY_CHAR , offsetof( Face , nr_vertices ) ) };
+	template<> const inline PlyProperty Face< unsigned int       , true  >::Properties[] = { PlyProperty( "vertex_indices" , PLY_UINT      , PLY_UINT      , offsetof( Face , vertices ) , 1 , PLY_CHAR , PLY_CHAR , offsetof( Face , nr_vertices ) ) };
+	template<> const inline PlyProperty Face<          long long , true  >::Properties[] = { PlyProperty( "vertex_indices" , PLY_LONGLONG  , PLY_LONGLONG  , offsetof( Face , vertices ) , 1 , PLY_CHAR , PLY_CHAR , offsetof( Face , nr_vertices ) ) };
+	template<> const inline PlyProperty Face< unsigned long long , true  >::Properties[] = { PlyProperty( "vertex_indices" , PLY_ULONGLONG , PLY_ULONGLONG , offsetof( Face , vertices ) , 1 , PLY_CHAR , PLY_CHAR , offsetof( Face , nr_vertices ) ) };
+
+	// Read
+	inline PlyFile *ReadHeader( std::string fileName , int &fileType , std::vector< std::tuple< std::string , size_t , std::vector< PlyProperty > > > &elems , std::vector< std::string > &comments )
+	{
+		std::vector< std::string > elist;
+		float version;
+
+		PlyFile *ply = PlyFile::Read( fileName , elist , fileType , version );
+		if( !ply ) MK_THROW( "Could not open ply file for reading: " , fileName );
+
+		elems.resize( elist.size() );
+		for( unsigned int i=0 ; i<elist.size() ; i++ )
+		{
+			std::get<0>( elems[i] ) = elist[i];
+			std::get<2>( elems[i] ) = ply->get_element_description( std::get<0>( elems[i] ) , std::get<1>( elems[i] ) );
+		}
+
+		comments.resize( ply->comments.size() );
+		for( int i=0 ; i<ply->comments.size() ; i++ ) comments[i] = ply->comments[i];
+
+		return ply;
+	}
+
+	inline PlyFile *WriteHeader( std::string fileName , int fileType , const std::vector< std::tuple< std::string , size_t , std::vector< PlyProperty > > > &elems , const std::vector< std::string > &comments )
+	{
+		PlyFile *ply = NULL;
+		{
+			float version;
+			std::vector< std::string > elist( elems.size() );
+			for( unsigned int i=0 ; i<elems.size() ; i++ ) elist[i] = std::get<0>( elems[i] );
+			ply = PlyFile::Write( fileName , elist , fileType , version );
+		}
+		if( !ply ) MK_THROW( "Could not open ply for writing: " , fileName );
+		for( unsigned int i=0 ; i<elems.size() ; i++ )
+		{
+			ply->element_count( std::get<0>( elems[i] ) , std::get<1>( elems[i] ) );
+			const std::vector< PlyProperty > &props = std::get<2>( elems[i] );
+			for( unsigned int j=0 ; j<props.size() ; j++ ) ply->describe_property( std::get<0>( elems[i] ) , &props[j] );
+		}
+
+		for( int i=0 ; i<comments.size() ; i++ ) ply->put_comment( comments[i] );
+		ply->header_complete();
+
+		return ply;
+	}
+
+	inline PlyFile *ReadHeader( std::string fileName , int &fileType , std::vector< std::tuple< std::string , size_t , std::vector< PlyProperty > > > &elems )
+	{
+		std::vector< std::string > comments;
+		return ReadHeader( fileName , fileType , elems , comments );
+	}
+
+	inline PlyFile *WriteHeader( std::string fileName , int fileType , const std::vector< std::tuple< std::string , size_t , std::vector< PlyProperty > > > &elems )
+	{
+		std::vector< std::string > comments;
+		return WriteHeader( fileName , fileType , elems , comments );
+	}
+
+	template< typename VertexFactory >
+	inline int ReadVertexHeader( std::string fileName , const VertexFactory &vFactory , bool *readFlags )
+	{
+		int fileType;
+		std::vector< std::string > elist;
+		float version;
+
+		PlyFile *ply = PlyFile::Read( fileName , elist , fileType , version );
+		if( !ply ) MK_THROW( "could not create read ply file: " , fileName );
+
+		for( int i=0 ; i<(int)elist.size() ; i++ ) if( elist[i]=="vertex" ) for( unsigned int j=0 ; j<vFactory.plyReadNum() ; j++ )
+		{
+			PlyProperty prop;
+			if constexpr( VertexFactory::IsStaticallyAllocated() ) prop = vFactory.plyStaticReadProperty(j);
+			else                                                   prop = vFactory.plyReadProperty(j);
+			readFlags[j] = ( ply->get_property( elist[i] , &prop )!=0 );
+		}
+
+		delete ply;
+		return fileType;
+	}
+
+	template< typename VertexFactory >
+	inline int ReadVertexHeader( std::string fileName , const VertexFactory &vFactory , bool *readFlags , std::vector< PlyProperty > &unprocessedProperties , size_t &vNum )
+	{
+		int fileType;
+		std::vector< std::string > elist;
+		float version;
+
+		PlyFile *ply = PlyFile::Read( fileName, elist, fileType, version );
+		if( !ply ) MK_THROW( "Failed to open ply file for reading: " , fileName );
+
+		std::vector< PlyProperty > plist = ply->get_element_description( "vertex" , vNum );
+		if( !plist.size() ) MK_THROW( "Failed to get element description: vertex" );
+		for( unsigned int i=0 ; i<vFactory.plyReadNum() ; i++ ) readFlags[i] = false;
+
+		for( int i=0 ; i<plist.size() ; i++ )
+		{
+			bool found = false;
+			for( unsigned int j=0 ; j<vFactory.plyReadNum() ; j++ )
+			{
+				PlyProperty prop;
+				if constexpr( VertexFactory::IsStaticallyAllocated() ) prop = vFactory.plyStaticReadProperty(j);
+				else                                                   prop = vFactory.plyReadProperty(j);
+				if( prop.name==plist[i].name ) found = readFlags[j] = true;
+			}
+			if( !found ) unprocessedProperties.push_back( plist[i] );
+		}
+		delete ply;
+		return fileType;
+	}
+	template< typename VertexFactory >
+	inline int ReadVertexHeader( std::string fileName , const VertexFactory &vFactory , bool *readFlags , std::vector< PlyProperty > &unprocessedProperties )
+	{
+		size_t vNum;
+		return ReadVertexHeader( fileName , vFactory , readFlags , unprocessedProperties , vNum );
+	}
+
+	inline int ReadVertexHeader( std::string fileName , std::vector< PlyProperty > &properties , size_t &vNum )
+	{
+		int fileType;
+		std::vector< std::string > elist;
+		float version;
+
+		PlyFile *ply = PlyFile::Read( fileName, elist, fileType, version );
+		if( !ply ) MK_THROW( "Failed to open ply file for reading: " , fileName );
+
+		std::vector< PlyProperty > plist = ply->get_element_description( "vertex" , vNum );
+		for( int i=0 ; i<plist.size() ; i++ ) properties.push_back( plist[i] );
+		delete ply;
+		return fileType;
+	}
+
+	inline int ReadVertexHeader( std::string fileName , std::vector< PlyProperty > &properties )
+	{
+		size_t vNum;
+		return ReadVertexHeader( fileName , properties , vNum );
+	}
+
+	template< typename VertexFactory , typename Index >
+	void ReadEdges( std::string fileName , const VertexFactory &vFactory , std::vector< typename VertexFactory::VertexType > &vertices , std::vector< std::pair< Index , Index > > &edges , int &file_type , std::vector< std::string > &comments , bool *readFlags )
+	{
+		std::vector< std::string > elist;
+		float version;
+
+		PlyFile *ply = PlyFile::Read( fileName , elist , file_type , version );
+		if( !ply ) MK_THROW( "Could not create ply file for reading: " , fileName );
+
+		comments.reserve( comments.size() + ply->comments.size() );
+		for( int i=0 ; i<ply->comments.size() ; i++ ) comments.push_back( ply->comments[i] );
+
+		for( int i=0 ; i<elist.size() ; i++ )
+		{
+			std::string &elem_name = elist[i];
+			size_t num_elems;
+			std::vector< PlyProperty > plist = ply->get_element_description( elem_name , num_elems );
+			if( !plist.size() ) MK_THROW( "Could not read element properties: " , elem_name );
+			if( elem_name=="vertex" )
+			{
+				for( unsigned int i=0 ; i<vFactory.plyReadNum() ; i++ )
+				{
+					PlyProperty prop;
+					if constexpr( VertexFactory::IsStaticallyAllocated() ) prop = vFactory.plyStaticReadProperty(i);
+					else                                                   prop = vFactory.plyReadProperty(i);
+					int hasProperty = ply->get_property( elem_name , &prop );
+					if( readFlags ) readFlags[i] = (hasProperty!=0);
+				}
+				vertices.resize( num_elems , vFactory() );
+				Pointer( char ) buffer = NewPointer< char >( vFactory.bufferSize() );
+				for( size_t j=0 ; j<num_elems ; j++ )
+				{
+					if constexpr( VertexFactory::IsStaticallyAllocated() ) ply->get_element( (void*)&vertices[j] );
+					else
+					{
+						ply->get_element( PointerAddress( buffer ) );
+						vFactory.fromBuffer( buffer , vertices[j] );
+					}
+				}
+				DeletePointer( buffer );
+			}
+			else if( elem_name=="edge" )
+			{
+				ply->get_property( elem_name , &Edge< Index >::Properties[0] );
+				ply->get_property( elem_name , &Edge< Index >::Properties[1] );
+				edges.resize( num_elems );
+				for( size_t j=0 ; j<num_elems ; j++ )
+				{
+					Edge< Index > ply_edge;
+					ply->get_element( (void *)&ply_edge );
+					edges[j].first  = ply_edge.v1;
+					edges[j].second = ply_edge.v2;
+				}  // for, read edges
+			}  // if face
+			else ply->get_other_element( elem_name , num_elems );
+		}  // for each type of element
+
+		delete ply;
+	}
+
+	template< typename VertexFactory , typename Index >
+	void ReadPolygons( std::string fileName , const VertexFactory &vFactory , std::vector< typename VertexFactory::VertexType > &vertices , std::vector< std::vector< Index > > &polygons , int &file_type , std::vector< std::string > &comments , bool *readFlags )
+	{
+		std::vector< std::string > elist;
+		float version;
+
+		PlyFile *ply = PlyFile::Read( fileName , elist , file_type , version );
+		if( !ply ) MK_THROW( "Could not create ply file for reading: " , fileName );
+
+		comments.reserve( comments.size() + ply->comments.size() );
+		for( int i=0 ; i<ply->comments.size() ; i++ ) comments.push_back( ply->comments[i] );
+
+		for( int i=0 ; i<elist.size() ; i++ )
+		{
+			std::string &elem_name = elist[i];
+			size_t num_elems;
+			std::vector< PlyProperty > plist = ply->get_element_description( elem_name , num_elems );
+			if( !plist.size() ) MK_THROW( "Could not read element properties: " , elem_name );
+			if( elem_name=="vertex" )
+			{
+				for( unsigned int i=0 ; i<vFactory.plyReadNum() ; i++)
+				{
+					PlyProperty prop;
+					if constexpr( VertexFactory::IsStaticallyAllocated() ) prop = vFactory.plyStaticReadProperty(i);
+					else                                                   prop = vFactory.plyReadProperty(i);
+					int hasProperty = ply->get_property( elem_name , &prop );
+					if( readFlags ) readFlags[i] = (hasProperty!=0);
+				}
+				vertices.resize( num_elems , vFactory() );
+				Pointer( char ) buffer = NewPointer< char >( vFactory.bufferSize() );
+				for( size_t j=0 ; j<num_elems ; j++ )
+				{
+					if constexpr( VertexFactory::IsStaticallyAllocated() ) ply->get_element( (void*)&vertices[j] );
+					else
+					{
+						ply->get_element( PointerAddress( buffer ) );
+						vFactory.fromBuffer( buffer , vertices[j] );
+					}
+				}
+				DeletePointer( buffer );
+			}
+			else if( elem_name=="face" )
+			{
+				ply->get_property( elem_name , Face< Index >::Properties );
+				polygons.resize( num_elems );
+				for( size_t j=0 ; j<num_elems ; j++ )
+				{
+					Face< Index > ply_face;
+					ply->get_element( (void *)&ply_face );
+					polygons[j].resize( ply_face.nr_vertices );
+					for( unsigned int k=0 ; k<ply_face.nr_vertices ; k++ ) polygons[j][k] = ply_face.vertices[k];
+					free( ply_face.vertices );
+				}  // for, read faces
+			}  // if face
+			else ply->get_other_element( elem_name , num_elems );
+		}  // for each type of element
+
+		delete ply;
+	}
+
+	template< typename VertexFactory , typename Index , bool UseCharIndex >
+	void WritePolygons( std::string fileName , const VertexFactory &vFactory , const std::vector< typename VertexFactory::VertexType > &vertices , const std::vector< std::vector< Index > > &polygons , int file_type , const std::vector< std::string > &comments )
+	{
+		size_t nr_vertices = vertices.size();
+		size_t nr_faces = polygons.size();
+		float version;
+		std::vector< std::string > elem_names = { std::string( "vertex" ) , std::string( "face" ) };
+		PlyFile *ply = PlyFile::Write( fileName , elem_names , file_type , version );
+		if( !ply ) MK_THROW( "Could not create ply file for writing: " , fileName );
+
+		//
+		// describe vertex and face properties
+		//
+		ply->element_count( "vertex", nr_vertices );
+		for( unsigned int i=0 ; i<vFactory.plyWriteNum() ; i++ )
+		{
+			PlyProperty prop;
+			if constexpr( VertexFactory::IsStaticallyAllocated() ) prop = vFactory.plyStaticWriteProperty(i);
+			else                                                   prop = vFactory.plyWriteProperty(i);
+			ply->describe_property( "vertex" , &prop );
+		}
+		ply->element_count( "face" , nr_faces );
+		ply->describe_property( "face" , Face< Index , UseCharIndex >::Properties );
+
+		// Write in the comments
+		for( int i=0 ; i<comments.size() ; i++ ) ply->put_comment( comments[i] );
+		ply->header_complete();
+
+		// write vertices
+		ply->put_element_setup( elem_names[0] );
+
+		Pointer( char ) buffer = NewPointer< char >( vFactory.bufferSize() );
+		for( size_t j=0 ; j<vertices.size() ; j++ )
+		{
+			if constexpr( VertexFactory::IsStaticallyAllocated() ) ply->put_element( (void *)&vertices[j] );
+			else
+			{
+				vFactory.toBuffer( vertices[j] , buffer );
+				ply->put_element( PointerAddress( buffer ) );
+			}
+		}
+		DeletePointer( buffer );
+
+		// write faces
+		Face< Index > ply_face;
+		int maxFaceVerts=3;
+		ply_face.nr_vertices = 3;
+		ply_face.vertices = new Index[3];
+
+		ply->put_element_setup( elem_names[1] );
+		for( size_t i=0 ; i<nr_faces ; i++ )
+		{
+			if( (int)polygons[i].size()>maxFaceVerts )
+			{
+				delete[] ply_face.vertices;
+				maxFaceVerts = (int)polygons[i].size();
+				ply_face.vertices=new Index[ maxFaceVerts ];
+			}
+			ply_face.nr_vertices = (int)polygons[i].size();
+			for( size_t j=0 ; j<ply_face.nr_vertices ; j++ ) ply_face.vertices[j] = polygons[i][j];
+			ply->put_element( (void *)&ply_face );
+		}
+
+		delete[] ply_face.vertices;
+		delete ply;
+	}
+
+	template< typename VertexFactory , typename Index , class Real , int Dim , typename OutputIndex , bool UseCharIndex >
+	void Write( std::string fileName , const VertexFactory &vFactory , size_t vertexNum , size_t polygonNum , InputDataStream< typename VertexFactory::VertexType > &vertexStream , InputDataStream< std::vector< Index > > &polygonStream , int file_type , const std::vector< std::string > &comments )
+	{
+		if( vertexNum>(size_t)std::numeric_limits< OutputIndex >::max() )
+		{
+			if( std::is_same< Index , OutputIndex >::value ) MK_THROW( "more vertices than can be represented using " , Traits< Index >::name );
+			MK_WARN( "more vertices than can be represented using " , Traits< OutputIndex >::name , " using " , Traits< Index >::name , " instead" );
+			return Write< VertexFactory , Index , Real , Dim , Index >( fileName , vFactory , vertexNum , polygonNum , vertexStream , polygonStream , file_type , comments );
+		}
+		float version;
+		std::vector< std::string > elem_names = { std::string( "vertex" ) , std::string( "face" ) };
+		PlyFile *ply = PlyFile::Write( fileName , elem_names , file_type , version );
+		if( !ply ) MK_THROW( "Could not create ply file for writing: " , fileName );
+
+		vertexStream.reset();
+		polygonStream.reset();
+
+		//
+		// describe vertex and face properties
+		//
+		ply->element_count( "vertex" , vertexNum );
+		for( unsigned int i=0 ; i<vFactory.plyWriteNum() ; i++ )
+		{
+			PlyProperty prop;
+			if constexpr( VertexFactory::IsStaticallyAllocated() ) prop = vFactory.plyStaticWriteProperty(i);
+			else                                                   prop = vFactory.plyWriteProperty(i);
+			ply->describe_property( "vertex" , &prop );
+		}
+		ply->element_count( "face" , polygonNum );
+		ply->describe_property( "face" , Face< OutputIndex , UseCharIndex >::Properties );
+
+		// Write in the comments
+		for( int i=0 ; i<comments.size() ; i++ ) ply->put_comment( comments[i] );
+		ply->header_complete();
+
+		// write vertices
+		ply->put_element_setup( "vertex" );
+		if constexpr( VertexFactory::IsStaticallyAllocated() )
+		{
+			for( size_t i=0; i<vertexNum ; i++ )
+			{
+				typename VertexFactory::VertexType vertex = vFactory();
+				if( !vertexStream.read( vertex ) ) MK_THROW( "Failed to read vertex " , i , " / " , vertexNum );
+				ply->put_element( (void *)&vertex );
+			}
+		}
+		else
+		{
+			Pointer( char ) buffer = NewPointer< char >( vFactory.bufferSize() );
+			for( size_t i=0; i<vertexNum ; i++ )
+			{
+				typename VertexFactory::VertexType vertex = vFactory();
+				if( !vertexStream.read( vertex ) ) MK_THROW( "Failed to read vertex " , i , " / " , vertexNum );
+				vFactory.toBuffer( vertex , buffer );
+				ply->put_element( PointerAddress( buffer ) );
+			}
+			DeletePointer( buffer );
+		}
+
+		// write faces
+		std::vector< Index > polygon;
+		ply->put_element_setup( "face" );
+		for( size_t i=0 ; i<polygonNum ; i++ )
+		{
+			//
+			// create and fill a struct that the ply code can handle
+			//
+			Face< OutputIndex > ply_face;
+			if( !polygonStream.read( polygon ) ) MK_THROW( "Failed to read polygon " , i , " / " , polygonNum ); 
+			ply_face.nr_vertices = int( polygon.size() );
+			ply_face.vertices = new OutputIndex[ polygon.size() ];
+			for( int j=0 ; j<int(polygon.size()) ; j++ ) ply_face.vertices[j] = (OutputIndex)polygon[j];
+			ply->put_element( (void *)&ply_face );
+			delete[] ply_face.vertices;
+		}  // for, write faces
+
+
+		delete ply;
+	}
+
+	template< typename VertexFactory , typename Index , class Real , int Dim , typename OutputIndex >
+	void Write( std::string fileName , const VertexFactory &vFactory , size_t vertexNum , size_t edgeNum , InputDataStream< typename VertexFactory::VertexType > &vertexStream , InputDataStream< std::pair< Index , Index > > &edgeStream , int file_type , const std::vector< std::string > &comments )
+	{
+		if( vertexNum>(size_t)std::numeric_limits< OutputIndex >::max() )
+		{
+			if( std::is_same< Index , OutputIndex >::value ) MK_THROW( "more vertices than can be represented using " , Traits< Index >::name );
+			MK_WARN( "more vertices than can be represented using " , Traits< OutputIndex >::name , " using " , Traits< Index >::name , " instead" );
+			return Write< VertexFactory , Index , Real , Dim , Index >( fileName , vFactory , vertexNum , edgeNum , vertexStream , edgeStream , file_type , comments );
+		}
+		float version;
+		std::vector< std::string > elem_names = { std::string( "vertex" ) , std::string( "edge" ) };
+		PlyFile *ply = PlyFile::Write( fileName , elem_names , file_type , version );
+		if( !ply ) MK_THROW( "Could not create ply file for writing: " , fileName );
+
+		vertexStream.reset();
+		edgeStream.reset();
+
+		//
+		// describe vertex and face properties
+		//
+		ply->element_count( "vertex" , vertexNum );
+		for( unsigned int i=0 ; i<vFactory.plyWriteNum() ; i++ )
+		{
+			PlyProperty prop;
+			if constexpr( VertexFactory::IsStaticallyAllocated() ) prop = vFactory.plyStaticWriteProperty(i);
+			else                                                   prop = vFactory.plyWriteProperty(i);
+			ply->describe_property( "vertex" , &prop );
+		}
+		ply->element_count( "edge" , edgeNum );
+		ply->describe_property( "edge" , &Edge< OutputIndex >::Properties[0] );
+		ply->describe_property( "edge" , &Edge< OutputIndex >::Properties[1] );
+
+		// Write in the comments
+		for( int i=0 ; i<comments.size() ; i++ ) ply->put_comment( comments[i] );
+		ply->header_complete();
+
+		// write vertices
+		ply->put_element_setup( "vertex" );
+		if constexpr( VertexFactory::IsStaticallyAllocated() )
+		{
+			for( size_t i=0; i<vertexNum ; i++ )
+			{
+				typename VertexFactory::VertexType vertex = vFactory();
+				if( !vertexStream.read( vertex ) ) MK_THROW( "Failed to read vertex " , i , " / " , vertexNum );
+				ply->put_element( (void *)&vertex );
+			}
+		}
+		else
+		{
+			Pointer( char ) buffer = NewPointer< char >( vFactory.bufferSize() );
+			for( size_t i=0; i<vertexNum ; i++ )
+			{
+				typename VertexFactory::VertexType vertex = vFactory();
+				if( !vertexStream.read( vertex ) ) MK_THROW( "Failed to read vertex " , i , " / " , vertexNum );
+				vFactory.toBuffer( vertex , buffer );
+				ply->put_element( PointerAddress( buffer ) );
+			}
+			DeletePointer( buffer );
+		}
+
+		// write edges
+		std::pair< Index , Index > edge;
+		ply->put_element_setup( "edge" );
+		for( size_t i=0 ; i<edgeNum ; i++ )
+		{
+			//
+			// create and fill a struct that the ply code can handle
+			//
+			Edge< OutputIndex > ply_edge;
+			if( !edgeStream.read( edge ) ) MK_THROW( "Failed to read edge " , i , " / " , edgeNum ); 
+			ply_edge.v1 = (OutputIndex)edge.first;
+			ply_edge.v2 = (OutputIndex)edge.second;
+			ply->put_element( (void *)&ply_edge );
+		}  // for, write edges
+
+		delete ply;
+	}
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/PlyFile.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PlyFile.h
@@ -1,0 +1,276 @@
+/*
+
+Header for PLY polygon files.
+
+- Greg Turk, March 1994
+
+A PLY file contains a single polygonal _object_.
+
+An object is composed of lists of _elements_.  Typical elements are
+vertices, faces, edges and materials.
+
+Each type of element for a given object has one or more _properties_
+associated with the element type.  For instance, a vertex element may
+have as properties three floating-point values x,y,z and three unsigned
+chars for red, green and blue.
+
+---------------------------------------------------------------
+
+Copyright (c) 2020, Georgia Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer. Redistributions in binary form
+must reproduce the above copyright notice, this list of conditions and the
+following disclaimer in the documentation and/or other materials provided with
+the distribution. 
+
+Neither the name of the Georgia Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef PLY_FILE_INCLUDED
+#define PLY_FILE_INCLUDED
+
+#include <string>
+#include <vector>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include <math.h>
+#include "MyMiscellany.h"
+#include "Streams.h"
+
+namespace PoissonRecon
+{
+
+#define PLY_ASCII         1      /* ascii PLY file */
+#define PLY_BINARY_BE     2      /* binary PLY file, big endian */
+#define PLY_BINARY_LE     3      /* binary PLY file, little endian */
+#define PLY_BINARY_NATIVE 4      /* binary PLY file, same endianness as current architecture */
+
+#define PLY_OKAY    0           /* ply routine worked okay */
+#define PLY_ERROR  -1           /* error in ply routine */
+
+	/* scalar data types supported by PLY format */
+
+#define PLY_START_TYPE 0
+#define PLY_CHAR       1
+#define PLY_SHORT      2
+#define PLY_INT        3
+#define PLY_LONGLONG   4
+#define PLY_UCHAR      5
+#define PLY_USHORT     6
+#define PLY_UINT       7
+#define PLY_ULONGLONG  8
+#define PLY_FLOAT      9
+#define PLY_DOUBLE     10
+#define PLY_INT_8      11
+#define PLY_UINT_8     12
+#define PLY_INT_16     13
+#define PLY_UINT_16    14
+#define PLY_INT_32     15
+#define PLY_UINT_32    16
+#define PLY_INT_64     17
+#define PLY_UINT_64    18
+#define PLY_FLOAT_32   19
+#define PLY_FLOAT_64   20
+
+#define PLY_END_TYPE   21
+
+#define  PLY_SCALAR  0
+#define  PLY_LIST    1
+
+#define PLY_STRIP_COMMENT_HEADER 0
+
+	const std::string PlyTypes[]
+	{
+		"start type" ,
+		"char" ,
+		"short" ,
+		"int" ,
+		"long long " ,
+		"unsigned char" ,
+		"unsigned short" ,
+		"unsigned int" ,
+		"unsigned long long" ,
+		"float" ,
+		"double" ,
+		"int8" ,
+		"unsigned int8" ,
+		"int16" ,
+		"unsigned int16" ,
+		"int32" ,
+		"unsigned int32" ,
+		"int64" ,
+		"unsigned int64" ,
+		"float32" ,
+		"float64"
+	};
+
+	/* description of a property */
+	struct PlyProperty
+	{
+		std::string name;                     /* property name */
+		int external_type;                    /* file's data type */
+		int internal_type;                    /* program's data type */
+		int offset;                           /* offset bytes of prop in a struct */
+
+		int is_list;                          /* 1 = list, 0 = scalar */
+		int count_external;                   /* file's count type */
+		int count_internal;                   /* program's count type */
+		int count_offset;                     /* offset byte for list count */
+
+		PlyProperty( const std::string &n , int et , int it , int o , int il=0 , int ce=0 , int ci=0 , int co=0 ) : name(n) , external_type(et) , internal_type(it) , offset(o) , is_list(il) , count_external(ce) , count_internal(ci) , count_offset(co){ }
+		PlyProperty( const std::string &n ) : PlyProperty( n , 0 , 0 , 0 , 0 , 0 , 0 , 0 ){ }
+		PlyProperty( void ) : external_type(0) , internal_type(0) , offset(0) , is_list(0) , count_external(0) , count_internal(0) , count_offset(0){ }
+
+		void write( BinaryStream &stream ) const
+		{
+			stream.write( name );
+			stream.write( external_type );
+			stream.write( offset );
+			stream.write( is_list );
+			stream.write( count_external );
+			stream.write( count_internal );
+			stream.write( count_offset );
+		}
+		void read( BinaryStream &stream )
+		{
+			if( !stream.read( name ) ) MK_THROW( "Failed to read name" );
+			if( !stream.read( external_type ) ) MK_THROW( "Failed to read external_type" );
+			if( !stream.read( offset ) ) MK_THROW( "Failed to read offset" );
+			if( !stream.read( is_list ) ) MK_THROW( "Failed to read is_list" );
+			if( !stream.read( count_external ) ) MK_THROW( "Failed to read count_external" );
+			if( !stream.read( count_internal ) ) MK_THROW( "Failed to read count_internal" );
+			if( !stream.read( count_offset ) ) MK_THROW( "Failed to read count_offset" );
+		}
+	};
+
+	inline std::ostream &operator << ( std::ostream &os , PlyProperty p )
+	{
+		if( p.is_list ) return os << "{ " << p.name << " , " << PlyTypes[ p.count_external ] << " -> " << PlyTypes[ p.count_internal ] << " , " << PlyTypes[ p.external_type ] << " -> " << PlyTypes[ p.internal_type ] << " , " << p.offset << " }";
+		else            return os << "{ " << p.name << " , " <<                                                                                    PlyTypes[ p.external_type ] << " -> " << PlyTypes[ p.internal_type ] << " , " << p.offset << " }";
+	}
+
+	struct PlyStoredProperty
+	{
+		PlyProperty prop ; char store;
+		PlyStoredProperty( void ){ }
+		PlyStoredProperty( const PlyProperty &p , char s ) : prop(p) , store(s){ }
+	};
+
+	/* description of an element */
+	struct PlyElement
+	{
+		std::string name;             /* element name */
+		size_t num;                   /* number of elements in this object */
+		int size;                     /* size of element (bytes) or -1 if variable */
+		std::vector< PlyStoredProperty > props; /* list of properties in the file */
+		int other_offset;             /* offset to un-asked-for props, or -1 if none*/
+		int other_size;               /* size of other_props structure */
+		inline PlyProperty *find_property( const std::string &prop_name , int &index );
+	};
+
+	/* describes other properties in an element */
+	struct PlyOtherProp
+	{
+		std::string name;                   /* element name */
+		int size;                           /* size of other_props */
+		std::vector< PlyProperty > props;   /* list of properties in other_props */
+	};
+
+	/* storing other_props for an other element */
+	struct OtherData
+	{
+		void *other_props;
+		OtherData( void ) : other_props(NULL){ }
+		~OtherData( void ){ if( other_props ) free( other_props ); }
+	};
+
+	/* data for one "other" element */
+	struct OtherElem
+	{
+		std::string elem_name;                /* names of other elements */
+		std::vector< OtherData > other_data;  /* actual property data for the elements */
+		PlyOtherProp other_props;             /* description of the property data */
+	};
+
+	/* "other" elements, not interpreted by user */
+	struct PlyOtherElems
+	{
+		std::vector< OtherElem > other_list; /* list of data for other elements */
+	};
+
+	/* description of PLY file */
+	struct PlyFile
+	{
+		FILE *fp;                            /* file pointer */
+		int file_type;                       /* ascii or binary */
+		float version;                       /* version number of file */
+		std::vector< PlyElement > elems;     /* list of elements of object */
+		std::vector< std::string > comments; /* list of comments */
+		std::vector< std::string > obj_info; /* list of object info items */
+		PlyElement *which_elem;              /* which element we're currently writing */
+		PlyOtherElems *other_elems;         /* "other" elements from a PLY file */
+
+		static inline PlyFile *Write( const std::string & , const std::vector< std::string > & , int   , float & );
+		static inline PlyFile *Read ( const std::string & ,       std::vector< std::string > & , int & , float & );
+
+		PlyFile( FILE *f ) : fp(f) , other_elems(NULL) , version(1.) { }
+		~PlyFile( void ){ if( fp ) fclose(fp) ; if(other_elems) delete other_elems; }
+
+		inline void describe_element ( const std::string & , size_t , int , const PlyProperty * );
+		inline void describe_property( const std::string & , const PlyProperty * );
+		inline void describe_other_elements( PlyOtherElems * );
+		inline PlyElement *find_element( const std::string & );
+		inline void element_count( const std::string & , size_t );
+		inline void header_complete( void );
+		inline void put_element_setup( const std::string & );
+		inline void put_element ( void * );
+		inline void put_comment ( const std::string & );
+		inline void put_obj_info( const std::string & );
+		inline void put_other_elements( void );
+		inline void add_element ( const std::vector< std::string > & );
+		inline void add_property( const std::vector< std::string > & );
+		inline void add_comment ( const std::string & );
+		inline void add_obj_info( const std::string & );
+
+		inline std::vector< PlyProperty > get_element_description( const std::string & , size_t & );
+		inline void get_element_setup( const std::string & , int , PlyProperty * );
+		inline int get_property( const std::string & , const PlyProperty * );
+		inline void describe_other_properties( const PlyOtherProp & , int );
+		inline bool set_other_properties( const std::string & , int , PlyOtherProp & );
+		inline void get_element( void * );
+		inline std::vector< std::string > &get_comments( void );
+		inline std::vector< std::string > &get_obj_info( void );
+		inline void get_info( float & , int & );
+		inline PlyOtherElems *get_other_element( std::string & , size_t );
+	protected:
+		inline void _ascii_get_element ( void * );
+		inline void _binary_get_element( void * );
+		static inline PlyFile *_Write( FILE * , const std::vector< std::string > & , int );
+		static inline PlyFile *_Read ( FILE * ,       std::vector< std::string > & );
+	};
+
+#include "PlyFile.inl"
+}
+#endif // PLY_FILE_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/PlyFile.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PlyFile.inl
@@ -1,0 +1,1991 @@
+/*
+
+The interface routines for reading and writing PLY polygon files.
+
+Greg Turk, February 1994
+
+---------------------------------------------------------------
+
+A PLY file contains a single polygonal _object_.
+
+An object is composed of lists of _elements_.  Typical elements are
+vertices, faces, edges and materials.
+
+Each type of element for a given object has one or more _properties_
+associated with the element type.  For instance, a vertex element may
+have as properties the floating-point values x,y,z and the three unsigned
+chars representing red, green and blue.
+
+---------------------------------------------------------------
+
+Copyright (c) 2020, Georgia Institute of Technology
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer. Redistributions in binary form
+must reproduce the above copyright notice, this list of conditions and the
+following disclaimer in the documentation and/or other materials provided with
+the distribution. 
+
+Neither the name of the Georgia Institute of Technology nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+static const char *type_names[] =
+{
+	"invalid",
+	"char",
+	"short",
+	"int",
+	"longlong",
+	"uchar",
+	"ushort",
+	"uint",
+	"ulonglong",
+	"float",
+	"double",
+	"int8",       // character                 1
+	"uint8",      // unsigned character        1
+	"int16",      // short integer             2
+	"uint16",     // unsigned short integer    2
+	"int32",      // integer                   4
+	"uint32",     // unsigned integer          4
+	"int64",      // integer                   8
+	"uint64",     // unsigned integer          8
+	"float32",    // single-precision float    4
+	"float64",    // double-precision float    8
+};
+
+static const int ply_type_size[] =
+{
+	0,
+	1,
+	2,
+	4,
+	8,
+	1,
+	2,
+	4,
+	8,
+	4,
+	8,
+	1,
+	1,
+	2,
+	2,
+	4,
+	4,
+	8,
+	8,
+	4,
+	8
+};
+
+typedef union
+{
+	int  int_value;
+	char byte_values[sizeof(int)];
+} endian_test_type;
+
+
+static int native_binary_type = -1;
+static int types_checked = 0;
+
+static const int no_other_props = -1;
+
+static const int dont_store_prop = 0;
+static const int      store_prop = 1;
+
+static const int other_prop = 0;
+static const int named_prop = 1;
+
+
+/* write to a file the word describing a PLY file data type */
+inline void write_scalar_type( FILE * , int );
+
+/* read a line from a file and break it up into separate words */
+inline std::vector< std::string > get_words( FILE * , char ** );
+
+/* write to a file the word describing a PLY file data type */
+inline void write_scalar_type( FILE * , int );
+
+/* write an item to a file */
+inline void write_binary_item( FILE * , int , int , unsigned int , long long , unsigned long long , double , int );
+inline void write_ascii_item ( FILE * ,       int , unsigned int , long long , unsigned long long , double , int );
+
+/* store a value into where a pointer and a type specify */
+inline void store_item( void * , int , int , unsigned int , long long , unsigned long long , double );
+
+/* return the value of a stored item */
+inline void get_stored_item( void * , int , int & , unsigned int & , long long & , unsigned long long & , double & );
+
+/* return the value stored in an item, given ptr to it and its type */
+inline double get_item_value( const void * , int );
+
+/* get binary or ascii item and store it according to ptr and type */
+inline void get_ascii_item( const std::string & , int , int & , unsigned int & , long long & , unsigned long long & , double & );
+inline void get_binary_item( FILE * , int       , int , int & , unsigned int & , long long & , unsigned long long & , double & );
+
+/* byte ordering */
+inline void get_native_binary_type();
+inline void swap_bytes( void * , int );
+
+inline void check_types( void );
+
+inline int get_prop_type( const std::string &type_name );
+inline void setup_other_props( PlyElement *elem );
+
+/*************/
+/*  Writing  */
+/*************/
+
+
+/******************************************************************************
+Given a file pointer, get ready to write PLY data to the file.
+
+Entry:
+fp         - the given file pointer
+nelems     - number of elements in object
+elem_names - list of element names
+file_type  - file type, either ascii or binary
+
+Exit:
+returns a pointer to a PlyFile, used to refer to this file, or NULL if error
+******************************************************************************/
+
+PlyFile *PlyFile::_Write( FILE *fp , const std::vector< std::string > &elem_names , int file_type )
+{
+	/* check for NULL file pointer */
+	if( fp==NULL ) return NULL;
+
+	if( native_binary_type==-1 ) get_native_binary_type();
+	if( !types_checked ) check_types();
+
+	/* create a record for this object */
+
+	PlyFile *plyfile = new PlyFile( fp );
+	if( file_type==PLY_BINARY_NATIVE ) plyfile->file_type = native_binary_type;
+	else                               plyfile->file_type = file_type;
+
+	/* tuck aside the names of the elements */
+	plyfile->elems.resize( elem_names.size() );
+	for( int i=0 ; i<elem_names.size() ; i++ )
+	{
+		plyfile->elems[i].name = elem_names[i];
+		plyfile->elems[i].num =  0;
+	}
+
+	/* return pointer to the file descriptor */
+	return plyfile;
+}
+
+
+/******************************************************************************
+Open a polygon file for writing.
+
+Entry:
+filename   - name of file to read from
+nelems     - number of elements in object
+elem_names - list of element names
+file_type  - file type, either ascii or binary
+
+Exit:
+version - version number of PLY file
+returns a file identifier, used to refer to this file, or NULL if error
+******************************************************************************/
+
+PlyFile *PlyFile::Write( const std::string &filename , const std::vector< std::string > &elem_names , int file_type , float &version )
+{
+	/* tack on the extension .ply, if necessary */
+	std::string name = filename;
+	if( name.length()<4 || name.substr( name.length()-4 )!=".ply" ) name += ".ply";
+
+	/* open the file for writing */
+	FILE *fp = fopen( name.c_str() , "wb" );
+	if( fp==NULL ) return NULL;
+
+	/* create the actual PlyFile structure */
+	PlyFile *plyfile = _Write( fp , elem_names , file_type );
+
+	/* say what PLY file version number we're writing */
+	version = plyfile->version;
+
+	/* return pointer to the file descriptor */
+	return plyfile;
+}
+
+
+/******************************************************************************
+Describe an element, including its properties and how many will be written
+to the file.
+
+Entry:
+elem_name - name of element that information is being specified about
+nelems    - number of elements of this type to be written
+nprops    - number of properties contained in the element
+prop_list - list of properties
+******************************************************************************/
+
+void PlyFile::describe_element( const std::string &elem_name , size_t nelems , int nprops , const PlyProperty *prop_list )
+{
+	/* look for appropriate element */
+	PlyElement *elem = find_element( elem_name );
+	if( elem==NULL ) MK_THROW( "Can't find element '" , elem_name , "'" );
+
+	elem->num = nelems;
+
+	/* copy the list of properties */
+	elem->props.resize( nprops );
+	for( int i=0 ; i<nprops ; i++ ) elem->props[i] = PlyStoredProperty( prop_list[i] , named_prop );
+}
+
+
+/******************************************************************************
+Describe a property of an element.
+
+Entry:
+elem_name - name of element that information is being specified about
+prop      - the new property
+******************************************************************************/
+
+void PlyFile::describe_property( const std::string &elem_name , const PlyProperty *prop )
+{
+	/* look for appropriate element */
+	PlyElement *elem = find_element( elem_name );
+	if( elem == NULL )
+	{
+		MK_WARN( "Can't find element '" , elem_name , "'" );
+		return;
+	}
+
+	elem->props.push_back( PlyStoredProperty( *prop , named_prop ) );
+}
+
+
+/******************************************************************************
+Describe what the "other" properties are that are to be stored, and where
+they are in an element.
+******************************************************************************/
+
+void PlyFile::describe_other_properties( const PlyOtherProp &other , int offset )
+{
+	/* look for appropriate element */
+	PlyElement *elem = find_element( other.name );
+	if( elem==NULL )
+	{
+		MK_WARN( "Can't find element '" , other.name , "'" );
+		return;
+	}
+
+	elem->props.reserve( elem->props.size() + other.props.size() );
+	for( int i=0 ; i<other.props.size() ; i++ ) elem->props.push_back( PlyStoredProperty( other.props[i] , other_prop ) );
+
+	/* save other info about other properties */
+	elem->other_size = other.size;
+	elem->other_offset = offset;
+}
+
+
+/******************************************************************************
+State how many of a given element will be written.
+
+Entry:
+elem_name - name of element that information is being specified about
+nelems    - number of elements of this type to be written
+******************************************************************************/
+void PlyFile::element_count( const std::string &elem_name , size_t nelems )
+{
+	/* look for appropriate element */
+	PlyElement *elem = find_element( elem_name );
+	if( elem==NULL ) MK_THROW( "Can't find element '" , elem_name , "'" );
+
+	elem->num = nelems;
+}
+
+
+/******************************************************************************
+Signal that we've described everything a PLY file's header and that the
+header should be written to the file.
+******************************************************************************/
+
+void PlyFile::header_complete( void )
+{
+	fprintf( fp , "ply\n" );
+	switch( file_type )
+	{
+	case PLY_ASCII: fprintf( fp , "format ascii 1.0\n" )                    ; break;
+	case PLY_BINARY_BE: fprintf( fp , "format binary_big_endian 1.0\n" )    ; break;
+	case PLY_BINARY_LE: fprintf( fp , "format binary_little_endian 1.0\n" ) ; break;
+	default: MK_THROW( "Bad file type: " , file_type );
+	}
+
+	/* write out the comments */
+	for( int i=0 ; i<comments.size() ; i++ ) fprintf( fp , "comment %s\n" , comments[i].c_str() );
+
+	/* write out object information */
+	for( int i=0 ; i<obj_info.size() ; i++ ) fprintf( fp , "obj_info %s\n" , obj_info[i].c_str() );
+
+	/* write out information about each element */
+	for( int i=0 ; i<elems.size() ; i++ )
+	{
+		fprintf( fp , "element %s %llu\n" , elems[i].name.c_str() , (unsigned long long)elems[i].num );
+
+		for( int j=0 ; j<elems[i].props.size() ; j++ )
+		{
+			if( elems[i].props[j].prop.is_list )
+			{
+				fprintf( fp , "property list " );
+				write_scalar_type( fp , elems[i].props[j].prop.count_external );
+				fprintf( fp , " " );
+				write_scalar_type( fp , elems[i].props[j].prop.external_type );
+				fprintf( fp , " %s\n", elems[i].props[j].prop.name.c_str() );
+			}
+			else
+			{
+				fprintf( fp , "property " );
+				write_scalar_type( fp , elems[i].props[j].prop.external_type );
+				fprintf( fp , " %s\n", elems[i].props[j].prop.name.c_str() );
+			}
+		}
+	}
+
+	fprintf( fp , "end_header\n" );
+}
+
+
+/******************************************************************************
+Specify which elements are going to be written.  This should be called
+before a call to the routine ply_put_element().
+
+Entry:
+elem_name - name of element we're talking about
+******************************************************************************/
+
+void PlyFile::put_element_setup( const std::string &elem_name )
+{
+	PlyElement *elem = find_element( elem_name );
+	if( elem==NULL ) MK_THROW( "Can't find element '" , elem_name , "'" );
+	which_elem = elem;
+}
+
+
+/******************************************************************************
+Write an element to the file.  This routine assumes that we're
+writing the type of element specified in the last call to the routine
+ply_put_element_setup().
+
+Entry:
+elem_ptr - pointer to the element
+******************************************************************************/
+
+void PlyFile::put_element( void *elem_ptr )
+{
+	char *elem_data,*item;
+	char **item_ptr;
+	int list_count;
+	int item_size;
+	int int_val;
+	unsigned int uint_val;
+	long long longlong_val;
+	unsigned long long ulonglong_val;
+	double double_val;
+	char **other_ptr;
+
+	PlyElement *elem = which_elem;
+	elem_data = (char *)elem_ptr;
+	other_ptr = (char **) (((char *) elem_ptr) + elem->other_offset);
+
+	/* write out either to an ascii or binary file */
+
+	if( file_type==PLY_ASCII )	/* write an ascii file */
+	{
+		/* write out each property of the element */
+		for( int j=0 ; j<elem->props.size() ; j++ )
+		{
+			if( elem->props[j].store==other_prop ) elem_data = *other_ptr;
+			else                                   elem_data = (char *)elem_ptr;
+			if( elem->props[j].prop.is_list )
+			{
+				item = elem_data + elem->props[j].prop.count_offset;
+				get_stored_item( (void *)item , elem->props[j].prop.count_internal , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+				write_ascii_item( fp , int_val , uint_val , longlong_val , ulonglong_val , double_val , elem->props[j].prop.count_external );
+				list_count = uint_val;
+				item_ptr = (char **)( elem_data + elem->props[j].prop.offset );
+				item = item_ptr[0];
+				item_size = ply_type_size[ elem->props[j].prop.internal_type ];
+				for( int k=0 ; k<list_count ; k++ )
+				{
+					get_stored_item( (void *)item , elem->props[j].prop.internal_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+					write_ascii_item( fp , int_val , uint_val , longlong_val , ulonglong_val , double_val , elem->props[j].prop.external_type );
+					item += item_size;
+				}
+			}
+			else
+			{
+				item = elem_data + elem->props[j].prop.offset;
+				get_stored_item( (void *)item , elem->props[j].prop.internal_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+				write_ascii_item( fp , int_val , uint_val , longlong_val , ulonglong_val , double_val , elem->props[j].prop.external_type );
+			}
+		}
+		fprintf( fp , "\n" );
+	}
+	else		/* write a binary file */
+	{
+		/* write out each property of the element */
+		for( int j=0 ; j<elem->props.size() ; j++ )
+		{
+			if (elem->props[j].store==other_prop ) elem_data = *other_ptr;
+			else                                   elem_data = (char *)elem_ptr;
+			if( elem->props[j].prop.is_list )
+			{
+				item = elem_data + elem->props[j].prop.count_offset;
+				item_size = ply_type_size[ elem->props[j].prop.count_internal ];
+				get_stored_item( (void *)item , elem->props[j].prop.count_internal , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+				write_binary_item( fp , file_type , int_val , uint_val , longlong_val , ulonglong_val , double_val , elem->props[j].prop.count_external );
+				list_count = uint_val;
+				item_ptr = (char **)( elem_data + elem->props[j].prop.offset );
+				item = item_ptr[0];
+				item_size = ply_type_size[ elem->props[j].prop.internal_type ];
+				for( int k=0 ; k<list_count ; k++ )
+				{
+					get_stored_item( (void *)item , elem->props[j].prop.internal_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+					write_binary_item( fp , file_type , int_val , uint_val , longlong_val , ulonglong_val , double_val , elem->props[j].prop.external_type );
+					item += item_size;
+				}
+			}
+			else
+			{
+				item = elem_data + elem->props[j].prop.offset;
+				item_size = ply_type_size[ elem->props[j].prop.internal_type ];
+				get_stored_item( (void *)item , elem->props[j].prop.internal_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+				write_binary_item( fp , file_type , int_val , uint_val , longlong_val , ulonglong_val , double_val , elem->props[j].prop.external_type );
+			}
+		}
+	}
+}
+
+
+/******************************************************************************
+Specify a comment that will be written in the header.
+
+Entry:
+comment - the comment to be written
+******************************************************************************/
+
+void PlyFile::put_comment( const std::string &comment ){ comments.push_back( comment ); }
+
+
+/******************************************************************************
+Specify a piece of object information (arbitrary text) that will be written
+in the header.
+
+Entry:
+obj_info - the text information to be written
+******************************************************************************/
+
+void PlyFile::put_obj_info( const std::string &obj_info ){ this->obj_info.push_back( obj_info ); }
+
+
+/*************/
+/*  Reading  */
+/*************/
+
+
+
+/******************************************************************************
+Given a file pointer, get ready to read PLY data from the file.
+
+Entry:
+fp - the given file pointer
+
+Exit:
+nelems     - number of elements in object
+elem_names - list of element names
+returns a pointer to a PlyFile, used to refer to this file, or NULL if error
+******************************************************************************/
+
+PlyFile *PlyFile::_Read( FILE *fp , std::vector< std::string > &elem_names )
+{
+	char *orig_line;
+	/* check for NULL file pointer */
+	if( fp==NULL ) return NULL;
+
+	if( native_binary_type==-1 ) get_native_binary_type();
+	if( !types_checked ) check_types();
+
+	/* create record for this object */
+	std::vector< std::string > words;
+	PlyFile *plyfile = new PlyFile( fp );
+
+	/* read and parse the file's header */
+	words = get_words( plyfile->fp , &orig_line );
+	if( !words.size() || words[0]!="ply" ) return NULL;
+	while( words.size() )
+	{
+		/* parse words */
+		if( words[0]=="format" )
+		{
+			if( words.size()!=3 ) return NULL;
+			if     ( words[1]=="ascii"                ) plyfile->file_type = PLY_ASCII;
+			else if( words[1]=="binary_big_endian"    ) plyfile->file_type = PLY_BINARY_BE;
+			else if( words[1]=="binary_little_endian" ) plyfile->file_type = PLY_BINARY_LE;
+			else return NULL;
+			plyfile->version = (float)atof( words[2].c_str() );
+		}
+		else if( words[0]=="element"    ) plyfile->add_element ( words );
+		else if( words[0]=="property"   ) plyfile->add_property( words );
+		else if( words[0]=="comment"    ) plyfile->add_comment ( orig_line );
+		else if( words[0]=="obj_info"   ) plyfile->add_obj_info( orig_line );
+		else if( words[0]=="end_header" ) break;
+
+		words = get_words( plyfile->fp , &orig_line );
+	}
+
+	/* create tags for each property of each element, to be used */
+	/* later to say whether or not to store each property for the user */
+	for( int i=0 ; i<plyfile->elems.size() ; i++ )
+	{
+		for( int j=0 ; j<plyfile->elems[i].props.size() ; j++ ) plyfile->elems[i].props[j].store = dont_store_prop;
+		plyfile->elems[i].other_offset = no_other_props; /* no "other" props by default */
+	}
+
+	/* set return values about the elements */
+	elem_names.resize( plyfile->elems.size() );
+	for( int i=0 ; i<elem_names.size() ; i++ ) elem_names[i] = plyfile->elems[i].name;
+
+	/* return a pointer to the file's information */
+	return plyfile;
+}
+
+
+/******************************************************************************
+Open a polygon file for reading.
+
+Entry:
+filename - name of file to read from
+
+Exit:
+nelems     - number of elements in object
+elem_names - list of element names
+file_type  - file type, either ascii or binary
+version    - version number of PLY file
+returns a file identifier, used to refer to this file, or NULL if error
+******************************************************************************/
+
+PlyFile *PlyFile::Read( const std::string &filename , std::vector< std::string > &elem_names , int &file_type , float &version )
+{
+	/* tack on the extension .ply, if necessary */
+	std::string name = filename;
+	if( name.length()<4 || name.substr( name.length()-4 )!=".ply" ) name += ".ply";
+
+	/* open the file for reading */
+	FILE *fp = fopen( name.c_str() , "rb" );
+	if( fp==NULL ) return NULL;
+
+	/* create the PlyFile data structure */
+	PlyFile *plyfile = _Read( fp , elem_names );
+
+	/* determine the file type and version */
+	file_type = plyfile->file_type;
+	version = plyfile->version;
+
+	/* return a pointer to the file's information */
+	return plyfile;
+}
+
+
+/******************************************************************************
+Get information about a particular element.
+
+Entry:
+elem_name - name of element to get information about
+
+Exit:
+nelems   - number of elements of this type in the file
+nprops   - number of properties
+returns a list of properties, or NULL if the file doesn't contain that elem
+******************************************************************************/
+
+std::vector< PlyProperty > PlyFile::get_element_description( const std::string &elem_name , size_t &nelems )
+{
+	std::vector< PlyProperty > prop_list;
+
+	/* find information about the element */
+	PlyElement *elem = find_element( elem_name );
+	if( elem==NULL ) return prop_list;
+	nelems = elem->num;
+
+	/* make a copy of the element's property list */
+	prop_list.resize( elem->props.size() );
+	for( int i=0 ; i<elem->props.size() ; i++ ) prop_list[i] = elem->props[i].prop;
+
+	/* return this duplicate property list */
+	return prop_list;
+}
+
+/******************************************************************************
+Specify which properties of an element are to be returned.  This should be
+called before a call to the routine ply_get_element().
+
+Entry:
+elem_name - which element we're talking about
+nprops    - number of properties
+prop_list - list of properties
+******************************************************************************/
+
+void PlyFile::get_element_setup( const std::string &elem_name , int nprops , PlyProperty *prop_list )
+{
+	/* find information about the element */
+	PlyElement *elem = find_element( elem_name );
+	which_elem = elem;
+
+	/* deposit the property information into the element's description */
+	for( int i=0 ; i<nprops ; i++ )
+	{
+		/* look for actual property */
+		int index;
+		PlyProperty *prop = elem->find_property( prop_list[i].name , index );
+		if( prop==NULL )
+		{
+			MK_WARN( "Can't find property '" , prop_list[i].name , "' in element '" , elem_name , "'" );
+			continue;
+		}
+
+		/* store its description */
+		prop->internal_type = prop_list[i].internal_type;
+		prop->offset = prop_list[i].offset;
+		prop->count_internal = prop_list[i].count_internal;
+		prop->count_offset = prop_list[i].count_offset;
+
+		/* specify that the user wants this property */
+		elem->props[index].store = store_prop;
+	}
+}
+
+
+/******************************************************************************
+Specify a property of an element that is to be returned.  This should be
+called (usually multiple times) before a call to the routine ply_get_element().
+This routine should be used in preference to the less flexible old routine
+called ply_get_element_setup().
+
+Entry:
+elem_name - which element we're talking about
+prop      - property to add to those that will be returned
+******************************************************************************/
+
+int PlyFile::get_property( const std::string &elem_name , const PlyProperty *prop )
+{
+	/* find information about the element */
+	PlyElement *elem = find_element( elem_name );
+	which_elem = elem;
+
+	/* deposit the property information into the element's description */
+	int index;
+	PlyProperty *prop_ptr = elem->find_property( prop->name , index );
+	if( prop_ptr==NULL ) return 0;
+	prop_ptr->internal_type  = prop->internal_type;
+	prop_ptr->offset         = prop->offset;
+	prop_ptr->count_internal = prop->count_internal;
+	prop_ptr->count_offset   = prop->count_offset;
+
+	/* specify that the user wants this property */
+	elem->props[index].store = store_prop;
+
+	return 1;
+}
+
+
+/******************************************************************************
+Read one element from the file.  This routine assumes that we're reading
+the type of element specified in the last call to the routine
+ply_get_element_setup().
+
+Entry:
+elem_ptr - pointer to location where the element information should be put
+******************************************************************************/
+
+void PlyFile::get_element( void *elem_ptr )
+{
+	if( file_type==PLY_ASCII ) _ascii_get_element( elem_ptr );
+	else                      _binary_get_element( elem_ptr );
+}
+
+/******************************************************************************
+Extract the comments from the header information of a PLY file.
+
+Exit:
+num_comments - number of comments returned
+returns a pointer to a list of comments
+******************************************************************************/
+
+std::vector< std::string > &PlyFile::get_comments( void ){ return comments; }
+
+/******************************************************************************
+Extract the object information (arbitrary text) from the header information
+of a PLY file.
+
+Exit:
+num_obj_info - number of lines of text information returned
+returns a pointer to a list of object info lines
+******************************************************************************/
+std::vector< std::string > &PlyFile::get_obj_info( void ){ return obj_info; }
+
+/******************************************************************************
+Make ready for "other" properties of an element-- those properties that
+the user has not explicitly asked for, but that are to be stashed away
+in a special structure to be carried along with the element's other
+information.
+
+Entry:
+elem    - element for which we want to save away other properties
+******************************************************************************/
+
+void setup_other_props( PlyElement *elem )
+{
+	int size = 0;
+
+	/* Examine each property in decreasing order of size. */
+	/* We do this so that all data types will be aligned by */
+	/* word, half-word, or whatever within the structure. */
+
+	for( int type_size=8 ; type_size>0 ; type_size/=2 )
+	{
+
+		/* add up the space taken by each property, and save this information */
+		/* away in the property descriptor */
+		for( int i=0 ; i<elem->props.size() ; i++ )
+		{
+			/* don't bother with properties we've been asked to store explicitly */
+			if( elem->props[i].store ) continue;
+			PlyProperty &prop = elem->props[i].prop;
+
+			/* internal types will be same as external */
+			prop.internal_type = prop.external_type;
+			prop.count_internal = prop.count_external;
+
+			/* check list case */
+			if( prop.is_list )
+			{
+				/* pointer to list */
+				if( type_size==sizeof(void *) )
+				{
+					prop.offset = size;
+					size += sizeof( void * );    /* always use size of a pointer here */
+				}
+
+				/* count of number of list elements */
+				if( type_size==ply_type_size[ prop.count_external ] )
+				{
+					prop.count_offset = size;
+					size += ply_type_size[ prop.count_external ];
+				}
+			}
+			/* not list */
+			else if( type_size==ply_type_size[ prop.external_type ] )
+			{
+				prop.offset = size;
+				size += ply_type_size[ prop.external_type ];
+			}
+		}
+	}
+
+	/* save the size for the other_props structure */
+	elem->other_size = size;
+}
+
+
+/******************************************************************************
+Specify that we want the "other" properties of an element to be tucked
+away within the user's structure.  The user needn't be concerned for how
+these properties are stored.
+
+Entry:
+elem_name - name of element that we want to store other_props in
+offset    - offset to where other_props will be stored inside user's structure
+
+Exit:
+returns pointer to structure containing description of other_props
+******************************************************************************/
+
+bool PlyFile::set_other_properties( const std::string &elem_name , int offset , PlyOtherProp &other )
+{
+	/* find information about the element */
+	PlyElement *elem = find_element( elem_name );
+	if( elem==NULL )
+	{
+		MK_WARN( "Can't find element '" , elem_name , "'" );
+		return false;
+	}
+
+	/* remember that this is the "current" element */
+	which_elem = elem;
+
+	/* save the offset to where to store the other_props */
+	elem->other_offset = offset;
+
+	/* place the appropriate pointers, etc. in the element's property list */
+	setup_other_props( elem );
+
+	/* create structure for describing other_props */
+	other.size = elem->other_size;
+	other.props.reserve( elem->props.size() );
+	for( int i=0 ; i<elem->props.size() ; i++ ) if( !elem->props[i].store ) other.props.push_back( elem->props[i].prop );
+
+	/* set other_offset pointer appropriately if there are NO other properties */
+	if( !other.props.size() ) elem->other_offset = no_other_props;
+	return true;
+}
+
+/*************************/
+/*  Other Element Stuff  */
+/*************************/
+
+
+
+
+/******************************************************************************
+Grab all the data for an element that a user does not want to explicitly
+read in.
+
+Entry:
+elem_name  - name of element whose data is to be read in
+elem_count - number of instances of this element stored in the file
+
+Exit:
+returns pointer to ALL the "other" element data for this PLY file
+******************************************************************************/
+
+PlyOtherElems *PlyFile::get_other_element( std::string &elem_name , size_t elem_count )
+{
+	/* look for appropriate element */
+	PlyElement *elem = find_element( elem_name );
+	if( elem==NULL ) MK_THROW( "Can't find element '" , elem_name , "'" );
+
+	if( other_elems==NULL ) other_elems = new PlyOtherElems();
+	other_elems->other_list.resize( other_elems->other_list.size()+1 );
+	OtherElem *other = &other_elems->other_list.back();
+
+	/* save name of element */
+	other->elem_name = elem_name;
+
+	/* create a list to hold all the current elements */
+	other->other_data.resize( elem_count );
+
+	/* set up for getting elements */
+	set_other_properties( elem_name , offsetof( OtherData , other_props ) , other->other_props );
+
+	/* grab all these elements */
+	for( int i=0 ; i<other->other_data.size() ; i++ )
+	{
+		/* grab and element from the file */
+		get_element( (void *)&other->other_data[i] );
+	}
+
+	/* return pointer to the other elements data */
+	return other_elems;
+}
+
+
+/******************************************************************************
+Pass along a pointer to "other" elements that we want to save in a given
+PLY file.  These other elements were presumably read from another PLY file.
+
+Entry:
+other_elems - info about other elements that we want to store
+******************************************************************************/
+
+void PlyFile::describe_other_elements( PlyOtherElems *other_elems )
+{
+	/* ignore this call if there is no other element */
+	if( other_elems==NULL ) return;
+
+	/* save pointer to this information */
+	this->other_elems = other_elems;
+
+	/* describe the other properties of this element */
+	/* store them in the main element list as elements with
+	only other properties */
+
+	elems.reserve( elems.size() + other_elems->other_list.size() );
+	for( int i=0 ; i<other_elems->other_list.size() ; i++ )
+	{
+		PlyElement elem;
+		elem.name = other_elems->other_list[i].elem_name;
+		elem.num = other_elems->other_list[i].other_data.size();
+		elem.props.resize(0);
+		describe_other_properties( other_elems->other_list[i].other_props , offsetof( OtherData , other_props ) );
+		elems.push_back( elem );
+	}
+}
+
+
+/******************************************************************************
+Write out the "other" elements specified for this PLY file.
+******************************************************************************/
+
+void PlyFile::put_other_elements( void )
+{
+	OtherElem *other;
+
+	/* make sure we have other elements to write */
+	if( other_elems==NULL ) return;
+
+	/* write out the data for each "other" element */
+	for( int i=0 ; i<other_elems->other_list.size() ; i++ )
+	{
+		other = &(other_elems->other_list[i]);
+		put_element_setup( other->elem_name );
+
+		/* write out each instance of the current element */
+		for( int j=0 ; j<other->other_data.size() ; j++ ) put_element( (void *)&other->other_data[j] );
+	}
+}
+
+/*******************/
+/*  Miscellaneous  */
+/*******************/
+
+/******************************************************************************
+Get version number and file type of a PlyFile.
+
+Exit:
+version - version of the file
+file_type - PLY_ASCII, PLY_BINARY_BE, or PLY_BINARY_LE
+******************************************************************************/
+
+void PlyFile::get_info( float &version, int &file_type ){ version = this->version , file_type = this->file_type; }
+
+/******************************************************************************
+Find an element from the element list of a given PLY object.
+
+Entry:
+element - name of element we're looking for
+
+Exit:
+returns the element, or NULL if not found
+******************************************************************************/
+
+PlyElement *PlyFile::find_element( const std::string &element )
+{
+	for( int i=0 ; i<elems.size() ; i++ ) if( element==elems[i].name ) return &elems[i];
+	return NULL;
+}
+
+
+/******************************************************************************
+Find a property in the list of properties of a given element.
+
+Entry:
+elem      - pointer to element in which we want to find the property
+prop_name - name of property to find
+
+Exit:
+index - index to position in list
+returns a pointer to the property, or NULL if not found
+******************************************************************************/
+
+PlyProperty *PlyElement::find_property( const std::string &prop_name , int &index )
+{
+	for( int i=0 ; i<props.size() ; i++ ) if( prop_name==props[i].prop.name ){ index = i ; return &props[i].prop; }
+	index = -1;
+	return NULL;
+}
+
+/******************************************************************************
+Read an element from an ascii file.
+
+Entry:
+elem_ptr - pointer to element
+******************************************************************************/
+
+void PlyFile::_ascii_get_element( void *elem_ptr )
+{
+	std::vector< std::string > words;
+	PlyElement *elem;
+	int which_word;
+	void *elem_data , *item=NULL;
+	char *item_ptr;
+	int item_size;
+	int int_val;
+	unsigned int uint_val;
+	long long longlong_val;
+	unsigned long long ulonglong_val;
+	double double_val;
+	int list_count;
+	int store_it;
+	char **store_array;
+	char *orig_line;
+	char *other_data=NULL;
+	int other_flag;
+
+	/* the kind of element we're reading currently */
+	elem = which_elem;
+
+	/* do we need to setup for other_props? */
+	if( elem->other_offset!=no_other_props )
+	{
+		char **ptr;
+		other_flag = 1;
+		/* make room for other_props */
+		other_data = (char *)malloc( elem->other_size );
+		/* store pointer in user's structure to the other_props */
+		ptr = (char **) ( (char*)elem_ptr + elem->other_offset);
+		*ptr = other_data;
+	}
+	else other_flag = 0;
+
+	/* read in the element */
+	words = get_words( fp , &orig_line );
+	if( !words.size() ) MK_THROW( "Unexpected end of file" );
+
+	which_word = 0;
+
+	for( int j=0 ; j<elem->props.size() ; j++ )
+	{
+		PlyProperty &prop = elem->props[j].prop;
+		store_it = (elem->props[j].store | other_flag);
+
+		/* store either in the user's structure or in other_props */
+		if( elem->props[j].store ) elem_data = elem_ptr;
+		else                       elem_data = other_data;
+
+		if( prop.is_list )       /* a list */
+		{
+			/* get and store the number of items in the list */
+			get_ascii_item( words[which_word++] , prop.count_external , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+			if( store_it )
+			{
+				item = (char *)elem_data + prop.count_offset;
+				store_item( item , prop.count_internal , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+			}
+
+			/* allocate space for an array of items and store a ptr to the array */
+			list_count = int_val;
+			item_size = ply_type_size[ prop.internal_type ];
+			store_array = (char **)( (char *)elem_data + prop.offset );
+
+			if( list_count==0 )
+			{
+				if( store_it ) *store_array = NULL;
+			}
+			else
+			{
+				if( store_it )
+				{
+					item_ptr = (char *) malloc (sizeof (char) * item_size * list_count);
+					item = item_ptr;
+					*store_array = item_ptr;
+				}
+
+				/* read items and store them into the array */
+				for( int k=0 ; k<list_count ; k++ )
+				{
+					get_ascii_item( words[which_word++] , prop.external_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+					if( store_it )
+					{
+						store_item( item , prop.internal_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+						item = (char *)item + item_size;
+					}
+				}
+			}
+		}
+		else                     /* not a list */
+		{
+			get_ascii_item( words[which_word++] , prop.external_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+			if( store_it )
+			{
+				item = (char *)elem_data + prop.offset;
+				store_item( item , prop.internal_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+			}
+		}
+	}
+}
+
+/******************************************************************************
+Read an element from a binary file.
+
+Entry:
+elem_ptr - pointer to an element
+******************************************************************************/
+
+void PlyFile::_binary_get_element( void *elem_ptr )
+{
+	PlyElement *elem;
+	void *elem_data , *item=NULL;
+	char *item_ptr;
+	int item_size;
+	int int_val;
+	unsigned int uint_val;
+	long long longlong_val;
+	unsigned long long ulonglong_val;
+	double double_val;
+	int list_count;
+	int store_it;
+	char **store_array;
+	char *other_data=NULL;
+	int other_flag;
+
+	/* the kind of element we're reading currently */
+	elem = which_elem;
+
+	/* do we need to setup for other_props? */
+	if( elem->other_offset!=no_other_props )
+	{
+		char **ptr;
+		other_flag = 1;
+		/* make room for other_props */
+		other_data = (char *) malloc (elem->other_size);
+		/* store pointer in user's structure to the other_props */
+		ptr = (char **) ((char *)elem_ptr + elem->other_offset);
+		*ptr = other_data;
+	}
+	else other_flag = 0;
+
+	/* read in a number of elements */
+
+	for( int j=0 ; j<elem->props.size() ; j++ )
+	{
+		PlyProperty &prop = elem->props[j].prop;
+		store_it = ( elem->props[j].store | other_flag );
+
+		/* store either in the user's structure or in other_props */
+		if( elem->props[j].store ) elem_data = elem_ptr;
+		else                       elem_data = other_data;
+
+		if( prop.is_list )       /* a list */
+		{
+			/* get and store the number of items in the list */
+			get_binary_item( fp , file_type , prop.count_external , int_val, uint_val , longlong_val , ulonglong_val , double_val );
+			if( store_it )
+			{
+				item = (char *)elem_data + prop.count_offset;
+				store_item( item , prop.count_internal , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+			}
+
+			/* allocate space for an array of items and store a ptr to the array */
+			list_count = int_val;
+			item_size = ply_type_size[ prop.internal_type ];
+			store_array = (char **) ((char *)elem_data + prop.offset);
+			if( list_count==0 )
+			{
+				if( store_it ) *store_array = NULL;
+			}
+			else
+			{
+				if( store_it )
+				{
+					item_ptr = (char *)malloc(sizeof (char) * item_size * list_count);
+					item = item_ptr;
+					*store_array = item_ptr;
+				}
+
+				/* read items and store them into the array */
+				for( int k=0 ; k<list_count ; k++ )
+				{
+					get_binary_item( fp , file_type , prop.external_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+					if( store_it )
+					{
+						store_item( item , prop.internal_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+						item = (char *)item + item_size;
+					}
+				}
+			}
+		}
+		else                     /* not a list */
+		{
+			get_binary_item( fp , file_type , prop.external_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+			if( store_it )
+			{
+				item = (char *)elem_data + prop.offset;
+				store_item( item , prop.internal_type , int_val , uint_val , longlong_val , ulonglong_val , double_val );
+			}
+		}
+	}
+}
+
+
+/******************************************************************************
+Write to a file the word that represents a PLY data type.
+
+Entry:
+fp   - file pointer
+code - code for type
+******************************************************************************/
+
+void write_scalar_type( FILE *fp , int code )
+{
+	/* make sure this is a valid code */
+	if( code<=PLY_START_TYPE || code>=PLY_END_TYPE ) MK_THROW( "Bad data code: " , code );
+
+	/* write the code to a file */
+	fprintf( fp , "%s" , type_names[code] );
+}
+
+/******************************************************************************
+Reverse the order in an array of bytes.  This is the conversion from big
+endian to little endian and vice versa
+
+Entry:
+bytes     - array of bytes to reverse (in place)
+num_bytes - number of bytes in array
+******************************************************************************/
+
+void swap_bytes( void *bytes , int num_bytes )
+{
+	char *chars = (char *)bytes;
+
+	for( int i=0 ; i<num_bytes/2 ; i++ )
+	{
+		char temp = chars[i];
+		chars[i] = chars[(num_bytes-1)-i];
+		chars[(num_bytes-1)-i] = temp;
+	}
+}
+
+/******************************************************************************
+Find out if this machine is big endian or little endian
+
+Exit:
+set global variable, native_binary_type =
+either PLY_BINARY_BE or PLY_BINARY_LE
+
+******************************************************************************/
+
+void get_native_binary_type( void )
+{
+	endian_test_type test;
+
+	test.int_value = 0;
+	test.int_value = 1;
+	if     ( test.byte_values[0]==1 ) native_binary_type = PLY_BINARY_LE;
+	else if( test.byte_values[sizeof(int)-1] == 1) native_binary_type = PLY_BINARY_BE;
+	else MK_THROW( "Couldn't determine machine endianness" );
+}
+
+/******************************************************************************
+Verify that all the native types are the sizes we need
+
+
+******************************************************************************/
+
+void check_types()
+{
+	if( (ply_type_size[PLY_CHAR] != sizeof(char)) ||
+		(ply_type_size[PLY_SHORT] != sizeof(short)) ||	
+		(ply_type_size[PLY_INT] != sizeof(int)) ||	
+		(ply_type_size[PLY_LONGLONG] != sizeof(long long)) ||	
+		(ply_type_size[PLY_UCHAR] != sizeof(unsigned char)) ||	
+		(ply_type_size[PLY_USHORT] != sizeof(unsigned short)) ||	
+		(ply_type_size[PLY_UINT] != sizeof(unsigned int)) ||	
+		(ply_type_size[PLY_ULONGLONG] != sizeof(unsigned long long)) ||	
+		(ply_type_size[PLY_FLOAT] != sizeof(float)) ||	
+		(ply_type_size[PLY_DOUBLE] != sizeof(double)))
+		MK_THROW( "Type sizes do not match built-in types" );
+
+	types_checked = 1;
+}
+
+/******************************************************************************
+Get a text line from a file and break it up into words.
+
+IMPORTANT: The calling routine call "free" on the returned pointer once
+finished with it.
+
+Entry:
+fp - file to read from
+
+Exit:
+nwords    - number of words returned
+orig_line - the original line of characters
+returns a list of words from the line, or NULL if end-of-file
+******************************************************************************/
+
+std::vector< std::string > get_words( FILE *fp , char **orig_line )
+{
+	static const unsigned int BigString = 4096;
+	static char str[BigString];
+	static char str_copy[BigString];
+	std::vector< std::string > words;
+	int max_words = 10;
+	int num_words = 0;
+	char *ptr , *ptr2;
+	char *result;
+
+	/* read in a line */
+	result = fgets( str , BigString , fp );
+	if( result==NULL )
+	{
+		*orig_line = NULL;
+		return words;
+	}
+	/* convert line-feed and tabs into spaces */
+	/* (this guarentees that there will be a space before the */
+	/*  null character at the end of the string) */
+
+	str[BigString-2] = ' ';
+	str[BigString-1] = '\0';
+
+	for( ptr=str , ptr2=str_copy ; *ptr!='\0' ; ptr++ , ptr2++ )
+	{
+		*ptr2 = *ptr;
+		// Added line here to manage carriage returns
+		if( *ptr == '\t' || *ptr == '\r' )
+		{
+			*ptr = ' ';
+			*ptr2 = ' ';
+		}
+		else if( *ptr=='\n' )
+		{
+			*ptr = ' ';
+			*ptr2 = '\0';
+			break;
+		}
+	}
+
+	/* find the words in the line */
+
+	ptr = str;
+	while( *ptr!='\0' )
+	{
+		/* jump over leading spaces */
+		while( *ptr==' ' ) ptr++;
+
+		/* break if we reach the end */
+		if( *ptr=='\0' ) break;
+
+		char *_ptr = ptr;
+
+		/* jump over non-spaces */
+		while( *ptr!=' ' ) ptr++;
+
+		/* place a null character here to mark the end of the word */
+		*ptr++ = '\0';
+
+		/* save pointer to beginning of word */
+		words.push_back( _ptr );
+	}
+
+	/* return the list of words */
+	*orig_line = str_copy;
+	return words;
+}
+
+/******************************************************************************
+Return the value of an item, given a pointer to it and its type.
+
+Entry:
+item - pointer to item
+type - data type that "item" points to
+
+Exit:
+returns a double-precision float that contains the value of the item
+******************************************************************************/
+
+double get_item_value( const void *item , int type )
+{
+	switch( type )
+	{
+	case PLY_CHAR:
+	case PLY_INT_8:     return (double)*(const               char *)item;
+	case PLY_UCHAR:
+	case PLY_UINT_8:    return (double)*(const unsigned      char *)item;
+	case PLY_SHORT:
+	case PLY_INT_16:    return (double)*(const          short int *)item;
+	case PLY_USHORT:
+	case PLY_UINT_16:   return (double)*(const unsigned short int *)item;
+	case PLY_INT:
+	case PLY_INT_32:    return (double)*(const                int *)item;
+	case PLY_LONGLONG:
+	case PLY_INT_64:    return (double)*(const          long long *)item;
+	case PLY_UINT:
+	case PLY_UINT_32:   return (double)*(const unsigned       int *)item;
+	case PLY_ULONGLONG:
+	case PLY_UINT_64:   return (double)*(const unsigned long long *)item;
+	case PLY_FLOAT:
+	case PLY_FLOAT_32:  return (double)*(const              float *)item;
+	case PLY_DOUBLE:
+	case PLY_FLOAT_64:  return (double)*(const             double *)item;
+	default: MK_THROW( "Bad type: " , type );
+	}
+	return 0;
+}
+
+
+/******************************************************************************
+Write out an item to a file as raw binary bytes.
+
+Entry:
+fp         - file to write to
+int_val    - integer version of item
+uint_val   - unsigned integer version of item
+double_val - double-precision float version of item
+type       - data type to write out
+******************************************************************************/
+
+void write_binary_item( FILE *fp , int file_type , int int_val , unsigned int uint_val , long long longlong_val , unsigned long long ulonglong_val , double double_val , int type )
+{
+	unsigned char uchar_val;
+	char char_val;
+	unsigned short ushort_val;
+	short short_val;
+	float float_val;
+	void *value = NULL;
+
+	switch (type) {
+	case PLY_CHAR:
+	case PLY_INT_8:
+		char_val = char(int_val);
+		value = &char_val;
+		break;
+	case PLY_SHORT:
+	case PLY_INT_16:
+		short_val = short(int_val);
+		value = &short_val;
+		break;
+	case PLY_INT:
+	case PLY_INT_32:
+		value = &int_val;
+		break;
+	case PLY_LONGLONG:
+	case PLY_INT_64:
+		value = &longlong_val;
+		break;
+	case PLY_UCHAR:
+	case PLY_UINT_8:
+		uchar_val = (unsigned char)(uint_val);
+		value = &uchar_val;
+		break;
+	case PLY_USHORT:
+	case PLY_UINT_16:
+		ushort_val = (unsigned short)(uint_val);
+		value = &ushort_val;
+		break;
+	case PLY_UINT:
+	case PLY_UINT_32:
+		value = &uint_val;
+		break;
+	case PLY_ULONGLONG:
+	case PLY_UINT_64:
+		value = &ulonglong_val;
+		break;
+	case PLY_FLOAT:
+	case PLY_FLOAT_32:
+		float_val = (float)double_val;
+		value = &float_val;
+		break;
+	case PLY_DOUBLE:
+	case PLY_FLOAT_64:
+		value = &double_val;
+		break;
+	default: MK_THROW( "Bad type: " , type );
+	}
+
+
+	if( (file_type!=native_binary_type) && (ply_type_size[type]>1) ) swap_bytes( (char *)value , ply_type_size[type] );
+	if( fwrite( value , ply_type_size[type] , 1 , fp )!=1 ) MK_THROW( "Failed to write binary item" );
+}
+
+
+/******************************************************************************
+Write out an item to a file as ascii characters.
+
+Entry:
+fp         - file to write to
+int_val    - integer version of item
+uint_val   - unsigned integer version of item
+double_val - double-precision float version of item
+type       - data type to write out
+******************************************************************************/
+
+void write_ascii_item( FILE *fp , int int_val , unsigned int uint_val , long long longlong_val , unsigned long long ulonglong_val , double double_val , int type )
+{
+	switch (type)
+	{
+	case PLY_CHAR:
+	case PLY_INT_8:
+	case PLY_SHORT:
+	case PLY_INT_16:
+	case PLY_INT:
+	case PLY_INT_32:
+		if( fprintf( fp , "%d " , int_val )<=0 ) MK_THROW( "fprintf() failed -- aborting" );
+		break;
+	case PLY_LONGLONG:
+	case PLY_INT_64:
+		if( fprintf( fp , "%lld " , longlong_val )<=0 ) MK_THROW( "fprintf() failed -- aborting" );
+		break;
+	case PLY_UCHAR:
+	case PLY_UINT_8:
+	case PLY_USHORT:
+	case PLY_UINT_16:
+	case PLY_UINT:
+	case PLY_UINT_32:
+		if( fprintf( fp , "%u " , uint_val )<=0 ) MK_THROW( "fprintf() failed -- aborting" );
+		break;
+	case PLY_ULONGLONG:
+	case PLY_UINT_64:
+		if( fprintf( fp , "%llu " , ulonglong_val )<=0 ) MK_THROW( "fprintf() failed -- aborting" );
+		break;
+	case PLY_FLOAT:
+	case PLY_FLOAT_32:
+	case PLY_DOUBLE:
+	case PLY_FLOAT_64:
+		if( fprintf( fp , "%g " , double_val )<=0 ) MK_THROW( "fprintf() failed -- aborting" );
+		break;
+	default: MK_THROW( "Bad type: " , type );
+	}
+}
+
+/******************************************************************************
+Get the value of an item that is in memory, and place the result
+into an integer, an unsigned integer and a double.
+
+Entry:
+ptr  - pointer to the item
+type - data type supposedly in the item
+
+Exit:
+int_val    - integer value
+uint_val   - unsigned integer value
+double_val - double-precision floating point value
+******************************************************************************/
+
+void get_stored_item( void *ptr , int type , int &int_val , unsigned int &uint_val , long long &longlong_val , unsigned long long &ulonglong_val , double &double_val )
+{
+	switch( type )
+	{
+	case PLY_CHAR:
+	case PLY_INT_8:
+		int_val = *((char *) ptr);
+		uint_val = int_val;
+		double_val = int_val;
+		longlong_val = (long long)int_val;
+		ulonglong_val = (unsigned long long)int_val;
+		break;
+	case PLY_UCHAR:
+	case PLY_UINT_8:
+		uint_val = *((unsigned char *) ptr);
+		int_val = uint_val;
+		double_val = uint_val;
+		longlong_val = (long long)uint_val;
+		ulonglong_val = (unsigned long long)uint_val;
+		break;
+	case PLY_SHORT:
+	case PLY_INT_16:
+		int_val = *((short int *) ptr);
+		uint_val = int_val;
+		double_val = int_val;
+		longlong_val = (long long)int_val;
+		ulonglong_val = (unsigned long long)int_val;
+		break;
+	case PLY_USHORT:
+	case PLY_UINT_16:
+		uint_val = *((unsigned short int *) ptr);
+		int_val = uint_val;
+		double_val = uint_val;
+		longlong_val = (long long)uint_val;
+		ulonglong_val = (unsigned long long)uint_val;
+		break;
+	case PLY_INT:
+	case PLY_INT_32:
+		int_val = *((int *) ptr);
+		uint_val = int_val;
+		double_val = int_val;
+		longlong_val = (long long)int_val;
+		ulonglong_val = (unsigned long long)int_val;
+		break;
+	case PLY_UINT:
+	case PLY_UINT_32:
+		uint_val = *((unsigned int *) ptr);
+		int_val = uint_val;
+		double_val = uint_val;
+		longlong_val = (long long)uint_val;
+		ulonglong_val = (unsigned long long)uint_val;
+		break;
+	case PLY_LONGLONG:
+	case PLY_INT_64:
+		longlong_val = *((long long *) ptr);
+		ulonglong_val = (unsigned long long)longlong_val;
+		int_val = (int)longlong_val;
+		uint_val = (unsigned int)longlong_val;
+		double_val = (double)longlong_val;
+		break;
+	case PLY_ULONGLONG:
+	case PLY_UINT_64:
+		ulonglong_val = *((unsigned long long *) ptr);
+		longlong_val = (long long)ulonglong_val;
+		int_val = (int)ulonglong_val;
+		uint_val = (unsigned int)ulonglong_val;
+		double_val = (double)ulonglong_val;
+		break;
+	case PLY_FLOAT:
+	case PLY_FLOAT_32:
+		double_val = *((float *) ptr);
+		int_val = (int)double_val;
+		uint_val = (unsigned int)double_val;
+		longlong_val = (long long)double_val;
+		ulonglong_val = (unsigned long long)double_val;
+		break;
+	case PLY_DOUBLE:
+	case PLY_FLOAT_64:
+		double_val = *((double *) ptr);
+		int_val = (int)double_val;
+		uint_val = (unsigned int)double_val;
+		longlong_val = (long long)double_val;
+		ulonglong_val = (unsigned long long)double_val;
+		break;
+	default: MK_THROW( "Bad type: " , type );
+	}
+}
+
+/******************************************************************************
+Get the value of an item from a binary file, and place the result
+into an integer, an unsigned integer and a double.
+
+Entry:
+fp   - file to get item from
+type - data type supposedly in the word
+
+Exit:
+int_val    - integer value
+uint_val   - unsigned integer value
+double_val - double-precision floating point value
+******************************************************************************/
+
+void get_binary_item( FILE *fp , int file_type , int type , int &int_val , unsigned int &uint_val , long long &longlong_val , unsigned long long &ulonglong_val , double &double_val )
+{
+	// Use memcpy instead of type-punning pointer casts to read from the
+	// buffer. At -O3 GCC exploits casted pointers and may reorder or eliminate the loads, returning garbage.
+	//
+	// For the float/double cases we also avoid direct casts from
+	// floating-point to unsigned integer types, which are UB when the
+	// value is negative or out-of-range.  Instead we convert through
+	// long long first (well-defined truncation from double for values
+	// within ±2^63) and then use the well-defined signed-to-unsigned
+	// integer conversion.
+	char c[8];
+
+	if( fread( c , ply_type_size[type] , 1 , fp )!=1 ) MK_THROW( "fread() failed -- aborting: " , std::string( type_names[type] ) );
+	if( ( file_type!=native_binary_type ) && ( ply_type_size[type]>1 ) ) swap_bytes( c , ply_type_size[type] );
+
+	switch( type )
+	{
+	case PLY_CHAR:
+	case PLY_INT_8:
+		int_val = (signed char)c[0];
+		uint_val = int_val;
+		longlong_val = int_val;
+		ulonglong_val = int_val;
+		double_val = int_val;
+		break;
+	case PLY_UCHAR:
+	case PLY_UINT_8:
+		uint_val = (unsigned char)c[0];
+		int_val = uint_val;
+		longlong_val = int_val;
+		ulonglong_val = int_val;
+		double_val = uint_val;
+		break;
+	case PLY_SHORT:
+	case PLY_INT_16:
+		{ short v; memcpy( &v , c , sizeof(v) ); int_val = v; }
+		uint_val = int_val;
+		longlong_val = int_val;
+		ulonglong_val = int_val;
+		double_val = int_val;
+		break;
+	case PLY_USHORT:
+	case PLY_UINT_16:
+		{ unsigned short v; memcpy( &v , c , sizeof(v) ); uint_val = v; }
+		int_val = uint_val;
+		longlong_val = int_val;
+		ulonglong_val = int_val;
+		double_val = uint_val;
+		break;
+	case PLY_INT:
+	case PLY_INT_32:
+		memcpy( &int_val , c , sizeof(int_val) );
+		uint_val = int_val;
+		longlong_val = int_val;
+		ulonglong_val = int_val;
+		double_val = int_val;
+		break;
+	case PLY_UINT:
+	case PLY_UINT_32:
+		memcpy( &uint_val , c , sizeof(uint_val) );
+		int_val = uint_val;
+		longlong_val = int_val;
+		ulonglong_val = int_val;
+		double_val = uint_val;
+		break;
+	case PLY_LONGLONG:
+	case PLY_INT_64:
+		memcpy( &longlong_val , c , sizeof(longlong_val) );
+		ulonglong_val = (unsigned long long)longlong_val;
+		int_val = (int)longlong_val;
+		uint_val = (unsigned int)longlong_val;
+		double_val = (double)longlong_val;
+		break;
+	case PLY_ULONGLONG:
+	case PLY_UINT_64:
+		memcpy( &ulonglong_val , c , sizeof(ulonglong_val) );
+		longlong_val = (long long)ulonglong_val;
+		int_val = (int)ulonglong_val;
+		uint_val = (unsigned int)ulonglong_val;
+		double_val = (double)ulonglong_val;
+		break;
+	case PLY_FLOAT:
+	case PLY_FLOAT_32:
+		{ float v; memcpy( &v , c , sizeof(v) ); double_val = v; }
+		longlong_val = (long long)double_val;
+		int_val = (int)longlong_val;
+		uint_val = (unsigned int)longlong_val;
+		ulonglong_val = (unsigned long long)longlong_val;
+		break;
+	case PLY_DOUBLE:
+	case PLY_FLOAT_64:
+		memcpy( &double_val , c , sizeof(double_val) );
+		longlong_val = (long long)double_val;
+		int_val = (int)longlong_val;
+		uint_val = (unsigned int)longlong_val;
+		ulonglong_val = (unsigned long long)longlong_val;
+		break;
+	default: MK_THROW( "Bad type: " , type );
+	}
+}
+
+/******************************************************************************
+Extract the value of an item from an ascii word, and place the result
+into an integer, an unsigned integer and a double.
+
+Entry:
+word - word to extract value from
+type - data type supposedly in the word
+
+Exit:
+int_val    - integer value
+uint_val   - unsigned integer value
+double_val - double-precision floating point value
+******************************************************************************/
+void get_ascii_item( const std::string &word , int type , int &int_val , unsigned int &uint_val , long long &longlong_val , unsigned long long &ulonglong_val , double &double_val )
+{
+	switch( type )
+	{
+	case PLY_CHAR:
+	case PLY_INT_8:
+	case PLY_UCHAR:
+	case PLY_UINT_8:
+	case PLY_SHORT:
+	case PLY_INT_16:
+	case PLY_USHORT:
+	case PLY_UINT_16:
+	case PLY_INT:
+	case PLY_INT_32:
+		int_val = atoi( word.c_str() );
+		uint_val = (unsigned int)int_val;
+		double_val = (double)int_val;
+		longlong_val = (long long)int_val;
+		ulonglong_val = (unsigned long long)int_val;
+		break;
+
+	case PLY_UINT:
+	case PLY_UINT_32:
+		uint_val = strtol( word.c_str() , (char **)NULL , 10 );
+		int_val = (int)uint_val;
+		double_val = (double)uint_val;
+		longlong_val = (long long)uint_val;
+		ulonglong_val = (unsigned long long)uint_val;
+		break;
+	case PLY_LONGLONG:
+	case PLY_INT_64:
+		longlong_val = std::stoll( word.c_str() );
+		ulonglong_val = (unsigned long long)longlong_val;
+		int_val = (int)longlong_val;
+		uint_val = (unsigned int)longlong_val;
+		double_val = (double)longlong_val;
+		break;
+	case PLY_ULONGLONG:
+	case PLY_UINT_64:
+		ulonglong_val = std::stoull( word.c_str() );
+		longlong_val = (long long)ulonglong_val;
+		int_val = (int)ulonglong_val;
+		uint_val = (unsigned int)ulonglong_val;
+		double_val = (double)ulonglong_val;
+		break;
+	case PLY_FLOAT:
+	case PLY_FLOAT_32:
+	case PLY_DOUBLE:
+	case PLY_FLOAT_64:
+		double_val = atof( word.c_str() );
+		int_val = (int)double_val;
+		uint_val = (unsigned int)double_val;
+		longlong_val = (long long)double_val;
+		ulonglong_val = (unsigned long long)double_val;
+		break;
+	default: MK_THROW( "Bad type: " , type );
+	}
+}
+
+/******************************************************************************
+Store a value into a place being pointed to, guided by a data type.
+
+Entry:
+item       - place to store value
+type       - data type
+int_val    - integer version of value
+uint_val   - unsigned integer version of value
+double_val - double version of value
+
+Exit:
+item - pointer to stored value
+******************************************************************************/
+
+void store_item( void *item , int type , int int_val , unsigned int uint_val , long long longlong_val , unsigned long long ulonglong_val , double double_val )
+{
+	switch( type )
+	{
+	case PLY_CHAR:
+	case PLY_INT_8:   *(          char *)item = (          char)   int_val ; break;
+	case PLY_UCHAR:
+	case PLY_UINT_8:  *(unsigned  char *)item = (unsigned  char)  uint_val ; break;
+	case PLY_SHORT:
+	case PLY_INT_16:  *(         short *)item = (         short)   int_val ; break;
+	case PLY_USHORT:
+	case PLY_UINT_16: *(unsigned short *)item = (unsigned short)  uint_val ; break;
+	case PLY_INT:
+	case PLY_INT_32:  *(           int *)item = (           int)   int_val ; break;
+	case PLY_UINT:
+	case PLY_UINT_32: *(unsigned   int *)item = (unsigned   int)  uint_val ; break;
+	case PLY_LONGLONG:
+	case PLY_INT_64:  *(     long long *)item = (     long long)longlong_val ; break;
+	case PLY_ULONGLONG:
+	case PLY_UINT_64: *(unsigned long long *)item = (unsigned long long)ulonglong_val ; break;
+	case PLY_FLOAT:
+	case PLY_FLOAT_32: *(        float *)item = (         float)double_val ; break;
+	case PLY_DOUBLE:
+	case PLY_FLOAT_64: *(       double *)item = (        double)double_val ; break;
+	default: MK_THROW( "Bad type: " , type );
+	}
+}
+
+
+/******************************************************************************
+Add an element to a PLY file descriptor.
+
+Entry:
+plyfile - PLY file descriptor
+words   - list of words describing the element
+nwords  - number of words in the list
+******************************************************************************/
+
+void PlyFile::add_element( const std::vector< std::string > &words )
+{
+	PlyElement elem;
+
+	/* set the new element */
+	elem.name = words[1];
+	elem.num = std::stoull( words[2] );
+	elem.props.resize(0);
+
+	/* add the new element to the object's list */
+	elems.push_back( elem );
+}
+
+/******************************************************************************
+Return the type of a property, given the name of the property.
+
+Entry:
+name - name of property type
+
+Exit:
+returns integer code for property, or 0 if not found
+******************************************************************************/
+
+int get_prop_type( const std::string &type_name )
+{
+	for( int i=PLY_START_TYPE+1 ; i<PLY_END_TYPE ; i++ ) if( type_name==type_names[i] ) return i;
+
+	/* if we get here, we didn't find the type */
+	return 0;
+}
+
+/******************************************************************************
+Add a property to a PLY file descriptor.
+
+Entry:
+plyfile - PLY file descriptor
+words   - list of words describing the property
+nwords  - number of words in the list
+******************************************************************************/
+
+void PlyFile::add_property( const std::vector< std::string > &words )
+{
+	PlyProperty prop;
+	if( words[1]=="list" )       /* is a list */
+	{
+		prop.count_external = get_prop_type( words[2] );
+		prop.external_type = get_prop_type( words[3]) ;
+		prop.name = words[4];
+		prop.is_list = 1;
+	}
+	else         /* not a list */
+	{
+		prop.external_type = get_prop_type( words[1] );
+		prop.name = words[2];
+		prop.is_list = 0;
+	}
+
+	/* add this property to the list of properties of the current element */
+	elems.back().props.push_back( PlyStoredProperty( prop , dont_store_prop ) );
+}
+
+
+/******************************************************************************
+Add a comment to a PLY file descriptor.
+
+Entry:
+plyfile - PLY file descriptor
+line    - line containing comment
+******************************************************************************/
+
+void PlyFile::add_comment( const std::string &line )
+{
+	/* skip over "comment" and leading spaces and tabs */
+	int i = 7;
+	while( line[i]==' ' || line[i] =='\t' ) i++;
+
+	put_comment( line.substr(i) );
+}
+
+
+/******************************************************************************
+Add a some object information to a PLY file descriptor.
+
+Entry:
+plyfile - PLY file descriptor
+line    - line containing text info
+******************************************************************************/
+
+void PlyFile::add_obj_info( const std::string &line )
+{
+	/* skip over "obj_info" and leading spaces and tabs */
+	int i = 8;
+	while( line[i]==' ' || line[i]=='\t' ) i++;
+	put_obj_info( line.substr(i) );
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/PointExtent.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PointExtent.h
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2023, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef POINT_EXTENT_INCLUDED
+#define POINT_EXTENT_INCLUDED
+
+#include <ostream>
+#include "Geometry.h"
+#include "DataStream.h"
+
+namespace PoissonRecon
+{
+	namespace PointExtent
+	{
+		template< typename Real , unsigned int Dim , bool ExtendedAxes >
+		struct Frame
+		{
+			static const unsigned int DirectionN = ExtendedAxes ? ( Dim==2 ? 4 : 9 ) : Dim;
+			Point< Real , Dim > directions[ DirectionN ];
+			unsigned int frames[DirectionN][Dim];
+			Frame( void );
+		};
+
+		template< typename Real , unsigned int Dim , bool ExtendedAxes=true >
+		struct Extent
+		{
+			static const unsigned int DirectionN = Frame< Real , Dim , ExtendedAxes >::DirectionN;
+			static Point< Real , Dim > Direction( unsigned int d ){ return _Frame.directions[d]; }
+			static const unsigned int *Frame( unsigned int d ){ return _Frame.frames[d]; }
+
+			std::pair< Real , Real > extents[ DirectionN ];
+			std::pair< Real , Real > &operator[]( unsigned int d ){ return extents[d]; }
+			const std::pair< Real , Real > &operator[]( unsigned int d ) const { return extents[d]; }
+
+			Extent( void );
+			void add( Point< Real , Dim > p );
+			Extent operator + ( const Extent &e ) const;
+		protected:
+			static const PointExtent::Frame< Real , Dim , ExtendedAxes > _Frame;
+
+			template< typename _Real , unsigned int _Dim , bool _ExtendedAxes >
+			friend std::ostream &operator << ( std::ostream & , const Extent< _Real , _Dim , _ExtendedAxes > & );
+		};
+
+		template< typename Real , unsigned int Dim , bool ExtendedAxes >
+		const Frame< Real , Dim , ExtendedAxes > Extent< Real , Dim , ExtendedAxes >::_Frame;
+
+		template< class Real , unsigned int Dim , bool ExtendedAxes , typename ... Data >
+		Extent< Real , Dim , ExtendedAxes > GetExtent( InputDataStream< Point< Real , Dim > , Data ... > &stream , Data ... data );
+
+		template< class Real , unsigned int Dim >
+		XForm< Real , Dim+1 > GetXForm( Point< Real , Dim > min , Point< Real , Dim > max , Real scaleFactor , bool rotate=true );
+
+		template< class Real , unsigned int Dim , bool ExtendedAxes >
+		XForm< Real , Dim+1 > GetXForm( const Extent< Real , Dim , ExtendedAxes > &extent , Real scaleFactor , unsigned int dir );
+
+		template< class Real , unsigned int Dim , bool ExtendedAxes , typename ... Data >
+		XForm< Real , Dim+1 > GetXForm( InputDataStream< Point< Real , Dim > , Data ... > &stream , Data ... data , Real scaleFactor , unsigned int dir );
+
+#include "PointExtent.inl"
+	}
+}
+
+#endif // POINT_EXTENT_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/PointExtent.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PointExtent.inl
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2023, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+
+////////////////////
+// GetBoundingBox //
+////////////////////
+template< class Real , unsigned int Dim >
+XForm< Real , Dim+1 > GetXForm( Point< Real , Dim > min , Point< Real , Dim > max , Real scaleFactor , bool rotate )
+{
+	Point< Real , Dim > center = ( max + min ) / 2;
+	Real scale = max[0] - min[0];
+	for( int d=1 ; d<Dim ; d++ ) scale = std::max< Real >( scale , max[d]-min[d] );
+	scale *= scaleFactor;
+	for( int i=0 ; i<Dim ; i++ ) center[i] -= scale/2;
+	XForm< Real , Dim+1 > tXForm = XForm< Real , Dim+1 >::Identity() , sXForm = XForm< Real , Dim+1 >::Identity() , rXForm = XForm< Real , Dim+1 >::Identity();
+	for( int i=0 ; i<Dim ; i++ ) sXForm(i,i) = (Real)(1./scale ) , tXForm(Dim,i) = -center[i];
+	unsigned int maxDim = 0;
+	for( int i=1 ; i<Dim ; i++ ) if( (max[i]-min[i])>(max[maxDim]-min[maxDim]) ) maxDim = i;
+	if( rotate )
+	{
+		for( int i=0 ; i<Dim ; i++ ) rXForm(i,i) = 0;
+		for( int i=0 ; i<Dim ; i++ ) rXForm((maxDim+i)%Dim,(Dim-1+i)%Dim) = 1;
+	}
+	return rXForm * sXForm * tXForm;
+}
+
+template< class Real , unsigned int Dim , bool ExtendedAxes >
+XForm< Real , Dim+1 > GetXForm( const Extent< Real , Dim , ExtendedAxes > &extent , Real scaleFactor , unsigned int dir )
+{
+	using _Extent = Extent< Real , Dim , ExtendedAxes >;
+	bool rotate = ( dir >= _Extent::DirectionN );
+
+	if( rotate ) // Find the direction of maximal extent
+	{
+		dir = 0;
+		for( unsigned int d=1 ; d<_Extent::DirectionN ; d++ ) if( extent[d].second - extent[d].first > extent[dir].second - extent[dir].first ) dir = d;
+	}
+
+	const unsigned int *frame = _Extent::Frame(dir);
+
+	// Compute the rotation taking the direction of maximal extent to the last axis
+	XForm< Real , Dim+1 > R = XForm< Real , Dim+1 >::Identity();
+	for( unsigned int c=0 ; c<Dim ; c++ ) for( unsigned int r=0 ; r<Dim ; r++ ) R(r,c) = _Extent::Direction( frame[c] )[r];
+
+	// Get the bounding box with respect to the maximal extent direction's frame
+	Point< Real , Dim >  bBox[2];
+	for( unsigned int d=0 ; d<Dim ; d++ )
+	{
+		bBox[0][d] = extent[ frame[d] ].first;
+		bBox[1][d] = extent[ frame[d] ].second;
+	}
+	return GetXForm( bBox[0] , bBox[1] , scaleFactor , rotate ) * R;
+}
+
+///////////
+// Frame //
+///////////
+template< typename Real , unsigned int Dim , bool ExtendedAxes >
+Frame< Real , Dim , ExtendedAxes >::Frame( void )
+{
+	for( unsigned int d=0 ; d<Dim ; d++ )
+	{
+		directions[d][d] = 1;
+		for( unsigned int dd=0 ; dd<Dim ; dd++ ) frames[d][dd] = (d+1+dd) % Dim;
+	}
+
+	if constexpr( ExtendedAxes )
+	{
+		static_assert( Dim==2 || Dim==3 , "[ERROR] Non-axis extents only supported for dimensions 2 and 3" );
+		if constexpr( Dim==2 )
+		{
+			directions[2] = Point< Real , 2 >( 1 , 1 )/(Real)sqrt(2.);
+			directions[3] = Point< Real , 2 >( 1 ,-1 )/(Real)sqrt(2.);
+			frames[2][0] = 2 , frames[2][1] = 3;
+			frames[3][0] = 3 , frames[3][1] = 2;
+		}
+		else
+		{
+			directions[3] = Point< Real , 3 >( 1 , 1 , 0 )/(Real)sqrt(2.);
+			directions[4] = Point< Real , 3 >( 1 , 0 , 1 )/(Real)sqrt(2.);
+			directions[5] = Point< Real , 3 >( 0 , 1 , 1 )/(Real)sqrt(2.);
+			directions[6] = Point< Real , 3 >( 1 ,-1 , 0 )/(Real)sqrt(2.);
+			directions[7] = Point< Real , 3 >( 1 , 0 ,-1 )/(Real)sqrt(2.);
+			directions[8] = Point< Real , 3 >( 0 , 1 ,-1 )/(Real)sqrt(2.);
+			frames[3][0] = 2 , frames[3][1] = 6 , frames[3][2] = 3;
+			frames[4][0] = 7 , frames[4][1] = 1 , frames[4][2] = 4;
+			frames[5][0] = 0 , frames[5][1] = 8 , frames[5][2] = 5;
+			frames[6][0] = 3 , frames[6][1] = 2 , frames[6][2] = 6;
+			frames[7][0] = 1 , frames[7][1] = 4 , frames[7][2] = 7;
+			frames[8][0] = 5 , frames[8][1] = 0 , frames[8][2] = 8;
+		}
+	}
+}
+
+////////////
+// Extent //
+////////////
+template< typename Real , unsigned int Dim , bool ExtendedAxes >
+Extent< Real , Dim , ExtendedAxes >::Extent( void )
+{
+	Real inf = std::numeric_limits< Real >::infinity();
+	for( unsigned int d=0 ; d<DirectionN ; d++ ) extents[d].first = inf , extents[d].second = -inf;
+}
+
+template< typename Real , unsigned int Dim , bool ExtendedAxes >
+void Extent< Real , Dim , ExtendedAxes >::add( Point< Real , Dim > p )
+{
+	for( unsigned int d=0 ; d<DirectionN ; d++ )
+	{
+		extents[d].first  = std::min< Real >( extents[d].first  , Point< Real , Dim >::Dot( p , _Frame.directions[d] ) );
+		extents[d].second = std::max< Real >( extents[d].second , Point< Real , Dim >::Dot( p , _Frame.directions[d] ) );
+	}
+}
+
+template< typename Real , unsigned int Dim , bool ExtendedAxes >
+Extent< Real , Dim , ExtendedAxes > Extent< Real , Dim , ExtendedAxes >::operator + ( const Extent &e ) const
+{
+	Extent _e;
+	for( unsigned int d=0 ; d<DirectionN ; d++ )
+	{
+		_e.extents[d].first  = std::min< Real >( extents[d].first  , e.extents[d].first  );
+		_e.extents[d].second = std::max< Real >( extents[d].second , e.extents[d].second );
+	}
+	return _e;
+}
+
+template< typename Real , unsigned int Dim , bool ExtendedAxes >
+std::ostream &operator << ( std::ostream &os , const Extent< Real , Dim , ExtendedAxes > &e )
+{
+	for( unsigned int d=0 ; d<Extent< Real , Dim , ExtendedAxes >::DirectionN ; d++ )
+	{
+		os << Extent< Real , Dim , ExtendedAxes >::_Frame.directions[d] << " : [ " << e.extents[d].first << " , " << e.extents[d].second << " ]";
+		os << "\t(" << e.extents[d].second - e.extents[d].first << " )" << std::endl;
+	}
+	return os;
+}
+
+template< class Real , unsigned int Dim , bool ExtendedAxes , typename ... Data >
+Extent< Real , Dim , ExtendedAxes > GetExtent( InputDataStream< Point< Real , Dim > , Data ... > &stream , Data ... data )
+{
+	Point< Real,  Dim > p;
+	Extent< Real , Dim , ExtendedAxes > e;
+	while( stream.read( p , data... ) ) e.add(p);
+	return e;
+}
+
+template< class Real , unsigned int Dim , bool ExtendedAxes , typename ... Data >
+XForm< Real , Dim+1 > GetXForm( InputDataStream< Point< Real , Dim > , Data ... > &stream , Data ... data , Real scaleFactor , unsigned int dir )
+{
+	return GetXForm( GetExtent< Real , Dim , ExtendedAxes >( stream  , data... ) , scaleFactor , dir );
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/PointPartition.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PointPartition.h
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2023, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef POINT_PARTITION_INCLUDED
+#define POINT_PARTITION_INCLUDED
+
+#include <string>
+#include <sstream>
+#include <filesystem>
+#include "Streams.h"
+#include "MyMiscellany.h"
+#include "Ply.h"
+#include "DataStream.h"
+#include "PointExtent.h"
+
+namespace PoissonRecon
+{
+	static const unsigned int BUFFER_IO = 1<<14;			// Buffer the points before reading/writing
+
+
+	namespace PointPartition
+	{
+		template< typename Real , unsigned int Dim >
+		struct PointSetInfo
+		{
+			std::string header;
+			unsigned filesPerDir;
+			XForm< Real , Dim+1 > modelToUnitCube;
+			std::vector< size_t > pointsPerSlab;
+			std::vector< PlyProperty > auxiliaryProperties;
+
+			PointSetInfo( void );
+			PointSetInfo( unsigned int slabs );
+			PointSetInfo( BinaryStream &stream );
+
+			void write( BinaryStream &stream ) const;
+		};
+
+
+		struct Partition
+		{
+			Partition( void );
+			Partition( unsigned int dCount , const std::vector< size_t > &slabSizes );
+
+#ifdef ADAPTIVE_PADDING
+			void optimize( bool useMax );
+			std::pair< unsigned int , unsigned int > range( unsigned int i ) const;
+			size_t size( unsigned int i ) const;
+			void printDistribution( void ) const;
+			double l2Energy( void ) const;
+			double maxEnergy( void ) const;
+#else // !ADAPTIVE_PADDING
+			void optimize( bool useMax , unsigned int padSize );
+			std::pair< unsigned int , unsigned int > range( unsigned int i , unsigned int padSize ) const;
+			size_t size( unsigned int i , unsigned int padSize ) const;
+			void printDistribution( unsigned int padSize ) const;
+			double l2Energy( unsigned int padSize ) const;
+			double maxEnergy( unsigned int padSize ) const;
+#endif // ADAPTIVE_PADDING
+			size_t size( void ) const;
+			unsigned int partitions( void ) const;
+			unsigned int slabs( void ) const;
+
+		protected:
+			std::vector< unsigned int > _starts;
+			std::vector< size_t  > _slabSizes;
+		};
+
+		long ReadPLYProperties( FILE *fp , std::vector< PlyProperty > &properties );
+		long ReadPLYProperties( const char *fileName , std::vector< PlyProperty > &properties );
+		long WritePLYProperties( FILE *fp , const std::vector< PlyProperty > &properties );
+		long WritePLYProperties( const char *fileName , const std::vector< PlyProperty > &properties );
+
+		template< typename InputFactory >
+		struct BufferedBinaryInputDataStream : public InputDataStream< typename InputFactory::VertexType >
+		{
+
+			typedef typename InputFactory::VertexType Data;
+			BufferedBinaryInputDataStream( const char *fileName , const InputFactory &factory , size_t bufferSize );
+			~BufferedBinaryInputDataStream( void );
+			void reset( void );
+			bool read( Data &d );
+		protected:
+			size_t _bufferSize , _current , _inBuffer , _elementSize;
+			Pointer( char ) _buffer;
+			FILE *_fp;
+			const InputFactory &_factory;
+			long _inset;
+		};
+
+		template< typename OutputFactory >
+		struct BufferedBinaryOutputDataStream : public OutputDataStream< typename OutputFactory::VertexType >
+		{
+			typedef typename OutputFactory::VertexType Data;
+			BufferedBinaryOutputDataStream( const char *fileName , const OutputFactory &factory , size_t bufferSize );
+			~BufferedBinaryOutputDataStream( void );
+			void reset( void );
+			size_t write( const Data &d );
+			size_t size( void ) const;
+		protected:
+			size_t _bufferSize , _current , _elementSize;
+			Pointer( char ) _buffer;
+			FILE *_fp;
+			const OutputFactory &_factory;
+			long _inset;
+		};
+
+		void RemovePointSlabDirs( std::string dir );
+		static void CreatePointSlabDirs( std::string dir , unsigned int count , unsigned int filesPerDir );
+
+		std::string FileDir( std::string dir , std::string header );
+		std::string FileDir( std::string dir , std::string header , unsigned int clientIndex );
+
+		std::string FileName( std::string dir ,                                                 unsigned int slab , unsigned int slabs , unsigned int filesPerDir );
+		std::string FileName( std::string dir , std::string header ,                            unsigned int slab , unsigned int slabs , unsigned int filesPerDir );
+		std::string FileName( std::string dir , std::string header , unsigned int clientIndex , unsigned int slab , unsigned int slabs , unsigned int filesPerDir );
+
+		std::string PointSetInfoName( std::string dir , std::string header );
+
+#include "PointPartition.inl"
+	}
+}
+
+#endif // POINT_PARTITION_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/PointPartition.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PointPartition.inl
@@ -1,0 +1,585 @@
+/*
+Copyright (c) 2023, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+std::string FileDir( std::string dir , std::string header )
+{
+	if( dir.back()!=FileSeparator ) dir += std::string(1,FileSeparator);
+	return dir + header;
+}
+
+std::string FileDir( std::string dir , std::string header , unsigned int clientIndex )
+{
+	std::stringstream sStream;
+	sStream << header << "_" << clientIndex;
+	return FileDir( dir , sStream.str() );
+}
+
+std::string FileName( std::string dir , unsigned int slab , unsigned int slabs , unsigned int filesPerDir )
+{
+	if( filesPerDir<=1 ) MK_THROW( "Need at least two files per directory" );
+
+	if( !dir.length() ) dir = std::string( "." );
+	if( dir.back()!=FileSeparator ) dir.push_back( FileSeparator );
+
+	std::vector< unsigned int > factors;
+	factors.push_back(slab);
+	while( slabs>filesPerDir )
+	{
+		factors.push_back( (slab / filesPerDir) % filesPerDir );
+		slab /= filesPerDir;
+		slabs /= filesPerDir;
+	}
+
+	std::stringstream sStream;
+	sStream << dir;
+
+	for( unsigned int i=(unsigned int)factors.size()-1 ; i!=0 ; i-- ) sStream << factors[i] << std::string(1,FileSeparator);
+	sStream << factors[0] << ".points";
+	return sStream.str();
+}
+
+std::string FileName( std::string dir , std::string header , unsigned int slab , unsigned int slabs , unsigned int filesPerDir )
+{
+	return FileName( FileDir( dir , header ) , slab , slabs , filesPerDir );
+}
+
+std::string FileName( std::string dir , std::string header , unsigned int clientIndex , unsigned int slab , unsigned int slabs , unsigned int filesPerDir )
+{
+	return FileName( FileDir( dir , header , clientIndex ) , slab , slabs , filesPerDir );
+}
+
+std::string PointSetInfoName( std::string dir , std::string header )
+{
+	if( dir.back()==FileSeparator ) return dir + header + std::string( ".psi" );
+	else return dir + std::string(1,FileSeparator) + header + std::string( ".psi" );
+}
+
+
+//////////////////
+// PointSetInfo //
+//////////////////
+template< typename Real , unsigned int Dim >
+PointSetInfo< Real , Dim >::PointSetInfo( void ) : modelToUnitCube( XForm< Real , Dim+1 >::Identity() ) , filesPerDir(-1) {}
+
+template< typename Real , unsigned int Dim >
+PointSetInfo< Real , Dim >::PointSetInfo( unsigned int slabs ) : modelToUnitCube( XForm< Real , Dim+1 >::Identity() ) , filesPerDir(-1) 
+{
+	pointsPerSlab.resize( slabs , 0 );
+}
+
+template< typename Real , unsigned int Dim >
+PointSetInfo< Real , Dim >::PointSetInfo( BinaryStream &stream )
+{
+	if( !stream.read( header ) ) MK_THROW( "Failed to read header" );
+	if( !stream.read( modelToUnitCube ) ) MK_THROW( "Failed to read model-to-unit-cube transform" );
+	if( !stream.read( pointsPerSlab ) ) MK_THROW( "Failed to read points-per-slab" );
+	{
+		size_t sz;
+		if( !stream.read( sz ) ) MK_THROW( "Failed to read number of auxiliary properties" );
+		auxiliaryProperties.resize(sz);
+		for( size_t i=0 ; i<sz ; i++ ) auxiliaryProperties[i].read( stream );
+	}
+	if( !stream.read( filesPerDir ) ) MK_THROW( "Failed to read files-per-directory" );
+}
+
+template< typename Real , unsigned int Dim >
+void PointSetInfo< Real , Dim >::write( BinaryStream &stream ) const
+{
+	stream.write( header );
+	stream.write( modelToUnitCube );
+	stream.write( pointsPerSlab );
+	{
+		size_t sz = auxiliaryProperties.size();
+		stream.write( sz );
+		for( size_t i=0 ; i<sz ; i++ ) auxiliaryProperties[i].write( stream );
+	}
+	stream.write( filesPerDir );
+}
+
+void RemovePointSlabDirs( std::string dir ){ std::filesystem::remove_all( dir ); }
+void CreatePointSlabDirs( std::string dir , unsigned int count , unsigned int filesPerDir )
+{
+	if( filesPerDir<=1 ) MK_THROW( "Need at least two files per directory" );
+	if( !dir.length() ) dir = std::string( "." );
+	if( dir.back()!=FileSeparator ) dir += std::string(1,FileSeparator);
+
+	try{ std::filesystem::create_directories( dir ); }
+	catch( ... ){ MK_THROW( "Failed to create directory: " , dir ); }
+
+	unsigned int depth = 0;
+	{
+		size_t _filesPerDir = filesPerDir;
+		while( count>_filesPerDir ) _filesPerDir *= filesPerDir , depth++;
+	}
+
+	auto _exp = []( unsigned int filesPerDir , unsigned int depth )
+	{
+		unsigned int e = 1;
+		for( unsigned int d=0 ; d<depth ; d++ ) e *= filesPerDir;
+		return e;
+	};
+
+	std::function< void ( std::string , unsigned int , unsigned int , unsigned int ) > MakeDirs = [&]( std::string dir , unsigned int count , unsigned int depth , unsigned int filesPerDir )
+	{
+		if( depth )
+		{
+			unsigned int _filesPerDir = _exp( filesPerDir , depth );
+			for( unsigned int i=0 ; i*_filesPerDir<count ; i++ )
+			{
+				std::stringstream sStream;
+				sStream << dir << i << FileSeparator;
+				std::string _dir = sStream.str();
+				try{ std::filesystem::create_directories( _dir ); }
+				catch( ... ){ MK_THROW( "Failed to create directory: " , _dir ); }
+				MakeDirs( _dir , std::min< unsigned int >( count-(i*_filesPerDir) , _filesPerDir ) , depth-1 , filesPerDir );
+			}
+		}
+	};
+	MakeDirs( dir , count , depth , filesPerDir );
+}
+///////////////
+// Partition //
+///////////////
+// Energy:
+//		An object supporting bool operator < ( const Energy & ) const;
+template< typename Energy >
+struct _DynamicProgrammingPartition
+{
+	// EnergyFunctor:
+	//		A functor that that takes the start and end of the range and returns the associated energy
+	// MergeFunctor:
+	//		A functor that takes two energies and turns them into one
+	template< typename EnergyFunctor , typename MergeFunctor >
+	_DynamicProgrammingPartition( const EnergyFunctor &energy , const MergeFunctor &merge , unsigned int slabs , unsigned int interiorBoundaries )
+	{
+		_solutions.resize( slabs+1 );
+		for( unsigned int start=0 ; start<_solutions.size() ; start++ )
+		{
+			_solutions[start].resize( slabs+1 );
+			for( unsigned int end=start+1 ; end<_solutions[start].size() ; end++ ) _solutions[start][end].resize( interiorBoundaries+1 );
+		}
+		_energies.resize( slabs+1 );
+		for( unsigned int i=0 ; i<=slabs ; i++ )
+		{
+			_energies[i].resize( slabs+1 );
+			for( unsigned int j=i ; j<=slabs ; j++ ) _energies[i][j] = energy( i , j );
+		}
+		_getSolution( merge , 0 , slabs , interiorBoundaries , Energy() );
+	}
+
+	std::pair< Energy , std::vector< unsigned int > > solution( void ) const
+	{
+		std::pair< Energy , std::vector< unsigned int > > sol;
+		unsigned int start = 0 , end = (unsigned int)_solutions[0].size()-1;
+		unsigned int interiorBoundaries = (unsigned int)_solutions[start][end].size()-1;
+		sol.first = _solutions[0].back().back().e;
+		while( _solutions[start][end][interiorBoundaries].idx!=-1 )
+		{
+			sol.second.push_back( _solutions[start][end][interiorBoundaries].idx );
+			start = _solutions[start][end][interiorBoundaries].idx;
+			interiorBoundaries--;
+		}
+		return sol;
+	}
+
+	template< typename EnergyFunctor , typename MergeFunctor >
+	static std::pair< Energy , std::vector< unsigned int > > Partition( const EnergyFunctor &energy , const MergeFunctor &merge , unsigned int slabs , unsigned int interiorBoundaries )
+	{
+		return _DynamicProgrammingPartition( energy , merge , slabs , interiorBoundaries ).solution();
+	}
+
+protected:
+	struct _Solution
+	{
+		unsigned int idx;
+		Energy e;
+		_Solution( void ) : idx(-1){}
+	};
+
+
+	// A solution is indexed by the start index, end index, and the number of interior boundaries
+	// The extent is defined by [start,end)
+	std::vector< std::vector< std::vector< _Solution > > > _solutions;
+	std::vector< std::vector< Energy > > _energies;
+	template< typename MergeFunctor >
+	Energy _getSolution( const MergeFunctor &merge , unsigned int start , unsigned int end , unsigned int interiorBoundaries , Energy minEnergy )
+	{
+		// Assuming that:
+		//		start<end
+		//		interiorBoundaries+1<(end-start)
+
+		// If we have a solution for this range, return it
+		if( _solutions[start][end][interiorBoundaries].idx!=-1 ) return _solutions[start][end][interiorBoundaries].e;
+
+		// If the range does not need to be partitioned
+		else if( interiorBoundaries==0 ) return ( _solutions[start][end][interiorBoundaries].e = _energies[start][end] );
+
+		// Otherwise
+		else
+		{
+			// 1. Split [start,end) into [start,_start) and [_start,end)
+			// 2. Find interiorBoundaries-1 interior boundaries for [_start,end)
+			// 3. Merge
+			unsigned int minIndex = -1;
+			unsigned int _interiorBoundaries = interiorBoundaries-1;
+			for( unsigned int _start=start+1 ; _start<end ; _start++ )
+			{
+				if( _interiorBoundaries<(end-_start) )
+				{
+					if( !(minEnergy<_energies[start][_start]) )
+					{
+						Energy e = merge( _energies[start][_start] , _getSolution( merge , _start , end , _interiorBoundaries , minEnergy ) );
+						if( minIndex==-1 || e<minEnergy ) minEnergy = e , minIndex = _start;
+					}
+				}
+			}
+			if( minIndex==-1 ) MK_THROW( "Could not find a solution: [ " , start , " , " , end , " ) " , interiorBoundaries );
+			_solutions[start][end][interiorBoundaries].e = minEnergy;
+			_solutions[start][end][interiorBoundaries].idx = minIndex;
+			return minEnergy;
+		}
+	}
+};
+Partition::Partition( void ) : _slabSizes(1,0) , _starts(0) {}
+
+Partition::Partition( unsigned int dCount , const std::vector< size_t > &slabSizes ) : _slabSizes( slabSizes )
+{
+	unsigned int sCount = (unsigned int)_slabSizes.size();
+	_starts.resize( dCount-1 );
+	for( unsigned int i=1 ; i<dCount ; i++ ) _starts[i-1] = ( sCount * i ) / dCount;
+}
+
+#ifdef ADAPTIVE_PADDING
+void Partition::optimize( bool useMax )
+#else // !ADAPTIVE_PADDING
+void Partition::optimize( bool useMax , unsigned int padSize )
+#endif // ADAPTIVE_PADDING
+{
+#ifdef ADAPTIVE_PADDING
+#else // !ADAPTIVE_PADDING
+	auto paddedStart = [&]( unsigned int start ){ return start>padSize ?  (start-padSize) : 0; };
+	auto paddedEnd = [&]( unsigned int end ){ return ( end+padSize<=_slabSizes.size() ) ? (end+padSize) : (unsigned int)_slabSizes.size(); };
+#endif // ADAPTIVE_PADDING
+
+	struct L2Energy
+	{
+		double e;
+		L2Energy( void ) : e( std::numeric_limits<double>::infinity() ) {}
+		L2Energy( double e ) : e(e) {}
+		bool operator < ( const L2Energy &energy ) const { return e<energy.e; }
+	};
+	struct MaxEnergy
+	{
+		std::vector< double > e;
+		MaxEnergy( void ){}
+		MaxEnergy( double e ) { this->e.resize(1,e); }
+		bool operator < ( const MaxEnergy &energy ) const
+		{
+			for( unsigned int i=0 ; i<e.size() && i<energy.e.size() ; i++ )
+			{
+				if     ( e[i]<energy.e[i] ) return true;
+				else if( e[i]>energy.e[i] ) return false;
+			}
+			return false;
+		}
+	};
+
+	auto energy = [&]( unsigned int start , unsigned int end )
+	{
+		double e = 0;
+#ifdef ADAPTIVE_PADDING
+		for( unsigned int i=start ; i<end ; i++ ) e += _slabSizes[i];
+#else // !ADAPTIVE_PADDING
+		for( unsigned int i=paddedStart(start) ; i<paddedEnd(end) ; i++ ) e += _slabSizes[i];
+#endif // ADAPTIVE_PADDING
+		return e*e;
+	};
+	auto  l2Energy = [&]( unsigned int start , unsigned int end ){ return L2Energy( energy(start,end) ); };
+	auto maxEnergy = [&]( unsigned int start , unsigned int end ){ return MaxEnergy( energy(start,end) ); };
+
+	auto  l2Merge = [](  L2Energy e1 ,  L2Energy e2 ){ return  L2Energy( e1.e + e2.e ); };
+	auto maxMerge = []( MaxEnergy e1 , MaxEnergy e2 )
+	{
+		MaxEnergy e;
+		e.e.reserve( e1.e.size() + e2.e.size() );
+		for( unsigned int i=0 ; i<e1.e.size() ; i++ ) e.e.push_back( e1.e[i] );
+		for( unsigned int i=0 ; i<e2.e.size() ; i++ ) e.e.push_back( e2.e[i] );
+		std::sort( e.e.begin() , e.e.end() , []( double e1 , double e2 ){ return e1>e2; } );
+		return e;
+	};
+
+	if( useMax ) _starts = _DynamicProgrammingPartition< MaxEnergy >::Partition( maxEnergy , maxMerge , (unsigned)_slabSizes.size() , (unsigned int)_starts.size() ).second;
+	else         _starts = _DynamicProgrammingPartition<  L2Energy >::Partition(  l2Energy ,  l2Merge , (unsigned)_slabSizes.size() , (unsigned int)_starts.size() ).second;
+}
+
+#ifdef ADAPTIVE_PADDING
+std::pair< unsigned int , unsigned int > Partition::range( unsigned int i ) const
+#else // !ADAPTIVE_PADDING
+std::pair< unsigned int , unsigned int > Partition::range( unsigned int i , unsigned int padSize ) const
+#endif // ADAPTIVE_PADDING
+{
+	unsigned int begin = i==0 ? 0 : _starts[i-1];
+	unsigned int   end = i==_starts.size() ? (unsigned int)_slabSizes.size() : _starts[i];
+#ifdef ADAPTIVE_PADDING
+#else // !ADAPTIVE_PADDING
+	if( begin<padSize ) begin = 0;
+	else begin -= padSize;
+	if( end+padSize>_slabSizes.size() ) end = (unsigned int)_slabSizes.size();
+	else end += padSize;
+#endif // ADAPTIVE_PADDING
+	return std::pair< unsigned int , unsigned int >( begin , end );
+}
+
+#ifdef ADAPTIVE_PADDING
+size_t Partition::size( unsigned int i ) const
+#else // !ADAPTIVE_PADDING
+size_t Partition::size( unsigned int i , unsigned int padSize ) const
+#endif // ADAPTIVE_PADDING
+{
+	if( i>_starts.size() ) MK_THROW( "Index out of bounds: 0 <= " , i , " <= " , _starts.size() );
+#ifdef ADAPTIVE_PADDING
+	std::pair< unsigned int , unsigned int > r = range( i );
+#else // !ADAPTIVE_PADDING
+	std::pair< unsigned int , unsigned int > r = range( i , padSize );
+#endif // ADAPTIVE_PADDING
+	size_t count = 0;
+	for( unsigned int j=r.first ; j<r.second ; j++ ) count += _slabSizes[j];
+	return count;
+}
+
+size_t Partition::size( void ) const
+{
+	size_t count = 0;
+#ifdef ADAPTIVE_PADDING
+	for( unsigned int i=0 ; i<=_starts.size() ; i++ ) count += size(i);
+#else // !ADAPTIVE_PADDING
+	for( unsigned int i=0 ; i<=_starts.size() ; i++ ) count += size(i,0);
+#endif // ADAPTIVE_PADDING
+	return count;
+}
+
+#ifdef ADAPTIVE_PADDING
+void Partition::printDistribution( void ) const
+#else // !ADAPTIVE_PADDING
+void Partition::printDistribution( unsigned int padSize ) const
+#endif // ADAPTIVE_PADDING
+{
+	for( unsigned int i=0 ; i<=_starts.size() ; i++ )
+	{
+#ifdef ADAPTIVE_PADDING
+		std::pair< unsigned int , unsigned int > r = range(i);
+		std::cout << "Slab[ " << i << " ] [ " << r.first << " , " << r.second << " ) " << size(i) << std::endl;
+#else // !ADAPTIVE_PADDING
+		std::pair< unsigned int , unsigned int > r = range(i,0) , _r = range( i , padSize );
+		if( padSize )
+			std::cout << "Slab[ " << i << " ] [ " << r.first << " , " << r.second << " ) [ " << _r.first << " , " << _r.second << " ) " << size(i,0) << " " << size(i,padSize) << std::endl;
+		else
+			std::cout << "Slab[ " << i << " ] [ " << r.first << " , " << r.second << " ) " << size(i,0) << std::endl;
+#endif // ADAPTIVE_PADDING
+	}
+}
+
+#ifdef ADAPTIVE_PADDING
+double Partition::l2Energy( void ) const
+#else // !ADAPTIVE_PADDING
+double Partition::l2Energy( unsigned int padSize ) const
+#endif // ADAPTIVE_PADDING
+{
+	double e = 0;
+	for( unsigned int i=0 ; i<=_starts.size() ; i++ )
+	{
+#ifdef ADAPTIVE_PADDING
+		double d = (double)size(i);
+#else // !ADAPTIVE_PADDING
+		double d = (double)size(i,padSize);
+#endif // ADAPTIVE_PADDING
+		e += d*d;
+	}
+	return sqrt(e);
+}
+
+#ifdef ADAPTIVE_PADDING
+double Partition::maxEnergy( void ) const
+#else // !ADAPTIVE_PADDING
+double Partition::maxEnergy( unsigned int padSize ) const
+#endif // ADAPTIVE_PADDING
+{
+	double e = 0;
+#ifdef ADAPTIVE_PADDING
+	for( unsigned int i=0 ; i<=_starts.size() ; i++ ) e = std::max< double >( e , (double)size(i) );
+#else // !ADAPTIVE_PADDING
+	for( unsigned int i=0 ; i<=_starts.size() ; i++ ) e = std::max< double >( e , (double)size(i,padSize) );
+#endif // ADAPTIVE_PADDING
+	return e;
+}
+
+unsigned int Partition::slabs( void ) const { return (unsigned int)_slabSizes.size(); }
+
+unsigned int Partition::partitions( void ) const{ return (unsigned int)_starts.size()+1; }
+
+///////////////////////////////
+// Read/Write Ply Properties //
+///////////////////////////////
+long ReadPLYProperties( FILE *fp , std::vector< PlyProperty > &properties )
+{
+	size_t sz;
+	if( fread( &sz , sizeof( size_t ) , 1 , fp )!=1 ) MK_THROW( "Failed to read property size" );
+	properties.resize( sz );
+	FileStream fs(fp);
+	for( size_t i=0 ; i<sz ; i++ ) properties[i].read( fs );
+	return ftell( fp );
+}
+
+long ReadPLYProperties( const char *fileName , std::vector< PlyProperty > &properties )
+{
+	FILE *fp = fopen( fileName , "rb" );
+	if( !fp ) MK_THROW( "Could not open file for reading: " , fileName );
+	long pos = ReadPLYProperties( fp , properties );
+	fclose( fp );
+	return pos;
+}
+
+long WritePLYProperties( FILE *fp , const std::vector< PlyProperty > &properties )
+{
+	size_t sz = properties.size();
+	fwrite( &sz , sizeof( size_t ) , 1 , fp );
+	FileStream fs(fp);
+	for( size_t i=0 ; i<sz ; i++ ) properties[i].write( fs );
+	return ftell( fp );
+}
+
+long WritePLYProperties( const char *fileName , const std::vector< PlyProperty > &properties )
+{
+	FILE *fp = fopen( fileName , "wb" );
+	if( !fp ) MK_THROW( "Could not open file for writing: " , fileName );
+	long pos = WritePLYProperties( fp , properties );
+	fclose( fp );
+	return pos;
+}
+
+///////////////////////////////////
+// BufferedBinaryInputDataStream //
+///////////////////////////////////
+template< typename InputFactory >
+BufferedBinaryInputDataStream< InputFactory >::BufferedBinaryInputDataStream( const char *fileName , const InputFactory &factory , size_t bufferSize ) : _factory(factory) , _bufferSize(bufferSize) , _current(0) , _inBuffer(0)
+{
+
+	if( !_bufferSize )
+	{
+		MK_WARN_ONCE( "BufferSize cannot be zero , setting to one" );
+		_bufferSize = 1;
+	}
+	_elementSize = _factory.bufferSize();
+	_buffer = AllocPointer< char >( _elementSize*_bufferSize );
+	_fp = fopen( fileName , "rb" );
+	if( !_fp ) MK_THROW( "Could not open file for reading: " , fileName );
+	std::vector< PlyProperty > properties;
+	_inset = ReadPLYProperties( _fp , properties );
+}
+
+template< typename InputFactory >
+BufferedBinaryInputDataStream< InputFactory >::~BufferedBinaryInputDataStream( void )
+{
+	FreePointer( _buffer );
+	fclose( _fp );
+}
+
+template< typename InputFactory >
+void BufferedBinaryInputDataStream< InputFactory >::reset( void )
+{
+	fseek( _fp , _inset , SEEK_SET );
+	_current = 0;
+	_inBuffer = 0;
+}
+
+template< typename InputFactory >
+bool BufferedBinaryInputDataStream< InputFactory >::read( Data &d )
+{
+	if( _current==_inBuffer ) 
+	{
+		_inBuffer = fread( _buffer , _elementSize , _bufferSize , _fp );
+		_current = 0;
+	}
+	if( !_inBuffer ) return false;
+
+	_factory.fromBuffer( _buffer + _elementSize*_current , d );
+	_current++;
+
+	return true;
+}
+
+////////////////////////////////////
+// BufferedBinaryOutputDataStream //
+////////////////////////////////////
+
+template< typename OutputFactory >
+BufferedBinaryOutputDataStream< OutputFactory >::BufferedBinaryOutputDataStream( const char *fileName , const OutputFactory &factory , size_t bufferSize ) : _factory(factory) , _bufferSize(bufferSize) , _current(0)
+{
+	if( !_bufferSize )
+	{
+		MK_WARN_ONCE( "BufferSize cannot be zero , setting to one" );
+		_bufferSize = 1;
+	}
+	_elementSize = _factory.bufferSize();
+	_buffer = AllocPointer< char >( _elementSize*_bufferSize );
+	_fp = fopen( fileName , "wb" );
+	if( !_fp ) MK_THROW( "Could not open file for writing: " , fileName );
+	std::vector< PlyProperty > properties( factory.plyWriteNum() );
+	for( unsigned int i=0 ; i<factory.plyWriteNum() ; i++ ) properties[i] = factory.plyWriteProperty(i);
+	_inset = WritePLYProperties( _fp , properties );
+}
+
+template< typename OutputFactory >
+BufferedBinaryOutputDataStream< OutputFactory >::~BufferedBinaryOutputDataStream( void )
+{
+	if( _current ) fwrite( _buffer , _elementSize , _current , _fp );
+	FreePointer( _buffer );
+	fclose( _fp );
+}
+
+template< typename OutputFactory >
+void BufferedBinaryOutputDataStream< OutputFactory >::reset( void )
+{
+	fseek( _fp , _inset , SEEK_SET );
+	_current = 0;
+}
+
+template< typename OutputFactory >
+size_t BufferedBinaryOutputDataStream< OutputFactory >::write( const Data &d )
+{
+	if( _current==_bufferSize ) 
+	{
+		fwrite( _buffer , _elementSize , _bufferSize , _fp );
+		_current = 0;
+	}
+	_factory.toBuffer( d , _buffer + _elementSize*_current );
+	return _current++;
+}
+
+template< typename OutputFactory >
+size_t BufferedBinaryOutputDataStream< OutputFactory >::size( void ) const { return _current; }

--- a/LiverResections/Algorithm/PoissonRecon/Src/PoissonRecon.client.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PoissonRecon.client.inl
@@ -1,0 +1,1557 @@
+/*
+Copyright (c) 2023, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+struct Client
+{
+	typedef typename FEMTree< Dim , Real >::template DensityEstimator< Reconstructor::WeightDegree > DensityEstimator;
+	typedef typename FEMTree< Dim , Real >::template ApproximatePointInterpolationInfo< Real , 0 , Reconstructor::Poisson::ConstraintDual< Dim , Real > , Reconstructor::Poisson::SystemDual< Dim , Real > > ApproximatePointInterpolationInfo;
+	typedef IsotropicUIntPack< Dim , FEMDegreeAndBType< Degree , BType >::Signature > Sigs;
+	typedef IsotropicUIntPack< Dim , Degree > Degrees;
+	typedef IsotropicUIntPack< Dim , FEMDegreeAndBType< Reconstructor::Poisson::NormalDegree , DerivativeBoundary< BType , 1 >::BType >::Signature > NormalSigs;
+	static const unsigned int DataSig = FEMDegreeAndBType< Reconstructor::DataDegree , BOUNDARY_FREE >::Signature;
+	typedef VertexFactory::DynamicFactory< Real > AuxDataFactory;
+	typedef typename AuxDataFactory::VertexType AuxData;
+	typedef VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , VertexFactory::Factory< Real , VertexFactory::NormalFactory< Real , Dim > , AuxDataFactory > > InputSampleFactory;
+	typedef VertexFactory::Factory< Real , VertexFactory::NormalFactory< Real , Dim > , AuxDataFactory > InputSampleDataFactory;
+	typedef DirectSum< Real , Point< Real , Dim > , typename AuxDataFactory::VertexType > InputSampleDataType;
+	typedef DirectSum< Real , Point< Real , Dim > , InputSampleDataType > InputSampleType;
+	typedef InputDataStream< InputSampleType > InputPointStream;
+	typedef RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > FEMTreeNode;
+	using BoundaryData = std::conditional_t< Dim==3 , typename LevelSetExtractor< Real , 2 , Point< Real , 2 > >::TreeSliceValuesAndVertexPositions , char >;
+
+	~Client( void );
+
+	static std::function< int ( Point< Real , Dim > ) > PointDepthFunctor( Real begin , Real end , unsigned int padSize , unsigned int minDepth , unsigned int maxDepth );
+protected:
+	unsigned int _index;
+	SocketStream _serverSocket;
+	std::pair< unsigned int , unsigned int > _range;
+	XForm< Real , Dim+1 > _modelToUnitCube;
+	FEMTree< Dim , Real > _tree;
+
+	DensityEstimator *_density;																							// Phases [1,7]
+	SparseNodeData< Point< Real , Dim > , NormalSigs > *_normalInfo , *_paddedNormalInfo;								// Phases [1,3]
+	std::vector< typename FEMTree< Dim , Real >::PointSample >       _samples;											// Phases [1,5]
+	std::vector< typename FEMTree< Dim , Real >::PointSample > _paddedSamples;											// Phases [1,3]
+	std::vector< InputSampleDataType > _sampleData , _paddedSampleData;													// Phases [1,3]
+	DenseNodeData< Real , Sigs > _constraints;																			// Phases [3,5]
+	DenseNodeData< Real , Sigs > _solution;																				// Phases [5,7]
+	ApproximatePointInterpolationInfo *_iInfo;																			// Phases [3,5]
+	SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > > _auxDataField;				// Phases [3,7]
+
+	static std::pair< unsigned int , unsigned int > _PaddedRange( std::pair< unsigned int , unsigned int > range , unsigned int depth , unsigned int padSize );
+
+	struct _State3
+	{
+		_State3( void ) : subNodes( NullPointer( FEMTreeNode ) ) {}
+		~_State3( void ){ DeletePointer( subNodes ); }
+		Pointer( FEMTreeNode ) subNodes;
+		size_t subNodeCount;
+		DenseNodeData< Real , Sigs > constraints;
+		ApproximatePointInterpolationInfo iInfo;
+		SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > > auxDataField;
+	};
+	struct _State5
+	{
+		using Data = ProjectiveData< AuxData , Real >;
+
+		_State5( void ) : auxDataField(NULL) , subNodes( NullPointer( FEMTreeNode ) ) {}
+		~_State5( void )
+		{
+			DeletePointer( subNodes );
+			delete auxDataField;
+		}
+
+		struct BoundaryInfo
+		{
+			using SliceSigs = typename Sigs::Transpose::Rest::Transpose;
+			FEMTree< Dim-1 , Real > *tree;
+			DenseNodeData< Real , SliceSigs > solution , dSolution;
+			BoundaryInfo( void ) : tree(NULL) {}
+			~BoundaryInfo( void ){ delete tree; }
+		};
+
+		Pointer( FEMTreeNode ) subNodes;
+		DenseNodeData< Real , Sigs > solution;
+		SparseNodeData< Data , IsotropicUIntPack< Dim , DataSig > > *auxDataField;
+		std::pair< BoundaryInfo , BoundaryInfo > boundaryInfo;
+	};
+	struct _State7
+	{
+		BoundaryData *backBoundary , *frontBoundary;
+		std::vector< std::vector< Real > > backDValues , frontDValues;
+		Real isoValue;
+
+		_State7( void ) : backBoundary(NULL) , frontBoundary(NULL) , isoValue((Real)0.5){}
+		~_State7( void )
+		{
+			delete  backBoundary;
+			delete frontBoundary;
+		}
+	};
+
+	PhaseInfo _phase1( const ClientReconstructionInfo< Real , Dim > &clientReconInfo, Profiler &profiler );
+	PhaseInfo _phase3( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State3 &state3 , Profiler &profiler );
+	PhaseInfo _phase5( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler );
+	PhaseInfo _phase7( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler );
+
+	size_t _receive1( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler );
+	void _process1( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::pair< size_t , size_t > &nodeCounts , Profiler &profiler );
+	size_t _send1( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > pointWeight , std::pair< size_t , size_t > nodeCounts , Profiler &profiler );
+
+	size_t _receive3( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > &cumulativePointWeight , Profiler &profiler );
+	void _process3( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > cumulativePointWeight , _State3 &state3 , Profiler &profiler );
+	size_t _send3( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , const _State3 &state3 , Profiler &profiler );
+
+	size_t _receive5( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State5 &state5 , Profiler &profiler );
+	std::pair< double , double > _process5( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State5 &state5 , Profiler &profiler );
+	size_t _send5( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , const _State5 &state5 , Profiler &profiler );
+
+	size_t _receive7( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State7 &state7 , Profiler &profiler );
+	void _process7( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State7 &state7 , Profiler &profiler );
+
+	Client( void );
+	Client( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , BinaryStream &stream , unsigned int phase );
+	void _write( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , BinaryStream &stream , unsigned int phase ) const;
+
+	template< typename _Real , unsigned int _Dim , BoundaryType _BType , unsigned int _Degree >
+	friend void RunClient( std::vector< Socket > &serverSockets , unsigned int sampleMS );
+
+	template< bool HasGradients , bool HasDensity >
+	void _writeMeshWithData( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State7 &state7 , XForm< Real , Dim+1 > unitCubeToModel );
+};
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+void RunClient( std::vector< Socket > &serverSockets , unsigned int sampleMS )
+{
+	std::vector< SocketStream > serverSocketStreams( serverSockets.size() );
+	for( unsigned int i=0 ; i<serverSocketStreams.size() ; i++ ) serverSocketStreams[i] = SocketStream( serverSockets[i] );
+	Profiler profiler( sampleMS );
+	std::vector< FileStream > cacheFiles;
+	ClientReconstructionInfo< Real , Dim > clientReconInfo;
+	std::vector< unsigned int > clientIndices( serverSocketStreams.size() );
+
+	for( unsigned int i=0 ; i<serverSocketStreams.size() ; i++ ) clientReconInfo = ClientReconstructionInfo< Real , Dim >( serverSocketStreams[i] );
+	for( unsigned int i=0 ; i<serverSocketStreams.size() ; i++ ) serverSocketStreams[i].read( clientIndices[i] );
+
+	if( serverSocketStreams.size()>1 ) for( unsigned int idx=0 ; idx<serverSocketStreams.size() ; idx++ ) cacheFiles.emplace_back( std::tmpfile() );
+
+	Client< Real , Dim , BType , Degree > *client = NULL;
+	if( serverSocketStreams.size()==1 )
+	{
+		client = new Client< Real , Dim , BType , Degree >();
+		client->_serverSocket = serverSocketStreams[0];
+		client->_index        = clientIndices[0];
+	}
+
+	// Phase 1
+	{
+		PhaseInfo phaseInfo;
+		double cacheTime = 0;
+		size_t cacheBytes = 0;
+
+		profiler.reset();
+		for( unsigned int i=0 ; i<serverSocketStreams.size() ; i++ )
+		{
+			if( serverSocketStreams.size()>1 )
+			{
+				client = new Client< Real , Dim , BType , Degree >();
+				client->_serverSocket = serverSocketStreams[i];
+				client->_index        = clientIndices[i];
+			}
+
+			phaseInfo += client->_phase1( clientReconInfo , profiler );
+
+			if( serverSocketStreams.size()>1 )
+			{
+				Timer timer;
+
+				cacheFiles[i].reset();
+				cacheFiles[i].ioBytes = 0;
+				client->_write( clientReconInfo , cacheFiles[i] , 1 );
+				cacheBytes += cacheFiles[i].ioBytes;
+				delete client;
+				client = NULL;
+
+				cacheTime += timer.wallTime();
+			}
+		}
+		if( clientReconInfo.verbose>0 )
+		{
+			StreamFloatPrecision sfp( std::cout , 1 );
+			std::cout << ReceiveDataString( 1 , phaseInfo.readBytes ) << phaseInfo.readTime << " (s)" << std::endl;
+			std::cout << "[PROCESS 1]         : " << phaseInfo.processTime << " (s), " << profiler(false) << std::endl;
+			std::cout << SendDataString( 1 , phaseInfo.writeBytes ) << phaseInfo.writeTime << " (s)" << std::endl;
+			if( serverSocketStreams.size()>1 ) std::cout << "[CACHE   1]         : " << cacheTime << " (s) , " << (cacheBytes>>20) << " (MB)" << std::endl;
+		}
+	}
+
+	// Phase 3
+	{
+		PhaseInfo phaseInfo;
+		double cacheTime = 0;
+		size_t cacheBytes = 0;
+
+		profiler.reset();
+		for( unsigned int i=0 ; i<serverSocketStreams.size() ; i++ )
+		{
+			typename Client< Real , Dim , BType , Degree >::_State3 state3;
+
+			if( serverSocketStreams.size()>1 )
+			{
+				Timer timer;
+				cacheFiles[i].ioBytes = 0;
+				cacheFiles[i].reset();
+				client = new Client< Real , Dim , BType , Degree >( clientReconInfo , cacheFiles[i] , 3 );
+				cacheTime += timer.wallTime();
+				cacheBytes += cacheFiles[i].ioBytes;
+				client->_serverSocket = serverSocketStreams[i];
+			}
+
+			phaseInfo += client->_phase3( clientReconInfo , state3 , profiler );
+
+			if( serverSocketStreams.size()>1 )
+			{
+				Timer timer;
+				cacheFiles[i].ioBytes = 0;
+				cacheFiles[i].reset();
+				client->_write( clientReconInfo , cacheFiles[i] , 3 );
+				delete client;
+				client = NULL;
+				cacheTime += timer.wallTime();
+				cacheBytes += cacheFiles[i].ioBytes;
+			}
+		}
+
+		if( clientReconInfo.verbose>0 )
+		{
+			StreamFloatPrecision sfp( std::cout , 1 );
+			std::cout << ReceiveDataString( 3 , phaseInfo.readBytes ) << phaseInfo.readTime << " (s)" << std::endl;
+			std::cout << "[PROCESS 3]         : " << phaseInfo.processTime << " (s), " << profiler(false) << std::endl;
+			std::cout << SendDataString( 3 , phaseInfo.writeBytes ) << phaseInfo.writeTime << " (s)" << std::endl;
+			if( serverSocketStreams.size()>1 ) std::cout << "[CACHE   3]         : " << cacheTime << " (s) , " << (cacheBytes>>20) << " (MB)" << std::endl;
+		}
+	}
+
+	// Phase 5
+	{
+		PhaseInfo phaseInfo;
+		double cacheTime = 0;
+		size_t cacheBytes = 0;
+
+		profiler.reset();
+		for( unsigned int i=0 ; i<serverSocketStreams.size() ; i++ )
+		{
+			if( serverSocketStreams.size()>1 )
+			{
+				Timer timer;
+				cacheFiles[i].ioBytes = 0;
+				cacheFiles[i].reset();
+				client = new Client< Real , Dim , BType , Degree >( clientReconInfo , cacheFiles[i] , 5 );
+				cacheTime += timer.wallTime();
+				cacheBytes += cacheFiles[i].ioBytes;
+				client->_serverSocket = serverSocketStreams[i];
+			}
+
+			phaseInfo += client->_phase5( clientReconInfo , profiler );
+
+			if( serverSocketStreams.size()>1 )
+			{
+				Timer timer;
+				cacheFiles[i].ioBytes = 0;
+				cacheFiles[i].reset();
+				client->_write( clientReconInfo , cacheFiles[i] , 5 );
+				delete client;
+				client = NULL;
+				cacheTime += timer.wallTime();
+				cacheBytes += cacheFiles[i].ioBytes;
+			}
+		}
+
+		if( clientReconInfo.verbose>0 )
+		{
+			StreamFloatPrecision sfp( std::cout , 1 );
+			std::cout << ReceiveDataString( 5 , phaseInfo.readBytes ) << phaseInfo.readTime << " (s)" << std::endl;
+			std::cout << "[PROCESS 5]         : " << phaseInfo.processTime << " (s), " << profiler(false) << std::endl;
+			std::cout << SendDataString( 5 , phaseInfo.writeBytes ) << phaseInfo.writeTime << " (s)" << std::endl;
+			if( serverSocketStreams.size()>1 ) std::cout << "[CACHE   5]         : " << cacheTime << " (s) , " << (cacheBytes>>20) << " (MB)" << std::endl;
+		}
+	}
+	// Phase 7
+	{
+		PhaseInfo phaseInfo;
+		double cacheTime = 0;
+		size_t cacheBytes = 0;
+
+		profiler.reset();
+		for( unsigned int i=0 ; i<serverSocketStreams.size() ; i++ )
+		{
+			if( serverSocketStreams.size()>1 )
+			{
+				Timer timer;
+				cacheFiles[i].ioBytes = 0;
+				cacheFiles[i].reset();
+				client = new Client< Real , Dim , BType , Degree >( clientReconInfo , cacheFiles[i] , 7 );
+				cacheTime += timer.wallTime();
+				cacheBytes += cacheFiles[i].ioBytes;
+				client->_serverSocket = serverSocketStreams[i];
+			}
+
+			phaseInfo += client->_phase7( clientReconInfo , profiler );
+
+			if( serverSocketStreams.size()>1 )
+			{
+				delete client;
+				client = NULL;
+			}
+		}
+
+		if( clientReconInfo.verbose>0 )
+		{
+			StreamFloatPrecision sfp( std::cout , 1 );
+			std::cout << ReceiveDataString( 7 , phaseInfo.readBytes ) << phaseInfo.readTime << " (s)" << std::endl;
+			std::cout << "[PROCESS 7]         : " << phaseInfo.processTime << " (s), " << profiler(false) << std::endl;
+			if( serverSocketStreams.size()>1 ) std::cout << "[CACHE   7]         : " << cacheTime << " (s) , " << (cacheBytes>>20) << " (MB)" << std::endl;
+		}
+	}
+	if( serverSocketStreams.size()==1 ) delete client;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+Client< Real , Dim , BType , Degree >::Client( void )
+	: _serverSocket( _INVALID_SOCKET_ ) , _tree( MEMORY_ALLOCATOR_BLOCK_SIZE ) , _density(NULL) , _normalInfo(NULL) , _paddedNormalInfo(NULL) , _iInfo(NULL) , _index(-1)
+{
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+Client< Real , Dim , BType , Degree >::~Client( void )
+{
+	if( _density ) delete _density;
+	if( _normalInfo ) delete _normalInfo;
+	if( _paddedNormalInfo ) delete _paddedNormalInfo;
+	if( _iInfo ) delete _iInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+std::pair< unsigned int , unsigned int > Client< Real , Dim , BType , Degree >::_PaddedRange( std::pair< unsigned int , unsigned int > range , unsigned int depth , unsigned int padSize )
+{
+	std::pair< unsigned int , unsigned int > paddedRange;
+	if( range.first<=padSize ) paddedRange.first = 0;
+	else paddedRange.first = range.first - padSize;
+	if( range.second+padSize>(1u<<depth) ) paddedRange.second = (1<<depth);
+	else paddedRange.second = range.second + padSize;
+	return paddedRange;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+std::function< int ( Point< Real , Dim > ) > Client< Real , Dim , BType , Degree >::PointDepthFunctor( Real begin , Real end , unsigned int padSize , unsigned int minDepth , unsigned int maxDepth )
+{
+	// Using a padding size of two should do the trick. And it does, but only if we don't use adaptive
+	const double Log2 = log(2.);
+	return [begin,end,padSize,minDepth,maxDepth,Log2]( Point< Real , Dim > p )
+	{
+		// For interior points, add to the full depth
+		if( p[Dim-1]>=begin && p[Dim-1]<=end ) return (int)maxDepth;
+		else if( p[Dim-1]<begin )
+		{
+			// Solve for the largest d s.t.:
+			//		p[Dim-1] >= b-padSize/(1<<d)
+			//		b-p[Dim-1] <= padSize/(1<<d)
+			//		(b-p[Dim-1])/padSize <= 1/(1<<d)
+			//		padSize/(b-p[Dim-1]) >= (1<<d)
+			//		log_2( padSize/(b-p[Dim-1]) ) >= d
+			// =>	d = floor( log_2( padSize/(b-p[Dim-1]) ) )
+			return std::max< int >( std::min< int >( (int)floor( log( padSize/( begin - p[Dim-1] ) ) / Log2 ) , (int)maxDepth ) , (int)minDepth );
+		}
+		else if( p[Dim-1]>end )
+		{
+			// Solve for the largest d s.t.:
+			//		p[Dim-1] <= e+padSize/(1<<d)
+			//		p[Dim-1]-e <= padSize/(1<<d)
+			//		(p[Dim-1]-d)/padSize <= 1/(1<<d)
+			//		padSize/(p[Dim-1]-e) >= (1<<d)
+			//		log_2( padSize/(p[Dim-1]-e) ) >= d
+			// =>	d = floor( log_2( padSize/(p[Dim-1]-e) ) )
+			return std::max< int >( std::min< int >( (int)floor( log( padSize/( p[Dim-1] - end ) ) / Log2 ) , (int)maxDepth ) , (int)minDepth );
+		}
+		else return -1;
+	};
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+PhaseInfo Client< Real , Dim , BType , Degree >::_phase1( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler )
+{
+	PhaseInfo phaseInfo;
+	ProjectiveData< Point< Real , 2 > , Real > pointDepthAndWeight;
+	std::pair< size_t , size_t > nodeCounts;
+
+	{
+		Timer timer;
+		phaseInfo.readBytes += _receive1( clientReconInfo , profiler );
+		phaseInfo.readTime += timer.wallTime();
+	}
+	if( clientReconInfo.verbose>1 ) std::cout << "Range[" << _index << "]: [ " << _range.first << " , " << _range.second << " ) +/- " << clientReconInfo.padSize << std::endl;
+
+	{
+		Timer timer;
+		_process1( clientReconInfo , pointDepthAndWeight , nodeCounts , profiler );
+		phaseInfo.processTime += timer.wallTime();
+	}
+
+	ProjectiveData< Real , Real > pointWeight;
+	pointWeight.data = pointDepthAndWeight.data[1];
+	pointWeight.weight = pointDepthAndWeight.weight;
+	{
+		Timer timer;
+		phaseInfo.writeBytes += _send1( clientReconInfo , pointWeight , nodeCounts , profiler );
+		phaseInfo.writeTime += timer.wallTime();
+	}
+	return phaseInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+size_t Client< Real , Dim , BType , Degree >::_receive1( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler )
+{
+	ClientServerStream< true > serverStream( _serverSocket , _index , clientReconInfo );
+	serverStream.ioBytes = 0;
+
+	if( !serverStream.read( _modelToUnitCube ) ) MK_THROW( "Failed to read model-to-unit-cube transform" );
+	serverStream.read( _range );
+	profiler.update();
+
+	return serverStream.ioBytes;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+size_t Client< Real , Dim , BType , Degree >::_send1( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > pointWeight , std::pair< size_t , size_t > nodeCounts , Profiler &profiler )
+{
+	ClientServerStream< false > serverStream( _serverSocket , _index , clientReconInfo );
+	serverStream.ioBytes = 0;
+	serverStream.write( pointWeight );
+	serverStream.write( nodeCounts );
+	profiler.update();
+	return serverStream.ioBytes;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+void Client< Real , Dim , BType , Degree >::_process1( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Point< Real , 2 > , Real > &pointDepthAndWeight , std::pair< size_t , size_t > &nodeCounts , Profiler &profiler )
+{
+	std::pair< unsigned int , unsigned int > paddedRange = _PaddedRange( _range  , clientReconInfo.sharedDepth , clientReconInfo.padSize );
+	AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+	InputSampleFactory inputSampleFactory( VertexFactory::PositionFactory< Real , Dim >() , InputSampleDataFactory( VertexFactory::NormalFactory< Real , Dim >() , auxDataFactory ) );
+	InputSampleDataFactory inputSampleDataFactory( VertexFactory::NormalFactory< Real , Dim >() , auxDataFactory );
+
+	size_t pointCount = 0 , paddedPointCount = 0;
+	ProjectiveData< Point< Real , 2 > , Real > paddedPointDepthAndWeight;
+	paddedPointDepthAndWeight.data = Point< Real , 2 >();
+	paddedPointDepthAndWeight.weight = 0;
+
+	unsigned int beginIndex=_range.first , endIndex = _range.second;
+	unsigned int beginPaddedIndex = paddedRange.first , endPaddedIndex = paddedRange.second;
+
+	pointDepthAndWeight.data = Point< Real , 2 >();
+	pointDepthAndWeight.weight = 0;
+
+	FEMTreeInitializer< Dim , Real >::Initialize( _tree.spaceRoot() , clientReconInfo.baseDepth , []( int , int[] ){ return true; } , _tree.nodeAllocators[0] , _tree.initializer() );
+
+
+#ifdef ADAPTIVE_PADDING
+	std::function< int ( Point< Real , Dim > ) > pointDepthFunctor = PointDepthFunctor( (Real)_range.first/(1<<clientReconInfo.sharedDepth) , (Real)_range.second/(1<<clientReconInfo.sharedDepth) , clientReconInfo.padSize , clientReconInfo.kernelDepth , clientReconInfo.reconstructionDepth );
+#endif // ADAPTIVE_PADDING
+	// Read in the samples (and color data)
+	{
+		Timer timer;
+		auto ProcessData = [&]( const Point< Real , Dim > &p , InputSampleDataType &d )
+			{
+				Real l = (Real)Length( d.template get<0>() );
+				if( !l || !std::isfinite( l ) ) return (Real)-1.;
+				d.template get<0>() /= l;
+				return clientReconInfo.confidence ? l : (Real)1.;
+			};
+
+		std::vector< InputDataStream< typename InputSampleFactory::VertexType > * > pointStreams( endPaddedIndex - beginPaddedIndex , NULL );
+		auto PointStreamFunctor = [&]( unsigned int idx )
+		{
+			std::string fileName = PointPartition::FileName( clientReconInfo.header , idx , 1<<clientReconInfo.sharedDepth , clientReconInfo.filesPerDir );
+
+			fileName = PointPartition::FileDir( clientReconInfo.inDir , fileName );
+			pointStreams[idx-beginPaddedIndex] = new PointPartition::BufferedBinaryInputDataStream< InputSampleFactory >( fileName.c_str() , inputSampleFactory , clientReconInfo.bufferSize );
+		};
+		{
+			std::vector< std::thread > pointStreamThreads;
+			pointStreamThreads.reserve( endPaddedIndex - beginPaddedIndex );
+			for( unsigned int i=beginPaddedIndex ; i<endPaddedIndex ; i++ ) pointStreamThreads.emplace_back( PointStreamFunctor , i );
+			for( unsigned int i=0 ; i<( endPaddedIndex - beginPaddedIndex ) ; i++ ) pointStreamThreads[i].join();
+		}
+
+		using MultiPointStream = MultiInputDataStream< typename InputSampleFactory::VertexType >;
+
+		using ExternalType = std::tuple< Point< Real , Dim > , InputSampleDataType >;
+		using InternalType = std::tuple< typename InputSampleFactory::VertexType >;
+		auto converter = []( const InternalType &iType )
+			{
+				ExternalType xType;
+				std::get< 0 >( xType )                   = std::get< 0 >( iType ).template get<0>();
+				std::get< 1 >( xType ).template get<0>() = std::get< 0 >( iType ).template get<1>().template get<0>();
+				std::get< 1 >( xType ).template get<1>() = std::get< 0 >( iType ).template get<1>().template get<1>();
+				return xType;
+			};
+
+		auto ProcessInteriorPointSlabs = [&]( typename FEMTreeInitializer< Dim , Real >::StreamInitializationData &sid , unsigned int start , unsigned int end )
+		{
+			if( start==end ) return;
+			MultiPointStream pointStream( &pointStreams[start-beginPaddedIndex] , end - start );
+			typename InputSampleDataFactory::VertexType zeroData = inputSampleDataFactory();
+			InputDataStreamConverter< InternalType , ExternalType > _pointStream( pointStream , converter , inputSampleFactory() );
+			pointCount += FEMTreeInitializer< Dim , Real >::template Initialize< InputSampleDataType >( sid , _tree.spaceRoot() , _pointStream , zeroData , clientReconInfo.reconstructionDepth , _samples , _sampleData , _tree.nodeAllocators[0] , _tree.initializer() , ProcessData );
+			profiler.update();
+		};
+		auto ProcessPadPointSlabs = [&]( typename FEMTreeInitializer< Dim , Real >::StreamInitializationData &sid , unsigned int start , unsigned int end )
+		{
+			if( start==end ) return;
+			MultiPointStream pointStream( &pointStreams[start-beginPaddedIndex] , end - start );
+			typename InputSampleDataFactory::VertexType zeroData = inputSampleDataFactory();
+			InputDataStreamConverter< InternalType , ExternalType > _pointStream( pointStream , converter , inputSampleFactory() );
+#ifdef ADAPTIVE_PADDING
+			paddedPointCount += FEMTreeInitializer< Dim , Real >::template Initialize< InputSampleDataType >( sid , _tree.spaceRoot() , _pointStream , zeroData , clientReconInfo.reconstructionDepth , pointDepthFunctor , _paddedSamples , _paddedSampleData , _tree.nodeAllocators[0] , _tree.initializer() , ProcessData );
+#else // !ADAPTIVE_PADDING
+			paddedPointCount += FEMTreeInitializer< Dim , Real >::template Initialize< InputSampleDataType >( sid , _tree.spaceRoot() , _pointStream , zeroData , clientReconInfo.reconstructionDepth , _paddedSamples , _paddedSampleData , _tree.nodeAllocators[0] , _tree.initializer() , ProcessData );
+#endif // ADAPTIVE_PADDING
+			profiler.update();
+		};
+
+		auto ProcessPointSlab = [&]( typename FEMTreeInitializer< Dim , Real >::StreamInitializationData &sid , unsigned int idx )
+		{
+			InputDataStream< typename InputSampleFactory::VertexType > &pointStream = *pointStreams[idx-beginPaddedIndex];
+				
+			if( idx>=beginIndex && idx<endIndex )
+			{
+				typename InputSampleDataFactory::VertexType zeroData = inputSampleDataFactory();
+				InputDataStreamConverter< InternalType , ExternalType > _pointStream( pointStream , converter , inputSampleFactory() );
+				pointCount += FEMTreeInitializer< Dim , Real >::template Initialize< InputSampleDataType >( sid , _tree.spaceRoot() , _pointStream , zeroData , clientReconInfo.reconstructionDepth , _samples , _sampleData , _tree.nodeAllocators[0] , _tree.initializer() , ProcessData );
+			}
+			else
+			{
+				typename InputSampleDataFactory::VertexType zeroData = inputSampleDataFactory();
+				InputDataStreamConverter< InternalType , ExternalType > _pointStream( pointStream , converter , inputSampleFactory() );
+#ifdef ADAPTIVE_PADDING
+				paddedPointCount += FEMTreeInitializer< Dim , Real >::template Initialize< InputSampleDataType >( sid , _tree.spaceRoot() , _pointStream , zeroData , clientReconInfo.reconstructionDepth , pointDepthFunctor , _paddedSamples , _paddedSampleData , _tree.nodeAllocators[0] , _tree.initializer() , ProcessData );
+#else // !ADAPTIVE_PADDING
+				paddedPointCount += FEMTreeInitializer< Dim , Real >::template Initialize< InputSampleDataType >( sid , _tree.spaceRoot() , _pointStream , zeroData , clientReconInfo.reconstructionDepth , _paddedSamples , _paddedSampleData , _tree.nodeAllocators[0] , _tree.initializer() , ProcessData );
+#endif // ADAPTIVE_PADDING
+			}
+			profiler.update();
+		};
+
+		{
+			typename FEMTreeInitializer< Dim , Real >::StreamInitializationData sid;
+			ProcessInteriorPointSlabs( sid , beginIndex , endIndex );
+		}
+		nodeCounts.first = _tree.spaceRoot().nodes();
+
+		{
+			typename FEMTreeInitializer< Dim , Real >::StreamInitializationData sid;
+			ProcessPadPointSlabs( sid , beginPaddedIndex , beginIndex );
+			ProcessPadPointSlabs( sid , endIndex , endPaddedIndex );
+		}
+		for( unsigned int i=0 ; i<pointStreams.size() ; i++ ) delete pointStreams[i];
+
+
+
+		nodeCounts.second = _tree.spaceRoot().nodes();
+
+		if( clientReconInfo.verbose>1 ) std::cout << "Input Points / Padded Input Points / Samples / Padded Samples: " << pointCount << " / " << paddedPointCount << " / " << _samples.size() << " / " << _paddedSamples.size() << std::endl;
+		if( clientReconInfo.verbose>1 ) std::cout << "#          Read input into tree: " << timer << std::endl;
+	}
+
+	if( clientReconInfo.verbose>1 ) std::cout << "Nodes [Initialized]: " << _tree.allNodes() << std::endl;
+
+	// Get the kernel density estimator
+	{
+		Timer timer;
+		_density = _tree.template setDensityEstimator< 1 , Reconstructor::WeightDegree >( _samples , clientReconInfo.kernelDepth , clientReconInfo.samplesPerNode );
+#ifdef ADAPTIVE_PADDING
+		_tree.template updateDensityEstimator< 1 , Reconstructor::WeightDegree >( *_density , _paddedSamples , 0 , clientReconInfo.kernelDepth , pointDepthFunctor );
+#else // !ADAPTIVE_PADDING
+		_tree.template updateDensityEstimator< 1 , Reconstructor::WeightDegree >( *_density , _paddedSamples , 0 , clientReconInfo.kernelDepth );
+#endif // ADAPTIVE_PADDING
+		profiler.update();
+		if( clientReconInfo.verbose>1 ) std::cout << "#            Got kernel density: " << timer << std::endl;
+	}
+
+	if( clientReconInfo.verbose>1 ) std::cout << "Nodes [Density Estimator]: " << _tree.allNodes() << std::endl;
+
+	// Transform the Hermite samples into a vector field
+	{
+		Timer timer;
+		_normalInfo = new SparseNodeData< Point< Real , Dim > , NormalSigs >();
+		_paddedNormalInfo = new SparseNodeData< Point< Real , Dim > , NormalSigs >();
+
+		std::function< bool ( InputSampleDataType , Point< Real , Dim >& ) > ConversionFunction = []( InputSampleDataType in , Point< Real , Dim > &out )
+		{
+			Point< Real , Dim > n = in.template get<0>();
+			Real l = (Real)Length( n );
+			// It is possible that the samples have non-zero normals but there are two co-located samples with negative normals...
+			if( !l ) return false;
+			out = n / l;
+			return true;
+		};
+
+		{
+			*_normalInfo = _tree.setInterpolatedDataField( Point< Real , Dim >() , NormalSigs() , _samples , _sampleData , _density , clientReconInfo.sharedDepth , clientReconInfo.reconstructionDepth , (Real)0 , pointDepthAndWeight , ConversionFunction );
+			if( clientReconInfo.verbose>1 ) std::cout << "Nodes [Interior Data Field " << _normalInfo->size() << " / " << _normalInfo->reserved() << "]: " << _tree.allNodes() << std::endl;
+#ifdef ADAPTIVE_PADDING
+			*_paddedNormalInfo = _tree.setInterpolatedDataField( Point< Real , Dim >() , NormalSigs() , _paddedSamples , _paddedSampleData , _density , clientReconInfo.sharedDepth , clientReconInfo.reconstructionDepth , pointDepthFunctor , (Real)0 , paddedPointDepthAndWeight , ConversionFunction );
+#else // !ADAPTIVE_PADDING
+			*_paddedNormalInfo = _tree.setInterpolatedDataField( Point< Real , Dim >() , NormalSigs() , _paddedSamples , _paddedSampleData , _density , clientReconInfo.sharedDepth , clientReconInfo.reconstructionDepth , (Real)0 , paddedPointDepthAndWeight , ConversionFunction );
+#endif // ADAPTIVE_PADDING
+		}
+
+		ThreadPool::ParallelFor( 0 , _normalInfo->size() , [&]( unsigned int , size_t i ){ (*_normalInfo)[i] *= (Real)-1.; } );
+		ThreadPool::ParallelFor( 0 , _paddedNormalInfo->size() , [&]( unsigned int , size_t i ){ (*_paddedNormalInfo)[i] *= (Real)-1.; } );
+		profiler.update();
+		if( clientReconInfo.verbose>1 )
+		{
+			std::cout << "#              Got normal field: " << timer << std::endl;
+			std::cout << "Point Depth / Point Weight / Padded Point Depth / Padded Point Weight / Estimated Measure /  Estimated Padded Measure: " << pointDepthAndWeight.value()[0] << " / " << pointDepthAndWeight.value()[1] << " / " << paddedPointDepthAndWeight.value()[0] << " / " << paddedPointDepthAndWeight.value()[1] << " / " << pointCount* pointDepthAndWeight.value()[1] << " / " << paddedPointCount* paddedPointDepthAndWeight.value()[1] << std::endl;
+		}
+	}
+	if( clientReconInfo.verbose>1 ) std::cout << "Nodes [Padded Data Field " << _paddedNormalInfo->size() << " / " << _paddedNormalInfo->reserved() << "]: " << _tree.allNodes() << std::endl;
+
+	_tree.resetNodeIndices( 0 , std::make_tuple( _density , _normalInfo , _paddedNormalInfo ) );
+
+	if( clientReconInfo.verbose>1 ) std::cout << "Memory Usage: " << float( MemoryInfo::Usage() )/(1<<20) << " MB" << std::endl;
+	profiler.update();
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+PhaseInfo Client< Real , Dim , BType , Degree >::_phase3( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State3 &state3 , Profiler &profiler )
+{
+	PhaseInfo phaseInfo;
+	ProjectiveData< Real , Real > cumulativePointWeight;
+
+	{
+		Timer timer;
+		phaseInfo.readBytes += _receive3( clientReconInfo , cumulativePointWeight , profiler );
+		phaseInfo.readTime += timer.wallTime();
+	}
+
+	{
+		Timer timer;
+		_process3( clientReconInfo , cumulativePointWeight , state3 , profiler );
+		phaseInfo.processTime += timer.wallTime();
+	}
+
+	{
+		Timer timer;
+		phaseInfo.writeBytes += _send3( clientReconInfo , state3 , profiler );
+		phaseInfo.writeTime += timer.wallTime();
+	}
+
+	return phaseInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+size_t Client< Real , Dim , BType , Degree >::_receive3( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > &cumulativePointWeight , Profiler &profiler )
+{
+	ClientServerStream< true > serverStream( _serverSocket , _index , clientReconInfo );
+	serverStream.ioBytes = 0;
+	if( !serverStream.read( cumulativePointWeight ) ) MK_THROW( "Could not read cumulative point weight" );
+	profiler.update();
+	return serverStream.ioBytes;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+size_t Client< Real , Dim , BType , Degree >::_send3( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , const _State3 &state3 , Profiler &profiler )
+{
+	size_t ioBytes = 0;
+	{
+		ClientServerStream< false > serverStream( _serverSocket , _index , clientReconInfo , ClientReconstructionInfo< Real , Dim >::BACK );
+		serverStream.ioBytes = 0;
+
+		serverStream.write( state3.subNodeCount );
+		TreeAddressesToIndices( state3.subNodes , state3.subNodeCount );
+		serverStream.write( state3.subNodes , state3.subNodeCount );
+		ioBytes += serverStream.ioBytes;
+		profiler.update();
+	}
+	{
+		AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+		bool needAuxData = clientReconInfo.dataX>0 && auxDataFactory.bufferSize();
+
+		ClientServerStream< false > serverStream( _serverSocket , _index , clientReconInfo , ClientReconstructionInfo< Real , Dim >::FRONT );
+		serverStream.ioBytes = 0;
+
+		state3.constraints.write( serverStream );
+		state3.iInfo.write( serverStream );
+
+		if( needAuxData )
+		{
+			if constexpr( !AuxDataFactory::IsStaticallyAllocated() )
+			{
+				ProjectiveAuxDataTypeSerializer< Real > serializer( clientReconInfo.auxProperties );
+				state3.auxDataField.write( serverStream , serializer );
+			}
+			else state3.auxDataField.write( serverStream );
+		}
+		ioBytes += serverStream.ioBytes;
+		profiler.update();
+	}
+	return ioBytes;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+void Client< Real , Dim , BType , Degree >::_process3( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > cumulativePointWeight , _State3 &state3 , Profiler &profiler )
+{
+	std::pair< unsigned int , unsigned int > paddedRange = _PaddedRange( _range  , clientReconInfo.sharedDepth , clientReconInfo.padSize );
+	AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+
+	InputSampleFactory inputSampleFactory( VertexFactory::PositionFactory< Real , Dim >() , InputSampleDataFactory( VertexFactory::NormalFactory< Real , Dim >() , auxDataFactory ) );
+	InputSampleDataFactory inputSampleDataFactory( VertexFactory::NormalFactory< Real , Dim >() , auxDataFactory );
+
+	bool needAuxData = clientReconInfo.dataX>0 && auxDataFactory.bufferSize();
+
+	Real targetValue = clientReconInfo.targetValue;
+
+	unsigned int beginIndex = _range.first , endIndex = _range.second;
+	unsigned int beginPaddedIndex = paddedRange.first , endPaddedIndex = paddedRange.second;
+
+	ApproximatePointInterpolationInfo *iInfo = NULL;
+	ApproximatePointInterpolationInfo *paddedIInfo = NULL;
+
+	// Add the interpolation constraints
+	{
+		Timer timer;
+		iInfo       = FEMTree< Dim , Real >::template InitializeApproximatePointInterpolationInfo< Real , 0 > ( _tree ,       _samples , Reconstructor::Poisson::ConstraintDual< Dim , Real >( targetValue , clientReconInfo.pointWeight * cumulativePointWeight.value() ) , Reconstructor::Poisson::SystemDual< Dim , Real >( clientReconInfo.pointWeight * cumulativePointWeight.value() ) , true , clientReconInfo.reconstructionDepth , 1 );
+		paddedIInfo = FEMTree< Dim , Real >::template InitializeApproximatePointInterpolationInfo< Real , 0 > ( _tree , _paddedSamples , Reconstructor::Poisson::ConstraintDual< Dim , Real >( targetValue , clientReconInfo.pointWeight * cumulativePointWeight.value() ) , Reconstructor::Poisson::SystemDual< Dim , Real >( clientReconInfo.pointWeight * cumulativePointWeight.value() ) , true , clientReconInfo.reconstructionDepth , 1 );
+		profiler.update();
+
+		if( clientReconInfo.verbose>1 ) std::cout << "# Set interpolation constraints: " << timer << std::endl;
+	}
+
+	// Trim the tree and prepare for multigrid
+	{
+		Timer timer;
+
+		constexpr int MaxDegree = Reconstructor::Poisson::NormalDegree > Degrees::Max() ? Reconstructor::Poisson::NormalDegree : Degrees::Max();
+		typename FEMTree< Dim , Real >::template HasNormalDataFunctor< NormalSigs > hasNormalDataFunctor( *_normalInfo );
+		typename FEMTree< Dim , Real >::template HasNormalDataFunctor< NormalSigs > hasPaddedNormalDataFunctor( *_paddedNormalInfo );
+		auto hasDataFunctor = [&]( const FEMTreeNode *node ){ return hasNormalDataFunctor( node ) || hasPaddedNormalDataFunctor( node ); };
+
+		const int StartOffset = BSplineSupportSizes< MaxDegree >::SupportStart;
+		const int   EndOffset = BSplineSupportSizes< MaxDegree >::SupportEnd+1;
+		auto addNodeFunctor = [&]( int d , const int off[Dim] )
+		{
+			if( d<0 ) return true;
+			else if( d>(int)clientReconInfo.baseDepth ) return false;
+			else
+			{
+				int start = ( off[Dim-1] + StartOffset )<<(clientReconInfo.sharedDepth-d);
+				int end   = ( off[Dim-1] +   EndOffset )<<(clientReconInfo.sharedDepth-d);
+				return start<(int)endPaddedIndex && end>(int)beginPaddedIndex;
+			}
+		};
+		_tree.template finalizeForMultigrid< MaxDegree , Degrees::Max() >( clientReconInfo.baseDepth , addNodeFunctor , hasDataFunctor , std::make_tuple( iInfo , paddedIInfo ) , std::make_tuple( _normalInfo , _paddedNormalInfo , _density ) );
+		profiler.update();
+		if( clientReconInfo.verbose>1 )
+		{
+			std::cout << "All Nodes / Active Nodes / Ghost Nodes: " << _tree.allNodes() << " / " << _tree.activeNodes() << " / " << _tree.ghostNodes() << std::endl;
+			std::cout << "#                Finalized tree: " << timer << std::endl;
+		}
+	}
+
+	// Compute the FEM constraints for the points interior to the slab
+	{
+		_constraints = _tree.initDenseNodeData( Sigs() );
+
+		// Add Poisson constraints
+		{
+			Timer timer;
+			typename FEMIntegrator::template Constraint< Sigs , IsotropicUIntPack< Dim , 1 > , NormalSigs , IsotropicUIntPack< Dim , 0 > , Dim > F;
+			unsigned int derivatives2[Dim];
+			for( int d=0 ; d<Dim ; d++ ) derivatives2[d] = 0;
+			typedef IsotropicUIntPack< Dim , 1 > Derivatives1;
+			typedef IsotropicUIntPack< Dim , 0 > Derivatives2;
+			for( int d=0 ; d<Dim ; d++ )
+			{
+				unsigned int derivatives1[Dim];
+				for( int dd=0 ; dd<Dim ; dd++ ) derivatives1[dd] = dd==d ? 1 : 0;
+				F.weights[d][ TensorDerivatives< Derivatives1 >::Index( derivatives1 ) ][ TensorDerivatives< Derivatives2 >::Index( derivatives2 ) ] = 1;
+			}
+			_tree.addFEMConstraints( F , *_normalInfo , _constraints , clientReconInfo.reconstructionDepth );
+			if( clientReconInfo.verbose>1 ) std::cout << "#  Set interior FEM constraints: " << timer << std::endl;
+		}
+		profiler.update();
+
+		// Free up the normal info
+		delete _normalInfo , _normalInfo = NULL;
+
+		{
+			Timer timer;
+			_tree.addInterpolationConstraints( _constraints , clientReconInfo.reconstructionDepth , std::make_tuple( iInfo ) );
+			profiler.update();
+			if( clientReconInfo.verbose>1 ) std::cout << "#Set interior point constraints: " << timer << std::endl;
+		}
+	}
+	if( needAuxData ) _auxDataField = _tree.template setExtrapolatedDataField< DataSig , false , Reconstructor::WeightDegree , AuxData >( auxDataFactory() , _samples.size() , [&]( size_t i ) -> const typename FEMTree< Dim , Real >::PointSample & { return _samples[i]; } , [&]( size_t i ) -> const AuxData & { return _sampleData[i].template get<1>(); } , (DensityEstimator*)NULL );
+
+	// Get the shared tree, constraints, interpolation info, and data-field
+	{
+		auto keepNodeFunctor = [&]( const FEMTreeNode *node )
+		{
+			int d , off[Dim];
+			_tree.depthAndOffset( node , d , off );
+
+			return d<=(int)clientReconInfo.sharedDepth;
+		};
+		state3.subNodes = _tree.tree().serializeSubTree( keepNodeFunctor , state3.subNodeCount );
+		state3.constraints = _tree.trimToDepth( _constraints , clientReconInfo.sharedDepth );
+		state3.iInfo = _tree.trimToDepth( *iInfo , clientReconInfo.sharedDepth );
+		if( needAuxData ) state3.auxDataField = _tree.trimToDepth( _auxDataField , clientReconInfo.sharedDepth );
+	}
+
+	if( needAuxData )
+	{
+		_tree.template updateExtrapolatedDataField< DataSig , false >( auxDataFactory() , _auxDataField , _paddedSamples.size() , [&]( size_t i ) -> const typename FEMTree< Dim , Real >::PointSample & { return _paddedSamples[i]; } , [&]( size_t i ) -> const AuxData & { return _paddedSampleData[i].template get<1>(); } , (DensityEstimator*)NULL );
+		auto nodeFunctor = [&]( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *n )
+		{
+			ProjectiveData< AuxData , Real >* clr = _auxDataField( n );
+			if( clr ) (*clr) *= (Real)pow( clientReconInfo.dataX , _tree.depth( n ) );
+		};
+		_tree.tree().processNodes( nodeFunctor );
+	}
+
+	// Add the FEM constraints for the points in the padding region
+	{
+		Timer timer;
+		// Add Poisson constraints
+		{
+			typename FEMIntegrator::template Constraint< Sigs , IsotropicUIntPack< Dim , 1 > , NormalSigs , IsotropicUIntPack< Dim , 0 > , Dim > F;
+			unsigned int derivatives2[Dim];
+			for( int d=0 ; d<Dim ; d++ ) derivatives2[d] = 0;
+			typedef IsotropicUIntPack< Dim , 1 > Derivatives1;
+			typedef IsotropicUIntPack< Dim , 0 > Derivatives2;
+			for( int d=0 ; d<Dim ; d++ )
+			{
+				unsigned int derivatives1[Dim];
+				for( int dd=0 ; dd<Dim ; dd++ ) derivatives1[dd] = dd==d ? 1 : 0;
+				F.weights[d][ TensorDerivatives< Derivatives1 >::Index( derivatives1 ) ][ TensorDerivatives< Derivatives2 >::Index( derivatives2 ) ] = 1;
+			}
+			_tree.addFEMConstraints( F , *_paddedNormalInfo , _constraints , clientReconInfo.reconstructionDepth );
+		}
+		if( clientReconInfo.verbose>1 ) std::cout << "#    Set padded FEM constraints: " << timer << std::endl;
+
+		profiler.update();
+
+		// Free up the normal info
+		delete _paddedNormalInfo , _paddedNormalInfo = NULL;
+
+		{
+			Timer timer;
+			_tree.addInterpolationConstraints( _constraints , clientReconInfo.reconstructionDepth , std::make_tuple( paddedIInfo ) );
+			profiler.update();
+			if( clientReconInfo.verbose>1 ) std::cout << "#  Set padded point constraints: " << timer << std::endl;
+		}
+	}
+
+	// Merge the interpolation information
+	{
+		Timer timer;
+		using InterpolationData = typename ApproximatePointInterpolationInfo::Data;
+		auto  preMergeFunctor = []( InterpolationData data ){ data.position *= data.weight ; return data; };
+		auto postMergeFunctor = []( InterpolationData data ){ data.position /= data.weight ; return data; };
+
+		_iInfo = new ApproximatePointInterpolationInfo( Reconstructor::Poisson::ConstraintDual< Dim , Real >( targetValue , clientReconInfo.pointWeight * cumulativePointWeight.value() ) , Reconstructor::Poisson::SystemDual< Dim , Real >( clientReconInfo.pointWeight * cumulativePointWeight.value() ) , true );
+		_iInfo->iData.reserve( _tree.nodesSize() );
+
+		_iInfo->iData.merge( iInfo->iData , preMergeFunctor );
+		_iInfo->iData.merge( paddedIInfo->iData , preMergeFunctor );
+
+		for( unsigned int i=0 ; i<_iInfo->iData.size() ; i++ ) _iInfo->iData[i] = postMergeFunctor( _iInfo->iData[i] );
+
+		if( clientReconInfo.verbose>1 ) std::cout << "#         Merged interpolation: " << timer << std::endl;
+	}
+	if( clientReconInfo.verbose>1 ) std::cout << "Memory Usage: " << float( MemoryInfo::Usage() )/(1<<20) << " MB" << std::endl;
+	profiler.update();
+	delete iInfo;
+	delete paddedIInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+PhaseInfo Client< Real , Dim , BType , Degree >::_phase5( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler )
+{
+	PhaseInfo phaseInfo;
+	std::pair< double , double > isoInfo;
+
+	typename Client< Real , Dim , BType , Degree >::_State5 state5;
+	{
+		Timer timer;
+		phaseInfo.readBytes += _receive5( clientReconInfo , state5 , profiler );
+		phaseInfo.readTime += timer.wallTime();
+	}
+
+	{
+		Timer timer;
+		isoInfo = _process5( clientReconInfo , state5 , profiler );
+		phaseInfo.processTime += timer.wallTime();
+	}
+
+	{
+		Timer timer;
+		_serverSocket.write( isoInfo );
+		phaseInfo.writeBytes += _send5( clientReconInfo , state5 , profiler );
+		phaseInfo.writeTime += timer.wallTime();
+	}
+	return phaseInfo;
+}
+
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+size_t Client< Real , Dim , BType , Degree >::_receive5( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State5 &state5 , Profiler &profiler )
+{
+	AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+	bool needAuxData = clientReconInfo.dataX>0 && auxDataFactory.bufferSize();
+
+	ClientServerStream< true > serverStream( _serverSocket , _index , clientReconInfo );
+	serverStream.ioBytes = 0;
+	size_t subNodeCount;
+	serverStream.read( subNodeCount );
+	state5.subNodes = NewPointer< FEMTreeNode >( subNodeCount );
+	serverStream.read( state5.subNodes , subNodeCount );
+	TreeIndicesToAddresses( state5.subNodes , subNodeCount );
+	state5.solution.read( serverStream );
+
+	if( needAuxData )
+	{
+		using Data = typename _State5::Data;
+		Data defaultValue;
+
+		if constexpr( !AuxDataFactory::IsStaticallyAllocated() )
+		{
+			ProjectiveAuxDataTypeSerializer< Real > serializer( clientReconInfo.auxProperties );
+			state5.auxDataField = new SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > >( serverStream , serializer );
+		}
+		else state5.auxDataField = new SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > >( serverStream );
+	}
+	profiler.update();
+
+	return serverStream.ioBytes;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+size_t Client< Real , Dim , BType , Degree >::_send5( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , const _State5 &state5 , Profiler &profiler )
+{
+	size_t ioBytes = 0;
+
+	auto Send = [&]( const typename Client::_State5::BoundaryInfo &bInfo , typename ClientReconstructionInfo< Real , Dim >::ShareType st )
+	{
+		ClientServerStream< false > serverStream( _serverSocket , _index , clientReconInfo , st );
+		serverStream.ioBytes=0;
+
+		XForm< Real , Dim > sliceModelToUnitCube;
+		{
+			for( unsigned int i=0 ; i<Dim-1 ; i++ )
+			{
+				for( unsigned int j=0 ; j<Dim-1 ; j++ ) sliceModelToUnitCube(i,j) = _modelToUnitCube(i,j);
+				sliceModelToUnitCube(Dim-1,i) = _modelToUnitCube(Dim,i);
+			}
+			sliceModelToUnitCube(Dim-1,Dim-1) = 1;
+		}
+
+		if( bInfo.tree )
+		{
+			bInfo.tree->write( serverStream , true );
+			serverStream.write( sliceModelToUnitCube );
+			bInfo.solution.write( serverStream );
+			bInfo.dSolution.write( serverStream );
+		}
+		profiler.update();
+		return serverStream.ioBytes;
+	};
+	if( _range.first!=0 )                                 ioBytes += Send( state5.boundaryInfo.first  , ClientReconstructionInfo< Real , Dim >::BACK  );
+	if( _range.second!=(1<<clientReconInfo.sharedDepth) ) ioBytes += Send( state5.boundaryInfo.second , ClientReconstructionInfo< Real , Dim >::FRONT );
+
+	return ioBytes;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+std::pair< double , double > Client< Real , Dim , BType , Degree >::_process5( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State5 &state5 , Profiler &profiler )
+{
+	AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+	bool needAuxData = clientReconInfo.dataX>0 && auxDataFactory.bufferSize();
+
+	// Refine the client's tree so that it contains the server's subtree
+	{
+		Timer timer;
+		// Refine client nodes as needed
+		std::function< void ( const FEMTreeNode * , FEMTreeNode * ) > ProcessIndices = [&]( const FEMTreeNode *serverNode , FEMTreeNode *clientNode )
+		{
+			if( serverNode->children )
+			{
+				if( !clientNode->children ) clientNode->template initChildren< false >( _tree.nodeAllocators[0] , _tree.initializer() );
+				for( int c=0 ; c<(1<<Dim) ; c++ ) ProcessIndices( serverNode->children+c , clientNode->children+c );
+			}
+		};
+		ProcessIndices( &state5.subNodes[0] , const_cast< FEMTreeNode * >( &_tree.tree() ) );
+		// Re-finalize and re-index
+		auto addNodeFunctor = [&]( int d , const int off[Dim] ){ return d<=(int)clientReconInfo.baseDepth; };
+		auto hasDataFunctor = []( const FEMTreeNode * ){ return true; };
+
+		constexpr int MaxDegree = Reconstructor::Poisson::NormalDegree > Degrees::Max() ? Reconstructor::Poisson::NormalDegree : Degrees::Max();
+		SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > > *auxDataField = needAuxData ? &_auxDataField : NULL;
+		DenseNodeData< Real , Sigs > *constraints = &_constraints;
+
+		// [WARNING] This assumes that nothing needs to be done with the Dirichlet flags
+		_tree.setSortedTreeNodes( std::make_tuple( _iInfo ) , std::make_tuple( _density , constraints , auxDataField ) );
+		profiler.update();
+
+		if( clientReconInfo.verbose>1 ) std::cout << "#  Updated client tree: " << timer << std::endl;
+	}
+
+	{
+		Timer timer;
+		_solution = _tree.initDenseNodeData( Sigs() );
+		std::vector< node_index_type > clientToServer( _tree.nodesSize() , -1 );
+		{
+			std::function< void ( const FEMTreeNode * , const FEMTreeNode * ) > ProcessIndices = [&]( const FEMTreeNode *serverNode , const FEMTreeNode *clientNode )
+			{
+				if( clientNode->nodeData.nodeIndex!=-1 )
+				{
+					if( clientNode->nodeData.nodeIndex>=(node_index_type)clientToServer.size() ) MK_THROW( "More client nodes than server nodes" );
+					clientToServer[ clientNode->nodeData.nodeIndex ] = serverNode->nodeData.nodeIndex;
+				}
+				if( _tree.depth( clientNode )<(int)clientReconInfo.sharedDepth && clientNode->children )
+				{
+					if( serverNode->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) ProcessIndices( serverNode->children+c , clientNode->children+c );
+				}
+			};
+			ProcessIndices( &state5.subNodes[0] , &_tree.tree() );
+		}
+		profiler.update();
+		if( clientReconInfo.verbose>1 ) std::cout << "# Set client-to-server: " << timer << std::endl;
+
+		if( needAuxData )
+		{
+			Timer timer;
+			using Data = ProjectiveData< AuxData , Real >;
+			Data defaultValue = auxDataFactory();
+
+			// Clearing the low freqeuncy
+			auto nodeFunctor = [&]( const FEMTreeNode *n )
+			{
+				if( n->nodeData.nodeIndex!=-1 )
+				{
+					node_index_type idx = state5.auxDataField->index( clientToServer[ n->nodeData.nodeIndex ] );
+					if( idx!=-1 ) _auxDataField[n] = (*state5.auxDataField)[idx];
+				}
+				return _tree.depth( n )<(int)clientReconInfo.sharedDepth;
+			};
+			_tree.tree().processNodes( nodeFunctor );
+			profiler.update();
+			if( clientReconInfo.verbose>1 ) std::cout << "#      Copied aux data: " << profiler << std::endl;
+		}
+
+		// (Over-)write coarse solution
+		for( unsigned int i=0 ; i<_solution.size() ; i++ ) if( clientToServer[i]!=-1 ) _solution[i] = state5.solution[ clientToServer[i] ];
+		profiler.update();
+		if( clientReconInfo.verbose>1 ) std::cout << "#      Copied solution: " << timer << std::endl;
+	}
+
+	// Solve the linear system
+	{
+		Timer timer;
+		typename FEMTree< Dim , Real >::SolverInfo sInfo;
+		sInfo.cgDepth = 0 , sInfo.cascadic = true , sInfo.vCycles = 1 , sInfo.iters = clientReconInfo.iters , sInfo.cgAccuracy = 0 , sInfo.verbose = clientReconInfo.verbose>1 , sInfo.showResidual = clientReconInfo.verbose>2 , sInfo.showGlobalResidual = SHOW_GLOBAL_RESIDUAL_NONE , sInfo.sliceBlockSize = 1;
+		sInfo.baseVCycles = 0 , sInfo.clearSolution = false;
+		typename FEMIntegrator::template System< Sigs , IsotropicUIntPack< Dim , 1 > > F( { 0. , 1. } );
+		_tree.solveSystem( Sigs() , F , _constraints , _solution , []( Real v , Real w ){ return v*w; } , clientReconInfo.sharedDepth+1 , clientReconInfo.solveDepth , sInfo , std::make_tuple( _iInfo ) );
+
+		profiler.update();
+		if( _iInfo ) delete _iInfo , _iInfo = NULL;
+
+		if( clientReconInfo.verbose>1 ) std::cout << "# Linear system solved: " << timer << std::endl;
+	}
+
+	std::pair< double , double > isoInfo(0.,0.);
+	// Compute the average iso-value
+	{
+		Timer timer;
+		typename FEMTree< Dim , Real >::template MultiThreadedEvaluator< Sigs , 0 > evaluator( &_tree , _solution );
+		std::vector< double > valueSums( ThreadPool::NumThreads() , 0 ) , weightSums( ThreadPool::NumThreads() , 0 );
+		ThreadPool::ParallelFor( 0 , _samples.size() , [&]( unsigned int thread , size_t j )
+			{
+				ProjectiveData< Point< Real , Dim > , Real > &sample = _samples[j].sample;
+				Real w = sample.weight;
+				if( w>0 ) weightSums[thread] += w , valueSums[thread] += evaluator.values( sample.data / sample.weight , thread , _samples[j].node )[0] * w;
+			}
+		);
+		for( size_t t=0 ; t<valueSums.size() ; t++ ) isoInfo.first += valueSums[t] , isoInfo.second += weightSums[t];
+		profiler.update();
+		if( clientReconInfo.verbose>1 ) std::cout << "#        Got iso-value: " << timer << std::endl;
+	}
+
+	// Set the boundary information
+	if constexpr( Dim==3 )
+	{
+		Timer timer;
+		using SliceSigs = typename Sigs::Transpose::Rest::Transpose;
+		static const unsigned int CrossSig = Sigs::Transpose::First;
+
+		auto SetBoundary = [&]( unsigned int index , typename _State5::BoundaryInfo &boundaryInfo )
+		{
+			bool needsPadding = !clientReconInfo.linearFit && FEMSignature< CrossSig >::Degree==1;
+			if( needsPadding ) boundaryInfo.tree = FEMTree< Dim-1 , Real >::template Slice< FEMSignature< CrossSig >::Degree , 1 >( _tree , clientReconInfo.sharedDepth , index , true , MEMORY_ALLOCATOR_BLOCK_SIZE );
+			else               boundaryInfo.tree = FEMTree< Dim-1 , Real >::template Slice< FEMSignature< CrossSig >::Degree , 0 >( _tree , clientReconInfo.sharedDepth , index , true , MEMORY_ALLOCATOR_BLOCK_SIZE );
+			boundaryInfo.solution = boundaryInfo.tree->initDenseNodeData( SliceSigs() );
+			boundaryInfo.dSolution = boundaryInfo.tree->initDenseNodeData( SliceSigs() );
+			boundaryInfo.tree->template slice< 0 , CrossSig >( _tree , 0 , _solution , boundaryInfo.solution , clientReconInfo.sharedDepth , index );
+			if( needsPadding ) boundaryInfo.tree->template slice< 1 , CrossSig >( _tree , 1 , _solution , boundaryInfo.dSolution , clientReconInfo.sharedDepth , index );
+			else               boundaryInfo.tree->template slice< 0 , CrossSig >( _tree , 1 , _solution , boundaryInfo.dSolution , clientReconInfo.sharedDepth , index );
+		};
+		if( _range.first !=0                                ) SetBoundary( _range.first  , state5.boundaryInfo.first  );
+		if( _range.second!=(1<<clientReconInfo.sharedDepth) ) SetBoundary( _range.second , state5.boundaryInfo.second );
+		profiler.update();
+		if( clientReconInfo.verbose>1 ) std::cout << "#    Set boundary info: " << timer << std::endl;
+	}
+
+	if( clientReconInfo.outputSolution )
+	{
+		std::string outFileName = std::string( "solution." ) + std::to_string(_index) + std::string( ".tree" );
+		if( clientReconInfo.outDir.length() ) outFileName = PointPartition::FileDir( clientReconInfo.outDir , outFileName );
+
+		FILE* fp = fopen( outFileName.c_str() , "wb" );
+		if( !fp ) MK_THROW( "Failed to open file for writing: " , outFileName );
+		FileStream fs(fp);
+		FEMTree< Dim , Real >::WriteParameter( fs );
+		DenseNodeData< Real , Sigs >::WriteSignatures( fs );
+		XForm< Real , Dim+1 > voxelToUnitCube = XForm< Real , Dim+1 >::Identity();
+		_tree.write( fs , false );
+		fs.write( voxelToUnitCube );
+		_solution.write( fs );
+		fclose( fp );
+	}
+
+	return isoInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+PhaseInfo Client< Real , Dim , BType , Degree >::_phase7( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler )
+{
+	PhaseInfo phaseInfo;
+
+	typename Client< Real , Dim , BType , Degree >::_State7 state7;
+	if constexpr( Dim==3 ) if( clientReconInfo.mergeType!=ClientReconstructionInfo< Real , Dim >::MergeType::NONE )
+	{
+		Timer timer;
+		phaseInfo.readBytes += _receive7( clientReconInfo , state7 , profiler );
+		phaseInfo.readTime += timer.wallTime();
+	}
+
+	{
+		Timer timer;
+		_process7( clientReconInfo , state7 , profiler );
+		phaseInfo.processTime += timer.wallTime();
+	}
+	return phaseInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+size_t Client< Real , Dim , BType , Degree >::_receive7( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State7 &state7 , Profiler &profiler )
+{
+	size_t ioBytes = 0;
+	auto Receive = [&]( BoundaryData *&boundary , std::vector< std::vector< Real > > &dValues , typename ClientReconstructionInfo< Real , Dim >::ShareType st )
+	{
+		ClientServerStream< true > serverStream( _serverSocket , _index , clientReconInfo , st );
+		serverStream.ioBytes = 0;
+		serverStream.read( state7.isoValue );
+		if( clientReconInfo.mergeType!=ClientReconstructionInfo< Real , Dim >::MergeType::NONE )
+		{
+			XForm< Real , Dim > modelToUnitCube;
+			boundary = new BoundaryData( serverStream , modelToUnitCube , MEMORY_ALLOCATOR_BLOCK_SIZE );
+			if( !clientReconInfo.linearFit )
+			{
+				dValues.resize( boundary->sliceValues.size() );
+				for( unsigned int i=0 ; i<dValues.size() ; i++ ) serverStream.read( dValues[i] );
+			}
+		}
+		profiler.update();
+		return serverStream.ioBytes;
+	};
+
+	if( _range.first!=0 )                                 ioBytes += Receive( state7.backBoundary  , state7.backDValues  , ClientReconstructionInfo< Real , Dim >::BACK );
+	if( _range.second!=(1<<clientReconInfo.sharedDepth) ) ioBytes += Receive( state7.frontBoundary , state7.frontDValues , ClientReconstructionInfo< Real , Dim >::FRONT );
+
+	return ioBytes;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+template< bool HasGradients , bool HasDensity >
+void Client< Real , Dim , BType , Degree >::_writeMeshWithData( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State7 &state7 , XForm< Real , Dim+1 > unitCubeToModel )
+{
+	Timer timer;
+	std::string tempHeader( "PR_" );
+	using AuxData = typename AuxDataFactory::VertexType;
+	AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+	if( clientReconInfo.tempDir.length() ) tempHeader = PointPartition::FileDir( clientReconInfo.tempDir , tempHeader );
+
+	SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > > *auxDataField = NULL;
+	if( _auxDataField.size() ) auxDataField = &_auxDataField;
+
+	std::string outFileName;
+	{
+		std::stringstream ss;
+		ss << clientReconInfo.header << "." << _index << ".ply";
+		outFileName = ss.str();
+	}
+
+	if( clientReconInfo.outDir.length() ) outFileName = PointPartition::FileDir( clientReconInfo.outDir , outFileName );
+
+
+	// A description of the output vertex information
+	using VInfo = Reconstructor::OutputVertexInfo< Real , Dim , HasGradients , HasDensity , AuxDataFactory >;
+
+	// A factory generating the output vertices
+	using Factory = typename VInfo::Factory;
+	Factory factory = VInfo::GetFactory( auxDataFactory );
+
+	// A backing stream for the vertices
+	Reconstructor::OutputInputFactoryTypeStream< Real , Dim , Factory , false , true , AuxData > vertexStream( factory , VInfo::Convert );
+	Reconstructor::OutputInputFaceStream< Dim-1 , false , true > faceStream;
+
+	typename LevelSetExtractor< Real , Dim , AuxData >::Stats stats;
+
+	{
+		// The transformed stream
+		Reconstructor::TransformedOutputLevelSetVertexStream< Real , Dim , AuxData > __vertexStream( unitCubeToModel , vertexStream );
+
+		// Extract the mesh
+		stats = LevelSetExtractor< Real , Dim , AuxData >::template Extract< Reconstructor::WeightDegree , DataSig >
+			(
+				Sigs() ,
+				UIntPack< Reconstructor::WeightDegree >() ,
+				UIntPack< DataSig >() ,
+				_tree ,
+				clientReconInfo.reconstructionDepth ,
+				_density ,
+				auxDataField ,
+				_solution ,
+				state7.isoValue ,
+				clientReconInfo.sharedDepth ,
+				_range.first ,
+				_range.second ,
+				__vertexStream ,
+				faceStream ,
+				auxDataFactory() ,
+				!clientReconInfo.linearFit ,
+				HasGradients , false , true , false ,
+				state7.backBoundary ,
+				state7.frontBoundary ,
+				state7.backDValues ,
+				state7.frontDValues ,
+				clientReconInfo.mergeType==ClientReconstructionInfo< Real , Dim >::MergeType::TOPOLOGY_AND_FUNCTION
+			);
+	}
+
+	if( clientReconInfo.verbose>1 )
+	{
+		std::cout << "Vertices / Faces: " << vertexStream.size() << " / " << faceStream.size() << std::endl;
+		std::cout << stats.toString() << std::endl;
+		std::cout << "#            Got faces: " << timer << std::endl;
+	}
+
+	// Write the mesh to a .ply file
+	std::vector< std::string > noComments;
+	vertexStream.reset();
+	PLY::Write< Factory , node_index_type , Real , Dim >( outFileName.c_str() , factory , vertexStream.size() , faceStream.size() , vertexStream , faceStream , PLY_BINARY_NATIVE , noComments );
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+void Client< Real , Dim , BType , Degree >::_process7( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , _State7 &state7 , Profiler &profiler )
+{
+	static const bool HasAuxData = !std::is_same< AuxDataFactory , VertexFactory::EmptyFactory< Real > >::value;
+	AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+
+	// Extract the mesh
+	if constexpr( Dim==3 )
+	{
+		XForm< Real , Dim+1 > unitCubeToModel;
+		if( clientReconInfo.gridCoordinates )
+		{
+			unitCubeToModel = XForm< Real , Dim+1 >::Identity();
+			unsigned int res = 1<<clientReconInfo.reconstructionDepth;
+			for( unsigned int d=0 ; d<Dim ; d++ ) unitCubeToModel(d,d) = (Real)res;
+		}
+		else unitCubeToModel = _modelToUnitCube.inverse();
+		if( clientReconInfo.density ) _writeMeshWithData< false , true  >( clientReconInfo , state7 , unitCubeToModel );
+		else                          _writeMeshWithData< false , false >( clientReconInfo , state7 , unitCubeToModel );
+	}
+
+	if( clientReconInfo.ouputVoxelGrid )
+	{
+		std::string outFileName;
+		{
+			std::stringstream ss;
+			ss << clientReconInfo.header << "." << _index << ".grid";
+			outFileName = ss.str();
+		}
+
+		if( clientReconInfo.outDir.length() ) outFileName = PointPartition::FileDir( clientReconInfo.outDir , outFileName );
+
+		unsigned int begin[Dim] , end[Dim] , res[Dim];
+		for( unsigned int d=0 ; d<Dim-1 ; d++ ) begin[d] = 0 , end[d] = 1<<clientReconInfo.reconstructionDepth;
+		begin[Dim-1] = _range.first<<( clientReconInfo.reconstructionDepth - clientReconInfo.sharedDepth ) , end[Dim-1] = _range.second<<( clientReconInfo.reconstructionDepth - clientReconInfo.sharedDepth );
+
+		Pointer( Real ) values = _tree.template regularGridEvaluate< true >( _solution , begin , end , res );
+
+		XForm< Real , Dim+1 > voxelToUnitCube = XForm< Real , Dim+1 >::Identity();
+		for( int d=0 ; d<Dim ; d++ ) voxelToUnitCube( d , d ) = (Real)( 1. / res[d] ) , voxelToUnitCube( Dim , d ) = (Real)( 0.5 / res[d] );
+		XForm< Real , Dim+1 > unitCubeToModel = _modelToUnitCube.inverse();
+		RegularGrid< Real , Dim >::Write( outFileName , res , values , unitCubeToModel * voxelToUnitCube );
+
+		DeletePointer( values );
+	}
+
+	profiler.update();
+}
+
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+Client< Real , Dim , BType , Degree >::Client( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , BinaryStream &stream , unsigned int phase )
+	: _serverSocket( _INVALID_SOCKET_ ) , _tree( stream , MEMORY_ALLOCATOR_BLOCK_SIZE ) , _density(NULL) , _normalInfo(NULL) , _paddedNormalInfo(NULL) , _iInfo(NULL) , _index(-1)
+{
+	stream.read( _modelToUnitCube );
+
+	AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+	bool needAuxData = clientReconInfo.dataX>0 && auxDataFactory.bufferSize();
+
+	if( phase!=3 && phase!=5 && phase!=7 ) MK_THROW( "Only phases 3, 5, and 7 supported: " , phase );
+
+	stream.read( _index );
+	stream.read( _range );
+
+	_density = new DensityEstimator( stream );
+
+	auto readSamples = [&]( BinaryStream &stream , std::vector< typename FEMTree< Dim , Real >::PointSample > &samples )
+	{
+		using SampleType = ProjectiveData< Point< Real , Dim > , Real >;
+		struct T{ SampleType sample; node_index_type index; };
+
+		{
+			std::vector< FEMTreeNode * > nodes( _tree.spaceRoot().nodes() , NULL );
+			size_t idx = 0;
+			_tree.spaceRoot().processNodes( [&]( FEMTreeNode *node ){ nodes[idx++] = node; } );
+if( idx!=nodes.size() ) MK_THROW( "uhoh" );
+
+			std::vector< T > _samples;
+			if( !stream.read( _samples ) ) MK_THROW( "Failed to read samples" );
+			samples.resize( _samples.size() );
+			// Convert indices to node pointers
+			for( size_t i=0 ; i<samples.size() ; i++ ) samples[i].sample = _samples[i].sample , samples[i].node = nodes[ _samples[i].index ];
+		}
+	};
+
+	if( phase==3 )
+	{
+		std::vector< FEMTreeNode * > nodes;
+		auto readSamplesAndData = [&]( BinaryStream &stream , std::vector< typename FEMTree< Dim , Real >::PointSample > &samples , std::vector< InputSampleDataType > &sampleData )
+		{
+			using SampleType = ProjectiveData< Point< Real , Dim > , Real >;
+			struct T
+			{
+				SampleType sample;
+				node_index_type index;
+			};
+			{
+				std::vector< T > _samples;
+				if( !stream.read( _samples ) ) MK_THROW( "Failed to read samples" );
+				size_t sz = _samples.size();
+				SampleDataTypeSerializer< Real , Dim > serializer( clientReconInfo.auxProperties );
+				samples.resize( sz );
+				sampleData.resize( sz );
+				size_t serializedSize = serializer.size();
+				{
+					Pointer( char ) buffer = NewPointer< char >( sz * serializedSize );
+					if( !stream.read( buffer , sz*serializedSize ) ) MK_THROW( "Failed to read sample data" );
+					for( unsigned int i=0 ; i<sz ; i++ ) serializer.deserialize( buffer+i*serializedSize , sampleData[i] );
+					DeletePointer( buffer );
+				}
+				// Convert indices to node pointers
+				for( size_t i=0 ; i<samples.size() ; i++ ) samples[i].sample = _samples[i].sample , samples[i].node = nodes[ _samples[i].index ];
+			}
+		};
+
+		// Get the mapping from indices to node pointers
+		{
+			FEMTreeNode *root = &_tree.spaceRoot();
+			while( root->parent ) root = root->parent;
+			nodes.reserve( _tree.tree().nodes() );
+			root->processNodes( [&]( FEMTreeNode *node ){ nodes.push_back( node ); } );
+		}
+		_normalInfo = new SparseNodeData< Point< Real , Dim > , NormalSigs >( stream );
+		_paddedNormalInfo = new SparseNodeData< Point< Real , Dim > , NormalSigs >( stream );
+		readSamplesAndData( stream , _samples , _sampleData );
+		readSamplesAndData( stream , _paddedSamples , _paddedSampleData );
+	}
+	else if( phase==5 )
+	{
+		_constraints.read( stream );
+
+		_iInfo = new ApproximatePointInterpolationInfo( stream );
+
+		readSamples( stream , _samples );
+
+		if( needAuxData )
+		{
+			if constexpr( !AuxDataFactory::IsStaticallyAllocated() )
+			{
+				ProjectiveAuxDataTypeSerializer< Real > serializer( clientReconInfo.auxProperties );
+				_auxDataField.read( stream , serializer );
+			}
+			else _auxDataField.read( stream );
+		}
+	}
+	else if( phase==7 )
+	{
+		_solution.read( stream );
+
+		bool needAuxData = clientReconInfo.dataX>0 && auxDataFactory.bufferSize();
+		if( needAuxData )
+		{
+			if constexpr( !AuxDataFactory::IsStaticallyAllocated() )
+			{
+				ProjectiveAuxDataTypeSerializer< Real > serializer( clientReconInfo.auxProperties );
+				_auxDataField.read( stream , serializer );
+			}
+			else _auxDataField.read( stream );
+		}
+	}
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+void Client< Real , Dim , BType , Degree >::_write( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , BinaryStream &stream , unsigned int phase ) const
+{
+	AuxDataFactory auxDataFactory( clientReconInfo.auxProperties );
+	bool needAuxData = clientReconInfo.dataX>0 && auxDataFactory.bufferSize();
+
+	if( phase!=1 && phase!=3 && phase!=5 ) MK_THROW( "Only phases 1, 3, and 5 supported: " , phase );
+
+	_tree.write( stream , false );
+	stream.write( _modelToUnitCube );
+
+	stream.write( _index );
+	stream.write( _range );
+
+	_density->write( stream );
+
+	auto writeSamples = [&]( BinaryStream &stream , const std::vector< typename FEMTree< Dim , Real >::PointSample > &samples )
+	{
+		// [NOTE] The samples may be assigned to ghost nodes, so we can't just use the node index
+		using SampleType = ProjectiveData< Point< Real , Dim > , Real >;
+		struct T { SampleType sample ; node_index_type index; };
+
+		std::vector< node_index_type > oldIndices( _tree.spaceRoot().nodes() , -1 );
+		std::vector< T > _samples( samples.size() );
+
+		// Grab the old indices and over-write
+		{
+			size_t idx = 0;
+			const_cast< FEMTree< Dim , Real > & >( _tree ).spaceRoot().processNodes( [&]( FEMTreeNode *node ){ oldIndices[idx] = node->nodeData.nodeIndex ; node->nodeData.nodeIndex = idx++; } );
+		}
+
+		for( size_t i=0 ; i<samples.size() ; i++ ) _samples[i].sample = samples[i].sample , _samples[i].index = samples[i].node->nodeData.nodeIndex;
+		stream.write( _samples );
+
+		// Set the node indices back
+		{
+			size_t idx = 0;
+			const_cast< FEMTree< Dim , Real > & >( _tree ).spaceRoot().processNodes( [&]( FEMTreeNode *node ){ node->nodeData.nodeIndex = oldIndices[ idx++ ]; } );
+		}
+	};
+
+	if( phase==1 )
+	{
+		auto writeSamplesAndData = [&]( BinaryStream &stream , const std::vector< typename FEMTree< Dim , Real >::PointSample > &samples , const std::vector< InputSampleDataType > &sampleData )
+		{
+			using SampleType = ProjectiveData< Point< Real , Dim > , Real >;
+			struct T
+			{
+				SampleType sample;
+				node_index_type index;
+			};
+			std::vector< T > _samples( samples.size() );
+			for( size_t i=0 ; i<samples.size() ; i++ ) _samples[i].sample = samples[i].sample , _samples[i].index = samples[i].node->nodeData.nodeIndex;
+			stream.write( _samples );
+
+			SampleDataTypeSerializer< Real , Dim > serializer( clientReconInfo.auxProperties );
+			size_t serializedSize = serializer.size();
+			{
+				Pointer( char ) buffer = NewPointer< char >( samples.size() * serializedSize );
+				for( unsigned int i=0 ; i<samples.size() ; i++ ) serializer.serialize( sampleData[i] , buffer+i*serializedSize );
+				stream.write( buffer , samples.size()*serializedSize );
+				DeletePointer( buffer );
+			}
+		};
+		_normalInfo->write( stream );
+		_paddedNormalInfo->write( stream );
+		writeSamplesAndData( stream , _samples , _sampleData );
+		writeSamplesAndData( stream , _paddedSamples , _paddedSampleData );
+	}
+	else if( phase==3 )
+	{
+		_constraints.write( stream );
+
+		_iInfo->write( stream );
+
+		writeSamples( stream , _samples );
+
+		if( needAuxData )
+		{
+			if constexpr( !AuxDataFactory::IsStaticallyAllocated() )
+			{
+				ProjectiveAuxDataTypeSerializer< Real > serializer( clientReconInfo.auxProperties );
+				_auxDataField.write( stream , serializer );
+			}
+			else _auxDataField.write( stream );
+		}
+	}
+	else if( phase==5 )
+	{
+		_solution.write( stream );
+
+		if( _auxDataField.size() )
+		{
+			if constexpr( !AuxDataFactory::IsStaticallyAllocated() )
+			{
+				ProjectiveAuxDataTypeSerializer< Real > serializer( clientReconInfo.auxProperties );
+				_auxDataField.write( stream , serializer );
+			}
+			else _auxDataField.write( stream );			
+		}
+	}
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/PoissonRecon.server.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PoissonRecon.server.inl
@@ -1,0 +1,770 @@
+/*
+Copyright (c) 2023, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+struct Server
+{
+	typedef typename FEMTree< Dim , Real >::template DensityEstimator< Reconstructor::WeightDegree > DensityEstimator;
+	typedef typename FEMTree< Dim , Real >::template ApproximatePointInterpolationInfo< Real , 0 , Reconstructor::Poisson::ConstraintDual< Dim , Real > , Reconstructor::Poisson::SystemDual< Dim , Real > > ApproximatePointInterpolationInfo;
+	typedef IsotropicUIntPack< Dim , FEMDegreeAndBType< Degree , BType >::Signature > Sigs;
+	typedef IsotropicUIntPack< Dim , Degree > Degrees;
+	typedef IsotropicUIntPack< Dim , FEMDegreeAndBType< Reconstructor::Poisson::NormalDegree , DerivativeBoundary< BType , 1 >::BType >::Signature > NormalSigs;
+	static const unsigned int DataSig = FEMDegreeAndBType< Reconstructor::DataDegree , BOUNDARY_FREE >::Signature;
+	typedef VertexFactory::DynamicFactory< Real > AuxDataFactory;
+	typedef typename AuxDataFactory::VertexType AuxData;
+	typedef VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , VertexFactory::Factory< Real , VertexFactory::NormalFactory< Real , Dim > , AuxDataFactory > > InputSampleFactory;
+	typedef VertexFactory::Factory< Real , VertexFactory::NormalFactory< Real , Dim > , AuxDataFactory > InputSampleDataFactory;
+	typedef DirectSum< Real , Point< Real , Dim > , typename AuxDataFactory::VertexType > InputSampleDataType;
+	typedef DirectSum< Real , Point< Real , Dim > , InputSampleDataType > InputSampleType;
+	typedef InputDataStream< InputSampleType > InputPointStream;
+	typedef RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > FEMTreeNode;
+
+protected:
+	std::vector< SocketStream > _clientSockets;
+	PointPartition::PointSetInfo< Real , Dim > _pointSetInfo;
+	PointPartition::Partition _pointPartition;
+
+	struct _State4
+	{
+		FEMTree< Dim , Real > tree;
+		DenseNodeData< Real , Sigs > constraints , solution;
+		ApproximatePointInterpolationInfo *iInfo;
+		SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > > *auxDataField;
+
+		_State4( void ) : tree( MEMORY_ALLOCATOR_BLOCK_SIZE ) , iInfo(NULL) , auxDataField(NULL) {}
+		~_State4( void ){ delete iInfo ; delete auxDataField; }
+	};
+	struct _State6
+	{
+		using SliceSigs = typename Sigs::Transpose::Rest::Transpose;
+		using Vertex = typename VertexFactory::PositionFactory< Real , Dim-1 >::VertexType;
+		FEMTree< Dim-1 , Real > *sliceTree;
+		XForm< Real , Dim > xForm;
+		DenseNodeData< Real , SliceSigs > solution , dSolution;
+		std::vector< std::conditional_t< Dim==3 , typename LevelSetExtractor< Real , 2 >::SliceValues , char > > sliceValues , dSliceValues;
+		std::vector< Point< Real , Dim-1 > > vertices;
+
+		_State6( void ) : sliceTree(NULL) {}
+		~_State6( void ){ delete sliceTree; }
+	};
+
+	PhaseInfo _phase0( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler );
+	PhaseInfo _phase2( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > &cumulativePointWeight , Profiler &profiler );
+	PhaseInfo _phase4( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > cumulativePointWeight , unsigned int baseVCycles , Real &isoValue , Profiler &profiler );
+	PhaseInfo _phase6( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Real isoValue , bool showDiscontinuity , bool outputBoundarySlices , std::vector< unsigned int > &sharedVertexCounts , Profiler &profiler );
+
+	template< typename _Real , unsigned int _Dim , BoundaryType _BType , unsigned int _Degree >
+	friend std::vector< unsigned int > RunServer( PointPartition::PointSetInfo< _Real , _Dim > , PointPartition::Partition , std::vector< Socket > , ClientReconstructionInfo< _Real , _Dim > , unsigned int , unsigned int , bool , bool );
+};
+
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+std::vector< unsigned int > RunServer
+(
+	PointPartition::PointSetInfo< Real , Dim > pointSetInfo ,
+	PointPartition::Partition pointPartition ,
+	std::vector< Socket > clientSockets ,
+	ClientReconstructionInfo< Real , Dim > clientReconInfo , 
+	unsigned int baseVCycles , 
+	unsigned int sampleMS ,
+	bool showDiscontinuity ,
+	bool outputBoundarySlices
+)
+{
+	std::vector< unsigned int > sharedVertexCounts;
+	Server< Real , Dim , BType , Degree > server;
+	Profiler profiler( sampleMS );
+
+	clientReconInfo.auxProperties = pointSetInfo.auxiliaryProperties;
+
+	// Initialization
+	{
+		server._pointSetInfo = pointSetInfo;
+		server._pointPartition = pointPartition;
+		server._clientSockets.resize( clientSockets.size() );
+
+		for( unsigned int i=0 ; i<clientSockets.size() ; i++ ) server._clientSockets[i] = SocketStream( clientSockets[i] );
+
+		for( unsigned int i=0 ; i<clientSockets.size() ; i++ ) clientReconInfo.write( server._clientSockets[i] );
+		for( unsigned int i=0 ; i<clientSockets.size() ; i++ ) server._clientSockets[i].write( i );
+	}
+
+	if( clientReconInfo.verbose>1 )
+	{
+		for( unsigned int i=0 ; i<clientSockets.size() ; i++ )
+		{
+#ifdef ADAPTIVE_PADDING
+			std::pair< unsigned int , unsigned int > range = pointPartition.range( i );
+			if( range.first<clientReconInfo.padSize ) range.first = 0;
+			else range.first -= clientReconInfo.padSize;
+			if( range.second+clientReconInfo.padSize>pointPartition.slabs() ) range.second = pointPartition.slabs();
+			else range.second += clientReconInfo.padSize;
+#else // !ADAPTIVE_PADDING
+			std::pair< unsigned int , unsigned int > range = pointPartition.range( i , clientReconInfo.padSize );
+#endif // ADAPTIVE_PADDING
+			std::cout << "Range[ " << i << " ]: [ " << range.first << " , "  << range.second << " )" << std::endl;
+		}
+		std::cout << "Boundary-type = " << BoundaryNames[BType] << " ; Degree = " << Degree << std::endl;
+	}
+
+	ProjectiveData< Real , Real > cumulativePointWeight;
+	Real isoValue;
+
+	// [PHASE 0] Send the client initial information
+	{
+		profiler.reset();
+		PhaseInfo phaseInfo = server._phase0( clientReconInfo , profiler );
+		if( clientReconInfo.verbose>0 )
+		{
+			StreamFloatPrecision sfp( std::cout , 1 );
+			std::cout << SendDataString( 0 , phaseInfo.writeBytes ) << phaseInfo.writeTime << " (s)" << std::endl;
+		}
+	}
+
+	// [PHASE 2] Accumulate/Send the point weight
+	{
+		profiler.reset();
+		PhaseInfo phaseInfo = server._phase2( clientReconInfo , cumulativePointWeight , profiler );
+		if( clientReconInfo.verbose>0 )
+		{
+			StreamFloatPrecision sfp( std::cout , 1 );
+			std::cout << ReceiveDataString( 2 , phaseInfo.readBytes ) << phaseInfo.readTime << " (s)" << std::endl;
+			std::cout << "[PROCESS 2]         : " << phaseInfo.processTime << " (s), " << profiler(false) << std::endl;
+			std::cout << SendDataString( 2 , phaseInfo.writeBytes ) << phaseInfo.writeTime << " (s)" << std::endl;
+		}
+	}
+
+	// [PHASE 4] Accumulate/solve/send coarse system
+	{
+		profiler.reset();
+		PhaseInfo phaseInfo = server._phase4( clientReconInfo , cumulativePointWeight , baseVCycles , isoValue , profiler );
+		if( clientReconInfo.verbose>0 )
+		{
+			StreamFloatPrecision sfp( std::cout , 1 );
+			std::cout << ReceiveDataString( 4 , phaseInfo.readBytes ) << phaseInfo.readTime << " (s)" << std::endl;
+			std::cout << "[PROCESS 4]         : " << phaseInfo.processTime << " (s), " << profiler(false) << std::endl;
+			std::cout << SendDataString( 4 , phaseInfo.writeBytes ) << phaseInfo.writeTime << " (s)" << std::endl;
+		}
+	}
+
+	// [PHASE 6] Accumulate/merge/send boundary tree info
+	{
+		profiler.reset();
+		PhaseInfo phaseInfo = server._phase6( clientReconInfo , isoValue , showDiscontinuity , outputBoundarySlices , sharedVertexCounts , profiler );
+		if( clientReconInfo.verbose>0 )
+		{
+			StreamFloatPrecision sfp( std::cout , 1 );
+			std::cout << ReceiveDataString( 6 , phaseInfo.readBytes ) << phaseInfo.readTime << " (s)" << std::endl;
+			std::cout << "[PROCESS 6]         : " << phaseInfo.processTime << " (s), " << profiler(false) << std::endl;
+			std::cout << SendDataString( 6 , phaseInfo.writeBytes ) << phaseInfo.writeTime << " (s)" << std::endl;
+		}
+	}
+	return sharedVertexCounts;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+PhaseInfo Server< Real , Dim , BType , Degree >::_phase0( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Profiler &profiler )
+{
+	PhaseInfo phaseInfo;
+
+	Timer timer;
+	for( unsigned int i=0 ; i<_clientSockets.size() ; i++ )
+	{
+		ClientServerStream< false > clientStream( _clientSockets[i] , i , clientReconInfo );
+		clientStream.ioBytes = 0;
+
+		// Send the information about the point-set
+		clientStream.write( _pointSetInfo.modelToUnitCube );
+
+		// Send the client's range
+#ifdef ADAPTIVE_PADDING
+		std::pair< unsigned int , unsigned int > range = _pointPartition.range( i );
+#else // !ADAPTIVE_PADDING
+		std::pair< unsigned int , unsigned int > range = _pointPartition.range( i , 0 );
+#endif // ADAPTIVE_PADDING
+		clientStream.write( range );
+
+		phaseInfo.writeBytes += clientStream.ioBytes;
+	}
+	phaseInfo.writeTime += timer.wallTime();
+	profiler.update();
+	return phaseInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+PhaseInfo Server< Real , Dim , BType , Degree >::_phase2( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > &cumulativePointWeight , Profiler &profiler )
+{
+	PhaseInfo phaseInfo;
+	std::pair< size_t , size_t > cumulativeNodeCounts;
+
+
+	cumulativeNodeCounts = std::pair< size_t , size_t >(0,0);
+	cumulativePointWeight = ProjectiveData< Real , Real >( (Real)0. );
+
+	for( unsigned int i=0 ; i<_clientSockets.size() ; i++ )
+	{
+		Timer timer;
+		ProjectiveData< Real , Real > pointWeight;
+		std::pair< size_t , size_t > nodeCounts;
+		ClientServerStream< true > clientStream( _clientSockets[i] , i , clientReconInfo );
+		clientStream.ioBytes = 0;
+		clientStream.read( pointWeight );
+		clientStream.read( nodeCounts );
+		phaseInfo.readBytes += clientStream.ioBytes;
+		phaseInfo.readTime += timer.wallTime();
+
+		timer = Timer();
+		cumulativePointWeight += pointWeight;
+		cumulativeNodeCounts.first += nodeCounts.first;
+		cumulativeNodeCounts.second += nodeCounts.second;
+		phaseInfo.processTime += timer.wallTime();
+	}
+
+	Timer timer;
+	for( unsigned int i=0 ; i<_clientSockets.size() ; i++ )
+	{
+		ClientServerStream< false > clientStream( _clientSockets[i] , i , clientReconInfo );
+		clientStream.ioBytes = 0;
+		clientStream.write( cumulativePointWeight );
+		phaseInfo.writeBytes += clientStream.ioBytes;
+	}
+	phaseInfo.writeTime = timer.wallTime();
+
+	if( clientReconInfo.verbose>1 ) std::cout << "Redundancy: " << cumulativeNodeCounts.second << " / " << cumulativeNodeCounts.first << " = " << (double)cumulativeNodeCounts.second/cumulativeNodeCounts.first << std::endl;
+
+	profiler.update();
+
+	return phaseInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+PhaseInfo Server< Real , Dim , BType , Degree >::_phase4( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , ProjectiveData< Real , Real > cumulativePointWeight , unsigned int baseVCycles , Real &isoValue , Profiler &profiler )
+{
+	constexpr int MaxDegree = Reconstructor::Poisson::NormalDegree > Degrees::Max() ? Reconstructor::Poisson::NormalDegree : Degrees::Max();
+	const int StartOffset = BSplineSupportSizes< MaxDegree >::SupportStart;
+	const int   EndOffset = BSplineSupportSizes< MaxDegree >::SupportEnd+1;
+	PhaseInfo phaseInfo;
+
+	_State4 state4;
+
+	std::vector< std::vector< node_index_type > > clientsToServer( _clientSockets.size() );
+
+	// Initialize the tree
+	{
+		Timer timer;
+		FEMTreeInitializer< Dim , Real >::Initialize( state4.tree.spaceRoot() , clientReconInfo.baseDepth , []( int , int[] ){ return true; } , state4.tree.nodeAllocators[0] , state4.tree.initializer() );
+
+		auto hasDataFunctor = []( const FEMTreeNode * ){ return false; };
+
+		// Set the root of the tree so we can copy constraints into it
+		auto addNodeFunctor = [&]( int d , const int off[Dim] ){ return d<=(int)clientReconInfo.baseDepth; };
+		state4.tree.template finalizeForMultigrid< MaxDegree , Degrees::Max() >( clientReconInfo.baseDepth , addNodeFunctor , hasDataFunctor , std::make_tuple() , std::make_tuple() );
+		phaseInfo.processTime += timer.wallTime();
+		profiler.update();
+	}
+
+	// Get/merge client data
+	for( unsigned int i=0 ; i<_clientSockets.size() ; i++ )
+	{
+		Timer timer;
+
+		std::vector< node_index_type > &clientToServer = clientsToServer[i];
+		ClientServerStream< true > clientStream( _clientSockets[i] , i , clientReconInfo , ClientReconstructionInfo< Real , Dim >::BACK );
+		clientStream.ioBytes = 0;
+
+		// The number of nodes in the client's coarse sub-tree
+		size_t subNodeCount;
+		clientStream.read( subNodeCount );
+
+		// The nodes in the client's coarse sub-tree
+		Pointer( FEMTreeNode ) subNodes = NewPointer< FEMTreeNode >( subNodeCount );
+		clientStream.read( subNodes , subNodeCount );
+
+		phaseInfo.readBytes += clientStream.ioBytes;
+		phaseInfo.readTime += timer.wallTime();
+
+
+		timer = Timer();
+		// Transform the nodes indices back to pointers
+		TreeIndicesToAddresses( subNodes , subNodeCount );
+		clientToServer.resize( subNodeCount , -1 );
+
+		// Find the map from client to index to server index and add client nodes as necessary
+		std::function< void ( FEMTreeNode * , const FEMTreeNode * ) > ProcessIndices = [&]( FEMTreeNode *serverNode , const FEMTreeNode *clientNode )
+		{
+			if( clientNode->nodeData.nodeIndex!=-1 ) clientToServer[ clientNode->nodeData.nodeIndex ] = serverNode->nodeData.nodeIndex;
+			if( clientNode->children )
+			{
+				if( !serverNode->children ) serverNode->template initChildren< false >( state4.tree.nodeAllocators[0] , state4.tree.initializer() );
+				for( int c=0 ; c<(1<<Dim) ; c++ ) ProcessIndices( serverNode->children+c , clientNode->children+c );
+			}
+		};
+		ProcessIndices( const_cast< FEMTreeNode * >( &state4.tree.tree() ) , &subNodes[0] );
+		profiler.update();
+		DeletePointer( subNodes );
+		phaseInfo.processTime += timer.wallTime();
+	}
+
+	{
+		Timer timer;
+		constexpr int MaxDegree = Reconstructor::Poisson::NormalDegree > Degrees::Max() ? Reconstructor::Poisson::NormalDegree : Degrees::Max();
+		auto hasDataFunctor = []( const FEMTreeNode * ){ return true; };
+		auto addNodeFunctor = [&]( int d , const int off[Dim] ){ return d<=(int)clientReconInfo.baseDepth; };
+		std::vector< node_index_type > newToOld = state4.tree.template finalizeForMultigrid< MaxDegree , Degrees::Max() >( clientReconInfo.baseDepth , addNodeFunctor , hasDataFunctor , std::make_tuple() , std::make_tuple() );
+		node_index_type idx = newToOld[0];
+		for( unsigned int i=0 ; i<newToOld.size() ; i++ ) idx = std::max< node_index_type >( idx , newToOld[i] );
+		idx++;
+		std::vector< node_index_type > oldToNew( idx , -1 );
+		for( unsigned int i=0 ; i<newToOld.size() ; i++ ) if( newToOld[i]!=-1 ) oldToNew[ newToOld[i] ] = i;
+		for( unsigned int i=0 ; i<clientsToServer.size() ; i++ ) for( unsigned int j=0 ; j<clientsToServer[i].size() ; j++ ) clientsToServer[i][j] = oldToNew[ clientsToServer[i][j] ];
+		phaseInfo.processTime += timer.wallTime();
+		profiler.update();
+	}
+
+	Timer timer;
+	AuxDataFactory auxDataFactory( _pointSetInfo.auxiliaryProperties );
+	bool needAuxData = clientReconInfo.dataX>0 && auxDataFactory.bufferSize();
+
+	state4.constraints = state4.tree.initDenseNodeData( Sigs() );
+
+	{
+		Real targetValue = clientReconInfo.targetValue;
+		state4.iInfo = new ApproximatePointInterpolationInfo( Reconstructor::Poisson::ConstraintDual< Dim , Real >( targetValue , clientReconInfo.pointWeight * cumulativePointWeight.value() ) , Reconstructor::Poisson::SystemDual< Dim , Real >( clientReconInfo.pointWeight * cumulativePointWeight.value() ) , true );
+		state4.iInfo->iData.reserve( state4.tree.nodesSize() );
+	}
+
+	using InterpolationData = typename ApproximatePointInterpolationInfo::Data;
+	auto  preMergeFunctor = []( InterpolationData data ){ data.position *= data.weight ; return data; };
+	auto postMergeFunctor = []( InterpolationData data ){ data.position /= data.weight ; return data; };
+
+	if( needAuxData )
+	{
+		state4.auxDataField = new SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > >();
+		state4.auxDataField->reserve( state4.tree.nodesSize() );
+	}
+	phaseInfo.processTime += timer.wallTime();
+	profiler.update();
+
+	for( unsigned int i=0 ; i<_clientSockets.size() ; i++ )
+	{
+		std::vector< node_index_type > &clientToServer = clientsToServer[i];
+		ClientServerStream< true > clientStream( _clientSockets[i] , i , clientReconInfo , ClientReconstructionInfo< Real , Dim >::FRONT );
+		clientStream.ioBytes = 0;
+
+		// The constraints
+		{
+			Timer timer;
+			DenseNodeData< Real , Sigs > _constraints( clientStream );
+			phaseInfo.readTime += timer.wallTime();
+
+			timer = Timer();
+			for( unsigned int i=0 ; i<_constraints.size() ; i++ )
+				if( clientToServer[i]==-1 || clientToServer[i]>=(node_index_type)state4.constraints.size() ){ MK_WARN_ONCE( "Unmatched client node(s): " , clientToServer[i] ); }
+				else state4.constraints[ clientToServer[i] ] += _constraints[i];
+			phaseInfo.processTime += timer.wallTime();
+		}
+
+		// The points
+		{
+			Timer timer;
+			ApproximatePointInterpolationInfo _iInfo( clientStream );
+			phaseInfo.readTime += timer.wallTime();
+
+			timer = Timer();
+			state4.iInfo->iData.mergeFromTarget( _iInfo.iData , [&]( unsigned int idx ){ return clientToServer[idx]; } , preMergeFunctor );
+			phaseInfo.processTime += timer.wallTime();
+		}
+		// The data field
+		if( needAuxData )
+		{
+			Timer timer;
+			SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > > *_auxDataField;
+			if constexpr( !AuxDataFactory::IsStaticallyAllocated() )
+			{
+				ProjectiveAuxDataTypeSerializer< Real > serializer( clientReconInfo.auxProperties );
+				_auxDataField = new SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > >( clientStream , serializer );
+			}
+			else _auxDataField = new SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > >( clientStream );
+			phaseInfo.readTime += timer.wallTime();
+
+			timer = Timer();
+			state4.auxDataField->mergeFromTarget( *_auxDataField , [&]( unsigned int idx ){ return clientToServer[idx]; } );
+			phaseInfo.processTime += timer.wallTime();
+
+			profiler.update();
+			delete _auxDataField;
+		}
+		else profiler.update();
+		phaseInfo.readBytes += clientStream.ioBytes;
+	}
+
+	if( needAuxData )
+	{
+		Timer timer;
+		auto nodeFunctor = [&]( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type >* n )
+		{
+			ProjectiveData< AuxData , Real >* clr = state4.auxDataField->operator()( n );
+			if( clr ) (*clr) *= (Real)pow( clientReconInfo.dataX , state4.tree.depth( n ) );
+		};
+		state4.tree.tree().processNodes( nodeFunctor );
+		phaseInfo.processTime += timer.wallTime();
+	}
+	{
+		Timer timer;
+		for( unsigned int i=0 ; i<state4.iInfo->iData.size() ; i++ ) state4.iInfo->iData[i] = postMergeFunctor( state4.iInfo->iData[i] );
+		phaseInfo.processTime += timer.wallTime();
+	}
+
+	{
+		Timer timer;
+
+		typename FEMTree< Dim , Real >::SolverInfo sInfo;
+		sInfo.cgDepth = 0 , sInfo.cascadic = true , sInfo.vCycles = 1 , sInfo.iters = clientReconInfo.iters , sInfo.cgAccuracy = clientReconInfo.cgSolverAccuracy , sInfo.verbose = clientReconInfo.verbose>1 , sInfo.showResidual = clientReconInfo.verbose>2 , sInfo.showGlobalResidual = SHOW_GLOBAL_RESIDUAL_NONE , sInfo.sliceBlockSize = 1;
+		sInfo.baseVCycles = baseVCycles;
+		typename FEMIntegrator::template System< Sigs , IsotropicUIntPack< Dim , 1 > > F( { 0. , 1. } );
+		state4.solution = state4.tree.solveSystem( Sigs() , F , state4.constraints , clientReconInfo.baseDepth , std::min< unsigned int >( clientReconInfo.sharedDepth , clientReconInfo.solveDepth ) , sInfo , std::make_tuple( state4.iInfo ) );
+		phaseInfo.processTime += timer.wallTime();
+
+		profiler.update();
+	}
+
+	for( unsigned int i=0 ; i<_clientSockets.size() ; i++ )
+	{
+		Timer timer;
+		std::pair< unsigned int , unsigned int > range;
+#ifdef ADAPTIVE_PADDING
+		// Compute the range of slices @ clientReconInfo.sharedDepth that can contribute to the client
+		{
+			range = _pointPartition.range( i );
+			if( range.first<clientReconInfo.padSize ) range.first = 0;
+			else range.first -= clientReconInfo.padSize;
+			if( range.second+clientReconInfo.padSize>_pointPartition.slabs() ) range.second = _pointPartition.slabs();
+			else range.second += clientReconInfo.padSize;
+		}
+#else // !ADAPTIVE_PADDING
+		range = _pointPartition.range( i , clientReconInfo.padSize );
+#endif // ADAPTIVE_PADDING
+
+		ClientServerStream< false > clientStream( _clientSockets[i] , i , clientReconInfo );
+		clientStream.ioBytes = 0;
+		auto keepNodeFunctor = [&]( const FEMTreeNode *node )
+		{
+			int d , off[Dim];
+			state4.tree.depthAndOffset( node , d , off );
+
+			// Pre-tree nodes need to be shared and nodes finer than @ clientReconInfo.sharedDepth don't need to be
+			if( d<0 ) return true;
+			else if( d>(int)clientReconInfo.sharedDepth )
+			{
+				MK_WARN( "Why does the client have fine nodes?" );
+				return false;
+			}
+			else
+			{
+				// Compute the space of the range of the support @ clientReconInfo.sharedDepth
+				int start = ( off[Dim-1] + StartOffset )<<(clientReconInfo.sharedDepth-d);
+				int end   = ( off[Dim-1] +   EndOffset )<<(clientReconInfo.sharedDepth-d);
+
+				// Keep the node if its support fall within the client's range
+				return start<(int)range.second && end>(int)range.first;
+			}
+		};
+		size_t subNodeCount;
+		Pointer( FEMTreeNode ) subNodes = state4.tree.tree().serializeSubTree( keepNodeFunctor , subNodeCount );
+
+		node_index_type count = 0;
+		subNodes[0].processNodes( [&]( const FEMTreeNode *node ){ if( node->nodeData.nodeIndex!=-1 ) count++; } );
+		std::vector< node_index_type > newToOld( count );
+		count = 0;
+		for( size_t i=0 ; i<subNodeCount ; i++ ) if( subNodes[i].nodeData.nodeIndex!=-1 )
+		{
+			newToOld[ count ] = subNodes[i].nodeData.nodeIndex;
+			subNodes[i].nodeData.nodeIndex = count++;
+		}
+
+		TreeAddressesToIndices( subNodes , subNodeCount );
+		phaseInfo.processTime += timer.wallTime();
+
+		timer = Timer();
+		clientStream.write( subNodeCount );
+		clientStream.write( subNodes , subNodeCount );
+		phaseInfo.writeTime += timer.wallTime();
+
+		timer = Timer();
+		DenseNodeData< Real , Sigs > _solution( count );
+		for( unsigned int i=0 ; i<newToOld.size() ; i++ ) _solution[i] = state4.solution[ newToOld[i] ];
+		phaseInfo.processTime += timer.wallTime();
+
+		timer = Timer();
+		_solution.write( clientStream );
+		phaseInfo.writeTime += timer.wallTime();
+
+		if( needAuxData )
+		{
+			Timer timer;
+			SparseNodeData< ProjectiveData< AuxData , Real > , IsotropicUIntPack< Dim , DataSig > > _auxDataField;
+			_auxDataField.reserve( count );
+			for( size_t i=0 ; i<subNodeCount ; i++ ) if( subNodes[i].nodeData.nodeIndex!=-1 )
+			{
+				const FEMTreeNode *node = state4.tree.node( newToOld[ subNodes[i].nodeData.nodeIndex ] );
+				ProjectiveData< AuxData , Real > *data = state4.auxDataField->operator()( node );
+				if( data ) _auxDataField[ subNodes+i ] = *data;
+			}
+			phaseInfo.processTime += timer.wallTime();
+
+			timer = Timer();
+			if constexpr( !AuxDataFactory::IsStaticallyAllocated() )
+			{
+				ProjectiveAuxDataTypeSerializer< Real > serializer( clientReconInfo.auxProperties );
+				_auxDataField.write( clientStream , serializer );
+			}
+			else _auxDataField.write( clientStream );
+			phaseInfo.writeTime += timer.wallTime();
+		}
+		profiler.update();
+		DeletePointer( subNodes );
+		phaseInfo.writeBytes += clientStream.ioBytes;
+	}
+
+	{
+		std::pair< double , double > isoInfo(0.,0.);
+		for( unsigned int i=0 ; i<_clientSockets.size() ; i++ )
+		{
+			std::pair< double , double > _isoInfo(0.,0.);
+			_clientSockets[i].read( _isoInfo );
+			isoInfo.first += _isoInfo.first;
+			isoInfo.second += _isoInfo.second;
+		}
+		if( clientReconInfo.verbose>1 ) std::cout << "Iso-value: " << ( isoInfo.first / isoInfo.second ) << std::endl;
+		isoValue = (Real)( isoInfo.first / isoInfo.second );
+	}
+
+	if( clientReconInfo.outputSolution )
+	{
+		std::string outFileName = std::string( "solution.tree" );
+		if( clientReconInfo.outDir.length() ) outFileName = PointPartition::FileDir( clientReconInfo.outDir , outFileName );
+
+		FILE* fp = fopen( outFileName.c_str() , "wb" );
+		if( !fp ) MK_THROW( "Failed to open file for writing: " , outFileName );
+		FileStream fs(fp);
+		FEMTree< Dim , Real >::WriteParameter( fs );
+		DenseNodeData< Real , Sigs >::WriteSignatures( fs );
+		XForm< Real , Dim+1 > voxelToUnitCube = XForm< Real , Dim+1 >::Identity();
+		state4.tree.write( fs , false );
+		fs.write( voxelToUnitCube );
+		state4.solution.write( fs );
+		fclose( fp );
+	}
+
+	return phaseInfo;
+}
+
+template< typename Real , unsigned int Dim , BoundaryType BType , unsigned int Degree >
+PhaseInfo Server< Real , Dim , BType , Degree >::_phase6( const ClientReconstructionInfo< Real , Dim > &clientReconInfo , Real isoValue , bool showDiscontinuity , bool outputBoundarySlices , std::vector< unsigned int > &sharedVertexCounts , Profiler &profiler )
+{
+	using SliceSigs = typename _State6::SliceSigs;
+	using Vertex = typename _State6::Vertex;
+	PhaseInfo phaseInfo;
+
+	sharedVertexCounts.resize( _clientSockets.size()-1 );
+
+	if constexpr( Dim==3 ) for( unsigned int i=0 ; i<_clientSockets.size()-1 ; i++ )
+	{
+		_State6 state6;
+
+		auto ReadSlice = [&]( BinaryStream &clientStream , DenseNodeData< Real , SliceSigs > &solution , DenseNodeData< Real , SliceSigs > &dSolution , XForm< Real , Dim > &modelToUnitCube )
+		{
+			FEMTree< Dim-1 , Real > *sliceTree = new FEMTree< Dim-1 , Real >( clientStream , MEMORY_ALLOCATOR_BLOCK_SIZE );
+			clientStream.read( modelToUnitCube );
+			solution.read( clientStream );
+			if( !clientReconInfo.linearFit ) dSolution.read( clientStream );
+			return sliceTree;
+		};
+
+
+		{
+			ClientServerStream< true > clientStream0( _clientSockets[i+0] , i+0 , clientReconInfo , ClientReconstructionInfo< Real , Dim >::FRONT );
+			ClientServerStream< true > clientStream1( _clientSockets[i+1] , i+1 , clientReconInfo , ClientReconstructionInfo< Real , Dim >::BACK  );
+			DenseNodeData< Real , SliceSigs > backSolution , frontSolution , backDSolution , frontDSolution;
+			FEMTree< Dim-1 , Real > *backSliceTree , *frontSliceTree;
+			XForm< Real , Dim > backXForm , frontXForm;
+
+			Timer timer;
+			backSliceTree  = ReadSlice( clientStream0 ,  backSolution ,  backDSolution , backXForm );
+			frontSliceTree = ReadSlice( clientStream1 , frontSolution , frontDSolution , frontXForm );
+			phaseInfo.readTime += timer.wallTime();
+
+			if( showDiscontinuity )
+			{
+				double discontinuityTime = 0;
+				size_t discontinuityCount = 0;
+				double l1 = 0 , l2 = 0 , d2 = 0 , dInf = 0;
+
+				double t = Time();
+
+				int res1 = 0 , res2 = 0;
+				Pointer( Real ) values1 =  backSliceTree->template regularGridEvaluate< true >(  backSolution , res1 , -1 , false );
+				Pointer( Real ) values2 = frontSliceTree->template regularGridEvaluate< true >( frontSolution , res2 , -1 , false );
+				if( res1!=res2 ) MK_THROW( "Different resolutions: " , res1 , " != " , res2 );
+				size_t count = 1;
+				for( unsigned int d=0 ; d<(Dim-1) ; d++ ) count *= (unsigned int)res1;
+				discontinuityCount += count;
+				for( unsigned int i=0 ; i<count ; i++ ) l1 += values1[i] * values1[i] , l2 += values2[i] * values2[i] , d2 += ( values1[i] - values2[i] ) * ( values1[i] - values2[i] ) , dInf = std::max< double >( dInf , fabs( values1[i]-values2[i] ) );
+				DeletePointer( values1 );
+				DeletePointer( values2 );
+
+				discontinuityTime += Time()-t;
+
+				if( discontinuityCount )
+				{
+					d2 /= discontinuityCount;
+					l1 /= discontinuityCount;
+					l2 /= discontinuityCount;
+					std::cout << "Discontinuity L2 / L-infinity: " << sqrt(d2) << " / " << dInf << " [ " << sqrt(l1) << " , " << sqrt(l2) << " ] " << discontinuityTime << " (s)" << std::endl;
+				}
+				profiler.update();
+			}
+
+			timer = Timer();
+			state6.sliceTree = FEMTree< Dim-1 , Real >::Merge( *backSliceTree , *frontSliceTree , MEMORY_ALLOCATOR_BLOCK_SIZE );
+			state6.solution = state6.sliceTree->initDenseNodeData( SliceSigs() );
+			state6.sliceTree->merge( * backSliceTree ,  backSolution , state6.solution );
+			state6.sliceTree->merge( *frontSliceTree , frontSolution , state6.solution );
+			for( unsigned int j=0 ; j<state6.solution.size() ; j++ ) state6.solution[j] /= (Real)2.;
+			if( !clientReconInfo.linearFit )
+			{
+				state6.dSolution = state6.sliceTree->initDenseNodeData( SliceSigs() );
+				state6.sliceTree->merge( * backSliceTree ,  backDSolution , state6.dSolution );
+				state6.sliceTree->merge( *frontSliceTree , frontDSolution , state6.dSolution );
+				for( unsigned int j=0 ; j<state6.dSolution.size() ; j++ ) state6.dSolution[j] /= (Real)2.;
+			}
+			state6.xForm = ( backXForm + frontXForm )/(Real)2.;
+			phaseInfo.processTime += timer.wallTime();
+
+			profiler.update();
+
+			if( outputBoundarySlices )
+			{
+				auto WriteBoundary = [&]( std::string fileName , const FEMTree< Dim-1 , Real > *sliceTree , const DenseNodeData< Real , SliceSigs > &solution )
+				{
+					FILE* fp = fopen( fileName.c_str() , "wb" );
+					if( !fp ) MK_THROW( "Failed to open file for writing: " , fileName );
+					FileStream fs(fp);
+					FEMTree< Dim-1 , Real >::WriteParameter( fs );
+					DenseNodeData< Real , SliceSigs >::WriteSignatures( fs );
+					sliceTree->write( fs , false );
+					fs.write( state6.xForm );
+					solution.write( fs );
+					fclose( fp );
+				};
+				{
+					std::stringstream ss;
+					ss << "back." << i << ".tree";
+					WriteBoundary( ss.str() , backSliceTree , backSolution );
+				}
+				{
+					std::stringstream ss;
+					ss << "front." << i << ".tree";
+					WriteBoundary( ss.str() , frontSliceTree , frontSolution );
+				}
+				{
+					std::stringstream ss;
+					ss << "merged." << i << ".tree";
+					WriteBoundary( ss.str() , state6.sliceTree , state6.solution );
+				}
+			}
+			delete backSliceTree;
+			delete frontSliceTree;
+
+			phaseInfo.readBytes += clientStream0.ioBytes + clientStream1.ioBytes;
+		}
+
+		{
+			Timer timer;
+			using Factory = VertexFactory::EmptyFactory< Real >;
+			using Data = typename Factory::VertexType;
+			Factory factory;
+			const typename FEMTree< Dim-1 , Real >::template DensityEstimator< Reconstructor::WeightDegree > *density=NULL;
+			const SparseNodeData< ProjectiveData< Data , Real > , IsotropicUIntPack< Dim-1 , DataSig > > *data=NULL;
+			{
+				VectorBackedOutputDataStream< Point< Real , Dim-1 > > _vertexStream( state6.vertices );
+				using ExternalType = std::tuple< Point< Real , Dim-1 > , Point< Real , Dim-1 > , Real >;
+				using InternalType = std::tuple< Point< Real , Dim-1 > >;
+				auto converter = []( const ExternalType &xType )
+					{
+						InternalType iType;
+						std::get< 0 >( iType ) = std::get< 0 >( xType );
+						return iType;
+					};
+				OutputDataStreamConverter< InternalType , ExternalType > __vertexStream( _vertexStream , converter );
+
+				LevelSetExtractor< Real , Dim-1 >::SetSliceValues( SliceSigs() , UIntPack< Reconstructor::WeightDegree >() , *state6.sliceTree , clientReconInfo.reconstructionDepth , density , state6.solution , isoValue , __vertexStream , !clientReconInfo.linearFit , false , state6.sliceValues , LevelSetExtractor< Real , Dim-1 , Vertex >::SetIsoEdgesFlag() );
+				if( !clientReconInfo.linearFit ) LevelSetExtractor< Real , Dim-1 >::SetSliceValues( SliceSigs() , UIntPack< Reconstructor::WeightDegree >() , *state6.sliceTree , clientReconInfo.reconstructionDepth , density , state6.dSolution , isoValue , __vertexStream , false , false , state6.dSliceValues , LevelSetExtractor< Real , Dim-1 , Vertex >::SetCornerValuesFlag() );
+			}
+			sharedVertexCounts[i] = (unsigned int)state6.vertices.size();
+			phaseInfo.processTime += timer.wallTime();
+		}
+		profiler.update();
+
+		{
+			Timer timer;
+			ClientServerStream< false > clientStream0( _clientSockets[i+0] , i+0 , clientReconInfo , ClientReconstructionInfo< Real , Dim >::FRONT );
+			ClientServerStream< false > clientStream1( _clientSockets[i+1] , i+1 , clientReconInfo , ClientReconstructionInfo< Real , Dim >::BACK  );
+			clientStream0.ioBytes = 0;
+			clientStream1.ioBytes = 0;
+			clientStream0.write( isoValue );
+			clientStream1.write( isoValue );
+			if( clientReconInfo.mergeType!=ClientReconstructionInfo< Real , Dim >::MergeType::NONE )
+			{
+				LevelSetExtractor< Real , Dim-1 >::TreeSliceValuesAndVertexPositions::Write( clientStream0 , state6.sliceTree , state6.xForm , state6.sliceValues , state6.vertices , true );
+				if( !clientReconInfo.linearFit )
+				{
+					for( unsigned int i=0 ; i<state6.dSliceValues.size() ; i++ )
+					{
+						clientStream0.write( state6.dSliceValues[i].cellIndices.counts[0] );
+						clientStream0.write( state6.dSliceValues[i].cornerValues , state6.dSliceValues[i].cellIndices.counts[0] );
+					}
+				}
+				LevelSetExtractor< Real , Dim-1 >::TreeSliceValuesAndVertexPositions::Write( clientStream1 , state6.sliceTree , state6.xForm , state6.sliceValues , state6.vertices , true );
+				if( !clientReconInfo.linearFit )
+				{
+					for( unsigned int i=0 ; i<state6.dSliceValues.size() ; i++ )
+					{
+						clientStream1.write( state6.dSliceValues[i].cellIndices.counts[0] );
+						clientStream1.write( state6.dSliceValues[i].cornerValues , state6.dSliceValues[i].cellIndices.counts[0] );
+					}
+				}
+			}
+			phaseInfo.writeBytes += clientStream0.ioBytes + clientStream1.ioBytes;
+			phaseInfo.writeTime += timer.wallTime();
+		}
+		profiler.update();
+	}
+
+	return phaseInfo;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/Polynomial.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Polynomial.h
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef POLYNOMIAL_INCLUDED
+#define POLYNOMIAL_INCLUDED
+
+#include <float.h>
+#include <math.h>
+#include <algorithm>
+#include "Factor.h"
+
+namespace PoissonRecon
+{
+
+	template< int Degree >
+	class Polynomial
+	{
+	public:
+		double coefficients[Degree+1];
+
+		Polynomial( void );
+		template< int Degree2 > Polynomial( const Polynomial< Degree2 >& P );
+		double operator()( double t ) const;
+		double integral( double tMin , double tMax ) const;
+
+		int operator == (const Polynomial& p) const;
+		int operator != (const Polynomial& p) const;
+		int isZero(void) const;
+		void setZero(void);
+
+		template<int Degree2>
+		Polynomial& operator  = (const Polynomial<Degree2> &p);
+		Polynomial& operator += (const Polynomial& p);
+		Polynomial& operator -= (const Polynomial& p);
+		Polynomial  operator -  (void) const;
+		Polynomial  operator +  (const Polynomial& p) const;
+		Polynomial  operator -  (const Polynomial& p) const;
+		template<int Degree2>
+		Polynomial<Degree+Degree2>  operator *  (const Polynomial<Degree2>& p) const;
+
+		Polynomial& operator += ( double s );
+		Polynomial& operator -= ( double s );
+		Polynomial& operator *= ( double s );
+		Polynomial& operator /= ( double s );
+		Polynomial  operator +  ( double s ) const;
+		Polynomial  operator -  ( double s ) const;
+		Polynomial  operator *  ( double s ) const;
+		Polynomial  operator /  ( double s ) const;
+
+		Polynomial scale( double s ) const;
+		Polynomial shift( double t ) const;
+
+		template< int _Degree=Degree >
+		typename std::enable_if< (_Degree==0) , Polynomial< Degree   > >::type derivative( void ) const { return Polynomial< Degree >(); }
+		template< int _Degree=Degree >
+		typename std::enable_if< (_Degree> 0) , Polynomial< Degree-1 > >::type derivative( void ) const
+		{
+			Polynomial< Degree-1 > p;
+			for( int i=0 ; i<Degree ; i++ ) p.coefficients[i] = coefficients[i+1]*(i+1);
+			return p;
+		}
+		Polynomial< Degree+1 > integral(void) const;
+
+		void printnl( void ) const;
+
+		Polynomial& addScaled(const Polynomial& p,double scale);
+		static void Negate(const Polynomial& in,Polynomial& out);
+		static void Subtract(const Polynomial& p1,const Polynomial& p2,Polynomial& q);
+		static void Scale(const Polynomial& p,double w,Polynomial& q);
+		static void AddScaled(const Polynomial& p1,double w1,const Polynomial& p2,double w2,Polynomial& q);
+		static void AddScaled(const Polynomial& p1,const Polynomial& p2,double w2,Polynomial& q);
+		static void AddScaled(const Polynomial& p1,double w1,const Polynomial& p2,Polynomial& q);
+
+		int getSolutions( double c , double* roots , double EPS ) const;
+
+		// [NOTE] Both of these methods define the indexing according to DeBoor's algorithm, so that
+		// Polynomial< Degree >BSplineComponent( 0 )( 1.0 )=0 for all Degree>0.
+		static Polynomial BSplineComponent( int i );
+		static void BSplineComponentValues( double x , double* values );
+		static void BinomialCoefficients( int bCoefficients[Degree+1] );
+	};
+
+#include "Polynomial.inl"
+}
+#endif // POLYNOMIAL_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Polynomial.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Polynomial.inl
@@ -1,0 +1,364 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+////////////////
+// Polynomial //
+////////////////
+template<int Degree>
+Polynomial<Degree>::Polynomial(void){memset(coefficients,0,sizeof(double)*(Degree+1));}
+template<int Degree>
+template<int Degree2>
+Polynomial<Degree>::Polynomial(const Polynomial<Degree2>& P){
+	memset(coefficients,0,sizeof(double)*(Degree+1));
+	for(int i=0;i<=Degree && i<=Degree2;i++){coefficients[i]=P.coefficients[i];}
+}
+
+
+template<int Degree>
+template<int Degree2>
+Polynomial<Degree>& Polynomial<Degree>::operator  = (const Polynomial<Degree2> &p){
+	int d=Degree<Degree2?Degree:Degree2;
+	memset(coefficients,0,sizeof(double)*(Degree+1));
+	memcpy(coefficients,p.coefficients,sizeof(double)*(d+1));
+	return *this;
+}
+
+template<int Degree>
+Polynomial<Degree+1> Polynomial<Degree>::integral(void) const{
+	Polynomial<Degree+1> p;
+	p.coefficients[0]=0;
+	for(int i=0;i<=Degree;i++){p.coefficients[i+1]=coefficients[i]/(i+1);}
+	return p;
+}
+
+template< > inline double Polynomial< 0 >::operator() ( double t ) const { return coefficients[0]; }
+template< > inline double Polynomial< 1 >::operator() ( double t ) const { return coefficients[0]+coefficients[1]*t; }
+template< > inline double Polynomial< 2 >::operator() ( double t ) const { return coefficients[0]+(coefficients[1]+coefficients[2]*t)*t; }
+template< int Degree >
+double Polynomial<Degree>::operator() ( double t ) const{
+	double v=coefficients[Degree];
+	for( int d=Degree-1 ; d>=0 ; d-- ) v = v*t + coefficients[d];
+	return v;
+}
+template<int Degree>
+double Polynomial<Degree>::integral( double tMin , double tMax ) const
+{
+	double v=0;
+	double t1,t2;
+	t1=tMin;
+	t2=tMax;
+	for(int i=0;i<=Degree;i++){
+		v+=coefficients[i]*(t2-t1)/(i+1);
+		if(t1!=-DBL_MAX && t1!=DBL_MAX){t1*=tMin;}
+		if(t2!=-DBL_MAX && t2!=DBL_MAX){t2*=tMax;}
+	}
+	return v;
+}
+template<int Degree>
+int Polynomial<Degree>::operator == (const Polynomial& p) const{
+	for(int i=0;i<=Degree;i++){if(coefficients[i]!=p.coefficients[i]){return 0;}}
+	return 1;
+}
+template<int Degree>
+int Polynomial<Degree>::operator != (const Polynomial& p) const{
+	for(int i=0;i<=Degree;i++){if(coefficients[i]==p.coefficients[i]){return 0;}}
+	return 1;
+}
+template<int Degree>
+int Polynomial<Degree>::isZero(void) const{
+	for(int i=0;i<=Degree;i++){if(coefficients[i]!=0){return 0;}}
+	return 1;
+}
+template<int Degree>
+void Polynomial<Degree>::setZero(void){memset(coefficients,0,sizeof(double)*(Degree+1));}
+
+template<int Degree>
+Polynomial<Degree>& Polynomial<Degree>::addScaled(const Polynomial& p,double s){
+	for(int i=0;i<=Degree;i++){coefficients[i]+=p.coefficients[i]*s;}
+	return *this;
+}
+template<int Degree>
+Polynomial<Degree>& Polynomial<Degree>::operator += (const Polynomial<Degree>& p){
+	for(int i=0;i<=Degree;i++){coefficients[i]+=p.coefficients[i];}
+	return *this;
+}
+template<int Degree>
+Polynomial<Degree>& Polynomial<Degree>::operator -= (const Polynomial<Degree>& p){
+	for(int i=0;i<=Degree;i++){coefficients[i]-=p.coefficients[i];}
+	return *this;
+}
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::operator + (const Polynomial<Degree>& p) const{
+	Polynomial q;
+	for(int i=0;i<=Degree;i++){q.coefficients[i]=(coefficients[i]+p.coefficients[i]);}
+	return q;
+}
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::operator - (const Polynomial<Degree>& p) const{
+	Polynomial q;
+	for(int i=0;i<=Degree;i++)	{q.coefficients[i]=coefficients[i]-p.coefficients[i];}
+	return q;
+}
+template<int Degree>
+void Polynomial<Degree>::Scale(const Polynomial& p,double w,Polynomial& q){
+	for(int i=0;i<=Degree;i++){q.coefficients[i]=p.coefficients[i]*w;}
+}
+template<int Degree>
+void Polynomial<Degree>::AddScaled(const Polynomial& p1,double w1,const Polynomial& p2,double w2,Polynomial& q){
+	for(int i=0;i<=Degree;i++){q.coefficients[i]=p1.coefficients[i]*w1+p2.coefficients[i]*w2;}
+}
+template<int Degree>
+void Polynomial<Degree>::AddScaled(const Polynomial& p1,double w1,const Polynomial& p2,Polynomial& q){
+	for(int i=0;i<=Degree;i++){q.coefficients[i]=p1.coefficients[i]*w1+p2.coefficients[i];}
+}
+template<int Degree>
+void Polynomial<Degree>::AddScaled(const Polynomial& p1,const Polynomial& p2,double w2,Polynomial& q){
+	for(int i=0;i<=Degree;i++){q.coefficients[i]=p1.coefficients[i]+p2.coefficients[i]*w2;}
+}
+
+template<int Degree>
+void Polynomial<Degree>::Subtract(const Polynomial &p1,const Polynomial& p2,Polynomial& q){
+	for(int i=0;i<=Degree;i++){q.coefficients[i]=p1.coefficients[i]-p2.coefficients[i];}
+}
+template<int Degree>
+void Polynomial<Degree>::Negate(const Polynomial& in,Polynomial& out){
+	out=in;
+	for(int i=0;i<=Degree;i++){out.coefficients[i]=-out.coefficients[i];}
+}
+
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::operator - (void) const{
+	Polynomial q=*this;
+	for(int i=0;i<=Degree;i++){q.coefficients[i]=-q.coefficients[i];}
+	return q;
+}
+template<int Degree>
+template<int Degree2>
+Polynomial<Degree+Degree2> Polynomial<Degree>::operator * (const Polynomial<Degree2>& p) const{
+	Polynomial<Degree+Degree2> q;
+	for(int i=0;i<=Degree;i++){for(int j=0;j<=Degree2;j++){q.coefficients[i+j]+=coefficients[i]*p.coefficients[j];}}
+	return q;
+}
+
+template<int Degree>
+Polynomial<Degree>& Polynomial<Degree>::operator += ( double s )
+{
+	coefficients[0]+=s;
+	return *this;
+}
+template<int Degree>
+Polynomial<Degree>& Polynomial<Degree>::operator -= ( double s )
+{
+	coefficients[0]-=s;
+	return *this;
+}
+template<int Degree>
+Polynomial<Degree>& Polynomial<Degree>::operator *= ( double s )
+{
+	for(int i=0;i<=Degree;i++){coefficients[i]*=s;}
+	return *this;
+}
+template<int Degree>
+Polynomial<Degree>& Polynomial<Degree>::operator /= ( double s )
+{
+	for(int i=0;i<=Degree;i++){coefficients[i]/=s;}
+	return *this;
+}
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::operator + ( double s ) const
+{
+	Polynomial<Degree> q=*this;
+	q.coefficients[0]+=s;
+	return q;
+}
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::operator - ( double s ) const
+{
+	Polynomial q=*this;
+	q.coefficients[0]-=s;
+	return q;
+}
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::operator * ( double s ) const
+{
+	Polynomial q;
+	for(int i=0;i<=Degree;i++){q.coefficients[i]=coefficients[i]*s;}
+	return q;
+}
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::operator / ( double s ) const
+{
+	Polynomial q;
+	for( int i=0 ; i<=Degree ; i++ ) q.coefficients[i] = coefficients[i]/s;
+	return q;
+}
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::scale( double s ) const
+{
+	Polynomial q=*this;
+	double s2=1.0;
+	for(int i=0;i<=Degree;i++){
+		q.coefficients[i]*=s2;
+		s2/=s;
+	}
+	return q;
+}
+template<int Degree>
+Polynomial<Degree> Polynomial<Degree>::shift( double t ) const
+{
+	Polynomial<Degree> q;
+	for(int i=0;i<=Degree;i++){
+		double temp=1;
+		for(int j=i;j>=0;j--){
+			q.coefficients[j]+=coefficients[i]*temp;
+			temp*=-t*j;
+			temp/=(i-j+1);
+		}
+	}
+	return q;
+}
+template<int Degree>
+void Polynomial<Degree>::printnl(void) const{
+	for(int j=0;j<=Degree;j++){
+		printf("%6.4f x^%d ",coefficients[j],j);
+		if(j<Degree && coefficients[j+1]>=0){printf("+");}
+	}
+	printf("\n");
+}
+
+template< >
+inline int Polynomial< 1 >::getSolutions( double c , double* roots , double EPS ) const
+{
+	std::complex< double > _roots[4];
+	int _rCount = Factor( coefficients[1] , coefficients[0]-c , _roots , EPS );
+	int rCount = 0;
+	for( int i=0 ; i<_rCount ; i++ ) if( fabs( _roots[i].imag() )<=EPS ) roots[rCount++] = _roots[i].real();
+	return rCount;
+}
+
+template< >
+inline int Polynomial< 2 >::getSolutions( double c , double* roots , double EPS ) const
+{
+	std::complex< double > _roots[4];
+	int _rCount = Factor( coefficients[2] , coefficients[1] , coefficients[0]-c , _roots , EPS );
+	int rCount = 0;
+	for( int i=0 ; i<_rCount ; i++ ) if( fabs( _roots[i].imag() )<=EPS ) roots[rCount++] = _roots[i].real();
+	return rCount;
+}
+
+template< >
+inline int Polynomial< 3 >::getSolutions( double c , double* roots , double EPS ) const
+{
+	std::complex< double > _roots[4];
+	int _rCount = Factor( coefficients[3] , coefficients[2] , coefficients[1] , coefficients[0]-c , _roots , EPS );
+	int rCount = 0;
+	for( int i=0 ; i<_rCount ; i++ ) if( fabs( _roots[i].imag() )<=EPS ) roots[rCount++] = _roots[i].real();
+	return rCount;
+}
+
+#if 0
+template< >
+inline int Polynomial< 4 >::getSolutions( double c , double* roots , double EPS ) const
+{
+	std::complex< double > _roots[4];
+	int _rCount = Factor( coefficients[4] , coefficients[3] , coefficients[2] , coefficients[1] , coefficients[0]-c , _roots , EPS );
+	int rCount = 0;
+	for( int i=0 ; i<_rCount ; i++ ) if( fabs( _roots[i].imag() )<=EPS ) roots[rCount++] = _roots[i].real();
+	return rCount;
+}
+#endif
+
+template< int Degree >
+int Polynomial<Degree>::getSolutions( double c , double* roots , double EPS ) const
+{
+	MK_THROW( "Can't solve polynomial of degree: " , Degree );
+	return 0;
+}
+
+// The 0-th order B-spline
+template< >
+inline Polynomial< 0 > Polynomial< 0 >::BSplineComponent( int i )
+{
+	Polynomial p;
+	p.coefficients[0] = 1.;
+	return p;
+}
+
+// The Degree-th order B-spline
+template< int Degree >
+Polynomial< Degree > Polynomial< Degree >::BSplineComponent( int i )
+{
+	// B_d^i(x) = \int_x^1 B_{d-1}^{i}(y) dy + \int_0^x B_{d-1}^{i-1} y dy
+	//          = \int_0^1 B_{d-1}^{i}(y) dy - \int_0^x B_{d-1}^{i}(y) dy + \int_0^x B_{d-1}^{i-1} y dy
+	Polynomial p;
+	if( i<Degree )
+	{
+		Polynomial< Degree > _p = Polynomial< Degree-1 >::BSplineComponent( i ).integral();
+		p -= _p;
+		p.coefficients[0] += _p(1);
+	}
+	if( i>0 )
+	{
+		Polynomial< Degree > _p = Polynomial< Degree-1 >::BSplineComponent( i-1 ).integral();
+		p += _p;
+	}
+	return p;
+}
+
+
+// The 0-th order B-spline values
+template< > inline void Polynomial< 0 >::BSplineComponentValues( double x , double* values ){ values[0] = 1.; }
+// The Degree-th order B-spline
+template< int Degree > void Polynomial< Degree >::BSplineComponentValues( double x , double* values )
+{
+	const double Scale = 1./Degree;
+	Polynomial< Degree-1 >::BSplineComponentValues( x , values+1 );
+	values[0] = values[1] * (1.-x) * Scale;
+	for( int i=1 ; i<Degree ; i++ )
+	{
+		double x1 = (x-i+Degree) , x2 = (-x+i+1);
+		values[i] = ( values[i]*x1 + values[i+1]*x2 ) * Scale;
+	}
+	values[Degree] *= x * Scale;
+}
+
+// Using the recurrence formulation for Pascal's triangle
+template< > inline void Polynomial< 0 >::BinomialCoefficients( int bCoefficients[1] ){ bCoefficients[0] = 1; }
+
+template< int Degree > void Polynomial< Degree >::BinomialCoefficients( int bCoefficients[Degree+1] )
+{
+	Polynomial< Degree-1 >::BinomialCoefficients( bCoefficients );
+	int leftValue = 0;
+	for( int i=0 ; i<Degree ; i++ )
+	{
+		int temp = bCoefficients[i];
+		bCoefficients[i] += leftValue;
+		leftValue = temp;
+	}
+	bCoefficients[Degree] = 1;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/PreProcessor.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/PreProcessor.h
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2019, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef PRE_PROCESSOR_INCLUDED
+#define PRE_PROCESSOR_INCLUDED
+
+#ifndef BIG_DATA								// Allow over-riding if defined before PreProcessor.h
+#undef BIG_DATA									// Supports processing requiring more than 32-bit integers for indexing
+												// Note: enabling BIG_DATA can generate .ply files using "longlong" for vertex indices instead of "int".
+												// These are not standardly supported by .ply reading/writing applications.
+												// The executable ChunkPLY can help by partitioning the mesh into more manageable chunks
+												// (each of which is small enough to be represented using 32-bit indexing.)
+#endif // BIG_DATA
+
+#define USE_JPEG_TURBO							// JPEG turbo library
+
+//#define SANITIZED_PR								// If enabled, produces CLANG-sanitized code [thread/undefined/address]
+//#define FAST_COMPILE								// If enabled, only a single version of the code is compiled
+#undef SHOW_WARNINGS							// Display compilation warnings
+#undef ARRAY_DEBUG								// If enabled, array access is tested for validity
+
+#ifdef BIG_DATA
+#define USE_DEEP_TREE_NODES						// Chances are that if you are using big data, you want to support a tree with depth>15.
+#endif // BIG_DATA
+
+#define ADAPTIVE_SOLVERS_VERSION "18.76"		// The version of the code
+#define MEMORY_ALLOCATOR_BLOCK_SIZE 1<<12		// The chunk size for memory allocation
+
+#define ADAPTIVE_PADDING						// Only pushes padding points deep enough so that they are "close" to the slab in terms of units at that depth
+#define NESTED_VECTOR_LEVELS 1					// The number of nesting levels for the nested-vector
+
+#endif // PRE_PROCESSOR_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Rasterizer.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Rasterizer.h
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2019, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef RASTERIZER_INCLUDED
+#define RASTERIZER_INCLUDED
+
+#include <mutex>
+#include "Array.h"
+#include "Geometry.h"
+#include "RegularGrid.h"
+#include "MyMiscellany.h"
+
+namespace PoissonRecon
+{
+
+	template< typename Real , unsigned int Dim >
+	struct Rasterizer
+	{
+		struct ThreadSafety
+		{
+			enum Type
+			{
+				MUTEXES ,
+				MAP_REDUCE ,
+				SINGLE_THREADED
+			};
+			Type type;
+			unsigned int lockDepth;
+			ThreadSafety( Type t=MUTEXES , unsigned int ld=0 ) : type(t) , lockDepth(ld) { }
+		};
+		template< typename IndexType , unsigned int K > using SimplexRasterizationGrid = RegularGrid< std::vector< std::pair< IndexType , Simplex< Real , Dim , K > > > , Dim >;
+
+		// This templated function rasterizes simplices.
+		// It is assumed that the simplices are scaled to be contained in the cube [0,1]^3.
+		// Template parameters:
+		//		IndexType: specifies the storage for vertex/simplex indices
+		// Input:
+		//		vertices: the vertices of the mesh
+		//		simplices: the connectivity of the mesh
+		//		depth: the depth of the voxel grid, generating a grid of size (2^depth) x (2^depth) x (2^depth)
+		//		lockDepth: the depth of the voxel grid storing the locks
+		// Output:
+		//		A RegularGrid object where each cell stores the list of pairs containing the index into the original simplex list and the (clipped) simplex
+		template< typename IndexType , unsigned int K >
+		static SimplexRasterizationGrid< IndexType , K > Rasterize( const SimplicialComplex< Real , Dim , K > &simplicialComplex , unsigned int depth , ThreadSafety threadSafety );
+
+	protected:
+		struct _RegularGridIndex
+		{
+			unsigned int depth , index[Dim];
+			_RegularGridIndex( void );
+			_RegularGridIndex( unsigned int d , Point< Real , Dim > p );
+			template< unsigned int K > _RegularGridIndex( unsigned int maxDepth , Simplex< Real , Dim , K > simplex );
+
+			bool operator != ( const _RegularGridIndex &idx ) const;
+			bool operator == ( const _RegularGridIndex &idx ) const { return !( (*this)!=idx ); }
+
+			_RegularGridIndex child( unsigned int c ) const;
+		};
+
+		struct _RegularGridMutexes
+		{
+			_RegularGridMutexes( unsigned int lockDepth , unsigned int maxDepth )
+			{
+				if( lockDepth>maxDepth )
+				{
+					MK_WARN( "Lock depth exceeds max depth: " , lockDepth , " > " ,  maxDepth );
+					lockDepth = maxDepth;
+				}
+				_bitShift = maxDepth - lockDepth;
+				unsigned int _res = 1<<lockDepth;
+				unsigned int res[Dim];
+				for( int d=0 ; d<Dim ; d++ ) res[d] = _res;
+				_mutexes.resize( res );
+			}
+
+			std::mutex &operator() ( const unsigned int idx[Dim] )
+			{
+				unsigned int _idx[Dim];
+				for( int d=0 ; d<Dim ; d++ ) _idx[d] = idx[d] >> _bitShift;
+				return _metexes( _idx );
+			}
+			std::mutex &operator() ( unsigned int idx[Dim] )
+			{
+				unsigned int _idx[Dim];
+				for( int d=0 ; d<Dim ; d++ ) _idx[d] = idx[d] >> _bitShift;
+				return _mutexes( _idx );
+			}
+			template< typename ... UnsignedInts >
+			std::mutex &operator()( UnsignedInts ... idx )
+			{
+				unsigned int _idx[] = { idx ... };
+				for( int d=0 ; d<Dim ; d++ ) _idx[d] = _idx[d] >> _bitShift;
+				return _mutexes( _idx );
+			}
+
+		protected:
+			RegularGrid< std::mutex , Dim > _mutexes;
+			size_t _bitShift;
+		};
+
+		template< typename IndexType , unsigned int K >
+		static size_t _Rasterize( _RegularGridMutexes &mutexes , SimplexRasterizationGrid< IndexType , K > &raster , IndexType simplexIndex , Simplex< Real , Dim , K > simplex , unsigned int depth , _RegularGridIndex idx );
+
+		template< typename IndexType , unsigned int K >
+		static size_t _Rasterize( SimplexRasterizationGrid< IndexType , K > &raster , IndexType simplexIndex , Simplex< Real , Dim , K > simplex , unsigned int depth , _RegularGridIndex idx );
+	};
+#include "Rasterizer.inl"
+}
+#endif // RASTERIZER_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Rasterizer.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Rasterizer.inl
@@ -1,0 +1,274 @@
+/*
+Copyright (c) 2019, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+///////////////////////////////////
+// Rasterizer::_RegularGridIndex //
+///////////////////////////////////
+template< typename Real , unsigned int Dim >
+Rasterizer< Real , Dim >::_RegularGridIndex::_RegularGridIndex( void )
+{
+	depth = 0;
+	for( int d=0 ; d<Dim ; d++ ) index[d] = 0;
+}
+
+template< typename Real , unsigned int Dim >
+Rasterizer< Real , Dim >::_RegularGridIndex::_RegularGridIndex( unsigned int depth , Point< Real , Dim > point )
+{
+	this->depth = depth;
+	// After clipping the coordinate could be equal to exactly one, in which case we want to round down.
+	for( unsigned int d=0 ; d<Dim ; d++ ) index[d] = std::min< unsigned int >( (unsigned int)( point[d] * (1<<depth) ) , (1<<depth)-1 );
+}
+
+template< typename Real , unsigned int Dim >
+template< unsigned int K >
+Rasterizer< Real , Dim >::_RegularGridIndex::_RegularGridIndex( unsigned int maxDepth , Simplex< Real , Dim , K > simplex )
+{
+	for( depth=0 ; depth<maxDepth ; depth++ )
+	{
+		_RegularGridIndex idx( depth , simplex[0] );
+
+		bool done = false;
+		for( int k=1 ; k<=K && !done ; k++ ) if( _RegularGridIndex( depth , simplex[k] )!=idx ) done = true;
+		if( done ) break;
+	}
+	if( depth==0 ) MK_THROW( "Simplex is not in unit cube: " , simplex );
+	else *this = _RegularGridIndex( depth-1 , simplex[0] );
+}
+
+
+template< typename Real , unsigned int Dim >
+bool Rasterizer< Real , Dim >::_RegularGridIndex::operator != ( const _RegularGridIndex &idx ) const
+{
+	if( depth!=idx.depth ) return false;
+	for( int d=0 ; d<Dim ; d++ ) if( index[d]!=idx.index[d] ) return true;
+	return false;
+}
+
+template< typename Real , unsigned int Dim >
+typename Rasterizer< Real , Dim >::_RegularGridIndex Rasterizer< Real , Dim >::_RegularGridIndex::child( unsigned int c ) const
+{
+	_RegularGridIndex idx;
+	idx.depth = depth+1;
+	for( int d=0 ; d<Dim ; d++ ) idx.index[d] = index[d]*2 + ( c&(1<<d) ? 1 : 0 );
+	return idx;
+}
+
+////////////////
+// Rasterizer //
+////////////////
+
+template< typename Real , unsigned int Dim >
+template< typename IndexType , unsigned int K >
+size_t Rasterizer< Real , Dim >::_Rasterize( _RegularGridMutexes &mutexes , SimplexRasterizationGrid< IndexType , K > &raster , IndexType simplexIndex , Simplex< Real , Dim , K > simplex , unsigned int maxDepth , _RegularGridIndex idx )
+{
+	if( idx.depth==maxDepth )
+	{
+		// If the simplex has non-zero size, add it to the list
+		Real weight = simplex.measure();
+		if( weight && weight==weight )
+		{
+			std::lock_guard< std::mutex > lock( mutexes( idx.index ) );
+			raster( idx.index ).push_back( std::pair< IndexType , Simplex< Real , Dim , K > >( simplexIndex , simplex ) );
+		}
+		return 1;
+	}
+	else
+	{
+		size_t sCount = 0;
+
+		// Split up the simplex and pass the parts on to the children
+		Point< Real , Dim > center;
+		for( unsigned int d=0 ; d<Dim ; d++ ) center[d] = (Real)( idx.index[d] + 0.5 ) / (1<<idx.depth);
+
+		std::vector< std::vector< Simplex< Real , Dim , K > > > childSimplices( 1 );
+		childSimplices[0].push_back( simplex );
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			Point< Real , Dim > n ; n[Dim-d-1] = 1;
+			std::vector< std::vector< Simplex< Real , Dim , K > > > temp( (int)( 1<<(d+1) ) );
+			for( int c=0 ; c<(1<<d) ; c++ ) for( int i=0 ; i<childSimplices[c].size() ; i++ ) childSimplices[c][i].split( n , center[Dim-d-1] , temp[2*c] , temp[2*c+1] );
+			childSimplices = temp;
+		}
+		for( int c=0 ; c<(1<<Dim) ; c++ ) for( int i=0 ; i<childSimplices[c].size() ; i++ ) sCount += _Rasterize( mutexes , raster , simplexIndex , childSimplices[c][i] , maxDepth , idx.child(c) );
+		return sCount;
+	}
+}
+
+template< typename Real , unsigned int Dim >
+template< typename IndexType , unsigned int K >
+size_t Rasterizer< Real , Dim >::_Rasterize( SimplexRasterizationGrid< IndexType , K > &raster , IndexType simplexIndex , Simplex< Real , Dim , K > simplex , unsigned int maxDepth , _RegularGridIndex idx )
+{
+	if( idx.depth==maxDepth )
+	{
+		// If the simplex has non-zero size, add it to the list
+		Real weight = simplex.measure();
+		if( weight && weight==weight ) raster( idx.index ).push_back( std::pair< IndexType , Simplex< Real , Dim , K > >( simplexIndex , simplex ) );
+		return 1;
+	}
+	else
+	{
+		size_t sCount = 0;
+
+		// Split up the simplex and pass the parts on to the children
+		Point< Real , Dim > center;
+		for( unsigned int d=0 ; d<Dim ; d++ ) center[d] = (Real)( idx.index[d] + 0.5 ) / (1<<idx.depth);
+
+		std::vector< std::vector< Simplex< Real , Dim , K > > > childSimplices( 1 );
+		childSimplices[0].push_back( simplex );
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			Point< Real , Dim > n ; n[Dim-d-1] = 1;
+			std::vector< std::vector< Simplex< Real , Dim , K > > > temp( (int)( 1<<(d+1) ) );
+			for( int c=0 ; c<(1<<d) ; c++ ) for( int i=0 ; i<childSimplices[c].size() ; i++ ) childSimplices[c][i].split( n , center[Dim-d-1] , temp[2*c] , temp[2*c+1] );
+			childSimplices = temp;
+		}
+		for( int c=0 ; c<(1<<Dim) ; c++ ) for( int i=0 ; i<childSimplices[c].size() ; i++ ) sCount += _Rasterize( raster , simplexIndex , childSimplices[c][i] , maxDepth , idx.child(c) );
+		return sCount;
+	}
+}
+template< typename Real , unsigned int Dim >
+template< typename IndexType , unsigned int K >
+typename Rasterizer< Real , Dim >::template SimplexRasterizationGrid< IndexType , K > Rasterizer< Real , Dim >::Rasterize( const SimplicialComplex< Real , Dim , K > &simplicialComplex , unsigned int depth , ThreadSafety threadSafety )
+{
+	unsigned int res = 1<<depth;
+
+	SimplexRasterizationGrid< IndexType , K > raster;
+	{
+		unsigned int _res[Dim];
+		for( int d=0 ; d<Dim ; d++ ) _res[d] = res;
+		raster.resize( _res );
+	}
+
+	if( threadSafety.type==ThreadSafety::MUTEXES )
+	{
+		if( threadSafety.lockDepth>depth ) MK_THROW( "Lock depth cannot excceed depth: " , threadSafety.lockDepth , " <= " , depth );
+		_RegularGridMutexes mutexes( threadSafety.lockDepth , depth );
+
+		ThreadPool::ParallelFor( 0 , simplicialComplex.size() , [&]( unsigned int t , size_t  i )
+		{
+			std::vector< Simplex< Real , Dim , K > > subSimplices;
+			subSimplices.push_back( simplicialComplex[i] );
+
+			// Clip the simplex to the unit cube
+			{
+				for( int d=0 ; d<Dim ; d++ )
+				{
+					Point< Real , Dim > n;
+					n[d] = 1;
+					{
+						std::vector< Simplex< Real , Dim , K > > back , front;
+						for( int i=0 ; i<subSimplices.size() ; i++ ) subSimplices[i].split( n , 0 , back , front );
+						subSimplices = front;
+					}
+					{
+						std::vector< Simplex< Real , Dim , K > > back , front;
+						for( int i=0 ; i<subSimplices.size() ; i++ ) subSimplices[i].split( n , 1 , back , front );
+						subSimplices = back;
+					}
+				}
+			}
+			for( int j=0 ; j<subSimplices.size() ; j++ ) _Rasterize< IndexType , K >( mutexes , raster , (IndexType)i , subSimplices[j] , depth , _RegularGridIndex( depth , subSimplices[j] ) );
+		} );
+	}
+	else if( threadSafety.type==ThreadSafety::SINGLE_THREADED )
+	{
+		for( size_t i=0 ; i<simplicialComplex.size() ; i++ )
+		{
+			std::vector< Simplex< Real , Dim , K > > subSimplices;
+			subSimplices.push_back( simplicialComplex[i] );
+
+			// Clip the simplex to the unit cube
+			{
+				for( int d=0 ; d<Dim ; d++ )
+				{
+					Point< Real , Dim > n;
+					n[d] = 1;
+					{
+						std::vector< Simplex< Real , Dim , K > > back , front;
+						for( int i=0 ; i<subSimplices.size() ; i++ ) subSimplices[i].split( n , 0 , back , front );
+						subSimplices = front;
+					}
+					{
+						std::vector< Simplex< Real , Dim , K > > back , front;
+						for( int i=0 ; i<subSimplices.size() ; i++ ) subSimplices[i].split( n , 1 , back , front );
+						subSimplices = back;
+					}
+				}
+			}
+			for( int j=0 ; j<subSimplices.size() ; j++ ) _Rasterize< IndexType , K >( raster , (IndexType)i , subSimplices[j] , depth , _RegularGridIndex( depth , subSimplices[j] ) );
+		}
+	}
+	else if( threadSafety.type==ThreadSafety::MAP_REDUCE )
+	{
+		std::vector< SimplexRasterizationGrid< IndexType , K > > rasters( ThreadPool::NumThreads() );
+		for( int t=0 ; t<rasters.size() ; t++ )
+		{
+			unsigned int _res[Dim];
+			for( int d=0 ; d<Dim ; d++ ) _res[d] = res;
+			rasters[t].resize( _res );
+		}
+
+		// Map
+		ThreadPool::ParallelFor( 0 , simplicialComplex.size() , [&]( unsigned int t , size_t  i )
+		{
+			std::vector< Simplex< Real , Dim , K > > subSimplices;
+			subSimplices.push_back( simplicialComplex[i] );
+
+			// Clip the simplex to the unit cube
+			{
+				for( int d=0 ; d<Dim ; d++ )
+				{
+					Point< Real , Dim > n;
+					n[d] = 1;
+					{
+						std::vector< Simplex< Real , Dim , K > > back , front;
+						for( int i=0 ; i<subSimplices.size() ; i++ ) subSimplices[i].split( n , 0 , back , front );
+						subSimplices = front;
+					}
+					{
+						std::vector< Simplex< Real , Dim , K > > back , front;
+						for( int i=0 ; i<subSimplices.size() ; i++ ) subSimplices[i].split( n , 1 , back , front );
+						subSimplices = back;
+					}
+				}
+			}
+			for( int j=0 ; j<subSimplices.size() ; j++ ) _Rasterize< IndexType , K >( rasters[t] , (IndexType)i , subSimplices[j] , depth , _RegularGridIndex( depth , subSimplices[j] ) );
+		} );
+
+		// Reduce
+		ThreadPool::ParallelFor( 0 , raster.resolution() , [&]( unsigned int , size_t i )
+		{
+			size_t count = 0;
+			for( int t=0 ; t<rasters.size() ; t++ ) count += rasters[t][i].size();
+			raster[i].reserve( count );
+			for( int t=0 ; t<rasters.size() ; t++ ) for( int j=0 ; j<rasters[t][i].size() ; j++ ) raster[i].push_back( rasters[t][i][j] );
+		} );
+	}
+	else MK_THROW( "Unrecognized thread safety type: " , threadSafety.type );
+	return raster;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/Reconstructors.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Reconstructors.h
@@ -1,0 +1,1314 @@
+/*
+Copyright (c) 2022, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef RECONSTRUCTORS_INCLUDED
+#define RECONSTRUCTORS_INCLUDED
+
+#include "PreProcessor.h"
+#include "MyMiscellany.h"
+#include "DataStream.imp.h"
+#include "FEMTree.h"
+#include "PointExtent.h"
+#include "Reconstructors.streams.h"
+
+namespace PoissonRecon
+{
+
+	namespace Reconstructor
+	{
+		static unsigned int ProfilerMS = 20;		// The number of ms at which to poll the performance (set to zero for no polling)
+		static const unsigned int DataDegree = 0;	// The order of the B-Spline used to splat in data for auxiliary data interpolation
+		static const unsigned int WeightDegree = 2;	// The order of the B-Spline used to splat in the weights for density estimation
+
+		// Declare a type for storing the solution information
+		template< typename Real , unsigned int Dim , typename FEMSigPack /* = UIntPack< FEMSigs... >*/ , typename ... AuxData > struct Implicit;
+
+		// Parameters for mesh extraction
+		struct LevelSetExtractionParameters
+		{
+			bool linearFit;
+			bool outputGradients;
+			bool forceManifold;
+			bool polygonMesh;
+			bool gridCoordinates;
+			bool outputDensity;
+			bool verbose;
+			LevelSetExtractionParameters( void ) : linearFit(false) , outputGradients(false) , forceManifold(true) , polygonMesh(false) , gridCoordinates(false) , verbose(false) , outputDensity(false) {}
+		};
+
+		// General solver parameters
+		template< typename Real >
+		struct SolutionParameters
+		{
+			bool verbose;
+			bool exactInterpolation;
+			bool showResidual;
+			bool confidence;
+			Real scale;
+			Real lowDepthCutOff;
+			Real width;
+			Real samplesPerNode;
+			Real cgSolverAccuracy;
+			Real perLevelDataScaleFactor;
+			unsigned int depth;
+			unsigned int solveDepth;
+			unsigned int baseDepth;
+			unsigned int fullDepth;
+			unsigned int kernelDepth;
+			unsigned int baseVCycles;
+			unsigned int iters;
+			unsigned int alignDir;
+
+			SolutionParameters( void ) :
+				verbose(false) , exactInterpolation(false) , showResidual(false) , confidence(false) ,
+				scale((Real)1.1) ,
+				lowDepthCutOff((Real)0.) , width((Real)0.) ,
+				samplesPerNode((Real)1.5) , cgSolverAccuracy((Real)1e-3 ) , perLevelDataScaleFactor((Real)32.) ,
+				depth((unsigned int)8) , solveDepth((unsigned int)-1) , baseDepth((unsigned int)-1) , fullDepth((unsigned int)5) , kernelDepth((unsigned int)-1) ,
+				baseVCycles((unsigned int)1) , iters((unsigned int)8) , alignDir(0)
+			{}
+
+			template< unsigned int Dim >
+			void testAndSet( XForm< Real , Dim+1 > unitCubeToModel )
+			{
+				if( width>0 )
+				{
+					Real maxScale = 0;
+					for( unsigned int i=0 ; i<Dim ; i++ )
+					{
+						Real l2 = 0;
+						for( unsigned int j=0 ; j<Dim ; j++ ) l2 += unitCubeToModel(i,j) * unitCubeToModel(i,j);
+						if( l2>maxScale ) maxScale = l2;
+					}
+					maxScale = sqrt( maxScale );
+					depth = (unsigned int)ceil( std::max< double >( 0. , log( maxScale/width )/log(2.) ) );
+				}
+
+				if( solveDepth>depth )
+				{
+					if( solveDepth!=-1 ) MK_WARN( "Solution depth cannot exceed system depth: " , solveDepth , " <= " , depth );
+					solveDepth = depth;
+				}
+				if( fullDepth>solveDepth )
+				{
+					if( fullDepth!=-1 ) MK_WARN( "Full depth cannot exceed system depth: " , fullDepth , " <= " , solveDepth );
+					fullDepth = solveDepth;
+				}
+				if( baseDepth>fullDepth )
+				{
+					if( baseDepth!=-1 ) MK_WARN( "Base depth must be smaller than full depth: " , baseDepth , " <= " , fullDepth );
+					baseDepth = fullDepth;
+				}
+				if( kernelDepth==-1 ) kernelDepth = depth>2 ? depth-2 : 0;
+				if( kernelDepth>depth )
+				{
+					if( kernelDepth!=-1 ) MK_WARN( "Kernel depth cannot exceed system depth: " , kernelDepth , " <= " , depth );
+					kernelDepth = depth;
+				}
+			}
+		};
+		struct Poisson;
+		struct SSD;
+
+		// Specialized solution information without auxiliary data
+		template< typename Real , unsigned int Dim , unsigned int ... FEMSigs , typename ... AuxData >
+		struct Implicit< Real , Dim , UIntPack< FEMSigs ... > , AuxData ... >
+		{
+			static_assert( sizeof...(FEMSigs)==Dim , "[ERROR] Number of FEM signatures doesn't match dimension" );
+
+			// The internal type representing the auxiliary data
+			using InternalAuxData = DirectSum< Real , AuxData... >;
+
+			// The internal type representing the normal and auxiliary data
+			using InternalNormalAndAuxData = DirectSum< Real , Normal< Real , Dim > , InternalAuxData >;
+
+			// The signature pack
+			using Sigs = UIntPack< FEMSigs ... >;
+
+			// The type representing the point sampling density
+			typedef typename FEMTree< Dim , Real >::template DensityEstimator< Reconstructor::WeightDegree > DensityEstimator;
+
+			// The signature of the finite-element used for data extrapolation
+			static const unsigned int DataSig = FEMDegreeAndBType< Reconstructor::DataDegree , BOUNDARY_FREE >::Signature;
+
+			// The constructor
+			Implicit( AuxData ... zeroAuxData ) : density(nullptr) , isoValue(0) , tree(MEMORY_ALLOCATOR_BLOCK_SIZE) , unitCubeToModel( XForm< Real , Dim+1 >::Identity() ) , _auxData(nullptr) , _zeroAuxData(zeroAuxData...) { _zeroNormalAndAuxData = InternalNormalAndAuxData( Normal< Real , Dim >() , _zeroAuxData ); }
+
+			// The desctructor
+			~Implicit( void ){ delete density ; density = nullptr ; delete _auxData ; _auxData = nullptr; }
+
+			// Write out to file
+			void write( BinaryStream &stream ) const
+			{
+				tree.write( stream , false );
+				stream.write( isoValue );
+				stream.write( unitCubeToModel );
+				solution.write( stream );
+				density->write( stream );
+				if constexpr( sizeof...(AuxData) ) _auxData->write( stream );
+			}
+
+			// The transformation taking points in the unit cube back to world coordinates
+			XForm< Real , Dim+1 > unitCubeToModel;
+
+			// The octree adapted to the points
+			FEMTree< Dim , Real > tree;
+
+			// The solution coefficients
+			DenseNodeData< Real , Sigs > solution;
+
+			// The average value at the sample positions
+			Real isoValue;
+
+			// The density estimator computed from the samples
+			DensityEstimator *density;
+
+			// A method that writes the extracted mesh to the streams
+			void extractLevelSet( OutputLevelSetVertexStream< Real , Dim , AuxData... > &vertexStream , OutputFaceStream< Dim-1 > &faceStream , LevelSetExtractionParameters params ) const;
+
+			struct Evaluator
+			{
+				struct OutOfUnitCubeException : public std::exception
+				{
+					OutOfUnitCubeException( Point< Real , Dim > world , Point< Real , Dim > cube )
+					{
+						std::stringstream sStream;
+						sStream << "Out-of-unit-cube input: " << world << " -> " << cube;
+						_message = sStream.str();						
+					}
+					const char * what( void ) const noexcept { return _message.c_str(); }
+				protected:
+					std::string _message;
+				};
+
+				Evaluator( const FEMTree< Dim , Real > *tree , const DenseNodeData< Real , Sigs > &coefficients , XForm< Real , Dim+1 > worldToUnitCube )
+					: _evaluator( tree , coefficients , ThreadPool::NumThreads() ) , _xForm(worldToUnitCube) { _gxForm = XForm< Real , Dim >(_xForm).transpose(); }
+
+				Point< Real , Dim > grad( unsigned int t , Point< Real , Dim > p )
+				{
+					CumulativeDerivativeValues< Real , Dim , 1 > v = _values( t , p );
+					Point< Real , Dim > g;
+					for( unsigned int d=0 ; d<Dim ; d++ ) g[d] = v[d+1];
+					return _gxForm * g;
+				}
+				Real operator()( unsigned int t , Point< Real , Dim > p ){ return _values(t,p)[0]; }
+
+				Real operator()( Point< Real , Dim > p ){ return operator()( 0 , p ); }
+				Point< Real , Dim > grad( Point< Real , Dim > p ){ return grad( 0 , p ); }
+			protected:
+				CumulativeDerivativeValues< Real , Dim , 1 > _values( unsigned int t , Point< Real , Dim > p )
+				{
+					Point< Real , Dim > q = _xForm * p;
+					for( unsigned int d=0 ; d<Dim ; d++ ) if( q[d]<0 || q[d]>1 ) throw OutOfUnitCubeException(p,q);
+					return _evaluator.values( q , t );
+				}
+
+				typename FEMTree< Dim , Real >::template MultiThreadedEvaluator< Sigs , 1 > _evaluator;
+				XForm< Real , Dim+1 > _xForm;
+				XForm< Real , Dim > _gxForm;
+			};
+			Evaluator evaluator( void ) const { return Evaluator( &tree , solution , unitCubeToModel.inverse() ); }
+
+			struct AuxEvaluator
+			{
+				struct OutOfUnitCubeException : public std::exception
+				{
+					OutOfUnitCubeException( Point< Real , Dim > world , Point< Real , Dim > cube )
+					{
+						std::stringstream sStream;
+						sStream << "Out-of-unit-cube input: " << world << " -> " << cube;
+						_message = sStream.str();						
+					}
+					const char * what( void ) const noexcept { return _message.c_str(); }
+				protected:
+					std::string _message;
+				};
+
+				AuxEvaluator( const FEMTree< Dim , Real > *tree , const SparseNodeData< ProjectiveData< InternalAuxData , Real > , IsotropicUIntPack< Dim , DataSig > > &coefficients , XForm< Real , Dim+1 > worldToUnitCube , InternalAuxData zero )
+					: _auxEvaluator( tree , coefficients , ThreadPool::NumThreads() ) , _xForm(worldToUnitCube) , _zero(zero) {}
+
+				void set( unsigned int t , Point< Real , Dim > p , AuxData&...d ){ _SetFromInternal( _value(t,p) , d... ); }
+
+				void set( Point< Real , Dim > p , AuxData&...d ){ return operator()( 0 , p , d... ); }
+
+				XForm< Real , Dim+1 > worldToUnitCubeTransform( void ) const { return worldToUnitCubeTransform(); }
+			protected:
+				InternalAuxData _value( unsigned int t , Point< Real , Dim > p )
+				{
+					Point< Real , Dim > q = _xForm * p;
+					for( unsigned int d=0 ; d<Dim ; d++ ) if( q[d]<0 || q[d]>1 ) throw OutOfUnitCubeException(p,q);
+					ProjectiveData< InternalAuxData , Real > pData( _zero );
+					_auxEvaluator.addValue( q , pData );
+					return pData.value();
+				}
+
+				template< typename D , typename ... Ds >
+				static void _SetFromInternal( InternalAuxData iData , D &d , Ds&... ds )
+				{
+					d = iData.template get< sizeof...(AuxData) - sizeof...(Ds) - 1 >();
+					if constexpr( sizeof...(Ds) ) _SetFromInternal( iData , ds... );
+				}
+
+				typename FEMTree< Dim , Real >::template MultiThreadedSparseEvaluator< IsotropicUIntPack< Dim , DataSig > , ProjectiveData< InternalAuxData , Real > > _auxEvaluator;
+				XForm< Real , Dim+1 > _xForm;
+				InternalAuxData _zero;
+			};
+
+			AuxEvaluator auxEvaluator( void ) const
+			{
+				static_assert( sizeof...(AuxData) , "No auxiliary data" );
+				return AuxEvaluator( &tree , *_auxData , unitCubeToModel.inverse() , _zeroAuxData );
+			}
+
+		protected:
+			// The auxiliary information stored with the oriented vertices
+			SparseNodeData< ProjectiveData< InternalAuxData , Real > , IsotropicUIntPack< Dim , DataSig > > *_auxData;
+
+			// An instance of "zero" AuxData
+			InternalAuxData _zeroAuxData;
+
+			InternalNormalAndAuxData _zeroNormalAndAuxData;
+
+			struct _VertexTypeConverter
+			{
+				using ExternalVertexType = std::tuple< Position< Real , Dim > , Gradient< Real , Dim > , Weight< Real > , InternalAuxData >;
+				using InternalVertexType = std::tuple< Position< Real , Dim > , Gradient< Real , Dim > , Weight< Real > , AuxData...  >;
+
+				static ExternalVertexType ConvertI2X( const InternalVertexType &iType )
+				{
+					ExternalVertexType xType;
+
+					// Copy the position information
+					std::get< 0 >( xType ) = std::get< 0 >( iType );
+					std::get< 1 >( xType ) = std::get< 1 >( iType );
+					std::get< 2 >( xType ) = std::get< 2 >( iType );
+					// Copy the remainder of the information
+					_SetAuxData< 0 >( iType , xType );
+					return xType;
+				}
+				static InternalVertexType ConvertX2I( const ExternalVertexType &xType )
+				{
+					InternalVertexType iType;
+
+					// Copy the position information
+					std::get< 0 >( iType ) = std::get< 0 >( xType );
+					std::get< 1 >( iType ) = std::get< 1 >( xType );
+					std::get< 2 >( iType ) = std::get< 2 >( xType );
+					// Copy the remainder of the information
+					_SetAuxData< 0 >( xType , iType );
+					return iType;
+				}
+			protected:
+				template< unsigned int I >
+				static void _SetAuxData( const InternalVertexType &iType , ExternalVertexType &xType )
+				{
+					std::get< 3 >( xType ).template get< I >() = std::get< I+3 >( iType );
+					if constexpr( I+1<sizeof...(AuxData) ) _SetAuxData< I+1 >( iType , xType );
+				}
+				template< unsigned int I >
+				static void _SetAuxData( const ExternalVertexType &xType , InternalVertexType &iType )
+				{
+					std::get< I+3 >( iType ) = std::get< 3 >( xType ).template get< I >();
+					if constexpr( I+1<sizeof...(AuxData) ) _SetAuxData< I+1 >( xType , iType );
+				}
+			};
+
+			struct _SampleTypeConverter
+			{
+				using ExternalSampleType = std::tuple< Position< Real , Dim > , InternalNormalAndAuxData >;
+				using InternalSampleType = std::tuple< Position< Real , Dim > , Normal< Real , Dim > , AuxData... >;
+
+				static ExternalSampleType ConvertI2X( const InternalSampleType &iType )
+				{
+					ExternalSampleType xType;
+
+					// Copy the position information
+					std::get< 0 >( xType ) = std::get< 0 >( iType );
+					// Copy the remainder of the information
+					_SetNormalAndAuxData< 0 >( iType , xType );
+					return xType;
+				}
+				static InternalSampleType ConvertX2I( const ExternalSampleType &xType )
+				{
+					InternalSampleType iType;
+
+					// Copy the position information
+					std::get< 0 >( iType ) = std::get< 0 >( xType );
+					// Copy the remainder of the information
+					_SetNormalAndAuxData< 0 >( xType , iType );
+					return iType;
+				}
+			protected:
+				template< unsigned int I >
+				static void _SetNormalAndAuxData( const InternalSampleType &iType , ExternalSampleType &xType )
+				{
+					std::get< 1 >( xType ).template get< I >() = std::get< I+1 >( iType );
+					if constexpr( I<sizeof...(AuxData) ) _SetNormalAndAuxData< I+1 >( iType , xType );
+				}
+				template< unsigned int I >
+				static void _SetNormalAndAuxData( const ExternalSampleType &xType , InternalSampleType &iType )
+				{
+					std::get< I+1 >( iType ) = std::get< 1 >( xType ).template get< I >();
+					if constexpr( I<sizeof...(AuxData) ) _SetNormalAndAuxData< I+1 >( xType , iType );
+				}
+			};
+
+			friend Poisson;
+			friend SSD;
+		};
+
+
+		struct Poisson
+		{
+			static const unsigned int NormalDegree = 2;							// The order of the B-Spline used to splat in the normals for constructing the Laplacian constraints
+			static const unsigned int DefaultFEMDegree = 1;						// The default finite-element degree (has to be at least 1)
+			static const BoundaryType DefaultFEMBoundary = BOUNDARY_NEUMANN;	// The default finite-element boundary type {BOUNDARY_FREE, BOUNDARY_DIRICHLET, BOUNDARY_NEUMANN}
+			inline static const float WeightMultiplier = 2.f;					// The default degree-to-point-weight scaling
+
+			template< unsigned int Dim , typename Real >
+			struct ConstraintDual
+			{
+				Real target , weight;
+				ConstraintDual( void ) : target(0) , weight(0) {}
+				ConstraintDual( Real t , Real w ) : target(t) , weight(w) {}
+				CumulativeDerivativeValues< Real , Dim , 0 > operator()( const Point< Real , Dim >& p ) const { return CumulativeDerivativeValues< Real , Dim , 0 >( target*weight ); };
+			};
+
+			template< unsigned int Dim , typename Real >
+			struct SystemDual
+			{
+				Real weight;
+				SystemDual( void ) : weight(0) {}
+				SystemDual( Real w ) : weight(w) {}
+				CumulativeDerivativeValues< Real , Dim , 0 > operator()( const Point< Real , Dim >& p , const CumulativeDerivativeValues< Real , Dim , 0 >& dValues ) const { return dValues * weight; };
+				CumulativeDerivativeValues< double , Dim , 0 > operator()( const Point< Real , Dim >& p , const CumulativeDerivativeValues< double , Dim , 0 >& dValues ) const { return dValues * weight; };
+			};
+
+			template< unsigned int Dim >
+			struct SystemDual< Dim , double >
+			{
+				typedef double Real;
+				Real weight;
+				SystemDual( void ) : weight(0) {}
+				SystemDual( Real w ) : weight(w) {}
+				CumulativeDerivativeValues< Real , Dim , 0 > operator()( const Point< Real , Dim >& p , const CumulativeDerivativeValues< Real , Dim , 0 >& dValues ) const { return dValues * weight; };
+			};
+
+			template< unsigned int Dim , typename Real >
+			struct ValueInterpolationConstraintDual
+			{
+				typedef DirectSum< Real , Real > PointSampleData;
+				Real vWeight;
+				ValueInterpolationConstraintDual( Real v ) : vWeight(v){ }
+				CumulativeDerivativeValues< Real , Dim , 0 > operator()( const Point< Real , Dim > &p , const DirectSum< Real , Real >& data ) const 
+				{
+					Real value = data.template get<0>();
+					CumulativeDerivativeValues< Real , Dim , 0 > cdv;
+					cdv[0] = value*vWeight;
+					return cdv;
+				}
+			};
+
+			template< unsigned int Dim , typename Real >
+			struct ValueInterpolationSystemDual
+			{
+				CumulativeDerivativeValues< Real , Dim , 0 > weight;
+				ValueInterpolationSystemDual( Real v ){ weight[0] = v; }
+				CumulativeDerivativeValues< Real , Dim , 0 > operator()( Point< Real , Dim > p , const DirectSum< Real , Real > &data , const CumulativeDerivativeValues< Real , Dim , 0 > &dValues ) const
+				{
+					return dValues * weight;
+				}
+				CumulativeDerivativeValues< double , Dim , 0 > operator()( Point< Real , Dim > p , const DirectSum< Real , Real > &data , const CumulativeDerivativeValues< double , Dim , 0 > &dValues ) const
+				{
+					return dValues * weight;
+				}
+			};
+
+			template< unsigned int Dim >
+			struct ValueInterpolationSystemDual< Dim , double >
+			{
+				typedef double Real;
+				Real weight;
+				ValueInterpolationSystemDual( void ) : weight(0) {}
+				ValueInterpolationSystemDual( Real v ) : weight(v) {}
+				CumulativeDerivativeValues< Real , Dim , 0 > operator()( Point< Real , Dim > p , const DirectSum< Real , Real > &data , const CumulativeDerivativeValues< Real , Dim , 0 > &dValues ) const
+				{
+					return dValues * weight;
+				}
+			};
+
+			template< typename Real >
+			struct SolutionParameters : public Reconstructor::SolutionParameters< Real >
+			{
+				bool dirichletErode;
+				Real pointWeight;
+				Real valueInterpolationWeight;
+				unsigned int envelopeDepth;
+
+				SolutionParameters( void ) :
+					dirichletErode(false) ,
+					pointWeight((Real)( WeightMultiplier * DefaultFEMDegree ) ) , valueInterpolationWeight((Real)0.) ,
+					envelopeDepth((unsigned int)-1)
+				{}
+
+				template< unsigned int Dim >
+				void testAndSet( XForm< Real , Dim+1 > unitCubeToModel )
+				{
+					Reconstructor::SolutionParameters< Real >::template testAndSet< Dim >( unitCubeToModel );
+					if( envelopeDepth==-1 ) envelopeDepth = Reconstructor::SolutionParameters< Real >::baseDepth;
+					if( envelopeDepth>Reconstructor::SolutionParameters< Real >::depth )
+					{
+						if( envelopeDepth!=-1 ) MK_WARN( "Envelope depth cannot exceed system depth:  " , envelopeDepth , " <= " , Reconstructor::SolutionParameters< Real >::depth );
+						envelopeDepth = Reconstructor::SolutionParameters< Real >::depth;
+					}
+					if( envelopeDepth<Reconstructor::SolutionParameters< Real >::baseDepth )
+					{
+						MK_WARN( "Envelope depth cannot be less than base depth: " , envelopeDepth , " >= " , Reconstructor::SolutionParameters< Real >::baseDepth );
+						envelopeDepth = Reconstructor::SolutionParameters< Real >::baseDepth;
+					}
+				}
+			};
+
+			template< typename Real , unsigned int Dim >
+			struct EnvelopeMesh
+			{
+				std::vector< Point< Real , Dim > > vertices;
+				std::vector< SimplexIndex< Dim-1 , node_index_type > > simplices;
+			};
+
+			template< typename Real , unsigned int Dim , typename FEMSigPack , typename ... AuxData > struct Solver;
+
+			template< typename Real , unsigned int Dim , unsigned int ... FEMSigs , typename ... AuxData >
+			struct Solver< Real , Dim , UIntPack< FEMSigs... > , AuxData... >
+			{
+				static Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... > *Solve( InputOrientedSampleStream< Real , Dim , AuxData... > &pointStream , SolutionParameters< Real > params , AuxData ... zero , const EnvelopeMesh< Real , Dim > *envelopeMesh=nullptr , InputValuedSampleStream< Real , Dim > *valueInterpolationStream=nullptr );
+			};
+		};
+
+		struct SSD
+		{
+			static const unsigned int NormalDegree = 2;									// The order of the B-Spline used to splat in the normals for constructing the Laplacian constraints
+			static const unsigned int DefaultFEMDegree = 2;								// The default finite-element degree (has to be at least 2)
+			static const BoundaryType DefaultFEMBoundary = BOUNDARY_NEUMANN;			// The default finite-element boundary type {BOUNDARY_FREE, BOUNDARY_DIRICHLET, BOUNDARY_NEUMANN}
+			inline static const double WeightMultipliers[] = { 5e+1f , 5e-4f , 1e-5f };	// The default weights for balancing the value, gradient, and laplacian energy terms
+
+			template< typename Real , unsigned int Dim , typename ... AuxData >
+			using NormalAndAuxData = DirectSum< Real , Normal< Real , Dim > , DirectSum< Real , AuxData... > >;
+
+			template< unsigned int Dim , typename Real , typename ... AuxData >
+			struct ConstraintDual
+			{
+				Real target , vWeight , gWeight;
+				ConstraintDual( Real t , Real v , Real g ) : target(t) , vWeight(v) , gWeight(g) { }
+				CumulativeDerivativeValues< Real , Dim , 1 > operator()( const Point< Real , Dim >& p , const NormalAndAuxData< Real , Dim , AuxData... > &normalAndAuxData ) const 
+				{
+					Point< Real , Dim > n = normalAndAuxData.template get<0>();
+					CumulativeDerivativeValues< Real , Dim , 1 > cdv;
+					cdv[0] = target*vWeight;
+					for( int d=0 ; d<Dim ; d++ ) cdv[1+d] = -n[d]*gWeight;
+					return cdv;
+				}
+			};
+
+			template< unsigned int Dim , typename Real , typename ... AuxData >
+			struct SystemDual
+			{
+				CumulativeDerivativeValues< Real , Dim , 1 > weight;
+				SystemDual( Real v , Real g )
+				{
+					weight[0] = v;
+					for( int d=0 ; d<Dim ; d++ ) weight[d+1] = g;
+				}
+				CumulativeDerivativeValues< Real , Dim , 1 > operator()( Point< Real , Dim > p , const NormalAndAuxData< Real , Dim , AuxData... > & , const CumulativeDerivativeValues< Real , Dim , 1 >& dValues ) const
+				{
+					return dValues * weight;
+				}
+				CumulativeDerivativeValues< double , Dim , 1 > operator()( Point< Real , Dim > p , const NormalAndAuxData< Real , Dim , AuxData... > & , const CumulativeDerivativeValues< double , Dim , 1 >& dValues ) const
+				{
+					return dValues * weight;
+				};
+			};
+
+			template< unsigned int Dim , typename ... AuxData >
+			struct SystemDual< Dim , double , AuxData... >
+			{
+				typedef double Real;
+				CumulativeDerivativeValues< Real , Dim , 1 > weight;
+				SystemDual( Real v , Real g ) : weight( v , g , g , g ) { }
+				CumulativeDerivativeValues< Real , Dim , 1 > operator()( Point< Real , Dim > p , const NormalAndAuxData< Real , Dim , AuxData... > & , const CumulativeDerivativeValues< Real , Dim , 1 >& dValues ) const
+				{
+					return dValues * weight;
+				}
+			};
+
+			template< typename Real >
+			struct SolutionParameters : public Reconstructor::SolutionParameters< Real >
+			{
+				Real pointWeight;
+				Real gradientWeight;
+				Real biLapWeight;
+
+				SolutionParameters( void ) :
+					pointWeight((Real)WeightMultipliers[0]) , gradientWeight((Real)WeightMultipliers[1]) , biLapWeight((Real)WeightMultipliers[2])
+				{}
+			};
+
+			template< typename Real , unsigned int Dim , typename FEMSigPack , typename ... AuxData > struct Solver;
+
+			template< typename Real , unsigned int Dim , unsigned int ... FEMSigs , typename ... AuxData >
+			struct Solver< Real , Dim , UIntPack< FEMSigs... > , AuxData... >
+			{
+				static Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... > *Solve( InputOrientedSampleStream< Real , Dim , AuxData... > &pointStream , SolutionParameters< Real > params , AuxData ... zero );
+			};
+		};
+
+		// Implementation of the base Implicit class's level-set extraction
+		template< typename Real , unsigned int Dim , unsigned int ... FEMSigs , typename ... AuxData >
+		void Implicit< Real , Dim , UIntPack< FEMSigs ... > , AuxData ... >::extractLevelSet( OutputLevelSetVertexStream< Real , Dim , AuxData... > &vertexStream , OutputFaceStream< Dim-1 > &faceStream , LevelSetExtractionParameters params ) const
+		{
+			XForm< Real , Dim+1 > unitCubeToModel;
+			if( params.gridCoordinates )
+			{
+				unitCubeToModel = XForm< Real , Dim+1 >::Identity();
+				unsigned int res = 1<<tree.depth();
+				for( unsigned int d=0 ; d<Dim ; d++ ) unitCubeToModel(d,d) = (Real)res;
+			}
+			else unitCubeToModel = this->unitCubeToModel;
+
+			DensityEstimator *density = params.outputDensity ? this->density : nullptr;
+
+			if constexpr( Dim==2 || Dim==3 )
+			{
+				Profiler profiler( ProfilerMS );
+
+				std::string statsString;
+
+				TransformedOutputLevelSetVertexStream< Real , Dim , AuxData... > _vertexStream( unitCubeToModel , vertexStream );
+				if constexpr( sizeof...(AuxData) )
+				{
+					// Convert stream:
+					// OutputDataStream< Position< Real , Dim > , Gradient< Real , Dim > , Weight< Real > , AuxData... >
+					// -> OutputDataStream< Position< Real , Dim > , Gradient< Real , Dim > , Weight< Real > , InternalAuxData >
+					OutputDataStreamConverter< typename _VertexTypeConverter::InternalVertexType , typename _VertexTypeConverter::ExternalVertexType > __vertexStream( _vertexStream , _VertexTypeConverter::ConvertX2I );
+					typename LevelSetExtractor< Real , Dim , InternalAuxData >::Stats stats;
+					if constexpr( Dim==3 )
+						stats = LevelSetExtractor< Real , Dim , InternalAuxData >::Extract( Sigs() , UIntPack< Reconstructor::WeightDegree >() , UIntPack< DataSig >() , tree , density , _auxData , solution , isoValue , __vertexStream , faceStream , _zeroAuxData , !params.linearFit , params.outputGradients , params.forceManifold , params.polygonMesh , false );
+					else if constexpr( Dim==2 )
+						stats = LevelSetExtractor< Real , Dim , InternalAuxData >::Extract( Sigs() , UIntPack< Reconstructor::WeightDegree >() , UIntPack< DataSig >() , tree , density , _auxData , solution , isoValue , __vertexStream , faceStream , _zeroAuxData , !params.linearFit , params.outputGradients , false );
+					statsString = stats.toString();
+				}
+				else
+				{
+					typename LevelSetExtractor< Real , Dim >::Stats stats;
+					if constexpr( Dim==3 )
+						stats = LevelSetExtractor< Real , Dim >::Extract( Sigs() , UIntPack< Reconstructor::WeightDegree >() , tree , density , solution , isoValue , _vertexStream , faceStream , !params.linearFit , params.outputGradients , params.forceManifold , params.polygonMesh , false );
+					else if constexpr( Dim==2 )
+						stats = LevelSetExtractor< Real , Dim >::Extract( Sigs() , UIntPack< Reconstructor::WeightDegree >() , tree , density , solution , isoValue , _vertexStream , faceStream , !params.linearFit , params.outputGradients , false );
+					statsString = stats.toString();
+				}
+
+				if( params.verbose )
+				{
+					std::cout << "Vertices / Faces: " << vertexStream.size() << " / " << faceStream.size() << std::endl;
+					std::cout << statsString << std::endl;
+					std::cout << "#            Got Faces: " << profiler << std::endl;
+				}
+			}
+			else MK_WARN( "Extraction only supported for dimensions 2 and 3" );
+		}
+
+		// Implementation of the derived Poisson::Implicit's constructor
+		template< typename Real , unsigned int Dim , unsigned int ... FEMSigs , typename ... AuxData >
+		Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... > *Poisson::Solver< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::Solve( InputOrientedSampleStream< Real , Dim , AuxData... > &pointStream , SolutionParameters< Real > params , AuxData ... zero , const EnvelopeMesh< Real , Dim > *envelopeMesh , InputValuedSampleStream< Real , Dim > *valueInterpolationStream )
+		{
+			Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... > *implicitPtr = new Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >( zero... );
+			Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... > &implicit = *implicitPtr;
+
+			if( params.valueInterpolationWeight<0 )
+			{
+				MK_WARN( "Negative value interpolation weight clamped to zero" );
+				params.valueInterpolationWeight = 0;
+			}
+			if( valueInterpolationStream && !params.valueInterpolationWeight ) MK_WARN( "Value interpolation stream provided but interpolation weight is zero" );
+
+			// The signature for the finite-elements representing the auxiliary data (if it's there)
+			static const unsigned int DataSig = FEMDegreeAndBType< Reconstructor::DataDegree , BOUNDARY_FREE >::Signature;
+
+			///////////////
+			// Types --> //
+			using InternalAuxData          = typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::InternalAuxData;
+			using InternalNormalAndAuxData = typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::InternalNormalAndAuxData;
+			using _SampleTypeConverter     = typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::_SampleTypeConverter;
+			using Sigs                     = typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::Sigs;
+
+			// The degrees of the finite elements across the different axes
+			typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > Degrees;
+
+			// The signature describing the normals elements
+			typedef UIntPack< FEMDegreeAndBType< Poisson::NormalDegree , DerivativeBoundary< FEMSignature< FEMSigs >::BType , 1 >::BType >::Signature ... > NormalSigs;
+
+			// Type for tracking sample interpolation
+			typedef typename FEMTree< Dim , Real >::template InterpolationInfo< Real , 0 > InterpolationInfo;
+
+			// The finite-element tracking tree node
+			typedef RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > FEMTreeNode;
+
+			typedef typename FEMTreeInitializer< Dim , Real >::GeometryNodeType GeometryNodeType;
+			// <-- Types //
+			///////////////
+
+			XForm< Real , Dim+1 > modelToUnitCube = XForm< Real , Dim+1 >::Identity();
+
+			Profiler profiler( ProfilerMS );
+
+			size_t pointCount;
+
+			ProjectiveData< Point< Real , 2 > , Real > pointDepthAndWeight;
+			std::vector< typename FEMTree< Dim , Real >::PointSample > *valueInterpolationSamples = nullptr;
+			std::vector< Real > *valueInterpolationSampleData = nullptr;
+			DenseNodeData< GeometryNodeType , IsotropicUIntPack< Dim , FEMTrivialSignature > > geometryNodeDesignators;
+			SparseNodeData< Point< Real , Dim > , NormalSigs > *normalInfo = nullptr;
+			std::vector< typename FEMTree< Dim , Real >::PointSample > *samples = new std::vector< typename FEMTree< Dim , Real >::PointSample >();
+			std::vector< InternalNormalAndAuxData > *sampleNormalAndAuxData = new std::vector< InternalNormalAndAuxData >();
+
+			Real targetValue = (Real)0.5;
+
+			// Read in the samples (and auxiliary data)
+			{
+				profiler.reset();
+
+				pointStream.reset();
+				modelToUnitCube = params.scale>0 ? PointExtent::GetXForm< Real , Dim , true , Normal< Real , Dim > , AuxData... >( pointStream , Normal< Real , Dim >() , zero... , params.scale , params.alignDir ) * modelToUnitCube : modelToUnitCube;
+				implicit.unitCubeToModel = modelToUnitCube.inverse();
+				pointStream.reset();
+
+				params.template testAndSet< Dim >( implicit.unitCubeToModel );
+
+				{
+					// Apply the transformation
+					TransformedInputOrientedSampleStream< Real , Dim , AuxData... > _pointStream( modelToUnitCube , pointStream );
+
+					std::vector< node_index_type > nodeToIndexMap;
+
+					auto IsValid = [&]( const Point< Real , Dim > &p , const Normal< Real , Dim > &n , AuxData ... d )
+						{
+							Real l = Point< Real , Dim >::SquareNorm( n );
+							return l>0 && std::isfinite(l);
+						};
+
+					auto Process = [&]( FEMTreeNode &node , const Point< Real , Dim > &p , Normal< Real , Dim > &n , AuxData ... d )
+						{
+							Real l = (Real)Length( n );
+							Real weight = params.confidence ? l : (Real)1.;
+							n /= l;
+
+							node_index_type nodeIndex = node.nodeData.nodeIndex;
+							// If the node's index exceeds what's stored in the node-to-index map, grow the node-to-index map
+							if( nodeIndex>=(node_index_type)nodeToIndexMap.size() ) nodeToIndexMap.resize( nodeIndex+1 , -1 );
+
+							node_index_type idx = nodeToIndexMap[ nodeIndex ];
+							if( idx==-1 )
+							{
+								idx = (node_index_type)samples->size();
+								nodeToIndexMap[ nodeIndex ] = idx;
+								samples->resize( idx+1 ) , (*samples)[idx].node = &node;
+								sampleNormalAndAuxData->resize( idx+1 );
+								(*samples)[idx].sample = ProjectiveData< Point< Real , Dim > , Real >( p*weight , weight );
+								(*sampleNormalAndAuxData)[idx] = InternalNormalAndAuxData( n , DirectSum< Real , AuxData... >( d... ) ) * weight;
+							}
+							else
+							{
+								(*samples)[idx].sample += ProjectiveData< Point< Real , Dim > , Real >( p*weight , weight );
+								(*sampleNormalAndAuxData)[idx] += InternalNormalAndAuxData( n , DirectSum< Real , AuxData... >( d... ) ) * weight;
+							}
+							return true;
+						};
+
+					auto F = [&]( AuxData ... zeroAuxData )
+						{
+							pointCount = FEMTreeInitializer< Dim , Real >::template Initialize< decltype(IsValid) , decltype(Process) , Normal< Real , Dim > , AuxData... >( implicit.tree.spaceRoot() , _pointStream , Normal< Real , Dim >() , zeroAuxData... , params.depth , implicit.tree.nodeAllocators.size() ? implicit.tree.nodeAllocators[0] : nullptr , implicit.tree.initializer() , IsValid , Process );
+						};
+					implicit._zeroAuxData.process( F );
+				}
+
+
+				if( params.verbose )
+				{
+					std::cout << "Input Points / Samples: " << pointCount << " / " << samples->size() << std::endl;
+					std::cout << "# Read input into tree: " << profiler << std::endl;
+				}
+			}
+
+			if( valueInterpolationStream && params.valueInterpolationWeight )
+			{
+				valueInterpolationSamples = new std::vector< typename FEMTree< Dim , Real >::PointSample >();
+				valueInterpolationSampleData = new std::vector< Real >();
+				// Wrap the point stream in a transforming stream
+				TransformedInputValuedSampleStream< Real , Dim > _valueInterpolationStream( modelToUnitCube , *valueInterpolationStream );
+
+				// Assign each sample a weight of 1.
+				auto ProcessData = []( const Point< Real , Dim > &p , Real &d ){ return (Real)1.; };
+				Real zeroValue = (Real)0.;
+				size_t count = FEMTreeInitializer< Dim , Real >::template Initialize< Real >( implicit.tree.spaceRoot() , _valueInterpolationStream , zeroValue , params.depth , *valueInterpolationSamples , *valueInterpolationSampleData , implicit.tree.nodeAllocators.size() ? implicit.tree.nodeAllocators[0] : NULL , implicit.tree.initializer() , ProcessData );
+				if( params.verbose ) std::cout << "Input Interpolation Points / Samples: " << count << " / " << valueInterpolationSamples->size() << std::endl;
+			}
+
+			{
+				InterpolationInfo *valueInterpolationInfo = NULL;
+				DenseNodeData< Real , Sigs > constraints;
+				InterpolationInfo *iInfo = NULL;
+				int solveDepth = params.depth;
+
+				implicit.tree.resetNodeIndices( 0 , std::make_tuple() );
+
+				// Get the kernel density estimator
+				{
+					profiler.reset();
+					implicit.density = implicit.tree.template setDensityEstimator< 1 , Reconstructor::WeightDegree >( *samples , params.kernelDepth , params.samplesPerNode );
+					if( params.verbose ) std::cout << "#   Got kernel density: " << profiler << std::endl;
+				}
+
+				// Transform the Hermite samples into a vector field
+				{
+					profiler.reset();
+					normalInfo = new SparseNodeData< Point< Real , Dim > , NormalSigs >();
+
+					std::function< bool ( InternalNormalAndAuxData , Point< Real , Dim > & ) > ConversionFunction;
+					std::function< bool ( InternalNormalAndAuxData , Point< Real , Dim > & , Real & ) > ConversionAndBiasFunction;
+					ConversionFunction = []( InternalNormalAndAuxData in , Normal< Real , Dim > &out )
+						{
+							Normal< Real , Dim > n = in.template get<0>();
+							Real l = (Real)Length( n );
+							// It is possible that the samples have non-zero normals but there are two co-located samples with negative normals...
+							if( !l ) return false;
+							out = n / l;
+							return true;
+						};
+					*normalInfo = implicit.tree.setInterpolatedDataField( Point< Real , Dim >() , NormalSigs() , *samples , *sampleNormalAndAuxData , implicit.density , params.baseDepth , params.depth , params.lowDepthCutOff , pointDepthAndWeight , ConversionFunction );
+
+					ThreadPool::ParallelFor( 0 , normalInfo->size() , [&]( unsigned int , size_t i ){ (*normalInfo)[i] *= (Real)-1.; } );
+					if( params.verbose )
+					{
+						std::cout << "#     Got normal field: " << profiler << std::endl;
+						std::cout << "Point depth / Point weight / Estimated measure: " << pointDepthAndWeight.value()[0] << " / " << pointDepthAndWeight.value()[1] << " / " << pointCount*pointDepthAndWeight.value()[1] << std::endl;
+					}
+				}
+
+				// Get the geometry designators indicating if the space node are interior to, exterior to, or contain the envelope boundary
+				if( envelopeMesh )
+				{
+					profiler.reset();
+					{
+						// Make the octree complete up to the base depth
+						FEMTreeInitializer< Dim , Real >::Initialize( implicit.tree.spaceRoot() , params.baseDepth , []( int , int[] ){ return true; } , implicit.tree.nodeAllocators.size() ?  implicit.tree.nodeAllocators[0] : NULL , implicit.tree.initializer() );
+
+						std::vector< Point< Real , Dim > > vertices( envelopeMesh->vertices.size() );
+						for( unsigned int i=0 ; i<vertices.size() ; i++ ) vertices[i] = modelToUnitCube * envelopeMesh->vertices[i];
+						geometryNodeDesignators = FEMTreeInitializer< Dim , Real >::GetGeometryNodeDesignators( &implicit.tree.spaceRoot() , vertices , envelopeMesh->simplices , params.baseDepth , params.envelopeDepth , implicit.tree.nodeAllocators , implicit.tree.initializer() );
+
+						// Make nodes in the support of the vector field @{ExactDepth} interior
+						if( params.dirichletErode )
+						{
+							// What to do if we find a node in the support of the vector field
+							auto SetScratchFlag = [&]( FEMTreeNode *node )
+								{
+									if( node )
+									{
+										while( node->depth()>(int)params.baseDepth ) node = node->parent;
+										node->nodeData.setScratchFlag( true );
+									}
+								};
+
+							std::function< void ( FEMTreeNode * ) > PropagateToLeaves = [&]( const FEMTreeNode *node )
+								{
+									geometryNodeDesignators[ node ] = GeometryNodeType::INTERIOR;
+									if( node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) PropagateToLeaves( node->children+c );
+								};
+
+							// Flags indicating if a node contains a non-zero vector field coefficient
+							std::vector< bool > isVectorFieldElement( implicit.tree.nodeCount() , false );
+
+							// Get the set of base nodes
+							std::vector< FEMTreeNode * > baseNodes;
+							auto nodeFunctor = [&]( FEMTreeNode *node )
+								{
+									if( node->depth()==params.baseDepth ) baseNodes.push_back( node );
+									return node->depth()<(int)params.baseDepth;
+								};
+							implicit.tree.spaceRoot().processNodes( nodeFunctor );
+
+							std::vector< node_index_type > vectorFieldElementCounts( baseNodes.size() );
+							for( int i=0 ; i<vectorFieldElementCounts.size() ; i++ ) vectorFieldElementCounts[i] = 0;
+
+							// In parallel, iterate over the base nodes and mark the nodes containing non-zero vector field coefficients
+							ThreadPool::ParallelFor( 0 , baseNodes.size() , [&]( unsigned int t , size_t  i )
+								{
+									auto nodeFunctor = [&]( FEMTreeNode *node )
+										{
+											Point< Real , Dim > *n = (*normalInfo)( node );
+											if( n && Point< Real , Dim >::SquareNorm( *n ) ) isVectorFieldElement[ node->nodeData.nodeIndex ] = true , vectorFieldElementCounts[i]++;
+										};
+									baseNodes[i]->processNodes( nodeFunctor );
+								} );
+							size_t vectorFieldElementCount = 0;
+							for( int i=0 ; i<vectorFieldElementCounts.size() ; i++ ) vectorFieldElementCount += vectorFieldElementCounts[i];
+
+							// Get the subset of nodes containing non-zero vector field coefficients and disable the "scratch" flag
+							std::vector< FEMTreeNode * > vectorFieldElements;
+							vectorFieldElements.reserve( vectorFieldElementCount );
+							{
+								std::vector< std::vector< FEMTreeNode * > > _vectorFieldElements( baseNodes.size() );
+								for( int i=0 ; i<_vectorFieldElements.size() ; i++ ) _vectorFieldElements[i].reserve( vectorFieldElementCounts[i] );
+								ThreadPool::ParallelFor( 0 , baseNodes.size() , [&]( unsigned int t , size_t  i )
+									{
+										auto nodeFunctor = [&]( FEMTreeNode *node )
+											{
+												if( isVectorFieldElement[ node->nodeData.nodeIndex ] ) _vectorFieldElements[i].push_back( node );
+												node->nodeData.setScratchFlag( false );
+											};
+										baseNodes[i]->processNodes( nodeFunctor );
+									} );
+								for( int i=0 ; i<_vectorFieldElements.size() ; i++ ) vectorFieldElements.insert( vectorFieldElements.end() , _vectorFieldElements[i].begin() , _vectorFieldElements[i].end() );
+							}
+
+							// Set the scratch flag for the base nodes on which the vector field is supported
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] In principal, we should unlock finite elements whose support overlaps the vector field" )
+#endif // SHOW_WARNINGS
+							implicit.tree.template processNeighboringLeaves< -BSplineSupportSizes< Poisson::NormalDegree >::SupportStart , BSplineSupportSizes< Poisson::NormalDegree >::SupportEnd >( &vectorFieldElements[0] , vectorFieldElements.size() , SetScratchFlag , false );
+
+							// Set sub-trees rooted at interior nodes @ ExactDepth to interior
+							ThreadPool::ParallelFor( 0 , baseNodes.size() , [&]( unsigned int , size_t  i ){ if( baseNodes[i]->nodeData.getScratchFlag() ) PropagateToLeaves( baseNodes[i] ); } );
+
+							// Adjust the coarser node designators in case exterior nodes have become boundary.
+							ThreadPool::ParallelFor( 0 , baseNodes.size() , [&]( unsigned int , size_t  i ){ FEMTreeInitializer< Dim , Real >::PullGeometryNodeDesignatorsFromFiner( baseNodes[i] , geometryNodeDesignators ); } );
+							FEMTreeInitializer< Dim , Real >::PullGeometryNodeDesignatorsFromFiner( &implicit.tree.spaceRoot() , geometryNodeDesignators , params.baseDepth );
+						}
+					}
+					if( params.verbose ) std::cout << "#               Initialized envelope constraints: " << profiler << std::endl;
+				}
+
+				if constexpr( sizeof...(AuxData) )
+				{
+					profiler.reset();
+					auto PointSampleFunctor = [&]( size_t i ) -> const typename FEMTree< Dim , Real >::PointSample & { return (*samples)[i]; };
+					auto AuxDataSampleFunctor = [&]( size_t i ) -> const typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::InternalAuxData & { return (*sampleNormalAndAuxData)[i].template get<1>(); };
+					implicit._auxData = new SparseNodeData< ProjectiveData< InternalAuxData , Real > , IsotropicUIntPack< Dim , DataSig > >
+						(
+							implicit.tree.template setExtrapolatedDataField< DataSig , false , Reconstructor::WeightDegree , InternalAuxData >
+							(
+								InternalAuxData( zero... ) ,
+								samples->size() ,
+								PointSampleFunctor ,
+								AuxDataSampleFunctor ,
+								(typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::DensityEstimator*)nullptr
+							)
+						);
+					auto nodeFunctor = [&]( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *n )
+						{
+							ProjectiveData< InternalAuxData , Real >* clr = (*implicit._auxData)( n );
+							if( clr ) (*clr) *= (Real)pow( (Real)params.perLevelDataScaleFactor , implicit.tree.depth( n ) );
+						};
+					implicit.tree.tree().processNodes( nodeFunctor );
+					if( params.verbose ) std::cout << "#         Got aux data: " << profiler << std::endl;
+				}
+
+				delete sampleNormalAndAuxData;
+
+				// Add the interpolation constraints
+				if( params.pointWeight>0 )
+				{
+					profiler.reset();
+					if( params.exactInterpolation ) iInfo = FEMTree< Dim , Real >::template       InitializeExactPointInterpolationInfo< Real , 0 > ( implicit.tree , *samples , Poisson::ConstraintDual< Dim , Real >( targetValue , params.pointWeight * pointDepthAndWeight.value()[1] ) , Poisson::SystemDual< Dim , Real >( params.pointWeight * pointDepthAndWeight.value()[1] ) , true , false );
+					else                            iInfo = FEMTree< Dim , Real >::template InitializeApproximatePointInterpolationInfo< Real , 0 > ( implicit.tree , *samples , Poisson::ConstraintDual< Dim , Real >( targetValue , params.pointWeight * pointDepthAndWeight.value()[1] ) , Poisson::SystemDual< Dim , Real >( params.pointWeight * pointDepthAndWeight.value()[1] ) , true , params.depth , 1 );
+					if( params.verbose ) std::cout <<  "#Initialized point interpolation constraints: " << profiler << std::endl;
+				}
+
+				// Trim the tree and prepare for multigrid
+				{
+					profiler.reset();
+					constexpr int MaxDegree = Poisson::NormalDegree > Degrees::Max() ? Poisson::NormalDegree : Degrees::Max();
+					typename FEMTree< Dim , Real >::template HasNormalDataFunctor< NormalSigs > hasNormalDataFunctor( *normalInfo );
+					auto hasDataFunctor = [&]( const FEMTreeNode *node ){ return hasNormalDataFunctor( node ); };
+					auto addNodeFunctor = [&]( int d , const int off[Dim] ){ return d<=(int)params.fullDepth; };
+					if constexpr( sizeof...(AuxData) )
+					{
+						if( geometryNodeDesignators.size() ) implicit.tree.template finalizeForMultigridWithDirichlet< MaxDegree , Degrees::Max() >( params.baseDepth , addNodeFunctor , hasDataFunctor , [&]( const FEMTreeNode *node ){ return node->nodeData.nodeIndex<(node_index_type)geometryNodeDesignators.size() && geometryNodeDesignators[node]==GeometryNodeType::EXTERIOR; } , std::make_tuple( iInfo ) , std::make_tuple( normalInfo , implicit.density , implicit._auxData , &geometryNodeDesignators ) );
+						else                                 implicit.tree.template finalizeForMultigrid             < MaxDegree , Degrees::Max() >( params.baseDepth , addNodeFunctor , hasDataFunctor ,                                                                                                                                                                                   std::make_tuple( iInfo ) , std::make_tuple( normalInfo , implicit.density , implicit._auxData ) );
+					}
+					else
+					{
+						if( geometryNodeDesignators.size() ) implicit.tree.template finalizeForMultigridWithDirichlet< MaxDegree , Degrees::Max() >( params.baseDepth , addNodeFunctor , hasDataFunctor , [&]( const FEMTreeNode *node ){ return node->nodeData.nodeIndex<(node_index_type)geometryNodeDesignators.size() && geometryNodeDesignators[node]==GeometryNodeType::EXTERIOR; } , std::make_tuple( iInfo ) , std::make_tuple( normalInfo , implicit.density , &geometryNodeDesignators ) );
+						else                                 implicit.tree.template finalizeForMultigrid             < MaxDegree , Degrees::Max() >( params.baseDepth , addNodeFunctor , hasDataFunctor ,                                                                                                                                                                                   std::make_tuple( iInfo ) , std::make_tuple( normalInfo , implicit.density ) );
+					}
+
+					if( params.verbose ) std::cout << "#       Finalized tree: " << profiler << std::endl;
+				}
+
+				// Add the FEM constraints
+				{
+					profiler.reset();
+					constraints = implicit.tree.initDenseNodeData( Sigs() );
+
+					// Add Poisson constraints
+					{
+						typename FEMIntegrator::template Constraint< Sigs , IsotropicUIntPack< Dim , 1 > , NormalSigs , IsotropicUIntPack< Dim , 0 > , Dim > F;
+						unsigned int derivatives2[Dim];
+						for( int d=0 ; d<Dim ; d++ ) derivatives2[d] = 0;
+						typedef IsotropicUIntPack< Dim , 1 > Derivatives1;
+						typedef IsotropicUIntPack< Dim , 0 > Derivatives2;
+						for( int d=0 ; d<Dim ; d++ )
+						{
+							unsigned int derivatives1[Dim];
+							for( int dd=0 ; dd<Dim ; dd++ ) derivatives1[dd] = dd==d ? 1 : 0;
+							F.weights[d][ TensorDerivatives< Derivatives1 >::Index( derivatives1 ) ][ TensorDerivatives< Derivatives2 >::Index( derivatives2 ) ] = 1;
+						}
+						implicit.tree.addFEMConstraints( F , *normalInfo , constraints , solveDepth );
+					}
+					if( params.verbose ) std::cout << "#  Set FEM constraints: " << profiler << std::endl;
+				}
+
+				// Free up the normal info
+				delete normalInfo , normalInfo = NULL;
+
+				if( params.pointWeight>0 )
+				{
+					profiler.reset();
+					implicit.tree.addInterpolationConstraints( constraints , solveDepth , std::make_tuple( iInfo ) );
+					if( params.verbose ) std::cout << "#Set point constraints: " << profiler << std::endl;
+				}
+
+				if( valueInterpolationSamples && params.valueInterpolationWeight )
+				{
+					profiler.reset();
+					if( params.exactInterpolation ) valueInterpolationInfo = FEMTree< Dim , Real >::template       InitializeExactPointAndDataInterpolationInfo< Real , Real , 0 > ( implicit.tree , *valueInterpolationSamples , GetPointer( *valueInterpolationSampleData ) , Poisson::ValueInterpolationConstraintDual< Dim , Real >( params.valueInterpolationWeight ) , Poisson::ValueInterpolationSystemDual< Dim , Real >( params.valueInterpolationWeight ) , true , false );
+					else                            valueInterpolationInfo = FEMTree< Dim , Real >::template InitializeApproximatePointAndDataInterpolationInfo< Real , Real , 0 > ( implicit.tree , *valueInterpolationSamples , GetPointer( *valueInterpolationSampleData ) , Poisson::ValueInterpolationConstraintDual< Dim , Real >( params.valueInterpolationWeight ) , Poisson::ValueInterpolationSystemDual< Dim , Real >( params.valueInterpolationWeight ) , true , params.depth , 1 );
+					delete valueInterpolationSamples , valueInterpolationSamples = NULL;
+					delete valueInterpolationSampleData , valueInterpolationSampleData = NULL;
+
+					implicit.tree.addInterpolationConstraints( constraints , solveDepth , std::make_tuple( valueInterpolationInfo ) );
+					if( params.verbose ) std::cout << "#Set value interpolation constraints: " << profiler << std::endl;
+				}
+
+				if( params.verbose ) std::cout << "All Nodes / Active Nodes / Ghost Nodes / Dirichlet Supported Nodes: " << implicit.tree.allNodes() << " / " << implicit.tree.activeNodes() << " / " << implicit.tree.ghostNodes() << " / " << implicit.tree.dirichletElements() << std::endl;
+				if( params.verbose ) std::cout << "Memory Usage: " << float( MemoryInfo::Usage())/(1<<20) << " MB" << std::endl;
+
+				// Solve the linear system
+				{
+					profiler.reset();
+					typename FEMTree< Dim , Real >::SolverInfo _sInfo;
+					_sInfo.cgDepth = 0 , _sInfo.cascadic = true , _sInfo.vCycles = 1 , _sInfo.iters = params.iters , _sInfo.cgAccuracy = params.cgSolverAccuracy , _sInfo.verbose = params.verbose , _sInfo.showResidual = params.showResidual , _sInfo.showGlobalResidual = SHOW_GLOBAL_RESIDUAL_NONE , _sInfo.sliceBlockSize = 1;
+					_sInfo.baseVCycles = params.baseVCycles;
+					typename FEMIntegrator::template System< Sigs , IsotropicUIntPack< Dim , 1 > > F( { 0. , 1. } );
+					if( valueInterpolationInfo ) implicit.solution = implicit.tree.solveSystem( Sigs() , F , constraints , params.baseDepth , params.solveDepth , _sInfo , std::make_tuple( iInfo , valueInterpolationInfo ) );
+					else                         implicit.solution = implicit.tree.solveSystem( Sigs() , F , constraints , params.baseDepth , params.solveDepth , _sInfo , std::make_tuple( iInfo ) );
+					if( params.verbose ) std::cout << "# Linear system solved: " << profiler << std::endl;
+					if( iInfo ) delete iInfo , iInfo = NULL;
+					if( valueInterpolationInfo ) delete valueInterpolationInfo , valueInterpolationInfo = NULL;
+				}
+			}
+
+			// Get the iso-value
+			{
+				profiler.reset();
+				double valueSum = 0 , weightSum = 0;
+				typename FEMTree< Dim , Real >::template MultiThreadedEvaluator< Sigs , 0 > evaluator( &implicit.tree , implicit.solution );
+				std::vector< double > valueSums( ThreadPool::NumThreads() , 0 ) , weightSums( ThreadPool::NumThreads() , 0 );
+				ThreadPool::ParallelFor( 0 , samples->size() , [&]( unsigned int thread , size_t j )
+					{
+						ProjectiveData< Point< Real , Dim > , Real >& sample = (*samples)[j].sample;
+						Real w = sample.weight;
+						if( w>0 ) weightSums[thread] += w , valueSums[thread] += evaluator.values( sample.data / sample.weight , thread , (*samples)[j].node )[0] * w;
+					} );
+				for( size_t t=0 ; t<valueSums.size() ; t++ ) valueSum += valueSums[t] , weightSum += weightSums[t];
+				implicit.isoValue = (Real)( valueSum / weightSum );
+				if( params.verbose )
+				{
+					std::cout << "Got average: " << profiler << std::endl;
+					std::cout << "Iso-Value: " << implicit.isoValue << " = " << valueSum << " / " << weightSum << std::endl;
+				}
+			}
+			delete samples;
+			return implicitPtr;
+		}
+
+		// Implementation of the derived Poisson::Implicit's constructor
+		template< typename Real , unsigned int Dim , unsigned int ... FEMSigs , typename ... AuxData >
+		Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... > *SSD::Solver< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::Solve( InputOrientedSampleStream< Real , Dim , AuxData... > &pointStream , SolutionParameters< Real > params , AuxData ... zero )
+		{
+			Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... > *implicitPtr = new Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >( zero... );
+			Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... > &implicit = *implicitPtr;
+
+			// The signature for the finite-elements representing the auxiliary data (if it's there)
+			static const unsigned int DataSig = FEMDegreeAndBType< Reconstructor::DataDegree , BOUNDARY_FREE >::Signature;
+
+			///////////////
+			// Types --> //
+			using InternalAuxData          = typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::InternalAuxData;
+			using InternalNormalAndAuxData = typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::InternalNormalAndAuxData;
+			using _SampleTypeConverter     = typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::_SampleTypeConverter;
+			using Sigs                     = typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::Sigs;
+
+			// The degrees of the finite elements across the different axes
+			typedef UIntPack< FEMSignature< FEMSigs >::Degree ... > Degrees;
+
+			// The signature describing the normals elements
+			typedef UIntPack< FEMDegreeAndBType< SSD::NormalDegree , DerivativeBoundary< FEMSignature< FEMSigs >::BType , 1 >::BType >::Signature ... > NormalSigs;
+
+			// Type for tracking sample interpolation
+			typedef typename FEMTree< Dim , Real >::template InterpolationInfo< Real , 1 > InterpolationInfo;
+
+			// The finite-element tracking tree node
+			typedef RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > FEMTreeNode;
+			// <-- Types //
+			///////////////
+
+			XForm< Real , Dim+1 > modelToUnitCube = XForm< Real , Dim+1 >::Identity();
+
+			Profiler profiler( ProfilerMS );
+
+			size_t pointCount;
+
+			ProjectiveData< Point< Real , 2 > , Real > pointDepthAndWeight;
+			SparseNodeData< Point< Real , Dim > , NormalSigs > *normalInfo = nullptr;
+			std::vector< typename FEMTree< Dim , Real >::PointSample > *samples = new std::vector< typename FEMTree< Dim , Real >::PointSample >();
+			std::vector< InternalNormalAndAuxData > *sampleNormalAndAuxData = new std::vector< InternalNormalAndAuxData >();;
+
+			Real targetValue = (Real)0.0;
+
+			// Read in the samples (and auxiliary data)
+			{
+				profiler.reset();
+
+				pointStream.reset();
+				modelToUnitCube = params.scale>0 ? PointExtent::GetXForm< Real , Dim , true , Normal< Real , Dim > , AuxData... >( pointStream , Normal< Real , Dim >() , zero... , params.scale , params.alignDir ) * modelToUnitCube : modelToUnitCube;
+				implicit.unitCubeToModel = modelToUnitCube.inverse();
+				pointStream.reset();
+
+				params.template testAndSet< Dim >( implicit.unitCubeToModel );
+
+				{
+					// Apply the transformation
+					TransformedInputOrientedSampleStream< Real , Dim , AuxData... > _pointStream( modelToUnitCube , pointStream );
+
+					// Convert:
+					// InputDataStream< Position< Real , Dim > , Normal< Real , Dim > , AuxData ... >
+					//	 -> InputDataStream< Position< Real , Dim > , InternalNormalAndAuxData >
+					InputDataStreamConverter< typename _SampleTypeConverter::InternalSampleType , typename _SampleTypeConverter::ExternalSampleType > __pointStream( _pointStream , _SampleTypeConverter::ConvertI2X , Position< Real , Dim >() , Normal< Real , Dim >() , zero... );
+
+					std::vector< node_index_type > nodeToIndexMap;
+
+					auto IsValid = [&]( const Point< Real , Dim > &p , const Normal< Real , Dim > &n , AuxData ... d )
+						{
+							Real l = Point< Real , Dim >::SquareNorm( n );
+							return l>0 && std::isfinite(l);
+						};
+
+					auto Process = [&]( FEMTreeNode &node , const Point< Real , Dim > &p , Normal< Real , Dim > &n , AuxData ... d )
+						{
+							Real l = (Real)Length( n );
+							Real weight = params.confidence ? l : (Real)1.;
+							n /= l;
+
+							node_index_type nodeIndex = node.nodeData.nodeIndex;
+							// If the node's index exceeds what's stored in the node-to-index map, grow the node-to-index map
+							if( nodeIndex>=(node_index_type)nodeToIndexMap.size() ) nodeToIndexMap.resize( nodeIndex+1 , -1 );
+
+							node_index_type idx = nodeToIndexMap[ nodeIndex ];
+							if( idx==-1 )
+							{
+								idx = (node_index_type)samples->size();
+								nodeToIndexMap[ nodeIndex ] = idx;
+								samples->resize( idx+1 ) , (*samples)[idx].node = &node;
+								sampleNormalAndAuxData->resize( idx+1 );
+								(*samples)[idx].sample = ProjectiveData< Point< Real , Dim > , Real >( p*weight , weight );
+								(*sampleNormalAndAuxData)[idx] = InternalNormalAndAuxData( n , DirectSum< Real , AuxData... >( d... ) ) * weight;
+							}
+							else
+							{
+								(*samples)[idx].sample += ProjectiveData< Point< Real , Dim > , Real >( p*weight , weight );
+								(*sampleNormalAndAuxData)[idx] += InternalNormalAndAuxData( n , DirectSum< Real , AuxData... >( d... ) ) * weight;
+							}
+							return true;
+						};
+					auto F = [&]( AuxData ... zeroAuxData )
+						{
+							pointCount = FEMTreeInitializer< Dim , Real >::template Initialize< decltype(IsValid) , decltype(Process) , Normal< Real , Dim > , AuxData... >( implicit.tree.spaceRoot() , _pointStream , Normal< Real , Dim >() , zeroAuxData... , params.depth , implicit.tree.nodeAllocators.size() ? implicit.tree.nodeAllocators[0] : nullptr , implicit.tree.initializer() , IsValid , Process );
+						};
+					implicit._zeroAuxData.process( F );
+				}
+
+				if( params.verbose )
+				{
+					std::cout << "Input Points / Samples: " << pointCount << " / " << samples->size() << std::endl;
+					std::cout << "# Read input into tree: " << profiler << std::endl;
+				}
+			}
+			{
+				DenseNodeData< Real , Sigs > constraints;
+				InterpolationInfo *iInfo = NULL;
+				int solveDepth = params.depth;
+
+				implicit.tree.resetNodeIndices( 0 , std::make_tuple() );
+
+				// Get the kernel density estimator
+				{
+					profiler.reset();
+					implicit.density = implicit.tree.template setDensityEstimator< 1 , Reconstructor::WeightDegree >( *samples , params.kernelDepth , params.samplesPerNode );
+					if( params.verbose ) std::cout << "#   Got kernel density: " << profiler << std::endl;
+				}
+
+				// Transform the Hermite samples into a vector field
+				{
+					profiler.reset();
+					normalInfo = new SparseNodeData< Point< Real , Dim > , NormalSigs >();
+
+					std::function< bool ( InternalNormalAndAuxData , Point< Real , Dim > & ) > ConversionFunction;
+					std::function< bool ( InternalNormalAndAuxData , Point< Real , Dim > & , Real & ) > ConversionAndBiasFunction;
+					ConversionFunction = []( InternalNormalAndAuxData in , Normal< Real , Dim > &out )
+						{
+							Normal< Real , Dim > n = in.template get<0>();
+							Real l = (Real)Length( n );
+							// It is possible that the samples have non-zero normals but there are two co-located samples with negative normals...
+							if( !l ) return false;
+							out = n / l;
+							return true;
+						};
+					*normalInfo = implicit.tree.setInterpolatedDataField( Point< Real , Dim >() , NormalSigs() , *samples , *sampleNormalAndAuxData , implicit.density , params.baseDepth , params.depth , params.lowDepthCutOff , pointDepthAndWeight , ConversionFunction );
+
+					if( params.verbose )
+					{
+						std::cout << "#     Got normal field: " << profiler << std::endl;
+						std::cout << "Point depth / Point weight / Estimated measure: " << pointDepthAndWeight.value()[0] << " / " << pointDepthAndWeight.value()[1] << " / " << pointCount*pointDepthAndWeight.value()[1] << std::endl;
+					}
+				}
+
+				if constexpr( sizeof...(AuxData) )
+				{
+					profiler.reset();
+					auto PointSampleFunctor = [&]( size_t i ) -> const typename FEMTree< Dim , Real >::PointSample & { return (*samples)[i]; };
+					auto AuxDataSampleFunctor = [&]( size_t i ) -> const typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::InternalAuxData & { return (*sampleNormalAndAuxData)[i].template get<1>(); };
+					implicit._auxData = new SparseNodeData< ProjectiveData< InternalAuxData , Real > , IsotropicUIntPack< Dim , DataSig > >
+						(
+							implicit.tree.template setExtrapolatedDataField< DataSig , false , Reconstructor::WeightDegree , InternalAuxData >
+							(
+								InternalAuxData( zero... ) ,
+								samples->size() ,
+								PointSampleFunctor ,
+								AuxDataSampleFunctor ,
+								(typename Reconstructor::Implicit< Real , Dim , UIntPack< FEMSigs... > , AuxData... >::DensityEstimator*)nullptr
+							)
+						);
+					auto nodeFunctor = [&]( const RegularTreeNode< Dim , FEMTreeNodeData , depth_and_offset_type > *n )
+						{
+							ProjectiveData< InternalAuxData , Real >* clr = (*implicit._auxData)( n );
+							if( clr ) (*clr) *= (Real)pow( (Real)params.perLevelDataScaleFactor , implicit.tree.depth( n ) );
+						};
+					implicit.tree.tree().processNodes( nodeFunctor );
+					if( params.verbose ) std::cout << "#         Got aux data: " << profiler << std::endl;
+				}
+				// Add the interpolation constraints
+				if( params.pointWeight>0 || params.gradientWeight>0 )
+				{
+					profiler.reset();
+					if( params.exactInterpolation ) iInfo = FEMTree< Dim , Real >::template       InitializeExactPointAndDataInterpolationInfo< Real , InternalNormalAndAuxData , 1 >( implicit.tree , *samples , GetPointer( *sampleNormalAndAuxData ) , SSD::ConstraintDual< Dim , Real , AuxData... >( targetValue , params.pointWeight * pointDepthAndWeight.value()[1] , params.gradientWeight * pointDepthAndWeight.value()[1]  ) , SSD::SystemDual< Dim , Real , AuxData... >( params.pointWeight * pointDepthAndWeight.value()[1] , params.gradientWeight * pointDepthAndWeight.value()[1] ) , true , false );
+					else                            iInfo = FEMTree< Dim , Real >::template InitializeApproximatePointAndDataInterpolationInfo< Real , InternalNormalAndAuxData , 1 >( implicit.tree , *samples , GetPointer( *sampleNormalAndAuxData ) , SSD::ConstraintDual< Dim , Real , AuxData... >( targetValue , params.pointWeight * pointDepthAndWeight.value()[1] , params.gradientWeight * pointDepthAndWeight.value()[1]  ) , SSD::SystemDual< Dim , Real , AuxData... >( params.pointWeight * pointDepthAndWeight.value()[1] , params.gradientWeight * pointDepthAndWeight.value()[1] ) , true , params.depth , 1 );
+					if( params.verbose ) std::cout <<  "#Initialized point interpolation constraints: " << profiler << std::endl;
+				}
+
+				delete sampleNormalAndAuxData;
+
+
+				// Trim the tree and prepare for multigrid
+				{
+					profiler.reset();
+					constexpr int MaxDegree = SSD::NormalDegree > Degrees::Max() ? SSD::NormalDegree : Degrees::Max();
+					typename FEMTree< Dim , Real >::template HasNormalDataFunctor< NormalSigs > hasNormalDataFunctor( *normalInfo );
+					auto hasDataFunctor = [&]( const FEMTreeNode *node ){ return hasNormalDataFunctor( node ); };
+					auto addNodeFunctor = [&]( int d , const int off[Dim] ){ return d<=(int)params.fullDepth; };
+					if constexpr( sizeof...(AuxData) ) implicit.tree.template finalizeForMultigrid< MaxDegree , Degrees::Max() >( params.baseDepth , addNodeFunctor , hasDataFunctor , std::make_tuple( iInfo ) , std::make_tuple( normalInfo , implicit.density , implicit._auxData ) );
+					else implicit.tree.template finalizeForMultigrid< MaxDegree , Degrees::Max() >( params.baseDepth , addNodeFunctor , hasDataFunctor , std::make_tuple( iInfo ) , std::make_tuple( normalInfo , implicit.density ) );
+
+					if( params.verbose ) std::cout << "#       Finalized tree: " << profiler << std::endl;
+				}
+
+				// Free up the normal info
+				delete normalInfo , normalInfo = NULL;
+
+				if( params.pointWeight>0 || params.gradientWeight>0 )
+				{
+					profiler.reset();
+					constraints = implicit.tree.initDenseNodeData( Sigs() );
+					implicit.tree.addInterpolationConstraints( constraints , solveDepth , std::make_tuple( iInfo ) );
+					if( params.verbose ) std::cout << "#Set point constraints: " << profiler << std::endl;
+				}
+
+				if( params.verbose ) std::cout << "All Nodes / Active Nodes / Ghost Nodes: " << implicit.tree.allNodes() << " / " << implicit.tree.activeNodes() << " / " << implicit.tree.ghostNodes() << std::endl;
+				if( params.verbose ) std::cout << "Memory Usage: " << float( MemoryInfo::Usage())/(1<<20) << " MB" << std::endl;
+
+				// Solve the linear system
+				{
+					profiler.reset();
+					typename FEMTree< Dim , Real >::SolverInfo _sInfo;
+					_sInfo.cgDepth = 0 , _sInfo.cascadic = true , _sInfo.vCycles = 1 , _sInfo.iters = params.iters , _sInfo.cgAccuracy = params.cgSolverAccuracy , _sInfo.verbose = params.verbose , _sInfo.showResidual = params.showResidual , _sInfo.showGlobalResidual = SHOW_GLOBAL_RESIDUAL_NONE , _sInfo.sliceBlockSize = 1;
+					_sInfo.baseVCycles = params.baseVCycles;
+					typename FEMIntegrator::template System< Sigs , IsotropicUIntPack< Dim , 2 > > F( { 0. , 0. , (double)params.biLapWeight } );
+					implicit.solution = implicit.tree.solveSystem( Sigs() , F , constraints , params.baseDepth , params.solveDepth , _sInfo , std::make_tuple( iInfo ) );
+					if( params.verbose ) std::cout << "# Linear system solved: " << profiler << std::endl;
+					if( iInfo ) delete iInfo , iInfo = NULL;
+				}
+			}
+
+			// Get the iso-value
+			{
+				profiler.reset();
+				double valueSum = 0 , weightSum = 0;
+				typename FEMTree< Dim , Real >::template MultiThreadedEvaluator< Sigs , 0 > evaluator( &implicit.tree , implicit.solution );
+				std::vector< double > valueSums( ThreadPool::NumThreads() , 0 ) , weightSums( ThreadPool::NumThreads() , 0 );
+				ThreadPool::ParallelFor( 0 , samples->size() , [&]( unsigned int thread , size_t j )
+					{
+						ProjectiveData< Point< Real , Dim > , Real >& sample = (*samples)[j].sample;
+						Real w = sample.weight;
+						if( w>0 ) weightSums[thread] += w , valueSums[thread] += evaluator.values( sample.data / sample.weight , thread , (*samples)[j].node )[0] * w;
+					} );
+				for( size_t t=0 ; t<valueSums.size() ; t++ ) valueSum += valueSums[t] , weightSum += weightSums[t];
+				implicit.isoValue = (Real)( valueSum / weightSum );
+				if( params.verbose )
+				{
+					std::cout << "Got average: " << profiler << std::endl;
+					std::cout << "Iso-Value: " << implicit.isoValue << " = " << valueSum << " / " << weightSum << std::endl;
+				}
+			}
+			delete samples;
+			return implicitPtr;
+		}
+	}
+}
+
+
+#endif // RECONSTRUCTORS_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Reconstructors.streams.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Reconstructors.streams.h
@@ -1,0 +1,534 @@
+/*
+Copyright (c) 2022, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef RECONSTRUCTORS_STREAMS_INCLUDED
+#define RECONSTRUCTORS_STREAMS_INCLUDED
+
+#include "FEMTree.h"
+#include "MyExceptions.h"
+#include "Array.h"
+
+namespace PoissonRecon
+{
+	namespace Reconstructor
+	{
+		template< typename Real , unsigned int Dim > using Position = Point< Real , Dim >;
+		template< typename Real , unsigned int Dim > using Normal   = Point< Real , Dim >;
+		template< typename Real , unsigned int Dim > using Gradient = Point< Real , Dim >;
+		template< typename Real > using Weight = Real;
+		template< typename Real > using Value = Real;
+
+		////////////////////////
+		// Input stream types //
+		////////////////////////
+
+		template< typename Real , unsigned int Dim , typename ... Data > using InputSampleStream = InputDataStream< Point< Real , Dim > , Data ... >;
+		template< typename Real , unsigned int Dim , typename ... Data > struct TransformedInputSampleStream;
+
+		template< typename Real , unsigned int Dim , typename ... Data > using InputOrientedSampleStream = InputDataStream< Position< Real , Dim > , Normal< Real , Dim > , Data ... >;
+		template< typename Real , unsigned int Dim , typename ... Data > struct TransformedInputOrientedSampleStream;
+
+		template< typename Real , unsigned int Dim , typename ... Data > using InputValuedSampleStream = InputSampleStream< Real , Dim , Value< Real > , Data ... >;
+		template< typename Real , unsigned int Dim , typename ... Data > using TransformedInputValuedSampleStream = TransformedInputSampleStream< Real , Dim , Value< Real > , Data ... >;
+
+
+		/////////////////////////
+		// Output stream types //
+		/////////////////////////
+
+		template< typename Real , unsigned int Dim , typename ... Data > using OutputLevelSetVertexStream = OutputDataStream< Position< Real , Dim > , Gradient< Real , Dim > , Weight< Real > , Data ... >;
+		template< typename Real , unsigned int Dim , typename ... Data > struct TransformedOutputLevelSetVertexStream;
+
+		//////////////////
+		// Face streams //
+		//////////////////
+		template< unsigned int FaceDim , typename T=node_index_type > using Face = std::conditional_t< FaceDim==2 , std::vector< T > , std::conditional_t< FaceDim==1 , std::pair< T , T > , void * > >;
+		template< unsigned int FaceDim > using  InputFaceStream =  InputDataStream< Face< FaceDim > >;
+		template< unsigned int FaceDim > using OutputFaceStream = OutputDataStream< Face< FaceDim > >;
+
+		//////////////////////////////////////////////
+		// Information about the output vertex type //
+		//////////////////////////////////////////////
+		template< typename Real , unsigned int Dim , bool HasGradients , bool HasDensity , typename ... AxuDataFactories > struct OutputVertexInfo;
+
+		//////////////////////////////////////////
+		// Transformed Input Sample Data Stream //
+		//////////////////////////////////////////
+		template< typename Real , unsigned int Dim , typename ... Data >
+		struct TransformedInputSampleStream : public InputSampleStream< Real , Dim , Data ... >
+		{
+			// A constructor initialized with the transformation to be applied to the samples, and a sample stream
+			TransformedInputSampleStream( XForm< Real , Dim+1 > xForm , InputSampleStream< Real , Dim , Data ... > &stream ) : _stream(stream) , _xForm(xForm) {}
+
+			// Functionality to reset the stream to the start
+			void reset( void ){ _stream.reset(); }
+
+			// Functionality to extract the next position/normal pair.
+			// The method returns true if there was another point in the stream to read, and false otherwise
+			bool read( Position< Real , Dim > &p , Data& ... d )
+			{
+				if( !_stream.read( p , d... ) ) return false;
+				p = _xForm * p;
+				return true;
+			}
+			bool read( unsigned int thread , Position< Real , Dim > &p , Data& ... d )
+			{
+				if( !_stream.read( thread , p , d... ) ) return false;
+				p = _xForm * p;
+				return true;
+			}
+
+		protected:
+			// A reference to the underlying stream
+			InputSampleStream< Real , Dim , Data ... > &_stream;
+
+			// The affine transformation to be applied to the positions
+			XForm< Real , Dim+1 > _xForm;
+		};
+
+		//////////////////////////////////////////////////
+		// Transformed Input Oriente Sample Data Stream //
+		//////////////////////////////////////////////////
+		template< typename Real , unsigned int Dim , typename ... Data >
+		struct TransformedInputOrientedSampleStream : public InputOrientedSampleStream< Real , Dim , Data ... >
+		{
+			// A constructor initialized with the transformation to be applied to the samples, and a sample stream
+			TransformedInputOrientedSampleStream( XForm< Real , Dim+1 > xForm , InputOrientedSampleStream< Real , Dim , Data ... > &stream ) : _stream(stream) , _positionXForm(xForm)
+			{
+				_normalXForm = XForm< Real , Dim > ( xForm ).inverse().transpose() * (Real)pow( fabs( xForm.determinant() ) , 1./Dim );
+			}
+
+			// Functionality to reset the stream to the start
+			void reset( void ){ _stream.reset(); }
+
+			// Functionality to extract the next position/normal pair.
+			// The method returns true if there was another point in the stream to read, and false otherwise
+			bool read( Position< Real , Dim > &p , Normal< Real , Dim > &n , Data& ... d )
+			{
+				if( !_stream.read( p , n , d... ) ) return false;
+				p = _positionXForm * p , n = _normalXForm * n;
+				return true;
+			}
+			bool read( unsigned int thread , Position< Real , Dim > &p , Normal< Real , Dim > &n , Data& ... d )
+			{
+				if( !_stream.read( thread , p , n , d... ) ) return false;
+				p = _positionXForm * p , n = _normalXForm * n;
+				return true;
+			}
+
+		protected:
+			// A reference to the underlying stream
+			InputOrientedSampleStream< Real , Dim , Data ... > &_stream;
+
+			// The affine transformation to be applied to the positions
+			XForm< Real , Dim+1 > _positionXForm;
+
+			// The linear transformation to be applied to the normals
+			XForm< Real , Dim > _normalXForm;
+		};
+
+		//////////////////////////////////////
+		// Transformed Output Vertex Stream //
+		//////////////////////////////////////
+		template< typename Real , unsigned int Dim , typename ... Data >
+		struct TransformedOutputLevelSetVertexStream : public OutputLevelSetVertexStream< Real , Dim , Data ... >
+		{
+			// A constructor initialized with the transformation to be applied to the samples, and a sample stream
+			TransformedOutputLevelSetVertexStream( XForm< Real , Dim+1 > xForm , OutputLevelSetVertexStream< Real , Dim , Data ... > &stream ) : _stream(stream) , _positionXForm(xForm)
+			{
+				_gradientXForm = XForm< Real , Dim > ( xForm ).inverse().transpose() * (Real)pow( xForm.determinant() , 1./Dim );
+			}
+
+			// Need to write the union to ensure that the counter gets set
+			size_t write(                       const Position< Real , Dim > &p , const Gradient< Real , Dim > &g , const Weight< Real > &w , const Data& ... d ){ return _stream.write(          _positionXForm * p , _gradientXForm * g , w , d... ); }
+			size_t write( unsigned int thread , const Position< Real , Dim > &p , const Gradient< Real , Dim > &g , const Weight< Real > &w , const Data& ... d ){ return _stream.write( thread , _positionXForm * p , _gradientXForm * g , w , d... ); }
+			size_t size( void ) const { return _stream.size(); }
+
+		protected:
+			// A reference to the underlying stream
+			OutputLevelSetVertexStream< Real , Dim , Data ... > &_stream;
+
+			// The affine transformation to be applied to the positions
+			XForm< Real , Dim+1 > _positionXForm;
+
+			// The linear transformation to be applied to the normals
+			XForm< Real , Dim > _gradientXForm;
+		};
+
+
+		//////////////////////////////////
+		// File-backed streaming memory //
+		//////////////////////////////////
+		class FileBackedReadWriteStream
+		{
+		public:
+			struct FileDescription
+			{
+				FILE *fp;
+
+				FileDescription( FILE *fp ) : fp(fp) , _closeFile(false)
+				{
+					if( !this->fp )
+					{
+						this->fp = std::tmpfile();
+						_closeFile = true;
+						if( !this->fp ) MK_THROW( "Failed to open temporary file" );
+					}
+				}
+				~FileDescription( void ){ if( _closeFile ) fclose(fp); }
+			protected:
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Probably can let the system handle closing the file" )
+#endif // SHOW_WARNINGS
+				bool _closeFile;
+			};
+
+			FileBackedReadWriteStream( FILE *fp ) : _fd(fp) {}
+			bool write( ConstPointer(char) data , size_t size ){ return fwrite( data , sizeof(char) , size , _fd.fp )==size; }
+			bool read( Pointer(char) data , size_t size ){ return fread( data , sizeof(char) , size , _fd.fp )==size; }
+			void reset( void ){ fseek( _fd.fp , 0 , SEEK_SET ); }
+		protected:
+			FileDescription _fd;
+		};
+
+
+		//////////////////////////////////////////////////////////////////////////////
+		// Output and the input face stream, backed either by a file or by a vector //
+		//////////////////////////////////////////////////////////////////////////////
+		// [WARNING] These assume that the stream starts as write-only and after the reset method is invoked, the stream becomes read-only.
+
+		template< unsigned int FaceDim , bool InCore , bool Parallel >
+		struct OutputInputFaceStream
+			: public OutputFaceStream< FaceDim >
+			, public  InputFaceStream< FaceDim >
+		{
+			// The streams for communicating the information
+			InputFaceStream < FaceDim > * inStream;
+			OutputFaceStream< FaceDim > *outStream;
+
+			void reset( void ){ inStream->reset(); }
+			bool read(                  Face< FaceDim > &f ){ return inStream->read(  f); }
+			bool read( unsigned int t , Face< FaceDim > &f ){ return inStream->read(t,f); }
+			size_t write(                  const Face< FaceDim > &f ){ return outStream->write(  f); }
+			size_t write( unsigned int t , const Face< FaceDim > &f ){ return outStream->write(t,f); }
+			size_t size( void ) const { return outStream->size(); }
+
+			OutputInputFaceStream( void )
+			{
+				size_t sz = ThreadPool::NumThreads();
+
+				_backingVectors.resize( sz , nullptr );
+
+				_backingFiles.resize( sz , nullptr );
+
+				_inStreams.resize( sz , nullptr );
+				_outStreams.resize( sz , nullptr );
+
+				if constexpr( InCore )
+				{
+					if constexpr( Parallel )
+					{
+						for( unsigned int i=0 ; i<sz ; i++ )
+						{
+							_backingVectors[i] = new std::vector< Face< FaceDim > >();
+							_inStreams[i] = new VectorBackedInputDataStream< Face< FaceDim > >( *_backingVectors[i] );
+							_outStreams[i] = new VectorBackedOutputDataStream< Face< FaceDim > >( *_backingVectors[i] );
+						}
+						inStream = new MultiInputDataStream< Face< FaceDim > >( _inStreams );
+						outStream = new MultiOutputDataStream< Face< FaceDim > >( _outStreams );
+					}
+					else
+					{
+						_backingVector = new std::vector< Face< FaceDim > >();
+						inStream = new VectorBackedInputDataStream< Face< FaceDim > >( *_backingVector );
+						outStream = new VectorBackedOutputDataStream< Face< FaceDim > >( *_backingVector );
+					}
+				}
+				else
+				{
+					if constexpr( Parallel )
+					{
+						for( unsigned int i=0 ; i<sz ; i++ )
+						{
+							_backingFiles[i] = new FileBackedReadWriteStream::FileDescription( NULL );
+							_inStreams[i] = new FileBackedInputDataStream< Face< FaceDim > >( _backingFiles[i]->fp );
+							_outStreams[i] = new FileBackedOutputDataStream< Face< FaceDim > >( _backingFiles[i]->fp );
+						}
+						inStream = new MultiInputDataStream< Face< FaceDim > >( _inStreams );
+						outStream = new MultiOutputDataStream< Face< FaceDim > >( _outStreams );
+					}
+					else
+					{
+						_backingFile = new FileBackedReadWriteStream::FileDescription( NULL );
+						inStream = new FileBackedInputDataStream< Face< FaceDim > >( _backingFile->fp );
+						outStream = new FileBackedOutputDataStream< Face< FaceDim > >( _backingFile->fp );
+					}
+				}
+			}
+
+			~OutputInputFaceStream( void )
+			{
+				size_t sz = ThreadPool::NumThreads();
+
+				delete _backingVector;
+				delete _backingFile;
+
+				for( unsigned int i=0 ; i<sz ; i++ )
+				{
+					delete _backingVectors[i];
+					delete _backingFiles[i];
+					delete  _inStreams[i];
+					delete _outStreams[i];
+				}
+
+				delete  inStream;
+				delete outStream;
+			}
+		protected:
+			std::vector< Face< FaceDim > > *_backingVector = nullptr;
+			FileBackedReadWriteStream::FileDescription *_backingFile = nullptr;
+			std::vector< std::vector< Face< FaceDim > > * > _backingVectors;
+			std::vector< FileBackedReadWriteStream::FileDescription * > _backingFiles;
+			std::vector<  InputDataStream< Face< FaceDim > > * >  _inStreams;
+			std::vector< OutputDataStream< Face< FaceDim > > * > _outStreams;
+		};
+
+
+		template< typename Real , unsigned int Dim , typename Factory , bool InCore , bool Parallel , typename ... Data >
+		struct OutputInputFactoryTypeStream
+			: public OutputDataStream< Position< Real , Dim > , Gradient< Real , Dim > , Weight< Real > , Data ... >
+			, public InputDataStream< typename Factory::VertexType >
+		{
+			using Vertex = typename Factory::VertexType;
+
+			// The streams for communicating the information
+			using OutputStreamType = OutputDataStream< Vertex >;
+			using  InputStreamType =  InputDataStream< Vertex >;
+			OutputStreamType *outStream;
+			InputStreamType  * inStream;
+
+			void reset( void ){ inStream->reset(); }
+			size_t write( const Position< Real , Dim > &p , const Gradient< Real , Dim > &g , const Weight< Real > &w , const Data& ... d )
+			{
+				Vertex v = _converter( p , g , w , d... );
+				return outStream->write( v );
+			}
+			size_t write( unsigned int thread , const Position< Real , Dim > &p , const Gradient< Real , Dim > &g , const Weight< Real > &w , const Data& ... d )
+			{
+				Vertex v = _converter( p , g , w , d... );
+				return outStream->write( thread , v );
+			}
+			bool read(                       Vertex &v ){ return inStream->read(          v ); }
+			bool read( unsigned int thread , Vertex &v ){ return inStream->read( thread , v ); }
+
+			size_t size( void ) const { return outStream->size(); }
+
+			OutputInputFactoryTypeStream( Factory &factory , std::function< Vertex ( const Position< Real , Dim > & , const Gradient< Real , Dim > & , const Weight< Real > & , const Data & ...  ) > converter )
+				: _converter( converter )
+			{
+				size_t sz = ThreadPool::NumThreads();
+
+				_backingVectors.resize( sz , nullptr );
+
+				_backingFiles.resize( sz , nullptr );
+
+				_inStreams.resize( sz , nullptr );
+				_outStreams.resize( sz , nullptr );
+
+				if constexpr( Parallel )
+				{
+					for( unsigned int i=0 ; i<sz ; i++ )
+					{
+						if constexpr( InCore )
+						{
+							_backingVectors[i] = new std::vector< std::pair< size_t , Vertex > >();
+							_outStreams[i] = new VectorBackedOutputIndexedDataStream< Vertex >( *_backingVectors[i] );
+							_inStreams[i] = new VectorBackedInputIndexedDataStream< Vertex >( *_backingVectors[i] );
+						}
+						else
+						{
+							_backingFiles[i] = new FileBackedReadWriteStream::FileDescription( NULL );
+							_outStreams[i] = new FileBackedOutputIndexedFactoryTypeStream< Factory >( _backingFiles[i]->fp , factory  );
+							_inStreams[i] = new FileBackedInputIndexedFactoryTypeStream< Factory >( _backingFiles[i]->fp , factory );
+						}
+					}
+					outStream = new DeInterleavedMultiOutputIndexedDataStream< Vertex >( _outStreams );
+					inStream = new InterleavedMultiInputIndexedDataStream< Vertex >( _inStreams );
+				}
+				else
+				{
+					if constexpr( InCore )
+					{
+						_backingVector = new std::vector< Vertex >();
+						outStream = new VectorBackedOutputDataStream< Vertex >( *_backingVector );
+						inStream = new VectorBackedInputDataStream< Vertex >( *_backingVector );
+					}
+					else
+					{
+						_backingFile = new FileBackedReadWriteStream::FileDescription( NULL );
+						outStream = new FileBackedOutputFactoryTypeStream< Factory >( _backingFile->fp , factory );
+						inStream = new FileBackedInputFactoryTypeStream< Factory >( _backingFile->fp , factory );
+					}
+				}
+			}
+
+			~OutputInputFactoryTypeStream( void )
+			{
+				size_t sz = ThreadPool::NumThreads();
+
+				delete _backingVector;
+				delete _backingFile;
+
+				for( unsigned int i=0 ; i<sz ; i++ )
+				{
+					delete _backingVectors[i];
+					delete _backingFiles[i];
+					delete  _inStreams[i];
+					delete _outStreams[i];
+				}
+
+				delete  inStream;
+				delete outStream;
+				delete _inMultiStream;
+			}
+		protected:
+			std::function< Vertex ( const Position< Real , Dim > & , const Gradient< Real , Dim > & , const Weight< Real > & , const Data & ...  ) > _converter;
+			std::vector< Vertex > *_backingVector = nullptr;
+			FileBackedReadWriteStream::FileDescription *_backingFile = nullptr;
+			std::vector< std::vector< std::conditional_t< Parallel , std::pair< size_t , Vertex > , Vertex > > * >_backingVectors;
+			std::vector< FileBackedReadWriteStream::FileDescription * > _backingFiles;
+			std::vector< OutputIndexedDataStream< Vertex > * > _outStreams;
+			std::vector<  InputIndexedDataStream< Vertex > * >  _inStreams;
+			MultiInputIndexedDataStream< Vertex > *_inMultiStream = nullptr;
+		};
+
+		template< typename Real , unsigned int Dim , bool HasGradients , bool HasDensity >
+		struct OutputVertexInfo< Real , Dim , HasGradients , HasDensity >
+		{
+			using Factory =
+				typename std::conditional_t
+				<
+				HasGradients ,
+				typename std::conditional_t
+				<
+				HasDensity ,
+				VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , VertexFactory::NormalFactory< Real , Dim > , VertexFactory::ValueFactory< Real > > ,
+				VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , VertexFactory::NormalFactory< Real , Dim > >
+				> ,
+				typename std::conditional_t
+				<
+				HasDensity ,
+				VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , VertexFactory::ValueFactory< Real > > ,
+				VertexFactory::PositionFactory< Real , Dim >
+				>
+				>;
+			using Vertex = typename Factory::VertexType;
+
+			static Factory GetFactory( void ){ return Factory(); }
+
+			static Vertex Convert( const Position< Real , Dim > &p , const Gradient< Real , Dim > &g , const Weight< Real > & w )
+			{
+				Vertex v;
+				if constexpr( !HasGradients && !HasDensity ) v = p;
+				else
+				{
+					v.template get<0>() = p;
+					if constexpr( HasGradients )
+					{
+						if constexpr( HasDensity ) v.template get<1>() = g , v.template get<2>() = w;
+						else                       v.template get<1>() = g;
+					}
+					else
+					{
+						if constexpr( HasDensity ) v.template get<1>() = w;
+					}
+				}
+				return v;
+			}
+		};
+
+		template< typename Real , unsigned int Dim , bool HasGradients , bool HasDensity , typename AuxDataFactory >
+		struct OutputVertexInfo< Real , Dim , HasGradients , HasDensity , AuxDataFactory >
+		{
+			using Factory =
+				typename std::conditional
+				<
+				HasGradients ,
+				typename std::conditional
+				<
+				HasDensity ,
+				VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , VertexFactory::NormalFactory< Real , Dim > , VertexFactory::ValueFactory< Real > , AuxDataFactory > ,
+				VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , VertexFactory::NormalFactory< Real , Dim > , AuxDataFactory >
+				>::type ,
+				typename std::conditional
+				<
+				HasDensity ,
+				VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , VertexFactory::ValueFactory< Real > , AuxDataFactory > ,
+				VertexFactory::Factory< Real , VertexFactory::PositionFactory< Real , Dim > , AuxDataFactory >
+				>::type
+				>::type;
+			using AuxData = typename AuxDataFactory::VertexType;
+
+			using _Vertex = DirectSum< Real , Point< Real , Dim > , Point< Real , Dim > , Real , typename AuxDataFactory::VertexType >;
+			using Vertex = typename Factory::VertexType;
+
+			static Factory GetFactory( AuxDataFactory auxDataFactory )
+			{
+				if constexpr( HasGradients )
+				{
+					if constexpr( HasDensity ) return Factory( VertexFactory::PositionFactory< Real , Dim >() , VertexFactory::NormalFactory< Real , Dim >() , VertexFactory::ValueFactory< Real >() , auxDataFactory );
+					else                       return Factory( VertexFactory::PositionFactory< Real , Dim >() , VertexFactory::NormalFactory< Real , Dim >() ,                                         auxDataFactory );
+				}
+				else
+				{
+					if constexpr( HasDensity ) return Factory( VertexFactory::PositionFactory< Real , Dim >() ,                                                VertexFactory::ValueFactory< Real >() , auxDataFactory );
+					else                       return Factory( VertexFactory::PositionFactory< Real , Dim >() ,                                                                                        auxDataFactory );
+				}
+			}
+
+			static Vertex Convert( const Position< Real , Dim > &p , const Gradient< Real , Dim > &g , const Weight< Real > & w , const AuxData &data )
+			{
+				Vertex v;
+				v.template get<0>() = p;
+				if constexpr( HasGradients )
+				{
+					if constexpr( HasDensity ) v.template get<1>() = g , v.template get<2>() = w , v.template get<3>() = data;
+					else                       v.template get<1>() = g , v.template get<2>() = data;
+				}
+				else
+				{
+					if constexpr( HasDensity ) v.template get<1>() = w , v.template get<2>() = data;
+					else                       v.template get<1>() = data;
+				}
+				return v;
+			}
+		};
+	}
+}
+
+#endif // RECONSTRUCTORS_STREAMS_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/RegularGrid.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/RegularGrid.h
@@ -1,0 +1,154 @@
+/*
+Copyright (c) 2019, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef REGULAR_GRID_INCLUDED
+#define REGULAR_GRID_INCLUDED
+
+#include <type_traits>
+#include "Array.h"
+#include "Geometry.h"
+#include "MyMiscellany.h"
+
+namespace PoissonRecon
+{
+
+	template< typename ... Type > struct RegularGridDataType{};
+
+	template<>
+	struct RegularGridDataType<>
+	{
+		static inline void Write( FILE *fp , unsigned int dim , std::string name );
+		static inline bool Read( FILE *fp , unsigned int dim , std::string name );
+	};
+
+	template<> struct RegularGridDataType< char >{ static const std::string Name ; static void Write( FILE *fp ){ RegularGridDataType<>::Write( fp , 1 , Name ); } ; static bool Read( FILE *fp ){ return RegularGridDataType<>::Read( fp , 1 , Name ); } };
+	inline const std::string RegularGridDataType< char >::Name = "CHAR";
+	template<> struct RegularGridDataType< unsigned char >{ static const std::string Name ; static void Write( FILE *fp ){ RegularGridDataType<>::Write( fp , 1 , Name ); } static bool Read( FILE *fp ){ return RegularGridDataType<>::Read( fp , 1 , Name ); } };
+	inline const std::string RegularGridDataType< unsigned char >::Name = "UNSIGNED_CHAR";
+	template<> struct RegularGridDataType< int >{ static const std::string Name ; static void Write( FILE *fp ){ RegularGridDataType<>::Write( fp , 1 , Name ); } static bool Read( FILE *fp ){ return RegularGridDataType<>::Read( fp , 1 , Name ); } };
+	inline const std::string RegularGridDataType< int >::Name = "INT";
+	template<> struct RegularGridDataType< unsigned int >{ static const std::string Name ; static void Write( FILE *fp ){ RegularGridDataType<>::Write( fp , 1 , Name ); } static bool Read( FILE *fp ){ return RegularGridDataType<>::Read( fp , 1 , Name ); } };
+	inline const std::string RegularGridDataType< unsigned int >::Name = "UNSIGNED_INT";
+	template<> struct RegularGridDataType< float >{ static const std::string Name ; static void Write( FILE *fp ){ RegularGridDataType<>::Write( fp , 1 , Name ); } static bool Read( FILE *fp ){ return RegularGridDataType<>::Read( fp , 1 , Name ); } };
+	inline const std::string RegularGridDataType< float >::Name = "FLOAT";
+	template<> struct RegularGridDataType< double >{ static const std::string Name ; static void Write( FILE *fp ){ RegularGridDataType<>::Write( fp , 1 , Name ); } static bool Read( FILE *fp ){ return RegularGridDataType<>::Read( fp , 1 , Name ); } };
+	inline const std::string RegularGridDataType< double >::Name = "DOUBLE";
+
+	template< typename Real , unsigned int Dim > struct RegularGridDataType< Point< Real , Dim > >{ static const std::string Name ; static void Write( FILE *fp ){ RegularGridDataType<>::Write( fp , Dim , Name ); } static bool Read( FILE *fp ){ return RegularGridDataType<>::Read( fp , Dim , Name ); } };
+	template< typename Real , unsigned int Dim > const std::string RegularGridDataType< Point< Real , Dim > >::Name = RegularGridDataType< Real >::Name;
+
+
+	template< typename DataType , unsigned int Dim >
+	struct RegularGrid
+	{
+		static bool ReadHeader( std::string fileName , unsigned int &dim , std::string &type );
+
+		RegularGrid( void ) : _values( NullPointer( DataType ) ){ for( unsigned int d=0 ; d<Dim ; d++ ) _res[d] = 0; }
+		~RegularGrid( void ){ DeletePointer( _values ); }
+
+		template< typename Real > static void Read( std::string fileName , unsigned int res[Dim] , Pointer( DataType ) &values , XForm< Real , Dim+1 > &gridToModel );
+		template< typename Real > static void Write( std::string fileName , const unsigned int res[Dim] , ConstPointer( DataType ) values , XForm< Real , Dim+1 > gridToModel );
+
+		template< typename Real > void read( std::string fileName , XForm< Real , Dim+1 > &gridToModel );
+		template< typename Real > void write( std::string fileName , XForm< Real , Dim+1 > gridToModel ) const;
+
+		Pointer( DataType ) operator()( void ){ return _values; }
+		ConstPointer( DataType ) operator()( void ) const { return _values; }
+
+		DataType &operator[]( size_t idx ){ return _values[idx]; }
+		const DataType &operator[]( size_t idx ) const { return _values[idx]; }
+
+		// Take the Dim coordinates and transform them into an index
+		template< typename Int  >                    typename std::enable_if< std::is_integral< Int >::value , size_t >::type index( const Int coords[] ) const { return _index( coords , 0 ); }
+		template< typename Int  >                    typename std::enable_if< std::is_integral< Int >::value , size_t >::type index(       Int coords[] ) const { return _index( coords , 0 ); }
+		template< typename Int , typename ... Ints > typename std::enable_if< std::is_integral< Int >::value , size_t >::type index( Int coord , Ints ... coords ) const { static_assert( sizeof...(coords)+1==Dim , "[ERROR] number of coordinates does not match the number of dimensions" ) ; const Int c[] = { coord , coords ... } ; return index( c ); }
+
+		// Take the index and transform it into the Dim coordinate
+		template< typename Int  >                    typename std::enable_if< std::is_integral< Int >::value >::type setIndex( size_t idx , Int coords[] ) const { _setIndex( idx , coords ); }
+
+		template< typename Int >                     typename std::enable_if< std::is_integral< Int >::value >::type resize( const Int res[] );
+		template< typename Int >                     typename std::enable_if< std::is_integral< Int >::value >::type resize(       Int res[] );
+		template< typename Int , typename ... Ints > typename std::enable_if< std::is_integral< Int >::value >::type resize( Int res , Ints ...  ress );
+
+		template< typename Int >                     typename std::enable_if< std::is_integral< Int >::value ,       DataType & >::type operator()( const Int coords[] )       { return operator[]( index( coords ) ); }
+		template< typename Int >                     typename std::enable_if< std::is_integral< Int >::value ,       DataType & >::type operator()(       Int coords[] )       { return operator[]( index( coords ) ); }
+		template< typename Int >                     typename std::enable_if< std::is_integral< Int >::value , const DataType & >::type operator()( const Int coords[] ) const { return operator[]( index( coords ) ); }
+		template< typename Int >                     typename std::enable_if< std::is_integral< Int >::value , const DataType & >::type operator()(       Int coords[] ) const { return operator[]( index( coords ) ); }
+		template< typename Int , typename ... Ints > typename std::enable_if< std::is_integral< Int >::value ,       DataType & >::type operator()( Int coord , Ints ... coords )       { static_assert( sizeof...(coords)+1==Dim , "[ERROR] number of coordinates does not match the number of dimensions" ) ; const Int c[] = { coord , coords ... } ; return operator()( c ); }
+		template< typename Int , typename ... Ints > typename std::enable_if< std::is_integral< Int >::value , const DataType & >::type operator()( Int coord , Ints ... coords ) const { static_assert( sizeof...(coords)+1==Dim , "[ERROR] number of coordinates does not match the number of dimensions" ) ; const Int c[] = { coord , coords ... } ; return operator()( c ); }
+
+		template< typename Real > typename std::enable_if< !std::is_integral< Real >::value , ProjectiveData< Real , DataType > >::type operator()(       Real coords[] )       { return _Sample( _res , coords , _values ); }
+		template< typename Real > typename std::enable_if< !std::is_integral< Real >::value , ProjectiveData< Real , DataType > >::type operator()( const Real coords[] )       { return _Sample( _res , coords , _values ); }
+		template< typename Real > typename std::enable_if< !std::is_integral< Real >::value , ProjectiveData< Real , DataType > >::type operator()(       Real coords[] ) const { return _Sample( _res , coords , _values ); }
+		template< typename Real > typename std::enable_if< !std::is_integral< Real >::value , ProjectiveData< Real , DataType > >::type operator()( const Real coords[] ) const { return _Sample( _res , coords , _values ); }
+		template< typename Real , typename ... Reals > typename std::enable_if< !std::is_integral< Real >::value , ProjectiveData< Real , DataType > >::type operator()( Real coord , Reals ...  coords  )       { static_assert( sizeof...(coords)+1==Dim , "[ERROR] number of coordinates does not match the number of dimensions" ) ; const Real c[] = { coord , coords ... } ; return operator()( c ); }
+		template< typename Real , typename ... Reals > typename std::enable_if< !std::is_integral< Real >::value , ProjectiveData< Real , DataType > >::type operator()( Real coord , Reals ...  coords  ) const { static_assert( sizeof...(coords)+1==Dim , "[ERROR] number of coordinates does not match the number of dimensions" ) ; const Real c[] = { coord , coords ... } ; return operator()( c ); }
+		template< typename Real > ProjectiveData< Real , DataType > operator()( Point< Real , Dim > coords )       { return operator()( &coords[0] ); }
+		template< typename Real > ProjectiveData< Real , DataType > operator()( Point< Real , Dim > coords ) const { return operator()( &coords[0] ); }
+
+		template< typename Int >                     typename std::enable_if< std::is_integral< int >::value , bool >::type inBounds( const Int coords[] ) const { return _inBounds< Dim-1 >( coords ); }
+		template< typename Int >                     typename std::enable_if< std::is_integral< int >::value , bool >::type inBounds(       Int coords[] ) const { return _inBounds< Dim-1 >( coords ); }
+		template< typename Int , typename ... Ints > typename std::enable_if< std::is_integral< int >::value , bool >::type inBounds( Ints ...  coords   ) const { static_assert( sizeof...(coords)+1==Dim , "[ERROR] number of coordinates does not match the number of dimensions" ) ; const Int c[] = { coords ... } ; return inBounds( c ); }
+
+		const unsigned int *res( void ) const { return _res; }
+		unsigned int res( unsigned int d ) const { return _res[d]; }
+		size_t resolution( void ) const { return _Resolution< Dim >( _res ); }
+
+	protected:
+		template< unsigned int D=Dim > static typename std::enable_if< D==1 , size_t >::type _Resolution( const unsigned int res[] ) { return res[0]; }
+		template< unsigned int D=Dim > static typename std::enable_if< D!=1 , size_t >::type _Resolution( const unsigned int res[] ) { return res[D-1] * _Resolution<D-1>(res); }
+
+		template< typename Real , unsigned int D=Dim > static typename std::enable_if< D==1 , ProjectiveData< Real , DataType > >::type _Sample( const unsigned int res[] , const Real coords[] , ConstPointer( DataType ) values );
+		template< typename Real , unsigned int D=Dim > static typename std::enable_if< D!=1 , ProjectiveData< Real , DataType > >::type _Sample( const unsigned int res[] , const Real coords[] , ConstPointer( DataType ) values );
+
+		// _index( x[0] , ... , x[D-1] ) = x[0] + ... + x[D-1] * ( res[0] * ... * res[D-1] )
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D==Dim-1 && D!=0 , size_t >::type _index(       Int coords[] , size_t idx ) const { return _index< Int , D-1 >( coords , coords[D]               ); }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D!=Dim-1 && D!=0 , size_t >::type _index(       Int coords[] , size_t idx ) const { return _index< Int , D-1 >( coords , coords[D] + idx*_res[D] ); }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D!=Dim-1 && D==0 , size_t >::type _index(       Int coords[] , size_t idx ) const { return                               coords[D] + idx*_res[D]  ; }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D==Dim-1 && D==0 , size_t >::type _index(       Int coords[] , size_t idx ) const { return                               coords[D]                ; }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D==Dim-1 && D!=0 , size_t >::type _index( const Int coords[] , size_t idx ) const { return _index< Int , D-1 >( coords , coords[D]               ); }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D!=Dim-1 && D!=0 , size_t >::type _index( const Int coords[] , size_t idx ) const { return _index< Int , D-1 >( coords , coords[D] + idx*_res[D] ); }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D!=Dim-1 && D==0 , size_t >::type _index( const Int coords[] , size_t idx ) const { return                               coords[D] + idx*_res[D]  ; }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D==Dim-1 && D==0 , size_t >::type _index( const Int coords[] , size_t idx ) const { return                               coords[D]                ; }
+
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D!=0 , size_t >::type _setIndex( size_t idx , Int coords[] ) const { idx = _setIndex< Int , D-1 >( idx , coords ) ; coords[D] = (Int)( idx % _res[D] ) ; return idx / _res[D]; }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D==0 , size_t >::type _setIndex( size_t idx , Int coords[] ) const {                                                coords[D] = (Int)( idx % _res[D] ) ; return idx / _res[D]; }
+
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D==0 , bool >::type _inBounds(       Int coords[] ) const { return coords[0]>=0 && coords[0]<_res[0];                               }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D!=0 , bool >::type _inBounds(       Int coords[] ) const { return coords[D]>=0 && coords[D]<_res[D] && _inBounds< D-1 >( coords ); }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D==0 , bool >::type _inBounds( const Int coords[] ) const { return coords[0]>=0 && coords[0]<_res[0];                               }
+		template< typename Int , unsigned int D=Dim-1 > typename std::enable_if< D!=0 , bool >::type _inBounds( const Int coords[] ) const { return coords[D]>=0 && coords[D]<_res[D] && _inBounds< D-1 >( coords ); }
+
+
+		unsigned int _res[Dim];
+		Pointer( DataType ) _values;
+	};
+#include "RegularGrid.inl"
+}
+
+#endif // REGULAR_GRID_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/RegularGrid.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/RegularGrid.inl
@@ -1,0 +1,220 @@
+/*
+Copyright (c) 2019, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+/////////////////////////
+// RegularGridTypeData //
+/////////////////////////
+
+void RegularGridDataType<>::Write( FILE *fp , unsigned int dim , std::string name ){ fprintf( fp , "%d %s\n" , (int)dim , name.c_str() ); }
+bool RegularGridDataType<>::Read( FILE *fp , unsigned int dim , std::string name )
+{
+	char line[1024];
+	int d;
+	if( fscanf( fp , " %d %s " , &d , line )!=2 ) return false;
+	return d==dim && name==std::string(line);
+}
+
+/////////////////
+// RegularGrid //
+/////////////////
+
+template< typename DataType , unsigned int Dim >
+template< typename Int >
+typename std::enable_if< std::is_integral< Int >::value >::type RegularGrid< DataType , Dim >::resize( Int res[] )
+{
+	if( _values ) DeletePointer( _values );
+	size_t resolution = 1;
+	for( int d=0 ; d<Dim ; d++ ) _res[d] = (unsigned int)res[d] , resolution *= (size_t)res[d];
+	if( resolution ) _values = NewPointer< DataType >( resolution );
+}
+
+template< typename DataType , unsigned int Dim >
+template< typename Int >
+typename std::enable_if< std::is_integral< Int >::value >::type RegularGrid< DataType , Dim >::resize( const Int res[] )
+{
+	if( _values ) DeletePointer( _values );
+	size_t resolution = 1;
+	for( int d=0 ; d<Dim ; d++ ) _res[d] = (unsigned int)res[d] , resolution *= (size_t)res[d];
+	if( resolution ) _values = NewPointer< DataType >( resolution );
+}
+
+template< typename DataType , unsigned int Dim >
+template< typename Int , typename ... Ints >
+typename std::enable_if< std::is_integral< Int >::value >::type RegularGrid< DataType , Dim >::resize( Int res , Ints ... ress )
+{
+	static_assert( sizeof...(ress)+1==Dim , "[ERROR] number of resolutions does not match the number of dimensions" );
+	const Int r[] = { res , ress ... };
+	return resize( r );
+}
+
+template< typename DataType , unsigned int Dim >
+template< typename Real , unsigned int D >
+typename std::enable_if< D==1 , ProjectiveData< Real , DataType > >::type RegularGrid< DataType , Dim >::_Sample( const unsigned int res[] , const Real coords[] , ConstPointer( DataType ) values )
+{
+	int iCoord1 = (int)floor(coords[0]) , iCoord2 = (int)floor(coords[0])+1;
+	Real dx1 = (Real)( iCoord2 - coords[0] ) , dx2 = (Real)( coords[0] - iCoord1 );
+	ProjectiveData< Real , DataType > d;
+	if( iCoord1>=0 && iCoord1<(int)res[0] ) d += ProjectiveData< Real , DataType >( values[ iCoord1 ] * dx1 , dx1 );
+	if( iCoord2>=0 && iCoord2<(int)res[0] ) d += ProjectiveData< Real , DataType >( values[ iCoord2 ] * dx2 , dx2 );
+	return d;
+}
+
+template< typename DataType , unsigned int Dim >
+template< typename Real , unsigned int D >
+typename std::enable_if< D!=1 , ProjectiveData< Real , DataType > >::type RegularGrid< DataType , Dim >::_Sample( const unsigned int res[] , const Real coords[] , ConstPointer( DataType ) values )
+{
+	int iCoord1 = (int)floor(coords[D-1]) , iCoord2 = (int)floor(coords[D-1])+1;
+	Real dx1 = (Real)( iCoord2 - coords[D-1] ) , dx2 = (Real)( coords[D-1] - iCoord1 );
+	ProjectiveData< Real , DataType > d;
+	if( iCoord1>=0 && iCoord1<(int)res[D-1] ) d += _Sample< Real , D-1 >( res , coords , values + _Resolution< D-1 >(res) * iCoord1 ) * dx1;
+	if( iCoord2>=0 && iCoord2<(int)res[D-1] ) d += _Sample< Real , D-1 >( res , coords , values + _Resolution< D-1 >(res) * iCoord2 ) * dx2;
+	return d;
+}
+
+template< typename DataType , unsigned int Dim >
+bool RegularGrid< DataType , Dim >::ReadHeader( std::string fileName , unsigned int &dim , std::string &name )
+{
+	FILE *fp = fopen( fileName.c_str() , "rb" );
+	if( !fp ) return false;
+	else
+	{
+		// Write the magic number
+		int d;
+		if( fscanf( fp , " G%d " , &d )!=1 || d!=Dim ){ fclose(fp) ; return false; }
+
+		char line[1024];
+		if( fscanf( fp , " %d %s " , &d , line )!=2 ){ fclose(fp) ; return false; }
+		dim = d , name =std::string( line );
+		fclose( fp );
+	}
+	return true;
+}
+
+template< typename DataType , unsigned int Dim >
+template< typename Real >
+void RegularGrid< DataType , Dim >::Write( std::string fileName , const unsigned int res[Dim] , ConstPointer( DataType ) values , XForm< Real , Dim+1 > gridToModel )
+{
+	FILE *fp = fopen( fileName.c_str() , "wb" );
+	if( !fp ) MK_THROW( "Failed to open grid file for writing: " , fileName );
+	else
+	{
+		// Write the magic number
+		fprintf( fp , "G%d\n" , (int)Dim );
+
+		RegularGridDataType< DataType >::Write( fp );
+
+		// Write the dimensions
+		for( int d=0 ; d<Dim ; d++ )
+		{
+			fprintf( fp , "%d" , (int)res[d] );
+			if( d==Dim-1 ) fprintf( fp , "\n" );
+			else           fprintf( fp , " " );
+		}
+
+		// Write the transformation
+		for( int j=0 ; j<Dim+1 ; j++ ) for( int i=0 ; i<Dim+1 ; i++ )
+		{
+			fprintf( fp , "%f" , (float)gridToModel(i,j) );
+			if( i==Dim ) fprintf( fp , "\n" );
+			else         fprintf( fp , " " );
+		}
+
+		// Write the grid values
+		fwrite( values , sizeof(DataType) , _Resolution(res) , fp );
+		fclose( fp );
+	}
+}
+
+
+template< typename DataType , unsigned int Dim >
+template< typename Real >
+void RegularGrid< DataType , Dim >::write( std::string fileName , XForm< Real , Dim+1 > gridToModel ) const
+{
+	Write( fileName , _res , _values , gridToModel );
+}
+
+
+template< typename DataType , unsigned int Dim >
+template< typename Real >
+void RegularGrid< DataType , Dim >::Read( std::string fileName , unsigned int res[Dim] , Pointer( DataType ) &values , XForm< Real , Dim+1 > &gridToModel )
+{
+	FILE *fp = fopen( fileName.c_str() , "rb" );
+	if( !fp ) MK_THROW( "Failed to open grid file for reading: " , fileName );
+	else
+	{
+		// Read the magic number
+		{
+			int dim;
+			if( fscanf( fp , " G%d " , &dim )!=1 ) MK_THROW( "Failed to read magic number: " , fileName );
+			if( dim!=Dim ) MK_THROW( "Dimensions don't match: " , Dim , " != " , dim );
+		}
+
+		// Read the data type
+		if( !RegularGridDataType< DataType >::Read( fp ) ) MK_THROW( "Failed to read type" );
+
+		// Read the dimensions
+		{
+			int r;
+			for( int d=0 ; d<Dim ; d++ )
+			{
+				if( fscanf( fp , " %d " , &r )!=1 ) MK_THROW( "Failed to read dimension[ " , d , " ]" );
+				res[d] = r;
+			}
+		}
+
+		// Read the transformation
+		{
+			float x;
+			for( int j=0 ; j<Dim+1 ; j++ ) for( int i=0 ; i<Dim+1 ; i++ )
+			{
+				if( fscanf( fp , " %f" , &x )!=1 ) MK_THROW( "Failed to read xForm( " , i , " , " , j , " )" );
+				gridToModel(i,j) = x;
+			}
+		}
+
+		// Read through the end of the line
+		{
+			char line[1024];
+			if( !fgets( line , sizeof(line)/sizeof(char) , fp ) ) MK_THROW( "Could not read end of line" );
+		}
+
+		values = NewPointer< DataType >( _Resolution(res) );
+
+		// Write the grid values
+		fread( values , sizeof(DataType) , _Resolution(res) , fp );
+		fclose( fp );
+	}
+}
+
+
+template< typename DataType , unsigned int Dim >
+template< typename Real >
+void RegularGrid< DataType , Dim >::read( std::string fileName , XForm< Real , Dim+1 > &gridToModel )
+{
+	Read( fileName , _res , _values , gridToModel );
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/RegularTree.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/RegularTree.h
@@ -1,0 +1,412 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef REGULAR_TREE_NODE_INCLUDED
+#define REGULAR_TREE_NODE_INCLUDED
+
+#include <functional>
+#include <stdlib.h>
+#include <math.h>
+#include <algorithm>
+#include "Streams.h"
+#include "Allocator.h"
+#include "BinaryNode.h"
+#include "Window.h"
+#include "MyMiscellany.h"
+#include "Array.h"
+#include "MyAtomic.h"
+
+namespace PoissonRecon
+{
+	template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+	struct RegularTreeNode
+	{
+		// This struct temporarily makes a node appear to be a root node by removing the parent reference
+		struct SubTreeExtractor
+		{
+			SubTreeExtractor( RegularTreeNode &root ) : _root(root)
+			{
+				_rootParent = _root.parent;
+				_root.parent = NULL;
+				_root.depthAndOffset( _depth , _offset );
+				int depth=0 , offset[Dim];
+				for( unsigned int d=0 ; d<Dim ; d++ ) offset[d] = 0;
+				RegularTreeNode::ResetDepthAndOffset( &_root , depth , offset );
+			}
+			SubTreeExtractor( RegularTreeNode *root ) : SubTreeExtractor( *root ){}
+			~SubTreeExtractor( void )
+			{
+				RegularTreeNode::ResetDepthAndOffset( &_root , _depth , _offset );
+				_root.parent = _rootParent;
+			}
+		protected:
+			RegularTreeNode &_root , *_rootParent;
+			int _depth , _offset[Dim];
+		};
+
+		struct DepthAndOffset
+		{
+			DepthAndOffsetType depth , offset[Dim];
+			DepthAndOffset( void ){ depth = 0 , memset( offset , 0 , sizeof(DepthAndOffsetType) * Dim ); }
+			DepthAndOffset( DepthAndOffsetType d , const DepthAndOffsetType off[] ){ depth = d , memcpy( offset , off , sizeof(DepthAndOffsetType) * Dim ); }
+			bool operator == ( const DepthAndOffset &doff ) const
+			{
+				if( depth!=doff.depth ) return false;
+				for( int d=0 ; d<Dim ; d++ ) if( offset[d]!=doff.offset[d] ) return false;
+				return true;
+			}
+
+			friend std::ostream &operator << ( std::ostream &os , const DepthAndOffset &depthAndOffset )
+			{
+				os << "( " << depthAndOffset.offset[0];
+				for( unsigned int d=1 ; d<Dim ; d++ ) os << " , " << depthAndOffset.offset[d];
+				return os << " ) @ " << depthAndOffset.depth;
+			}
+		};
+	private:
+		DepthAndOffsetType _depth , _offset[Dim];
+		template< typename Initializer >
+		bool _initChildren  ( Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer );
+		template< typename Initializer >
+		bool _initChildren_s( Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer );
+	public:
+
+		RegularTreeNode* parent;
+		RegularTreeNode* children;
+		NodeData nodeData;
+
+		RegularTreeNode( void );
+		static RegularTreeNode* NewBrood( Allocator< RegularTreeNode >* nodeAllocator )
+		{
+			auto initializer = []( RegularTreeNode & ){};
+			return NewBrood( nodeAllocator , initializer );
+		}
+
+		template< typename Initializer >
+		RegularTreeNode( Initializer &initializer );
+		template< typename Initializer >
+		static RegularTreeNode* NewBrood( Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer );
+		template< bool ThreadSafe >
+		bool initChildren( Allocator< RegularTreeNode >* nodeAllocator )
+		{
+			auto initializer = []( RegularTreeNode & ){};
+			return this->template initChildren< ThreadSafe >( nodeAllocator , initializer );
+		}
+		template< bool ThreadSafe , typename Initializer >
+		bool initChildren( Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer )
+		{
+			return ThreadSafe ? _initChildren_s( nodeAllocator , initializer ) : _initChildren( nodeAllocator , initializer );
+		}
+		void cleanChildren( bool deleteChildren );
+		static void ResetDepthAndOffset( RegularTreeNode* root , int d , int off[Dim] );
+		~RegularTreeNode( void );
+
+		// KeepNodeFunctor looks like std::function< bool ( const RegularTreeNode * ) >
+		template< typename KeepNodeFunctor >
+		void copySubTree( RegularTreeNode &subTree , const KeepNodeFunctor &keepNodeFunctor , Allocator< RegularTreeNode > *nodeAllocator=NULL ) const;
+
+		template< typename KeepNodeFunctor >
+		Pointer( RegularTreeNode ) serializeSubTree( const KeepNodeFunctor &keepNodeFunctor , size_t &nodeCount ) const;
+
+		// The merge functor takes two objects of type NodeData and returns an object of type NodeData
+		// [NOTE] We are assuming that the merge functor is symmetric, f(a,b) = f(b,a), and implicity satisfies f(a) = a
+		template< class MergeFunctor >
+		void merge( RegularTreeNode* node , MergeFunctor& f );
+
+		void depthAndOffset( int& depth , int offset[Dim] ) const;
+		DepthAndOffset depthAndOffset( void ) const;
+		void centerIndex( int index[Dim] ) const;
+		int depth( void ) const;
+		template< class Real > void centerAndWidth( Point< Real , Dim >& center , Real& width ) const;
+		template< class Real > void startAndWidth( Point< Real , Dim >& start , Real& width ) const;
+		template< class Real > bool isInside( Point< Real , Dim > p ) const;
+
+		size_t leaves( void ) const;
+		size_t maxDepthLeaves( int maxDepth ) const;
+		size_t nodes( void ) const;
+		int maxDepth( void ) const;
+
+		const RegularTreeNode* root( void ) const;
+
+		/* These functions apply the functor to the node and all descendents, terminating either at a leaf or when the functor returns false. */
+		template< typename NodeFunctor /* = std::function< bool/void ( RegularTreeNode * ) > */ >
+		void processNodes( NodeFunctor nodeFunctor );
+		template< typename NodeFunctor /* = std::function< bool/void ( const RegularTreeNode * ) > */ >
+		void processNodes( NodeFunctor nodeFunctor ) const;
+		template< typename NodeFunctor /* = std::function< void ( RegularTreeNode * ) > */ >
+		void processLeaves( NodeFunctor nodeFunctor );
+		template< typename NodeFunctor /* = std::function< void ( const RegularTreeNode * ) > */ >
+		void processLeaves( NodeFunctor nodeFunctor ) const;
+	protected:
+		template< typename NodeFunctor /* = std::function< bool/void ( RegularTreeNode * ) > */ >
+		void _processChildNodes( NodeFunctor &nodeFunctor );
+		template< typename NodeFunctor /* = std::function< bool/void ( const RegularTreeNode * ) > */ >
+		void _processChildNodes( NodeFunctor &nodeFunctor ) const;
+		template< typename NodeFunctor /* = std::function< bool/void ( RegularTreeNode * ) > */ >
+		void _processChildLeaves( NodeFunctor &nodeFunctor );
+		template< typename NodeFunctor /* = std::function< bool/void ( const RegularTreeNode * ) > */ >
+		void _processChildLeaves( NodeFunctor &nodeFunctor ) const;
+	public:
+
+		void setFullDepth( int maxDepth , Allocator< RegularTreeNode >* nodeAllocator )
+		{
+			auto initializer = []( RegularTreeNode & ){};
+			return setFullDepth( nodeAllocator , initializer );
+		}
+		template< typename Initializer >
+		void setFullDepth( int maxDepth , Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer );
+
+		template< typename PruneChildrenFunctor >
+		void pruneChildren( const PruneChildrenFunctor pruneFunctor , bool deleteChildren );
+
+		void printLeaves( void ) const;
+		void printRange( void ) const;
+
+		template< class Real > static int ChildIndex( const Point< Real , Dim >& center , const Point< Real , Dim > &p );
+
+		// WriteNodeFunctor looks like std::function< bool ( const RegularTreeNode * ) >
+		template< typename WriteNodeFunctor >
+		bool write( BinaryStream &stream , bool serialize , const WriteNodeFunctor &writeNodeFunctor ) const;
+		bool write( BinaryStream &stream , bool serialize ) const { return write( stream , serialize , []( const RegularTreeNode * ){ return true; } ); }
+
+		template< typename Initializer >
+		bool read( BinaryStream &stream , Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer );
+		bool read( BinaryStream &stream , Allocator< RegularTreeNode >* nodeAllocator )
+		{
+			auto initializer = []( RegularTreeNode & ){};
+			return read( stream , nodeAllocator , initializer );
+		}
+
+		template< typename Pack > struct Neighbors{};
+
+		template< unsigned int ... Widths >
+		struct Neighbors< ParameterPack::UIntPack< Widths ... > >
+		{
+			using StaticWindow = Window::StaticWindow< RegularTreeNode * , Widths ... >;
+			StaticWindow neighbors;
+			Neighbors( void );
+			void clear( void );
+		};
+		template< typename Pack > struct ConstNeighbors{};
+		template< unsigned int ... Widths >
+		struct ConstNeighbors< ParameterPack::UIntPack< Widths ... > >
+		{
+			using StaticWindow = Window::StaticWindow< const RegularTreeNode * , Widths ... >;
+			StaticWindow neighbors;
+			ConstNeighbors( void );
+			void clear( void );
+		};
+
+		template< typename LeftPack , typename RightPack > struct NeighborKey{};
+		template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+		struct NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >
+		{
+		protected:
+			static_assert( sizeof...(LeftRadii)==sizeof...(RightRadii) , "[ERROR] Left and right radii dimensions don't match" );
+			int _depth;
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int ... _PLeftRadii , unsigned int ... _PRightRadii , unsigned int ... _CLeftRadii , unsigned int ... _CRightRadii >
+			static unsigned int _NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadii ... > , Window::ConstSlice< RegularTreeNode* , ( _PLeftRadii+_PRightRadii+1 ) ... > pNeighbors , Window::Slice< RegularTreeNode* , ( _CLeftRadii+_CRightRadii+1 ) ... > cNeighbors , int cIdx , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer );
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int ... _PLeftRadii , unsigned int ... _PRightRadii , unsigned int ... _CLeftRadii , unsigned int ... _CRightRadii >
+			static unsigned int _NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadii ... > ,      Window::Slice< RegularTreeNode* , ( _PLeftRadii+_PRightRadii+1 ) ... > pNeighbors , Window::Slice< RegularTreeNode* , ( _CLeftRadii+_CRightRadii+1 ) ... > cNeighbors , int cIdx , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer );
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , typename PLeft , typename PRight , typename CLeft , typename CRight > struct _Run{};
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int _PLeftRadius , unsigned int ... _PLeftRadii , unsigned int _PRightRadius , unsigned int ... _PRightRadii , unsigned int _CLeftRadius , unsigned int ... _CLeftRadii , unsigned int _CRightRadius , unsigned int ... _CRightRadii >
+			struct _Run< CreateNodes , ThreadSafe , NodeInitializer , ParameterPack::UIntPack< _PLeftRadius , _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadius , _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadius , _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadius , _CRightRadii ... > >
+			{
+				static unsigned int Run( Window::ConstSlice< RegularTreeNode* , _PLeftRadius+_PRightRadius+1 , ( _PLeftRadii+_PRightRadii+1 ) ... > pNeighbors , Window::Slice< RegularTreeNode* , _CLeftRadius+_CRightRadius+1 , ( _CLeftRadii+_CRightRadii+1 ) ... > cNeighbors , int* c , int cornerIndex , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer );
+			};
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int _PLeftRadius , unsigned int _PRightRadius , unsigned int _CLeftRadius , unsigned int _CRightRadius >
+			struct _Run< CreateNodes , ThreadSafe , NodeInitializer , ParameterPack::UIntPack< _PLeftRadius > , ParameterPack::UIntPack< _PRightRadius > , ParameterPack::UIntPack< _CLeftRadius > , ParameterPack::UIntPack< _CRightRadius > >
+			{
+				static unsigned int Run( Window::ConstSlice< RegularTreeNode* , _PLeftRadius+_PRightRadius+1 > pNeighbors , Window::Slice< RegularTreeNode* , _CLeftRadius+_CRightRadius+1 > cNeighbors , int* c , int cornerIndex , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer );
+			};
+		public:
+			static const unsigned int CenterIndex = Window::Index< ( LeftRadii + RightRadii + 1 ) ... >::template I< LeftRadii ... >();
+			typedef Neighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > > NeighborType;
+			NeighborType* neighbors;
+
+
+			NeighborKey( void );
+			NeighborKey( const NeighborKey& key );
+			~NeighborKey( void );
+
+			int depth( void ) const { return _depth; }
+			void set( int depth );
+
+			RegularTreeNode *center( unsigned int depth ){ return neighbors[depth].neighbors.data[ CenterIndex ]; }
+			const RegularTreeNode *center( unsigned int depth ) const { return neighbors[depth].neighbors.data[ CenterIndex ]; }
+
+			template< bool CreateNodes , bool ThreadSafe >
+			typename RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::template Neighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& getNeighbors( RegularTreeNode* node , Allocator< RegularTreeNode >* nodeAllocator )
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getNeighbors< CreateNodes , ThreadSafe >( node , nodeAllocator , initializer );				
+			}
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer >
+			typename RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::template Neighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& getNeighbors( RegularTreeNode* node , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &nodeInitializer );
+
+			NeighborType& getNeighbors( const RegularTreeNode* node )
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getNeighbors< false , false >( (RegularTreeNode*)node , NULL , initializer );
+			}
+
+			template< bool CreateNodes , bool ThreadSafe , unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+			void getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > ,       RegularTreeNode* node , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors , Allocator< RegularTreeNode >* nodeAllocator )
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getNeighbors( ParameterPack::UIntPack< _LeftRadii ... >() , ParameterPack::UIntPack< _RightRadii ... >() , node , neighbors , nodeAllocator , initializer );
+			}
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+			void getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > ,       RegularTreeNode* node , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer );
+
+			template< unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+			void getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > , const RegularTreeNode* node , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors )
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getNeighbors< false , false >( ParameterPack::UIntPack< _LeftRadii ... >() , ParameterPack::UIntPack< _RightRadii ... >() , (RegularTreeNode*)node , NULL , initializer );
+			}
+
+			template< bool CreateNodes , bool ThreadSafe , unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+			void getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > ,       RegularTreeNode* node , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& pNeighbors , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors , Allocator< RegularTreeNode >* nodeAllocator )
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getNeighbors( ParameterPack::UIntPack< _LeftRadii ... >() , ParameterPack::UIntPack< _RightRadii ... >() , node , pNeighbors , neighbors , nodeAllocator , initializer );
+			}
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+			void getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > ,       RegularTreeNode* node , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& pNeighbors , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer );
+
+			template< unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+			void getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > , const RegularTreeNode* node , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& pNeighbors , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors )
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getNeighbors< false , false >( ParameterPack::UIntPack< _LeftRadii ... >() , ParameterPack::UIntPack< _RightRadii ... >() , (RegularTreeNode*)node , NULL , initializer );
+			}
+
+			template< bool CreateNodes , bool ThreadSafe >
+			unsigned int getChildNeighbors( int cIdx , int d , NeighborType& childNeighbors , Allocator< RegularTreeNode >* nodeAllocator ) const
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getChildNeighbors( cIdx , d , childNeighbors , nodeAllocator , initializer );
+			}
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer >
+			unsigned int getChildNeighbors( int cIdx , int d , NeighborType& childNeighbors , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer ) const;
+
+			unsigned int getChildNeighbors( int cIdx , int d , NeighborType& childNeighbors ) const
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getChildNeighbors< false , false >( cIdx , d , childNeighbors , NULL , initializer );
+			}
+
+			template< bool CreateNodes , bool ThreadSafe , class Real >
+			unsigned int getChildNeighbors( Point< Real , Dim > p , int d , NeighborType& childNeighbors , Allocator< RegularTreeNode >* nodeAllocator ) const
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getChildNeighbors( p , d , childNeighbors , nodeAllocator , initializer );
+			}
+
+			template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , class Real >
+			unsigned int getChildNeighbors( Point< Real , Dim > p , int d , NeighborType& childNeighbors , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer ) const;
+
+			template< class Real >
+			unsigned int getChildNeighbors( Point< Real , Dim > p , int d , NeighborType& childNeighbors ) const
+			{
+				auto initializer = []( RegularTreeNode & ){};
+				return getChildNeighbors< false , false , Real >( p , d , childNeighbors , NULL , initializer );
+			}
+
+			void setLeafNeighbors( RegularTreeNode *node , Window::StaticWindow< RegularTreeNode * , ( LeftRadii + RightRadii + 1 ) ... > &leaves );
+		};
+
+		template< typename LeftPack , typename RightPack > struct ConstNeighborKey{};
+
+		template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+		struct ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >
+		{
+		protected:
+			static_assert( sizeof...(LeftRadii)==sizeof...(RightRadii) , "[ERROR] Left and right radii dimensions don't match" );
+			int _depth;
+
+			template< unsigned int ... _PLeftRadii , unsigned int ... _PRightRadii , unsigned int ... _CLeftRadii , unsigned int ... _CRightRadii >
+			static unsigned int _NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadii ... > , Window::ConstSlice< const RegularTreeNode* , ( _PLeftRadii+_PRightRadii+1 ) ... > pNeighbors , Window::Slice< const RegularTreeNode* , ( _CLeftRadii+_CRightRadii+1 ) ... > cNeighbors , int cIdx );
+			template< unsigned int ... _PLeftRadii , unsigned int ... _PRightRadii , unsigned int ... _CLeftRadii , unsigned int ... _CRightRadii >
+			static unsigned int _NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadii ... > , Window::Slice< const RegularTreeNode* , ( _PLeftRadii+_PRightRadii+1 ) ... > pNeighbors , Window::Slice< const RegularTreeNode* , ( _CLeftRadii+_CRightRadii+1 ) ... > cNeighbors , int cIdx );
+
+			template< typename PLeft , typename PRight , typename CLeft , typename CRight > struct _Run{};
+
+			template< unsigned int _PLeftRadius , unsigned int ... _PLeftRadii , unsigned int _PRightRadius , unsigned int ... _PRightRadii , unsigned int _CLeftRadius , unsigned int ... _CLeftRadii , unsigned int _CRightRadius , unsigned int ... _CRightRadii >
+			struct _Run< ParameterPack::UIntPack< _PLeftRadius , _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadius , _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadius , _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadius , _CRightRadii ... > >
+			{
+				static unsigned int Run( Window::ConstSlice< const RegularTreeNode* , _PLeftRadius + _PRightRadius + 1 , ( _PLeftRadii+_PRightRadii+1 ) ... > pNeighbors , Window::Slice< const RegularTreeNode* , _CLeftRadius + _CRightRadius + 1 , ( _CLeftRadii+_CRightRadii+1 ) ... > cNeighbors , int* c , int cornerIndex );
+			};
+			template< unsigned int _PLeftRadius , unsigned int _PRightRadius , unsigned int _CLeftRadius , unsigned int _CRightRadius >
+			struct _Run< ParameterPack::UIntPack< _PLeftRadius > , ParameterPack::UIntPack< _PRightRadius > , ParameterPack::UIntPack< _CLeftRadius > , ParameterPack::UIntPack< _CRightRadius > >
+			{
+				static unsigned int Run( Window::ConstSlice< const RegularTreeNode* , _PLeftRadius+_PRightRadius+1 > pNeighbors , Window::Slice< const RegularTreeNode* , _CLeftRadius+_CRightRadius+1 > cNeighbors , int* c , int cornerIndex );
+			};
+
+		public:
+			static const unsigned int CenterIndex = Window::Index< ( LeftRadii + RightRadii + 1 ) ... >::template I< LeftRadii ... >();
+			typedef ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > > NeighborType;
+			NeighborType* neighbors;
+
+			ConstNeighborKey( void );
+			ConstNeighborKey( const ConstNeighborKey& key );
+			~ConstNeighborKey( void );
+			ConstNeighborKey& operator = ( const ConstNeighborKey& key );
+
+			int depth( void ) const { return _depth; }
+			void set( int depth );
+			const RegularTreeNode *center( unsigned int depth ) const { return neighbors[depth].neighbors.data[ CenterIndex ]; }
+
+			typename RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::template ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& getNeighbors( const RegularTreeNode* node );
+			template< unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+			void getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > , const RegularTreeNode* node , ConstNeighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors );
+			template< unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+			void getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > , const RegularTreeNode* node , ConstNeighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& pNeighbors , ConstNeighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors );
+			unsigned int getChildNeighbors( int cIdx , int d , NeighborType& childNeighbors ) const;
+			template< class Real >
+			unsigned int getChildNeighbors( Point< Real , Dim > p , int d , ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& childNeighbors ) const;
+
+			void setLeafNeighbors( const RegularTreeNode *node , Window::StaticWindow< RegularTreeNode * , ( LeftRadii + RightRadii + 1 ) ... > &leaves );
+		};
+
+		int width( int maxDepth ) const;
+	};
+
+#include "RegularTree.inl"
+}
+
+#endif // REGULAR_TREE_NODE_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/RegularTree.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/RegularTree.inl
@@ -1,0 +1,1065 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+/////////////////////
+// RegularTreeNode //
+/////////////////////
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::RegularTreeNode( void )
+{
+	parent = children = NULL;
+	_depth = 0;
+	memset( _offset , 0 , sizeof(_offset ) );
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename Initializer >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::RegularTreeNode( Initializer &initializer ) : RegularTreeNode() { initializer( *this ); }
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::cleanChildren( bool deleteChildren )
+{
+	if( children )
+	{
+		for( int c=0 ; c<(1<<Dim) ; c++ ) children[c].cleanChildren( deleteChildren );
+		if( deleteChildren ) delete[] children;
+	}
+	children = NULL;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::~RegularTreeNode(void)
+{
+#ifdef SHOW_WARNINGS
+#pragma message( "[WARNING] Deallocation of children is your responsibility" )
+#endif // SHOW_WARNINGS
+	parent = children = NULL;
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename Initializer >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >* RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NewBrood( Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer )
+{
+	RegularTreeNode< Dim , NodeData , DepthAndOffsetType >* brood;
+	if( nodeAllocator ) brood = PointerAddress( nodeAllocator->newElements( 1<<Dim ) );
+	else                brood = new RegularTreeNode[ 1<<Dim ];
+	for( int idx=0 ; idx<(1<<Dim) ; idx++ )
+	{
+		initializer( brood[idx] );
+		brood[idx]._depth = 0;
+		for( int d=0 ; d<Dim ; d++ ) brood[idx]._offset[d] = (idx>>d) & 1;
+	}
+	return brood;
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ResetDepthAndOffset( RegularTreeNode* root , int depth , int offset[Dim] )
+{
+	root->_depth = depth;
+	for( unsigned int d=0 ; d<Dim ; d++ ) root->_offset[d] = offset[d];
+	if( root->children )
+	{
+		int _offset[Dim];
+		for( unsigned int d=0 ; d<Dim ; d++ ) _offset[d] = offset[d]<<1;
+		for( unsigned int c=0 ; c<(1<<Dim) ; c++ )
+		{
+			for( unsigned int d=0 ; d<Dim ; d++ ) _offset[d] = ( offset[d]<<1 ) | ( (c>>d) & 1 );
+			ResetDepthAndOffset( root->children + c , depth+1 , _offset );
+		}
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename Initializer >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::setFullDepth( int maxDepth , Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer )
+{
+	if( maxDepth>0 )
+	{
+		if( !children ) initChildren< false >( nodeAllocator , initializer );
+		for( int i=0 ; i<(1<<Dim) ; i++ ) children[i].setFullDepth( maxDepth-1 , nodeAllocator , initializer );
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename PruneChildrenFunctor >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::pruneChildren( PruneChildrenFunctor pruneFunctor , bool deleteChildren )
+{
+	if( children )
+	{
+		if( pruneFunctor( this ) ) cleanChildren( deleteChildren );
+		else for( int i=0 ; i<(1<<Dim) ; i++ ) children[i].pruneChildren( pruneFunctor , deleteChildren );
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename Initializer >
+bool RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::_initChildren( Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer )
+{
+	if( nodeAllocator ) children = PointerAddress( nodeAllocator->newElements( 1<<Dim ) );
+	else
+	{
+		if( children ) delete[] children;
+		children = new RegularTreeNode[ 1<<Dim ];
+	}
+	if( !children ) MK_THROW( "Failed to initialize children" );
+	for( int idx=0 ; idx<(1<<Dim) ; idx++ )
+	{
+		children[idx].parent = this;
+		children[idx].children = NULL;
+		initializer( children[idx] );
+		children[idx]._depth = _depth+1;
+		for( int d=0 ; d<Dim ; d++ ) children[idx]._offset[d] = (_offset[d]<<1) | ( (idx>>d) & 1 );
+	}
+	return true;
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename Initializer >
+bool RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::_initChildren_s( Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer )
+{
+	RegularTreeNode * volatile & children = this->children;
+	RegularTreeNode *_children;
+
+	// Allocate the children
+	if( nodeAllocator ) _children = PointerAddress( nodeAllocator->newElements( 1<<Dim ) );
+	else                _children = new RegularTreeNode[ 1<<Dim ];
+	if( !_children ) MK_THROW( "Failed to initialize children" );
+	for( int idx=0 ; idx<(1<<Dim) ; idx++ )
+	{
+		_children[idx].parent = this;
+		_children[idx].children = NULL;
+		_children[idx]._depth = _depth+1;
+		for( int d=0 ; d<Dim ; d++ ) _children[idx]._offset[d] = (_offset[d]<<1) | ( (idx>>d) & 1 );
+		// [WARNING] We are assuming that it's OK to initialize nodes that may not be used.
+		for( int idx=0 ; idx<(1<<Dim) ; idx++ ) initializer( _children[idx] );
+	}
+
+	// If we are the first to set the child, initialize
+	if( SetAtomic( children , _children , (RegularTreeNode *)NULL ) ) return true;
+	// Otherwise clean up
+	else
+	{
+		if( nodeAllocator ) ;
+		else delete[] _children;
+		return false;
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< class MergeFunctor >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::merge( RegularTreeNode* node , MergeFunctor& f )
+{
+	if( node )
+	{
+		nodeData = f( nodeData , node->nodeData );
+		if( children && node->children ) for( int c=0 ; c<(1<<Dim) ; c++ ) children[c].merge( node->children[c] , f );
+		else if( node->children )
+		{
+			children = node->children;
+			for( int c=0 ; c<(1<<Dim) ; c++ ) children[c].parent = this;
+			node->children = NULL;
+		}
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+inline typename RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::DepthAndOffset RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::depthAndOffset( void ) const
+{
+	DepthAndOffset doff;
+	doff.depth = _depth;
+	for( int d=0 ; d<Dim ; d++ ) doff.offset[d] = _offset[d];
+	return doff;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+inline void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::depthAndOffset( int& depth , int offset[Dim] ) const
+{
+	depth = _depth;
+	for( int d=0 ; d<Dim ; d++ ) offset[d] = _offset[d];
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+inline void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::centerIndex( int index[Dim] ) const
+{
+	for( int i=0 ; i<Dim ; i++ ) index[i] = BinaryNode::CenterIndex( _depth , _offset[i] );
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+inline int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::depth( void ) const { return _depth; }
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< class Real >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::centerAndWidth( Point< Real , Dim >& center , Real& width ) const
+{
+	width = Real( 1.0 / (1<<_depth) );
+	for( int d=0 ; d<Dim ; d++ ) center[d] = Real( 0.5+_offset[d] ) * width;
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< class Real >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::startAndWidth( Point< Real , Dim >& start , Real& width ) const
+{
+	width = Real( 1.0 / (1<<_depth) );
+	for( int d=0 ; d<Dim ; d++ ) start[d] = Real( _offset[d] ) * width;
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< class Real >
+bool RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::isInside( Point< Real , Dim > p ) const
+{
+	Point< Real , Dim > c ; Real w;
+	centerAndWidth( c , w ) , w /= 2;
+	for( int d=0 ; d<Dim ; d++ ) if( p[d]<=(c[d]-w) || p[d]>(c[d]+w) ) return false;
+	return true;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::maxDepth(void) const
+{
+	if( !children ) return 0;
+	else
+	{
+		int c , d;
+		for( int i=0 ; i<(1<<Dim) ; i++ )
+		{
+			d = children[i].maxDepth();
+			if( !i || d>c ) c=d;
+		}
+		return c+1;
+	}
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+size_t RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::nodes( void ) const
+{
+	if( !children ) return 1;
+	else
+	{
+		size_t c=0;
+		for( int i=0 ; i<(1<<Dim) ; i++ ) c += children[i].nodes();
+		return c+1;
+	}
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+size_t RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::leaves( void ) const
+{
+	if( !children ) return 1;
+	else
+	{
+		size_t c=0;
+		for( int i=0 ; i<(1<<Dim) ; i++ ) c += children[i].leaves();
+		return c;
+	}
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+size_t RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::maxDepthLeaves( int maxDepth ) const
+{
+	if( depth()>maxDepth ) return 0;
+	if( !children ) return 1;
+	else
+	{
+		size_t c=0;
+		for( int i=0 ; i<(1<<Dim) ; i++ ) c += children[i].maxDepthLeaves(maxDepth);
+		return c;
+	}
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+const RegularTreeNode< Dim , NodeData , DepthAndOffsetType >* RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::root( void ) const
+{
+	const RegularTreeNode* temp = this;
+	while( temp->parent ) temp = temp->parent;
+	return temp;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename NodeFunctor /* = std::function< bool/void ( RegularTreeNode * ) > */ >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::processNodes( NodeFunctor nodeFunctor )
+{
+	if constexpr( std::is_same< bool , typename std::invoke_result< NodeFunctor , RegularTreeNode * >::type >::value )
+	{
+		if( nodeFunctor( this ) && children )
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+				if( nodeFunctor( children + c ) && children[c].children )
+					children[c]._processChildNodes( nodeFunctor );
+	}
+	else
+	{
+		nodeFunctor( this );
+		if( children ) for( int c=0 ; c<(1<<Dim) ; c++ )
+		{
+			nodeFunctor( children + c );
+			if( children[c].children ) children[c]._processChildNodes( nodeFunctor );
+		}
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename NodeFunctor /* = std::function< bool/void ( const RegularTreeNode * ) > */ >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::processNodes( NodeFunctor nodeFunctor ) const
+{
+	if constexpr( std::is_same< bool , typename std::invoke_result< NodeFunctor , RegularTreeNode * >::type >::value )
+	{
+		if( nodeFunctor( this ) && children )
+			for( int c=0 ; c<(1<<Dim) ; c++ )
+				if( nodeFunctor( children + c ) && children[c].children )
+					children[c]._processChildNodes( nodeFunctor );
+	}
+	else
+	{
+		nodeFunctor( this );
+		if( children ) for( int c=0 ; c<(1<<Dim) ; c++ )
+		{
+			nodeFunctor( children + c );
+			if( children[c].children ) children[c]._processChildNodes( nodeFunctor );
+		}
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename NodeFunctor /* = std::function< void ( RegularTreeNode * ) > */ >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::processLeaves( NodeFunctor nodeFunctor )
+{
+	if( children )
+	{
+		for( int c=0 ; c<(1<<Dim) ; c++ )
+			if( children[c].children ) children[c]._processChildLeaves( nodeFunctor );
+			else nodeFunctor( children+c );
+	}
+	else nodeFunctor( this );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename NodeFunctor /* = std::function< void ( const RegularTreeNode * ) > */ >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::processLeaves( NodeFunctor nodeFunctor ) const
+{
+	if( children )
+	{
+		for( int c=0 ; c<(1<<Dim) ; c++ )
+			if( children[c].children ) children[c]._processChildLeaves( nodeFunctor );
+			else nodeFunctor( children+c );
+	}
+	else nodeFunctor( this );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename NodeFunctor /* = std::function< bool/void ( RegularTreeNode * ) > */ >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::_processChildNodes( NodeFunctor &nodeFunctor )
+{
+	if constexpr( std::is_same< bool , typename std::invoke_result< NodeFunctor , RegularTreeNode * >::type >::value )
+	{
+		for( int c=0 ; c<(1<<Dim) ; c++ )
+			if( nodeFunctor( children + c ) && children[c].children )
+				children[c]._processChildNodes( nodeFunctor );
+	}
+	else
+	{
+		for( int c=0 ; c<(1<<Dim) ; c++ )
+		{
+			nodeFunctor( children + c );
+			if( children[c].children ) children[c]._processChildNodes( nodeFunctor );
+		}
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename NodeFunctor /* = std::function< bool/void ( const RegularTreeNode * ) > */ >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::_processChildNodes( NodeFunctor &nodeFunctor ) const
+{
+	if constexpr( std::is_same< bool , typename std::invoke_result< NodeFunctor , RegularTreeNode * >::type >::value )
+	{
+		for( int c=0 ; c<(1<<Dim) ; c++ )
+			if( nodeFunctor( children + c ) && children[c].children )
+				children[c]._processChildNodes( nodeFunctor );
+	}
+	else
+	{
+		for( int c=0 ; c<(1<<Dim) ; c++ )
+		{
+			nodeFunctor( children + c );
+			if( children[c].children ) children[c]._processChildNodes( nodeFunctor );
+		}
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename NodeFunctor /* = std::function< void ( RegularTreeNode * ) > */ >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::_processChildLeaves( NodeFunctor &nodeFunctor )
+{
+	for( int c=0 ; c<(1<<Dim) ; c++ )
+		if( children[c].children ) children[c]._processChildLeaves( nodeFunctor );
+		else nodeFunctor( children+c );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename NodeFunctor /* = std::function< void ( const RegularTreeNode * ) > */ >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::_processChildLeaves( NodeFunctor &nodeFunctor ) const
+{
+	for( int c=0 ; c<(1<<Dim) ; c++ )
+		if( children[c].children ) children[c]._processChildLeaves( nodeFunctor );
+		else nodeFunctor( children+c );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::printRange(void) const
+{
+	Point< float , Dim > center;
+	float width;
+	centerAndWidth( center , width );
+	for( int d=0 ; d<Dim ; d++ )
+	{
+		printf( "[%f,%f]" , center[d]-width/2 , center[d]+width/2 );
+		if( d<Dim-1 ) printf( " x " );
+		else printf("\n");
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< class Real >
+int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ChildIndex( const Point< Real , Dim >& center , const Point< Real , Dim >& p )
+{
+	int cIndex=0;
+	for( int d=0 ; d<Dim ; d++ ) if( p[d]>center[d] ) cIndex |= (1<<d);
+	return cIndex;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename KeepNodeFunctor >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::copySubTree( RegularTreeNode< Dim , NodeData , DepthAndOffsetType > &subTree , const KeepNodeFunctor &keepNodeFunctor , Allocator< RegularTreeNode > *nodeAllocator ) const
+{
+	bool copyChildren = false;
+	if( children ) for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) copyChildren |= keepNodeFunctor( children+c );
+	if( copyChildren )
+	{
+		if( nodeAllocator ) subTree.children = PointerAddress( nodeAllocator->newElements( 1<<Dim ) );
+		else                subTree.children = new RegularTreeNode[ 1<<Dim ];
+		for( unsigned int c=0 ; c<(1<<Dim) ; c++ )
+		{
+			subTree.children[c] = children[c];
+			subTree.children[c].children = NULL;
+			subTree.children[c].parent = &subTree;
+			children[c].copySubTree( subTree.children[c] , keepNodeFunctor );
+		}
+	}
+}
+
+// KeepNodeFunctor looks like std::function< bool ( const RegularTreeNode * ) >
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename KeepNodeFunctor >
+Pointer( RegularTreeNode< Dim , NodeData , DepthAndOffsetType > ) RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::serializeSubTree( const KeepNodeFunctor &keepNodeFunctor , size_t &nodeCount ) const
+{
+	std::function< size_t ( const RegularTreeNode * ) > ChildNodeCount = [&]( const RegularTreeNode *node )
+	{
+		size_t count = 0;
+		bool keepChildren = false;
+		if( node->children ) for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) keepChildren |= keepNodeFunctor( node->children+c );
+		if( keepChildren )
+		{
+			count += 1<<Dim;
+			for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) count += ChildNodeCount( node->children+c );
+		}
+		return count;
+	};
+
+	nodeCount = 1 + ChildNodeCount( this );
+	Pointer( RegularTreeNode ) nodes = NewPointer< RegularTreeNode >( nodeCount );
+
+	std::function< Pointer( RegularTreeNode ) ( const RegularTreeNode * , RegularTreeNode & , Pointer( RegularTreeNode ) ) > SetChildNodes = [&]( const RegularTreeNode *node , RegularTreeNode &subNode , Pointer( RegularTreeNode ) buffer )
+	{
+		bool keepChildren = false;
+		if( node->children ) for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) keepChildren |= keepNodeFunctor( node->children+c );
+		if( keepChildren )
+		{
+			subNode.children = PointerAddress( buffer );
+			for( unsigned int c=0 ; c<(1<<Dim) ; c++ )
+			{
+				buffer[c] = node->children[c];
+				buffer[c].parent = &subNode;
+				buffer[c].children = NULL;
+			}
+			buffer += 1<<Dim;
+			for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) buffer = SetChildNodes( node->children+c , subNode.children[c] , buffer );
+		}
+		return buffer;
+	};
+
+	nodes[0] = *this;
+	nodes[0].parent = NULL;
+	nodes[0].children = NULL;
+
+	SetChildNodes( this , nodes[0] , nodes+1 );
+
+	return nodes;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename WriteNodeFunctor >
+bool RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::write( BinaryStream &stream , bool serialize , const WriteNodeFunctor &writeNodeFunctor ) const
+{
+	if( serialize )
+	{
+		size_t nodeCount;
+		Pointer( RegularTreeNode ) nodes = serializeSubTree( writeNodeFunctor , nodeCount );
+		stream.write( nodes , nodeCount );
+		DeletePointer( nodes );
+	}
+	else
+	{
+		std::function< void ( const RegularTreeNode *node ) > WriteChildren = [&]( const RegularTreeNode *node )
+		{
+			bool writeChildren = false;
+			if( node->children ) for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) writeChildren |= writeNodeFunctor( node->children+c );
+			if( writeChildren )
+			{
+				stream.write( GetPointer( node->children , 1<<Dim ) , 1<<Dim );
+				for( unsigned int c=0 ; c<(1<<Dim) ; c++ ) WriteChildren( node->children+c );
+			}
+		};
+		stream.write( *this );
+		WriteChildren( this );
+	}
+	return true;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< typename Initializer >
+bool RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::read( BinaryStream &stream , Allocator< RegularTreeNode >* nodeAllocator , Initializer &initializer )
+{
+	std::function< void ( RegularTreeNode *node ) > ReadChildren = [&]( RegularTreeNode *node )
+	{
+		if( node->children )
+		{
+			node->children = NULL;
+			node->initChildren< false >( nodeAllocator , initializer );
+			if( !stream.read( GetPointer( node->children , 1<<Dim ) , 1<<Dim ) ) MK_THROW( "Failed to read children" );
+			for( int i=0 ; i<(1<<Dim) ; i++ )
+			{
+				node->children[i].parent = node;
+				ReadChildren( node->children+i );
+			}
+		}
+	};
+	if( !stream.read( *this ) ) MK_THROW( "Failed to read root" );
+	ReadChildren( this );
+	return true;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::width( int maxDepth ) const
+{
+	int d=depth();
+	return 1<<(maxDepth-d); 
+}
+
+////////////////////////////////
+// RegularTreeNode::Neighbors //
+////////////////////////////////
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... Widths >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::Neighbors< ParameterPack::UIntPack< Widths ... > >::Neighbors( void ){ static_assert( sizeof...(Widths)==Dim , "[ERROR] Window and tree dimensions don't match" ) ; clear(); }
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... Widths >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::Neighbors< ParameterPack::UIntPack< Widths ... > >::clear( void ){ for( unsigned int i=0 ; i<Window::Size< Widths... >() ; i++ ) neighbors.data[i] = NULL; }
+
+/////////////////////////////////////
+// RegularTreeNode::ConstNeighbors //
+/////////////////////////////////////
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... Widths >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighbors< ParameterPack::UIntPack< Widths ... > >::ConstNeighbors( void ){ static_assert( sizeof...(Widths)==Dim , "[ERROR] Window and tree dimensions don't match" ) ; clear(); }
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... Widths >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighbors< ParameterPack::UIntPack< Widths ... > >::clear( void ){ for( unsigned int i=0 ; i<Window::Size< Widths... >() ; i++ ) neighbors.data[i] = NULL; }
+
+//////////////////////////////////
+// RegularTreeNode::NeighborKey //
+//////////////////////////////////
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::NeighborKey( void ){ _depth=-1 , neighbors=NULL; }
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::NeighborKey( const NeighborKey& key )
+{
+	_depth = 0 , neighbors = NULL;
+	set( key._depth );
+	for( int d=0 ; d<=_depth ; d++ ) memcpy( &neighbors[d] , &key.neighbors[d] , sizeof( Neighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > > ) );
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::~NeighborKey( void )
+{
+	if( neighbors ) delete[] neighbors;
+	neighbors=NULL;
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::set( int d )
+{
+	if( neighbors ) delete[] neighbors;
+	neighbors = NULL;
+	_depth = d;
+	if( d<0 ) return;
+	neighbors = new NeighborType[d+1];
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int ... _PLeftRadii , unsigned int ... _PRightRadii , unsigned int ... _CLeftRadii , unsigned int ... _CRightRadii >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::_NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... > pLeftRadii , ParameterPack::UIntPack< _PRightRadii ... > pRightRadii , ParameterPack::UIntPack< _CLeftRadii ... > cLeftRadii , ParameterPack::UIntPack< _CRightRadii ... > cRightRadii , Window::ConstSlice< RegularTreeNode* , ( _PLeftRadii + _PRightRadii + 1 ) ... > pNeighbors , Window::Slice< RegularTreeNode* , ( _CLeftRadii + _CRightRadii + 1 ) ... > cNeighbors , int cIdx , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer )
+{
+	static_assert( Dim==sizeof ... ( _PLeftRadii ) && Dim==sizeof ... ( _PRightRadii ) && Dim==sizeof ... ( _CLeftRadii ) && Dim==sizeof ... ( _CRightRadii ) , "[ERROR] Dimensions don't match" );
+	int c[Dim];
+	for( int d=0 ; d<Dim ; d++ ) c[d] = ( cIdx>>d ) & 1;
+	return _Run< CreateNodes , ThreadSafe , NodeInitializer , ParameterPack::UIntPack< _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadii ... > >::Run( pNeighbors , cNeighbors , c , 0 , nodeAllocator , initializer );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int ... _PLeftRadii , unsigned int ... _PRightRadii , unsigned int ... _CLeftRadii , unsigned int ... _CRightRadii >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::_NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... > pLeftRadii , ParameterPack::UIntPack< _PRightRadii ... > pRightRadii , ParameterPack::UIntPack< _CLeftRadii ... > cLeftRadii , ParameterPack::UIntPack< _CRightRadii ... > cRightRadii , Window::Slice< RegularTreeNode* , ( _PLeftRadii + _PRightRadii + 1 ) ... > pNeighbors , Window::Slice< RegularTreeNode* , ( _CLeftRadii + _CRightRadii + 1 ) ... > cNeighbors , int cIdx , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer )
+{
+	return _NeighborsLoop< CreateNodes , ThreadSafe , NodeInitializer >( ParameterPack::UIntPack< _PLeftRadii ... >() , ParameterPack::UIntPack< _PRightRadii ... >() , ParameterPack::UIntPack< _CLeftRadii ... >() , ParameterPack::UIntPack< _CRightRadii ... >() , ( Window::ConstSlice< RegularTreeNode* , ( _PLeftRadii + _PRightRadii + 1 ) ... > )pNeighbors , cNeighbors , cIdx , nodeAllocator , initializer );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int _PLeftRadius , unsigned int ... _PLeftRadii , unsigned int _PRightRadius , unsigned int ... _PRightRadii , unsigned int _CLeftRadius , unsigned int ... _CLeftRadii , unsigned int _CRightRadius , unsigned int ... _CRightRadii >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::_Run< CreateNodes , ThreadSafe , NodeInitializer , ParameterPack::UIntPack< _PLeftRadius , _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadius , _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadius , _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadius , _CRightRadii ... > >::Run( Window::ConstSlice< RegularTreeNode* , _PLeftRadius + _PRightRadius + 1 , ( _PLeftRadii + _PRightRadii + 1 ) ... > pNeighbors , Window::Slice< RegularTreeNode* , _CLeftRadius + _CRightRadius + 1 , ( _CLeftRadii + _CRightRadii + 1 ) ... > cNeighbors , int* c , int cornerIndex , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer )
+{
+	static const int D = sizeof ... ( _PLeftRadii ) + 1;
+	unsigned int count=0;
+	for( int i=-(int)_CLeftRadius ; i<=(int)_CRightRadius ; i++ )
+	{
+		int _i = (i+c[Dim-D]) + ( _CLeftRadius<<1 ) , pi = ( _i>>1 ) - _CLeftRadius + _PLeftRadius  , ci = i + _CLeftRadius;
+		count += _Run< CreateNodes , ThreadSafe , NodeInitializer , ParameterPack::UIntPack< _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadii ... > >::Run( pNeighbors[pi] , cNeighbors[ci] , c , cornerIndex | ( ( _i&1)<<(Dim-D) ) , nodeAllocator , initializer );
+	}
+	return count;
+}
+
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int _PLeftRadius , unsigned int _PRightRadius , unsigned int _CLeftRadius , unsigned int _CRightRadius >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::_Run< CreateNodes , ThreadSafe , NodeInitializer , ParameterPack::UIntPack< _PLeftRadius > , ParameterPack::UIntPack< _PRightRadius > , ParameterPack::UIntPack< _CLeftRadius > , ParameterPack::UIntPack< _CRightRadius > >::Run( Window::ConstSlice< RegularTreeNode* , _PLeftRadius+_PRightRadius+1 > pNeighbors , Window::Slice< RegularTreeNode* , _CLeftRadius+_CRightRadius+1 > cNeighbors , int* c , int cornerIndex , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer )
+{
+	static const int D = 1;
+	unsigned int count=0;
+	for( int i=-(int)_CLeftRadius ; i<=(int)_CRightRadius ; i++ )
+	{
+		int _i = (i+c[Dim-1]) + ( _CLeftRadius<<1 ) , pi = ( _i>>1 ) - _CLeftRadius + _PLeftRadius  , ci = i + _CLeftRadius;
+		if( CreateNodes )
+		{
+			if( pNeighbors[pi] )
+			{
+#ifdef SANITIZED_PR
+//#ifdef NEW_CODE
+				RegularTreeNode * children = ReadAtomic( pNeighbors[pi]->children );
+				if( !children )
+				{
+					pNeighbors[pi]->template initChildren< ThreadSafe >( nodeAllocator , initializer );
+					children = ReadAtomic( pNeighbors[pi]->children );
+				}
+				cNeighbors[ci] = children + ( cornerIndex | ( ( _i&1)<<(Dim-1) ) );
+#else // !SANITIZED_PR
+				if( !pNeighbors[pi]->children ) pNeighbors[pi]->template initChildren< ThreadSafe >( nodeAllocator , initializer );
+				cNeighbors[ci] = pNeighbors[pi]->children + ( cornerIndex | ( ( _i&1)<<(Dim-1) ) );
+#endif // SANITIZED_PR
+				count++;
+			}
+			else cNeighbors[ci] = NULL;
+		}
+		else
+		{
+			if( pNeighbors[pi] && pNeighbors[pi]->children ) cNeighbors[ci] = pNeighbors[pi]->children + ( cornerIndex | ( ( _i&1)<<(Dim-1) ) ) , count++;
+			else cNeighbors[ci] = NULL;
+		}
+	}
+	return count;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getChildNeighbors( int cIdx , int d , NeighborType& cNeighbors , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer ) const
+{
+	NeighborType& pNeighbors = neighbors[d];
+	// Check that we actually have a center node
+	if( !pNeighbors.neighbors.data[ CenterIndex ] ) return 0;
+	return _NeighborsLoop< CreateNodes , ThreadSafe >( ParameterPack::UIntPack< LeftRadii ... >() , ParameterPack::UIntPack< RightRadii ... >() , ParameterPack::UIntPack< LeftRadii ... >() , ParameterPack::UIntPack< RightRadii ... >() , pNeighbors.neighbors() , cNeighbors.neighbors() , cIdx , nodeAllocator , initializer );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , class Real >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getChildNeighbors( Point< Real , Dim > p , int d , NeighborType& cNeighbors , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer ) const
+{
+	NeighborType& pNeighbors = neighbors[d];
+	// Check that we actually have a center node
+	if( !pNeighbors.neighbors.data[ CenterIndex ] ) return 0;
+	Point< Real , Dim > c;
+	Real w;
+	pNeighbors.neighbors.data[ CenterIndex ]->centerAndWidth( c , w );
+	return getChildNeighbors< CreateNodes , ThreadSafe >( CornerIndex( c , p ) , d , cNeighbors , nodeAllocator , initializer );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer >
+typename RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::template Neighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getNeighbors( RegularTreeNode< Dim , NodeData , DepthAndOffsetType >* node , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer )
+{
+	NeighborType& neighbors = this->neighbors[node->depth()];
+	// This is required in case the neighbors have been constructed between the last call to getNeighbors and this one
+	if( node==neighbors.neighbors.data[ CenterIndex ] )
+	{
+		bool reset = false;
+		for( unsigned int i=0 ; i<Window::Size< ( LeftRadii+RightRadii+1 ) ... >() ; i++ ) if( !neighbors.neighbors.data[i] ) reset = true;
+		if( reset ) neighbors.neighbors.data[ CenterIndex ] = NULL;
+	}
+	if( node!=neighbors.neighbors.data[ CenterIndex ] )
+	{
+		for( int d=node->depth()+1 ; d<=_depth && this->neighbors[d].neighbors.data[ CenterIndex ] ; d++ ) this->neighbors[d].neighbors.data[ CenterIndex ] = NULL;
+		neighbors.clear();
+		if( !node->parent ) neighbors.neighbors.data[ CenterIndex ] = node;
+		else _NeighborsLoop< CreateNodes , ThreadSafe >( ParameterPack::UIntPack< LeftRadii ... >() , ParameterPack::UIntPack< RightRadii ... >() , ParameterPack::UIntPack< LeftRadii ... >() , ParameterPack::UIntPack< RightRadii ... >() , getNeighbors< CreateNodes , ThreadSafe >( node->parent , nodeAllocator , initializer ).neighbors() , neighbors.neighbors() , (int)( node - node->parent->children ) , nodeAllocator , initializer );
+	}
+	return neighbors;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > , RegularTreeNode< Dim , NodeData , DepthAndOffsetType >* node , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer )
+{
+	static const unsigned int _CenterIndex = Window::Index( ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... >() , ParameterPack::UIntPack< _LeftRadii ... >() );
+	neighbors.clear();
+	if( !node ) return;
+
+	// [WARNING] This estimate of the required radius is somewhat conservative if the readius is odd (depending on where the node is relative to its parent)
+	ParameterPack::UIntPack<  LeftRadii ... >  leftRadii;
+	ParameterPack::UIntPack< RightRadii ... > rightRadii;
+	ParameterPack::UIntPack< (  _LeftRadii+1 )/2 ... >  pLeftRadii;
+	ParameterPack::UIntPack< ( _RightRadii+1 )/2 ... > pRightRadii;
+	ParameterPack::UIntPack<  _LeftRadii ... >  cLeftRadii;
+	ParameterPack::UIntPack< _RightRadii ... > cRightRadii;
+
+	// If we are at the root of the tree, we are done
+	if( !node->parent ) neighbors.neighbors.data[ _CenterIndex ] = node;
+	// If we can get the data from the the key for the parent node, do that
+	else if( pLeftRadii<=leftRadii && pRightRadii<=rightRadii )
+	{
+		getNeighbors< CreateNodes , ThreadSafe >( node->parent , nodeAllocator , initializer );
+		const Neighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& pNeighbors = this->neighbors[ node->depth()-1 ];
+		_NeighborsLoop< CreateNodes , ThreadSafe >( leftRadii , rightRadii , cLeftRadii , cRightRadii , pNeighbors.neighbors() , neighbors.neighbors() , (int)( node - node->parent->children ) , nodeAllocator , initializer );
+	}
+	// Otherwise recurse
+	else
+	{
+		Neighbors< ParameterPack::UIntPack< ( ( _LeftRadii+1 )/2  + ( _RightRadii+1 )/2 + 1 ) ... > > pNeighbors;
+		getNeighbors< CreateNodes , ThreadSafe >( pLeftRadii , pRightRadii , node->parent , pNeighbors , nodeAllocator , initializer );
+		_NeighborsLoop< CreateNodes , ThreadSafe >( pLeftRadii , pRightRadii , cLeftRadii , cRightRadii , pNeighbors.neighbors() , neighbors.neighbors() , (int)( node - node->parent->children ) , nodeAllocator , initializer );
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< bool CreateNodes , bool ThreadSafe , typename NodeInitializer , unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > , RegularTreeNode< Dim , NodeData , DepthAndOffsetType >* node , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& pNeighbors , Neighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors , Allocator< RegularTreeNode >* nodeAllocator , NodeInitializer &initializer )
+{
+	ParameterPack::UIntPack<  _LeftRadii ... >  leftRadii;
+	ParameterPack::UIntPack< _RightRadii ... > rightRadii;
+	if( !node->parent ) getNeighbors< CreateNodes , ThreadSafe >( leftRadii , rightRadii , node , neighbors , nodeAllocator , initializer );
+	else
+	{
+		getNeighbors< CreateNodes , ThreadSafe >( leftRadii , rightRadii , node->parent , pNeighbors , nodeAllocator , initializer );
+		_NeighborsLoop< CreateNodes , ThreadSafe >( leftRadii , rightRadii , leftRadii , rightRadii , pNeighbors.neighbors() , neighbors.neighbors() , (int)( node - node->parent->children ) , nodeAllocator , initializer );
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::NeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::setLeafNeighbors( RegularTreeNode *node , Window::StaticWindow< RegularTreeNode * , ( LeftRadii + RightRadii + 1 ) ... > &leaves )
+{
+	// Suppose that we have a node at index I and we want the leaf nodes supported on the (possibly virtual) node K away
+	// Case 1: The K-th neighbor exists
+	// ---> Iterate over the leaf nodes of the sub-tree rooted at the K-th neighbor
+	// Case 2: The K-th neighbor does not exist
+	// ---> The index of the K-th neighbor is I+K
+	// ---> The index of the parent is floor( I/2 )
+	// ---> The index of the K-th neighbors parent is floor( (I+K)/2 )
+	// ---> The parent of the K-th neighbor is the [ floor( (I+k)/2 ) - floor( I/2 ) ]-th neighbor of the parent
+
+	static const unsigned int _LeftRadii[] = { LeftRadii ... };
+	auto GetNeighborLeaf = [&]( unsigned int depth , const int index[Dim] , const int offset[Dim] )
+	{
+//		unsigned int _index[Dim] , _offset[Dim] , __offset[Dim];
+		int _index[Dim] , _offset[Dim] , __offset[Dim];
+		for( int dim=0 ; dim<Dim ; dim++ ) _index[dim] = index[dim] , _offset[dim] = offset[dim];
+		for( int d=depth ; d>=0 ; d-- )
+		{
+			for( int dim=0 ; dim<Dim ; dim++ ) __offset[dim] = _offset[dim] + _LeftRadii[dim];
+			if( neighbors[d].neighbors( __offset ) ) return neighbors[d].neighbors( __offset );
+			else
+			{
+				for( int dim=0 ; dim<Dim ; dim++ )
+				{
+					_offset[dim] = ( ( _index[dim] + _offset[dim] ) >> 1 ) - ( _index[dim] >> 1 );
+					_index[dim] >>= 1;
+				}
+			}
+		}
+		return ( RegularTreeNode * )NULL;
+	};
+	getNeighbors( node );
+	int depth , index[Dim] , offset[Dim] , _offset[Dim];
+	node->depthAndOffset( depth , index );
+
+	Window::Loop< Dim >::Run
+	(
+		ParameterPack::IsotropicUIntPack< Dim , 0 >() , ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... >() ,
+		[&]( int d , int i ){ offset[d] = i , _offset[d] = i-_LeftRadii[d]; } ,
+		[&]( void ){ leaves( offset ) = GetNeighborLeaf( depth , index , _offset ); }
+	);
+}
+
+///////////////////////////////////////
+// RegularTreeNode::ConstNeighborKey //
+///////////////////////////////////////
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::ConstNeighborKey( void ){ _depth=-1 , neighbors=NULL; }
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::ConstNeighborKey( const ConstNeighborKey& key )
+{
+	_depth = 0 , neighbors = NULL;
+	set( key._depth );
+	for( int d=0 ; d<=_depth ; d++ ) memcpy( &neighbors[d] , &key.neighbors[d] , sizeof( ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > > ) );
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::~ConstNeighborKey( void )
+{
+	if( neighbors ) delete[] neighbors;
+	neighbors=NULL;
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+typename RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::template ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >& RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::operator = ( const ConstNeighborKey& key )
+{
+	set( key._depth );
+	for( int d=0 ; d<=_depth ; d++ ) memcpy( &neighbors[d] , &key.neighbors[d] , sizeof( ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > > ) );
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::set( int d )
+{
+	if( neighbors ) delete[] neighbors;
+	neighbors = NULL;
+	_depth = d;
+	if( d<0 ) return;
+	neighbors = new NeighborType[d+1];
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< unsigned int ... _PLeftRadii , unsigned int ... _PRightRadii , unsigned int ... _CLeftRadii , unsigned int ... _CRightRadii >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::_NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... > pLeftRadii , ParameterPack::UIntPack< _PRightRadii ... > pRightRadii , ParameterPack::UIntPack< _CLeftRadii ... > cLeftRadii , ParameterPack::UIntPack< _CRightRadii ... > cRightRadii , Window::ConstSlice< const RegularTreeNode * , ( _PLeftRadii + _PRightRadii + 1 ) ... > pNeighbors , Window::Slice< const RegularTreeNode * , ( _CLeftRadii + _CRightRadii + 1 ) ... > cNeighbors , int cIdx )
+{
+	static_assert( Dim==sizeof ... ( _PLeftRadii ) && Dim==sizeof ... ( _PRightRadii ) && Dim==sizeof ... ( _CLeftRadii ) && Dim==sizeof ... ( _CRightRadii ) , "[ERROR] Dimensions don't match" );
+	int c[Dim];
+	for( int d=0 ; d<Dim ; d++ ) c[d] = ( cIdx>>d ) & 1;
+	return _Run< ParameterPack::UIntPack< _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadii ... > >::Run( pNeighbors , cNeighbors , c , 0 );
+}
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< unsigned int ... _PLeftRadii , unsigned int ... _PRightRadii , unsigned int ... _CLeftRadii , unsigned int ... _CRightRadii >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::_NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... > pLeftRadii , ParameterPack::UIntPack< _PRightRadii ... > pRightRadii , ParameterPack::UIntPack< _CLeftRadii ... > cLeftRadii , ParameterPack::UIntPack< _CRightRadii ... > cRightRadii , Window::Slice< const RegularTreeNode* , ( _PLeftRadii + _PRightRadii + 1 ) ... > pNeighbors , Window::Slice< const RegularTreeNode* , ( _CLeftRadii + _CRightRadii + 1 ) ... > cNeighbors , int cIdx )
+{
+	return _NeighborsLoop( ParameterPack::UIntPack< _PLeftRadii ... >() , ParameterPack::UIntPack< _PRightRadii ... >() , ParameterPack::UIntPack< _CLeftRadii ... >() , ParameterPack::UIntPack< _CRightRadii ... >() , ( Window::ConstSlice< const RegularTreeNode* , ( _PLeftRadii + _PRightRadii + 1 ) ... > )pNeighbors , cNeighbors , cIdx );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< unsigned int _PLeftRadius , unsigned int ... _PLeftRadii , unsigned int _PRightRadius , unsigned int ... _PRightRadii , unsigned int _CLeftRadius , unsigned int ... _CLeftRadii , unsigned int _CRightRadius , unsigned int ... _CRightRadii >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::_Run< ParameterPack::UIntPack< _PLeftRadius , _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadius , _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadius , _CLeftRadii ... > , ParameterPack::UIntPack< _CRightRadius , _CRightRadii ... > >::Run( Window::ConstSlice< const RegularTreeNode* , _PLeftRadius + _PRightRadius + 1 , ( _PLeftRadii + _PRightRadii + 1 ) ... > pNeighbors , Window::Slice< const RegularTreeNode* ,  _CLeftRadius + _CRightRadius + 1 , ( _CLeftRadii + _CRightRadii + 1 ) ... > cNeighbors , int* c , int cornerIndex )
+{
+	static const int D = sizeof ... ( _PLeftRadii ) + 1;
+	unsigned int count=0;
+	for( int i=-(int)_CLeftRadius ; i<=(int)_CRightRadius ; i++ )
+	{
+		int _i = (i+c[Dim-D]) + ( _CLeftRadius<<1 ) , pi = ( _i>>1 ) - _CLeftRadius + _PLeftRadius  , ci = i + _CLeftRadius;
+		count += _Run< ParameterPack::UIntPack< _PLeftRadii ... > , ParameterPack::UIntPack< _PRightRadii ... > , ParameterPack::UIntPack< _CLeftRadii ... > , ParameterPack::UIntPack<  _CRightRadii ... > >::Run( pNeighbors[pi] , cNeighbors[ci] , c , cornerIndex | ( ( _i&1)<<(Dim-D) ) );
+	}
+	return count;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< unsigned int _PLeftRadius , unsigned int _PRightRadius , unsigned int _CLeftRadius , unsigned int _CRightRadius  >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::_Run< ParameterPack::UIntPack< _PLeftRadius > , ParameterPack::UIntPack< _PRightRadius > , ParameterPack::UIntPack< _CLeftRadius > , ParameterPack::UIntPack< _CRightRadius > >::Run( Window::ConstSlice< const RegularTreeNode* , _PLeftRadius+_PRightRadius+1 > pNeighbors , Window::Slice< const RegularTreeNode* , _CLeftRadius+_CRightRadius+1 > cNeighbors , int* c , int cornerIndex )
+{
+	static const int D = 1;
+	unsigned int count=0;
+	for( int i=-(int)_CLeftRadius ; i<=(int)_CRightRadius ; i++ )
+	{
+		int _i = (i+c[Dim-D]) + ( _CLeftRadius<<1 ) , pi = ( _i>>1 ) - _CLeftRadius + _PLeftRadius  , ci = i + _CLeftRadius;
+		if( pNeighbors[pi] && pNeighbors[pi]->children ) cNeighbors[ci] = pNeighbors[pi]->children + ( cornerIndex | ( ( _i&1)<<(Dim-1) ) ) , count++;
+		else cNeighbors[ci] = NULL;
+	}
+	return count;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getChildNeighbors( int cIdx , int d , ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& cNeighbors ) const
+{
+	const ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& pNeighbors = neighbors[d];
+	// Check that we actually have a center node
+	if( !pNeighbors.neighbors.data[ CenterIndex ] ) return 0;
+
+	return _NeighborsLoop( ParameterPack::UIntPack< LeftRadii ... >() , ParameterPack::UIntPack< RightRadii ... >() , ParameterPack::UIntPack< LeftRadii ... >() , ParameterPack::UIntPack< RightRadii ... >() , pNeighbors.neighbors() , cNeighbors.neighbors() , cIdx );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+typename RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::template ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getNeighbors( const RegularTreeNode* node )
+{
+	ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& neighbors = this->neighbors[ node->depth() ];
+	if( node!=neighbors.neighbors.data[ CenterIndex ] )
+	{
+		for( int d=node->depth()+1 ; d<=_depth && this->neighbors[d].neighbors.data[ CenterIndex ] ; d++ ) this->neighbors[d].neighbors.data[ CenterIndex ] = NULL;
+		neighbors.clear();
+		if( !node->parent ) neighbors.neighbors.data[ CenterIndex ] = node;
+		else _NeighborsLoop( ParameterPack::UIntPack< LeftRadii ... >() , ParameterPack::UIntPack< RightRadii ... >() , ParameterPack::UIntPack< LeftRadii ... >() , ParameterPack::UIntPack< RightRadii ... >() , getNeighbors( node->parent ).neighbors() , neighbors.neighbors() , (int)( node - node->parent->children ) );
+	}
+	return neighbors;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > , const RegularTreeNode< Dim , NodeData , DepthAndOffsetType >* node , ConstNeighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors )
+{
+	static const unsigned int _CenterIndex = Window::Index< ( _LeftRadii + _RightRadii + 1 ) ... >::template I< _LeftRadii ... >();
+
+	neighbors.clear();
+	if( !node ) return;
+
+	ParameterPack::UIntPack<  LeftRadii ... >  leftRadii;
+	ParameterPack::UIntPack< RightRadii ... > rightRadii;
+	ParameterPack::UIntPack< (  _LeftRadii+1 )/2 ... >  pLeftRadii;
+	ParameterPack::UIntPack< ( _RightRadii+1 )/2 ... > pRightRadii;
+	ParameterPack::UIntPack<  _LeftRadii ... >  cLeftRadii;
+	ParameterPack::UIntPack< _RightRadii ... > cRightRadii;
+	// If we are at the root of the tree, we are done
+	if( !node->parent ) neighbors.neighbors.data[ _CenterIndex ] = node;
+	// If we can get the data from the the key for the parent node, do that
+	else if( pLeftRadii<=leftRadii && pRightRadii<=rightRadii )
+	{
+		getNeighbors( node->parent );
+		const ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& pNeighbors = this->neighbors[ node->depth()-1 ];
+		_NeighborsLoop( leftRadii , rightRadii , cLeftRadii , cRightRadii , pNeighbors.neighbors() , neighbors.neighbors() , (int)( node - node->parent->children ) );
+	}
+	// Otherwise recurse
+	else
+	{
+		ConstNeighbors< ParameterPack::UIntPack< ( ( _LeftRadii+1 )/2  + ( _RightRadii+1 )/2 + 1 ) ... > > pNeighbors;
+		getNeighbors( pLeftRadii , pRightRadii , node->parent , pNeighbors );
+		_NeighborsLoop( pLeftRadii , pRightRadii , cLeftRadii , cRightRadii , pNeighbors.neighbors() , neighbors.neighbors() , (int)( node - node->parent->children ) );
+	}
+	return;
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< unsigned int ... _LeftRadii , unsigned int ... _RightRadii >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getNeighbors( ParameterPack::UIntPack< _LeftRadii ... > , ParameterPack::UIntPack< _RightRadii ... > , const RegularTreeNode< Dim , NodeData , DepthAndOffsetType >* node , ConstNeighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& pNeighbors , ConstNeighbors< ParameterPack::UIntPack< ( _LeftRadii + _RightRadii + 1 ) ... > >& neighbors )
+{
+	ParameterPack::UIntPack<  _LeftRadii ... >  leftRadii;
+	ParameterPack::UIntPack< _RightRadii ... > rightRadii;
+	if( !node->parent ) return getNeighbors( leftRadii , rightRadii , node , neighbors );
+	else
+	{
+		 getNeighbors( leftRadii , rightRadii , node->parent , pNeighbors );
+		_NeighborsLoop( leftRadii , rightRadii , leftRadii , rightRadii , pNeighbors.neighbors() , neighbors.neighbors() , (int)( node - node->parent->children ) );
+	}
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+template< class Real >
+unsigned int RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::getChildNeighbors( Point< Real , Dim > p , int d , ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& cNeighbors ) const
+{
+	ConstNeighbors< ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... > >& pNeighbors = neighbors[d];
+	// Check that we actually have a center node
+	if( !pNeighbors.neighbors.data[ CenterIndex ] ) return 0;
+	Point< Real , Dim > c;
+	Real w;
+	pNeighbors.neighbors.data[ CenterIndex ]->centerAndWidth( c , w );
+	int cIdx = 0;
+	for( int d=0 ; d<Dim ; d++ ) if( p[d]>c[d] ) cIdx |= (1<<d);
+	return getChildNeighbors( cIdx , d , cNeighbors );
+}
+
+template< unsigned int Dim , class NodeData , class DepthAndOffsetType >
+template< unsigned int ... LeftRadii , unsigned int ... RightRadii >
+void RegularTreeNode< Dim , NodeData , DepthAndOffsetType >::ConstNeighborKey< ParameterPack::UIntPack< LeftRadii ... > , ParameterPack::UIntPack< RightRadii ... > >::setLeafNeighbors( const RegularTreeNode *node , Window::StaticWindow< RegularTreeNode * , ( LeftRadii + RightRadii + 1 ) ... > &leaves )
+{
+	// Suppose that we have a node at index I and we want the leaf nodes supported on the (possibly virtual) node K away
+	// Case 1: The K-th neighbor exists
+	// ---> Iterate over the leaf nodes of the sub-tree rooted at the K-th neighbor
+	// Case 2: The K-th neighbor does not exist
+	// ---> The index of the K-th neighbor is I+K
+	// ---> The index of the parent is floor( I/2 )
+	// ---> The index of the K-th neighbors parent is floor( (I+K)/2 )
+	// ---> The parent of the K-th neighbor is the [ floor( (I+k)/2 ) - floor( I/2 ) ]-th neighbor of the parent
+
+	static const unsigned int _LeftRadii[] = { LeftRadii ... };
+	auto GetNeighborLeaf = [&]( unsigned int depth , const int index[Dim] , const int offset[Dim] )
+	{
+		//		unsigned int _index[Dim] , _offset[Dim] , __offset[Dim];
+		int _index[Dim] , _offset[Dim] , __offset[Dim];
+		for( int dim=0 ; dim<Dim ; dim++ ) _index[dim] = index[dim] , _offset[dim] = offset[dim];
+		for( int d=depth ; d>=0 ; d-- )
+		{
+			for( int dim=0 ; dim<Dim ; dim++ ) __offset[dim] = _offset[dim] + _LeftRadii[dim];
+			if( neighbors[d].neighbors( __offset ) ) return neighbors[d].neighbors( __offset );
+			else
+			{
+				for( int dim=0 ; dim<Dim ; dim++ )
+				{
+					_offset[dim] = ( ( _index[dim] + _offset[dim] ) >> 1 ) - ( _index[dim] >> 1 );
+					_index[dim] >>= 1;
+				}
+			}
+		}
+		return ( RegularTreeNode * )NULL;
+	};
+	getNeighbors( node );
+	int depth , index[Dim] , offset[Dim] , _offset[Dim];
+	node->depthAndOffset( depth , index );
+
+	Window::Loop< Dim >::Run
+	(
+		ParameterPack::IsotropicUIntPack< Dim , 0 >() , ParameterPack::UIntPack< ( LeftRadii + RightRadii + 1 ) ... >() ,
+		[&]( int d , int i ){ offset[d] = i , _offset[d] = i-_LeftRadii[d]; } ,
+		[&]( void ){ leaves( offset ) = GetNeighborLeaf( depth , index , _offset ); }
+	);
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/SparseMatrix.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/SparseMatrix.h
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+#ifndef SPARSE_MATRIX_INCLUDED
+#define SPARSE_MATRIX_INCLUDED
+
+#include <float.h>
+#include <complex>
+#include <unordered_map>
+#include "SparseMatrixInterface.h"
+#include "Array.h"
+
+namespace PoissonRecon
+{
+
+	template< class T , class IndexType , size_t MaxRowSize=0 > class SparseMatrix;
+
+	template< class T , class IndexType > class SparseMatrix< T , IndexType , 0 > : public SparseMatrixInterface< T , ConstPointer( MatrixEntry< T , IndexType > ) >
+	{
+		template< class T2 , class IndexType2 , size_t MaxRowSize2 > friend class SparseMatrix;
+		Pointer( Pointer( MatrixEntry< T , IndexType > ) ) _entries;
+	public:
+		static void Swap( SparseMatrix& M1 , SparseMatrix& M2 )
+		{
+			std::swap( M1.rowNum , M2.rowNum );
+			std::swap( M1.rowSizes , M2.rowSizes );
+			std::swap( M1._entries , M2._entries );
+		}
+		typedef SparseMatrixInterface< T , ConstPointer( MatrixEntry< T , IndexType > ) > Interface;
+		typedef ConstPointer( MatrixEntry< T , IndexType > ) RowIterator;
+
+		size_t rowNum;
+		Pointer( size_t ) rowSizes;
+
+		SparseMatrix( void );
+		SparseMatrix( const SparseMatrix& M );
+		SparseMatrix( SparseMatrix&& M );
+		template< class T2 , class IndexType2 >
+		SparseMatrix( const SparseMatrix< T2 , IndexType2 , 0 >& M );
+		~SparseMatrix();
+		SparseMatrix& operator = ( SparseMatrix&& M );
+		SparseMatrix< T , IndexType >& operator = ( const SparseMatrix< T , IndexType >& M );
+		template< class T2 , class IndexType2 >
+		SparseMatrix< T , IndexType , 0 >& operator = ( const SparseMatrix< T2 , IndexType2 , 0 >& M );
+
+		template< class T2 > void operator()( const T2* in , T2* out ) const;
+
+		template< class T2 , class IndexType2 >
+		SparseMatrix< T , IndexType , 0 >& copy( const SparseMatrix< T2 , IndexType2 , 0 >& M );
+
+		inline ConstPointer( MatrixEntry< T , IndexType > ) begin( size_t row ) const { return _entries[row]; }
+		inline ConstPointer( MatrixEntry< T , IndexType > ) end  ( size_t row ) const { return _entries[row] + (unsigned long long)rowSizes[row]; }
+		inline size_t rows                              ( void )       const { return rowNum; }
+		inline size_t rowSize                           ( size_t idx ) const { return rowSizes[idx]; }
+
+		SparseMatrix( size_t rowNum );
+		void resize	( size_t rowNum );
+		void setRowSize( size_t row , size_t count );
+		void resetRowSize( size_t row , size_t count );
+		inline      Pointer( MatrixEntry< T , IndexType > ) operator[] ( size_t idx )       { return _entries[idx]; }
+		inline ConstPointer( MatrixEntry< T , IndexType > ) operator[] ( size_t idx ) const { return _entries[idx]; }
+
+		// With copy move, these should be well-behaved from a memory perspective
+		static SparseMatrix Identity( size_t dim );
+		SparseMatrix transpose(                  T (*TransposeFunction)( const T& )=NULL ) const;
+		SparseMatrix transpose( size_t outRows , T (*TransposeFunction)( const T& )=NULL ) const;
+		SparseMatrix  operator *  ( T s ) const;
+		SparseMatrix  operator /  ( T s ) const;
+		SparseMatrix  operator *  ( const SparseMatrix& M ) const;
+		SparseMatrix  operator +  ( const SparseMatrix& M ) const;
+		SparseMatrix  operator -  ( const SparseMatrix& M ) const;
+		SparseMatrix& operator *= ( T s );
+		SparseMatrix& operator /= ( T s );
+		SparseMatrix& operator *= ( const SparseMatrix& M );
+		SparseMatrix& operator += ( const SparseMatrix& M );
+		SparseMatrix& operator -= ( const SparseMatrix& M );
+
+		template< class A_const_iterator , class B_const_iterator >
+		static SparseMatrix Multiply( const SparseMatrixInterface< T , A_const_iterator >& A , const SparseMatrixInterface< T , B_const_iterator >& B );
+		template< class const_iterator >
+		static SparseMatrix Transpose( const SparseMatrixInterface< T , const_iterator >& At , T (*TransposeFunction)( const T& )=NULL );
+		template< class const_iterator >
+		static SparseMatrix Transpose( const SparseMatrixInterface< T , const_iterator >& At , size_t outRows , T (*TransposeFunction)( const T& )=NULL );
+	};
+
+	template< class T , class IndexType , size_t MaxRowSize > class SparseMatrix : public SparseMatrixInterface< T , ConstPointer( MatrixEntry< T , IndexType > ) >
+	{
+		template< class T2 , class IndexType2 > friend class _SparseMatrix;
+		Pointer( MatrixEntry< T , IndexType > ) _entries;
+		size_t _rowNum;
+		Pointer( size_t ) _rowSizes;
+		size_t _maxRows;
+	public:
+		static void Swap( SparseMatrix& M1 , SparseMatrix& M2 )
+		{
+			std::swap( M1._rowNum , M2._rowNum );
+			std::swap( M1._rowSizes , M2._rowSizes );
+			std::swap( M1._entries , M2._entries );
+		}
+		typedef SparseMatrixInterface< T , ConstPointer( MatrixEntry< T , IndexType > ) > Interface;
+		typedef ConstPointer( MatrixEntry< T , IndexType > ) RowIterator;
+
+		SparseMatrix( void );
+		SparseMatrix( const SparseMatrix& M );
+		SparseMatrix( SparseMatrix&& M );
+		template< class T2 , class IndexType2 >
+		SparseMatrix( const SparseMatrix< T2 , IndexType2 , MaxRowSize >& M );
+		SparseMatrix& operator = ( SparseMatrix&& M );
+		SparseMatrix< T , IndexType , MaxRowSize >& operator = ( const SparseMatrix< T , IndexType , MaxRowSize >& M );
+		template< class T2 , class IndexType2 >
+		SparseMatrix< T , IndexType , MaxRowSize >& operator = ( const SparseMatrix< T2 , IndexType2 , MaxRowSize >& M );
+		~SparseMatrix( void );
+
+		template< class T2 > void operator()( const T2* in , T2* out ) const;
+
+		inline ConstPointer( MatrixEntry< T , IndexType > ) begin( size_t row ) const { return _entries + MaxRowSize * row; }
+		inline ConstPointer( MatrixEntry< T , IndexType > ) end  ( size_t row ) const { return _entries + MaxRowSize * row + (unsigned long long)_rowSizes[row]; }
+		inline size_t rows                              ( void )       const { return _rowNum; }
+		inline size_t rowSize                           ( size_t idx ) const { return _rowSizes[idx]; }
+
+		SparseMatrix( size_t rowNum );
+		void resize	( size_t rowNum );
+		void setRowSize( size_t row , size_t rowSize );
+		void resetRowSize( size_t row , size_t rowSize );
+		inline      Pointer( MatrixEntry< T , IndexType > ) operator[] ( size_t idx )       { return _entries + MaxRowSize * idx; }
+		inline ConstPointer( MatrixEntry< T , IndexType > ) operator[] ( size_t idx ) const { return _entries + MaxRowSize * idx; }
+
+		// With copy move, these should be well-behaved from a memory perspective
+		SparseMatrix  operator *  ( T s ) const;
+		SparseMatrix  operator /  ( T s ) const;
+		SparseMatrix& operator *= ( T s );
+		SparseMatrix& operator /= ( T s );
+	};
+
+#include "SparseMatrix.inl"
+}
+
+#endif // SPARSE_MATRIX_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/SparseMatrix.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/SparseMatrix.inl
@@ -1,0 +1,658 @@
+/* -*- C++ -*-
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+///////////////////////////////////////////////////////////////
+//  SparseMatrix (unconstrained max row size specialization) //
+///////////////////////////////////////////////////////////////
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >::SparseMatrix( void )
+{
+	rowSizes = NullPointer( size_t );
+	rowNum = 0;
+	_entries = NullPointer( Pointer( MatrixEntry< T , IndexType > ) );
+}
+
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >::SparseMatrix( size_t rowNum )
+{
+	this->rowNum = 0;
+	rowSizes = NullPointer( size_t );
+	_entries= NullPointer( Pointer( MatrixEntry< T , IndexType > ) );
+	resize( rowNum );
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >::SparseMatrix( const SparseMatrix& M )
+{
+	rowSizes = NullPointer( size_t );
+	rowNum = 0;
+	_entries = NullPointer( Pointer( MatrixEntry< T , IndexType > ) );
+	resize( M.rowNum );
+	for( size_t i=0 ; i<rowNum ; i++ )
+	{
+		setRowSize( i , M.rowSizes[i] );
+		for( size_t j=0 ; j<rowSizes[i] ; j++ ) _entries[i][j] = M._entries[i][j];
+	}
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >::SparseMatrix( SparseMatrix&& M )
+{
+	rowSizes = NullPointer( size_t );
+	rowNum = 0;
+	_entries = NullPointer( Pointer( MatrixEntry< T , IndexType > ) );
+
+	Swap( *this , M );
+}
+template< class T , class IndexType >
+template< class T2 , class IndexType2 >
+SparseMatrix< T , IndexType , 0 >::SparseMatrix( const SparseMatrix< T2 , IndexType2 , 0 >& M )
+{
+	rowSizes = NullPointer( size_t );
+	rowNum = 0;
+	_entries = NULL;
+	resize( M.rowNum );
+	for( size_t i=0 ; i<rowNum ; i++ )
+	{
+		setRowSize( i , M.rowSizes[i] );
+		for( size_t j=0 ; j<rowSizes[i] ; j++ ) _entries[i][j] = MatrixEntry< T , IndexType >( M._entries[i][j].N , T( M._entries[i][j].Value ) );
+	}
+}
+
+template< class T , class IndexType >
+template< class T2 , class IndexType2 >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::copy( const SparseMatrix< T2 , IndexType2 , 0 >& M  )
+{
+	resize( M.rowNum );
+	for ( size_t i=0 ; i<rowNum ; i++)
+	{
+		setRowSize( i , M.rowSizes[i] );
+		for( size_t j=0 ; j<rowSizes[i] ; j++ )
+		{
+			IndexType2 idx = M._entries[i][j].N;
+			_entries[i][j] = MatrixEntry< T , IndexType >( (IndexType)idx , T( M[i][j].Value ) );
+		}
+	}
+	return *this;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::operator = ( SparseMatrix< T , IndexType , 0 >&& M )
+{
+	Swap( *this , M );
+	return *this;
+}
+
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::operator = ( const SparseMatrix< T , IndexType , 0 >& M )
+{
+	resize( M.rowNum );
+	for( size_t i=0 ; i<rowNum ; i++ )
+	{
+		setRowSize( i , M.rowSizes[i] );
+		for( size_t j=0 ; j<rowSizes[i] ; j++ ) _entries[i][j]=M._entries[i][j];
+	}
+	return *this;
+}
+template< class T , class IndexType >
+template< class T2 , class IndexType2 >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::operator = (const SparseMatrix< T2 , IndexType2 , 0 >& M)
+{
+	resize( M.rowNum );
+	for( size_t i=0 ; i<rowNum ; i++ )
+	{
+		setRowSize( i , M.rowSizes[i] );
+		for( size_t j=0 ; j<rowSizes[i] ; j++ ) _entries[i][j] = MatrixEntry< T , IndexType >( M._entries[i][j].N , T( M._entries[i][j].Value ) );
+	}
+	return *this;
+}
+
+template< class T , class IndexType >
+template< class T2 >
+void SparseMatrix< T , IndexType , 0 >::operator() ( const T2* in , T2* out ) const { Interface::multiply( in , out ); }
+
+template< class T , class IndexType > SparseMatrix< T , IndexType , 0 >::~SparseMatrix( void ) { resize( 0 ); }
+
+template< class T , class IndexType >
+void SparseMatrix< T , IndexType , 0 >::resize( size_t r )
+{
+	if( rowNum>0 )
+	{
+		for( size_t i=0 ; i<rowNum ; i++ ) FreePointer( _entries[i] );
+		FreePointer( _entries );
+		FreePointer( rowSizes );
+	}
+	rowNum = r;
+	if( r )
+	{
+		rowSizes = AllocPointer< size_t >( r ) , memset( rowSizes , 0 , sizeof(size_t)*r );
+		_entries = AllocPointer< Pointer( MatrixEntry< T , IndexType > ) >( r );
+		for( size_t i=0 ; i<r ; i++ ) _entries[i] = NullPointer( MatrixEntry< T , IndexType > );
+	}
+}
+
+template< class T , class IndexType >
+void SparseMatrix< T , IndexType , 0 >::setRowSize( size_t row , size_t count )
+{
+	if( row>=0 && row<rowNum )
+	{
+		FreePointer( _entries[row] );
+		if( count>0 )
+		{
+			_entries[ row ] = AllocPointer< MatrixEntry< T , IndexType > >( count );
+			memset( _entries[ row ] , 0 , sizeof( MatrixEntry< T , IndexType > )*count );
+		}
+		rowSizes[row] = count;
+	}
+	else MK_THROW( "Row is out of bounds: 0 <= " , row , " < " , rowNum );
+}
+template< class T , class IndexType >
+void SparseMatrix< T , IndexType , 0 >::resetRowSize( size_t row , size_t count )
+{
+	if( row>=0 && row<rowNum )
+	{
+		size_t oldCount = rowSizes[row];
+		_entries[row] = ReAllocPointer< MatrixEntry< T, IndexType > >( _entries[row] , count );
+		if( count>oldCount ) memset( _entries[row]+oldCount , 0 , sizeof( MatrixEntry< T , IndexType > ) * ( count - oldCount ) );
+		rowSizes[row] = count;
+	}
+	else MK_THROW( "Row is out of bounds: 0 <= " , row , " < " , rowNum );
+}
+
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::Identity( size_t dim )
+{
+	SparseMatrix I;
+	I.resize( dim );
+	for( size_t i=0 ; i<dim ; i++ ) I.setRowSize( i , 1 ) , I[i][0] = MatrixEntry< T , IndexType >( (IndexType)i , (T)1 );
+	return I;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::operator *= ( T s )
+{
+	ThreadPool::ParallelFor( 0 , rowNum , [&]( unsigned int , size_t i ){ for( size_t j=0 ; j<rowSizes[i] ; j++ ) _entries[i][j].Value *= s; } );
+	return *this;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::operator /= ( T s ){ return (*this) * ( (T)1./s ); }
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::operator *= ( const SparseMatrix< T , IndexType , 0 >& B )
+{
+	SparseMatrix foo = (*this) * B;
+	(*this) = foo;
+	return *this;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::operator += ( const SparseMatrix< T , IndexType , 0 >& B )
+{
+	SparseMatrix foo = (*this) + B;
+	(*this) = foo;
+	return *this;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 >& SparseMatrix< T , IndexType , 0 >::operator -= ( const SparseMatrix< T , IndexType , 0 >& B )
+{
+	SparseMatrix foo = (*this) - B;
+	(*this) = foo;
+	return *this;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::operator * ( T s ) const
+{
+	SparseMatrix out = (*this);
+	return out *= s;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::operator / ( T s ) const { return (*this) * ( (T)1. / s ); }
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::operator * ( const SparseMatrix< T , IndexType , 0 >& B ) const
+{
+	SparseMatrix out;
+	const SparseMatrix& A = *this;
+	size_t aCols = 0 , aRows = A.rowNum;
+	size_t bCols = 0 , bRows = B.rowNum;
+	for( size_t i=0 ; i<A.rowNum ; i++ ) for( size_t j=0 ; j<A.rowSizes[i] ; j++ ) if( aCols<=A[i][j].N ) aCols = A[i][j].N+1;
+	for( size_t i=0 ; i<B.rowNum ; i++ ) for( size_t j=0 ; j<B.rowSizes[i] ; j++ ) if( bCols<=B[i][j].N ) bCols = B[i][j].N+1;
+	if( bRows<aCols ) MK_THROW( "Matrix sizes do not support multiplication " , aRows , " x " , aCols , " * " , bRows , " x " , bCols );
+
+	out.resize( aRows );
+	ThreadPool::ParallelFor( 0 , aRows , [&]( unsigned int , size_t i )
+	{
+		std::unordered_map< IndexType , T > row;
+		for( size_t j=0 ; j<A.rowSizes[i] ; j++ )
+		{
+			IndexType idx1 = A[i][j].N;
+			T AValue = A[i][j].Value;
+			for( size_t k=0 ; k<B.rowSizes[idx1] ; k++ )
+			{
+				IndexType idx2 = B[idx1][k].N;
+				T BValue = B[idx1][k].Value;
+				typename std::unordered_map< IndexType , T >::iterator iter = row.find(idx2);
+				if( iter==row.end() ) row[idx2] = AValue * BValue;
+				else iter->second += AValue * BValue;
+			}
+		}
+		out.setRowSize( i , row.size() );
+		out.rowSizes[i] = 0;
+		for( typename std::unordered_map< IndexType , T >::iterator iter=row.begin() ; iter!=row.end() ; iter++ ) out[i][ out.rowSizes[i]++ ] = MatrixEntry< T , IndexType >( iter->first , iter->second );
+	}
+	);
+	return out;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::operator + ( const SparseMatrix< T , IndexType , 0 >& B ) const
+{
+	const SparseMatrix& A = *this;
+	size_t rowNum = std::max< size_t >( A.rowNum , B.rowNum );
+	SparseMatrix out;
+
+	out.resize( rowNum );
+	ThreadPool::ParallelFor( 0 , rowNum , [&]( unsigned int , size_t i )
+	{
+		std::unordered_map< IndexType , T > row;
+		if( i<A.rowNum )
+			for( size_t j=0 ; j<A.rowSizes[i] ; j++ )
+			{
+				IndexType idx = A[i][j].N;
+				typename std::unordered_map< IndexType , T >::iterator iter = row.find(idx);
+				if( iter==row.end() ) row[idx] = A[i][j].Value;
+				else iter->second += A[i][j].Value;
+			}
+		if( i<B.rowNum )
+			for( size_t j=0 ; j<B.rowSizes[i] ; j++ )
+			{
+				IndexType idx = B[i][j].N;
+				typename std::unordered_map< IndexType , T >::iterator iter = row.find(idx);
+				if( iter==row.end() ) row[idx] = B[i][j].Value;
+				else iter->second += B[i][j].Value;
+			}
+		out.setRowSize( i , row.size() );
+		out.rowSizes[i] = 0;
+		for( typename std::unordered_map< IndexType , T >::iterator iter=row.begin() ; iter!=row.end() ; iter++ ) out[i][ out.rowSizes[i]++ ] = MatrixEntry< T , IndexType >( iter->first , iter->second );
+	}
+	);
+	return out;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::operator - ( const SparseMatrix< T , IndexType , 0 >& B ) const
+{
+	const SparseMatrix& A = *this;
+	size_t rowNum = std::max< size_t >( A.rowNum , B.rowNum );
+	SparseMatrix out;
+
+	out.resize( rowNum );
+	ThreadPool::ParallelFor( 0 , rowNum , [&]( unsigned int , size_t i )
+	{
+		std::unordered_map< IndexType , T > row;
+		if( i<A.rowNum )
+			for( size_t j=0 ; j<A.rowSizes[i] ; j++ )
+			{
+				IndexType idx = A[i][j].N;
+				typename std::unordered_map< IndexType , T >::iterator iter = row.find(idx);
+				if( iter==row.end() ) row[idx] = A[i][j].Value;
+				else iter->second += A[i][j].Value;
+			}
+		if( i<B.rowNum )
+			for( size_t j=0 ; j<B.rowSizes[i] ; j++ )
+			{
+				IndexType idx = B[i][j].N;
+				typename std::unordered_map< IndexType , T >::iterator iter = row.find(idx);
+				if( iter==row.end() ) row[idx] = -B[i][j].Value;
+				else iter->second -= B[i][j].Value;
+			}
+		out.setRowSize( i , row.size() );
+		out.rowSizes[i] = 0;
+		for( typename std::unordered_map< IndexType , T >::iterator iter=row.begin() ; iter!=row.end() ; iter++ ) out[i][ out.rowSizes[i]++ ] = MatrixEntry< T , IndexType >( iter->first , iter->second );
+	}
+	);
+	return out;
+}
+
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::transpose( T (*TransposeFunction)( const T& ) ) const
+{
+	SparseMatrix A;
+	const SparseMatrix& At = *this;
+	size_t aRows = 0 , aCols = At.rowNum;
+	for( size_t i=0 ; i<At.rowNum ; i++ ) for( size_t j=0 ; j<At.rowSizes[i] ; j++ ) if( aRows<=At[i][j].N ) aRows = At[i][j].N+1;
+
+	A.resize( aRows );
+	const size_t One = 1;
+	for( size_t i=0 ; i<aRows ; i++ ) A.rowSizes[i] = 0;
+	ThreadPool::ParallelFor( 0 , At.rowNum , [&]( unsigned int , size_t i )
+	{
+		for( size_t j=0 ; j<At.rowSizes[i] ; j++ )
+		{
+			AddAtomic( A.rowSizes[ At[i][j].N ] , One );
+		}
+	}
+	);
+
+	ThreadPool::ParallelFor( 0 , A.rowNum , [&]( unsigned int , size_t i )
+	{
+		size_t t = A.rowSizes[i];
+		A.rowSizes[i] = 0;
+		A.setRowSize( i , t );
+		A.rowSizes[i] = 0;
+	}
+	);
+	if( TransposeFunction ) for( size_t i=0 ; i<At.rowNum ; i++ ) for( size_t j=0 ; j<At.rowSizes[i] ; j++ )
+	{
+		size_t ii = At[i][j].N;
+		A[ii][ A.rowSizes[ii]++ ] = MatrixEntry< T , IndexType >( (IndexType)i , TransposeFunction( At[i][j].Value ) );
+	}
+	else for( size_t i=0 ; i<At.rowNum ; i++ ) for( size_t j=0 ; j<At.rowSizes[i] ; j++ )
+	{
+		size_t ii = At[i][j].N;
+		A[ii][ A.rowSizes[ii]++ ] = MatrixEntry< T , IndexType >( (IndexType)i , At[i][j].Value );
+	}
+	return A;
+}
+template< class T , class IndexType >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::transpose( size_t aRows , T (*TransposeFunction)( const T& ) ) const
+{
+	SparseMatrix A;
+	const SparseMatrix& At = *this;
+	size_t _aRows = 0 , aCols = At.rowNum;
+	for( size_t i=0 ; i<At.rowNum ; i++ ) for( size_t j=0 ; j<At.rowSizes[i] ; j++ ) if( aCols<=At[i][j].N ) _aRows = At[i][j].N+1;
+	if( _aRows>aRows ) MK_THROW( "Prescribed output dimension too low: " , aRows , " < " , _aRows );
+
+	A.resize( aRows );
+	for( size_t i=0 ; i<aRows ; i++ ) A.rowSizes[i] = 0;
+	const size_t One = 1;
+	ThreadPool::ParallelFor( 0 , At.rowNum , [&]( unsigned int , size_t i )
+	{
+		for( size_t j=0 ; j<At.rowSizes[i] ; j++ ) AddAtomic( A.rowSizes[ At[i][j].N ] , One );
+	}
+	);
+
+	ThreadPool::ParallelFor( 0 , A.rowNum , [&]( unsigned int , size_t i )
+	{
+		size_t t = A.rowSizes[i];
+		A.rowSizes[i] = 0;
+		A.setRowSize( i , t );
+		A.rowSizes[i] = 0;
+	}
+	);
+	if( TransposeFunction )
+		for( size_t i=0 ; i<At.rowNum ; i++ ) for( size_t j=0 ; j<At.rowSizes[i] ; j++ )
+		{
+			size_t ii = At[i][j].N;
+			A[ii][ A.rowSizes[ii]++ ] = MatrixEntry< T , IndexType >( (IndexType)i , TransposeFunction( At[i][j].Value ) );
+		}
+	else
+		for( size_t i=0 ; i<At.rowNum ; i++ ) for( size_t j=0 ; j<At.rowSizes[i] ; j++ )
+		{
+			size_t ii = At[i][j].N;
+			A[ii][ A.rowSizes[ii]++ ] = MatrixEntry< T , IndexType >( (IndexType)i , At[i][j].Value );
+		}
+	return A;
+}
+
+template< class T , class IndexType >
+template< class A_const_iterator , class B_const_iterator >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::Multiply( const SparseMatrixInterface< T , A_const_iterator >& A , const SparseMatrixInterface< T , B_const_iterator >& B )
+{
+	SparseMatrix M;
+	size_t aCols = 0 , aRows = A.rows();
+	size_t bCols = 0 , bRows = B.rows();
+	for( size_t i=0 ; i<A.rows() ; i++ ) for( A_const_iterator iter=A.begin(i) ; iter!=A.end(i) ; iter++ ) if( aCols<=iter->N ) aCols = iter->N+1;
+	for( size_t i=0 ; i<B.rows() ; i++ ) for( B_const_iterator iter=B.begin(i) ; iter!=B.end(i) ; iter++ ) if( bCols<=iter->N ) bCols = iter->N+1;
+	if( bRows<aCols ) MK_THROW( "Matrix sizes do not support multiplication " , aRows , " x " , aCols , " * " , bRows , " x " , bCols );
+
+	M.resize( aRows );
+
+	ThreadPool::ParallelFor( 0 , aRows , [&]( unsigned int , size_t i )
+	{
+		std::unordered_map< IndexType , T > row;
+		for( A_const_iterator iterA=A.begin(i) ; iterA!=A.end(i) ; iterA++ )
+		{
+			IndexType idx1 = iterA->N;
+			T AValue = iterA->Value;
+			for( B_const_iterator iterB=B.begin(idx1) ; iterB!=B.end(idx1) ; iterB++ )
+			{
+				IndexType idx2 = iterB->N;
+				T BValue = iterB->Value;
+				T temp = BValue * AValue; // temp = A( i , idx1 ) * B( idx1 , idx2 )
+				typename std::unordered_map< IndexType , T >::iterator iter = row.find(idx2);
+				if( iter==row.end() ) row[idx2] = temp;
+				else iter->second += temp;
+			}
+		}
+		M.setRowSize( i , row.size() );
+		M.rowSizes[i] = 0;
+		for( typename std::unordered_map< IndexType , T >::iterator iter=row.begin() ; iter!=row.end() ; iter++ )
+			M[i][ M.rowSizes[i]++ ] = MatrixEntry< T , IndexType >( iter->first , iter->second );
+	}
+	);
+	return M;
+}
+template< class T , class IndexType >
+template< class const_iterator >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::Transpose( const SparseMatrixInterface< T , const_iterator >& At , T (*TransposeFunction)( const T& ) )
+{
+	SparseMatrix< T , IndexType , 0 > A;
+	size_t aRows = 0 , aCols = At.rows();
+	for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ ) if( aRows<=iter->N ) aRows = iter->N+1;
+
+	A.resize( aRows );
+	for( size_t i=0 ; i<aRows ; i++ ) A.rowSizes[i] = 0;
+	for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ ) A.rowSizes[ iter->N ]++;
+	for( size_t i=0 ; i<A.rows() ; i++ )
+	{
+		size_t t = A.rowSizes[i];
+		A.rowSizes[i] = 0;
+		A.setRowSize( i , t );
+		A.rowSizes[i] = 0;
+	}
+	if( TransposeFunction )
+		for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ )
+		{
+			size_t ii = (size_t)iter->N;
+			A[ii][ A.rowSizes[ii]++ ] = MatrixEntry< T , IndexType >( (IndexType)i , TransposeFunction( iter->Value ) );
+		}
+	else
+		for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ )
+		{
+			size_t ii = (size_t)iter->N;
+			A[ii][ A.rowSizes[ii]++ ] = MatrixEntry< T , IndexType >( (IndexType)i , iter->Value );
+		}
+	return A;
+}
+template< class T , class IndexType >
+template< class const_iterator >
+SparseMatrix< T , IndexType , 0 > SparseMatrix< T , IndexType , 0 >::Transpose( const SparseMatrixInterface< T , const_iterator >& At , size_t outRows , T (*TransposeFunction)( const T& ) )
+{
+	SparseMatrix< T , IndexType , 0 > A;
+	size_t _aRows = 0 , aCols = At.rows() , aRows = outRows;
+	for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ ) if( aCols<=iter->N ) _aRows = iter->N+1;
+	if( _aRows>aRows ) MK_THROW( "Prescribed output dimension too low: " , aRows , " < " , _aRows );
+
+	A.resize( aRows );
+	for( size_t i=0 ; i<aRows ; i++ ) A.rowSizes[i] = 0;
+	for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ ) A.rowSizes[ iter->N ]++;
+	for( size_t i=0 ; i<A.rows() ; i++ )
+	{
+		size_t t = A.rowSizes[i];
+		A.rowSizes[i] = 0;
+		A.setRowSize( i , t );
+		A.rowSizes[i] = 0;
+	}
+	if( TransposeFunction )
+		for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ )
+		{
+			size_t ii = (size_t)iter->N;
+			A[ii][ A.rowSizes[ii]++ ] = MatrixEntry< T , IndexType >( (IndexType)i , TransposeFunction( iter->Value ) );
+		}
+	else
+		for( size_t i=0 ; i<At.rows() ; i++ ) for( const_iterator iter=At.begin(i) ; iter!=At.end(i) ; iter++ )
+		{
+			size_t ii = (size_t)iter->N;
+			A[ii][ A.rowSizes[ii]++ ] = MatrixEntry< T , IndexType >( (IndexType)i , iter->Value );
+		}
+	return true;
+}
+
+///////////////////////////////////////////
+//  SparseMatrix (bounded max row size ) //
+///////////////////////////////////////////
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >::SparseMatrix( void )
+{
+	_rowSizes = NullPointer( size_t );
+	_rowNum = 0;
+	_entries = NullPointer( MatrixEntry< T , IndexType > );
+	_maxRows = 0;
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >::SparseMatrix( size_t rowNum ) : SparseMatrix()
+{
+	resize( rowNum );
+}
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >::SparseMatrix( const SparseMatrix& M ) : SparseMatrix()
+{
+	resize( M._rowNum );
+	for( size_t i=0 ; i<_rowNum ; i++ )
+	{
+		_rowSizes[i] = M._rowSizes[i];
+		for( size_t j=0 ; j<_rowSizes[i] ; j++ ) _entries[ i + MaxRowSize*j ] = M._rowEntries[ i + MaxRowSize*j ];
+	}
+}
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >::SparseMatrix( SparseMatrix&& M ) : SparseMatrix()
+{
+	Swap( *this , M );
+}
+template< class T , class IndexType , size_t MaxRowSize >
+template< class T2 , class IndexType2 >
+SparseMatrix< T , IndexType , MaxRowSize >::SparseMatrix( const SparseMatrix< T2 , IndexType2 , MaxRowSize >& M ) : SparseMatrix()
+{
+	resize( M._rowNum );
+	for( size_t i=0 ; i<_rowNum ; i++ )
+	{
+		_rowSizes[i] = M._rowSizes[i];
+		for( size_t j=0 ; j<_rowSizes[i] ; j++ ) _entries[ i + MaxRowSize*j ] = MatrixEntry< T , IndexType >( M._rowEntries[i][j].N , T( M._entries[ i + MaxRowSize*j ].Value ) );
+	}
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >& SparseMatrix< T , IndexType , MaxRowSize >::operator = ( SparseMatrix< T , IndexType , MaxRowSize >&& M )
+{
+	Swap( *this , M );
+	return *this;
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >& SparseMatrix< T , IndexType , MaxRowSize >::operator = ( const SparseMatrix< T , IndexType , MaxRowSize >& M )
+{
+	resize( M._rowNum );
+	for( size_t i=0 ; i<_rowNum ; i++ )
+	{
+		_rowSizes[i] = M._rowSizes[i];
+		for( size_t j=0 ; j<_rowSizes[i] ; j++ ) _entries[ i + MaxRowSize*j ] = M._entries[ i + MaxRowSize*j ];
+	}
+	return *this;
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+template< class T2 , class IndexType2 >
+SparseMatrix< T , IndexType , MaxRowSize >& SparseMatrix< T , IndexType , MaxRowSize >::operator = ( const SparseMatrix< T2 , IndexType2 , MaxRowSize >& M )
+{
+	resize( M._rowNum );
+	for( size_t i=0 ; i<_rowNum ; i++ )
+	{
+		_rowSizes[i] = M._rowSizes[i];
+		for( size_t j=0 ; j<_rowSizes[i] ; j++ ) _entries[ i + MaxRowSize*j ] = MatrixEntry< T , IndexType >( M._entries[ i + MaxRowSize*j ].N , T( M._entries[ i + MaxRowSize*j ].Value ) );
+	}
+	return *this;
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+template< class T2 >
+void SparseMatrix< T , IndexType , MaxRowSize >::operator() ( const T2* in , T2* out ) const { Interface::multiply( in , out ); }
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >::~SparseMatrix( void )
+{
+	FreePointer( _rowSizes );
+	FreePointer( _entries );
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+void SparseMatrix< T , IndexType , MaxRowSize >::resize( size_t rowNum )
+{
+	_rowNum = rowNum;
+	if( rowNum>_maxRows )
+	{
+		FreePointer( _rowSizes );
+		FreePointer( _entries );
+
+		if( rowNum )
+		{
+			_rowSizes = AllocPointer< size_t >( rowNum );
+			_entries = AllocPointer< MatrixEntry< T , IndexType > >( rowNum * MaxRowSize );
+			_maxRows = rowNum;
+		}
+	}
+	if( rowNum ) memset( _rowSizes , 0 , sizeof(size_t)*rowNum );
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+void SparseMatrix< T , IndexType , MaxRowSize >::setRowSize( size_t row , size_t rowSize )
+{
+	if( row>=_rowNum ) MK_THROW( "Row is out of bounds: 0 <= " , row , " < " , _rowNum );
+	else if( rowSize>MaxRowSize ) MK_THROW( "Row size larger than max row size: " , rowSize , " < " , MaxRowSize );
+	else _rowSizes[row] = rowSize;
+}
+template< class T , class IndexType , size_t MaxRowSize >
+void SparseMatrix< T , IndexType , MaxRowSize >::resetRowSize( size_t row , size_t rowSize )
+{
+	if( row>=_rowNum ) MK_THROW( "Row is out of bounds: 0 <= " , row , " < " , _rowNum );
+	else if( rowSize>MaxRowSize ) MK_THROW( "Row size larger than max row size: " , rowSize , " < " , MaxRowSize );
+	else _rowSizes[row] = rowSize;
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >& SparseMatrix< T , IndexType , MaxRowSize >::operator *= ( T s )
+{
+	ThreadPool::ParallelFor( 0 , _rowNum*MaxRowSize , [&]( unsigned int , size_t i ){ _entries[i].Value *= s; } );
+	return *this;
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize >& SparseMatrix< T , IndexType , MaxRowSize >::operator /= ( T s ){ return (*this) * ( (T)1./s ); }
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize > SparseMatrix< T , IndexType , MaxRowSize >::operator * ( T s ) const
+{
+	SparseMatrix out = (*this);
+	return out *= s;
+}
+
+template< class T , class IndexType , size_t MaxRowSize >
+SparseMatrix< T , IndexType , MaxRowSize > SparseMatrix< T , IndexType , MaxRowSize >::operator / ( T s ) const { return (*this) * ( (T)1. / s ); }

--- a/LiverResections/Algorithm/PoissonRecon/Src/SparseMatrixInterface.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/SparseMatrixInterface.h
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef SPARSE_MATRIX_INTERFACE_INCLUDED
+#define SPARSE_MATRIX_INTERFACE_INCLUDED
+
+#define FORCE_TWO_BYTE_ALIGNMENT
+#include "MyMiscellany.h"
+#include "Array.h"
+
+namespace PoissonRecon
+{
+
+#ifdef FORCE_TWO_BYTE_ALIGNMENT
+#pragma pack(push)
+#pragma pack(2)
+#endif // FORCE_TWO_BYTE_ALIGNMENT
+	template< class T , class IndexType >
+	struct MatrixEntry
+	{
+		MatrixEntry( void )             { N =-1 , Value = 0; }
+		MatrixEntry( IndexType i )      { N = i , Value = 0; }
+		MatrixEntry( IndexType n , T v ){ N = n , Value = v; }
+		IndexType N;
+		T Value;
+	};
+
+#ifdef FORCE_TWO_BYTE_ALIGNMENT
+#pragma pack(pop)
+#endif // FORCE_TWO_BYTE_ALIGNMENT
+
+	enum
+	{
+		MULTIPLY_ADD = 1 ,
+		MULTIPLY_NEGATE = 2
+	};
+
+	//#pragma message( "[WARNING] make me templated off of IndexType as well" )
+	template< class T , class const_iterator > class SparseMatrixInterface
+	{
+	public:
+		virtual const_iterator begin( size_t row ) const = 0;
+		virtual const_iterator end  ( size_t row ) const = 0;
+		virtual size_t rows   ( void )             const = 0;
+		virtual size_t rowSize( size_t idx )       const = 0;
+
+		size_t entries( void ) const;
+
+		double squareNorm( void ) const;
+		double squareASymmetricNorm( void ) const;
+		double squareASymmetricNorm( size_t &idx1 , size_t &idx2 ) const;
+
+		template< class T2 > void multiply      (           ConstPointer( T2 ) In , Pointer( T2 ) Out , char multiplyFlag=0 ) const;
+		template< class T2 > void multiplyScaled( T scale , ConstPointer( T2 ) In , Pointer( T2 ) Out , char multiplyFlag=0 ) const;
+		template< class T2 > void multiply      (                Pointer( T2 ) In , Pointer( T2 ) Out , char multiplyFlag=0 ) const { multiply      (         ( ConstPointer(T2) )( In ) , Out , multiplyFlag ); }
+		template< class T2 > void multiplyScaled( T scale ,      Pointer( T2 ) In , Pointer( T2 ) Out , char multiplyFlag=0 ) const { multiplyScaled( scale , ( ConstPointer(T2) )( In ) , Out , multiplyFlag ); }
+
+		void setDiagonal( Pointer( T ) diagonal ) const;
+		void setDiagonalR( Pointer( T ) diagonal ) const;
+		template< class T2 > void jacobiIteration( ConstPointer( T ) diagonal , ConstPointer( T2 ) b , ConstPointer( T2 ) in , Pointer( T2 ) out , bool dReciprocal ) const;
+		template< class T2 > void gsIteration( const              std::vector< size_t >  & multiColorIndices , ConstPointer( T ) diagonal , ConstPointer( T2 ) b , Pointer( T2 ) x ,                bool dReciprocal ) const;
+		template< class T2 > void gsIteration( const std::vector< std::vector< size_t > >& multiColorIndices , ConstPointer( T ) diagonal , ConstPointer( T2 ) b , Pointer( T2 ) x , bool forward , bool dReciprocal ) const;
+		template< class T2 > void gsIteration( ConstPointer( T ) diagonal , ConstPointer( T2 ) b , Pointer( T2 ) x , bool forward , bool dReciprocal ) const;
+	};
+
+	// Assuming that the SPDOperator class defines:
+	//		auto SPDOperator::()( ConstPointer( T ) , Pointer( T ) ) const
+	template< class SPDFunctor , class T , typename Real , class TDotTFunctor > size_t SolveCG( const SPDFunctor& M , size_t dim , ConstPointer( T ) b , size_t iters , Pointer( T ) x , double eps , TDotTFunctor Dot );
+	template< class SPDFunctor , class Preconditioner , class T , typename Real , class TDotTFunctor > size_t SolveCG( const SPDFunctor& M , const Preconditioner& P , size_t dim , ConstPointer( T ) b , size_t iters , Pointer( T ) x , double eps , TDotTFunctor Dot );
+
+	template< typename T >
+	struct AbstractArrayWrapper
+	{
+		virtual T operator[]( size_t i ) const = 0;
+	};
+	template< typename T , typename AbstractArrayWrapper1 , typename AbstractArrayWrapper2 > struct _VectorSum;
+	template< typename T , typename AbstractArrayWrapper1 , typename AbstractArrayWrapper2 > struct _VectorDifference;
+	template< typename T , typename Real , typename const_iterator , typename _AbstractArrayWrapper > struct _VectorProduct;
+
+	template< typename T , typename AbstractArrayWrapper1 , typename AbstractArrayWrapper2 >
+	struct _VectorSum : public AbstractArrayWrapper< T >
+	{
+		_VectorSum( const AbstractArrayWrapper1 &v1 , const AbstractArrayWrapper2 &v2 ) : _v1(v1) , _v2(v2)
+		{
+			//		static_assert( std::is_convertible< AbstractArrayWrapper1 , AbstractArrayWrapper< T > >::value || std::is_convertible< AbstractArrayWrapper1 , ConstPointer(T) >::value , "[ERROR] Bad AbstractArrayWrapper1" );
+			//		static_assert( std::is_convertible< AbstractArrayWrapper2 , AbstractArrayWrapper< T > >::value || std::is_convertible< AbstractArrayWrapper2 , ConstPointer(T) >::value , "[ERROR] Bad AbstractArrayWrapper2" );
+		}
+		T operator[] ( size_t i ) const { return _v1[i] + _v2[i]; }
+	protected:
+		const AbstractArrayWrapper1 &_v1;
+		const AbstractArrayWrapper2 &_v2;
+	};
+
+	template< typename T , typename AbstractArrayWrapper1 , typename AbstractArrayWrapper2 >
+	struct _VectorDifference : public AbstractArrayWrapper< T >
+	{
+		_VectorDifference( const AbstractArrayWrapper1 &v1 , const AbstractArrayWrapper2 &v2 ) : _v1(v1) , _v2(v2)
+		{
+			//		static_assert( std::is_convertible< AbstractArrayWrapper1 , AbstractArrayWrapper< T > >::value || std::is_convertible< AbstractArrayWrapper1 , ConstPointer(T) >::value , "[ERROR] Bad AbstractArrayWrapper1" );
+			//		static_assert( std::is_convertible< AbstractArrayWrapper2 , AbstractArrayWrapper< T > >::value || std::is_convertible< AbstractArrayWrapper2 , ConstPointer(T) >::value , "[ERROR] Bad AbstractArrayWrapper2" );
+		}
+		T operator[] ( size_t i ) const { return _v1[i] - _v2[i]; }
+	protected:
+		const AbstractArrayWrapper1 &_v1;
+		const AbstractArrayWrapper2 &_v2;
+	};
+
+	template< typename T , typename Real , typename const_iterator , typename _AbstractArrayWrapper >
+	struct _VectorProduct : public AbstractArrayWrapper< T >
+	{
+		_VectorProduct( const SparseMatrixInterface< Real , const_iterator > &M , const _AbstractArrayWrapper &v ) : _M(M) , _v(v)
+		{
+			//		static_assert( std::is_convertible< _AbstractArrayWrapper , AbstractArrayWrapper< T >  >::value || std::is_convertible< _AbstractArrayWrapper , ConstPointer(T) >::value , "[ERROR] Bad _AbstractArrayWrapper" );
+		}
+		T operator[] ( size_t i ) const
+		{
+			T t = {};
+			const_iterator e = _M.end( i );
+			for( const_iterator iter = _M.begin( i ) ; iter!=e ; iter++ ) t += _v[ iter->N ] * iter->Value;
+			return t;
+		}
+	protected:
+		const SparseMatrixInterface< Real , const_iterator > &_M;
+		const _AbstractArrayWrapper &_v;
+	};
+
+	template< typename T , typename AbstractArrayWrapper1 , typename AbstractArrayWrapper2 >
+	_VectorSum< T , AbstractArrayWrapper1 , AbstractArrayWrapper2 > VectorSum( const AbstractArrayWrapper1 &v1 , const AbstractArrayWrapper2 &v2 ){ return _VectorSum< T , AbstractArrayWrapper1 , AbstractArrayWrapper2 >( v1 , v2 ); }
+	template< typename T , typename AbstractArrayWrapper1 , typename AbstractArrayWrapper2 >
+	_VectorDifference< T , AbstractArrayWrapper1 , AbstractArrayWrapper2 > VectorDifference( const AbstractArrayWrapper1 &v1 , const AbstractArrayWrapper2 &v2 ){ return _VectorDifference< T , AbstractArrayWrapper1 , AbstractArrayWrapper2 >( v1 , v2 ); }
+	template< typename T , typename Real , typename const_iterator , typename _AbstractArrayWrapper >
+	_VectorProduct< T , Real , const_iterator , _AbstractArrayWrapper > VectorProduct( const SparseMatrixInterface< Real , const_iterator > &M , const _AbstractArrayWrapper &v ){ return _VectorProduct< T , Real , const_iterator , _AbstractArrayWrapper >( M , v ); }
+
+#include "SparseMatrixInterface.inl"
+}
+
+#endif // SPARSE_MATRIX_INTERFACE_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/SparseMatrixInterface.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/SparseMatrixInterface.inl
@@ -1,0 +1,378 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+template< class T , class const_iterator > size_t SparseMatrixInterface< T , const_iterator >::entries( void ) const
+{
+	size_t entries = 0;
+	for( size_t i=0 ; i<rows() ; i++ ) entries += rowSize( i );
+	return entries;
+}
+template< class T , class const_iterator > double SparseMatrixInterface< T , const_iterator >::squareNorm( void ) const
+{
+	double n=0;
+	for( size_t i=0 ; i<rows() ; i++ )
+	{
+		const_iterator e = end( i );
+		for( const_iterator iter = begin( i ) ; iter!=e ; iter++ ) n += iter->Value * iter->Value;
+	}
+	return n;
+
+}
+template< class T , class const_iterator > double SparseMatrixInterface< T , const_iterator >::squareASymmetricNorm( void ) const
+{
+	double n=0;
+	for( size_t i=0 ; i<rows() ; i++ )
+	{
+		const_iterator e = end( i );
+		for( const_iterator iter1 = begin( i ) ; iter1!=e ; iter1++ )
+		{
+			size_t j = iter1->N;
+			const_iterator e = end( j );
+			double value = 0;
+			for( const_iterator iter2 = begin( j ) ; iter2!=e ; iter2++ )
+			{
+				size_t k = iter2->N;
+				if( k==i ) value += iter2->Value;
+			}
+			n += (iter1->Value-value) * (iter1->Value-value);
+		}
+	}
+	return n;
+}
+template< class T , class const_iterator > double SparseMatrixInterface< T , const_iterator >::squareASymmetricNorm( size_t &idx1 , size_t &idx2 ) const
+{
+	double n=0;
+	double max=0;
+	for( size_t i=0 ; i<rows() ; i++ )
+	{
+		const_iterator e = end( i );
+		for( const_iterator iter = begin( i ) ; iter!=e ; iter++ )
+		{
+			size_t j = iter->N;
+			const_iterator e = end( j );
+			double value = 0;
+			for( const_iterator iter2 = begin( j ) ; iter2!=e ; iter2++ )
+			{
+				size_t k = iter2->N;
+				if( k==i ) value += iter2->Value;
+			}
+			double temp = (iter->Value-value) * (iter->Value-value);
+			n += temp;
+			if( temp>=max ) idx1 = i , idx2 = j , max=temp;
+		}
+	}
+	return n;
+}
+template< class T , class const_iterator >
+template< class T2 >
+void SparseMatrixInterface< T , const_iterator >::multiply( ConstPointer( T2 ) In , Pointer( T2 ) Out , char multiplyFlag ) const
+{
+	ConstPointer( T2 ) in = In;
+	ThreadPool::ParallelFor( 0 , rows() , [&]( unsigned int , size_t i )
+	{
+		T2 temp;
+		memset( &temp , 0 , sizeof(T2) );
+		ConstPointer( T2 ) _in = in;
+		const_iterator e = end( i );
+		for( const_iterator iter = begin( i ) ; iter!=e ; iter++ ) temp += (T2)( _in[ iter->N ] * iter->Value );
+		if( multiplyFlag & MULTIPLY_NEGATE ) temp = -temp;
+		if( multiplyFlag & MULTIPLY_ADD ) Out[i] += temp;
+		else                              Out[i]  = temp;
+	}
+	);
+}
+template< class T , class const_iterator >
+template< class T2 >
+void SparseMatrixInterface< T , const_iterator >::multiplyScaled( T scale , ConstPointer( T2 ) In , Pointer( T2 ) Out , char multiplyFlag ) const
+{
+	ConstPointer( T2 ) in = In;
+	ThreadPool::ParallelFor( 0 , rows() , [&]( unsigned int , size_t i )
+	{
+		T2 temp;
+		memset( &temp , 0 , sizeof(T2) );
+		ConstPointer( T2 ) _in = in;
+		const_iterator e = end( i );
+		for( const_iterator iter = begin( i ) ; iter!=e ; iter++ ) temp += _in[ iter->N ] * iter->Value;
+		temp *= scale;
+		if( multiplyFlag & MULTIPLY_NEGATE ) temp = -temp;
+		if( multiplyFlag & MULTIPLY_ADD ) Out[i] += temp;
+		else                              Out[i]  = temp;
+	}
+	);
+}
+
+template< class T , class const_iterator >
+void SparseMatrixInterface< T , const_iterator >::setDiagonal( Pointer( T ) diagonal ) const
+{
+	ThreadPool::ParallelFor( 0 , rows() , [&]( unsigned int , size_t i )
+	{
+		diagonal[i] = (T)0;
+		const_iterator e = end( i );
+		for( const_iterator iter = begin( i ) ; iter!=e ; iter++ ) if( iter->N==i ) diagonal[i] += iter->Value;
+	}
+	);
+}
+
+template< class T , class const_iterator >
+void SparseMatrixInterface< T , const_iterator >::setDiagonalR( Pointer( T ) diagonal ) const
+{
+	ThreadPool::ParallelFor( 0 , rows() , [&]( unsigned int , size_t i )
+	{
+		diagonal[i] = (T)0;
+		const_iterator e = end( i );
+		for( const_iterator iter = begin( i ) ; iter!=e ; iter++ ) if( iter->N==i ) diagonal[i] += iter->Value;
+		if( diagonal[i] ) diagonal[i] = (T)( 1./diagonal[i] );
+	}
+	);
+}
+
+template< class T , class const_iterator >
+template< class T2 >
+void SparseMatrixInterface< T , const_iterator >::jacobiIteration( ConstPointer( T ) diagonal , ConstPointer( T2 ) b , ConstPointer( T2 ) in , Pointer( T2 ) out , bool dReciprocal ) const
+{
+	multiply( in , out );
+	if( dReciprocal )
+		ThreadPool::ParallelFor( 0 , rows() , [&]( unsigned int , size_t i ){ out[i] = in[i] + ( b[i] - out[i] ) * diagonal[i]; } );
+	else
+		ThreadPool::ParallelFor( 0 , rows() , [&]( unsigned int , size_t i ){ out[i] = in[i] + ( b[i] - out[i] ) / diagonal[i]; } );
+}
+template< class T , class const_iterator >
+template< class T2 >
+void SparseMatrixInterface< T , const_iterator >::gsIteration( ConstPointer( T ) diagonal , ConstPointer( T2 ) b , Pointer( T2 ) x , bool forward , bool dReciprocal ) const
+{
+	if( dReciprocal )
+	{
+		auto Iterate = [&]( long long j )
+			{
+				T2 _b = b[j];
+				const_iterator e = end( j );
+				for( const_iterator iter = begin( j ) ; iter!=e ; iter++ ) _b -= x[iter->N] * iter->Value;
+				x[j] += _b * diagonal[j];
+			};
+		if( forward ) for( long long j=0 ; j<(long long)rows() ; j++ ){ Iterate( j ); }
+		else          for( long long j=(long long)rows()-1 ; j>=0 ; j-- ){ Iterate( j ); }
+	}
+	else
+	{
+		auto Iterate = [&]( long long j )
+			{
+				T2 _b = b[j];
+				const_iterator e = end( j );
+				for( const_iterator iter = begin( j ) ; iter!=e ; iter++ ) _b -= x[iter->N] * iter->Value;
+				x[j] += _b / diagonal[j];
+			};
+		if( forward ) for( long long j=0 ; j<(long long)rows() ; j++ ){ Iterate( j ); }
+		else          for( long long j=(long long)rows()-1 ; j>=0 ; j-- ){ Iterate( j ); }
+	}
+}
+template< class T , class const_iterator >
+template< class T2 >
+void SparseMatrixInterface< T , const_iterator >::gsIteration( const std::vector< size_t >& multiColorIndices , ConstPointer( T ) diagonal , ConstPointer( T2 ) b , Pointer( T2 ) x , bool dReciprocal ) const
+{
+	if( dReciprocal )
+		ThreadPool::ParallelFor( 0 , multiColorIndices.size() , [&]( unsigned int , size_t j )
+		{
+			size_t jj = multiColorIndices[j];
+			T2 _b = b[jj];
+			const_iterator e = end( jj );
+			for( const_iterator iter = begin( jj ) ; iter!=e ; iter++ ) _b -= x[iter->N] * iter->Value;
+			x[jj] += _b * diagonal[jj];
+		}
+	);
+	else
+			ThreadPool::ParallelFor( 0 , multiColorIndices.size() , [&]( unsigned int , size_t j )
+		{
+			size_t jj = multiColorIndices[j];
+			T2 _b = b[jj];
+			const_iterator e = end( jj );
+			for( const_iterator iter = begin( jj ) ; iter!=e ; iter++ ) _b -= x[iter->N] * iter->Value;
+			x[jj] += _b / diagonal[jj];
+		}
+	);
+}
+
+template< class T , class const_iterator >
+template< class T2 >
+void SparseMatrixInterface< T , const_iterator >::gsIteration( const std::vector< std::vector< size_t > >& multiColorIndices , ConstPointer( T ) diagonal , ConstPointer( T2 ) b , Pointer( T2 ) x , bool forward , bool dReciprocal ) const
+{
+	if( dReciprocal )
+	{
+		auto Iterate = [&]( const std::vector< size_t > &indices )
+			{
+				ThreadPool::ParallelFor( 0 , indices.size() , [&]( unsigned int , size_t k )
+					{
+						size_t jj = indices[k];
+						T2 _b = b[jj];
+						const_iterator e = end( jj );
+						for( const_iterator iter = begin( jj ) ; iter!=e ; iter++ ) _b -= x[iter->N] * iter->Value;
+						x[jj] += _b * diagonal[jj];
+					}
+				);
+			};
+		if( forward ) for( size_t j=0 ; j<multiColorIndices.size() ; j++ ){ Iterate( multiColorIndices[j] ); }
+		else for( long long j=(long long)multiColorIndices.size()-1 ; j>=0 ; j-- ){ Iterate( multiColorIndices[j] ); }
+	}
+	else
+	{
+		auto Iterate = [&]( const std::vector< size_t > &indices )
+			{
+				ThreadPool::ParallelFor( 0 , indices.size() , [&]( unsigned int , size_t k )
+					{
+						size_t jj = indices[k];
+						T2 _b = b[jj];
+						const_iterator e = end( jj );
+						for( const_iterator iter = begin( jj ) ; iter!=e ; iter++ ) _b -= x[iter->N] * iter->Value;
+						x[jj] += _b / diagonal[jj];
+					}
+				);
+			};
+		if( forward ) for( size_t j=0 ; j<multiColorIndices.size()  ; j++ ){ Iterate( multiColorIndices[j] ); }
+		else for( long long j=(long long)multiColorIndices.size()-1 ; j>=0 ; j-- ){ Iterate( multiColorIndices[j] ); }
+	}
+}
+template< class SPDFunctor , class T , typename Real , class TDotTFunctor > size_t SolveCG( const SPDFunctor& M , size_t dim , ConstPointer( T ) b , size_t iters , Pointer( T ) x , double eps , TDotTFunctor Dot )
+{
+	std::vector< Real > scratch( ThreadPool::NumThreads() , 0 );
+	eps *= eps;
+	Pointer( T ) r = AllocPointer< T >( dim );
+	Pointer( T ) d = AllocPointer< T >( dim );
+	Pointer( T ) q = AllocPointer< T >( dim );
+
+	Real delta_new = 0 , delta_0;
+	M( ( ConstPointer( T ) )x , r );
+	ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int thread , size_t i ){ d[i] = r[i] = b[i] - r[i] , scratch[thread] += Dot( r[i] , r[i] ); } );
+	for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ){ delta_new += scratch[t] ; scratch[t] = 0; }
+
+	delta_0 = delta_new;
+	if( delta_new<=eps )
+	{
+		FreePointer( r );
+		FreePointer( d );
+		FreePointer( q );
+		return 0;
+	}
+	size_t ii;
+	for( ii=0 ; ii<iters && delta_new>eps*delta_0 ; ii++ )
+	{
+		M( ( ConstPointer( T ) )d , q );
+		Real dDotQ = 0;
+		ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int thread , size_t i ){ scratch[thread] += Dot( d[i] , q[i] ); } );
+		for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ){ dDotQ += scratch[t] ; scratch[t] = 0; }
+		if( !dDotQ ) break;
+
+		Real alpha = delta_new / dDotQ;
+		Real delta_old = delta_new;
+		delta_new = 0;
+		if( (ii%50)==(50-1) )
+		{
+			ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int , size_t i ){ x[i] += (T)( d[i] * alpha ); } );
+			M( ( ConstPointer( T ) )x , r );
+			ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int thread , size_t i ){ r[i] = b[i] - r[i] , scratch[thread] += Dot( r[i] , r[i] ) , x[i] += (T)( d[i] * alpha ); } );
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ){ delta_new += scratch[t] ; scratch[t] = 0; }
+		}
+		else
+		{
+			ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int thread , size_t i ){ r[i] -=(T)( q[i] * alpha ) , scratch[thread] += Dot( r[i] , r[i] ) ,  x[i] += (T)( d[i] * alpha ); } );
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ){ delta_new += scratch[t] ; scratch[t] = 0; }
+		}
+
+		Real beta = delta_new / delta_old;
+		ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int , size_t i ){ d[i] = r[i] + (T)( d[i] * beta ); } );
+	}
+	FreePointer( r );
+	FreePointer( d );
+	FreePointer( q );
+	return ii;
+}
+template< class SPDFunctor , class Preconditioner , class T , typename Real , class TDotTFunctor > size_t SolveCG( const SPDFunctor& M , const Preconditioner& P , size_t dim , ConstPointer( T ) b , size_t iters , Pointer( T ) x , double eps , TDotTFunctor Dot  )
+{
+	std::vector< Real > scratch( ThreadPool::NumThreads() , 0 );
+	eps *= eps;
+	Pointer( T ) r = AllocPointer< T >( dim );
+	Pointer( T ) d = AllocPointer< T >( dim );
+	Pointer( T ) q = AllocPointer< T >( dim );
+	Pointer( T ) Pb = AllocPointer< T >( dim );
+	Pointer( T ) temp = AllocPointer< T >( dim );
+
+	auto PM = [&] ( ConstPointer(T) x , Pointer(T) y )
+	{
+		M( x , temp );
+		P( ( ConstPointer(T) )temp , y );
+	};
+
+	Real delta_new = 0 , delta_0;
+	P( b , Pb );
+	PM( ( ConstPointer( T ) )x , r );
+	ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int thread , size_t i ){ d[i] = r[i] = Pb[i] - r[i] , scratch[thread] += Dot( r[i] , r[i] ); } );
+	for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ){ delta_new += scratch[t] ; scratch[t] = 0; }
+
+	delta_0 = delta_new;
+	if( delta_new<=eps )
+	{
+		FreePointer( Pb );
+		FreePointer( r );
+		FreePointer( d );
+		FreePointer( q );
+		FreePointer( temp );
+		return 0;
+	}
+	size_t ii;
+	for( ii=0 ; ii<iters && delta_new>eps*delta_0 ; ii++ )
+	{
+		PM( ( ConstPointer( T ) )d , q );
+		Real dDotQ = 0;
+		ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int thread , size_t i ){ scratch[thread] += Dot( d[i] , q[i] ); } );
+		for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ){ dDotQ += scratch[t] ; scratch[t] = 0; }
+		if( !dDotQ ) break;
+
+		Real alpha = delta_new / dDotQ;
+		Real delta_old = delta_new;
+		delta_new = 0;
+		if( (ii%50)==(50-1) )
+		{
+			ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int , size_t i ){ x[i] += (T)( d[i] * alpha ); } );
+			PM( ( ConstPointer( T ) )x , r );
+			ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int thread , size_t i ){ r[i] = Pb[i] - r[i] , scratch[thread] += Dot( r[i] , r[i] ) , x[i] += (T)( d[i] * alpha ); } );
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) delta_new += scratch[t];
+		}
+		else
+		{
+			ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int thread , size_t i ){ r[i] -=(T)( q[i] * alpha ) , scratch[thread] += Dot( r[i] , r[i] ) ,  x[i] += (T)( d[i] * alpha ); } );
+			for( unsigned int t=0 ; t<ThreadPool::NumThreads() ; t++ ) delta_new += scratch[t];
+		}
+
+		Real beta = delta_new / delta_old;
+		ThreadPool::ParallelFor( 0 , dim , [&]( unsigned int , size_t i ){ d[i] = r[i] + (T)( d[i] * beta ); } );
+	}
+	FreePointer( Pb );
+	FreePointer( r );
+	FreePointer( d );
+	FreePointer( q );
+	FreePointer( temp );
+	return ii;
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/Streams.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Streams.h
@@ -1,0 +1,161 @@
+/*
+Copyright (c) 2022, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+#ifndef STREAMS_INCLUDED
+#define STREAMS_INCLUDED
+
+#include "Array.h"
+
+namespace PoissonRecon
+{
+	//////////////////
+	// BinaryStream //
+	//////////////////
+	struct BinaryStream
+	{
+		size_t ioBytes;
+		BinaryStream( void ) : ioBytes(0) {}
+
+		template< typename C > bool  read(       C &c ){ return  __read( (      Pointer( unsigned char ) )GetPointer( c ) , sizeof(C) ); }
+		template< typename C > bool write( const C &c ){ return __write( ( ConstPointer( unsigned char ) )GetPointer( c ) , sizeof(C) ); }
+		template< typename C > bool write(       C &c ){ return __write( ( ConstPointer( unsigned char ) )GetPointer( c ) , sizeof(C) ); }
+		template< typename C > bool  read(      Pointer( C ) c , size_t sz ){ return  __read( (      Pointer( unsigned char ) )c , sizeof(C)*sz ); }
+		template< typename C > bool write( ConstPointer( C ) c , size_t sz ){ return __write( ( ConstPointer( unsigned char ) )c , sizeof(C)*sz ); }
+		template< typename C > bool write(      Pointer( C ) c , size_t sz ){ return __write( ( ConstPointer( unsigned char ) )c , sizeof(C)*sz ); }
+
+		template< typename C >
+		bool read( std::vector< std::vector< C > > &c )
+		{
+			size_t sz;
+			if( !read( sz ) ) return false;
+			c.resize( sz );
+			bool ret = true;
+			for( size_t i=0 ; i<sz && ret ; i++ ) ret &= read( c[i] );
+			return ret;
+		}
+
+		template< typename C >
+		bool read( std::vector< C > &c )
+		{
+			size_t sz;
+			if( !read( sz ) ) return false;
+			c.resize( sz );
+			if( sz ) return read( GetPointer( c ) , sz );
+			else return true;
+		}
+
+		template< typename C >
+		bool write( const std::vector< std::vector< C > > &c )
+		{
+			size_t sz = c.size();
+			if( !write( sz ) ) return false;
+			bool ret = true;
+			for( size_t i=0 ; i<sz && ret ; i++ ) ret &= write( c[i] );
+			return ret;
+		}
+
+		template< typename C >
+		bool write( const std::vector< C > &c )
+		{
+			size_t sz = c.size();
+			if( !write( sz ) ) return false;
+			if( sz ) return write( GetPointer( c ) , sz );
+			else return true;
+		}
+
+		template< typename C >
+		bool write( std::vector< std::vector< C > > &c )
+		{
+			size_t sz = c.size();
+			if( !write( sz ) ) return false;
+			bool ret = true;
+			for( size_t i=0 ; i<sz && ret ; i++ ) ret &= write( c[i] );
+			return ret;
+		}
+
+		template< typename C >
+		bool write( std::vector< C > &c )
+		{
+			size_t sz = c.size();
+			if( !write( sz ) ) return false;
+			if( sz ) return write( GetPointer( c )  , sz );
+			else return true;
+		}
+
+		bool read( std::string &str )
+		{
+			size_t sz;
+			if( !read( sz ) ) return false;
+			char *_str = new char[sz+1];
+			bool ret = read( GetPointer( _str , sz+1 ) , sz+1 );
+			if( ret ) str = std::string( _str );
+			delete[] _str;
+			return ret;
+		}
+
+		bool write( const std::string &str )
+		{
+			size_t sz = strlen( str.c_str() );
+			if( !write( sz ) ) return false;
+			return write( GetPointer( str.c_str() , sz+1 ) , sz+1 );
+		}
+
+		bool write( std::string &str )
+		{
+			size_t sz = strlen( str.c_str() );
+			if( !write( sz ) ) return false;
+			return write( GetPointer( str.c_str() , sz+1 ) , sz+1 );
+		}
+	protected:
+		virtual bool  _read(      Pointer( unsigned char ) ptr , size_t sz ) = 0;
+		virtual bool _write( ConstPointer( unsigned char ) ptr , size_t sz ) = 0;
+		bool _write( Pointer( unsigned char ) ptr , size_t sz ){ return _write( ( ConstPointer( unsigned char ) )ptr , sz ); }
+		bool  __read(      Pointer( unsigned char ) ptr , size_t sz ){ ioBytes += sz ; return  _read( ptr , sz ); }
+		bool __write( ConstPointer( unsigned char ) ptr , size_t sz ){ ioBytes += sz ; return _write( ptr , sz ); }
+		bool __write(      Pointer( unsigned char ) ptr , size_t sz ){ ioBytes += sz ; return _write( ( ConstPointer( unsigned char ) )ptr , sz ); }
+	};
+
+	struct FileStream : public BinaryStream
+	{
+		FileStream( FILE *fp ) : _fp(fp){}
+		void reset( void ){ std::rewind( _fp ); }
+	protected:
+		FILE *_fp;
+		bool  _read(      Pointer( unsigned char ) ptr , size_t sz ){ return  fread( ptr , sizeof(unsigned char) , sz , _fp )==sz; }
+		bool _write( ConstPointer( unsigned char ) ptr , size_t sz ){ return fwrite( ptr , sizeof(unsigned char) , sz , _fp )==sz; }
+	};
+
+	template< typename C >
+	struct Serializer
+	{
+		virtual size_t size( void ) const = 0;
+		virtual void   serialize( const C & , Pointer( char ) buffer ) const = 0;
+		virtual void deserialize( ConstPointer( char ) buffer , C & ) const = 0;
+	};
+}
+
+#endif // STREAMS_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/VertexFactory.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/VertexFactory.h
@@ -1,0 +1,626 @@
+/*
+Copyright (c) 2020, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+#ifndef VERTEX_FACTORY_INCLUDED
+#define VERTEX_FACTORY_INCLUDED
+
+#include <inttypes.h>
+#include "Ply.h"
+#include "Array.h"
+
+namespace PoissonRecon
+{
+	namespace VertexFactory
+	{
+		// Mimicking the scalar types in Ply.inl
+		// Assuming Real is something that is castable to/from a double
+		enum TypeOnDisk
+		{
+			CHAR ,
+			UCHAR ,
+			INT ,
+			UINT ,
+			FLOAT ,
+			DOUBLE ,
+			INT_8 ,
+			UINT_8 ,
+			INT_16 ,
+			UINT_16 ,
+			INT_32 ,
+			UINT_32 ,
+			INT_64 ,
+			UINT_64 ,
+			UNKNOWN
+		};
+
+		inline int ToPlyType( TypeOnDisk typeOnDisk );
+		inline TypeOnDisk FromPlyType( int plyType );
+		template< typename Real > TypeOnDisk GetTypeOnDisk( void );
+
+		template< typename Real >
+		struct VertexIO
+		{
+			static bool ReadASCII  ( FILE *fp , TypeOnDisk typeOnDisk ,       Real &s );
+			static bool ReadBinary ( FILE *fp , TypeOnDisk typeOnDisk ,       Real &s );
+			static void WriteASCII ( FILE *fp , TypeOnDisk typeOnDisk , const Real &s );
+			static void WriteBinary( FILE *fp , TypeOnDisk typeOnDisk , const Real &s );
+
+			static bool ReadASCII  ( FILE *fp , TypeOnDisk typeOnDisk , size_t sz ,       Real *s );
+			static bool ReadBinary ( FILE *fp , TypeOnDisk typeOnDisk , size_t sz ,       Real *s );
+			static void WriteASCII ( FILE *fp , TypeOnDisk typeOnDisk , size_t sz , const Real *s );
+			static void WriteBinary( FILE *fp , TypeOnDisk typeOnDisk , size_t sz , const Real *s );
+
+		protected:
+			template< typename Type > static bool  _ReadBinary( FILE *fp , Real &s );
+			template< typename Type > static void _WriteBinary( FILE *fp , Real  s );
+		};
+
+		template< typename _VertexType , typename FactoryType >
+		struct _Factory
+		{
+			typedef _VertexType VertexType;
+			virtual VertexType operator()( void ) const = 0;
+
+			// Reading/writing methods for PLY format
+			virtual unsigned int  plyReadNum( void ) const = 0;
+			virtual unsigned int plyWriteNum( void ) const = 0;
+			virtual bool plyValidReadProperties( const bool *flags ) const = 0;
+
+			virtual PlyProperty  plyReadProperty( unsigned int idx ) const = 0;
+			virtual PlyProperty plyWriteProperty( unsigned int idx ) const = 0;
+
+			// Reading/writing methods for ASCII/Binary files
+			virtual bool   readASCII( FILE *fp ,       VertexType &dt ) const = 0;
+			virtual bool  readBinary( FILE *fp ,       VertexType &dt ) const = 0;
+			virtual void  writeASCII( FILE *fp , const VertexType &dt ) const = 0;
+			virtual void writeBinary( FILE *fp , const VertexType &dt ) const = 0;
+
+			virtual size_t bufferSize( void ) const = 0;
+			virtual void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const = 0;
+			virtual void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const = 0;
+
+			virtual PlyProperty  plyStaticReadProperty( unsigned int idx ) const = 0;
+			virtual PlyProperty plyStaticWriteProperty( unsigned int idx ) const = 0;
+
+			virtual bool operator == ( const FactoryType &factory ) const = 0;
+			bool operator != ( const FactoryType &factory ) const { return !( (*this)==factory ); }
+		};
+
+		// An empty factory
+		template< typename Real >
+		struct EmptyFactory : _Factory< EmptyVectorType< Real > , EmptyFactory< Real > >
+		{
+			typedef typename _Factory< EmptyVectorType< Real > , EmptyFactory< Real > >::VertexType VertexType;
+
+			struct Transform
+			{
+				Transform( void ){}
+				template< typename X > Transform( X ){}
+				void inPlace( VertexType &dt ) const {}
+			};
+
+			VertexType operator()( void ) const { return VertexType(); }
+
+			unsigned int  plyReadNum( void ) const { return 0; }
+			unsigned int plyWriteNum( void ) const { return 0; }
+			bool plyValidReadProperties( const bool *flags ) const { return true ; }
+			PlyProperty  plyReadProperty( unsigned int idx ) const { if( idx>= plyReadNum() ) MK_THROW(  "read property out of bounds" ) ; return PlyProperty(); }
+			PlyProperty plyWriteProperty( unsigned int idx ) const { if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" ) ; return PlyProperty(); }
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const { return true; }
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const { return true; }
+			void  writeASCII( FILE *fp , const VertexType &dt ) const {}
+			void writeBinary( FILE *fp , const VertexType &dt ) const {};
+
+			static constexpr bool IsStaticallyAllocated( void ){ return true; }
+
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const { if( idx>= plyReadNum() ) MK_THROW(  "read property out of bounds" ) ; return PlyProperty(); }
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const { if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" ) ; return PlyProperty(); }
+
+			size_t bufferSize( void ) const { return 0; }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const {}
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const {}
+
+			bool operator == ( const EmptyFactory &factory ) const { return true; }
+
+		};
+
+		// The position factory
+		template< typename Real , unsigned int Dim >
+		struct PositionFactory : _Factory< Point< Real , Dim > , PositionFactory< Real , Dim > >
+		{
+			typedef typename _Factory< Point< Real , Dim > , PositionFactory< Real , Dim > >::VertexType VertexType;
+
+			struct Transform
+			{
+				Transform( void ){ _xForm = XForm< Real , Dim+1 >::Identity(); }
+				Transform( XForm< Real , Dim > xForm ){ _xForm = XForm< Real , Dim+1 >::Identity() ; for( int i=0 ; i<Dim ; i++ ) for( int j=0 ; j<Dim ; j++ ) _xForm(i,j) = xForm(i,j); }
+				Transform( XForm< Real , Dim+1 > xForm ) : _xForm(xForm) {}
+				void inPlace( VertexType &dt ) const { dt = _xForm * dt; }
+			protected:
+				XForm< Real , Dim+1 > _xForm;
+			};
+
+			VertexType operator()( void ) const { return VertexType(); }
+
+			unsigned int  plyReadNum( void ) const { return Dim; }
+			unsigned int plyWriteNum( void ) const { return Dim; }
+			bool plyValidReadProperties( const bool *flags ) const { for( int d=0 ; d<Dim ; d++ ) if( !flags[d] ) return false ; return true ; }
+			PlyProperty  plyReadProperty( unsigned int idx ) const;
+			PlyProperty plyWriteProperty( unsigned int idx ) const;
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const { return VertexIO< Real >:: ReadASCII( fp , _typeOnDisk , Dim , &dt[0] ); }
+			void  writeASCII( FILE *fp , const VertexType &dt ) const { VertexIO< Real >:: WriteASCII( fp , _typeOnDisk , Dim , &dt[0] ); }
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) return fread( &dt[0] , sizeof(Real) , Dim , fp )==Dim;
+				else return VertexIO< Real >::ReadBinary( fp , _typeOnDisk , Dim , &dt[0] );
+			}
+			void writeBinary( FILE *fp , const VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) fwrite( &dt[0] , sizeof(Real) , Dim , fp );
+				else VertexIO< Real >::WriteBinary( fp , _typeOnDisk , Dim , &dt[0] );
+			}
+
+			static constexpr bool IsStaticallyAllocated( void ){ return true; } 
+
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const;
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const;
+
+			PositionFactory( TypeOnDisk typeOnDisk=GetTypeOnDisk< Real >() ) : _typeOnDisk( typeOnDisk ) { _realTypeOnDisk = GetTypeOnDisk< Real >()==_typeOnDisk; }
+
+			size_t bufferSize( void ) const { return sizeof( VertexType ); }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { memcpy( buffer , &dt , sizeof( VertexType ) ); }
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const { memcpy( &dt , buffer , sizeof( VertexType ) ); }
+
+			bool operator == ( const PositionFactory &factory ) const { return _typeOnDisk==factory._typeOnDisk; }
+		protected:
+			TypeOnDisk _typeOnDisk;
+			bool _realTypeOnDisk;
+			static std::string _PlyName( unsigned int idx );
+		};
+
+		// The vertex factory
+		template< typename Real , unsigned int Dim >
+		struct NormalFactory : public _Factory< Point< Real , Dim > , NormalFactory< Real , Dim > >
+		{
+			typedef typename _Factory< Point< Real , Dim > , NormalFactory< Real , Dim > >::VertexType VertexType;
+
+			struct Transform
+			{
+				Transform( void ){ _xForm = XForm< Real , Dim >::Identity(); }
+				Transform( XForm< Real , Dim > xForm ){ _xForm = xForm.inverse().transpose(); }
+				Transform( XForm< Real , Dim+1 > xForm )
+				{
+					for( int i=0 ; i<Dim ; i++ ) for( int j=0 ; j<Dim ; j++ ) _xForm(i,j) = xForm(i,j);
+					_xForm = _xForm.inverse().transpose();
+				}
+				void inPlace( VertexType &dt ) const { dt = _xForm * dt; }
+			protected:
+				XForm< Real , Dim > _xForm;
+			};
+
+			VertexType operator()( void ) const { return VertexType(); }
+
+			unsigned int  plyReadNum( void ) const { return Dim; }
+			unsigned int plyWriteNum( void ) const { return Dim; }
+			bool plyValidReadProperties( const bool *flags ) const { for( int d=0 ; d<Dim ; d++ ) if( !flags[d] ) return false ; return true ; }
+			PlyProperty  plyReadProperty( unsigned int idx ) const;
+			PlyProperty plyWriteProperty( unsigned int idx ) const;
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const { return VertexIO< Real >:: ReadASCII( fp , _typeOnDisk , Dim , &dt[0] ); }
+			void  writeASCII( FILE *fp , const VertexType &dt ) const { VertexIO< Real >:: WriteASCII( fp , _typeOnDisk , Dim , &dt[0] ); }
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) return fread( &dt[0] , sizeof(Real) , Dim , fp )==Dim;
+				else return VertexIO< Real >::ReadBinary( fp , _typeOnDisk , Dim , &dt[0] );
+			}
+			void writeBinary( FILE *fp , const VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) fwrite( &dt[0] , sizeof(Real) , Dim , fp );
+				else VertexIO< Real >::WriteBinary( fp , _typeOnDisk , Dim , &dt[0] );
+			}
+
+			static constexpr bool IsStaticallyAllocated( void ){ return true; } 
+
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const;
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const;
+
+			NormalFactory( TypeOnDisk typeOnDisk=GetTypeOnDisk< Real >() ) : _typeOnDisk( typeOnDisk ) { _realTypeOnDisk = GetTypeOnDisk< Real >()==_typeOnDisk; }
+
+			size_t bufferSize( void ) const { return sizeof( VertexType ); }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { memcpy( buffer , &dt , sizeof( VertexType ) ); }
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const { memcpy( &dt , buffer , sizeof( VertexType ) ); }
+
+			bool operator == ( const NormalFactory &factory ) const { return _typeOnDisk==factory._typeOnDisk; }
+		protected:
+			TypeOnDisk _typeOnDisk;
+			bool _realTypeOnDisk;
+				static std::string _PlyName( unsigned int idx );
+		};
+
+		// The texture factory
+		template< typename Real , unsigned int Dim >
+		struct TextureFactory : public _Factory< Point< Real , Dim > , TextureFactory< Real , Dim > >
+		{
+			typedef typename _Factory< Point< Real , Dim > , TextureFactory< Real , Dim > >::VertexType VertexType;
+
+			struct Transform
+			{
+				Transform( void ){}
+				template< typename XForm > Transform( XForm xForm ){}
+				void inPlace( VertexType &dt ) const {}
+			};
+
+			VertexType operator()( void ) const { return VertexType(); }
+
+			unsigned int  plyReadNum( void ) const { return Dim; }
+			unsigned int plyWriteNum( void ) const { return Dim; }
+			bool plyValidReadProperties( const bool *flags ) const { for( int d=0 ; d<Dim ; d++ ) if( !flags[d] ) return false ; return true ; }
+			PlyProperty  plyReadProperty( unsigned int idx ) const;
+			PlyProperty plyWriteProperty( unsigned int idx ) const;
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const { return VertexIO< Real >:: ReadASCII( fp , _typeOnDisk , Dim , &dt[0] ); }
+			void  writeASCII( FILE *fp , const VertexType &dt ) const { VertexIO< Real >:: WriteASCII( fp , _typeOnDisk , Dim , &dt[0] ); }
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) return fread( &dt[0] , sizeof(Real) , Dim , fp )==Dim;
+				else return VertexIO< Real >::ReadBinary( fp , _typeOnDisk , Dim , &dt[0] );
+			}
+			void writeBinary( FILE *fp , const VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) fwrite( &dt[0] , sizeof(Real) , Dim , fp );
+				VertexIO< Real >::WriteBinary( fp , _typeOnDisk , Dim , &dt[0] );
+			}
+
+			static constexpr bool IsStaticallyAllocated( void ){ return true; } 
+
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const;
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const;
+
+			TextureFactory( TypeOnDisk typeOnDisk=GetTypeOnDisk< Real >() ) : _typeOnDisk( typeOnDisk ) { _realTypeOnDisk = GetTypeOnDisk< Real >()==_typeOnDisk; }
+
+			size_t bufferSize( void ) const { return sizeof( VertexType ); }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { memcpy( buffer , &dt , sizeof( VertexType ) ); }
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const { memcpy( &dt , buffer , sizeof( VertexType ) ); }
+
+			bool operator == ( const TextureFactory &factory ) const { return _typeOnDisk==factory._typeOnDisk; }
+
+		protected:
+			TypeOnDisk _typeOnDisk;
+			bool _realTypeOnDisk;
+			static std::string _PlyName( unsigned int idx );
+		};
+
+		// The rgb color factory
+		template< typename Real >
+		struct RGBColorFactory : public _Factory< Point< Real , 3 > , RGBColorFactory< Real > >
+		{
+			typedef typename _Factory< Point< Real , 3 > , RGBColorFactory< Real > >::VertexType VertexType;
+
+			struct Transform
+			{
+				Transform( void ){}
+				template< typename XForm > Transform( XForm xForm ){}
+				void inPlace( VertexType &dt ) const {}
+			};
+
+			VertexType operator()( void ) const { return VertexType(); }
+
+			unsigned int  plyReadNum( void ) const { return 6; }
+			unsigned int plyWriteNum( void ) const { return 3; }
+			bool plyValidReadProperties( const bool *flags ) const { for( int d=0 ; d<3 ; d++ ) if( !flags[d] && !flags[d+3] ) return false ; return true ; }
+			PlyProperty  plyReadProperty( unsigned int idx ) const;
+			PlyProperty plyWriteProperty( unsigned int idx ) const;
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const { return VertexIO< Real >:: ReadASCII( fp , _typeOnDisk , 3 , &dt[0] ); }
+			void  writeASCII( FILE *fp , const VertexType &dt ) const { VertexIO< Real >:: WriteASCII( fp , _typeOnDisk , 3 , &dt[0] ); }
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) return fread( &dt[0] , sizeof(Real) , 3 , fp )==3;
+				else return VertexIO< Real >::ReadBinary( fp , _typeOnDisk , 3 , &dt[0] );
+			}
+			void writeBinary( FILE *fp , const VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) fwrite( &dt[0] , sizeof(Real) , 3 , fp );
+				VertexIO< Real >::WriteBinary( fp , _typeOnDisk , 3 , &dt[0] );
+			}
+
+			static constexpr bool IsStaticallyAllocated( void ){ return true; } 
+
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const;
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const;
+
+			RGBColorFactory( TypeOnDisk typeOnDisk=GetTypeOnDisk< unsigned char >() ) : _typeOnDisk( typeOnDisk ) { _realTypeOnDisk = GetTypeOnDisk< Real >()==_typeOnDisk; }
+
+			size_t bufferSize( void ) const { return sizeof( VertexType ); }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { memcpy( buffer , &dt , sizeof( VertexType ) ); }
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const { memcpy( &dt , buffer , sizeof( VertexType ) ); }
+
+			bool operator == ( const RGBColorFactory &factory ) const { return _typeOnDisk==factory._typeOnDisk; }
+		protected:
+			TypeOnDisk _typeOnDisk;
+			bool _realTypeOnDisk;
+			static std::string _PlyName( unsigned int idx );
+		};
+
+		// The rgba color factory
+		template< typename Real >
+		struct RGBAColorFactory : public _Factory< Point< Real , 4 > , RGBAColorFactory< Real > >
+		{
+			typedef typename _Factory< Point< Real , 4 > , RGBAColorFactory< Real > >::VertexType VertexType;
+
+			struct Transform
+			{
+				Transform( void ){}
+				template< typename XForm > Transform( XForm xForm ){}
+				void inPlace( VertexType &dt ) const {}
+			};
+
+			VertexType operator()( void ) const { return VertexType(); }
+
+			unsigned int  plyReadNum( void ) const { return 8; }
+			unsigned int plyWriteNum( void ) const { return 4; }
+			bool plyValidReadProperties( const bool *flags ) const { for( int d=0 ; d<4 ; d++ ) if( !flags[d] && !flags[d+4] ) return false ; return true ; }
+			PlyProperty  plyReadProperty( unsigned int idx ) const;
+			PlyProperty plyWriteProperty( unsigned int idx ) const;
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const { return VertexIO< Real >:: ReadASCII( fp , _typeOnDisk , 4 , &dt[0] ); }
+			void  writeASCII( FILE *fp , const VertexType &dt ) const { VertexIO< Real >:: WriteASCII( fp , _typeOnDisk , 4 , &dt[0] ); }
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) return fread( &dt[0] , sizeof(Real) , 4 , fp )==4;
+				else return VertexIO< Real >::ReadBinary( fp , _typeOnDisk , 4 , &dt[0] );
+			}
+			void writeBinary( FILE *fp , const VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) fwrite( &dt[0] , sizeof(Real) , 4 , fp );
+				VertexIO< Real >::WriteBinary( fp , _typeOnDisk , 4 , &dt[0] );
+			}
+
+			static constexpr bool IsStaticallyAllocated( void ){ return true; } 
+
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const;
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const;
+
+			RGBAColorFactory( TypeOnDisk typeOnDisk=GetTypeOnDisk< unsigned char >() ) : _typeOnDisk( typeOnDisk ) { _realTypeOnDisk = GetTypeOnDisk< Real >()==_typeOnDisk; }
+			size_t bufferSize( void ) const { return sizeof( VertexType ); }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { memcpy( buffer , &dt , sizeof( VertexType ) ); }
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const { memcpy( &dt , buffer , sizeof( VertexType ) ); }
+
+			bool operator == ( const RGBAColorFactory &factory ) const { return _typeOnDisk==factory._typeOnDisk; }
+		protected:
+			TypeOnDisk _typeOnDisk;
+			bool _realTypeOnDisk;
+			static std::string _PlyName( unsigned int idx );
+		};
+
+		// The value factory
+		template< typename Real >
+		struct ValueFactory : public _Factory< Real , ValueFactory< Real > >
+		{
+			typedef typename _Factory< Real , ValueFactory< Real > >::VertexType VertexType;
+
+			struct Transform
+			{
+				Transform( void ){}
+				template< typename XForm > Transform( XForm xForm ){}
+				void inPlace( VertexType &dt ) const {}
+			};
+
+			VertexType operator()( void ) const { return (Real)0; }
+
+			unsigned int  plyReadNum( void ) const { return 1; }
+			unsigned int plyWriteNum( void ) const { return 1; }
+			bool plyValidReadProperties( const bool *flags ) const { if( !flags[0] ) return false ; return true ; }
+			PlyProperty  plyReadProperty( unsigned int idx ) const;
+			PlyProperty plyWriteProperty( unsigned int idx ) const;
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const { return VertexIO< Real >:: ReadASCII( fp , _typeOnDisk , 1 , &dt ); }
+			void  writeASCII( FILE *fp , const VertexType &dt ) const { VertexIO< Real >:: WriteASCII( fp , _typeOnDisk , 1 , &dt ); }
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) return fread( &dt , sizeof(Real) , 1 , fp )==1;
+				else return VertexIO< Real >::ReadBinary( fp , _typeOnDisk , 1 , &dt );
+			}
+			void writeBinary( FILE *fp , const VertexType &dt ) const
+			{
+				if( _realTypeOnDisk ) fwrite( &dt , sizeof(Real) , 1 , fp );
+				else VertexIO< Real >::WriteBinary( fp , _typeOnDisk , 1 , &dt );
+			}
+
+			static constexpr bool IsStaticallyAllocated( void ){ return true; } 
+
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const;
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const;
+
+			ValueFactory( TypeOnDisk typeOnDisk=GetTypeOnDisk< Real >() ) : _typeOnDisk( typeOnDisk ) { _realTypeOnDisk = GetTypeOnDisk< Real >()==_typeOnDisk; }
+
+			size_t bufferSize( void ) const { return sizeof( VertexType ); }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { memcpy( buffer , &dt , sizeof( VertexType ) ); }
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const { memcpy( &dt , buffer , sizeof( VertexType ) ); }
+
+			bool operator == ( const ValueFactory &factory ) const { return _typeOnDisk==factory._typeOnDisk; }
+		protected:
+			TypeOnDisk _typeOnDisk;
+			bool _realTypeOnDisk;
+			static std::string _PlyName( unsigned int idx );
+		};
+
+		// The named array factory
+		template< typename Real >
+		struct DynamicFactory : public _Factory< Point< Real > , DynamicFactory< Real > >
+		{
+			typedef typename _Factory< Point< Real > , DynamicFactory< Real > >::VertexType VertexType;
+
+			struct Transform
+			{
+				Transform( void ){}
+				template< typename XForm > Transform( XForm xForm ){}
+				void inPlace( VertexType &dt ) const {}
+			};
+
+			VertexType operator()( void ) const { return Point< Real >( _namesAndTypesOnDisk.size() ); }
+			unsigned int  plyReadNum( void ) const { return (unsigned int )_namesAndTypesOnDisk.size(); }
+			unsigned int plyWriteNum( void ) const { return (unsigned int )_namesAndTypesOnDisk.size(); }
+			bool plyValidReadProperties( const bool *flags ) const { for( int d=0 ; d<_namesAndTypesOnDisk.size() ; d++ ) if( !flags[d] ) return false ; return true ; }
+			PlyProperty plyReadProperty( unsigned int idx ) const;
+			PlyProperty plyWriteProperty( unsigned int idx ) const;
+
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const;
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const;
+			void  writeASCII( FILE *fp , const VertexType &dt ) const;
+			void writeBinary( FILE *fp , const VertexType &dt ) const;
+
+			static constexpr bool IsStaticallyAllocated( void ){ return false; } 
+
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const { MK_THROW( "does not support static allocation" ) ; return PlyProperty(); }
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const { MK_THROW( "does not support static allocation" ) ; return PlyProperty(); }
+
+			size_t size( void ) const { return _namesAndTypesOnDisk.size(); }
+
+			DynamicFactory( const std::vector< std::pair< std::string , TypeOnDisk > > &namesAndTypesOnDisk );
+			DynamicFactory( const std::vector< PlyProperty > &plyProperties );
+			size_t bufferSize( void ) const { return sizeof(Real) * _namesAndTypesOnDisk.size(); }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { for( size_t i=0 ; i<_namesAndTypesOnDisk.size() ; i++ ) ( ( Pointer(Real) )(buffer) )[i] = dt[i]; }
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const { for( size_t i=0 ; i<_namesAndTypesOnDisk.size() ; i++ ) dt[i] = ( ( ConstPointer( Real ) )(buffer) )[i]; }
+
+			bool operator == ( const DynamicFactory &factory ) const;
+		protected:
+			bool _realTypeOnDisk;
+			std::vector< std::pair< std::string , TypeOnDisk > > _namesAndTypesOnDisk;
+		};
+
+		// A factory for building the union of multiple components
+		template< typename Real , typename ... Factories >
+		struct Factory :  public _Factory< DirectSum< Real , typename Factories::VertexType ... > , Factory< Real , Factories ... > >
+		{
+		protected:
+			typedef std::tuple< Factories ... > _FactoryTuple;
+		public:
+			typedef typename _Factory< DirectSum< Real , typename Factories::VertexType ... > , Factory< Real , Factories ... > >::VertexType VertexType;
+			template< unsigned int I > using FactoryType = typename std::tuple_element< I , _FactoryTuple >::type;
+			template< unsigned int I >       FactoryType< I >& get( void )       { return std::get< I >( _factoryTuple ); }
+			template< unsigned int I > const FactoryType< I >& get( void ) const { return std::get< I >( _factoryTuple ); }
+
+			struct Transform
+			{
+			protected:
+				typedef std::tuple< typename Factories::Transform ... > _TransformTuple;
+			public:
+				Transform( void ){}
+				template< typename XForm >
+				Transform( XForm xForm ){ _set<0>( xForm ); }
+				void inPlace( VertexType &dt ) const { _inPlace< 0 >( dt ); }
+
+				template< unsigned int I > using TransformType = typename std::tuple_element< I , _TransformTuple >::type;
+				template< unsigned int I >       TransformType< I >& get( void )       { return std::get< I >( _transformTuple ); }
+				template< unsigned int I > const TransformType< I >& get( void ) const { return std::get< I >( _transformTuple ); }
+			protected:
+				_TransformTuple _transformTuple;
+				template< unsigned int I , typename XForm > typename std::enable_if< I!=sizeof...(Factories) >::type _set( XForm xForm ){ this->template get<I>() = xForm ; _set< I+1 >( xForm ); }
+				template< unsigned int I , typename XForm > typename std::enable_if< I==sizeof...(Factories) >::type _set( XForm xForm ){}
+				template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) >::type _inPlace( VertexType &dt ) const { this->template get<I>().inPlace( dt.template get<I>() ) ; _inPlace< I+1 >( dt ); }
+				template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) >::type _inPlace( VertexType &dt ) const {}
+			};
+
+			Factory( void ){}
+			Factory( Factories ... factories ) : _factoryTuple( factories ... ){ }
+
+			VertexType operator()( void ) const{ return _VertexType( std::make_index_sequence< sizeof...(Factories) >() ); }
+
+			unsigned int  plyReadNum( void ) const { return  _plyReadNum<0>(); }
+			unsigned int plyWriteNum( void ) const { return _plyWriteNum<0>(); }
+			bool plyValidReadProperties( const bool *flags ) const { return _plyValidReadProperties<0>( flags ) ; }
+			template< unsigned int I > bool plyValidReadProperties( const bool* flags ) const { return get< I >().plyValidReadProperties( flags + _readOffset< I >() ) ; }
+			PlyProperty  plyReadProperty( unsigned int idx ) const { return  _plyReadProperty<0>( idx , 0 ); }
+			PlyProperty plyWriteProperty( unsigned int idx ) const { return _plyWriteProperty<0>( idx , 0 ); }
+			bool   readASCII( FILE *fp ,       VertexType &dt ) const { return  _readASCII<0>( fp , dt ); }
+			bool  readBinary( FILE *fp ,       VertexType &dt ) const { return _readBinary<0>( fp , dt ); }
+			void  writeASCII( FILE *fp , const VertexType &dt ) const {  _writeASCII<0>( fp , dt ); }
+			void writeBinary( FILE *fp , const VertexType &dt ) const { _writeBinary<0>( fp , dt ); }
+
+			static constexpr bool IsStaticallyAllocated( void ){ return _IsStaticallyAllocated<0>(); }
+			PlyProperty  plyStaticReadProperty( unsigned int idx ) const { if constexpr( IsStaticallyAllocated() ) return  _plyStaticReadProperty<0>( idx ) ; else return PlyProperty(); }
+			PlyProperty plyStaticWriteProperty( unsigned int idx ) const { if constexpr( IsStaticallyAllocated() ) return _plyStaticWriteProperty<0>( idx ) ; else return PlyProperty(); }
+
+			size_t bufferSize( void ) const { return _bufferSize<0>(); }
+			void toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { _toBuffer<0>( dt , buffer ); }
+			void fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const { _fromBuffer<0>( buffer , dt ); }
+
+			bool operator == ( const Factory &factory ) const { return _equal<0>( factory ); }
+		protected:
+			_FactoryTuple _factoryTuple;
+			template< size_t ... Is > VertexType _VertexType( std::index_sequence< Is ... > ) const{ return VertexType( get<Is>().operator()() ... ); }
+
+			template< typename Factory1 , typename Factory2 >
+			static typename std::enable_if< !std::is_same< Factory1 , Factory1 >::value , bool >::type _EqualFactories( const Factory1 &f1 , const Factory1 &f2 ){ return false; }
+			template< typename Factory1 , typename Factory2 >
+			static typename std::enable_if<  std::is_same< Factory1 , Factory1 >::value , bool >::type _EqualFactories( const Factory1 &f1 , const Factory1 &f2 ){ return f1==f2; }
+
+
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , unsigned int >::type _plyReadNum( void ) const { return get<I>().plyReadNum() + _plyReadNum< I+1 >(); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , unsigned int >::type _plyReadNum( void ) const { return 0; }
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , unsigned int >::type _plyWriteNum( void ) const { return get<I>().plyWriteNum() + _plyWriteNum< I+1 >(); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , unsigned int >::type _plyWriteNum( void ) const { return 0; }
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , bool >::type _plyValidReadProperties( const bool *flags ) const { return get< I >().plyValidReadProperties( flags ) && _plyValidReadProperties< I+1 >( flags + get< I >().plyReadNum() ); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , bool >::type _plyValidReadProperties( const bool *flags ) const { return true; }
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , PlyProperty >::type _plyReadProperty( unsigned int idx , size_t offset ) const;
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , PlyProperty >::type _plyWriteProperty( unsigned int idx , size_t offset ) const;
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , PlyProperty >::type _plyReadProperty( unsigned int idx , size_t offset ) const { MK_THROW( "read property out of bounds" ) ; return PlyProperty(); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , PlyProperty >::type _plyWriteProperty( unsigned int idx , size_t offset ) const { MK_THROW( "write property out of bounds" ) ; return PlyProperty(); }
+			template< unsigned int I > typename std::enable_if< I==0 , unsigned int >::type _readOffset( void ) const { return 0; }
+			template< unsigned int I > typename std::enable_if< I!=0 , unsigned int >::type _readOffset( void ) const { return _readOffset< I-1 >() + get< I-1 >().plyReadNum(); }
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , bool >::type _readASCII( FILE *fp , VertexType &dt ) const { return this->template get<I>().readASCII( fp , dt.template get<I>() ) && _readASCII< I+1 >( fp , dt ); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , bool >::type _readASCII( FILE *fp , VertexType &dt ) const { return true; }
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , bool >::type _readBinary( FILE *fp , VertexType &dt ) const { return this->template get<I>().readBinary( fp , dt.template get<I>() ) && _readBinary< I+1 >( fp , dt ); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , bool >::type _readBinary( FILE *fp , VertexType &dt ) const { return true; }
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) >::type  _writeASCII( FILE *fp , const VertexType &dt ) const { this->template get<I>().writeASCII( fp , dt.template get<I>() ) ; _writeASCII< I+1 >( fp , dt ); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) >::type  _writeASCII( FILE *fp , const VertexType &dt ) const {}
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) >::type _writeBinary( FILE *fp , const VertexType &dt ) const { this->template get<I>().writeBinary( fp , dt.template get<I>() ) ; _writeBinary< I+1 >( fp , dt ); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) >::type _writeBinary( FILE *fp , const VertexType &dt ) const {}
+
+			template< unsigned int I > static constexpr bool _IsStaticallyAllocated( void )
+			{
+				if constexpr( I<sizeof...(Factories) ) return FactoryType< I >::IsStaticallyAllocated() && _IsStaticallyAllocated< I+1 >();
+				else return true;
+			}
+
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , PlyProperty >::type _plyStaticReadProperty ( unsigned int idx ) const;
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , PlyProperty >::type _plyStaticWriteProperty( unsigned int idx ) const;
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , PlyProperty >::type _plyStaticReadProperty ( unsigned int idx ) const { MK_THROW(  "read property out of bounds" ) ; return PlyProperty(); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , PlyProperty >::type _plyStaticWriteProperty( unsigned int idx ) const { MK_THROW( "write property out of bounds" ) ; return PlyProperty(); }
+
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , size_t >::type _bufferSize( void ) const { return this->template get<I>().bufferSize() + _bufferSize< I+1 >(); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , size_t >::type _bufferSize( void ) const { return 0; }
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) >::type _toBuffer( const VertexType &dt , Pointer( char ) buffer ) const { this->template get<I>().toBuffer( dt.template get<I>() , buffer ) ; _toBuffer< I+1 >( dt , buffer + this->template get<I>().bufferSize() ); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) >::type _toBuffer( const VertexType &dt , Pointer( char ) buffer ) const {}
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) >::type _fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const {this->template  get<I>().fromBuffer( buffer , dt.template get<I>() ) ; _fromBuffer< I+1 >( buffer + this->template get<I>().bufferSize() , dt ); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) >::type _fromBuffer( ConstPointer( char ) buffer , VertexType &dt ) const {}
+
+			template< unsigned int I > typename std::enable_if< I!=sizeof...(Factories) , bool >::type _equal( const Factory &factory ) const { return _EqualFactories< FactoryType<I> , Factory >( this->template get< I >() , factory.template get<I>() ) && _equal< I+1 >( factory ); }
+			template< unsigned int I > typename std::enable_if< I==sizeof...(Factories) , bool >::type _equal( const Factory &factory ) const { return true; }
+		};
+	}
+
+#include "VertexFactory.inl"
+}
+
+#endif // VERTEX_FACTORY_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/VertexFactory.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/VertexFactory.inl
@@ -1,0 +1,567 @@
+/*
+Copyright (c) 2020, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+namespace VertexFactory
+{
+	int ToPlyType( TypeOnDisk typeOnDisk )
+	{
+		switch( typeOnDisk )
+		{
+			case TypeOnDisk::CHAR:    return PLY::Type<          char >();
+			case TypeOnDisk::UCHAR:   return PLY::Type< unsigned char >();
+			case TypeOnDisk::INT:     return PLY::Type<           int >();
+			case TypeOnDisk::UINT:    return PLY::Type< unsigned  int >();
+			case TypeOnDisk::FLOAT:   return PLY::Type<         float >();
+			case TypeOnDisk::DOUBLE:  return PLY::Type<        double >();
+			case TypeOnDisk::INT_8:   return PLY::Type<        int8_t >();
+			case TypeOnDisk::UINT_8:  return PLY::Type<       uint8_t >();
+			case TypeOnDisk::INT_16:  return PLY::Type<       int16_t >();
+			case TypeOnDisk::UINT_16: return PLY::Type<      uint16_t >();
+			case TypeOnDisk::INT_32:  return PLY::Type<       int32_t >();
+			case TypeOnDisk::UINT_32: return PLY::Type<      uint32_t >();
+			case TypeOnDisk::INT_64:  return PLY::Type<       int64_t >();
+			case TypeOnDisk::UINT_64: return PLY::Type<      uint64_t >();
+			default: MK_THROW( "Unrecognized type: " , typeOnDisk );
+		}
+		return -1;
+	}
+
+	TypeOnDisk FromPlyType( int plyType )
+	{
+		switch( plyType )
+		{
+			case PLY_INT:       return TypeOnDisk::INT;
+			case PLY_UINT:      return TypeOnDisk::UINT;
+			case PLY_CHAR:      return TypeOnDisk::CHAR;
+			case PLY_UCHAR:     return TypeOnDisk::UCHAR;
+			case PLY_FLOAT:     return TypeOnDisk::FLOAT;
+			case PLY_DOUBLE:    return TypeOnDisk::DOUBLE;
+			case PLY_INT_8:     return TypeOnDisk::INT_8;
+			case PLY_UINT_8:    return TypeOnDisk::UINT_8;
+			case PLY_INT_16:    return TypeOnDisk::INT_16;
+			case PLY_UINT_16:   return TypeOnDisk::UINT_16;
+			case PLY_INT_32:    return TypeOnDisk::INT_32;
+			case PLY_UINT_32:   return TypeOnDisk::UINT_32;
+			case PLY_INT_64:    return TypeOnDisk::INT_64;
+			case PLY_UINT_64:   return TypeOnDisk::UINT_64;
+			case PLY_FLOAT_32:  return TypeOnDisk::FLOAT;
+			case PLY_FLOAT_64:  return TypeOnDisk::DOUBLE;
+			default: MK_THROW( "Unrecognized type: " , plyType );
+		}
+		return TypeOnDisk::UNKNOWN;
+	}
+
+	template< typename Type > TypeOnDisk GetTypeOnDisk( void )
+	{
+		if      constexpr( std::is_same< Type ,          char >::value ) return TypeOnDisk::CHAR;
+		else if constexpr( std::is_same< Type , unsigned char >::value ) return TypeOnDisk::UCHAR;
+		else if constexpr( std::is_same< Type ,           int >::value ) return TypeOnDisk::INT;
+		else if constexpr( std::is_same< Type , unsigned  int >::value ) return TypeOnDisk::UINT;
+		else if constexpr( std::is_same< Type ,        int8_t >::value ) return TypeOnDisk::INT_8;
+		else if constexpr( std::is_same< Type ,       uint8_t >::value ) return TypeOnDisk::UINT_8;
+		else if constexpr( std::is_same< Type ,       int16_t >::value ) return TypeOnDisk::INT_16;
+		else if constexpr( std::is_same< Type ,      uint16_t >::value ) return TypeOnDisk::UINT_16;
+		else if constexpr( std::is_same< Type ,       int32_t >::value ) return TypeOnDisk::INT_32;
+		else if constexpr( std::is_same< Type ,      uint32_t >::value ) return TypeOnDisk::UINT_32;
+		else if constexpr( std::is_same< Type ,       int64_t >::value ) return TypeOnDisk::INT_64;
+		else if constexpr( std::is_same< Type ,      uint64_t >::value ) return TypeOnDisk::UINT_64;
+		else if constexpr( std::is_same< Type ,         float >::value ) return TypeOnDisk::FLOAT;
+		else if constexpr( std::is_same< Type ,        double >::value ) return TypeOnDisk::DOUBLE;
+		else MK_THROW( "Unrecognized type" );
+		return TypeOnDisk::UNKNOWN;
+	}
+
+	template< typename Real >
+	template< typename Type >
+	bool VertexIO< Real >::_ReadBinary( FILE *fp , Real &r )
+	{
+		Type t;
+		if( fread( &t , sizeof(Type) , 1 , fp )!=1 ) return false;
+		r = (Real)t;
+		return true;
+	}
+
+	template< typename Real >
+	template< typename Type >
+	void VertexIO< Real >::_WriteBinary( FILE *fp , Real r ){ Type t = (Type)r ; fwrite(  &t , sizeof(Type) , 1 , fp ); }
+
+	template< typename Real >
+	bool VertexIO< Real >::ReadASCII( FILE *fp , TypeOnDisk , Real &s )
+	{
+		double d;
+		if( fscanf( fp , " %lf"  , &d )!=1 ) return false;
+		s = (Real)d;
+		return true;
+	}
+
+	template< typename Real >
+	bool VertexIO< Real >::ReadBinary( FILE *fp , TypeOnDisk typeOnDisk , Real &s )
+	{
+		if( TypeOnDisk()==typeOnDisk ) return fread( &s , sizeof(Real) , 1 , fp )==1;
+		switch( typeOnDisk )
+		{
+			case TypeOnDisk::CHAR:    return _ReadBinary<          char >( fp , s );
+			case TypeOnDisk::UCHAR:   return _ReadBinary< unsigned char >( fp , s );
+			case TypeOnDisk::INT:     return _ReadBinary<           int >( fp , s );
+			case TypeOnDisk::UINT:    return _ReadBinary< unsigned  int >( fp , s );
+			case TypeOnDisk::FLOAT:   return _ReadBinary<         float >( fp , s );
+			case TypeOnDisk::DOUBLE:  return _ReadBinary<        double >( fp , s );
+			case TypeOnDisk::INT_8:   return _ReadBinary<        int8_t >( fp , s );
+			case TypeOnDisk::UINT_8:  return _ReadBinary<       uint8_t >( fp , s );
+			case TypeOnDisk::INT_16:  return _ReadBinary<       int16_t >( fp , s );
+			case TypeOnDisk::UINT_16: return _ReadBinary<      uint16_t >( fp , s );
+			case TypeOnDisk::INT_32:  return _ReadBinary<       int32_t >( fp , s );
+			case TypeOnDisk::UINT_32: return _ReadBinary<      uint32_t >( fp , s );
+			case TypeOnDisk::INT_64:  return _ReadBinary<       int64_t >( fp , s );
+			case TypeOnDisk::UINT_64: return _ReadBinary<      uint64_t >( fp , s );
+			default: MK_THROW( "Unrecognized type: " , typeOnDisk );
+		}
+		return true;
+	}
+	template< typename Real >
+	void VertexIO< Real >::WriteASCII( FILE *fp , TypeOnDisk typeOnDisk , const Real &s )
+	{
+		switch( typeOnDisk )
+		{
+			case TypeOnDisk::CHAR:    fprintf( fp , " %d"       , (         char)s ) ; break;
+			case TypeOnDisk::UCHAR:   fprintf( fp , " %u"       , (unsigned char)s ) ; break;
+			case TypeOnDisk::INT:     fprintf( fp , " %d"       , (          int)s ) ; break;
+			case TypeOnDisk::UINT:    fprintf( fp , " %u"       , (unsigned  int)s ) ; break;
+			case TypeOnDisk::FLOAT:   fprintf( fp , " %f"       , (        float)s ) ; break;
+			case TypeOnDisk::DOUBLE:  fprintf( fp , " %f"       , (       double)s ) ; break;
+			case TypeOnDisk::INT_8:   fprintf( fp , " %" PRId8  , (       int8_t)s ) ; break;
+			case TypeOnDisk::UINT_8:  fprintf( fp , " %" PRIu8  , (      uint8_t)s ) ; break;
+			case TypeOnDisk::INT_16:  fprintf( fp , " %" PRId16 , (      int16_t)s ) ; break;
+			case TypeOnDisk::UINT_16: fprintf( fp , " %" PRIu16 , (     uint16_t)s ) ; break;
+			case TypeOnDisk::INT_32:  fprintf( fp , " %" PRId32 , (      int32_t)s ) ; break;
+			case TypeOnDisk::UINT_32: fprintf( fp , " %" PRIu32 , (     uint32_t)s ) ; break;
+			case TypeOnDisk::INT_64:  fprintf( fp , " %" PRId64 , (      int64_t)s ) ; break;
+			case TypeOnDisk::UINT_64: fprintf( fp , " %" PRIu64 , (     uint64_t)s ) ; break;
+			default: MK_THROW( "Unrecongized type: " , typeOnDisk );
+		}
+	}
+
+	template< typename Real >
+	void VertexIO< Real >::WriteBinary( FILE *fp , TypeOnDisk typeOnDisk , const Real &s )
+	{
+		if( TypeOnDisk()==typeOnDisk ) fwrite( &s , sizeof(Real) , 1 , fp );
+		switch( typeOnDisk )
+		{
+			case TypeOnDisk::CHAR:    _WriteBinary<          char >( fp , s ) ; break;
+			case TypeOnDisk::UCHAR:   _WriteBinary< unsigned char >( fp , s ) ; break;
+			case TypeOnDisk::INT:     _WriteBinary<           int >( fp , s ) ; break;
+			case TypeOnDisk::UINT:    _WriteBinary< unsigned  int >( fp , s ) ; break;
+			case TypeOnDisk::FLOAT:   _WriteBinary<         float >( fp , s ) ; break;
+			case TypeOnDisk::DOUBLE:  _WriteBinary<        double >( fp , s ) ; break;
+			case TypeOnDisk::INT_8:   _WriteBinary<        int8_t >( fp , s ) ; break;
+			case TypeOnDisk::UINT_8:  _WriteBinary<       uint8_t >( fp , s ) ; break;
+			case TypeOnDisk::INT_16:  _WriteBinary<       int16_t >( fp , s ) ; break;
+			case TypeOnDisk::UINT_16: _WriteBinary<      uint16_t >( fp , s ) ; break;
+			case TypeOnDisk::INT_32:  _WriteBinary<       int32_t >( fp , s ) ; break;
+			case TypeOnDisk::UINT_32: _WriteBinary<      uint32_t >( fp , s ) ; break;
+			case TypeOnDisk::INT_64:  _WriteBinary<       int64_t >( fp , s ) ; break;
+			case TypeOnDisk::UINT_64: _WriteBinary<      uint64_t >( fp , s ) ; break;
+			default: MK_THROW( "Unrecongized type: " , typeOnDisk );
+		}
+	}
+
+	template< typename Real >
+	bool VertexIO< Real >::ReadASCII( FILE *fp , TypeOnDisk typeOnDisk , size_t sz , Real *s )
+	{
+		for( size_t i=0 ; i<sz ; i++ ) if( !ReadASCII( fp , typeOnDisk , s[i] ) ) return false;
+		return true;
+	}
+
+	template< typename Real >
+	bool VertexIO< Real >::ReadBinary( FILE *fp , TypeOnDisk typeOnDisk , size_t sz , Real *s )
+	{
+		if( TypeOnDisk()==typeOnDisk ) return fread( s , sizeof(Real) , sz , fp )==sz;
+		else for( size_t i=0 ; i<sz ; i++ ) if( !ReadBinary( fp , typeOnDisk , s[i] ) ) return false;
+		return true;
+	}
+	template< typename Real >
+	void VertexIO< Real >::WriteASCII( FILE *fp , TypeOnDisk typeOnDisk , size_t sz , const Real *s )
+	{
+		for( size_t i=0 ; i<sz ; i++ ) WriteASCII( fp , typeOnDisk , s[i] );
+	}
+
+	template< typename Real >
+	void VertexIO< Real >::WriteBinary( FILE *fp , TypeOnDisk typeOnDisk , size_t sz , const Real *s )
+	{
+		if( TypeOnDisk()==typeOnDisk ) fwrite( s , sizeof(Real) , sz , fp );
+		else for( size_t i=0 ; i<sz ; i++ ) WriteBinary( fp , typeOnDisk , s[i] );
+	}
+
+	/////////////////////
+	// PositionFactory //
+	/////////////////////
+	template< typename Real , unsigned int Dim >
+	PlyProperty PositionFactory< Real , Dim >::plyReadProperty( unsigned int idx ) const
+	{
+		if( idx>= plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+	template< typename Real , unsigned int Dim >
+	PlyProperty PositionFactory< Real , Dim >::plyWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real , unsigned int Dim >
+	PlyProperty PositionFactory< Real , Dim >::plyStaticReadProperty( unsigned int idx ) const
+	{
+		if( idx>=plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + idx*sizeof(Real) ) );
+	}
+	template< typename Real , unsigned int Dim >
+	PlyProperty PositionFactory< Real , Dim >::plyStaticWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + idx*sizeof(Real) ) );
+	}
+
+	template< typename Real , unsigned int Dim >
+	std::string PositionFactory< Real , Dim >::_PlyName( unsigned int idx )
+	{
+		static const std::string names[] = { "x" , "y" , "z" };
+		return names[idx];
+	}
+
+	///////////////////
+	// NormalFactory //
+	///////////////////
+	template< typename Real , unsigned int Dim >
+	PlyProperty NormalFactory< Real , Dim >::plyReadProperty( unsigned int idx ) const
+	{
+		if( idx>= plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+	template< typename Real , unsigned int Dim >
+	PlyProperty NormalFactory< Real , Dim >::plyWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real , unsigned int Dim >
+	PlyProperty NormalFactory< Real , Dim >::plyStaticReadProperty( unsigned int idx ) const
+	{
+		if( idx>=plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + idx*sizeof(Real) ) );
+	}
+	template< typename Real , unsigned int Dim >
+	PlyProperty NormalFactory< Real , Dim >::plyStaticWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + idx*sizeof(Real) ) );
+	}
+
+	template< typename Real , unsigned int Dim >
+	std::string NormalFactory< Real , Dim >::_PlyName( unsigned int idx )
+	{
+		static const std::string names[] = { "nx" , "ny" , "nz" };
+		return names[idx];
+	}
+
+	////////////////////
+	// TextureFactory //
+	////////////////////
+	template< typename Real , unsigned int Dim >
+	PlyProperty TextureFactory< Real , Dim >::plyReadProperty( unsigned int idx ) const
+	{
+		if( idx>= plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+	template< typename Real , unsigned int Dim >
+	PlyProperty TextureFactory< Real , Dim >::plyWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real , unsigned int Dim >
+	PlyProperty TextureFactory< Real , Dim >::plyStaticReadProperty( unsigned int idx ) const
+	{
+		if( idx>=plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + idx*sizeof(Real) ) );
+	}
+	template< typename Real , unsigned int Dim >
+	PlyProperty TextureFactory< Real , Dim >::plyStaticWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + idx*sizeof(Real) ) );
+	}
+
+	template< typename Real , unsigned int Dim >
+	std::string TextureFactory< Real , Dim >::_PlyName( unsigned int idx )
+	{
+		static const std::string names[] = { "u" , "v" , "w" };
+		return names[idx];
+	}
+
+	/////////////////////
+	// RGBColorFactory //
+	/////////////////////
+	template< typename Real >
+	PlyProperty RGBColorFactory< Real >::plyReadProperty( unsigned int idx ) const
+	{
+		if( idx>= plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+	template< typename Real >
+	PlyProperty RGBColorFactory< Real >::plyWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real >
+	PlyProperty RGBColorFactory< Real >::plyStaticReadProperty( unsigned int idx ) const
+	{
+		if( idx>=plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + (idx%3)*sizeof(Real) ) );
+	}
+	template< typename Real >
+	PlyProperty RGBColorFactory< Real >::plyStaticWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + idx*sizeof(Real) ) );
+	}
+
+	template< typename Real >
+	std::string RGBColorFactory< Real >::_PlyName( unsigned int idx )
+	{
+		static const std::string names[] = { "red" , "green" , "blue" , "r" , "g" , "b" };
+		return names[idx];
+	}
+
+	//////////////////////
+	// RGBAColorFactory //
+	//////////////////////
+	template< typename Real >
+	PlyProperty RGBAColorFactory< Real >::plyReadProperty( unsigned int idx ) const
+	{
+		if( idx>= plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real >
+	PlyProperty RGBAColorFactory< Real >::plyWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real >
+	PlyProperty RGBAColorFactory< Real >::plyStaticReadProperty( unsigned int idx ) const
+	{
+		if( idx>=plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + (idx%4)*sizeof(Real) ) );
+	}
+
+	template< typename Real >
+	PlyProperty RGBAColorFactory< Real >::plyStaticWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , (int)( offsetof( VertexType , coords ) + idx*sizeof(Real) ) );
+	}
+
+	template< typename Real >
+	std::string RGBAColorFactory< Real >::_PlyName( unsigned int idx )
+	{
+		static const std::string names[] = { "red" , "green" , "blue" , "alpha" , "r" , "g" , "b" , "a" };
+		return names[idx];
+	}
+
+	//////////////////
+	// ValueFactory //
+	//////////////////
+	template< typename Real >
+	PlyProperty ValueFactory< Real >::plyReadProperty( unsigned int idx ) const
+	{
+		if( idx>= plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real >
+	PlyProperty ValueFactory< Real >::plyWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real >
+	PlyProperty ValueFactory< Real >::plyStaticReadProperty( unsigned int idx ) const
+	{
+		if( idx>=plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , 0 );
+	}
+
+	template< typename Real >
+	PlyProperty ValueFactory< Real >::plyStaticWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _PlyName(idx) , ToPlyType( _typeOnDisk ) , PLY::Type< Real >() , 0 );
+	}
+
+	template< typename Real >
+	std::string ValueFactory< Real >::_PlyName( unsigned int idx )
+	{
+		static const std::string names[] = { "value" };
+		return names[idx];
+	}
+
+	////////////////////
+	// DynamicFactory //
+	////////////////////
+	template< typename Real >
+	DynamicFactory< Real >::DynamicFactory( const std::vector< std::pair< std::string , TypeOnDisk > > &namesAndTypesOnDisk ) : _namesAndTypesOnDisk(namesAndTypesOnDisk)
+	{
+		_realTypeOnDisk = true;
+		for( unsigned int i=0 ; i<_namesAndTypesOnDisk.size() ; i++ ) _realTypeOnDisk &= GetTypeOnDisk< Real>()!=_namesAndTypesOnDisk[i].second;
+	}
+	template< typename Real >
+	DynamicFactory< Real >::DynamicFactory( const std::vector< PlyProperty > &plyProperties )
+	{
+		for( int i=0 ; i<plyProperties.size() ; i++ )
+			if( !plyProperties[i].is_list ) _namesAndTypesOnDisk.push_back( std::pair< std::string , TypeOnDisk >( plyProperties[i].name , FromPlyType( plyProperties[i].external_type ) ) );
+			else MK_WARN( "List property not supported: " , plyProperties[i].name );
+		_realTypeOnDisk = true;
+		for( unsigned int i=0 ; i<_namesAndTypesOnDisk.size() ; i++ ) _realTypeOnDisk &= GetTypeOnDisk< Real>()!=_namesAndTypesOnDisk[i].second;
+	}
+
+	template< typename Real >
+	bool DynamicFactory< Real >::readASCII( FILE *fp , VertexType &dt ) const
+	{
+		for( unsigned int i=0 ; i<dt.dim() ; i++ ) if( !VertexIO< Real >::ReadASCII( fp , _namesAndTypesOnDisk[i].second , dt[i] ) ) return false;
+		return true;
+	}
+	template< typename Real >
+	bool DynamicFactory< Real >::readBinary( FILE *fp , VertexType &dt ) const
+	{
+		if( _realTypeOnDisk )
+		{
+			if( fread( &dt[0] , sizeof(Real) , dt.dim() , fp )!=dt.dim() ) return false;
+		}
+		else
+		{
+			for( unsigned int i=0 ; i<dt.dim() ; i++ ) if( !VertexIO< Real >::ReadBinary( fp , _namesAndTypesOnDisk[i].second , dt[i] ) ) return false;
+		}
+		return true;
+	}
+	template< typename Real >
+	void DynamicFactory< Real >::writeASCII( FILE *fp , const VertexType &dt ) const
+	{
+		for( unsigned int i=0 ; i<dt.dim() ; i++ ) VertexIO< Real >::WriteASCII( fp , _namesAndTypesOnDisk[i].second , dt[i] );
+	}
+	template< typename Real >
+	void DynamicFactory< Real >::writeBinary( FILE *fp , const VertexType &dt ) const
+	{
+		if( _realTypeOnDisk ) fwrite( &dt[0] , sizeof(Real) , dt.dim() , fp );
+		else  for( unsigned int i=0 ; i<dt.dim() ; i++ ) VertexIO< Real >::WriteBinary( fp , _namesAndTypesOnDisk[i].second , dt[i] );
+	}
+
+	template< typename Real >
+	PlyProperty DynamicFactory< Real >::plyReadProperty( unsigned int idx ) const
+	{
+		if( idx>=plyReadNum() ) MK_THROW( "read property out of bounds" );
+		return PlyProperty( _namesAndTypesOnDisk[idx].first , ToPlyType( _namesAndTypesOnDisk[idx].second ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+	template< typename Real >
+	PlyProperty DynamicFactory< Real >::plyWriteProperty( unsigned int idx ) const
+	{
+		if( idx>=plyWriteNum() ) MK_THROW( "write property out of bounds" );
+		return PlyProperty( _namesAndTypesOnDisk[idx].first , ToPlyType( _namesAndTypesOnDisk[idx].second ) , PLY::Type< Real >() , sizeof(Real)*idx );
+	}
+
+	template< typename Real >
+	bool DynamicFactory< Real >::operator == ( const DynamicFactory< Real > &factory ) const
+	{
+		if( size()!=factory.size() ) return false;
+		for( int i=0 ; i<size() ; i++ ) if( _namesAndTypesOnDisk[i].first!=factory._namesAndTypesOnDisk[i].first || _namesAndTypesOnDisk[i].second!=factory._namesAndTypesOnDisk[i].second ) return false;
+		return true;
+	}
+
+	/////////////
+	// Factory //
+	/////////////
+	template< typename Real , typename ... Factories >
+	template< unsigned int I >
+	typename std::enable_if< I!=sizeof...(Factories) , PlyProperty >::type Factory< Real , Factories ... >::_plyReadProperty( unsigned int idx , size_t offset ) const
+	{
+		if( idx<this->template get<I>().plyReadNum() )
+		{
+			PlyProperty prop = this->template get<I>().plyReadProperty(idx);
+			prop.offset += (int)offset;
+			return prop;
+		}
+		else return _plyReadProperty<I+1>( idx - this->template get<I>().plyReadNum() , offset + this->template get<I>().bufferSize() );
+	}
+
+	template< typename Real , typename ... Factories >
+	template< unsigned int I >
+	typename std::enable_if< I!=sizeof...(Factories) , PlyProperty >::type Factory< Real , Factories ... >::_plyWriteProperty( unsigned int idx , size_t offset ) const
+	{
+		if( idx<this->template get<I>().plyWriteNum() )
+		{
+			PlyProperty prop = this->template get<I>().plyWriteProperty(idx);
+			prop.offset += (int)offset;
+			return prop;
+		}
+		else return _plyWriteProperty<I+1>( idx - this->template get<I>().plyWriteNum() , offset + this->template get<I>().bufferSize() );
+	}
+
+	template< typename Real , typename ... Factories >
+	template< unsigned int I >
+	typename std::enable_if< I!=sizeof...(Factories) , PlyProperty >::type Factory< Real , Factories ... >::_plyStaticReadProperty( unsigned int idx ) const
+	{
+		if( idx<this->template get<I>().plyReadNum() )
+		{
+			VertexType v;
+			PlyProperty prop = this->template get<I>().plyStaticReadProperty( idx );
+			prop.offset += (int)( (size_t)&v.template get<I>() - (size_t)&v );
+			return prop;
+		}
+		else return _plyStaticReadProperty<I+1>( idx - this->template get<I>().plyReadNum() );
+	}
+
+	template< typename Real , typename ... Factories >
+	template< unsigned int I >
+	typename std::enable_if< I!=sizeof...(Factories) , PlyProperty >::type Factory< Real , Factories ... >::_plyStaticWriteProperty( unsigned int idx ) const
+	{
+		if( idx<this->template get<I>().plyWriteNum() )
+		{
+			VertexType v;
+			PlyProperty prop = this->template get<I>().plyStaticWriteProperty( idx );
+			prop.offset += (int)( (size_t)&v.template get<I>() - (size_t)&v );
+			return prop;
+		}
+		else return _plyStaticWriteProperty<I+1>( idx - this->template get<I>().plyWriteNum() ) ;
+	}
+}

--- a/LiverResections/Algorithm/PoissonRecon/Src/Window.h
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Window.h
@@ -1,0 +1,338 @@
+/*
+Copyright (c) 2016, Michael Kazhdan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#ifndef WINDOW_INCLUDED
+#define WINDOW_INCLUDED
+
+#include <functional>
+#include "Array.h"
+#include "ParameterPack.h"
+#include "MultiThreading.h"
+
+namespace Window
+{
+	using namespace PoissonRecon;
+	template< unsigned int Res , unsigned int ... Ress >
+	constexpr unsigned int Size( void )
+	{
+		if constexpr( sizeof...(Ress)==0 ) return Res;
+		else                               return Res * Size< Ress... >();
+	}
+
+	template< unsigned int Dim , unsigned int Res >
+	constexpr unsigned int IsotropicSize( void )
+	{
+		if constexpr( Dim==1 ) return Res;
+		else                   return Res * IsotropicSize< Dim-1 , Res >();
+	}
+
+	template< unsigned int Res , unsigned int ... Ress >
+	struct Index
+	{
+		template< unsigned int Idx , unsigned int ... Idxs >
+		static constexpr unsigned int I( void )
+		{
+			static_assert( sizeof...(Ress)==sizeof...(Idxs) , "[ERROR] sizes don't match" );
+			if constexpr( sizeof...(Ress)==0 ) return Idx;
+			else                               return Idx * Size< Ress ... >() + Index< Ress... >::template I< Idxs... >();
+		}
+	};
+
+	template< unsigned int Dim , unsigned int Res >
+	struct IsotropicIndex
+	{
+		template< unsigned int Idx >
+		static constexpr unsigned int I( void )
+		{
+			if constexpr( Dim==1 ) return Idx;
+			else                   return Idx * IsotropicSize< Dim-1 , Res >() + IsotropicIndex< Dim-1 , Res >::template I< Idx >();
+		}
+	};
+
+	template< unsigned int Res , unsigned int ... Ress >
+	unsigned int GetIndex( const unsigned int idx[] )
+	{
+		if constexpr( sizeof...(Ress)==0 ) return idx[0];
+		else                               return idx[0] * Size< Ress ... >() + GetIndex< Ress... >( idx+1 );
+	}
+
+	template< unsigned int Res , unsigned int ... Ress >
+	unsigned int GetIndex( const int idx[] )
+	{
+		if constexpr( sizeof...(Ress)==0 ) return idx[0];
+		else                               return idx[0] * Size< Ress ... >() + GetIndex< Ress... >( idx+1 );
+	};
+
+
+	template< class Data , unsigned int ... Res > struct ConstSlice{};
+
+	template< class Data , unsigned int Res , unsigned int ... Ress >
+	struct ConstSlice< Data , Res , Ress... >
+	{
+		using data_type = Data;
+		using data_reference_type = const Data &;
+		using const_data_reference_type = const Data &;
+		static constexpr unsigned int Size( void ){ return Window::Size< Res , Ress... >(); }
+
+		ConstSlice(      Pointer( Data ) d ) : data(d) {}
+		ConstSlice( ConstPointer( Data ) d ) : data(d) {}
+
+		std::conditional_t< sizeof...(Ress)==0 , data_reference_type , ConstSlice< Data , Ress... > > operator[]( int idx ) const
+		{
+			if constexpr( sizeof...(Ress)==0 ) return data[idx];
+			else                               return ConstSlice< Data , Ress... >( data + Window::Size< Ress... >() * idx );
+		}
+		data_reference_type operator()( const          int idx[] ) const { return data[ GetIndex< Res , Ress... >( idx ) ]; }
+		data_reference_type operator()( const unsigned int idx[] ) const { return data[ GetIndex< Res , Ress... >( idx ) ]; }
+		ConstPointer( Data ) data;
+	};
+
+	template< typename Data , unsigned Dim , unsigned int Res , unsigned int ... Ress >
+	struct _IsotropicConstSlice{ using Type = std::conditional_t< Dim==1 , ConstSlice< Data , Res , Ress... > , _IsotropicConstSlice< Data , Dim-1 , Res , Res , Ress... > >; };
+	template< typename Data , unsigned int Dim , unsigned int Res >
+	using IsotropicConstSlice = typename _IsotropicConstSlice< Data , Dim , Res >::Type;
+
+
+	template< class Data , unsigned int ... Res > struct Slice{};
+
+	template< class Data , unsigned int Res , unsigned int ... Ress >
+	struct Slice< Data , Res , Ress... >
+	{
+		using data_type = Data;
+		using data_reference_type = Data &;
+		using const_data_reference_type = const Data &;
+		static constexpr unsigned int Size( void ){ return Window::Size< Res , Ress... >(); }
+
+		Slice( Pointer( Data ) d ) : data(d) {}
+		std::conditional_t< sizeof...(Ress)==0 , data_reference_type , Slice< Data , Ress... > > operator[]( int idx )
+		{
+			if constexpr( sizeof...(Ress)==0 ) return data[idx];
+			else                               return Slice< Data , Ress... >( data + Window::Size< Ress... >() * idx );
+		}
+		std::conditional_t< sizeof...(Ress)==0 , const_data_reference_type , ConstSlice< Data , Ress... > > operator[]( int idx ) const
+		{
+			if constexpr( sizeof...(Ress)==0 ) return data[idx];
+			else                               return ConstSlice< Data , Ress... >( data + Window::Size< Ress... >() * idx );
+		}
+		data_reference_type operator()( const int idx[] )
+		{
+			if constexpr( sizeof...(Ress)==0 ) return operator[]( idx[0] );
+			else                               return operator[]( idx[0] )( idx+1 );
+		}
+		const_data_reference_type operator()( const int idx[] ) const
+		{
+			if constexpr( sizeof...(Ress)==0 ) return operator[]( idx[0] );
+			else                               return operator[]( idx[0] )( idx+1 );
+		}
+		data_reference_type operator()( const unsigned int idx[] )
+		{
+			if constexpr( sizeof...(Ress)==0 ) return operator[]( idx[0] );
+			else                               return operator[]( idx[0] )( idx+1 );
+		}
+		const_data_reference_type operator()( const unsigned int idx[] ) const
+		{
+			if constexpr( sizeof...(Ress)==0 ) return operator[]( idx[0] );
+			else                               return operator[]( idx[0] )( idx+1 );
+		}
+		operator ConstSlice< Data , Res , Ress... >() const { return ConstSlice< Data , Res , Ress... >( ( ConstPointer( Data ) )data ); }
+		Pointer( Data ) data;
+	};
+
+	template< typename Data , unsigned Dim , unsigned int Res , unsigned int ... Ress >
+	struct _IsotropicSlice{ using Type = std::conditional_t< Dim==1 , Slice< Data , Res , Ress... > , _IsotropicSlice< Data , Dim-1 , Res , Res , Ress... > >; };
+	template< typename Data , unsigned int Dim , unsigned int Res >
+	using IsotropicSlice = typename _IsotropicSlice< Data , Dim , Res >::Type;
+
+
+	template< class Data , unsigned int Res , unsigned int ... Ress >
+	struct StaticWindow
+	{
+		using const_window_slice_type = ConstSlice< Data , Res , Ress... >;
+		using window_slice_type = Slice< Data , Res , Ress... >;
+		using data_type = Data ;
+		static constexpr unsigned int Size( void ){ return Window::Size< Res , Ress... >(); }
+
+		std::conditional_t< sizeof...(Ress)==0 , Data & , Slice< Data , Ress... > > operator[]( int idx )
+		{
+			if constexpr( sizeof...(Ress)==0 ) return data[idx];
+			else                               return Slice< Data , Ress... >( GetPointer( data , Size() ) + Window::Size< Ress... >() * idx );
+		}
+
+		std::conditional_t< sizeof...(Ress)==0 , const Data & , ConstSlice< Data , Ress... > > operator[]( int idx ) const
+		{
+			if constexpr( sizeof...(Ress)==0 ) return data[idx];
+			else                               return ConstSlice< Data , Ress... >( ( ConstPointer( Data ) )GetPointer( data , Size() ) + Window::Size< Ress... >() * idx );
+		}
+
+		Slice< Data , Res , Ress... > operator()( void ){ return Slice< Data , Res , Ress... >( GetPointer( data , Size() ) ); }
+
+		ConstSlice< Data , Res , Ress... > operator()( void ) const { return ConstSlice< Data , Res , Ress... >( ( ConstPointer( Data ) )GetPointer( data , Size() ) ); }
+
+		Data& operator()( const unsigned int idx[] ){ return (*this)()( idx ); }
+		Data& operator()( const          int idx[] ){ return (*this)()( idx ); }
+
+		const Data& operator()( const unsigned int idx[] ) const { return data[ GetIndex< Res , Ress... >( idx ) ]; }
+		const Data& operator()( const          int idx[] ) const { return data[ GetIndex< Res , Ress... >( idx ) ]; }
+
+		Data data[ Window::Size< Res , Ress... >() ];
+	};
+
+	template< typename Data , unsigned Dim , unsigned int Res , unsigned int ... Ress >
+	struct _IsotropicStaticWindow{ using Type = std::conditional_t< Dim==1 , StaticWindow< Data , Res , Ress... > , _IsotropicStaticWindow< Data , Dim-1 , Res , Res , Ress... > >; };
+	template< typename Data , unsigned int Dim , unsigned int Res >
+	using IsotropicStaticWindow = typename _IsotropicStaticWindow< Data , Dim , Res >::Type;
+
+
+	template< class Data , unsigned int Res , unsigned int ... Ress >
+	struct DynamicWindow
+	{
+		using const_window_slice_type = ConstSlice< Data , Res , Ress... >;
+		using window_slice_type = Slice< Data , Res , Ress... >;
+		using data_type = Data;
+		static constexpr unsigned int Size( void ){ return Window::Size< Res , Ress... >(); }
+
+		std::conditional_t< sizeof...(Ress)==0 , Data & , Slice< Data , Ress... > > operator[]( int idx )
+		{
+			if constexpr( sizeof...(Ress)==0 ) return data[idx];
+			else                               return Slice< Data , Ress... >( data + Window::Size< Ress... >() * idx );
+		}
+
+		std::conditional_t< sizeof...(Ress)==0 , const Data & , ConstSlice< Data , Ress... > > operator[]( int idx ) const
+		{
+			if constexpr( sizeof...(Ress)==0 ) return data[idx];
+			else                               ConstSlice< Data , Ress... >( ( ConstPointer( Data ) )( data + Window::Size< Ress... >() * idx ) );
+		}
+
+		Slice< Data , Res , Ress... > operator()( void ){ return Slice< Data , Res , Ress... >( data ); }
+		ConstSlice< Data , Res , Ress... > operator()( void ) const { return ConstSlice< Data , Res , Ress... >( ( ConstPointer( Data ) )data ); }
+
+		Data& operator()( const int idx[] ){ return (*this)()( idx ); }
+		const Data& operator()( const int idx[] ) const { return (*this)()( idx ); }
+
+		DynamicWindow( void ){ data = NewPointer< Data >( Size() ); }
+
+		~DynamicWindow( void ){ DeletePointer( data ); }
+
+		Pointer( Data ) data;
+	};
+
+	template< typename Data , unsigned Dim , unsigned int Res , unsigned int ... Ress >
+	struct _IsotropicDynamicWindow{ using Type = std::conditional_t< Dim==1 , DynamicWindow< Data , Res , Ress... > , _IsotropicDynamicWindow< Data , Dim-1 , Res , Res , Ress... > >; };
+	template< typename Data , unsigned int Dim , unsigned int Res >
+	using IsotropicDynamicWindow = typename _IsotropicDynamicWindow< Data , Dim , Res >::Type;
+
+	// Recursive loop iterations for processing window slices
+	//		WindowDimension: the the window slice
+	//		IterationDimensions: the number of dimensions to process
+	//		Res: the resolution of the window
+
+	template< unsigned int WindowDimension , unsigned int IterationDimensions , unsigned int CurrentIteration > struct _Loop;
+
+	template< unsigned int WindowDimension , unsigned int IterationDimensions=WindowDimension >
+	struct Loop
+	{
+		template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+		static void Run( int begin , int end , UpdateFunction updateState , ProcessFunction function , Windows ... w )
+		{
+			_Loop< WindowDimension , IterationDimensions , IterationDimensions >::Run( begin , end , updateState , function , w ... ); 
+		}
+		template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+		static void Run( const int* begin , const int* end , UpdateFunction updateState , ProcessFunction function , Windows ... w )
+		{
+			_Loop< WindowDimension , IterationDimensions , IterationDimensions >::Run( begin , end , updateState , function , w ... ); 
+		}
+		template< unsigned int ... Begin , unsigned int ... End , typename UpdateFunction , typename ProcessFunction , class ... Windows >
+		static void Run( ParameterPack::UIntPack< Begin ... > begin , ParameterPack::UIntPack< End ... > end , UpdateFunction updateState , ProcessFunction function , Windows ... w )
+		{
+			_Loop< WindowDimension , IterationDimensions , IterationDimensions >::Run( begin , end , updateState , function , w ... ); 
+		}
+
+		template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+		static void RunParallel( int begin , int end , UpdateFunction updateState , ProcessFunction function , Windows ... w )
+		{
+			_Loop< WindowDimension , IterationDimensions , IterationDimensions >::RunParallel( begin , end , updateState , function , w ... ); 
+		}
+		template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+		static void RunParallel( const int* begin , const int* end , UpdateFunction updateState , ProcessFunction function , Windows ... w )
+		{
+			_Loop< WindowDimension , IterationDimensions , IterationDimensions >::RunParallel( begin , end , updateState , function , w ... ); 
+		}
+		template< unsigned int ... Begin , unsigned int ... End , typename UpdateFunction , typename ProcessFunction , class ... Windows >
+		static void RunParallel( ParameterPack::UIntPack< Begin ... > begin , ParameterPack::UIntPack< End ... > end , UpdateFunction updateState , ProcessFunction function , Windows ... w )
+		{
+			_Loop< WindowDimension , IterationDimensions , IterationDimensions >::RunParallel( begin , end , updateState , function , w ... ); 
+		}
+	};
+
+#include "Window.inl"
+}
+// Adding definitions to be consistent with old code
+namespace PoissonRecon
+{
+	template< typename Pack1 , typename Pack2 > struct WindowIndex;
+	template< unsigned int ... Res , unsigned int ... Idx >
+	struct WindowIndex< ParameterPack::UIntPack< Res... > , ParameterPack::UIntPack< Idx... > >{ static const unsigned int Index = Window::Index< Res... >::template I< Idx ... >(); };
+
+	template< int ... Values >
+	using IntPack = ParameterPack::IntPack< Values... >;
+
+	template< unsigned int ... Values >
+	using UIntPack = ParameterPack::UIntPack< Values... >;
+
+	template< unsigned int Dim , unsigned int Res >
+	using IsotropicUIntPack = ParameterPack::IsotropicPack< unsigned int , Dim , Res >;
+
+	template< unsigned int Dim >
+	using ZeroUIntPack = IsotropicUIntPack< Dim , 0 >;
+
+	template< typename Data , typename Pack > struct _WindowSlice;
+	template< typename Data , unsigned int ... Res > struct _WindowSlice< Data , ParameterPack::UIntPack< Res... > >{ using type = Window::Slice< Data , Res... >; };
+	template< typename Data , typename Pack > using WindowSlice = typename _WindowSlice< Data , Pack >::type;
+
+	template< typename Data , typename Pack > struct _ConstWindowSlice;
+	template< typename Data , unsigned int ... Res > struct _ConstWindowSlice< Data , ParameterPack::UIntPack< Res... > >{ using type = Window::ConstSlice< Data , Res... >; };
+	template< typename Data , typename Pack > using ConstWindowSlice = typename _ConstWindowSlice< Data , Pack >::type;
+
+	template< typename Data , typename Pack > struct StaticWindow;
+	template< typename Data , unsigned int ... Res >
+	struct StaticWindow< Data , ParameterPack::UIntPack< Res... > > : public Window::StaticWindow< Data , Res... >{};
+
+	template< typename Data , typename Pack > struct DynamicWindow;
+	template< typename Data , unsigned int ... Res >
+	struct DynamicWindow< Data , ParameterPack::UIntPack< Res... > > : public Window::DynamicWindow< Data , Res... >{};
+
+	template< typename Pack > struct WindowSize;
+	template< unsigned int ... Res > struct WindowSize< ParameterPack::UIntPack< Res... > >{ static const unsigned int Size = Window::Size< Res... >(); };
+
+	template< unsigned ... Res >
+	unsigned int GetWindowIndex( UIntPack< Res... > , const unsigned int idx[] ){ return Window::GetIndex< Res... >( idx ); }
+
+	template< unsigned int WindowDimension >
+	using WindowLoop = Window::Loop< WindowDimension >;
+}
+#endif // WINDOW_INCLUDED

--- a/LiverResections/Algorithm/PoissonRecon/Src/Window.inl
+++ b/LiverResections/Algorithm/PoissonRecon/Src/Window.inl
@@ -1,0 +1,160 @@
+/*
+Copyright (c) 2006, Michael Kazhdan and Matthew Bolitho
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the distribution. 
+
+Neither the name of the Johns Hopkins University nor the names of its contributors
+may be used to endorse or promote products derived from this software without specific
+prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+template< unsigned int WindowDimension , unsigned int IterationDimensions , unsigned int CurrentIteration >
+struct _Loop
+{
+	static_assert( IterationDimensions<=WindowDimension , "[ERROR] Iteration dimensions cannot excceed window dimension" );
+	static_assert( CurrentIteration>0 , "[ERROR] Current iteration cannot be zero" );
+	static_assert( CurrentIteration<=IterationDimensions , "[ERROR] Current iteration cannot exceed iteration dimensions" );
+
+protected:
+	static const int CurrentDimension = CurrentIteration + WindowDimension - IterationDimensions;
+	friend struct Loop< WindowDimension , IterationDimensions >;
+	friend struct _Loop< WindowDimension , IterationDimensions , CurrentIteration+1 >;
+
+
+	///////////////////////////////
+	// Single-threaded execution //
+	///////////////////////////////
+	template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void Run( int begin , int end , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		for( int i=begin ; i<end ; i++ )
+		{
+			updateState( WindowDimension - CurrentDimension , i );
+			if constexpr( CurrentIteration==1 ) function( w[i] ... );
+			else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::Run( begin , end , updateState , function , w[i] ... );
+		}
+	}
+
+	template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void Run( const int* begin , const int* end , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		for( int i=begin[0] ; i<end[0] ; i++ )
+		{
+			updateState( WindowDimension - CurrentDimension , i );
+			if constexpr( CurrentIteration==1 ) function( w[i] ... );
+			else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::Run( begin+1 , end+1 , updateState , function , w[i] ... );
+		}
+	}
+
+	template< unsigned int ... Begin , unsigned int ... End , typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void Run( ParameterPack::UIntPack< Begin ... > begin , ParameterPack::UIntPack< End ... > end , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		for( int i=ParameterPack::UIntPack< Begin ... >::First ; i<ParameterPack::UIntPack< End ... >::First ; i++ )
+		{
+			updateState( WindowDimension - CurrentDimension , i );
+			if constexpr( CurrentIteration==1 ) function( w[i] ... );
+			else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::Run( typename ParameterPack::UIntPack< Begin ... >::Rest() , typename ParameterPack::UIntPack< End ... >::Rest() , updateState , function , w[i] ... );
+		}
+	}
+
+
+	//////////////////////////////
+	// Multi-threaded execution //
+	//////////////////////////////
+	template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void RunParallel( int begin , int end , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		ThreadPool::ParallelFor
+		(
+			begin , end ,
+			[&]( unsigned int thread , size_t i )
+			{
+				updateState( thread , WindowDimension - CurrentDimension , i );
+				if constexpr( CurrentIteration==1 ) function( thread , w[i] ... );
+				else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::RunThread( begin , end , thread , updateState , function , w[i] ... );
+			}
+		);
+	}
+
+	template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void RunParallel( const int* begin , const int* end , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		ThreadPool::ParallelFor
+		(
+			begin[0] , end[0] ,
+			[&]( unsigned int thread , size_t i )
+			{
+				updateState( thread , WindowDimension - CurrentDimension , i );
+				if constexpr( CurrentIteration==1 ) function( thread , w[i] ... );
+				else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::RunThread( begin+1 , end+1 , thread , updateState , function , w[i] ... );
+			}
+		);
+	}
+
+	template< unsigned int ... Begin , unsigned int ... End , typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void RunParallel( ParameterPack::UIntPack< Begin ... > begin , ParameterPack::UIntPack< End ... > end , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		ThreadPool::ParallelFor
+		(
+			ParameterPack::UIntPack< Begin ... >::First , ParameterPack::UIntPack< End ... >::First ,
+			[&]( unsigned int thread , size_t i )
+			{
+				updateState( thread , WindowDimension - CurrentDimension , i );
+				if constexpr( CurrentIteration==1 ) function( thread , w[i] ... );
+				else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::RunThread( typename ParameterPack::UIntPack< Begin ... >::Rest() , typename ParameterPack::UIntPack< End ... >::Rest() , thread , updateState , function , w[i] ... );
+			}
+		);
+	}
+
+
+	template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void RunThread( int begin , int end , unsigned int thread , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		for( int i=begin ; i<end ; i++ )
+		{
+			updateState( thread , WindowDimension - CurrentDimension , i );
+			if constexpr( CurrentIteration==1 ) function( thread , w[i] ... );
+			else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::RunThread( begin , end , thread , updateState , function , w[i] ... );
+		}
+	}
+
+	template< typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void RunThread( const int* begin , const int* end , unsigned int thread , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		for( int i=begin[0] ; i<end[0] ; i++ )
+		{
+			updateState( thread , WindowDimension - CurrentDimension , i );
+			if constexpr( CurrentIteration==1 ) function( thread , w[i] ... );
+			else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::RunThread( begin+1 , end+1 , thread , updateState , function , w[i] ... );
+		}
+	}
+
+	template< unsigned int ... Begin , unsigned int ... End , typename UpdateFunction , typename ProcessFunction , class ... Windows >
+	static void RunThread( ParameterPack::UIntPack< Begin ... > begin , ParameterPack::UIntPack< End ... > end , unsigned int thread , UpdateFunction& updateState , ProcessFunction& function , Windows ... w )
+	{
+		for( int i=ParameterPack::UIntPack< Begin ... >::First ; i<ParameterPack::UIntPack< End ... >::First ; i++ )
+		{
+			updateState( thread , WindowDimension - CurrentDimension , i );
+			if constexpr( CurrentIteration==1 ) function( thread , w[i] ... );
+			else _Loop< WindowDimension , IterationDimensions , CurrentIteration-1 >::RunThread( typename ParameterPack::UIntPack< Begin ... >::Rest() , typename ParameterPack::UIntPack< End ... >::Rest() , thread , updateState , function , w[i] ... );
+		}
+	}
+};

--- a/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
@@ -20,6 +20,7 @@ set(KIT_TEST_SRCS
   vtkSlicerLiverBezierControlPolygonGeometryTest1.cxx
   vtkLiverResectogramAspectRatioTest.cxx
   vtkLiverResectogramPixelMappingTest.cxx
+  PoissonReconVendorTest.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -30,6 +31,7 @@ slicerMacroConfigureModuleCxxTestDriver(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_BINARY_DIR}/..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../PoissonRecon/Src
   WITH_VTK_DEBUG_LEAKS_CHECK
   WITH_VTK_ERROR_OUTPUT_CHECK
   )
@@ -95,3 +97,9 @@ SIMPLE_TEST(vtkLiverResectogramPixelMappingTest)
 set_tests_properties(vtkLiverResectogramPixelMappingTest PROPERTIES
   SKIP_RETURN_CODE 125
   )
+
+# Build-integration test for the vendored PoissonRecon drop (ADR-0040).
+# Not a Slicer-Liver class test -- it exists because a header-only
+# template library can sit in the tree unbuildable until something
+# instantiates it, so the drop and its first instantiation ship together.
+SIMPLE_TEST(PoissonReconVendorTest)

--- a/LiverResections/Algorithm/Testing/Cxx/PoissonReconVendorTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/PoissonReconVendorTest.cxx
@@ -1,0 +1,296 @@
+/*==============================================================================
+
+  Copyright (c) 2026 The Intervention Centre, Oslo University Hospital
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// Build-integration test for the VENDORED PoissonRecon drop
+// (ADR-0040 phase 3).  This does not test any Slicer-Liver class -- there
+// is none yet.  It answers the one question the vendor drop itself
+// raises: do upstream's headers compile, instantiate and RUN inside
+// Slicer's toolchain, as opposed to the standalone g++ invocation phase 1
+// proved them under?
+//
+// The risk being covered is specific to header-only, heavily templated
+// C++: the code that breaks is the code that gets instantiated, and
+// nothing is instantiated until something asks for it.  A vendor drop can
+// sit in the tree looking healthy while being unbuildable, so the drop
+// and its first real instantiation belong in the same commit.
+//
+// Deliberately built against Reconstructors.h ALONE -- no Image.h, no
+// PNG/JPEG/ZLIB, no Boost -- so a regression in the exclusion set
+// (LiverResections/Algorithm/PoissonRecon/README.md) fails here rather
+// than silently pulling a heavyweight dependency into the extension.
+
+#include "PreProcessor.h"
+
+#include "MyMiscellany.h"
+#include "Reconstructors.h"
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <map>
+#include <utility>
+#include <vector>
+
+using Real = float;
+static const unsigned int Dim = 3;
+
+namespace
+{
+
+// An oriented point cloud sampling a sphere, in upstream's stream form.
+// The VTK adapter of phase 3b replaces this with a stream over
+// vtkPolyData's points and normals -- same contract, different source.
+struct SphereSampleStream : public PoissonRecon::Reconstructor::InputOrientedSampleStream<Real, Dim>
+{
+  SphereSampleStream(const std::vector<std::array<Real, 6>>& s)
+    : Samples(s)
+  {
+  }
+  void reset(void) override { this->Index = 0; }
+  bool read(PoissonRecon::Point<Real, Dim>& p, PoissonRecon::Point<Real, Dim>& n) override
+  {
+    if (this->Index >= this->Samples.size())
+    {
+      return false;
+    }
+    for (unsigned int d = 0; d < Dim; d++)
+    {
+      p[d] = this->Samples[this->Index][d];
+      n[d] = this->Samples[this->Index][3 + d];
+    }
+    this->Index++;
+    return true;
+  }
+
+protected:
+  const std::vector<std::array<Real, 6>>& Samples;
+  size_t Index = 0;
+};
+
+struct VertexStream : public PoissonRecon::Reconstructor::OutputLevelSetVertexStream<Real, Dim>
+{
+  VertexStream(std::vector<Real>& v)
+    : Vertices(v)
+  {
+  }
+  size_t size(void) const override { return this->Vertices.size() / 3; }
+  size_t write(const PoissonRecon::Point<Real, Dim>& p, const PoissonRecon::Point<Real, Dim>&, const Real&) override
+  {
+    for (unsigned int d = 0; d < Dim; d++)
+    {
+      this->Vertices.push_back(p[d]);
+    }
+    return this->Vertices.size() / 3 - 1;
+  }
+
+protected:
+  std::vector<Real>& Vertices;
+};
+
+struct PolygonStream : public PoissonRecon::Reconstructor::OutputFaceStream<2>
+{
+  PolygonStream(std::vector<std::vector<int>>& f)
+    : Faces(f)
+  {
+  }
+  size_t size(void) const override { return this->Faces.size(); }
+  size_t write(const std::vector<PoissonRecon::node_index_type>& poly) override
+  {
+    std::vector<int> face(poly.size());
+    for (size_t i = 0; i < poly.size(); i++)
+    {
+      face[i] = static_cast<int>(poly[i]);
+    }
+    this->Faces.push_back(face);
+    return this->Faces.size() - 1;
+  }
+
+protected:
+  std::vector<std::vector<int>>& Faces;
+};
+
+} // namespace
+
+int PoissonReconVendorTest(int, char*[])
+{
+  // ---------------------------------------------------------------------
+  // An analytic sphere: positions on the surface, normals pointing out.
+  // Analytic rather than sampled from a labelmap so the expected answer
+  // is known in closed form and the assertions below can be tight.
+  // ---------------------------------------------------------------------
+  const Real radius = 1.0f;
+  std::vector<std::array<Real, 6>> samples;
+  const int nTheta = 60;
+  const int nPhi = 120;
+  for (int i = 1; i < nTheta; i++)
+  {
+    const double theta = M_PI * i / nTheta;
+    for (int j = 0; j < nPhi; j++)
+    {
+      const double phi = 2.0 * M_PI * j / nPhi;
+      const double nx = std::sin(theta) * std::cos(phi);
+      const double ny = std::sin(theta) * std::sin(phi);
+      const double nz = std::cos(theta);
+      samples.push_back(
+        { static_cast<Real>(radius * nx), static_cast<Real>(radius * ny), static_cast<Real>(radius * nz), static_cast<Real>(nx), static_cast<Real>(ny), static_cast<Real>(nz) });
+    }
+  }
+
+  static const unsigned int FEMSig =
+    PoissonRecon::FEMDegreeAndBType<PoissonRecon::Reconstructor::Poisson::DefaultFEMDegree, PoissonRecon::Reconstructor::Poisson::DefaultFEMBoundary>::Signature;
+  using FEMSigs = PoissonRecon::IsotropicUIntPack<Dim, FEMSig>;
+  using Implicit = PoissonRecon::Reconstructor::Implicit<Real, Dim, FEMSigs>;
+  using Solver = PoissonRecon::Reconstructor::Poisson::Solver<Real, Dim, FEMSigs>;
+
+  PoissonRecon::Reconstructor::Poisson::SolutionParameters<Real> solverParams;
+  solverParams.verbose = false;
+  // Depth 6 keeps the test near a second.  ADR-0040 fixes the PRODUCT
+  // default at 7 on the phase-1 evidence; this number is a test-runtime
+  // choice and carries no architectural weight.
+  solverParams.depth = 6;
+
+  PoissonRecon::Reconstructor::LevelSetExtractionParameters extractionParams;
+  extractionParams.verbose = false;
+
+  std::vector<Real> vertices;
+  std::vector<std::vector<int>> faces;
+  {
+    SphereSampleStream sampleStream(samples);
+    Implicit* implicit = Solver::Solve(sampleStream, solverParams);
+    if (!implicit)
+    {
+      std::cerr << "FAIL: the solver returned no implicit function" << std::endl;
+      return EXIT_FAILURE;
+    }
+    VertexStream vStream(vertices);
+    PolygonStream pStream(faces);
+    implicit->extractLevelSet(vStream, pStream, extractionParams);
+    delete implicit;
+  }
+
+  if (vertices.empty() || faces.empty())
+  {
+    std::cerr << "FAIL: reconstruction produced an empty mesh" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // ---------------------------------------------------------------------
+  // The mesh must be the SPHERE, not merely non-empty.  A build that
+  // links but mis-instantiates can return a plausible-looking blob; only
+  // checking against the analytic radius catches that.
+  //
+  // PSR reconstructs in a normalised cube and the level set is a smooth
+  // approximation, so the radius is checked with a tolerance rather than
+  // exactly -- but the SPREAD is what matters: a correct reconstruction
+  // has every vertex at essentially the same radius.
+  // ---------------------------------------------------------------------
+  const size_t nVerts = vertices.size() / 3;
+  double cx = 0.0, cy = 0.0, cz = 0.0;
+  for (size_t i = 0; i < nVerts; i++)
+  {
+    cx += vertices[3 * i];
+    cy += vertices[3 * i + 1];
+    cz += vertices[3 * i + 2];
+  }
+  cx /= nVerts;
+  cy /= nVerts;
+  cz /= nVerts;
+
+  double rMin = 1e30, rMax = -1e30, rMean = 0.0;
+  for (size_t i = 0; i < nVerts; i++)
+  {
+    const double dx = vertices[3 * i] - cx;
+    const double dy = vertices[3 * i + 1] - cy;
+    const double dz = vertices[3 * i + 2] - cz;
+    const double r = std::sqrt(dx * dx + dy * dy + dz * dz);
+    rMin = std::min(rMin, r);
+    rMax = std::max(rMax, r);
+    rMean += r;
+  }
+  rMean /= nVerts;
+
+  std::cout << "vendor smoke: " << nVerts << " vertices, " << faces.size() << " faces" << std::endl;
+  std::cout << "  radius min/mean/max = " << rMin << " / " << rMean << " / " << rMax << std::endl;
+
+  // Relative spread, so the assertion does not depend on PSR's internal
+  // normalisation of the input cube.
+  const double spread = (rMax - rMin) / rMean;
+  if (spread > 0.05)
+  {
+    std::cerr << "FAIL: reconstructed radii spread " << spread << " -- not a sphere" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // ---------------------------------------------------------------------
+  // Well-formedness: every face index must address a vertex that exists.
+  // An out-of-range index is the classic symptom of an index-width
+  // mismatch (node_index_type vs int) between upstream and our build --
+  // exactly the kind of thing that differs between the standalone g++ of
+  // phase 1 and Slicer's toolchain.
+  // ---------------------------------------------------------------------
+  for (const std::vector<int>& face : faces)
+  {
+    if (face.size() < 3)
+    {
+      std::cerr << "FAIL: degenerate face with " << face.size() << " vertices" << std::endl;
+      return EXIT_FAILURE;
+    }
+    for (const int idx : face)
+    {
+      if (idx < 0 || static_cast<size_t>(idx) >= nVerts)
+      {
+        std::cerr << "FAIL: face index " << idx << " out of range (" << nVerts << " vertices)" << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Closed surface: a sphere sampled all the way round leaves PSR no
+  // boundary to leave open, so every edge must be shared by exactly two
+  // faces.  This is the assertion that would catch a reconstruction
+  // silently truncated at the octree boundary.
+  // ---------------------------------------------------------------------
+  std::map<std::pair<int, int>, int> edgeUse;
+  for (const std::vector<int>& face : faces)
+  {
+    for (size_t i = 0; i < face.size(); i++)
+    {
+      const int a = face[i];
+      const int b = face[(i + 1) % face.size()];
+      edgeUse[{ std::min(a, b), std::max(a, b) }]++;
+    }
+  }
+  size_t nonManifold = 0;
+  for (const auto& e : edgeUse)
+  {
+    if (e.second != 2)
+    {
+      nonManifold++;
+    }
+  }
+  std::cout << "  edges " << edgeUse.size() << ", not shared by exactly 2 faces: " << nonManifold << std::endl;
+  if (nonManifold != 0)
+  {
+    std::cerr << "FAIL: reconstruction is not a closed surface" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "PoissonReconVendorTest passed" << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
**ADR-0040 phase 3, first half.** The vendored PoissonRecon core. Relates to **#310**; ADR in **#644**; the point-cloud extractor is **#645** (independent — this doesn't depend on it, and it doesn't depend on this).

No Slicer-Liver class uses this yet. The adapter is the next slice.

## Why this is its own PR

*"Did we vendor the right thing, pristinely"* is a different review question from *"is the adapter API right"*, and answering both in one diff would mean reading 2 MB of upstream alongside our own code. **Authored lines here: ~300** (one test) plus CMake and pre-commit wiring. The other 40 000 are upstream's, unedited.

## A drop, not a fork

Upstream `262b0f5` ("Version 8.76"), MIT. **Nothing under `Src/` is edited** — that's what makes a future upstream sync a re-copy rather than a merge. `PoissonRecon/README.md` carries the provenance, the exclusion rule, and the sync procedure.

## What's excluded, and why the rule survives an upstream bump

69 of upstream's 82 headers; none of its 13 command-line mains. **The 13 exclusions aren't a hand-picked minimal set** — they're two whole upstream *variants* we don't build, which is what keeps the rule re-derivable when upstream moves:

| Excluded | What it is |
| --- | --- |
| `Socket.{h,inl}`, `*ClientServer.h` | the **distributed** variant — the only files in `Src/` that reach for Boost. Dropping them is what makes this Boost-free, per your constraint. |
| `Image.h`, `PNG.h`, `JPEG.h` | the **image** path, reached only from upstream's own mains for their `--colors` option. Also the one genuinely unportable part of upstream: against a *system* libpng it fails with `invalid use of incomplete type 'png_struct'`, reaching into internals opaque since libpng 1.5. Upstream's vendored `PNG/` is load-bearing for *their* executable; adapting to `Reconstructors.h` sidesteps it. |

So none of upstream's four third-party trees are needed and no heavyweight dependency is inherited.

The transitive include closure of `Reconstructors.h` is **59 headers, a strict subset of the 69**. The extra ten are kept deliberately: "upstream minus two variants" is a rule a future maintainer can re-apply, where "whatever the compiler needed that day" rots the moment upstream adds an include.

## Build wiring

A plain **include directory**, not a library — upstream is header-only, so there's nothing to build or link and no `find_package` to fail.

The headers are kept **out of `${KIT}_SRCS`**, and that's load-bearing: this kit is Python-wrapped, and `SlicerMacroBuildModuleLogic` hands everything in `SRCS` to the VTK wrapper. Upstream's templates aren't wrappable and have no business being offered to Python. Only our adapter will be.

**OpenMP is not required** — `MultiThreading.h` guards it behind `#ifdef _OPENMP` and falls back to `std::async`, so this builds on toolchains without it.

## Pre-commit exclusions

clang-format, the whitespace fixers and the copyright-year check are excluded from the vendored path. Without that, the first commit touching the tree reformats 2 MB of upstream and destroys exactly the pristineness the sync procedure depends on. Upstream code keeps upstream's copyright notice.

**Verified, not assumed**: after the hooks ran, `diff -r` against upstream reports the vendored `Src/` byte-identical.

## The test ships with the drop

`PoissonReconVendorTest` doesn't wait for the adapter. In header-only template C++ **the code that breaks is the code that gets instantiated**, and nothing is instantiated until something asks — a vendor drop can sit in the tree looking healthy while being unbuildable. Phase 1 proved these headers under a standalone `g++`; this proves them under Slicer's toolchain, which is where they now live.

It reconstructs an analytic sphere and checks the result **is a sphere** — radius spread, not merely a non-empty mesh, since a mis-instantiated build can return a plausible blob. Plus two toolchain-specific traps: every face index in range (an index-width mismatch between `node_index_type` and `int` is exactly what differs between toolchains), and the surface closed (which catches a reconstruction silently truncated at the octree boundary).

```
vendor smoke: 15960 vertices, 31916 faces
  radius min/mean/max = 0.998874 / 1.00008 / 1.00122
  edges 47874, not shared by exactly 2 faces: 0
```

Radius spread **0.0023 against a 0.05 tolerance** — 20× headroom, deliberately, so the assertion doesn't become a cross-platform tripwire. Runs in 4.9 s. Full Algorithm suite green at **13/13**.

## Next

Phase 3b: `vtkLiverPoissonSurfaceReconstruction` — `vtkPolyData` in/out, depth defaulting to **7** per ADR-0040's phase-1 finding, and a **Python** test, which ADR-0040 §5 makes part of the definition of done rather than a nicety.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
