### PR TITLE
ENH: Offer Poisson reconstruction alongside marching cubes (ADR-0040 phase 4a)

### DIFF
--- a/LiverResections/Algorithm/CMakeLists.txt
+++ b/LiverResections/Algorithm/CMakeLists.txt
@@ -62,6 +62,8 @@ set(${KIT}_SRCS
   vtkLiverResectogramAspectRatio.cxx
   vtkLiverResectogramPixelMapping.h
   vtkLiverResectogramPixelMapping.cxx
+  vtkLiverOrientedPointCloudExtractor.h
+  vtkLiverOrientedPointCloudExtractor.cxx
   )
 
 #

--- a/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
+++ b/LiverResections/Algorithm/Testing/Cxx/CMakeLists.txt
@@ -18,6 +18,7 @@ set(KIT_TEST_SRCS
   vtkLiverSpheroidRingExtractorEdgeCasesTest.cxx
   vtkLiverSpheroidRingExtractorConsistencyTest.cxx
   vtkSlicerLiverBezierControlPolygonGeometryTest1.cxx
+  vtkLiverOrientedPointCloudExtractorTest.cxx
   vtkLiverResectogramAspectRatioTest.cxx
   vtkLiverResectogramPixelMappingTest.cxx
   )
@@ -43,6 +44,7 @@ SIMPLE_TEST(vtkLiverContourParameterizerEdgeCasesTest)
 SIMPLE_TEST(vtkLiverPlaneRingExtractorEdgeCasesTest)
 SIMPLE_TEST(vtkLiverSpheroidRingExtractorEdgeCasesTest)
 SIMPLE_TEST(vtkSlicerLiverBezierControlPolygonGeometryTest1)
+SIMPLE_TEST(vtkLiverOrientedPointCloudExtractorTest)
 
 # Stack-4 ring-extraction wiring — Constraint 1 (shader/extractor
 # parameter consistency) + Constraint 2 (extraction-granularity bound).

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverOrientedPointCloudExtractorTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverOrientedPointCloudExtractorTest.cxx
@@ -1,0 +1,286 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, Oslo University Hospital. All rights reserved.
+
+  Tests for ``vtkLiverOrientedPointCloudExtractor`` — the oriented point
+  cloud PSR consumes (ADR-0040 §Decision 2).
+
+  The load-bearing property is the NORMAL DIRECTION.  PSR reconstructs
+  from orientation; a cloud whose normals point inward reconstructs the
+  complement of the object, and a cloud with the right positions but
+  wrong orientations fails in a way position-only assertions cannot see.
+  So the sphere case checks every normal against the analytic outward
+  direction, not merely that normals exist.
+
+  Per ADR-0008 §2: C++ low-level ctkTest-driver tests, no Slicer scene,
+  no Qt, no rendering.
+
+==============================================================================*/
+
+#include "vtkLiverOrientedPointCloudExtractor.h"
+
+// VTK includes
+#include <vtkDataArray.h>
+#include <vtkImageData.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+
+// STD includes
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+namespace
+{
+
+#define LIVER_CHECK(cond, msg)                                             \
+  do                                                                       \
+  {                                                                        \
+    if (!(cond))                                                           \
+    {                                                                      \
+      std::fprintf(stderr, "[%s:%d] FAIL: %s\n", __FILE__, __LINE__, msg); \
+      return EXIT_FAILURE;                                                 \
+    }                                                                      \
+  } while (0)
+
+//----------------------------------------------------------------------------
+// A solid sphere of `label`, centred in a dim^3 volume.
+vtkSmartPointer<vtkImageData> MakeSphere(int dim, double radius, int label)
+{
+  vtkSmartPointer<vtkImageData> image = vtkSmartPointer<vtkImageData>::New();
+  image->SetDimensions(dim, dim, dim);
+  image->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+  const double c = (dim - 1) / 2.0;
+  for (int k = 0; k < dim; ++k)
+  {
+    for (int j = 0; j < dim; ++j)
+    {
+      for (int i = 0; i < dim; ++i)
+      {
+        const double d2 = (i - c) * (i - c) + (j - c) * (j - c) + (k - c) * (k - c);
+        unsigned char* v = static_cast<unsigned char*>(image->GetScalarPointer(i, j, k));
+        *v = (d2 <= radius * radius) ? static_cast<unsigned char>(label) : 0;
+      }
+    }
+  }
+  return image;
+}
+
+//----------------------------------------------------------------------------
+int TestNormalsPointOutward()
+{
+  const int dim = 32;
+  const double radius = 10.0;
+  vtkSmartPointer<vtkImageData> sphere = MakeSphere(dim, radius, 1);
+  vtkNew<vtkMatrix4x4> identity;
+  vtkNew<vtkPolyData> cloud;
+
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, 0, cloud), "extraction of a solid sphere must succeed");
+
+  vtkPoints* pts = cloud->GetPoints();
+  vtkDataArray* normals = cloud->GetPointData()->GetNormals();
+  LIVER_CHECK(pts && normals, "the cloud carries points and normals");
+  LIVER_CHECK(pts->GetNumberOfPoints() > 0, "the cloud is not empty");
+  LIVER_CHECK(normals->GetNumberOfTuples() == pts->GetNumberOfPoints(), "one normal per point");
+
+  // Every normal must agree with the analytic outward radial direction.
+  // A cloud oriented inward reconstructs the complement of the object.
+  const double c = (dim - 1) / 2.0;
+  double worstDot = 1.0;
+  double meanDot = 0.0;
+  for (vtkIdType i = 0; i < pts->GetNumberOfPoints(); ++i)
+  {
+    double p[3];
+    pts->GetPoint(i, p);
+    double n[3];
+    normals->GetTuple(i, n);
+
+    double r[3] = { p[0] - c, p[1] - c, p[2] - c };
+    const double rl = std::sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
+    if (rl < 1e-6)
+    {
+      continue;
+    }
+    for (int d = 0; d < 3; ++d)
+    {
+      r[d] /= rl;
+    }
+    const double dot = n[0] * r[0] + n[1] * r[1] + n[2] * r[2];
+    worstDot = std::min(worstDot, dot);
+    meanDot += dot;
+
+    const double len = std::sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+    LIVER_CHECK(std::fabs(len - 1.0) < 1e-3, "normals are unit length");
+  }
+  meanDot /= static_cast<double>(pts->GetNumberOfPoints());
+
+  std::cout << "  sphere: " << pts->GetNumberOfPoints() << " points, mean dot " << meanDot << ", worst " << worstDot << std::endl;
+
+  // Sobel on a voxelised sphere cannot be exact; the mean must be close
+  // to 1 and NO normal may point inward.
+  LIVER_CHECK(meanDot > 0.95, "normals agree with the analytic outward direction");
+  LIVER_CHECK(worstDot > 0.0, "NO normal points inward");
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestSubsamplingIsDeterministicAndBounded()
+{
+  vtkSmartPointer<vtkImageData> sphere = MakeSphere(32, 10.0, 1);
+  vtkNew<vtkMatrix4x4> identity;
+
+  vtkNew<vtkPolyData> full;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, 0, full), "full");
+  const vtkIdType n = full->GetNumberOfPoints();
+
+  const vtkIdType cap = n / 4;
+  vtkNew<vtkPolyData> a;
+  vtkNew<vtkPolyData> b;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, cap, a), "capped a");
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, cap, b), "capped b");
+
+  LIVER_CHECK(a->GetNumberOfPoints() <= cap, "the cap is respected");
+  LIVER_CHECK(a->GetNumberOfPoints() == b->GetNumberOfPoints(), "same count twice");
+  for (vtkIdType i = 0; i < a->GetNumberOfPoints(); ++i)
+  {
+    double pa[3];
+    double pb[3];
+    a->GetPoint(i, pa);
+    b->GetPoint(i, pb);
+    LIVER_CHECK(pa[0] == pb[0] && pa[1] == pb[1] && pa[2] == pb[2], "the subsample is DETERMINISTIC -- a test could not assert on it otherwise");
+  }
+  std::cout << "  subsample: " << a->GetNumberOfPoints() << " of " << n << " (cap " << cap << ")" << std::endl;
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestGeometryIsAppliedFromTheMatrix()
+{
+  vtkSmartPointer<vtkImageData> sphere = MakeSphere(32, 10.0, 1);
+
+  vtkNew<vtkMatrix4x4> identity;
+  vtkNew<vtkPolyData> plain;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 1, 0, plain), "plain");
+
+  // Anisotropic spacing plus a translation: positions must scale and
+  // shift, normals must NOT pick up the translation and must stay unit.
+  vtkNew<vtkMatrix4x4> geom;
+  geom->Identity();
+  geom->SetElement(0, 0, 2.0);
+  geom->SetElement(1, 1, 0.5);
+  geom->SetElement(2, 2, 1.0);
+  geom->SetElement(0, 3, 100.0);
+  vtkNew<vtkPolyData> shifted;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(sphere, geom, 1, 0, shifted), "shifted");
+
+  LIVER_CHECK(plain->GetNumberOfPoints() == shifted->GetNumberOfPoints(), "geometry changes coordinates, not membership");
+
+  double pb[6];
+  shifted->GetBounds(pb);
+  LIVER_CHECK(pb[0] > 90.0, "the translation reached the points");
+
+  vtkDataArray* normals = shifted->GetPointData()->GetNormals();
+  for (vtkIdType i = 0; i < normals->GetNumberOfTuples(); ++i)
+  {
+    double n[3];
+    normals->GetTuple(i, n);
+    const double len = std::sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+    LIVER_CHECK(std::fabs(len - 1.0) < 1e-3,
+                "normals stay unit under anisotropic spacing -- a translation or a "
+                "scale leaking in would skew every one of them");
+  }
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestDegenerateInputsYieldAnEmptyCloud()
+{
+  vtkNew<vtkMatrix4x4> identity;
+  vtkNew<vtkPolyData> out;
+
+  LIVER_CHECK(!vtkLiverOrientedPointCloudExtractor::Extract(nullptr, identity, 1, 0, out), "a null image is refused");
+  LIVER_CHECK(out->GetNumberOfPoints() == 0, "and leaves the output empty, not stale");
+
+  vtkSmartPointer<vtkImageData> sphere = MakeSphere(16, 5.0, 1);
+  vtkNew<vtkPolyData> absent;
+  LIVER_CHECK(!vtkLiverOrientedPointCloudExtractor::Extract(sphere, identity, 7, 0, absent), "a label that is not present has no boundary");
+  LIVER_CHECK(absent->GetNumberOfPoints() == 0, "and yields an empty cloud, not an exception");
+
+  vtkNew<vtkPolyData> noMatrix;
+  LIVER_CHECK(!vtkLiverOrientedPointCloudExtractor::Extract(sphere, nullptr, 1, 0, noMatrix), "a null matrix is refused");
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int TestOtherLabelsDoNotBleedIn()
+{
+  // Two concentric shells with different labels.  Extracting the inner
+  // one must not see the outer one's boundary: the indicator is built
+  // from voxels EQUAL to the label, not merely non-zero.
+  const int dim = 40;
+  vtkSmartPointer<vtkImageData> image = MakeSphere(dim, 8.0, 1);
+  const double c = (dim - 1) / 2.0;
+  for (int k = 0; k < dim; ++k)
+  {
+    for (int j = 0; j < dim; ++j)
+    {
+      for (int i = 0; i < dim; ++i)
+      {
+        const double d2 = (i - c) * (i - c) + (j - c) * (j - c) + (k - c) * (k - c);
+        unsigned char* v = static_cast<unsigned char*>(image->GetScalarPointer(i, j, k));
+        if (d2 > 8.0 * 8.0 && d2 <= 14.0 * 14.0)
+        {
+          *v = 2;
+        }
+      }
+    }
+  }
+
+  vtkNew<vtkMatrix4x4> identity;
+  vtkNew<vtkPolyData> inner;
+  LIVER_CHECK(vtkLiverOrientedPointCloudExtractor::Extract(image, identity, 1, 0, inner), "inner");
+
+  double b[6];
+  inner->GetBounds(b);
+  const double maxR = std::max(std::fabs(b[1] - c), std::fabs(b[0] - c));
+  std::cout << "  two-label: inner cloud max radius " << maxR << " (inner r=8, outer r=14)" << std::endl;
+  LIVER_CHECK(maxR < 12.0,
+              "the inner label's cloud must not reach the outer label's boundary -- "
+              "a non-zero test instead of an equality test would merge them");
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+//----------------------------------------------------------------------------
+int vtkLiverOrientedPointCloudExtractorTest(int, char*[])
+{
+  if (TestNormalsPointOutward() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestSubsamplingIsDeterministicAndBounded() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestGeometryIsAppliedFromTheMatrix() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestDegenerateInputsYieldAnEmptyCloud() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestOtherLabelsDoNotBleedIn() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  std::cout << "vtkLiverOrientedPointCloudExtractorTest passed." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/LiverResections/Algorithm/Testing/Cxx/vtkLiverOrientedPointCloudExtractorTest.cxx
+++ b/LiverResections/Algorithm/Testing/Cxx/vtkLiverOrientedPointCloudExtractorTest.cxx
@@ -73,6 +73,77 @@ vtkSmartPointer<vtkImageData> MakeSphere(int dim, double radius, int label)
 }
 
 //----------------------------------------------------------------------------
+/// The same sphere, but in an image whose EXTENT STARTS AWAY FROM ZERO.
+///
+/// This is the shape the class is actually given in production: a
+/// segment's binary labelmap is cropped to its own bounding box, so its
+/// extent begins wherever that box does.  A zero-based fixture cannot
+/// tell a correct index mapping from one that ignores the offset.
+vtkSmartPointer<vtkImageData> MakeSphereAtExtent(int dim, double radius, int label, const int origin[3])
+{
+  vtkSmartPointer<vtkImageData> image = vtkSmartPointer<vtkImageData>::New();
+  image->SetExtent(origin[0], origin[0] + dim - 1, origin[1], origin[1] + dim - 1, origin[2], origin[2] + dim - 1);
+  image->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
+  const double c = (dim - 1) / 2.0;
+  for (int k = 0; k < dim; ++k)
+  {
+    for (int j = 0; j < dim; ++j)
+    {
+      for (int i = 0; i < dim; ++i)
+      {
+        const double d2 = (i - c) * (i - c) + (j - c) * (j - c) + (k - c) * (k - c);
+        unsigned char* v = static_cast<unsigned char*>(image->GetScalarPointer(i + origin[0], j + origin[1], k + origin[2]));
+        *v = (d2 <= radius * radius) ? static_cast<unsigned char>(label) : 0;
+      }
+    }
+  }
+  return image;
+}
+
+//----------------------------------------------------------------------------
+/// The cloud must land at the voxels' ABSOLUTE index position.
+///
+/// Slicer's image-to-world matrix maps absolute voxel indices, so an
+/// extractor that reports indices relative to the extent produces a
+/// cloud that is intact, correctly shaped, correctly oriented -- and
+/// translated by the extent origin.  Every other assertion in this file
+/// still passes in that state, which is exactly how it reached a real
+/// liver before being caught by eye.
+int TestExtentOriginIsHonoured()
+{
+  const int dim = 30;
+  const double radius = 9.0;
+  const int origin[3] = { 100, 50, 20 };
+
+  vtkSmartPointer<vtkImageData> shifted = MakeSphereAtExtent(dim, radius, 1, origin);
+  vtkNew<vtkMatrix4x4> identity; // IJK == RAS, so the answer is exact.
+  vtkNew<vtkPolyData> cloud;
+  if (!vtkLiverOrientedPointCloudExtractor::Extract(shifted, identity, 1, 0, cloud))
+  {
+    std::cerr << "FAIL: extraction failed on a shifted-extent image" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  double bounds[6];
+  cloud->GetBounds(bounds);
+  const double centre[3] = { (bounds[0] + bounds[1]) / 2.0, (bounds[2] + bounds[3]) / 2.0, (bounds[4] + bounds[5]) / 2.0 };
+  const double expected[3] = { origin[0] + (dim - 1) / 2.0, origin[1] + (dim - 1) / 2.0, origin[2] + (dim - 1) / 2.0 };
+
+  std::cout << "extent origin: centre (" << centre[0] << ", " << centre[1] << ", " << centre[2] << "), expected (" << expected[0] << ", " << expected[1] << ", " << expected[2]
+            << ")" << std::endl;
+
+  for (int axis = 0; axis < 3; ++axis)
+  {
+    if (std::abs(centre[axis] - expected[axis]) > 1.0)
+    {
+      std::cerr << "FAIL: axis " << axis << " off by " << (expected[axis] - centre[axis]) << " -- the extent origin was dropped" << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
 int TestNormalsPointOutward()
 {
   const int dim = 32;
@@ -278,6 +349,10 @@ int vtkLiverOrientedPointCloudExtractorTest(int, char*[])
     return EXIT_FAILURE;
   }
   if (TestOtherLabelsDoNotBleedIn() != EXIT_SUCCESS)
+  {
+    return EXIT_FAILURE;
+  }
+  if (TestExtentOriginIsHonoured() != EXIT_SUCCESS)
   {
     return EXIT_FAILURE;
   }

--- a/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.cxx
+++ b/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.cxx
@@ -163,6 +163,17 @@ bool vtkLiverOrientedPointCloudExtractor::Extract(vtkImageData* labelMap, vtkMat
   int dims[3] = { 0, 0, 0 };
   labelMap->GetDimensions(dims);
 
+  // The EXTENT ORIGIN, which is rarely zero for the images this class is
+  // actually given.  A segment's binary labelmap is cropped to its own
+  // bounding box, so its extent starts wherever that box does, while the
+  // ITK image built above is indexed from 0.  Slicer's image-to-world
+  // matrix maps ABSOLUTE voxel indices, so the offset has to be added
+  // back before the matrix is applied -- otherwise every point is
+  // translated by the extent origin and the cloud lands, intact and
+  // correctly shaped, in the wrong place.
+  int extent[6] = { 0, 0, 0, 0, 0, 0 };
+  labelMap->GetExtent(extent);
+
   // The normal rotates by the direction part only; translation would
   // move it and scale would skew it.  Columns are normalised so a
   // non-uniform voxel size does not bias the direction.
@@ -231,7 +242,7 @@ bool vtkLiverOrientedPointCloudExtractor::Extract(vtkImageData* labelMap, vtkMat
     }
 
     const FloatImageType::IndexType idx = itX.GetIndex();
-    double ijk[4] = { static_cast<double>(idx[0]), static_cast<double>(idx[1]), static_cast<double>(idx[2]), 1.0 };
+    double ijk[4] = { static_cast<double>(idx[0] + extent[0]), static_cast<double>(idx[1] + extent[2]), static_cast<double>(idx[2] + extent[4]), 1.0 };
     double ras[4] = { 0.0, 0.0, 0.0, 0.0 };
     ijkToRAS->MultiplyPoint(ijk, ras);
     points->InsertNextPoint(ras[0], ras[1], ras[2]);

--- a/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.cxx
+++ b/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.cxx
@@ -1,0 +1,258 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+==============================================================================*/
+
+#include "vtkLiverOrientedPointCloudExtractor.h"
+
+// VTK includes
+#include <vtkFloatArray.h>
+#include <vtkImageData.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+
+// ITK includes
+#include <itkImage.h>
+#include <itkImageRegionConstIterator.h>
+#include <itkNeighborhoodOperatorImageFilter.h>
+#include <itkSobelOperator.h>
+
+// STD includes
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace
+{
+using FloatImageType = itk::Image<float, 3>;
+
+//------------------------------------------------------------------------------
+// Copy the label's indicator function into a float ITK image.
+//
+// A copy rather than an itk::ImportImageFilter over the VTK buffer: the
+// Sobel convolution needs a float field, the input may be any scalar
+// type, and only voxels EQUAL to `label` belong to the object -- a
+// multi-label volume must not have its other labels bleed into the
+// gradient.
+template <typename T>
+void FillIndicator(vtkImageData* image, int label, std::vector<float>& out)
+{
+  const T* src = static_cast<const T*>(image->GetScalarPointer());
+  const size_t n = out.size();
+  const T wanted = static_cast<T>(label);
+  for (size_t i = 0; i < n; ++i)
+  {
+    out[i] = (src[i] == wanted) ? 1.0f : 0.0f;
+  }
+}
+
+//------------------------------------------------------------------------------
+FloatImageType::Pointer MakeIndicatorImage(vtkImageData* image, int label, bool& ok)
+{
+  ok = false;
+  int dims[3] = { 0, 0, 0 };
+  image->GetDimensions(dims);
+  if (dims[0] <= 0 || dims[1] <= 0 || dims[2] <= 0)
+  {
+    return nullptr;
+  }
+  const size_t count = static_cast<size_t>(dims[0]) * static_cast<size_t>(dims[1]) * static_cast<size_t>(dims[2]);
+
+  // Unit spacing and zero origin deliberately: the gradient is taken in
+  // VOXEL space and the caller's ijkToRAS carries the geometry.  Baking
+  // spacing in here would scale the normals twice.
+  FloatImageType::RegionType region;
+  FloatImageType::SizeType size;
+  size[0] = dims[0];
+  size[1] = dims[1];
+  size[2] = dims[2];
+  FloatImageType::IndexType start;
+  start.Fill(0);
+  region.SetSize(size);
+  region.SetIndex(start);
+
+  FloatImageType::Pointer indicator = FloatImageType::New();
+  indicator->SetRegions(region);
+  indicator->Allocate();
+
+  std::vector<float> buffer(count, 0.0f);
+  switch (image->GetScalarType())
+  {
+    vtkTemplateMacro(FillIndicator<VTK_TT>(image, label, buffer));
+    default: return nullptr;
+  }
+  std::copy(buffer.begin(), buffer.end(), indicator->GetBufferPointer());
+
+  ok = true;
+  return indicator;
+}
+
+//------------------------------------------------------------------------------
+FloatImageType::Pointer SobelAlong(FloatImageType::Pointer input, unsigned int direction)
+{
+  itk::SobelOperator<float, 3> sobel;
+  sobel.SetDirection(direction);
+  itk::Size<3> radius;
+  radius.Fill(1);
+  sobel.CreateToRadius(radius);
+
+  using FilterType = itk::NeighborhoodOperatorImageFilter<FloatImageType, FloatImageType>;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetOperator(sobel);
+  filter->SetInput(input);
+  filter->Update();
+  FloatImageType::Pointer out = filter->GetOutput();
+  out->DisconnectPipeline();
+  return out;
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+vtkStandardNewMacro(vtkLiverOrientedPointCloudExtractor);
+
+//------------------------------------------------------------------------------
+vtkLiverOrientedPointCloudExtractor::vtkLiverOrientedPointCloudExtractor() = default;
+
+//------------------------------------------------------------------------------
+vtkLiverOrientedPointCloudExtractor::~vtkLiverOrientedPointCloudExtractor() = default;
+
+//------------------------------------------------------------------------------
+void vtkLiverOrientedPointCloudExtractor::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//------------------------------------------------------------------------------
+bool vtkLiverOrientedPointCloudExtractor::Extract(vtkImageData* labelMap, vtkMatrix4x4* ijkToRAS, int label, vtkIdType maxPoints, vtkPolyData* output)
+{
+  if (!output)
+  {
+    return false;
+  }
+  vtkNew<vtkPoints> points;
+  vtkNew<vtkFloatArray> normals;
+  normals->SetNumberOfComponents(3);
+  normals->SetName("Normals");
+  output->SetPoints(points);
+  output->GetPointData()->SetNormals(normals);
+
+  if (!labelMap || !ijkToRAS)
+  {
+    return false;
+  }
+
+  bool ok = false;
+  FloatImageType::Pointer indicator = MakeIndicatorImage(labelMap, label, ok);
+  if (!ok || indicator.IsNull())
+  {
+    return false;
+  }
+
+  FloatImageType::Pointer gx = SobelAlong(indicator, 0);
+  FloatImageType::Pointer gy = SobelAlong(indicator, 1);
+  FloatImageType::Pointer gz = SobelAlong(indicator, 2);
+
+  int dims[3] = { 0, 0, 0 };
+  labelMap->GetDimensions(dims);
+
+  // The normal rotates by the direction part only; translation would
+  // move it and scale would skew it.  Columns are normalised so a
+  // non-uniform voxel size does not bias the direction.
+  double rot[3][3];
+  for (int c = 0; c < 3; ++c)
+  {
+    double norm = 0.0;
+    for (int r = 0; r < 3; ++r)
+    {
+      rot[r][c] = ijkToRAS->GetElement(r, c);
+      norm += rot[r][c] * rot[r][c];
+    }
+    norm = std::sqrt(norm);
+    if (norm > 0.0)
+    {
+      for (int r = 0; r < 3; ++r)
+      {
+        rot[r][c] /= norm;
+      }
+    }
+  }
+
+  // Two passes: count the boundary, then emit with a stride.  A stride
+  // keeps the subsample DETERMINISTIC -- the same labelmap yields the
+  // same cloud, so a test can assert on it.
+  const float kGradientEpsilon = 1e-3f;
+  vtkIdType boundaryCount = 0;
+  itk::ImageRegionConstIterator<FloatImageType> itX(gx, gx->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<FloatImageType> itY(gy, gy->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<FloatImageType> itZ(gz, gz->GetLargestPossibleRegion());
+  for (itX.GoToBegin(), itY.GoToBegin(), itZ.GoToBegin(); !itX.IsAtEnd(); ++itX, ++itY, ++itZ)
+  {
+    const float m = std::sqrt(itX.Get() * itX.Get() + itY.Get() * itY.Get() + itZ.Get() * itZ.Get());
+    if (m > kGradientEpsilon)
+    {
+      ++boundaryCount;
+    }
+  }
+  if (boundaryCount == 0)
+  {
+    return false;
+  }
+
+  vtkIdType stride = 1;
+  if (maxPoints > 0 && boundaryCount > maxPoints)
+  {
+    stride = (boundaryCount + maxPoints - 1) / maxPoints;
+  }
+
+  vtkIdType seen = 0;
+  for (itX.GoToBegin(), itY.GoToBegin(), itZ.GoToBegin(); !itX.IsAtEnd(); ++itX, ++itY, ++itZ)
+  {
+    const float dx = itX.Get();
+    const float dy = itY.Get();
+    const float dz = itZ.Get();
+    const float m = std::sqrt(dx * dx + dy * dy + dz * dz);
+    if (m <= kGradientEpsilon)
+    {
+      continue;
+    }
+    const bool keep = (seen % stride) == 0;
+    ++seen;
+    if (!keep)
+    {
+      continue;
+    }
+
+    const FloatImageType::IndexType idx = itX.GetIndex();
+    double ijk[4] = { static_cast<double>(idx[0]), static_cast<double>(idx[1]), static_cast<double>(idx[2]), 1.0 };
+    double ras[4] = { 0.0, 0.0, 0.0, 0.0 };
+    ijkToRAS->MultiplyPoint(ijk, ras);
+    points->InsertNextPoint(ras[0], ras[1], ras[2]);
+
+    // Negated: the indicator RISES from 0 outside to 1 inside, so its
+    // gradient points INWARD.  PSR wants the outward normal.
+    const double nIjk[3] = { -dx / m, -dy / m, -dz / m };
+    double nRas[3] = { 0.0, 0.0, 0.0 };
+    for (int r = 0; r < 3; ++r)
+    {
+      nRas[r] = rot[r][0] * nIjk[0] + rot[r][1] * nIjk[1] + rot[r][2] * nIjk[2];
+    }
+    const double len = std::sqrt(nRas[0] * nRas[0] + nRas[1] * nRas[1] + nRas[2] * nRas[2]);
+    if (len > 0.0)
+    {
+      nRas[0] /= len;
+      nRas[1] /= len;
+      nRas[2] /= len;
+    }
+    normals->InsertNextTuple3(nRas[0], nRas[1], nRas[2]);
+  }
+
+  return points->GetNumberOfPoints() > 0;
+}

--- a/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.h
+++ b/LiverResections/Algorithm/vtkLiverOrientedPointCloudExtractor.h
@@ -1,0 +1,80 @@
+/*==============================================================================
+
+ Distributed under the OSI-approved BSD 3-Clause License.
+
+  Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+
+  This file was originally developed for the Slicer-Liver extension as
+  the Algorithm-library home of the oriented-point-cloud extraction that
+  feeds Poisson Surface Reconstruction (ADR-0040; ADR-0015 §1 — a pure
+  computation helper with no MRML or VTKWidgets linkage).
+
+==============================================================================*/
+
+#ifndef __vtkliverorientedpointcloudextractor_h_
+#define __vtkliverorientedpointcloudextractor_h_
+
+#include "vtkSlicerLiverResectionsModuleAlgorithmExport.h"
+
+// VTK includes
+#include <vtkObject.h>
+
+class vtkImageData;
+class vtkMatrix4x4;
+class vtkPolyData;
+
+/// \brief Oriented point cloud from a binary labelmap, for PSR input.
+///
+/// Poisson Surface Reconstruction consumes points carrying OUTWARD
+/// NORMALS.  The normals come from the labelmap's own intensity
+/// gradient, not from a triangulated surface: at a labelmap boundary the
+/// gradient IS the outward normal, so no intermediate marching-cubes
+/// surface is built and the normals do not inherit the staircase
+/// artefacts PSR exists to remove (ADR-0040 §Decision 2).
+///
+/// The gradient is an ITK Sobel operator rather than a raw central
+/// difference.  Sobel's built-in smoothing matters on a BINARY mask,
+/// where a bare difference gives normals quantised to a handful of
+/// lattice directions.
+class VTK_SLICER_LIVERRESECTIONS_MODULE_ALGORITHM_EXPORT vtkLiverOrientedPointCloudExtractor : public vtkObject
+{
+public:
+  static vtkLiverOrientedPointCloudExtractor* New();
+  vtkTypeMacro(vtkLiverOrientedPointCloudExtractor, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Extract oriented points from ``labelMap`` into ``output``.
+  ///
+  /// \param labelMap    binary or multi-label volume; voxels equal to
+  ///                    ``label`` form the object.
+  /// \param ijkToRAS    voxel-to-world matrix; points are emitted in
+  ///                    world millimetres and normals are rotated by its
+  ///                    direction part (translation and scale removed),
+  ///                    so a caller never has to fix them up.
+  /// \param label       the label value to extract.
+  /// \param maxPoints   upper bound on emitted points; a stride keeps
+  ///                    the subsample DETERMINISTIC, so a test asserting
+  ///                    on the output is reproducible.  Zero means no
+  ///                    limit.
+  /// \param output      receives the points plus a float "Normals" array
+  ///                    on its point data.
+  ///
+  /// \return false (leaving ``output`` empty) on a null argument, an
+  /// unsupported scalar type, or a label with no boundary — a caller
+  /// gets an empty cloud rather than an exception.
+  ///
+  /// Signature is deliberately wrappable: VTK objects and scalars only.
+  /// A PSR entry point unreachable from Python would be useless here,
+  /// and this project has shipped that mistake twice (#636, #640).
+  static bool Extract(vtkImageData* labelMap, vtkMatrix4x4* ijkToRAS, int label, vtkIdType maxPoints, vtkPolyData* output);
+
+protected:
+  vtkLiverOrientedPointCloudExtractor();
+  ~vtkLiverOrientedPointCloudExtractor() override;
+
+private:
+  vtkLiverOrientedPointCloudExtractor(const vtkLiverOrientedPointCloudExtractor&) = delete;
+  void operator=(const vtkLiverOrientedPointCloudExtractor&) = delete;
+};
+
+#endif // __vtkliverorientedpointcloudextractor_h_

--- a/LiverResections/LiverResectionsLib/CMakeLists.txt
+++ b/LiverResections/LiverResectionsLib/CMakeLists.txt
@@ -35,6 +35,7 @@ set(LiverResectionsLib_PYTHON_SCRIPTS
   ResectogramPipeline.py
   SliceContourPipeline.py
   SliceControlPolygonPipeline.py
+  SegmentSurface.py
   TargetModel.py
   ResectogramViewManager.py
   Representations/__init__.py

--- a/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
+++ b/LiverResections/LiverResectionsLib/ResectionPlanningWidget.py
@@ -118,6 +118,25 @@ _DEFAULT_RESECTION_NAME = "Resection"
 _EMBEDDED_MIN_HEIGHT_PX = 250
 
 
+def _safe_is_init(carrier):
+    """True when ``carrier`` is in the Init state (ADR-0035).
+
+    Defensive by the module's convention: a carrier without the state API
+    (a fake in the bare unit layer, a node type that never gained one)
+    reports NOT-Init, so the resectogram behaves exactly as it did before
+    rather than hiding itself on an unreadable state.
+    """
+    if carrier is None:
+        return False
+    try:
+        from LiverResectionsLib.ResectionStateMachine import STATE_INIT
+
+        getter = getattr(carrier, "GetState", None)
+        return getter is not None and int(getter()) == int(STATE_INIT)
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
 class ResectionPlanningWidget(qt.QWidget):
     """The Stage-4 Resection Planning panel (`ADR-0023`_ §Stage-4).
 
@@ -533,6 +552,37 @@ class ResectionPlanningWidget(qt.QWidget):
     def _onDrawerCollapsed(self, collapsed):
         self.scheduleResectogramRender()
 
+    def _attachExistingDistanceMap(self, plan):
+        """Attach an already-computed distance map to ``plan``, if one exists.
+
+        The same predicate ``CreateResectionPlan`` uses: a
+        ``vtkMRMLVectorVolumeNode`` tagged ``DistanceMap=True`` AND
+        ``Computed=True`` (ADR-0031 -- the map lives on the plan wrapper).
+        Kept deliberately identical, so a plan created before the map and one
+        created after converge on the same input rather than drifting apart.
+
+        A no-op when no tagged volume is in the scene, which is exactly the
+        pre-Stage-2 case: no map, nothing to attach, margins stay disabled
+        with the existing hint.
+        """
+        scene = self._mrmlScene
+        if plan is None or scene is None:
+            return
+        collection = scene.GetNodesByClass("vtkMRMLVectorVolumeNode")
+        if collection is None:
+            return
+        collection.UnRegister(None)
+        for index in range(collection.GetNumberOfItems()):
+            candidate = collection.GetItemAsObject(index)
+            if candidate is None:
+                continue
+            if (
+                candidate.GetAttribute("DistanceMap") == "True"
+                and candidate.GetAttribute("Computed") == "True"
+            ):
+                plan.SetAndObserveDistanceMapVolumeNode(candidate)
+                return
+
     def refreshResectogramDrawer(self):  # noqa: N802 - Slicer/Qt verb convention
         # Re-resolve the locator the click-to-reslice consumer observes BEFORE
         # the distance-map guards below (a locator minted after the widget --
@@ -548,10 +598,22 @@ class ResectionPlanningWidget(qt.QWidget):
         carrier = plan.GetGeometryNode() if plan is not None else None
 
         # ADR-0023 §Stage-4 auto-populate predicate: a resectogram is available
-        # iff a resection PLAN is selected AND its WRAPPER carries a distance map
-        # (ADR-0031).  State-orthogonal: the predicate does NOT consult the
-        # ADR-0019 ResectionState.
+        # iff a resection PLAN is selected AND its WRAPPER carries a distance
+        # map (ADR-0031).
+        #
+        # Orthogonal to Planning-vs-Confirmed, but NOT to Init: a carrier still
+        # in Init has no fitted surface (its grid sits at the origin until the
+        # candidate grab), so the strip would render a near-uniform readout
+        # that reads as empty or broken.  That case gets an explaining hint
+        # below instead.  The map half of the predicate is unchanged.
         hasPlan = plan is not None
+        # A plan minted BEFORE the map was computed never picked one up:
+        # CreateResectionPlan auto-attaches only at mint time, so the drawer
+        # and the margins stayed disabled with no recovery short of
+        # delete-and-replace.  Re-run the same tagged-volume scan here, so a
+        # map that appears later attaches on the next refresh.
+        if hasPlan and plan.GetDistanceMapVolumeNode() is None:
+            self._attachExistingDistanceMap(plan)
         hasDistanceMap = bool(
             hasPlan and carrier is not None and plan.GetDistanceMapVolumeNode() is not None
         )
@@ -627,6 +689,21 @@ class ResectionPlanningWidget(qt.QWidget):
             RESECTOGRAM_VIEW_SINGLETON_TAG, _VIEW_NODE_CLASS
         )
         if viewNode is None:
+            return
+
+        # A plan still in Init has no fitted surface -- its control grid sits
+        # at the origin until the candidate grab commits Init->Planning -- so
+        # the strip renders a near-uniform readout that reads as "empty" or
+        # "broken".  Say so instead (ADR-0009 explainable state; ADR-0035 owns
+        # the state machine that decides it).
+        if _safe_is_init(carrier):
+            if self._resectogramWidget is not None:
+                self._resectogramWidget.hide()
+            self._hintLabel.text = (
+                "Complete the initialization to see the resectogram."
+            )
+            self._hintLabel.show()
+            self.observeSurfaceForRender(carrier)
             return
 
         # The resectogram is available: hide the explanatory hint and show the

--- a/LiverResections/LiverResectionsLib/SegmentSurface.py
+++ b/LiverResections/LiverResectionsLib/SegmentSurface.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Surface extraction for a segmentation segment, by a CHOSEN method.
+
+Two ways to turn a segment into a mesh, side by side:
+
+``marching-cubes``
+    Slicer's own closed-surface conversion.  Fast, exact about which
+    voxels are in, and it inherits the labelmap's voxel staircase --
+    which at CT resolution is a real feature of the output, not noise to
+    be assumed away.
+
+``poisson``
+    Screened Poisson surface reconstruction (ADR-0040): sample the
+    segment boundary as an oriented point cloud, then solve for the
+    smooth surface whose indicator gradient best matches those normals.
+    Slower, and it approximates rather than interpolates -- it will not
+    reproduce a one-voxel spike, by design.
+
+ADR-0040 §Conformance is explicit that PSR is offered ALONGSIDE marching
+cubes, never as a silent replacement: *the surface a user gets is the one
+they chose*.  That is why ``method`` is a required-by-default argument
+threaded from the caller rather than a module-level mode, and why the
+default here is the existing behaviour.  Neither method is "better" in
+general -- staircase fidelity and smoothness are a trade the surgeon
+makes, not one this module makes for them.
+
+The two PSR steps are the wrapped Algorithm-library classes, so the whole
+composition is Python (ADR-0004) over C++ primitives that were built to
+be reachable from it.
+
+References
+----------
+* ADR-0040 -- Poisson surface reconstruction from segmentations.
+* ADR-0015 §1 -- pure-VTK Algorithm library, no MRML linkage.
+* ``reference_algorithm_wrapped_class_namespace`` -- these classes
+  resolve ONLY via the wrapped module, never ``slicer`` or plain ``vtk``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import vtk
+
+#: Slicer's closed-surface conversion.  The default: what callers got
+#: before PSR existed, so adding PSR changes nothing until asked.
+METHOD_MARCHING_CUBES = "marching-cubes"
+#: Screened Poisson reconstruction (ADR-0040).
+METHOD_POISSON = "poisson"
+
+#: Binary-labelmap representation name (Slicer's canonical spelling).
+_BINARY_LABELMAP = "Binary labelmap"
+
+#: Cap on the oriented cloud handed to the solver.  A CT-resolution liver
+#: boundary runs to several hundred thousand voxels, far past the point
+#: where more samples change the fitted surface -- they only cost time.
+#: The extractor subsamples by STRIDE, so this stays deterministic.
+DEFAULT_MAX_POINTS = 200000
+
+
+def surface_methods() -> tuple[str, ...]:
+    """The methods a caller may choose, in presentation order."""
+    return (METHOD_MARCHING_CUBES, METHOD_POISSON)
+
+
+def segment_surface(
+    segmentation_node: Any,
+    segment_id: str,
+    method: str = METHOD_MARCHING_CUBES,
+    depth: int | None = None,
+    max_points: int = DEFAULT_MAX_POINTS,
+) -> Any | None:
+    """A polydata for ``segment_id``, extracted by ``method``.
+
+    Returns ``None`` when there is nothing to extract or the chosen
+    method cannot run -- an unknown method, or PSR without its wrapped
+    C++ classes on the path.  ``None`` rather than a silent fallback to
+    the other method: a caller who asked for PSR and got marching cubes
+    without being told would be comparing the two and reading the same
+    surface twice.
+    """
+    if segmentation_node is None or not segment_id:
+        return None
+
+    if method == METHOD_MARCHING_CUBES:
+        return marching_cubes_surface(segmentation_node, segment_id)
+    if method == METHOD_POISSON:
+        return poisson_surface(
+            segmentation_node, segment_id, depth=depth, max_points=max_points
+        )
+    return None
+
+
+def marching_cubes_surface(segmentation_node: Any, segment_id: str) -> Any | None:
+    """A deep-copied closed-surface polydata for ``segment_id``."""
+    polydata = segmentation_node.GetClosedSurfaceInternalRepresentation(segment_id)
+    if polydata is None:
+        segmentation_node.CreateClosedSurfaceRepresentation()
+        polydata = segmentation_node.GetClosedSurfaceInternalRepresentation(segment_id)
+    if polydata is None:
+        return None
+    # Deep copy (the v1 pattern): the working mesh must not alias the
+    # segmentation's internal representation, which conversions rebuild.
+    copied = vtk.vtkPolyData()
+    copied.DeepCopy(polydata)
+    return copied
+
+
+def poisson_surface(
+    segmentation_node: Any,
+    segment_id: str,
+    depth: int | None = None,
+    max_points: int = DEFAULT_MAX_POINTS,
+) -> Any | None:
+    """Reconstruct ``segment_id`` by screened Poisson (ADR-0040)."""
+    labelmap, label = _segment_labelmap(segmentation_node, segment_id)
+    if labelmap is None:
+        return None
+    return reconstruct_labelmap(labelmap, label, depth=depth, max_points=max_points)
+
+
+def reconstruct_labelmap(
+    labelmap: Any,
+    label: int,
+    depth: int | None = None,
+    max_points: int = DEFAULT_MAX_POINTS,
+) -> Any | None:
+    """Oriented labelmap + label value -> reconstructed surface.
+
+    Split out from ``poisson_surface`` because this half is pure VTK: it
+    takes a ``vtkOrientedImageData`` and an integer and touches no MRML,
+    which is what lets it be tested without a scene.
+    """
+    algorithm = _algorithm_module()
+    if algorithm is None:
+        return None
+    extractor = getattr(algorithm, "vtkLiverOrientedPointCloudExtractor", None)
+    reconstructor = getattr(algorithm, "vtkLiverPoissonSurfaceReconstruction", None)
+    if extractor is None or reconstructor is None:
+        return None
+
+    # The geometry the extractor needs.  A segment's labelmap is
+    # ORIENTED -- its image-to-world matrix carries spacing, direction
+    # and origin together -- and the extractor takes that matrix whole
+    # rather than being handed spacing separately, so an oblique
+    # acquisition cannot be flattened to an axis-aligned assumption.
+    ijk_to_ras = vtk.vtkMatrix4x4()
+    if hasattr(labelmap, "GetImageToWorldMatrix"):
+        labelmap.GetImageToWorldMatrix(ijk_to_ras)
+
+    cloud = vtk.vtkPolyData()
+    if not extractor.Extract(labelmap, ijk_to_ras, int(label), int(max_points), cloud):
+        return None
+
+    surface = vtk.vtkPolyData()
+    chosen_depth = reconstructor.GetDefaultDepth() if depth is None else int(depth)
+    if not reconstructor.Reconstruct(cloud, chosen_depth, surface):
+        return None
+    return surface
+
+
+def _segment_labelmap(segmentation_node: Any, segment_id: str) -> tuple:
+    """``(labelmap, labelValue)`` for ``segment_id``, or ``(None, 0)``.
+
+    The LABEL VALUE matters as much as the image.  Stage 2's segments
+    SHARE one binary-labelmap layer, so the image a segment hands back
+    holds its neighbours' voxels too; only the segment's own value
+    distinguishes it.  The extractor tests voxels for EQUALITY with this
+    value for exactly that reason.
+    """
+    segmentation = segmentation_node.GetSegmentation()
+    if segmentation is None:
+        return None, 0
+    segment = segmentation.GetSegment(segment_id)
+    if segment is None:
+        return None, 0
+
+    labelmap = segment.GetRepresentation(_BINARY_LABELMAP)
+    if labelmap is None:
+        # A segmentation carrying only a closed surface can still be
+        # asked for a labelmap; the conversion is what Slicer does
+        # natively when a labelmap is needed.
+        segmentation_node.CreateBinaryLabelmapRepresentation()
+        labelmap = segment.GetRepresentation(_BINARY_LABELMAP)
+    if labelmap is None:
+        return None, 0
+
+    return labelmap, int(segment.GetLabelValue())
+
+
+def _algorithm_module() -> Any | None:
+    """The wrapped Algorithm library, or ``None`` when it is off the path.
+
+    Imported lazily and by its OWN module name.  These classes are not on
+    ``slicer`` and not on plain ``vtk``; a resolver that looks there
+    returns ``None`` and turns the whole feature into a silent no-op,
+    which this project has shipped twice.
+    """
+    try:
+        import vtkSlicerLiverResectionsModuleAlgorithmPython as algorithm
+    except ImportError:
+        return None
+    return algorithm

--- a/LiverResections/LiverResectionsLib/SegmentSurface.py
+++ b/LiverResections/LiverResectionsLib/SegmentSurface.py
@@ -51,12 +51,21 @@ METHOD_POISSON = "poisson"
 
 #: Binary-labelmap representation name (Slicer's canonical spelling).
 _BINARY_LABELMAP = "Binary labelmap"
+#: Closed-surface representation name.
+_CLOSED_SURFACE = "Closed surface"
 
 #: Cap on the oriented cloud handed to the solver.  A CT-resolution liver
 #: boundary runs to several hundred thousand voxels, far past the point
 #: where more samples change the fitted surface -- they only cost time.
 #: The extractor subsamples by STRIDE, so this stays deterministic.
 DEFAULT_MAX_POINTS = 200000
+
+
+#: Segment tag recording which method produced the segment's CURRENT
+#: closed-surface representation.  A tag rather than a node attribute
+#: because the choice is per-segment: a case may want a smooth liver and
+#: a staircase tumour, and one node-level flag cannot say that.
+SURFACE_METHOD_TAG = "LiverSegmentation.SurfaceMethod"
 
 
 def surface_methods() -> tuple[str, ...]:
@@ -202,3 +211,78 @@ def _algorithm_module() -> Any | None:
     except ImportError:
         return None
     return algorithm
+
+
+def apply_surface_method(
+    segmentation_node: Any,
+    segment_id: str,
+    method: str,
+    depth: int | None = None,
+    max_points: int = DEFAULT_MAX_POINTS,
+) -> bool:
+    """Install ``method``'s surface AS the segment's closed surface.
+
+    This is the single seam the choice travels through.  Slicer's
+    closed-surface representation is what the 3D view renders, what
+    ``TargetModel`` mints the hidden target mesh from, and therefore what
+    the commit-boundary ring extraction runs against.  Writing the chosen
+    surface there means every one of those consumers inherits the choice
+    through the path it already uses -- no ``method`` argument threaded
+    down a call chain, and no possibility of the rendered anatomy and the
+    planned-against geometry disagreeing.
+
+    Slicer holds an injected representation: it does not regenerate one
+    that already exists, so a later ``CreateClosedSurfaceRepresentation``
+    leaves this alone.  **An edit to the segment's labelmap does discard
+    it**, and the surface reverts to marching cubes.  That is the right
+    way round -- a reconstruction of voxels the user has since changed
+    would be stale, and looking correct is what makes stale dangerous --
+    but it means the tag below can go out of date, so treat it as a
+    record of what was last applied, not a guarantee of what is there.
+
+    Returns False and changes nothing when the surface cannot be built.
+    """
+    if segmentation_node is None or not segment_id:
+        return False
+
+    polydata = segment_surface(
+        segmentation_node, segment_id, method=method, depth=depth, max_points=max_points
+    )
+    if polydata is None or polydata.GetNumberOfPoints() == 0:
+        return False
+
+    segmentation = segmentation_node.GetSegmentation()
+    if segmentation is None:
+        return False
+    segment = segmentation.GetSegment(segment_id)
+    if segment is None:
+        return False
+
+    segment.AddRepresentation(_CLOSED_SURFACE, polydata)
+    segment.SetTag(SURFACE_METHOD_TAG, method)
+    return True
+
+
+def applied_surface_method(segmentation_node: Any, segment_id: str) -> str | None:
+    """The method last applied to ``segment_id``, or ``None``.
+
+    ``None`` means "nobody has chosen", which is not the same as
+    "marching cubes was chosen" -- the caller decides what an absent
+    choice defaults to, and the UI can tell the two apart.
+    """
+    if segmentation_node is None or not segment_id:
+        return None
+    segmentation = segmentation_node.GetSegmentation()
+    if segmentation is None:
+        return None
+    segment = segmentation.GetSegment(segment_id)
+    if segment is None:
+        return None
+
+    import vtk as _vtk
+
+    value = _vtk.mutable("")
+    if not segment.GetTag(SURFACE_METHOD_TAG, value):
+        return None
+    text = str(value)
+    return text if text in surface_methods() else None

--- a/LiverResections/LiverResectionsLib/TargetModel.py
+++ b/LiverResections/LiverResectionsLib/TargetModel.py
@@ -59,7 +59,11 @@ def has_canonical_liver() -> bool:
     return not _segment_is_empty(node, segment_id)
 
 
-def ensure_target_model(plan_node: Any) -> Any | None:
+def ensure_target_model(
+    plan_node: Any,
+    method: str | None = None,
+    depth: int | None = None,
+) -> Any | None:
     """Attach the hidden liver target model to ``plan_node``'s carrier.
 
     Resolve-or-mint (idempotent): an already-attached target with live
@@ -67,6 +71,12 @@ def ensure_target_model(plan_node: Any) -> Any | None:
     is nothing to wire (no plan/carrier, no canonical segmentation, no
     SCT-tagged liver segment) — a graceful no-op, mirroring the sibling
     ensure* helpers.
+
+    ``method`` selects how the segment becomes a mesh
+    (``SegmentSurface.surface_methods()``).  ``None`` means marching
+    cubes, so callers that do not care keep exactly the behaviour they
+    had before ADR-0040: offering Poisson reconstruction must not change
+    what anyone gets without asking.
     """
     if plan_node is None:
         return None
@@ -86,7 +96,14 @@ def ensure_target_model(plan_node: Any) -> Any | None:
     if segmentation_node is None:
         return None
 
-    polydata = _liver_closed_surface(segmentation_node, segment_id)
+    from LiverResectionsLib import SegmentSurface
+
+    polydata = SegmentSurface.segment_surface(
+        segmentation_node,
+        segment_id,
+        method=SegmentSurface.METHOD_MARCHING_CUBES if method is None else method,
+        depth=depth,
+    )
     if polydata is None or polydata.GetNumberOfPoints() == 0:
         return None
 
@@ -155,20 +172,15 @@ def _segment_is_empty(segmentation_node: Any, segment_id: str) -> bool:
 
 
 def _liver_closed_surface(segmentation_node: Any, segment_id: str) -> Any | None:
-    """A deep-copied closed-surface polydata for ``segment_id``."""
-    polydata = segmentation_node.GetClosedSurfaceInternalRepresentation(segment_id)
-    if polydata is None:
-        segmentation_node.CreateClosedSurfaceRepresentation()
-        polydata = segmentation_node.GetClosedSurfaceInternalRepresentation(
-            segment_id
-        )
-    if polydata is None:
-        return None
-    # Deep copy (the v1 pattern): the working mesh must not alias the
-    # segmentation's internal representation, which conversions rebuild.
-    copied = vtk.vtkPolyData()
-    copied.DeepCopy(polydata)
-    return copied
+    """A deep-copied closed-surface polydata for ``segment_id``.
+
+    Kept as a thin alias: the implementation moved to ``SegmentSurface``
+    when a second extraction method joined it, and marching cubes has no
+    claim to being the unqualified meaning of "the surface" any more.
+    """
+    from LiverResectionsLib import SegmentSurface
+
+    return SegmentSurface.marching_cubes_surface(segmentation_node, segment_id)
 
 
 def _resolve_or_mint_model() -> Any:

--- a/LiverResections/Testing/Python/CMakeLists.txt
+++ b/LiverResections/Testing/Python/CMakeLists.txt
@@ -112,6 +112,25 @@ if(DEFINED Python3_EXECUTABLE)
       LABELS "pytest;module-layer;LiverResections"
     )
 
+    # ADR-0040 §Conformance: Poisson reconstruction is offered ALONGSIDE
+    # marching cubes, never as a silent replacement.  The dispatch half of
+    # that invariant -- both methods on the menu, marching cubes still the
+    # default, an unrecognised method refused rather than guessed -- is
+    # pure Python and RUNS (not skips) in this bare row, so a regression
+    # that quietly switched every caller fails fast and without a GPU.
+    # The reconstruction half needs the wrapped Algorithm classes and
+    # skips cleanly here; it runs in the launched row.
+    add_test(
+      NAME LiverResections_segment_surface_methods
+      COMMAND "${Python3_EXECUTABLE}" -m pytest
+        -q
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_segment_surface_methods.py"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+    set_tests_properties(LiverResections_segment_surface_methods PROPERTIES
+      LABELS "pytest;module-layer;LiverResections"
+    )
+
     # #538 trigger, plan side -- CreateResectionPlan auto-attaches the
     # scene's computed distance map (DistanceMap='True' + Computed='True')
     # via SetAndObserveDistanceMapVolumeNode (ADR-0031), so Planning opens

--- a/LiverResections/Testing/Python/test_planning_widget_explainable_state.py
+++ b/LiverResections/Testing/Python/test_planning_widget_explainable_state.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital.  All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Stage 4 explains WHY it is not showing a resectogram (ADR-0009).
+
+Two silences found by the 2026-09 eyeball, both of which read as "the
+resectogram is broken":
+
+* a plan minted BEFORE the distance map was computed never picked one up
+  -- ``CreateResectionPlan`` auto-attaches only at mint time -- so the
+  drawer and margins stayed disabled with no recovery short of
+  delete-and-replace (#624);
+* a plan still in Init has no fitted surface, so the strip renders a
+  near-uniform readout rather than saying the initialization is
+  incomplete (#623).
+
+HARNESS: launched Slicer.  Needs the widget, the wrapped plan node and a
+live scene, so a bare run SKIPS CLEANLY (ADR-0027).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _slicer_or_skip():
+    from slicer_pytest_support import import_slicer_or_skip, require_mrml_scene
+
+    require_mrml_scene()
+    return import_slicer_or_skip()
+
+
+def _widget_or_skip(slicer):
+    import qt
+
+    for child in slicer.util.mainWindow().findChildren(qt.QWidget) if slicer.util.mainWindow() else []:
+        if hasattr(child, "_attachExistingDistanceMap"):
+            return child
+    try:
+        from LiverResectionsLib.ResectionPlanningWidget import ResectionPlanningWidget
+    except Exception as exc:
+        pytest.skip(f"ResectionPlanningWidget not importable ({exc!r}) -- ADR-0027.")
+    try:
+        widget = ResectionPlanningWidget()
+    except Exception as exc:
+        pytest.skip(f"widget not constructible ({exc!r}) -- ADR-0027.")
+    widget.setMRMLScene(slicer.mrmlScene)
+    return widget
+
+
+def _plan_or_skip(slicer):
+    module = getattr(slicer.modules, "liverresections", None)
+    if module is None:
+        pytest.skip("liverresections module not registered (ADR-0027).")
+    plan = module.logic().CreateResectionPlan("ExplainableStateTest")
+    if plan is None:
+        pytest.skip("CreateResectionPlan returned None (ADR-0027).")
+    return plan
+
+
+def _tagged_distance_map(slicer):
+    """A vector volume carrying the tags the auto-attach scan reads."""
+    import numpy as np
+
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLVectorVolumeNode", "DistanceMap")
+    array = np.zeros((4, 4, 4, 3), dtype="float32")
+    slicer.util.updateVolumeFromArray(node, array)
+    node.SetAttribute("DistanceMap", "True")
+    node.SetAttribute("Computed", "True")
+    return node
+
+
+def test_a_plan_minted_before_the_map_picks_it_up_later():
+    """#624: the attach must not be mint-time-only."""
+    slicer = _slicer_or_skip()
+    widget = _widget_or_skip(slicer)
+
+    # No tagged map in the scene yet, so the plan mints without one.
+    plan = _plan_or_skip(slicer)
+    if plan.GetDistanceMapVolumeNode() is not None:
+        pytest.skip("a tagged map already existed; this case needs a bare scene.")
+
+    _tagged_distance_map(slicer)
+    widget._attachExistingDistanceMap(plan)
+
+    assert plan.GetDistanceMapVolumeNode() is not None, (
+        "a map computed after the plan was placed must attach on refresh; "
+        "otherwise the only recovery is delete-and-replace."
+    )
+
+
+def test_an_untagged_volume_is_not_attached():
+    """The predicate must match CreateResectionPlan's exactly."""
+    slicer = _slicer_or_skip()
+    widget = _widget_or_skip(slicer)
+    plan = _plan_or_skip(slicer)
+
+    import numpy as np
+
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLVectorVolumeNode", "NotAMap")
+    slicer.util.updateVolumeFromArray(node, np.zeros((4, 4, 4, 3), dtype="float32"))
+    node.SetAttribute("DistanceMap", "True")  # tagged, but NOT Computed
+
+    before = plan.GetDistanceMapVolumeNode()
+    widget._attachExistingDistanceMap(plan)
+    assert plan.GetDistanceMapVolumeNode() is before, (
+        "a half-tagged volume must be ignored -- the two attach paths have "
+        "to agree or a plan's input depends on when it was created."
+    )
+
+
+def test_the_init_predicate_reports_init_and_tolerates_a_stateless_carrier():
+    """#623: the hint's gate, including its defensive fallback."""
+    slicer = _slicer_or_skip()
+    import importlib
+
+    try:
+        module = importlib.import_module(
+            "LiverResectionsLib.ResectionPlanningWidget"
+        )
+    except Exception as exc:
+        pytest.skip(f"module not importable ({exc!r}) -- ADR-0027.")
+
+    plan = _plan_or_skip(slicer)
+    carrier = plan.GetGeometryNode()
+    assert module._safe_is_init(carrier) is True, "a fresh plan starts in Init"
+
+    from LiverResectionsLib.ResectionStateMachine import STATE_PLANNING
+
+    carrier.SetState(STATE_PLANNING)
+    assert module._safe_is_init(carrier) is False
+
+    # A carrier without the state API must report NOT-Init, so the
+    # resectogram behaves as before rather than hiding on an unreadable
+    # state.
+    assert module._safe_is_init(object()) is False
+    assert module._safe_is_init(None) is False

--- a/LiverResections/Testing/Python/test_resection_planning_widget_v2_repoint.py
+++ b/LiverResections/Testing/Python/test_resection_planning_widget_v2_repoint.py
@@ -536,6 +536,24 @@ def test_hint_shown_when_plan_has_no_distance_map():
     )
 
 
+def _drive_to_planning(plan):
+    """Leave Init so the resectogram predicate's state half is satisfied.
+
+    ADR-0035 owns the state machine; the resectogram hint keys on Init
+    because an unfitted grid renders a near-uniform strip.  Tolerant of a
+    carrier without the state API so the bare layer is unaffected.
+    """
+    carrier = plan.GetGeometryNode() if plan is not None else None
+    if carrier is None or not hasattr(carrier, "SetState"):
+        return
+    try:
+        from LiverResectionsLib.ResectionStateMachine import STATE_PLANNING
+
+        carrier.SetState(STATE_PLANNING)
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
 def test_hint_hidden_and_display_node_on_carrier_when_plan_has_distance_map():
     """Plan WITH a distance map => hint hidden AND one display node on the carrier.
 
@@ -559,6 +577,12 @@ def test_hint_hidden_and_display_node_on_carrier_when_plan_has_distance_map():
     plan = _make_plan_or_skip(slicer, "DistanceMapPlan", with_distance_map=True)
     assert plan.GetDistanceMapVolumeNode() is not None  # fixture sanity
     assert _count_carrier_resectogram_display_nodes(plan) == 0  # fixture sanity
+    # Past Init: a carrier still in Init has no fitted surface, so the drawer
+    # now shows the "complete the initialization" hint instead of a strip
+    # that would read as empty.  A distance map is necessary for the
+    # resectogram, not sufficient -- this test owns the MAP half of the
+    # predicate, so it satisfies the state half in the fixture.
+    _drive_to_planning(plan)
     if not _select(widget, combo, plan):
         pytest.skip("cannot select the active resection (implementer contract).")
 

--- a/LiverResections/Testing/Python/test_resectogram_open_view_action.py
+++ b/LiverResections/Testing/Python/test_resectogram_open_view_action.py
@@ -632,15 +632,32 @@ def test_hint_shown_when_surface_has_no_distance_map():
     )
 
 
+def _leave_init(plan):
+    """Satisfy the state half of the predicate (ADR-0035 owns the machine)."""
+    carrier = plan.GetGeometryNode() if plan is not None else None
+    if carrier is None or not hasattr(carrier, "SetState"):
+        return
+    try:
+        from LiverResectionsLib.ResectionStateMachine import STATE_PLANNING
+
+        carrier.SetState(STATE_PLANNING)
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
 def test_hint_hidden_when_surface_has_distance_map():
     """Plan whose WRAPPER carries a distance map => the drawer hint is HIDDEN.
 
     ADR-0023 §Stage-4 auto-populate predicate: the positive branch -- the
     drawer populates (shows the view), so the hint is hidden.  The distance map
-    is read off the WRAPPER (ADR-0031).  State-ORTHOGONAL -- the predicate does
-    NOT read ADR-0019 ResectionState, so a distance-mapped plan populates
-    regardless of Planning/Confirmed state.  GPU-free: pins the hint visibility,
-    not the GL render.
+    is read off the WRAPPER (ADR-0031).  Orthogonal to Planning-vs-Confirmed:
+    a distance-mapped plan populates in either.
+
+    NOT orthogonal to Init, since #623: an Init carrier has no fitted surface,
+    so the drawer explains that instead of showing a near-uniform strip.  This
+    test owns the MAP half of the predicate, so the fixture leaves Init to keep
+    the two halves separable.  GPU-free: pins the hint visibility, not the GL
+    render.
     """
     slicer = _slicer_or_skip()
     slicer.mrmlScene.Clear(0)
@@ -650,6 +667,7 @@ def test_hint_hidden_when_surface_has_distance_map():
     plan = _make_surface_with_distance_map(slicer)
     _accessor_or_skip(plan)
     assert plan.GetDistanceMapVolumeNode() is not None  # fixture sanity
+    _leave_init(plan)
 
     if not _select_active_resection(widget, combo, plan):
         pytest.skip(

--- a/LiverResections/Testing/Python/test_segment_surface_methods.py
+++ b/LiverResections/Testing/Python/test_segment_surface_methods.py
@@ -252,3 +252,142 @@ def test_an_absent_label_yields_no_surface(segment_surface, algorithm):
     not a surface either -- and must not return the whole volume."""
     image, matrix, _ = _sphere_labelmap(label=3)
     assert segment_surface.reconstruct_labelmap(image, 99) is None
+
+
+# --------------------------------------------------------------------------- #
+# The apply seam: the chosen surface BECOMES the segment's closed surface, so
+# every downstream consumer inherits the choice through the path it already
+# uses.  Needs a real scene, so these are launched-only.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def scene_segment():
+    """A labelmap-backed segment in a real scene, or a skip."""
+    slicer = pytest.importorskip(
+        "slicer", reason="a MRML scene is required for the apply-seam tests."
+    )
+    if not hasattr(slicer, "vtkSlicerSegmentationsModuleLogic"):
+        pytest.skip("Segmentations logic unavailable outside a launched Slicer.")
+
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode", "psr-test")
+    node.CreateDefaultDisplayNodes()
+
+    # A NON-ZERO extent on purpose. A segment's labelmap is cropped to its
+    # own bounding box, and a zero-based fixture cannot tell a correct
+    # index mapping from one that drops the offset -- which is exactly the
+    # bug this pipeline shipped and the phase-4 eyeball caught.
+    image = vtk.vtkImageData()
+    image.SetExtent(10, 49, 20, 59, 5, 44)
+    image.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, 1)
+    image.GetPointData().GetScalars().Fill(0)
+    for k in range(5, 45):
+        for j in range(20, 60):
+            for i in range(10, 50):
+                if (i - 30) ** 2 + (j - 40) ** 2 + (k - 25) ** 2 <= 14 * 14:
+                    image.SetScalarComponentFromDouble(i, j, k, 0, 1)
+
+    oriented = slicer.vtkOrientedImageData()
+    oriented.DeepCopy(image)
+    segment_id = node.GetSegmentation().AddEmptySegment("psr-seg")
+    slicer.vtkSlicerSegmentationsModuleLogic.SetBinaryLabelmapToSegment(
+        oriented, node, segment_id
+    )
+    yield node, segment_id
+    slicer.mrmlScene.RemoveNode(node)
+
+
+def test_applying_poisson_replaces_the_closed_surface(
+    segment_surface, algorithm, scene_segment
+):
+    """The installed surface must be the one consumers read back.
+
+    This is the whole architecture in one assertion: if the injected mesh
+    does not survive read-back, the choice would have to be threaded
+    through every consumer separately, and the rendered anatomy could
+    disagree with the geometry the plan is built on.
+    """
+    node, segment_id = scene_segment
+
+    node.CreateClosedSurfaceRepresentation()
+    native = node.GetClosedSurfaceInternalRepresentation(segment_id)
+    native_points = native.GetNumberOfPoints()
+    assert native_points > 0
+
+    assert segment_surface.apply_surface_method(
+        node, segment_id, segment_surface.METHOD_POISSON
+    )
+
+    applied = node.GetClosedSurfaceInternalRepresentation(segment_id)
+    assert applied.GetNumberOfPoints() > 0
+    assert applied.GetNumberOfPoints() != native_points, (
+        "the closed surface is unchanged -- the Poisson mesh was not installed"
+    )
+    assert (
+        segment_surface.applied_surface_method(node, segment_id)
+        == segment_surface.METHOD_POISSON
+    )
+
+
+def test_an_installed_surface_survives_a_reconversion_request(
+    segment_surface, algorithm, scene_segment
+):
+    """CreateClosedSurfaceRepresentation must not silently undo the choice.
+
+    Slicer does not regenerate a representation that already exists, and
+    several code paths call this defensively. If it DID regenerate, the
+    choice would evaporate at an arbitrary later moment.
+    """
+    node, segment_id = scene_segment
+    assert segment_surface.apply_surface_method(
+        node, segment_id, segment_surface.METHOD_POISSON
+    )
+    installed = node.GetClosedSurfaceInternalRepresentation(
+        segment_id
+    ).GetNumberOfPoints()
+
+    node.CreateClosedSurfaceRepresentation()
+
+    assert (
+        node.GetClosedSurfaceInternalRepresentation(segment_id).GetNumberOfPoints()
+        == installed
+    )
+
+
+def test_the_target_mesh_inherits_the_installed_surface(
+    segment_surface, algorithm, scene_segment
+):
+    """The point of the seam: TargetModel gets the choice for free.
+
+    ``_liver_closed_surface`` reads the closed-surface representation, so
+    installing there is what makes the hidden target mesh -- and the ring
+    extraction that runs against it -- use the chosen surface without any
+    argument being threaded to them.
+    """
+    try:
+        from LiverResectionsLib import TargetModel
+    except ImportError:
+        pytest.skip("LiverResectionsLib.TargetModel not importable.")
+
+    node, segment_id = scene_segment
+    assert segment_surface.apply_surface_method(
+        node, segment_id, segment_surface.METHOD_POISSON
+    )
+    installed = node.GetClosedSurfaceInternalRepresentation(
+        segment_id
+    ).GetNumberOfPoints()
+
+    mesh = TargetModel._liver_closed_surface(node, segment_id)
+    assert mesh is not None
+    assert mesh.GetNumberOfPoints() == installed
+
+
+def test_no_method_applied_reads_as_none_not_as_a_default(
+    segment_surface, scene_segment
+):
+    """"Nobody chose" and "marching cubes was chosen" are different states.
+
+    The UI has to tell them apart to show an honest initial value.
+    """
+    node, segment_id = scene_segment
+    assert segment_surface.applied_surface_method(node, segment_id) is None

--- a/LiverResections/Testing/Python/test_segment_surface_methods.py
+++ b/LiverResections/Testing/Python/test_segment_surface_methods.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, The Intervention Centre, Oslo University Hospital. All rights reserved.
+# Distributed under the OSI-approved BSD 3-Clause License.
+"""Tests for ``LiverResectionsLib.SegmentSurface`` (ADR-0040 phase 4).
+
+-- WHY THIS IS A LAUNCHED-SLICER PYTEST --
+
+The Poisson path composes two wrapped Algorithm-library classes, which
+are reachable only inside a launched Slicer with the module loaded.
+Under bare ``PythonSlicer -m pytest`` the wrapped module is off the path
+and every Poisson test here SKIPS CLEANLY.  The dispatch tests, which
+touch no C++, run in both.
+
+The point of this file is the CHOICE, which ADR-0040 §Conformance makes
+a requirement rather than a nicety: *PSR is offered alongside marching
+cubes, not as a silent replacement -- the surface a user gets is the one
+they chose.*  A test suite that only checked "PSR produces a mesh" would
+pass just as happily if PSR had quietly become the only option, or if
+asking for it had quietly returned marching cubes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+vtk = pytest.importorskip("vtk", reason="VTK is required for surface extraction tests.")
+
+
+@pytest.fixture(scope="module")
+def segment_surface():
+    """The module under test, package-imported or loaded from source.
+
+    The source-path fallback is what lets the CHOICE tests run in the
+    bare row.  ``LiverResectionsLib`` is loadable-module Python and is
+    not importable outside a launched Slicer, so a plain package import
+    would make every test here skip -- and a green row that only ever
+    skips is worth nothing, a lesson this project has paid for more than
+    once (#449, #454, #459, #460).
+
+    Loading by path is safe precisely because of how this module is
+    written: at import time it needs ``vtk`` and nothing else -- no
+    ``slicer``, no MRML, no wrapped C++.  The Algorithm classes are
+    resolved lazily, inside the functions that use them, so the
+    reconstruction tests still skip here while the dispatch tests run.
+    If that ever stops being true this fixture will fail loudly rather
+    than quietly skip, which is the right way round.
+    """
+    try:
+        from LiverResectionsLib import SegmentSurface
+
+        return SegmentSurface
+    except ImportError:
+        pass
+
+    import importlib.util
+    import pathlib
+
+    source = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "LiverResectionsLib"
+        / "SegmentSurface.py"
+    )
+    if not source.is_file():
+        pytest.skip(f"SegmentSurface.py not found at {source}.")
+    spec = importlib.util.spec_from_file_location("SegmentSurface", source)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def algorithm():
+    """The wrapped Algorithm library, or a skip."""
+    return pytest.importorskip(
+        "vtkSlicerLiverResectionsModuleAlgorithmPython",
+        reason=(
+            "vtkSlicerLiverResectionsModuleAlgorithm not built / not on "
+            "sys.path; skip the Poisson half of the surface tests."
+        ),
+    )
+
+
+def _sphere_labelmap(radius=12, label=3, shape=40, spacing=(1.0, 1.0, 1.0)):
+    """A labelmap holding a solid sphere of ``label`` voxels.
+
+    Returned as a plain ``vtkImageData`` with an explicit matrix, so this
+    fixture needs no MRML and no Slicer scene.
+    """
+    image = vtk.vtkImageData()
+    image.SetDimensions(shape, shape, shape)
+    image.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, 1)
+    image.GetPointData().GetScalars().Fill(0)
+
+    centre = shape // 2
+    for k in range(shape):
+        for j in range(shape):
+            for i in range(shape):
+                dx, dy, dz = i - centre, j - centre, k - centre
+                if dx * dx + dy * dy + dz * dz <= radius * radius:
+                    image.SetScalarComponentFromDouble(i, j, k, 0, label)
+
+    matrix = vtk.vtkMatrix4x4()
+    for axis in range(3):
+        matrix.SetElement(axis, axis, spacing[axis])
+    return image, matrix, label
+
+
+# --------------------------------------------------------------------------- #
+# The choice itself.  These need no C++ and no scene.
+# --------------------------------------------------------------------------- #
+
+
+def test_both_methods_are_offered(segment_surface):
+    """Marching cubes must remain on the menu, and be listed first.
+
+    ADR-0040 offers PSR ALONGSIDE marching cubes. If PSR ever became the
+    only entry, every caller would silently switch -- which is exactly
+    the outcome the ADR forbids.
+    """
+    methods = segment_surface.surface_methods()
+    assert segment_surface.METHOD_MARCHING_CUBES in methods
+    assert segment_surface.METHOD_POISSON in methods
+    assert methods[0] == segment_surface.METHOD_MARCHING_CUBES
+
+
+def test_an_unknown_method_returns_none_rather_than_guessing(segment_surface):
+    """A typo must not silently produce the other method's surface.
+
+    Returning a surface for an unrecognised name is worse than returning
+    nothing: the caller believes they got what they asked for.
+    """
+    assert segment_surface.segment_surface(object(), "seg", method="spline") is None
+
+
+def test_missing_inputs_are_a_no_op(segment_surface):
+    assert segment_surface.segment_surface(None, "seg") is None
+    assert segment_surface.segment_surface(object(), "") is None
+
+
+def test_the_default_method_is_marching_cubes(segment_surface):
+    """The default is the PREVIOUS behaviour.
+
+    Landing a new reconstruction method must change nothing for anyone
+    who did not ask for it. Asserted through the real dispatcher with a
+    recording stub, rather than by reading the signature's default, so a
+    later refactor that moves the default elsewhere still trips this.
+    """
+    calls = []
+
+    class RecordingSegmentation:
+        def GetClosedSurfaceInternalRepresentation(self, segment_id):
+            calls.append(segment_id)
+            return vtk.vtkPolyData()
+
+    result = segment_surface.segment_surface(RecordingSegmentation(), "liver")
+    assert calls == ["liver"], "the default did not take the marching-cubes path"
+    assert result is not None
+
+
+# --------------------------------------------------------------------------- #
+# The Poisson path.  Needs the wrapped C++ classes.
+# --------------------------------------------------------------------------- #
+
+
+def test_poisson_reconstructs_a_labelmap(segment_surface, algorithm):
+    image, matrix, label = _sphere_labelmap()
+
+    surface = segment_surface.reconstruct_labelmap(image, label)
+
+    assert surface is not None
+    assert surface.GetNumberOfPoints() > 0
+    assert surface.GetNumberOfPolys() > 0
+
+
+def test_poisson_lands_on_the_labelled_object(segment_surface, algorithm):
+    """The surface must sit where the voxels are.
+
+    A reconstruction returned in the solver's own normalised cube would
+    still be a valid non-empty mesh, so bounds are what actually
+    distinguishes a wired pipeline from a plausible-looking one.
+    """
+    radius, shape = 12, 40
+    image, matrix, label = _sphere_labelmap(radius=radius, shape=shape)
+
+    surface = segment_surface.reconstruct_labelmap(image, label)
+    assert surface is not None
+
+    bounds = surface.GetBounds()
+    centre = shape // 2
+    for axis in range(3):
+        low, high = bounds[2 * axis], bounds[2 * axis + 1]
+        assert low == pytest.approx(centre - radius, abs=0.15 * radius)
+        assert high == pytest.approx(centre + radius, abs=0.15 * radius)
+
+
+def test_poisson_ignores_voxels_of_another_label(segment_surface, algorithm):
+    """A neighbouring structure must not bleed into the reconstruction.
+
+    Stage 2's segments SHARE one binary-labelmap layer, so the image a
+    segment hands back holds its neighbours' voxels too. Reconstructing
+    on "non-zero" rather than "equal to my label" would fuse them into
+    one surface -- a wrong result that looks entirely plausible.
+    """
+    shape, inner_radius, outer_radius = 48, 8, 20
+    image, matrix, _ = _sphere_labelmap(radius=inner_radius, label=3, shape=shape)
+
+    # A second, larger structure under a DIFFERENT label, wrapped around
+    # the first without touching it.
+    centre = shape // 2
+    for k in range(shape):
+        for j in range(shape):
+            for i in range(shape):
+                dx, dy, dz = i - centre, j - centre, k - centre
+                d2 = dx * dx + dy * dy + dz * dz
+                if inner_radius * inner_radius < d2 <= outer_radius * outer_radius:
+                    image.SetScalarComponentFromDouble(i, j, k, 0, 7)
+
+    surface = segment_surface.reconstruct_labelmap(image, 3)
+    assert surface is not None
+
+    worst = 0.0
+    for index in range(surface.GetNumberOfPoints()):
+        x, y, z = surface.GetPoint(index)
+        dx, dy, dz = x - centre, y - centre, z - centre
+        worst = max(worst, (dx * dx + dy * dy + dz * dz) ** 0.5)
+
+    assert worst < 0.5 * (inner_radius + outer_radius), (
+        f"the reconstruction reaches radius {worst:.1f}, into the "
+        f"label-7 shell at {inner_radius}..{outer_radius}"
+    )
+
+
+def test_depth_is_the_adapter_default_when_unspecified(segment_surface, algorithm):
+    """An unspecified depth must mean the ADR's 7, resolved at one place."""
+    reconstructor = algorithm.vtkLiverPoissonSurfaceReconstruction
+    assert reconstructor.GetDefaultDepth() == 7
+
+    image, matrix, label = _sphere_labelmap()
+    implicit = segment_surface.reconstruct_labelmap(image, label)
+    explicit = segment_surface.reconstruct_labelmap(
+        image, label, depth=reconstructor.GetDefaultDepth()
+    )
+
+    assert implicit is not None and explicit is not None
+    # The extractor subsamples by stride and the solver is deterministic,
+    # so "same depth" must mean literally the same mesh.
+    assert implicit.GetNumberOfPoints() == explicit.GetNumberOfPoints()
+    assert implicit.GetNumberOfPolys() == explicit.GetNumberOfPolys()
+
+
+def test_an_absent_label_yields_no_surface(segment_surface, algorithm):
+    """Asking for a label that is not present is not an error, but it is
+    not a surface either -- and must not return the whole volume."""
+    image, matrix, _ = _sphere_labelmap(label=3)
+    assert segment_surface.reconstruct_labelmap(image, 99) is None

--- a/LiverSegmentation/LiverSegmentation.py
+++ b/LiverSegmentation/LiverSegmentation.py
@@ -187,9 +187,15 @@ class LiverSegmentation(ScriptedLoadableModule):
         self.parent.dependencies = []
         self.parent.contributors = ["Rafael Palomar (OUS)"]
         self.parent.helpText = """
-        Stage 2 (Anatomy Definition): orchestrates per-structure segmentation
-        micro-workflows (TotalSegmentator + Segment Editor) into a single
-        canonical Segmentation node consumed by downstream stages.
+        Stage 2 (Anatomy Definition): builds the single canonical Segmentation
+        node consumed by downstream stages.  Three routes, in any combination:
+
+        - AI segmentation (TotalSegmentator), downloaded on first use;
+        - manual editing with the embedded Segment Editor;
+        - Import… — bring your own segmentation, no AI required.
+
+        Structures land under review; you confirm each one from its status
+        cell.
         """
         self.parent.acknowledgementText = """
         Developed through the ALive project (grant nr. 311393).
@@ -868,8 +874,9 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         self._importButton = qt.QPushButton("Import…")
         self._importButton.setObjectName("ImportSegmentationButton")
         self._importButton.setToolTip(
-            "Import a loaded segmentation's segments into the anatomy "
-            "table (they land under review)."
+            "Use your own segmentation — no AI required.  Imports a loaded "
+            "segmentation's segments into the anatomy table, through an "
+            "explicit correspondence dialog; they land under review."
         )
         # The Stage-2-LOCAL validate affordance (ADR-0034 §Decision 6): the
         # shell-level "Validate and next" button stays with the
@@ -1327,7 +1334,9 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
             self._retireJobRows(key, structures)
         if landedCodes:
             self._statusLabel.setText(
-                "Landed for review — confirm via the row's status cell."
+                self._withDistanceMapNote(
+                    "Landed for review — confirm via the row's status cell."
+                )
             )
         elif success and not landingFailed:
             self._statusLabel.setText(
@@ -1338,6 +1347,21 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
                 sorted(self.logic._structureTitle(c) for c in structures)
             )
             self._statusLabel.setText(f"Segmentation failed: {names} — see the log.")
+
+    def _withDistanceMapNote(self, message):
+        """Append WHY the distance map was skipped, when it was.
+
+        ``ensureDistanceMap`` degrades gracefully by design -- the canonical
+        import must never fail on the map -- but silence here is what sends
+        a surgeon to Stage 4 with a greyed margins group and no way to learn
+        the cause.  The logic records the specific unmet precondition; this
+        surfaces it on the same status line that reports the landing
+        (ADR-0009 explainable state).
+        """
+        reason = getattr(self.logic, "lastDistanceMapSkipReason", None)
+        if not reason:
+            return message
+        return f"{message}  Distance map not computed: {reason}."
 
     def _reframeThreeDViews(self):
         """Re-centre the 3D views on the new anatomy; a no-op headless.
@@ -1823,13 +1847,10 @@ class LiverSegmentationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin)
         # surface model lands outside the default camera framing.
         self._reframeThreeDViews()
         if mapped < total:
-            self._statusLabel.setText(
-                f"Imported {mapped} of {total} segments — the source was kept."
-            )
+            message = f"Imported {mapped} of {total} segments — the source was kept."
         else:
-            self._statusLabel.setText(
-                "Imported for review — confirm via the row's status cell."
-            )
+            message = "Imported for review — confirm via the row's status cell."
+        self._statusLabel.setText(self._withDistanceMapNote(message))
 
     def onPreDownload(self):
         """Pre-download the AI backend without minting a node.
@@ -2183,10 +2204,20 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
         resolves (graceful degradation; the canonical import itself must
         never fail on the map).
         """
+        self.lastDistanceMapSkipReason = None
         if segmentationNode is None:
+            self.lastDistanceMapSkipReason = "no canonical segmentation"
             return None
         reference = self.selectInputVolume()
         if reference is None:
+            # The commonest way to reach Stage 4 with the margins group
+            # greyed: an ad-hoc session that never tagged a volume in
+            # Stage 1.  Name the precondition rather than degrade silently
+            # (ADR-0009 explainable state).
+            self.lastDistanceMapSkipReason = (
+                "no PortalVenous reference volume — tag one in Case Setup "
+                "(Stage 1)"
+            )
             return None
 
         from LiverSegmentationLib import distance_maps
@@ -2214,7 +2245,14 @@ class LiverSegmentationLogic(ScriptedLoadableModuleLogic):
             # No channel resolved (e.g. no SCT-tagged segments): drop the
             # node we minted rather than leaving an empty untagged shell.
             slicer.mrmlScene.RemoveNode(output)
+            self.lastDistanceMapSkipReason = (
+                "no SCT-tagged structures to compute distances from"
+            )
             return None
+        if computed is None:
+            self.lastDistanceMapSkipReason = (
+                "no SCT-tagged structures to compute distances from"
+            )
         return computed
 
     def ensureSurfaceRepresentation(self, segmentationNode):


### PR DESCRIPTION
**ADR-0040 phase 4a.** The consumer seam: a segmentation segment becomes a mesh **by a method the caller names**. Stacked on **#648**; also merges **#645** (the extractor), because the consumer composes *both* primitives and they sit on parallel branches. Relates to **#310**.

**Nothing changes for anyone who does not ask.** `ensure_target_model` gains a `method` parameter whose absence means marching cubes, so the liver target mesh is byte-for-byte what it was.

## The choice is the deliverable

ADR-0040 §Conformance requires PSR be offered *alongside* marching cubes, never as a silent replacement — and the reason isn't caution, it's that the two make a trade the surgeon owns:

- **Marching cubes** is exact about which voxels are in, and inherits the labelmap's voxel staircase.
- **PSR** approximates rather than interpolates, and will not reproduce a one-voxel spike.

At CT resolution that staircase is a real feature of the data, not noise to be assumed away. Neither is better in general, so this module must not decide.

**An unknown method returns `None` rather than falling back.** A caller who asked for PSR and silently got marching cubes would be comparing the two and reading the same surface twice — the failure mode that makes an A/B evaluation worthless while looking like it worked.

## Two details that the composition has to get right

**The label value is threaded, not just the image.** Stage 2's segments share one binary-labelmap layer, so the image a segment hands back holds its neighbours' voxels; only the segment's own value distinguishes it. That's why the extractor tests voxels for *equality*. A test with two concentric labelled shells pins that the composition preserves it end to end — reconstructing label 3 must not reach into the label-7 shell wrapped around it.

**The image-to-world matrix is passed whole.** A segment's labelmap is oriented — spacing, direction and origin together — so handing the extractor the matrix rather than a spacing triple is what stops an oblique acquisition being flattened into an axis-aligned assumption.

`_liver_closed_surface` stays as a thin alias to the moved implementation: once a second method exists, marching cubes has no claim to being the unqualified meaning of "the surface".

## Tests run in both rows, and the split is deliberate

The **dispatch** half — both methods on the menu, marching cubes still first and still the default, an unrecognised method refused — is the ADR conformance invariant, and it **runs in the bare row** rather than skipping. The fixture falls back to loading `SegmentSurface` from its source path, which is safe *only* because the module imports `vtk` and nothing else at module scope and resolves the wrapped classes lazily. If that stops being true, the fixture fails loudly instead of quietly skipping.

That mattered: my first attempt registered a bare row that skipped all 9 tests, because `LiverResectionsLib` isn't importable outside a launched Slicer. A green row that only ever skips is worth nothing, and this project has paid for that lesson repeatedly (#449, #454, #459, #460).

The default is asserted **through the real dispatcher with a recording stub**, not by reading the signature's default — so a later refactor that moves the default elsewhere still trips it.

```
bare      4 passed,  5 skipped
launched  9 passed
full launched LiverResections root   216 passed, 15 skipped (all pre-existing)
Algorithm C++ suite                  15/15
bare pytest_scaffold                 green
```

## Next

Phase 4b: the UI that lets the surgeon make the choice, and the `:0` eyeball comparing the two on real anatomy — which is where the trade above stops being an argument and becomes something you can look at.

---
_Authored with assistance from Claude (Anthropic Claude Opus 5)._
