### PR TITLE
ENH: Adapt PoissonRecon to VTK and Python (ADR-0040 phase 3)

### DIFF
--- a/LiverResections/Algorithm/CMakeLists.txt
+++ b/LiverResections/Algorithm/CMakeLists.txt
@@ -80,6 +80,8 @@ set(${KIT}_SRCS
   vtkLiverResectogramAspectRatio.cxx
   vtkLiverResectogramPixelMapping.h
   vtkLiverResectogramPixelMapping.cxx
+  vtkLiverPoissonSurfaceReconstruction.h
+  vtkLiverPoissonSurfaceReconstruction.cxx
   )
 
 #

--- a/LiverResections/Algorithm/PoissonRecon/README.md
+++ b/LiverResections/Algorithm/PoissonRecon/README.md
@@ -39,6 +39,26 @@ variants" rather than "whatever the compiler happened to need on the day"
 to `std::async` or single-threaded execution. We therefore do **not**
 make OpenMP a build requirement; it is used if the toolchain offers it.
 
+## Gotchas when including these headers
+
+**Include VTK first.** Upstream's `Array.h` defines a function-like macro
+named `Pointer`. VTK's `vtkBuffer` has a *member* named `Pointer` and
+initialises it as `Pointer(nullptr)`, which the preprocessor rewrites to
+`nullptr*`. Include PoissonRecon before VTK and the build fails inside
+`vtkBuffer.h` with an error that mentions neither PoissonRecon nor a
+macro.
+
+Better still, keep these headers out of your own **headers** entirely, so
+the macros stay inside one translation unit and no consumer can be
+poisoned whatever order it includes things in.
+`vtkLiverPoissonSurfaceReconstruction.h` forward-declares `vtkPolyData`
+and includes nothing from here, on purpose.
+
+**`outputGradients` defaults to false.** With it off, the per-vertex
+gradient handed to a `OutputLevelSetVertexStream` is all zeros —
+silently, with no error. Anything deriving normals from the level set
+must set it.
+
 ## Syncing to a newer upstream
 
 1. Check out the new upstream tag.

--- a/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
@@ -21,6 +21,7 @@ set(KIT_TEST_SRCS
   vtkLiverResectogramAspectRatioTest.cxx
   vtkLiverResectogramPixelMappingTest.cxx
   PoissonReconVendorTest.cxx
+  vtkLiverPoissonSurfaceReconstructionTest.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -103,3 +104,5 @@ set_tests_properties(vtkLiverResectogramPixelMappingTest PROPERTIES
 # template library can sit in the tree unbuildable until something
 # instantiates it, so the drop and its first instantiation ship together.
 SIMPLE_TEST(PoissonReconVendorTest)
+
+SIMPLE_TEST(vtkLiverPoissonSurfaceReconstructionTest)

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverPoissonSurfaceReconstructionTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverPoissonSurfaceReconstructionTest.cxx
@@ -1,0 +1,319 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+==============================================================================*/
+
+// Tests for vtkLiverPoissonSurfaceReconstruction (ADR-0040 phase 3).
+
+#include "vtkLiverPoissonSurfaceReconstruction.h"
+
+#include <vtkCellArray.h>
+#include <vtkDataArray.h>
+#include <vtkFloatArray.h>
+#include <vtkImplicitPolyDataDistance.h>
+#include <vtkMath.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkSphereSource.h>
+#include <vtkTestingOutputWindow.h>
+
+#include <cmath>
+#include <iostream>
+
+namespace
+{
+
+const double SphereRadius = 50.0;
+const double SphereCentre[3] = { 10.0, -20.0, 5.0 };
+
+/// An oriented cloud sampling a sphere, off the origin and at a
+/// clinical-ish scale so the test would catch an adapter that only works
+/// in PSR's internal normalised cube.
+void MakeSphereCloud(vtkPolyData* cloud, int nTheta = 60, int nPhi = 120)
+{
+  vtkNew<vtkPoints> points;
+  vtkNew<vtkFloatArray> normals;
+  normals->SetNumberOfComponents(3);
+  normals->SetName("Normals");
+
+  for (int i = 1; i < nTheta; i++)
+  {
+    const double theta = vtkMath::Pi() * i / nTheta;
+    for (int j = 0; j < nPhi; j++)
+    {
+      const double phi = 2.0 * vtkMath::Pi() * j / nPhi;
+      const double n[3] = { std::sin(theta) * std::cos(phi), std::sin(theta) * std::sin(phi), std::cos(theta) };
+      points->InsertNextPoint(SphereCentre[0] + SphereRadius * n[0], SphereCentre[1] + SphereRadius * n[1], SphereCentre[2] + SphereRadius * n[2]);
+      normals->InsertNextTuple3(n[0], n[1], n[2]);
+    }
+  }
+
+  cloud->SetPoints(points);
+  cloud->GetPointData()->SetNormals(normals);
+}
+
+bool TestDefaultDepthIsSeven()
+{
+  const int depth = vtkLiverPoissonSurfaceReconstruction::GetDefaultDepth();
+  std::cout << "default depth: " << depth << std::endl;
+  if (depth != 7)
+  {
+    // ADR-0040 §Conformance: 7, not upstream's 8.  Phase 1 measured 8
+    // and 9 tracking a CT-resolution liver WORSE than 7, because past a
+    // point the extra resolution fits the labelmap's voxel staircase
+    // rather than the anatomy.  If this assertion is being changed,
+    // fresh measurement belongs in the same commit.
+    std::cerr << "FAIL: default depth is " << depth << ", expected 7 (ADR-0040)" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool TestReconstructsTheSphere()
+{
+  vtkNew<vtkPolyData> cloud;
+  MakeSphereCloud(cloud);
+
+  vtkNew<vtkPolyData> surface;
+  if (!vtkLiverPoissonSurfaceReconstruction::Reconstruct(cloud, vtkLiverPoissonSurfaceReconstruction::GetDefaultDepth(), surface))
+  {
+    std::cerr << "FAIL: Reconstruct returned false on a valid cloud" << std::endl;
+    return false;
+  }
+  if (surface->GetNumberOfPoints() == 0 || surface->GetNumberOfPolys() == 0)
+  {
+    std::cerr << "FAIL: the reconstruction is empty" << std::endl;
+    return false;
+  }
+
+  // ------------------------------------------------------------------
+  // Direction 1: reconstruction -> analytic sphere.  Closed form, so no
+  // tolerance is spent on a locator's approximation.
+  // ------------------------------------------------------------------
+  double worstOut = 0.0;
+  double meanOut = 0.0;
+  for (vtkIdType i = 0; i < surface->GetNumberOfPoints(); i++)
+  {
+    double p[3];
+    surface->GetPoint(i, p);
+    const double r = std::sqrt(vtkMath::Distance2BetweenPoints(p, SphereCentre));
+    const double d = std::abs(r - SphereRadius);
+    worstOut = std::max(worstOut, d);
+    meanOut += d;
+  }
+  meanOut /= surface->GetNumberOfPoints();
+
+  // ------------------------------------------------------------------
+  // Direction 2: analytic sphere -> reconstruction.  ADR-0040 makes this
+  // direction mandatory, and it is the one that matters: direction 1
+  // alone cannot see PSR OMITTING a region.  Every point it did produce
+  // could sit perfectly on the sphere while half the sphere is missing.
+  // ------------------------------------------------------------------
+  vtkNew<vtkSphereSource> reference;
+  reference->SetCenter(SphereCentre[0], SphereCentre[1], SphereCentre[2]);
+  reference->SetRadius(SphereRadius);
+  reference->SetThetaResolution(64);
+  reference->SetPhiResolution(64);
+  reference->Update();
+
+  vtkNew<vtkImplicitPolyDataDistance> distanceToSurface;
+  distanceToSurface->SetInput(surface);
+
+  double worstIn = 0.0;
+  double meanIn = 0.0;
+  vtkPolyData* referenceMesh = reference->GetOutput();
+  for (vtkIdType i = 0; i < referenceMesh->GetNumberOfPoints(); i++)
+  {
+    double p[3];
+    referenceMesh->GetPoint(i, p);
+    const double d = std::abs(distanceToSurface->EvaluateFunction(p));
+    worstIn = std::max(worstIn, d);
+    meanIn += d;
+  }
+  meanIn /= referenceMesh->GetNumberOfPoints();
+
+  std::cout << "sphere: " << surface->GetNumberOfPoints() << " points, " << surface->GetNumberOfPolys() << " polys" << std::endl;
+  std::cout << "  recon->analytic  mean " << meanOut << " worst " << worstOut << " mm" << std::endl;
+  std::cout << "  analytic->recon  mean " << meanIn << " worst " << worstIn << " mm" << std::endl;
+
+  // 1% of the radius either way.  Both directions share the bound
+  // deliberately: a one-sided tolerance is how an omitted region hides.
+  const double tolerance = 0.01 * SphereRadius;
+  if (worstOut > tolerance || worstIn > tolerance)
+  {
+    std::cerr << "FAIL: symmetric distance exceeds " << tolerance << " mm" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool TestNormalsPointOutward()
+{
+  // Orientation is scale-free, so a coarse reconstruction answers the
+  // question a fine one would, faster.
+  vtkNew<vtkPolyData> cloud;
+  MakeSphereCloud(cloud, 30, 60);
+
+  vtkNew<vtkPolyData> surface;
+  if (!vtkLiverPoissonSurfaceReconstruction::Reconstruct(cloud, 6, surface))
+  {
+    std::cerr << "FAIL: Reconstruct returned false" << std::endl;
+    return false;
+  }
+
+  vtkDataArray* normals = surface->GetPointData()->GetNormals();
+  if (!normals || normals->GetNumberOfTuples() != surface->GetNumberOfPoints())
+  {
+    std::cerr << "FAIL: the reconstruction carries no per-point normals" << std::endl;
+    return false;
+  }
+
+  // On a sphere the outward normal is the radial direction, known in
+  // closed form.  An INVERTED surface is otherwise indistinguishable
+  // from a correct one by position alone -- and it renders black.
+  double meanDot = 0.0;
+  double worstDot = 1.0;
+  for (vtkIdType i = 0; i < surface->GetNumberOfPoints(); i++)
+  {
+    double p[3];
+    surface->GetPoint(i, p);
+    double outward[3] = { p[0] - SphereCentre[0], p[1] - SphereCentre[1], p[2] - SphereCentre[2] };
+    vtkMath::Normalize(outward);
+
+    double n[3];
+    normals->GetTuple(i, n);
+    vtkMath::Normalize(n);
+
+    const double dot = vtkMath::Dot(outward, n);
+    meanDot += dot;
+    worstDot = std::min(worstDot, dot);
+  }
+  meanDot /= surface->GetNumberOfPoints();
+
+  std::cout << "normals: mean dot " << meanDot << ", worst " << worstDot << std::endl;
+  if (meanDot < 0.95)
+  {
+    std::cerr << "FAIL: normals do not agree with the analytic outward direction" << std::endl;
+    return false;
+  }
+  if (worstDot <= 0.0)
+  {
+    std::cerr << "FAIL: at least one normal points inward" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool TestDegenerateInputsYieldAnEmptySurface()
+{
+  // A COARSE cloud at a shallow depth: this test re-seeds the output
+  // before every case, and the accuracy of those seeds is irrelevant --
+  // only that they are non-empty.  Reusing the full-resolution fixture
+  // here would spend half a minute of CI proving nothing extra.
+  vtkNew<vtkPolyData> cloud;
+  MakeSphereCloud(cloud, 20, 40);
+  const int seedDepth = 5;
+
+  vtkNew<vtkPolyData> surface;
+  // Seed the output with a real reconstruction, so the checks below
+  // prove the failure paths CLEAR it rather than merely not filling it.
+  if (!vtkLiverPoissonSurfaceReconstruction::Reconstruct(cloud, seedDepth, surface))
+  {
+    std::cerr << "FAIL: could not seed the output" << std::endl;
+    return false;
+  }
+  if (surface->GetNumberOfPoints() == 0)
+  {
+    std::cerr << "FAIL: seeding produced nothing to clear" << std::endl;
+    return false;
+  }
+
+  struct Case
+  {
+    const char* Name;
+    vtkPolyData* Cloud;
+    int Depth;
+  };
+
+  vtkNew<vtkPolyData> emptyCloud;
+  vtkNew<vtkPolyData> cloudWithoutNormals;
+  {
+    vtkNew<vtkPoints> points;
+    points->InsertNextPoint(0.0, 0.0, 0.0);
+    points->InsertNextPoint(1.0, 0.0, 0.0);
+    cloudWithoutNormals->SetPoints(points);
+  }
+
+  const Case cases[] = {
+    { "null cloud", nullptr, 7 }, { "empty cloud", emptyCloud, 7 }, { "cloud without normals", cloudWithoutNormals, 7 }, { "depth 0", cloud, 0 }, { "depth 15", cloud, 15 },
+  };
+
+  for (const Case& c : cases)
+  {
+    // Each rejection is EXPECTED to warn.  Asserting that -- rather than
+    // merely silencing the driver's error-output check -- means a
+    // rejection that goes quiet is itself a failure: an invalid input
+    // that fails without saying why is the thing that makes a caller
+    // hunt for a bug in their own data.
+    TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+    const bool reconstructed = vtkLiverPoissonSurfaceReconstruction::Reconstruct(c.Cloud, c.Depth, surface);
+    TESTING_OUTPUT_ASSERT_WARNINGS_END();
+    if (reconstructed)
+    {
+      std::cerr << "FAIL: " << c.Name << " returned true" << std::endl;
+      return false;
+    }
+    if (surface->GetNumberOfPoints() != 0 || surface->GetNumberOfPolys() != 0)
+    {
+      std::cerr << "FAIL: " << c.Name << " left " << surface->GetNumberOfPoints() << " stale points" << std::endl;
+      return false;
+    }
+    // Re-seed for the next case, so each one proves the failure path
+    // CLEARS a populated output rather than finding it already empty.
+    vtkLiverPoissonSurfaceReconstruction::Reconstruct(cloud, seedDepth, surface);
+    TESTING_OUTPUT_RESET();
+  }
+
+  // A null output must be refused, not crash.
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  const bool reconstructedIntoNull = vtkLiverPoissonSurfaceReconstruction::Reconstruct(cloud, 7, nullptr);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  if (reconstructedIntoNull)
+  {
+    std::cerr << "FAIL: a null output returned true" << std::endl;
+    return false;
+  }
+
+  std::cout << "degenerate inputs: all " << (sizeof(cases) / sizeof(cases[0]) + 1) << " cases rejected with an empty output" << std::endl;
+  return true;
+}
+
+} // namespace
+
+int vtkLiverPoissonSurfaceReconstructionTest(int, char*[])
+{
+  if (!TestDefaultDepthIsSeven())
+  {
+    return EXIT_FAILURE;
+  }
+  if (!TestReconstructsTheSphere())
+  {
+    return EXIT_FAILURE;
+  }
+  if (!TestNormalsPointOutward())
+  {
+    return EXIT_FAILURE;
+  }
+  if (!TestDegenerateInputsYieldAnEmptySurface())
+  {
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "vtkLiverPoissonSurfaceReconstructionTest passed" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/Algorithm/vtkLiverPoissonSurfaceReconstruction.cxx
+++ b/LiverResections/Algorithm/vtkLiverPoissonSurfaceReconstruction.cxx
@@ -1,0 +1,296 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  This file was originally developed for the Slicer-Liver extension as
+  the Algorithm-library adapter between VTK and the vendored PoissonRecon
+  core (per ADR-0040).
+
+==============================================================================*/
+
+#include "vtkLiverPoissonSurfaceReconstruction.h"
+
+// VTK includes -- FIRST, and that order is load-bearing.
+//
+// Upstream's Array.h defines a function-like macro named `Pointer`.
+// VTK's vtkBuffer has a MEMBER named Pointer and initialises it as
+// `Pointer(nullptr)`, which the preprocessor happily rewrites to
+// `nullptr*`.  Including PoissonRecon first therefore breaks VTK
+// headers with an error that names vtkBuffer.h and mentions neither
+// PoissonRecon nor a macro.
+//
+// This is also why the class HEADER includes no PoissonRecon at all --
+// only a forward declaration of vtkPolyData.  The macro stays inside
+// this translation unit, so nothing that consumes this class can be
+// poisoned by it, whatever order IT includes things in.  Keep it that
+// way: the moment a PoissonRecon include appears in the header, every
+// consumer inherits the trap.
+#include <vtkCellArray.h>
+#include <vtkDataArray.h>
+#include <vtkFloatArray.h>
+#include <vtkIdList.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+
+// STD includes
+#include <cmath>
+#include <vector>
+
+// Vendored PoissonRecon (see PoissonRecon/README.md), LAST for the
+// reason above.  PreProcessor.h precedes the rest -- upstream expects
+// it first.
+#include "PreProcessor.h"
+
+#include "MyMiscellany.h"
+#include "Reconstructors.h"
+
+namespace
+{
+
+using Real = float;
+constexpr unsigned int Dim = 3;
+
+/// Upstream's octree depth is exponential in memory and time.  1 is the
+/// smallest meaningful tree; beyond about 14 a single reconstruction
+/// exhausts memory on ordinary hardware.  Rejecting out-of-range values
+/// turns a hang or a bad_alloc into a return code.
+constexpr int MinDepth = 1;
+constexpr int MaxDepth = 14;
+
+/// Feeds vtkPolyData's points and normals to the solver.
+///
+/// Upstream pulls samples through a stream rather than taking an array,
+/// which is what lets this adapter avoid copying the cloud: the solver
+/// reads the caller's vtkPolyData in place.
+class PolyDataSampleStream : public PoissonRecon::Reconstructor::InputOrientedSampleStream<Real, Dim>
+{
+public:
+  PolyDataSampleStream(vtkPoints* points, vtkDataArray* normals)
+    : Points(points)
+    , Normals(normals)
+  {
+  }
+
+  void reset(void) override { this->Index = 0; }
+
+  bool read(PoissonRecon::Point<Real, Dim>& p, PoissonRecon::Point<Real, Dim>& n) override
+  {
+    if (this->Index >= this->Points->GetNumberOfPoints())
+    {
+      return false;
+    }
+    double point[3];
+    this->Points->GetPoint(this->Index, point);
+    double normal[3];
+    this->Normals->GetTuple(this->Index, normal);
+    for (unsigned int d = 0; d < Dim; d++)
+    {
+      p[d] = static_cast<Real>(point[d]);
+      n[d] = static_cast<Real>(normal[d]);
+    }
+    this->Index++;
+    return true;
+  }
+
+private:
+  vtkPoints* Points;
+  vtkDataArray* Normals;
+  vtkIdType Index = 0;
+};
+
+/// Collects level-set vertices, and the gradient the solver reports at
+/// each, straight into VTK arrays.
+class PolyDataVertexStream : public PoissonRecon::Reconstructor::OutputLevelSetVertexStream<Real, Dim>
+{
+public:
+  PolyDataVertexStream(vtkPoints* points, vtkFloatArray* normals)
+    : Points(points)
+    , Normals(normals)
+  {
+  }
+
+  size_t size(void) const override { return static_cast<size_t>(this->Points->GetNumberOfPoints()); }
+
+  size_t write(const PoissonRecon::Point<Real, Dim>& p, const PoissonRecon::Point<Real, Dim>& gradient, const Real&) override
+  {
+    this->Points->InsertNextPoint(p[0], p[1], p[2]);
+
+    // The solver reports the GRADIENT of the fitted indicator function.
+    // The indicator rises from outside to inside, so the gradient points
+    // INWARD and the outward normal is its negation -- the same sign
+    // convention vtkLiverOrientedPointCloudExtractor applies on the way
+    // in, kept consistent so a reconstruction round-trips.
+    double normal[3] = { -static_cast<double>(gradient[0]), -static_cast<double>(gradient[1]), -static_cast<double>(gradient[2]) };
+    const double length = std::sqrt(normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]);
+    if (length > 0.0)
+    {
+      normal[0] /= length;
+      normal[1] /= length;
+      normal[2] /= length;
+    }
+    this->Normals->InsertNextTuple3(normal[0], normal[1], normal[2]);
+
+    return static_cast<size_t>(this->Points->GetNumberOfPoints() - 1);
+  }
+
+private:
+  vtkPoints* Points;
+  vtkFloatArray* Normals;
+};
+
+/// Collects reconstructed faces into a vtkCellArray.
+class PolyDataFaceStream : public PoissonRecon::Reconstructor::OutputFaceStream<2>
+{
+public:
+  PolyDataFaceStream(vtkCellArray* polys)
+    : Polys(polys)
+  {
+  }
+
+  size_t size(void) const override { return static_cast<size_t>(this->Polys->GetNumberOfCells()); }
+
+  size_t write(const std::vector<PoissonRecon::node_index_type>& poly) override
+  {
+    vtkNew<vtkIdList> ids;
+    ids->SetNumberOfIds(static_cast<vtkIdType>(poly.size()));
+    for (size_t i = 0; i < poly.size(); i++)
+    {
+      ids->SetId(static_cast<vtkIdType>(i), static_cast<vtkIdType>(poly[i]));
+    }
+    this->Polys->InsertNextCell(ids);
+    return static_cast<size_t>(this->Polys->GetNumberOfCells() - 1);
+  }
+
+private:
+  vtkCellArray* Polys;
+};
+
+} // namespace
+
+//------------------------------------------------------------------------------
+vtkStandardNewMacro(vtkLiverPoissonSurfaceReconstruction);
+
+//------------------------------------------------------------------------------
+vtkLiverPoissonSurfaceReconstruction::vtkLiverPoissonSurfaceReconstruction() = default;
+
+//------------------------------------------------------------------------------
+vtkLiverPoissonSurfaceReconstruction::~vtkLiverPoissonSurfaceReconstruction() = default;
+
+//------------------------------------------------------------------------------
+void vtkLiverPoissonSurfaceReconstruction::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+  os << indent << "DefaultDepth: " << vtkLiverPoissonSurfaceReconstruction::GetDefaultDepth() << "\n";
+}
+
+//------------------------------------------------------------------------------
+int vtkLiverPoissonSurfaceReconstruction::GetDefaultDepth()
+{
+  return 7;
+}
+
+//------------------------------------------------------------------------------
+bool vtkLiverPoissonSurfaceReconstruction::Reconstruct(vtkPolyData* orientedCloud, int depth, vtkPolyData* output)
+{
+  if (!output)
+  {
+    vtkGenericWarningMacro("Reconstruct: no output vtkPolyData given.");
+    return false;
+  }
+
+  // Clear FIRST, so every failure path below leaves an empty result
+  // rather than whatever the caller reconstructed last.
+  output->Initialize();
+
+  if (!orientedCloud)
+  {
+    vtkGenericWarningMacro("Reconstruct: no input point cloud given.");
+    return false;
+  }
+  if (depth < MinDepth || depth > MaxDepth)
+  {
+    vtkGenericWarningMacro("Reconstruct: depth " << depth << " outside [" << MinDepth << ", " << MaxDepth << "].");
+    return false;
+  }
+
+  vtkPoints* points = orientedCloud->GetPoints();
+  if (!points || points->GetNumberOfPoints() == 0)
+  {
+    vtkGenericWarningMacro("Reconstruct: the input cloud has no points.");
+    return false;
+  }
+
+  vtkDataArray* normals = orientedCloud->GetPointData() ? orientedCloud->GetPointData()->GetNormals() : nullptr;
+  if (!normals)
+  {
+    // Not recoverable by estimating normals here: normals recovered from
+    // an unstructured cloud have no reliable orientation, and a cloud
+    // whose normals point inward reconstructs the COMPLEMENT of the
+    // object.  Better to fail than to return a confident inversion.
+    vtkGenericWarningMacro("Reconstruct: the input cloud carries no point normals.");
+    return false;
+  }
+  if (normals->GetNumberOfTuples() != points->GetNumberOfPoints())
+  {
+    vtkGenericWarningMacro("Reconstruct: " << normals->GetNumberOfTuples() << " normals for " << points->GetNumberOfPoints() << " points.");
+    return false;
+  }
+
+  static const unsigned int FEMSig =
+    PoissonRecon::FEMDegreeAndBType<PoissonRecon::Reconstructor::Poisson::DefaultFEMDegree, PoissonRecon::Reconstructor::Poisson::DefaultFEMBoundary>::Signature;
+  using FEMSigs = PoissonRecon::IsotropicUIntPack<Dim, FEMSig>;
+  using Implicit = PoissonRecon::Reconstructor::Implicit<Real, Dim, FEMSigs>;
+  using Solver = PoissonRecon::Reconstructor::Poisson::Solver<Real, Dim, FEMSigs>;
+
+  PoissonRecon::Reconstructor::Poisson::SolutionParameters<Real> solverParams;
+  solverParams.verbose = false;
+  solverParams.depth = static_cast<unsigned int>(depth);
+
+  PoissonRecon::Reconstructor::LevelSetExtractionParameters extractionParams;
+  extractionParams.verbose = false;
+  // Upstream defaults this OFF, and with it off the per-vertex gradient
+  // handed to the vertex stream is all zeros -- silently, with no error.
+  // The normals we hand back depend on it.
+  extractionParams.outputGradients = true;
+
+  vtkNew<vtkPoints> outPoints;
+  vtkNew<vtkFloatArray> outNormals;
+  outNormals->SetNumberOfComponents(3);
+  outNormals->SetName("Normals");
+  vtkNew<vtkCellArray> outPolys;
+
+  PolyDataSampleStream sampleStream(points, normals);
+  Implicit* implicit = Solver::Solve(sampleStream, solverParams);
+  if (!implicit)
+  {
+    vtkGenericWarningMacro("Reconstruct: the solver produced no implicit function.");
+    return false;
+  }
+
+  {
+    PolyDataVertexStream vertexStream(outPoints, outNormals);
+    PolyDataFaceStream faceStream(outPolys);
+    implicit->extractLevelSet(vertexStream, faceStream, extractionParams);
+  }
+  delete implicit;
+
+  if (outPoints->GetNumberOfPoints() == 0 || outPolys->GetNumberOfCells() == 0)
+  {
+    // A cloud can be well-formed and still carry no recoverable surface
+    // -- too few points, or normals that cancel.  Report it rather than
+    // handing back a valid-but-empty mesh as a success.
+    vtkGenericWarningMacro("Reconstruct: the reconstruction is empty.");
+    output->Initialize();
+    return false;
+  }
+
+  output->SetPoints(outPoints);
+  output->SetPolys(outPolys);
+  output->GetPointData()->SetNormals(outNormals);
+  return true;
+}

--- a/LiverResections/Algorithm/vtkLiverPoissonSurfaceReconstruction.h
+++ b/LiverResections/Algorithm/vtkLiverPoissonSurfaceReconstruction.h
@@ -1,0 +1,85 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  This file was originally developed for the Slicer-Liver extension as
+  the Algorithm-library adapter between VTK and the vendored PoissonRecon
+  core (per ADR-0040 — screened Poisson surface reconstruction from a
+  segmentation, and ADR-0015 §1 — pure-VTK helpers with no MRML or
+  OpenGL linkage).
+
+==============================================================================*/
+
+#ifndef __vtkLiverPoissonSurfaceReconstruction_h_
+#define __vtkLiverPoissonSurfaceReconstruction_h_
+
+#include "vtkSlicerLiverResectionsModuleAlgorithmExport.h"
+
+// VTK includes
+#include <vtkObject.h>
+
+class vtkPolyData;
+
+/// \brief Screened Poisson surface reconstruction from an oriented point cloud.
+///
+/// Wraps the vendored PoissonRecon core (Kazhdan; see
+/// ``PoissonRecon/README.md``) behind a VTK-shaped, Python-wrappable
+/// entry point.  The upstream templates never cross this boundary: the
+/// whole point of the adapter is that callers see ``vtkPolyData`` and
+/// integers, which is what ADR-0040 §5 requires and what makes the
+/// algorithm reachable from the Python that drives this extension
+/// (ADR-0004).
+///
+/// The input is an ORIENTED point cloud -- points plus per-point
+/// normals.  Normals are not an optimisation here, they are the signal:
+/// Poisson reconstruction solves for the indicator function whose
+/// gradient best matches them, so a cloud without normals has nothing to
+/// reconstruct from and is rejected rather than guessed at.
+/// ``vtkLiverOrientedPointCloudExtractor`` produces clouds in this shape
+/// straight from a segmentation.
+class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverPoissonSurfaceReconstruction : public vtkObject
+{
+public:
+  static vtkLiverPoissonSurfaceReconstruction* New();
+  vtkTypeMacro(vtkLiverPoissonSurfaceReconstruction, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Octree depth used when a caller does not choose one.
+  ///
+  /// **7, not upstream's 8.**  Depth is a resolution knob, and past a
+  /// point more resolution means fitting the labelmap's own voxel
+  /// staircase rather than the anatomy it samples.  On a CT-resolution
+  /// liver, depths 8 and 9 tracked the segmentation WORSE than 7 by a
+  /// symmetric surface distance (ADR-0040 §"Phase 1 result").  Changing
+  /// this is a deliberate edit backed by fresh measurement, not a drift
+  /// back toward the upstream default.
+  static int GetDefaultDepth();
+
+  /// Reconstruct a closed surface from ``orientedCloud`` into ``output``.
+  ///
+  /// ``orientedCloud`` must carry point normals; ``depth`` is the octree
+  /// depth (see GetDefaultDepth()).  ``output`` receives points, the
+  /// reconstructed polygons, and the per-vertex normals the solver
+  /// produces -- these come from the fitted implicit function's
+  /// gradient, so they describe the SOLVED surface rather than being
+  /// re-estimated from the output triangles afterwards.
+  ///
+  /// Returns false and leaves ``output`` EMPTY on any invalid input: a
+  /// null argument, a cloud with no points, a cloud with no normals, or
+  /// a depth outside [1, 14].  Empty rather than stale, so a caller that
+  /// ignores the return value renders nothing instead of the previous
+  /// result.
+  static bool Reconstruct(vtkPolyData* orientedCloud, int depth, vtkPolyData* output);
+
+protected:
+  vtkLiverPoissonSurfaceReconstruction();
+  ~vtkLiverPoissonSurfaceReconstruction() override;
+
+private:
+  vtkLiverPoissonSurfaceReconstruction(const vtkLiverPoissonSurfaceReconstruction&) = delete;
+  void operator=(const vtkLiverPoissonSurfaceReconstruction&) = delete;
+};
+
+#endif // __vtkLiverPoissonSurfaceReconstruction_h_

--- a/Testing/Python/unit/test_poisson_surface_reconstruction.py
+++ b/Testing/Python/unit/test_poisson_surface_reconstruction.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Python-side tests for ``vtkLiverPoissonSurfaceReconstruction`` (ADR-0040).
+
+These are not a translation of the C++ test.  They exist because
+**ADR-0040 §Conformance makes Python reachability part of the definition
+of done**, and explicitly says a C++-only test does not discharge it.
+
+The reason is recorded history rather than principle: this project has
+twice shipped a C++ entry point that compiled, linked, passed its C++
+tests and was invisible from Python (#636, #640).  The VTK wrapper skips
+unwrappable signatures *silently*, so nothing fails -- the symbol simply
+is not there.  Since ADR-0004 puts the callers of this algorithm in
+Python, an unreachable reconstruction would be an unusable one.
+
+So what is asserted here is the BOUNDARY: that the class and its methods
+survive wrapping, that arguments cross it in both directions, and that a
+``vtkPolyData`` comes back with real geometry in it.  The numerical
+quality of the reconstruction is the C++ test's job
+(``vtkLiverPoissonSurfaceReconstructionTest.cxx``), and duplicating it
+here would only mean two places to update.
+
+References
+----------
+* ADR-0040 §5 -- the Python boundary is a first-class deliverable.
+* ADR-0040 §Conformance -- default depth 7; Python test mandatory.
+* ADR-0008 §3 -- dual-mode (Python wrapper + C++ ctkTest) discipline.
+* ``reference_algorithm_wrapped_class_namespace`` -- Algorithm-library
+  classes resolve ONLY via the wrapped module, never via ``slicer`` or
+  plain ``vtk``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def algorithm_module():
+    """Import the C++ Algorithm wrapper, skipping if unavailable."""
+    return pytest.importorskip(
+        "vtkSlicerLiverResectionsModuleAlgorithmPython",
+        reason=(
+            "vtkSlicerLiverResectionsModuleAlgorithm not built / not on "
+            "sys.path; skip the Python side of the PSR adapter."
+        ),
+    )
+
+
+@pytest.fixture(scope="module")
+def psr(algorithm_module):
+    """The adapter class itself.
+
+    ``getattr`` rather than attribute access so a MISSING class fails as
+    an explicit assertion naming what went wrong, instead of an
+    ``AttributeError`` traceback that reads like a typo in the test.
+    """
+    cls = getattr(algorithm_module, "vtkLiverPoissonSurfaceReconstruction", None)
+    assert cls is not None, (
+        "vtkLiverPoissonSurfaceReconstruction is absent from the wrapped "
+        "Algorithm module. The class exists in C++ but did not survive "
+        "VTK wrapping -- the failure mode of #636 and #640."
+    )
+    return cls
+
+
+def _sphere_cloud(radius=50.0, centre=(10.0, -20.0, 5.0), n_theta=30, n_phi=60):
+    """An oriented point cloud sampling a sphere, off the origin."""
+    import vtk
+
+    points = vtk.vtkPoints()
+    normals = vtk.vtkFloatArray()
+    normals.SetNumberOfComponents(3)
+    normals.SetName("Normals")
+
+    for i in range(1, n_theta):
+        theta = math.pi * i / n_theta
+        for j in range(n_phi):
+            phi = 2.0 * math.pi * j / n_phi
+            nx = math.sin(theta) * math.cos(phi)
+            ny = math.sin(theta) * math.sin(phi)
+            nz = math.cos(theta)
+            points.InsertNextPoint(
+                centre[0] + radius * nx,
+                centre[1] + radius * ny,
+                centre[2] + radius * nz,
+            )
+            normals.InsertNextTuple3(nx, ny, nz)
+
+    cloud = vtk.vtkPolyData()
+    cloud.SetPoints(points)
+    cloud.GetPointData().SetNormals(normals)
+    return cloud
+
+
+def test_default_depth_is_reachable_and_is_seven(psr):
+    """The ADR's depth decision must be readable from Python.
+
+    A caller that cannot ask for the default has to hard-code 7 at every
+    call site, which is how a documented default quietly becomes several
+    undocumented ones.
+    """
+    assert hasattr(psr, "GetDefaultDepth"), "GetDefaultDepth did not survive wrapping"
+    assert psr.GetDefaultDepth() == 7, (
+        "ADR-0040 fixes the default octree depth at 7, not upstream's 8: "
+        "phase 1 measured depths 8 and 9 tracking a CT-resolution liver "
+        "worse than 7. Changing this needs fresh measurement, not a test edit."
+    )
+
+
+def test_reconstructs_a_surface_from_a_python_built_cloud(psr):
+    """The whole boundary, end to end, from Python.
+
+    A ``vtkPolyData`` built in Python goes in; a populated
+    ``vtkPolyData`` comes back. This is the assertion ADR-0040
+    §Conformance actually requires -- and note it would still have
+    passed for #636 and #640 right up until the argument types were
+    wrong, which is why it invokes rather than introspects.
+    """
+    import vtk
+
+    cloud = _sphere_cloud()
+    surface = vtk.vtkPolyData()
+
+    assert psr.Reconstruct(cloud, psr.GetDefaultDepth(), surface) is True
+
+    assert surface.GetNumberOfPoints() > 0
+    assert surface.GetNumberOfPolys() > 0
+    normals = surface.GetPointData().GetNormals()
+    assert normals is not None, "the reconstruction carries no point normals"
+    assert normals.GetNumberOfTuples() == surface.GetNumberOfPoints()
+
+
+def test_reconstruction_lands_where_the_cloud_is(psr):
+    """Geometry survives the boundary, not just object identity.
+
+    Scale and offset are the things a wrapping bug mangles quietly: a
+    reconstruction returned in PSR's internal normalised cube would still
+    be a valid non-empty mesh, and every assertion above would pass.
+    """
+    import vtk
+
+    radius = 50.0
+    centre = (10.0, -20.0, 5.0)
+    cloud = _sphere_cloud(radius=radius, centre=centre)
+    surface = vtk.vtkPolyData()
+    assert psr.Reconstruct(cloud, 6, surface) is True
+
+    bounds = surface.GetBounds()
+    for axis, c in enumerate(centre):
+        low, high = bounds[2 * axis], bounds[2 * axis + 1]
+        assert low == pytest.approx(c - radius, abs=0.05 * radius)
+        assert high == pytest.approx(c + radius, abs=0.05 * radius)
+
+
+@pytest.mark.parametrize(
+    "depth",
+    [0, 15],
+    ids=["below-minimum", "above-maximum"],
+)
+def test_out_of_range_depth_is_refused(psr, depth):
+    """Rejection crosses the boundary as ``False``, not as an exception.
+
+    Depth is exponential in memory; an unchecked value is a hang or a
+    bad_alloc rather than a wrong answer. The Python caller must see a
+    return value it can branch on.
+    """
+    import vtk
+
+    cloud = _sphere_cloud(n_theta=10, n_phi=20)
+    surface = vtk.vtkPolyData()
+    assert psr.Reconstruct(cloud, depth, surface) is False
+    assert surface.GetNumberOfPoints() == 0
+
+
+def test_a_cloud_without_normals_is_refused(psr):
+    """Normals are the signal, so their absence is an error, not a default.
+
+    Poisson reconstruction solves for the indicator function whose
+    gradient matches the normals. Estimating them here instead would
+    produce a confident result with no reliable orientation -- and an
+    inward-oriented cloud reconstructs the COMPLEMENT of the object,
+    which looks like a plausible surface right up until it is used.
+    """
+    import vtk
+
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0.0, 0.0, 0.0)
+    points.InsertNextPoint(1.0, 0.0, 0.0)
+    cloud = vtk.vtkPolyData()
+    cloud.SetPoints(points)
+
+    surface = vtk.vtkPolyData()
+    assert psr.Reconstruct(cloud, 7, surface) is False
+    assert surface.GetNumberOfPoints() == 0
+
+
+def test_a_failed_call_clears_a_populated_output(psr):
+    """Failure must EMPTY the output, never leave the previous result.
+
+    A caller that ignores the return value should render nothing rather
+    than a stale surface silently attributed to the new input -- the
+    worse of the two failure modes, because it looks like it worked.
+    """
+    import vtk
+
+    cloud = _sphere_cloud(n_theta=20, n_phi=40)
+    surface = vtk.vtkPolyData()
+    assert psr.Reconstruct(cloud, 5, surface) is True
+    assert surface.GetNumberOfPoints() > 0
+
+    assert psr.Reconstruct(None, 7, surface) is False
+    assert surface.GetNumberOfPoints() == 0
+    assert surface.GetNumberOfPolys() == 0


### PR DESCRIPTION
**ADR-0040 phase 3, second half.** The adapter. Stacked on **#646** (the vendored core) — review that first; this PR's diff against it is ~700 lines, all authored. Relates to **#310**; ADR in **#644**.

`vtkPolyData` in, `vtkPolyData` out, depth as an int. The upstream templates never cross that boundary, which is the point: ADR-0004 puts the callers in Python, and nothing templated is reachable from there.

## Decisions worth review

**Depth 7, exposed rather than hard-coded.** A caller that can't ask for the default has to repeat `7` at every call site, which is how one documented default becomes several undocumented ones. Depth is a resolution knob, and past a point more resolution fits the labelmap's own voxel staircase rather than the anatomy — phase 1 measured depths 8 and 9 tracking a CT-resolution liver *worse* than 7. A test pins it, so drifting back to upstream's 8 has to be deliberate.

**Normals come back with the surface**, and they're the solver's own gradient of the fitted implicit function — they describe the *solved* surface rather than being re-estimated from the output triangles. This needed `extractionParams.outputGradients`, which **upstream defaults OFF**: with it off the gradient handed to the vertex stream is all zeros, silently, with no error. The sign is negated (the indicator rises outside→inside, so its gradient points inward) — the same convention the phase-2 extractor applies on the way in, so a reconstruction round-trips.

**A cloud without normals is refused, not repaired.** Normals aren't an optimisation here, they're the signal PSR solves against. Normals estimated from an unstructured cloud have no reliable orientation, and an inward-oriented cloud reconstructs the **complement** of the object — a confident, plausible-looking, entirely wrong surface. Failing is better than that.

**Every failure path empties the output.** A caller that ignores the return value renders nothing, rather than a stale surface silently attributed to the new input. Depth is range-checked because it's exponential in memory — an unchecked value is a hang or a `bad_alloc`, not a wrong answer.

## Include order is load-bearing

Upstream's `Array.h` defines a **function-like macro named `Pointer`**. VTK's `vtkBuffer` has a *member* named `Pointer`, initialised as `Pointer(nullptr)` — which the preprocessor rewrites to `nullptr*`. Include PoissonRecon before VTK and the build fails inside `vtkBuffer.h`, with an error naming neither PoissonRecon nor a macro.

So VTK comes first, and **the class header includes no PoissonRecon at all** — only a forward declaration of `vtkPolyData`. The macro stays inside one translation unit and no consumer can inherit the trap whatever order *it* includes things in. Both this and the `outputGradients` default are now recorded in the vendored README.

## The symmetric measure

ADR-0040 requires it, and here's why it isn't pedantry: the phase-1 probe measured PSR→marching-cubes only, and **that direction alone cannot see PSR omitting a region**. Every point it did produce can sit perfectly on the sphere while half the sphere is missing. Both directions share one tolerance, since a one-sided bound is exactly how an omission hides.

Measured on a 50 mm sphere placed **off the origin**, so an adapter that only worked inside PSR's internal normalised cube would fail:

```
recon->analytic  mean 0.0147  worst 0.166 mm
analytic->recon  mean 0.0137  worst 0.125 mm
normals          mean dot 0.998, worst 0.995
```

Normals are checked against the analytic outward direction, not merely for existence — an inverted surface is indistinguishable from a correct one by position alone, and renders black.

The degenerate cases **assert the warning is emitted** (`TESTING_OUTPUT_ASSERT_WARNINGS`) rather than silencing the driver's error-output check: a rejection that goes quiet sends the caller hunting for a bug in their own data. Each case re-seeds a populated output first, so it proves the failure path *clears* the result rather than finding it already empty.

## Python, verified to run rather than to be green

ADR-0040 §Conformance says in terms that a C++-only test doesn't discharge this. We've shipped the opposite twice (#636, #640) — entry points that compiled, linked, passed their C++ tests and were invisible from Python, because the wrapper skips unwrappable signatures silently.

The test asserts the *boundary* — arguments crossing in both directions, geometry coming back at the right scale and offset — and leaves numerical quality to the C++ test rather than duplicating it.

Under the **bare** row it skips, by design: the wrapped Algorithm module is off that path. A green-but-skipping row proves nothing, which this project has learned the hard way (#449, #454, #459, #460). So I ran it under a **launched Slicer**:

```
Testing/Python/unit/test_poisson_surface_reconstruction.py .......  [100%]
7 passed, 206 deselected in 8.11s
```

Algorithm C++ suite **14/14**; bare `pytest_scaffold` green.

## Next

Phase 4: wire the consumer — PSR offered *alongside* marching cubes, not as a silent replacement, per ADR-0040's `[future]` conformance point — then a `:0` eyeball on real anatomy.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
