### PR TITLE
DOC: Name the ring-group helper that actually exists

### DIFF
--- a/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
+++ b/LiverResections/MRML/vtkMRMLControlPolygonDisplayNode.h
@@ -144,9 +144,11 @@ public:
   ///    control polygon (every point, not only the boundary).  The frame
   ///    is the affordance; its action is global.
   ///  - ``GroupRing0`` and up — one ring from
-  ///    ``vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups``,
-  ///    whose drag moves ONLY that ring's points.  Ring ``k`` is
-  ///    ``GroupRing0 + k``.
+  ///    ``ControlPolygonRings.ring_groups``, whose drag moves ONLY that
+  ///    ring's points.  Ring ``k`` is ``GroupRing0 + k``, outermost
+  ///    first.  Ring membership is derived in Python, not here: this
+  ///    node carries only WHICH group is armed, so the enum stays valid
+  ///    whatever the grid shape.
   ///
   /// Frame and ring 0 cover the same boundary points but are distinct
   /// targets: the frame moves everything, ring 0 moves only the


### PR DESCRIPTION
Comment-only, one hunk.

`vtkMRMLControlPolygonDisplayNode`'s `GroupTarget` comment pointed at `vtkSlicerLiverBezierControlPolygonGeometry::BuildRingGroups` — **a C++ function that was never merged**. There is no such symbol anywhere in `preview`.

An earlier take on the #505 group gestures put ring membership in the Algorithm-library geometry class. What shipped derives it in Python instead (`ControlPolygonRings.ring_groups`, via `ControlPolygonPipeline._ring_members`) — the simplification that addressed rings by control *point* rather than by segment. The comment wasn't updated when the approach changed, so it sent the next reader hunting for a function that doesn't exist.

The reference now names the helper that does, and states the division of responsibility that change established: **this node carries only *which* group is armed**, while membership is derived from the grid shape elsewhere. That's why the enum needs no new value when the grid changes shape — worth saying out loud, since `GroupRing0 = 1` with "and up" otherwise looks like it must be extended per shape.

Found while auditing stale local branches: the abandoned C++ implementation was still sitting on one, which is what made the dangling name visible.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
